### PR TITLE
fix: collapse five duplicated primitives (shell quoting, duration parsing, fs locks, SSH transient list, triage watch exit code)

### DIFF
--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -11,7 +11,7 @@ use homeboy::core::notification_payload::{
 };
 use homeboy::core::notification_route::{self, NotificationRoute};
 use homeboy::core::notify::{self, NotifyEvent, NotifyOutcome};
-use homeboy::core::{Error, Result};
+use homeboy::core::Result;
 
 use super::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandJobRef, CommandNextAction,
@@ -532,43 +532,12 @@ fn notify_attachment(
     )
 }
 
+/// Parse `--interval` / `--duration` for `activity`.
+///
+/// Delegates to the shared unit table in `commands::utils::watch`, which also
+/// supplies the zero-check this parser previously lacked.
 fn parse_duration(raw: &str) -> Result<Duration> {
-    let trimmed = raw.trim();
-    let split = trimmed
-        .find(|ch: char| !ch.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (amount, unit) = trimmed.split_at(split);
-    if amount.is_empty() || unit.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "duration",
-            "expected duration like 2s, 30m, or 1h",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let amount = amount.parse::<u64>().map_err(|_| {
-        Error::validation_invalid_argument(
-            "duration",
-            "duration amount must be a positive integer",
-            Some(raw.to_string()),
-            None,
-        )
-    })?;
-    let seconds = match unit {
-        "s" | "sec" | "secs" | "second" | "seconds" => amount,
-        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
-        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
-        "d" | "day" | "days" => amount * 60 * 60 * 24,
-        _ => {
-            return Err(Error::validation_invalid_argument(
-                "duration",
-                "duration unit must be s, m, h, or d",
-                Some(raw.to_string()),
-                None,
-            ))
-        }
-    };
-    Ok(Duration::from_secs(seconds))
+    crate::commands::utils::watch::parse_duration("duration", raw)
 }
 
 fn truncate(value: &str, width: usize) -> String {
@@ -691,8 +660,8 @@ mod tests {
             show(&run.id).expect("show activity");
             watch(ActivityWatchArgs {
                 id: run.id.clone(),
-                timeout: Some("0s".to_string()),
-                interval: "0s".to_string(),
+                timeout: Some("1ms".to_string()),
+                interval: "1ms".to_string(),
                 notify: false,
             })
             .expect("watch activity");

--- a/crates/homeboy-cli/src/commands/observe.rs
+++ b/crates/homeboy-cli/src/commands/observe.rs
@@ -253,25 +253,13 @@ fn observe_command(args: &ObserveArgs) -> String {
     parts.join(" ")
 }
 
+/// clap `value_parser` for `observe`'s duration flags.
+///
+/// Kept under this name so the `#[arg(value_parser = parse_duration)]`
+/// declarations stay untouched; the unit table is the shared one in
+/// `commands::utils::watch`, which adds `d` and the long unit spellings here.
 fn parse_duration(raw: &str) -> Result<Duration, String> {
-    let split = raw
-        .trim()
-        .find(|c: char| !c.is_ascii_digit())
-        .ok_or_else(|| "expected duration like 500ms, 30s, 5m, or 1h".to_string())?;
-    let (amount, unit) = raw.trim().split_at(split);
-    let amount = amount
-        .parse::<u64>()
-        .map_err(|_| "duration amount must be a positive integer".to_string())?;
-    if amount == 0 {
-        return Err("duration amount must be greater than zero".to_string());
-    }
-    match unit {
-        "ms" => Ok(Duration::from_millis(amount)),
-        "s" => Ok(Duration::from_secs(amount)),
-        "m" => Ok(Duration::from_secs(amount * 60)),
-        "h" => Ok(Duration::from_secs(amount * 60 * 60)),
-        _ => Err("duration unit must be one of ms, s, m, or h".to_string()),
-    }
+    crate::commands::utils::watch::parse_duration_arg(raw)
 }
 
 fn format_duration(duration: Duration) -> String {

--- a/crates/homeboy-cli/src/commands/runs/common.rs
+++ b/crates/homeboy-cli/src/commands/runs/common.rs
@@ -76,55 +76,13 @@ pub fn since_threshold(raw: &str) -> homeboy::core::Result<String> {
     Ok((chrono::Utc::now() - chrono_duration).to_rfc3339())
 }
 
-/// Parse a duration string with units (s, m, h, d).
+/// Parse a duration string for the `--since` family of flags.
 ///
-/// Mirrors the parser in `bundle.rs`. Kept here so the gh-actions / query /
-/// drift commands can share the same surface without re-implementing it.
+/// The unit table lives in `commands::utils::watch` so every duration-taking
+/// flag in the CLI accepts the same units; this only names the field the error
+/// is attributed to.
 pub fn parse_duration(raw: &str) -> homeboy::core::Result<Duration> {
-    let trimmed = raw.trim();
-    let split = trimmed
-        .find(|ch: char| !ch.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (amount, unit) = trimmed.split_at(split);
-    if amount.is_empty() || unit.is_empty() || !unit.chars().all(|ch| ch.is_ascii_alphabetic()) {
-        return Err(Error::validation_invalid_argument(
-            "since",
-            "expected duration like 30m, 24h, or 7d",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let amount = amount.parse::<u64>().map_err(|_| {
-        Error::validation_invalid_argument(
-            "since",
-            "duration amount must be a positive integer",
-            Some(raw.to_string()),
-            None,
-        )
-    })?;
-    if amount == 0 {
-        return Err(Error::validation_invalid_argument(
-            "since",
-            "duration amount must be greater than zero",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let seconds = match unit {
-        "s" | "sec" | "secs" | "second" | "seconds" => amount,
-        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
-        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
-        "d" | "day" | "days" => amount * 60 * 60 * 24,
-        _ => {
-            return Err(Error::validation_invalid_argument(
-                "since",
-                "duration unit must be one of s, m, h, or d",
-                Some(raw.to_string()),
-                None,
-            ))
-        }
-    };
-    Ok(Duration::from_secs(seconds))
+    crate::commands::utils::watch::parse_duration("since", raw)
 }
 
 /// Compile a JSONPath expression. Returns a structured validation error on

--- a/crates/homeboy-cli/src/commands/triage.rs
+++ b/crates/homeboy-cli/src/commands/triage.rs
@@ -7,6 +7,7 @@ use homeboy_triage::{
 use std::path::PathBuf;
 
 use super::utils::args::ScopeArgs;
+use super::utils::watch::TIMEOUT_EXIT_CODE;
 use super::CmdResult;
 
 #[derive(Args)]
@@ -172,7 +173,18 @@ pub fn run(args: TriageArgs) -> CmdResult<TriageCommandOutput> {
             merge_method: args.merge_method,
         };
         let output = triage::watch(options)?;
-        let exit_code = if output.target_reached { 0 } else { 1 };
+        // USER-VISIBLE: this used to be a bare `1`. Every other watch surface
+        // (`runs watch`, `activity watch`) exits `TIMEOUT_EXIT_CODE` (124, the
+        // GNU timeout(1) convention) when it does not settle in time, and
+        // `triage --watch` only ever fails to reach its target by timing out --
+        // the loop breaks on all-reached or on the deadline, nothing else. A
+        // watch surface with its own exit-code convention is exactly the drift
+        // the shared constant exists to prevent.
+        let exit_code = if output.target_reached {
+            0
+        } else {
+            TIMEOUT_EXIT_CODE
+        };
         return Ok((TriageCommandOutput::Watch(output), exit_code));
     }
 

--- a/crates/homeboy-cli/src/commands/triage.rs
+++ b/crates/homeboy-cli/src/commands/triage.rs
@@ -244,42 +244,13 @@ pub fn run(args: TriageArgs) -> CmdResult<TriageCommandOutput> {
     ))
 }
 
+/// Parse `triage --timeout` / `--interval`.
+///
+/// Delegates to the shared unit table in `commands::utils::watch`, which is why
+/// `--timeout 7d` and `--interval 500ms` now work here as they already did on
+/// `runs watch` and `observe`.
 fn parse_watch_duration(name: &str, raw: &str) -> Result<std::time::Duration, Error> {
-    let trimmed = raw.trim();
-    let split = trimmed
-        .find(|ch: char| !ch.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (amount, unit) = trimmed.split_at(split);
-    let amount = amount.parse::<u64>().map_err(|_| {
-        Error::validation_invalid_argument(
-            format!("--{name}"),
-            "expected duration like 30s, 5m, or 1h",
-            Some(raw.to_string()),
-            None,
-        )
-    })?;
-    if amount == 0 {
-        return Err(Error::validation_invalid_argument(
-            format!("--{name}"),
-            "duration amount must be greater than zero",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let seconds = match unit {
-        "s" | "sec" | "secs" | "second" | "seconds" => amount,
-        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
-        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
-        _ => {
-            return Err(Error::validation_invalid_argument(
-                format!("--{name}"),
-                "duration unit must be one of s, m, or h",
-                Some(raw.to_string()),
-                None,
-            ))
-        }
-    };
-    Ok(std::time::Duration::from_secs(seconds))
+    crate::commands::utils::watch::parse_duration(&format!("--{name}"), raw)
 }
 
 fn resolve_component_target(

--- a/crates/homeboy-cli/src/commands/utils/watch.rs
+++ b/crates/homeboy-cli/src/commands/utils/watch.rs
@@ -55,6 +55,102 @@ pub struct WatchConfig {
     pub timeout: Option<Duration>,
 }
 
+/// Every duration unit any homeboy flag accepts, and what one of it is worth.
+///
+/// Four commands had grown their own copy of this table with three different
+/// unit sets, so `triage --timeout 7d` errored while `runs watch --timeout 7d`
+/// worked, and `activity --duration 500ms` errored while `observe --duration
+/// 500ms` did not. This is the union of all four: every command now accepts
+/// every unit.
+const DURATION_UNITS: &[(&str, u64)] = &[
+    ("ms", 1),
+    ("s", 1_000),
+    ("sec", 1_000),
+    ("secs", 1_000),
+    ("second", 1_000),
+    ("seconds", 1_000),
+    ("m", 60 * 1_000),
+    ("min", 60 * 1_000),
+    ("mins", 60 * 1_000),
+    ("minute", 60 * 1_000),
+    ("minutes", 60 * 1_000),
+    ("h", 60 * 60 * 1_000),
+    ("hr", 60 * 60 * 1_000),
+    ("hrs", 60 * 60 * 1_000),
+    ("hour", 60 * 60 * 1_000),
+    ("hours", 60 * 60 * 1_000),
+    ("d", 24 * 60 * 60 * 1_000),
+    ("day", 24 * 60 * 60 * 1_000),
+    ("days", 24 * 60 * 60 * 1_000),
+];
+
+/// Human-readable list of accepted units, for `--help` and error messages.
+pub const DURATION_UNITS_HINT: &str = "ms, s, m, h, or d";
+
+/// Parse a duration like `500ms`, `30s`, `5m`, `2h`, or `7d`.
+///
+/// Returns the plain message on failure; [`parse_duration`] wraps it into a
+/// structured argument error and [`parse_duration_arg`] hands it to clap.
+///
+/// A bare number with no unit is rejected, as it was by all four parsers this
+/// replaces -- `--timeout 30` is ambiguous and always was an error.
+fn parse_duration_parts(raw: &str) -> Result<Duration, String> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (amount, unit) = trimmed.split_at(split);
+
+    if amount.is_empty() || unit.is_empty() {
+        return Err(format!(
+            "expected duration like 500ms, 30s, 5m, 2h, or 7d (unit required: {DURATION_UNITS_HINT})"
+        ));
+    }
+
+    let amount = amount
+        .parse::<u64>()
+        .map_err(|_| "duration amount must be a positive integer".to_string())?;
+
+    // Preserved from three of the four parsers. `activity` was the one that
+    // lacked it, so `activity --interval 0s` used to spin with no delay.
+    if amount == 0 {
+        return Err("duration amount must be greater than zero".to_string());
+    }
+
+    let millis_per_unit = DURATION_UNITS
+        .iter()
+        .find(|(name, _)| *name == unit)
+        .map(|(_, millis)| *millis)
+        .ok_or_else(|| format!("duration unit must be one of {DURATION_UNITS_HINT}"))?;
+
+    // The parsers this replaces multiplied unchecked, so `9999999999999999999d`
+    // panicked in debug builds. Report it instead.
+    amount
+        .checked_mul(millis_per_unit)
+        .map(Duration::from_millis)
+        .ok_or_else(|| "duration is too large".to_string())
+}
+
+/// Parse a duration into a structured argument error attributed to `field`.
+///
+/// `field` is the name the user typed (`since`, `duration`, `--timeout`) so the
+/// error points at the flag that was wrong.
+pub fn parse_duration(field: &str, raw: &str) -> homeboy::core::Result<Duration> {
+    parse_duration_parts(raw).map_err(|message| {
+        homeboy::core::Error::validation_invalid_argument(
+            field,
+            message,
+            Some(raw.to_string()),
+            None,
+        )
+    })
+}
+
+/// Duration parser for clap `value_parser` attributes.
+pub fn parse_duration_arg(raw: &str) -> Result<Duration, String> {
+    parse_duration_parts(raw)
+}
+
 /// Why the loop returned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WatchConclusion {
@@ -124,6 +220,136 @@ where
         }
 
         sleep(config.interval);
+    }
+}
+
+#[cfg(test)]
+mod duration_tests {
+    use super::*;
+
+    /// The full accepted grid. Every one of these must work on *every* command
+    /// that takes a duration -- that is the point of the consolidation.
+    const ACCEPTED: &[(&str, u64)] = &[
+        ("1ms", 1),
+        ("500ms", 500),
+        ("1s", 1_000),
+        ("30s", 30_000),
+        ("30sec", 30_000),
+        ("30secs", 30_000),
+        ("30second", 30_000),
+        ("30seconds", 30_000),
+        ("5m", 300_000),
+        ("5min", 300_000),
+        ("5mins", 300_000),
+        ("5minute", 300_000),
+        ("5minutes", 300_000),
+        ("2h", 7_200_000),
+        ("2hr", 7_200_000),
+        ("2hrs", 7_200_000),
+        ("2hour", 7_200_000),
+        ("2hours", 7_200_000),
+        ("7d", 604_800_000),
+        ("7day", 604_800_000),
+        ("7days", 604_800_000),
+        // Surrounding whitespace was tolerated by three of the four parsers.
+        ("  10m  ", 600_000),
+    ];
+
+    #[test]
+    fn every_unit_parses_to_the_same_value_everywhere() {
+        for (raw, expected_millis) in ACCEPTED {
+            assert_eq!(
+                parse_duration_arg(raw),
+                Ok(Duration::from_millis(*expected_millis)),
+                "{raw} should parse to {expected_millis}ms"
+            );
+        }
+    }
+
+    /// The regressions this consolidation fixes. Before it, `triage` rejected
+    /// `d` and `ms`, and `activity`/`runs` rejected `ms`.
+    #[test]
+    fn units_that_used_to_be_rejected_per_command_now_parse() {
+        assert_eq!(
+            parse_duration("--timeout", "7d").expect("triage now accepts days"),
+            Duration::from_secs(7 * 24 * 60 * 60)
+        );
+        assert_eq!(
+            parse_duration("duration", "500ms").expect("activity now accepts millis"),
+            Duration::from_millis(500)
+        );
+    }
+
+    #[test]
+    fn zero_is_rejected_for_every_unit() {
+        for unit in ["ms", "s", "m", "h", "d"] {
+            let raw = format!("0{unit}");
+            assert_eq!(
+                parse_duration_arg(&raw),
+                Err("duration amount must be greater than zero".to_string()),
+                "0{unit} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_number_is_rejected_because_the_unit_is_ambiguous() {
+        for raw in ["30", "0", ""] {
+            assert!(parse_duration_arg(raw).is_err(), "{raw:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn unknown_units_are_rejected_with_the_full_unit_list() {
+        let error = parse_duration_arg("5w").expect_err("weeks are not a unit");
+        assert!(error.contains(DURATION_UNITS_HINT), "unexpected: {error}");
+        assert!(parse_duration_arg("5 s").is_err());
+        assert!(parse_duration_arg("-5s").is_err());
+        assert!(parse_duration_arg("1.5h").is_err());
+    }
+
+    /// The parsers this replaced multiplied unchecked and panicked in debug.
+    #[test]
+    fn an_overflowing_duration_is_an_error_not_a_panic() {
+        assert_eq!(
+            parse_duration_arg("99999999999999999999999d"),
+            Err("duration amount must be a positive integer".to_string()),
+        );
+        assert_eq!(
+            parse_duration_arg(&format!("{}d", u64::MAX)),
+            Err("duration is too large".to_string()),
+        );
+    }
+
+    #[test]
+    fn the_structured_error_is_attributed_to_the_field_that_was_wrong() {
+        let error = parse_duration("--timeout", "5w").expect_err("weeks are not a unit");
+        assert_eq!(
+            error.code,
+            homeboy::core::ErrorCode::ValidationInvalidArgument
+        );
+        assert!(
+            error.message.contains("--timeout"),
+            "unexpected: {}",
+            error.message
+        );
+        // The offending value is carried structurally, not only in the message.
+        assert_eq!(error.details["id"], serde_json::json!("5w"));
+        assert_eq!(error.details["field"], serde_json::json!("--timeout"));
+    }
+
+    /// Guards the table itself: a unit added to `DURATION_UNITS` with a bad
+    /// multiplier is caught here rather than in whichever command hits it.
+    #[test]
+    fn the_unit_table_is_internally_consistent() {
+        for (name, millis) in DURATION_UNITS {
+            assert!(*millis > 0, "{name} must have a positive multiplier");
+            assert_eq!(
+                parse_duration_arg(&format!("1{name}")),
+                Ok(Duration::from_millis(*millis)),
+                "1{name} must equal its table entry"
+            );
+        }
     }
 }
 

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fs4::fs_std::FileExt;
 use homeboy_engine_primitives::content_hash;
+use homeboy_engine_primitives::shell::quote_path;
 use serde::Serialize;
 use serde_json::json;
 
@@ -262,7 +263,7 @@ pub fn cleanup_shared_cargo_targets(
         let apply = if options.apply { " --apply" } else { "" };
         format!(
             "homeboy cleanup --include shared-cargo-targets{apply} --cursor {}",
-            shell_quote(cursor)
+            quote_path(cursor)
         )
     });
     let skipped_count = retained_by_reason.values().sum();
@@ -342,7 +343,7 @@ fn storage_status(
         legacy_discovery_command: moved.then(|| {
             format!(
                 "HOMEBOY_CARGO_TARGET_ROOT={} homeboy cleanup --include shared-cargo-targets",
-                shell_quote(&legacy_root.display().to_string())
+                quote_path(&legacy_root.display().to_string())
             )
         }),
     })
@@ -741,9 +742,6 @@ fn path_size(path: &Path) -> Result<u64> {
 }
 fn io_error(error: std::io::Error, operation: &str) -> Error {
     Error::internal_io(error.to_string(), Some(operation.to_string()))
-}
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
+++ b/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
@@ -47,12 +47,12 @@ pub(super) fn local_path_diagnostic_for(
         if standalone_registration_exists(id) {
             Some(format!(
                 "homeboy component reconcile {id} --apply # updates local_path to {}",
-                shell_quote_for_hint(&candidate)
+                quote_path(&candidate)
             ))
         } else {
             Some(format!(
                 "homeboy component set {id} --local-path {}",
-                shell_quote_for_hint(&candidate)
+                quote_path(&candidate)
             ))
         }
     } else if status != "ok" {
@@ -122,8 +122,4 @@ pub(super) fn detect_git_root(path: &Path) -> Option<PathBuf> {
     // helper (trimmed, non-empty toplevel as a `PathBuf`) instead of assembling
     // the raw arg-vector. The `.git`-exists fast path above is preserved.
     crate::git::repo_root(path)
-}
-
-fn shell_quote_for_hint(value: &str) -> String {
-    quote_path(value)
 }

--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -3,16 +3,12 @@
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, Result};
 use crate::paths;
+use homeboy_engine_primitives::fs_index_lock::{FsIndexLock, FsIndexLockConfig};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::thread;
-use std::time::{Duration, SystemTime};
 
-const LOCK_NAME: &str = ".index.lock";
-const LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
-const LOCK_ATTEMPTS: usize = 100;
-const LOCK_SLEEP: Duration = Duration::from_millis(20);
+const INVOCATION_INDEX_LOCK: FsIndexLockConfig = FsIndexLockConfig::index("invocation lease");
 const PORT_POOL_START: u16 = 20_000;
 const PORT_POOL_END: u16 = 60_999;
 
@@ -160,7 +156,7 @@ impl InvocationGuard {
 
         let mut port_base = None;
         let mut port_max = None;
-        let _lock = InvocationIndexLock::acquire()?;
+        let _lock = acquire_invocation_index_lock()?;
         fs::create_dir_all(invocation_leases_dir()?).map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to create invocation lease directory: {}",
@@ -366,7 +362,7 @@ impl Drop for InvocationGuard {
         let Some(id) = &self.lease_id else {
             return;
         };
-        let Ok(_lock) = InvocationIndexLock::acquire() else {
+        let Ok(_lock) = acquire_invocation_index_lock() else {
             return;
         };
         let Ok(path) = lease_path(id) else {
@@ -584,69 +580,15 @@ fn invocation_leases_dir() -> Result<PathBuf> {
     Ok(paths::homeboy()?.join("invocation-leases"))
 }
 
-struct InvocationIndexLock {
-    path: PathBuf,
-}
+type InvocationIndexLock = FsIndexLock;
 
-impl InvocationIndexLock {
-    fn acquire() -> Result<Self> {
-        let dir = invocation_leases_dir()?;
-        fs::create_dir_all(&dir).map_err(|e| {
-            Error::internal_unexpected(format!(
-                "Failed to create invocation lease directory: {}",
-                e
-            ))
-        })?;
-        let path = dir.join(LOCK_NAME);
-        for _ in 0..LOCK_ATTEMPTS {
-            match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path }),
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    remove_stale_index_lock(&path)?;
-                    thread::sleep(LOCK_SLEEP);
-                }
-                Err(e) => {
-                    return Err(Error::internal_unexpected(format!(
-                        "Failed to acquire invocation lease lock {}: {}",
-                        path.display(),
-                        e
-                    )))
-                }
-            }
-        }
-        Err(Error::internal_unexpected(format!(
-            "Timed out acquiring invocation lease lock {}",
-            path.display()
-        )))
-    }
-}
-
-impl Drop for InvocationIndexLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.path);
-    }
-}
-
-fn remove_stale_index_lock(path: &Path) -> Result<()> {
-    let Ok(metadata) = fs::metadata(path) else {
-        return Ok(());
-    };
-    let Ok(modified) = metadata.modified() else {
-        return Ok(());
-    };
-    if SystemTime::now()
-        .duration_since(modified)
-        .is_ok_and(|age| age > LOCK_STALE_AFTER)
-    {
-        fs::remove_dir(path).map_err(|e| {
-            Error::internal_unexpected(format!(
-                "Failed to remove stale invocation lease lock {}: {}",
-                path.display(),
-                e
-            ))
-        })?;
-    }
-    Ok(())
+/// Block until the invocation lease index lock is held. Released on drop.
+///
+/// Mechanics (mkdir-lock, mtime stale reclaim, the shared 30s/100-attempt/20ms
+/// tuning) live in `homeboy_engine_primitives::fs_index_lock`, which
+/// `homeboy-rig`'s lease index also uses.
+fn acquire_invocation_index_lock() -> Result<InvocationIndexLock> {
+    FsIndexLock::acquire_in(&invocation_leases_dir()?, INVOCATION_INDEX_LOCK)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/server/client/host.rs
+++ b/crates/homeboy-core/src/server/client/host.rs
@@ -87,24 +87,34 @@ fn successful_command_stdout(output: std::process::Output) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// SSH connection failures worth retrying, matched case-insensitively against
+/// lowercased stderr.
+///
+/// This is the single source of truth for the pattern list. Callers that work
+/// with a different output type (for example `homeboy-lab-runner`, which sees a
+/// raw `std::process::Output` from a piped `sh` invocation rather than a
+/// [`CommandOutput`]) import this constant instead of restating the patterns.
+pub const TRANSIENT_SSH_STDERR_PATTERNS: [&str; 10] = [
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "no route to host",
+    "network is unreachable",
+    "temporary failure in name resolution",
+    "could not resolve hostname",
+    "broken pipe",
+    "ssh_exchange_identification",
+    "connection closed by remote host",
+];
+
 /// Check if an SSH failure is a transient connection error worth retrying.
 pub fn is_transient_ssh_error(output: &CommandOutput) -> bool {
     let stderr = output.stderr.to_lowercase();
     // SSH exit code 255 = connection error (not a remote command failure)
     let is_connection_exit = output.exit_code == 255;
 
-    let transient_patterns = [
-        "connection refused",
-        "connection reset",
-        "connection timed out",
-        "no route to host",
-        "network is unreachable",
-        "temporary failure in name resolution",
-        "could not resolve hostname",
-        "broken pipe",
-        "ssh_exchange_identification",
-        "connection closed by remote host",
-    ];
-
-    is_connection_exit || transient_patterns.iter().any(|p| stderr.contains(p))
+    is_connection_exit
+        || TRANSIENT_SSH_STDERR_PATTERNS
+            .iter()
+            .any(|p| stderr.contains(p))
 }

--- a/crates/homeboy-core/src/server/client/mod.rs
+++ b/crates/homeboy-core/src/server/client/mod.rs
@@ -13,7 +13,7 @@ mod ssh_client;
 mod tests;
 
 pub use delegated::DELEGATED_RUN_STATUS_FILE_ENV;
-pub use host::is_transient_ssh_error;
+pub use host::{is_transient_ssh_error, TRANSIENT_SSH_STDERR_PATTERNS};
 pub use local_exec::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough,

--- a/crates/homeboy-core/src/server/health.rs
+++ b/crates/homeboy-core/src/server/health.rs
@@ -4,6 +4,7 @@
 //! to collect uptime, load, disk, memory, and service health from remote servers.
 
 use super::SshClient;
+use crate::engine::shell::quote_arg;
 use crate::project::Project;
 use serde::Serialize;
 use std::time::Duration;
@@ -113,7 +114,7 @@ fn collect_server_health(client: &SshClient, services: &[String]) -> ServerHealt
             cmd_parts.push(format!(
                 "echo '{}:'$(systemctl is-active {} 2>/dev/null || echo 'unknown')",
                 svc,
-                shell_quote_service(svc)
+                quote_arg(svc)
             ));
         }
     }
@@ -137,19 +138,6 @@ fn collect_server_health(client: &SshClient, services: &[String]) -> ServerHealt
 // ============================================================================
 // Parsing
 // ============================================================================
-
-/// Quote a service name for safe use in shell commands.
-fn shell_quote_service(name: &str) -> String {
-    // Only allow alphanumeric, dash, dot, underscore, @ (systemd instance separator)
-    if name
-        .chars()
-        .all(|c| c.is_alphanumeric() || matches!(c, '-' | '.' | '_' | '@'))
-    {
-        name.to_string()
-    } else {
-        format!("'{}'", name.replace('\'', "'\\''"))
-    }
-}
 
 /// Parse the structured health output from the compound SSH command.
 fn parse_health_output(output: &str, services: &[String]) -> ServerHealth {
@@ -653,16 +641,19 @@ Mem:          3.8Gi       1.5Gi       1.0Gi       0.0Ki       1.3Gi       2.0Gi
         assert!(warnings.is_empty());
     }
 
+    /// Systemd unit names must survive `quote_arg` unquoted -- `@` is the
+    /// instance separator and `.`/`-` are ordinary in unit names, so none of
+    /// them may be treated as shell metacharacters.
     #[test]
-    fn test_shell_quote_service_safe() {
-        assert_eq!(shell_quote_service("nginx"), "nginx");
-        assert_eq!(shell_quote_service("php8.4-fpm"), "php8.4-fpm");
-        assert_eq!(shell_quote_service("user@.service"), "user@.service");
+    fn test_quote_arg_leaves_service_names_unquoted() {
+        assert_eq!(quote_arg("nginx"), "nginx");
+        assert_eq!(quote_arg("php8.4-fpm"), "php8.4-fpm");
+        assert_eq!(quote_arg("user@.service"), "user@.service");
     }
 
     #[test]
-    fn test_shell_quote_service_unsafe() {
-        let quoted = shell_quote_service("foo; rm -rf /");
+    fn test_quote_arg_quotes_unsafe_service_names() {
+        let quoted = quote_arg("foo; rm -rf /");
         assert!(quoted.starts_with('\''));
     }
 }

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -15,7 +15,7 @@ pub use client::DELEGATED_RUN_STATUS_FILE_ENV;
 pub use client::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough, is_transient_ssh_error,
-    CommandOutput, SshClient, CHILD_SECRET_ENV_NAMES_ENV,
+    CommandOutput, SshClient, CHILD_SECRET_ENV_NAMES_ENV, TRANSIENT_SSH_STDERR_PATTERNS,
 };
 pub use client::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -1064,7 +1064,7 @@ mod tests {
         let pid_file = temp.path().join("descendant.pid");
         let script = format!(
             "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
-            shell_quote_path(&pid_file)
+            crate::shell::quote_path(&pid_file.display().to_string())
         );
         let mut command = Command::new("sh");
         command.args(["-c", &script]);
@@ -1091,7 +1091,7 @@ mod tests {
         let pid_file = temp.path().join("upload-child.pid");
         let script = format!(
             "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
-            shell_quote_path(&pid_file)
+            crate::shell::quote_path(&pid_file.display().to_string())
         );
         let mut command = Command::new("sh");
         command.args(["-c", &script]);
@@ -1145,7 +1145,7 @@ mod tests {
         let pid_file = temp.path().join("descendant.pid");
         let script = format!(
             "sleep 30 & echo $! > {}; printf done",
-            shell_quote_path(&pid_file)
+            crate::shell::quote_path(&pid_file.display().to_string())
         );
         let mut command = Command::new("sh");
         command.args(["-c", &script]);
@@ -1173,13 +1173,5 @@ mod tests {
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
         assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
-    }
-
-    #[cfg(unix)]
-    fn shell_quote_path(path: &std::path::Path) -> String {
-        format!(
-            "'{}'",
-            path.display().to_string().replace('\'', "'\\\"'\\\"'")
-        )
     }
 }

--- a/crates/homeboy-engine-primitives/src/fs_index_lock.rs
+++ b/crates/homeboy-engine-primitives/src/fs_index_lock.rs
@@ -1,0 +1,236 @@
+//! A mkdir-based advisory filesystem lock with mtime-based stale reclaim.
+//!
+//! `fs::create_dir` is atomic on every platform homeboy targets, so creating a
+//! directory is the cheapest cross-process mutex available without a daemon or
+//! a filesystem-specific advisory-lock API. Two subsystems had independently
+//! grown byte-identical implementations of it -- the invocation lease index in
+//! `homeboy-core` and the rig lease index in `homeboy-rig` -- with the same
+//! four tuning constants (`.index.lock`, 30s stale, 100 attempts, 20ms sleep)
+//! and the same reclaim rule. This is the one copy.
+//!
+//! # What this is not
+//!
+//! The reclaim rule here is *mtime only*: a lock directory older than
+//! `stale_after` is removed and the acquisition retried. That is correct for a
+//! lock held for milliseconds around an index read-modify-write, where an
+//! abandoned lock can only mean a crashed process.
+//!
+//! It is deliberately weaker than the runtime-temp cleanup lock in
+//! `homeboy_core::engine::temp`, which is held for minutes, writes an owner
+//! descriptor (`owner.json`) with a pid and a Linux process start-time, refuses
+//! to reclaim while that identity is still live, and quarantine-renames rather
+//! than deletes. Do not "unify" that one into this: it is a genuinely stronger
+//! lock, not a duplicate of this one.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use homeboy_error::{Error, Result};
+
+/// Tuning for an [`FsIndexLock`].
+#[derive(Debug, Clone, Copy)]
+pub struct FsIndexLockConfig {
+    /// Directory name created inside the lock's parent directory.
+    pub name: &'static str,
+    /// A lock directory whose mtime is older than this is considered
+    /// abandoned by a crashed process and is removed.
+    pub stale_after: Duration,
+    /// How many acquisition attempts before giving up.
+    pub attempts: usize,
+    /// How long to wait between attempts.
+    pub sleep: Duration,
+    /// Noun used in error messages, e.g. `"rig lease"` produces
+    /// "Failed to acquire rig lease lock ...".
+    pub subject: &'static str,
+}
+
+impl FsIndexLockConfig {
+    /// The settings shared by every index lock in the tree: `.index.lock`,
+    /// 30s stale, 100 attempts, 20ms apart (so ~2s of contention tolerance).
+    pub const fn index(subject: &'static str) -> Self {
+        Self {
+            name: ".index.lock",
+            stale_after: Duration::from_secs(30),
+            attempts: 100,
+            sleep: Duration::from_millis(20),
+            subject,
+        }
+    }
+}
+
+/// An acquired lock. Released on drop.
+#[derive(Debug)]
+pub struct FsIndexLock {
+    path: PathBuf,
+    config: FsIndexLockConfig,
+}
+
+impl FsIndexLock {
+    /// Create `dir` if needed, then block until the lock inside it is held or
+    /// `config.attempts` is exhausted.
+    pub fn acquire_in(dir: &Path, config: FsIndexLockConfig) -> Result<Self> {
+        fs::create_dir_all(dir).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to create {} directory: {}",
+                config.subject, e
+            ))
+        })?;
+        let path = dir.join(config.name);
+        for _ in 0..config.attempts {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path, config }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    remove_if_stale(&path, config)?;
+                    thread::sleep(config.sleep);
+                }
+                Err(e) => {
+                    return Err(Error::internal_unexpected(format!(
+                        "Failed to acquire {} lock {}: {}",
+                        config.subject,
+                        path.display(),
+                        e
+                    )))
+                }
+            }
+        }
+        Err(Error::internal_unexpected(format!(
+            "Timed out acquiring {} lock {}",
+            config.subject,
+            path.display()
+        )))
+    }
+
+    /// Path of the held lock directory.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for FsIndexLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+/// Remove a lock directory whose mtime is older than `config.stale_after`.
+///
+/// Every failure to *read* the lock's metadata is treated as "not stale" so a
+/// racing release (the directory vanishing between `create_dir` and
+/// `metadata`) is a retry rather than an error.
+fn remove_if_stale(path: &Path, config: FsIndexLockConfig) -> Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(());
+    };
+    if SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age > config.stale_after)
+    {
+        fs::remove_dir(path).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to remove stale {} lock {}: {}",
+                config.subject,
+                path.display(),
+                e
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fast(subject: &'static str) -> FsIndexLockConfig {
+        FsIndexLockConfig {
+            attempts: 3,
+            sleep: Duration::from_millis(1),
+            ..FsIndexLockConfig::index(subject)
+        }
+    }
+
+    #[test]
+    fn index_config_matches_the_constants_it_replaced() {
+        let config = FsIndexLockConfig::index("rig lease");
+        assert_eq!(config.name, ".index.lock");
+        assert_eq!(config.stale_after, Duration::from_secs(30));
+        assert_eq!(config.attempts, 100);
+        assert_eq!(config.sleep, Duration::from_millis(20));
+    }
+
+    #[test]
+    fn acquire_creates_the_lock_directory_and_drop_releases_it() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().join("leases");
+        let lock_path = {
+            let lock = FsIndexLock::acquire_in(&dir, fast("rig lease")).expect("acquire");
+            let path = lock.path().to_path_buf();
+            assert!(path.is_dir(), "lock directory should exist while held");
+            assert_eq!(path.file_name().unwrap(), ".index.lock");
+            path
+        };
+        assert!(!lock_path.exists(), "drop should release the lock");
+    }
+
+    #[test]
+    fn acquire_creates_missing_parent_directories() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().join("deeply").join("nested").join("leases");
+        let _lock = FsIndexLock::acquire_in(&dir, fast("invocation lease")).expect("acquire");
+        assert!(dir.is_dir());
+    }
+
+    #[test]
+    fn contended_lock_times_out_with_the_subject_in_the_message() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().to_path_buf();
+        let _held = FsIndexLock::acquire_in(&dir, fast("rig lease")).expect("first acquire");
+
+        let error = FsIndexLock::acquire_in(&dir, fast("rig lease"))
+            .expect_err("second acquire must not succeed while the first is held");
+        let message = error.to_string();
+        assert!(
+            message.contains("Timed out acquiring rig lease lock"),
+            "unexpected message: {message}"
+        );
+    }
+
+    #[test]
+    fn a_lock_older_than_stale_after_is_reclaimed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().to_path_buf();
+        let config = FsIndexLockConfig {
+            // Anything already on disk is stale.
+            stale_after: Duration::ZERO,
+            ..fast("invocation lease")
+        };
+
+        // Simulate a crashed holder: the directory exists with no live owner.
+        fs::create_dir_all(&dir).expect("create dir");
+        let abandoned = dir.join(config.name);
+        fs::create_dir(&abandoned).expect("create abandoned lock");
+
+        let lock = FsIndexLock::acquire_in(&dir, config).expect("stale lock should be reclaimed");
+        assert_eq!(lock.path(), abandoned);
+    }
+
+    #[test]
+    fn a_fresh_lock_is_not_reclaimed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path().to_path_buf();
+        let config = fast("invocation lease");
+
+        fs::create_dir_all(&dir).expect("create dir");
+        fs::create_dir(dir.join(config.name)).expect("create fresh lock");
+
+        // stale_after is 30s and the lock was made now, so it must be waited
+        // on rather than stolen.
+        assert!(FsIndexLock::acquire_in(&dir, config).is_err());
+        assert!(dir.join(config.name).is_dir(), "lock must not be stolen");
+    }
+}

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -16,6 +16,7 @@ pub mod content_hash;
 pub mod detail_output;
 pub mod edit_op;
 pub mod edit_op_apply;
+pub mod fs_index_lock;
 pub mod git_changes;
 pub mod grammar;
 pub mod identifier;

--- a/crates/homeboy-engine-primitives/src/shell.rs
+++ b/crates/homeboy-engine-primitives/src/shell.rs
@@ -110,6 +110,84 @@ fn escape_double_quoted_env_value(value: &str) -> String {
         .replace('`', "\\`")
 }
 
+/// `homeboy-error` carries a byte-for-byte duplicate of [`quote_arg`] named
+/// `posix_quote_arg`, because it sits below this crate in the dependency graph
+/// and cannot import it. That constraint is real, so the duplicate stays -- but
+/// the claim of byte-equality was previously only a comment. These tests
+/// enforce it, so the two implementations cannot drift silently.
+#[cfg(test)]
+mod error_crate_duplicate_parity_tests {
+    use super::quote_arg;
+    use homeboy_error::posix_quote_arg;
+
+    /// Every character `quote_arg` treats as a shell metacharacter, plus the
+    /// edge cases around them.
+    const PARITY_CASES: &[&str] = &[
+        "",
+        "plain",
+        "already-safe_arg.v1",
+        "/abs/path/to/file",
+        "has space",
+        "has\ttab",
+        "has\nnewline",
+        "has'single",
+        "has\"double",
+        "has\\backslash",
+        "has$dollar",
+        "has`backtick",
+        "has!bang",
+        "has*star",
+        "has?question",
+        "has[bracket",
+        "has]bracket",
+        "has(paren",
+        "has)paren",
+        "has{brace",
+        "has}brace",
+        "has<lt",
+        "has>gt",
+        "has|pipe",
+        "has&amp",
+        "has;semi",
+        "has#hash",
+        "has~tilde",
+        "'",
+        "''",
+        "a'b'c",
+        "'leading",
+        "trailing'",
+        "rm -rf / ; echo pwned",
+        "unicode-\u{e9}\u{4e2d}",
+    ];
+
+    #[test]
+    fn posix_quote_arg_is_byte_identical_to_quote_arg() {
+        for case in PARITY_CASES {
+            assert_eq!(
+                quote_arg(case),
+                posix_quote_arg(case),
+                "shell::quote_arg and homeboy_error::posix_quote_arg diverged on {case:?}"
+            );
+        }
+    }
+
+    /// Sweep the whole ASCII range so a metacharacter added to one table and
+    /// not the other is caught even if nobody remembers to extend
+    /// `PARITY_CASES`.
+    #[test]
+    fn posix_quote_arg_matches_quote_arg_across_ascii() {
+        for byte in 0u8..=127 {
+            let ch = byte as char;
+            let case = format!("a{ch}b");
+            assert_eq!(
+                quote_arg(&case),
+                posix_quote_arg(&case),
+                "shell::quote_arg and homeboy_error::posix_quote_arg diverged on ASCII {byte:#04x}"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod remote_env_tests {
     use super::*;

--- a/crates/homeboy-error/src/lib.rs
+++ b/crates/homeboy-error/src/lib.rs
@@ -66,9 +66,17 @@ impl ExecutableAction {
     }
 }
 
-// Kept byte-for-byte compatible with homeboy-engine-primitives::shell::quote_arg.
-// homeboy-error is below that crate in the dependency graph, so it cannot import it.
-fn posix_quote_arg(arg: &str) -> String {
+/// POSIX-quote a single argument for rendering a command back to the user.
+///
+/// Kept byte-for-byte compatible with
+/// `homeboy_engine_primitives::shell::quote_arg`. `homeboy-error` is *below*
+/// that crate in the dependency graph, so it cannot import the primitive and
+/// this duplicate is a genuine structural constraint rather than drift.
+///
+/// It is `pub` solely so `homeboy-engine-primitives` (which depends on this
+/// crate) can assert the byte-equality this comment claims. Prefer
+/// `shell::quote_arg` in any crate that can reach it.
+pub fn posix_quote_arg(arg: &str) -> String {
     if arg.is_empty() {
         return "''".to_string();
     }

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -259,7 +259,7 @@ pub fn run_deployment_provider(
             None,
         )
     })?;
-    let quoted_contract = shell_quote(contract);
+    let quoted_contract = shell::quote_path(contract);
     let command_template = if dry_run {
         provider.dry_run_command.as_deref().ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -300,10 +300,6 @@ pub fn run_deployment_provider(
         project_id: Some(project_id.to_string()),
         output: Some(execution.output),
     })
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Execute a extension action (API call).

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -1038,7 +1038,9 @@ mod tests {
             "-c",
             &format!(
                 "sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
-                shell_quote_path(&descendant_pid_file)
+                homeboy_engine_primitives::shell::quote_path(
+                    &descendant_pid_file.display().to_string()
+                )
             ),
         ]);
 
@@ -1066,14 +1068,6 @@ mod tests {
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
         assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
-    }
-
-    #[cfg(unix)]
-    fn shell_quote_path(path: &std::path::Path) -> String {
-        format!(
-            "'{}'",
-            path.display().to_string().replace('\'', "'\\\"'\\\"'")
-        )
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256};
 
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, ErrorCode, Result};
-use homeboy_core::server::{self, Server, SshClient};
+use homeboy_core::server::{self, Server, SshClient, TRANSIENT_SSH_STDERR_PATTERNS};
 
 use super::super::Runner;
 
@@ -182,23 +182,6 @@ pub(crate) fn run_shell_command(command: &str, action: &str) -> Result<()> {
         output.status.code().unwrap_or(-1),
     )))
 }
-
-/// SSH connection failures worth retrying, matched against the piped command's
-/// stderr. Kept in sync with `homeboy_core::server::is_transient_ssh_error`,
-/// which operates on the runner `CommandOutput` type rather than the local
-/// `sh` process output available here.
-const TRANSIENT_SSH_STDERR_PATTERNS: [&str; 10] = [
-    "connection refused",
-    "connection reset",
-    "connection timed out",
-    "no route to host",
-    "network is unreachable",
-    "temporary failure in name resolution",
-    "could not resolve hostname",
-    "broken pipe",
-    "ssh_exchange_identification",
-    "connection closed by remote host",
-];
 
 /// Return a retryable [`ErrorCode::RunnerLabTransportFailure`] when a piped
 /// materialization command failed because its SSH transport dropped, or `None`

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -7,6 +7,7 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::plan::PlanStep;
+use homeboy_engine_primitives::shell::quote_path;
 
 use super::advanced_remote;
 use super::context::load_component;
@@ -22,7 +23,7 @@ pub const RECOVERY_INCOMPLETE_EXIT_CODE: i32 = 4;
 fn publication_continuation_command(input: &ReleaseCommandInput) -> String {
     let mut command = format!("homeboy release {} --head", input.component_id);
     if let Some(path) = &input.path_override {
-        command.push_str(&format!(" --path {}", shell_quote(path)));
+        command.push_str(&format!(" --path {}", quote_path(path)));
     }
     if input.skip_checks {
         command.push_str(" --skip-checks");
@@ -42,14 +43,10 @@ fn publication_continuation_command(input: &ReleaseCommandInput) -> String {
         command.push_str(" --deploy");
     }
     if let Some(identity) = &input.git_identity {
-        command.push_str(&format!(" --git-identity {}", shell_quote(identity)));
+        command.push_str(&format!(" --git-identity {}", quote_path(identity)));
     }
     command.push_str(" --apply");
     command
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 pub(super) fn run_recover(

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -25,6 +25,7 @@ use super::spec::{RigResourcesSpec, RigSpec};
 use super::state::now_rfc3339;
 use homeboy_core::error::{Error, Result, RigResourceConflictInfo};
 use homeboy_core::paths;
+use homeboy_engine_primitives::shell::quote_arg;
 use lock::LeaseIndexLock;
 
 /// On-disk lease held by one active mutating rig command.
@@ -448,26 +449,15 @@ fn run_lease_diagnostic(lease: RigRunLease) -> RigRunLeaseDiagnostic {
         reclaimable_without_force,
         inspect_command: run_id.map(|run_id| format!("homeboy runs show {run_id}")),
         safe_cleanup_command: reclaimable_without_force.then(|| {
-            format!("homeboy rig release-lock {}", shell_quote(&lease.rig_id))
+            format!("homeboy rig release-lock {}", quote_arg(&lease.rig_id))
         }),
         reconcile_command: "homeboy runs resources --actionable".to_string(),
         force_release_warning: format!(
             "Do not use `homeboy rig release-lock {} --force` while pid {} is still running unless you have independently confirmed the holder is wedged and will never finish; force-release only removes the local guardrail and does not stop the holder process.",
-            shell_quote(&lease.rig_id),
+            quote_arg(&lease.rig_id),
             lease.pid
         ),
         resources: lease.resources,
-    }
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':'))
-    {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -26,7 +26,7 @@ use super::state::now_rfc3339;
 use homeboy_core::error::{Error, Result, RigResourceConflictInfo};
 use homeboy_core::paths;
 use homeboy_engine_primitives::shell::quote_arg;
-use lock::LeaseIndexLock;
+use lock::acquire as acquire_lease_index_lock;
 
 /// On-disk lease held by one active mutating rig command.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,7 +77,7 @@ pub struct ActiveRigRunLease {
 
 impl Drop for ActiveRigRunLease {
     fn drop(&mut self) {
-        let Ok(_lock) = LeaseIndexLock::acquire() else {
+        let Ok(_lock) = acquire_lease_index_lock() else {
             return;
         };
         let Ok(path) = lease_path(&self.rig_id) else {
@@ -109,7 +109,7 @@ pub fn acquire_active_run_lease_with_settings(
         return Ok(None);
     }
 
-    let _lock = LeaseIndexLock::acquire()?;
+    let _lock = acquire_lease_index_lock()?;
     fs::create_dir_all(paths::rig_leases_dir()?).map_err(|e| {
         Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
     })?;
@@ -371,7 +371,7 @@ pub enum ReleaseLeaseOutcome {
 /// local guardrail so a new run can proceed. With `force`, the caller is
 /// asserting the holder is dead or wedged.
 pub fn release_active_run_lease(rig_id: &str, force: bool) -> Result<ReleaseLeaseOutcome> {
-    let _lock = LeaseIndexLock::acquire()?;
+    let _lock = acquire_lease_index_lock()?;
     let path = lease_path(rig_id)?;
     let Some(lease) = read_lease(&path)? else {
         return Ok(ReleaseLeaseOutcome::NoLease {

--- a/crates/homeboy-rig/src/lease/lock.rs
+++ b/crates/homeboy-rig/src/lease/lock.rs
@@ -1,74 +1,19 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::thread;
-use std::time::{Duration, SystemTime};
+//! Advisory lock guarding read-modify-write of the rig lease index.
+//!
+//! The mkdir-lock mechanics live in
+//! [`homeboy_engine_primitives::fs_index_lock`]; this module only supplies the
+//! directory and the error-message subject.
 
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::Result;
 use homeboy_core::paths;
+use homeboy_engine_primitives::fs_index_lock::{FsIndexLock, FsIndexLockConfig};
 
-const INDEX_LOCK_NAME: &str = ".index.lock";
-const INDEX_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
-const INDEX_LOCK_ATTEMPTS: usize = 100;
-const INDEX_LOCK_SLEEP: Duration = Duration::from_millis(20);
+const CONFIG: FsIndexLockConfig = FsIndexLockConfig::index("rig lease");
 
-pub(super) struct LeaseIndexLock {
-    path: PathBuf,
-}
+pub(super) type LeaseIndexLock = FsIndexLock;
 
-impl LeaseIndexLock {
-    pub(super) fn acquire() -> Result<Self> {
-        let dir = paths::rig_leases_dir()?;
-        fs::create_dir_all(&dir).map_err(|e| {
-            Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
-        })?;
-        let path = dir.join(INDEX_LOCK_NAME);
-        for _ in 0..INDEX_LOCK_ATTEMPTS {
-            match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path }),
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    remove_stale_index_lock(&path)?;
-                    thread::sleep(INDEX_LOCK_SLEEP);
-                }
-                Err(e) => {
-                    return Err(Error::internal_unexpected(format!(
-                        "Failed to acquire rig lease lock {}: {}",
-                        path.display(),
-                        e
-                    )))
-                }
-            }
-        }
-        Err(Error::internal_unexpected(format!(
-            "Timed out acquiring rig lease lock {}",
-            path.display()
-        )))
-    }
-}
-
-impl Drop for LeaseIndexLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.path);
-    }
-}
-
-fn remove_stale_index_lock(path: &Path) -> Result<()> {
-    let Ok(metadata) = fs::metadata(path) else {
-        return Ok(());
-    };
-    let Ok(modified) = metadata.modified() else {
-        return Ok(());
-    };
-    if SystemTime::now()
-        .duration_since(modified)
-        .is_ok_and(|age| age > INDEX_LOCK_STALE_AFTER)
-    {
-        fs::remove_dir(path).map_err(|e| {
-            Error::internal_unexpected(format!(
-                "Failed to remove stale rig lease lock {}: {}",
-                path.display(),
-                e
-            ))
-        })?;
-    }
-    Ok(())
+/// Block until the rig lease index lock is held. Released when the returned
+/// guard drops.
+pub(super) fn acquire() -> Result<LeaseIndexLock> {
+    FsIndexLock::acquire_in(&paths::rig_leases_dir()?, CONFIG)
 }

--- a/crates/homeboy-triage/src/watch.rs
+++ b/crates/homeboy-triage/src/watch.rs
@@ -1,3 +1,32 @@
+//! `triage --watch`: poll a set of GitHub PRs/issues until they all reach a
+//! target state.
+//!
+//! # Why this does not use the shared `watch_loop`
+//!
+//! `homeboy-cli`'s `commands::utils::watch` owns the one bounded poll loop that
+//! `runs watch` and `activity watch` share. This loop is deliberately not a
+//! third consumer of it, for two reasons -- and both have to be fixed together,
+//! so do not attempt one without the other:
+//!
+//! 1. **Direction of the dependency.** `WatchPoller`/`watch_loop` are declared
+//!    in `homeboy-cli`, which depends on `homeboy-triage`. Implementing the
+//!    trait here would invert that. Unifying requires first relocating the loop
+//!    into a crate both can see (`homeboy-core`), which is a much larger change
+//!    than it looks: five CLI call sites import it today.
+//! 2. **The loop shapes differ in kind, not just detail.** `watch_loop` polls
+//!    *one* id and asks a stateless `is_terminal(&item)`. This polls *N* refs
+//!    and returns only when all of them have arrived, and its terminal
+//!    predicate is stateful: `state-changed` and `commit-pushed` are defined
+//!    relative to the previous poll's state (see [`watch_until_reached`]).
+//!    It also performs a side effect mid-loop (auto-merge). Generalizing
+//!    `watch_loop` to cover that means multi-id polling *and* a `&mut self`
+//!    poller, which is a redesign of the shared trait rather than an extension.
+//!
+//! What *has* been unified is the part that was drifting in a way users could
+//! see: the timeout exit code. `homeboy triage --watch` now exits
+//! `TIMEOUT_EXIT_CODE` (124) like every other watch surface, rather than the
+//! bare `1` it used to use. See `commands/triage.rs`.
+
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -517,16 +517,21 @@ fn source_swap_failure_diagnostics_for_paths(
         };
         format!(
             "{prefix} -m 0755 {} {}",
-            shell_quote_path(built),
-            shell_quote_path(active)
+            quote_path(&built.display().to_string()),
+            quote_path(&active.display().to_string())
         )
     });
 
     let built_binary_command = built_binary.map(|built| {
         let mut command = format!(
             "{} upgrade --method source --source-path {} --force",
-            shell_quote_path(built),
-            shell_quote_path(source_workspace.unwrap_or_else(|| Path::new(".")))
+            quote_path(&built.display().to_string()),
+            quote_path(
+                &source_workspace
+                    .unwrap_or_else(|| Path::new("."))
+                    .display()
+                    .to_string()
+            )
         );
         command.push_str(" --skip-runners --skip-extensions");
         command
@@ -676,10 +681,6 @@ fn make_source_install_executable(path: &Path) -> Result<()> {
 
 fn display_path(path: &Path) -> String {
     path.display().to_string()
-}
-
-fn shell_quote_path(path: &Path) -> String {
-    quote_path(&path.display().to_string())
 }
 
 /// Read back the active binary version after a successful swap, retrying while

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -100,7 +100,10 @@ fn source_upgrade_command_returns_after_same_binary_success() {
 fn source_upgrade_timeout_terminates_the_entire_child_process_group() {
     let workspace = tempfile::tempdir().expect("workspace");
     let pid_file = workspace.path().join("child.pid");
-    let command = format!("sleep 30 & echo $! > {}; wait", shell_quote_path(&pid_file));
+    let command = format!(
+        "sleep 30 & echo $! > {}; wait",
+        quote_path(&pid_file.display().to_string())
+    );
 
     let err = run_source_upgrade_command(&command, workspace.path(), Duration::from_millis(50))
         .expect_err("long-running source command times out");

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
@@ -737,7 +737,7 @@ fn explicit_source_upgrade_runs_build_phase_without_upstream_on_local_branch_or_
         let build_marker = checkout.path().join("build-phase");
         let upgrade_command = format!(
             "set -e\ngit fetch origin\ngit reset --hard origin/main\nsh -c 'git pull --ff-only'\nprintf built > {}",
-            shell_quote_path(&build_marker)
+            quote_path(&build_marker.display().to_string())
         );
         let command =
             source_upgrade_command_for_prepared_workspace(&upgrade_command, checkout.path(), true)
@@ -773,7 +773,7 @@ fn explicit_source_upgrade_skips_git_switch_main_and_reaches_build_phase() {
     // `set -e` would abort before the build). `git checkout -b` is also skipped.
     let upgrade_command = format!(
         "set -e\ngit switch main\ngit checkout main\nprintf built > {}",
-        shell_quote_path(&build_marker)
+        quote_path(&build_marker.display().to_string())
     );
     let command =
         source_upgrade_command_for_prepared_workspace(&upgrade_command, checkout.path(), true)

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2660,11 +2660,6 @@ fn assert_pid_exits(pid: libc::pid_t) {
 }
 
 #[cfg(unix)]
-fn shell_quote_path(path: &std::path::Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\"'\"'"))
-}
-
-#[cfg(unix)]
 #[test]
 fn daemon_cancellation_reaps_cooperative_child_process_group() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -2674,7 +2669,7 @@ fn daemon_cancellation_reaps_cooperative_child_process_group() {
         "-c",
         &format!(
             "sleep 30 & echo $! > {}; wait",
-            shell_quote_path(&descendant)
+            homeboy_engine_primitives::shell::quote_path(&descendant.display().to_string())
         ),
     ]);
     crate::engine::command::isolate_process_tree(&mut command);
@@ -2699,7 +2694,7 @@ fn daemon_cancellation_escalates_and_reaps_term_resistant_parent_and_descendant(
         "-c",
         &format!(
             "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
-            shell_quote_path(&descendant)
+            homeboy_engine_primitives::shell::quote_path(&descendant.display().to_string())
         ),
     ]);
     crate::engine::command::isolate_process_tree(&mut command);


### PR DESCRIPTION
Found during the 2026-08-01 consolidation investigation (#11151).

Five independent duplications, one commit each. Net **412 lines deleted / 721 added** across 28 files — the addition is almost entirely tests and the docs explaining what was left behind and why.

---

## :warning: Two user-visible changes

### 1. Duration flags now accept every unit (widening + one narrowing)

Four hand-rolled `parse_duration` implementations had **three different unit tables**:

| parser | units | note |
|---|---|---|
| `commands/runs/common.rs` | `s\|m\|h\|d` | header admitted *"Mirrors the parser in `bundle.rs`"* |
| `commands/activity.rs` | `s\|m\|h\|d` | byte-for-byte the same match table, differing only in an error field name and a missing zero-check |
| `commands/triage.rs` | `s\|m\|h` | no days |
| `commands/observe.rs` | `ms\|s\|m\|h` | no days, no long spellings |

So `homeboy triage --timeout 7d` errored while `runs watch --timeout 7d` worked, and `activity --duration 500ms` errored while `observe --duration 500ms` was fine.

**All four now share one table (`ms|s|m|h|d` + long spellings).** This is a strict widening — no previously-accepted input is now rejected — **except**:

- **The zero-check is now applied everywhere.** `activity` was the only parser missing it, so `activity --interval 0s` used to busy-spin with no delay. It is now rejected, as it already was on the other three. One existing `activity` test used `0s` for an instant timeout and now uses `1ms`.
- **Overflow is reported rather than panicking.** The old parsers multiplied unchecked, so `--timeout 99999999999999999999d` panicked in debug builds.

### 2. `homeboy triage --watch` now exits `124` on timeout, not `1`

`runs watch` and `activity watch` both exit `TIMEOUT_EXIT_CODE = 124` (the GNU `timeout(1)` convention). `triage --watch` had invented its own `0`/`1`. The constant exists precisely so watch surfaces cannot drift, and this one had.

The mapping is exact: triage's loop breaks on all-reached or on the deadline and nothing else, so "not reached" is always "timed out". **Any wrapper branching on `1` must now branch on `124`.**

---

## What was consolidated

### Part 5 — SSH transient-error list (~15 LOC removed)
`homeboy-lab-runner/src/workspace/util.rs` carried a second copy of the same 10-entry pattern list as `homeboy_core::server::is_transient_ssh_error`, under a comment saying it was *"kept in sync"* with nothing enforcing that. Promoted to `pub const TRANSIENT_SSH_STDERR_PATTERNS` in `core/server/client/host.rs`; both now read the same const, so drift is structurally impossible.

### Part 1 — shell quoting, 10 copies (~96 LOC removed)
`homeboy-engine-primitives::shell` already owned `quote_arg`/`quote_path`. Deleted and repointed:

| copy | shape |
|---|---|
| `homeboy-core/src/cleanup/cargo_targets.rs` | byte-identical to `quote_path` |
| `homeboy-extension/src/execution.rs` | byte-identical to `quote_path` |
| `homeboy-upgrade/src/upgrade/execution.rs` | pure wrapper over `quote_path` |
| `homeboy-core/src/component/inventory/path_diagnostics.rs` | pure wrapper over `quote_path` |
| `homeboy-release/src/release/workflow_recover.rs` | same output via the `'"'"'` escape instead of `'\''` — shell-equivalent |
| `homeboy-rig/src/lease.rs` | allowlist variant |
| `homeboy-core/src/server/health.rs` | allowlist variant |
| +3 test-local copies | engine-primitives, lab-runner, `tests/core/daemon_test.rs` |

**The two "divergent allowlist" variants are NOT validators.** Both have an `else` branch that single-quotes — they are quoters that trigger on an allowlist (`-_./:` and `-._@`) where `quote_arg` triggers on a metacharacter blocklist. Every character in either allowlist is absent from `SHELL_META`, so `quote_arg` leaves the same safe inputs unquoted and quotes everything the old helpers quoted. The `health.rs` systemd unit-name case is pinned by its pre-existing tests (retitled to name the primitive): `nginx`, `php8.4-fpm`, `user@.service` still pass through unquoted; `foo; rm -rf /` is still quoted.

### Part 4 — two byte-identical filesystem locks (~142 LOC removed)
`homeboy-core/src/engine/invocation.rs` and `homeboy-rig/src/lease/lock.rs` declared the same four constants (`.index.lock`, 30s stale, 100 attempts, 20ms sleep), the same `fs::create_dir` mkdir-lock loop, the same mtime stale-reclaim, and the same `Drop`. Promoted to `homeboy_engine_primitives::fs_index_lock::FsIndexLock` with an `FsIndexLockConfig { name, stale_after, attempts, sleep, subject }`. `subject` carries the error-message noun, so **every existing message is byte-identical**.

---

## What was deliberately left, and why

**`homeboy-error`'s `posix_quote_arg` stays.** It is genuinely below `engine-primitives` in the dependency graph and cannot import the primitive. Its *"kept byte-for-byte compatible"* comment was previously unenforced — it is now `pub`, and engine-primitives asserts parity two ways: a 36-case table covering every `SHELL_META` character, and **a sweep of the entire ASCII range**, so a metacharacter added to one table and not the other fails even if nobody updates the table.

**The third lock variant in `engine/temp/implementation.rs` is not a duplicate.** It writes an `owner.json` descriptor, gates reclaim on pid + Linux process start-time liveness rather than mtime alone, quarantine-renames instead of deleting, and uses a 300s window because it is held for minutes. Collapsing it would either lose the liveness check or force an owner-descriptor mode into the primitive. The primitive's module docs say so explicitly.

**`homeboy-agents`'s `is_transient_provider_error` is not a duplicate**, despite a comment referencing `is_transient_ssh_error`. Its 15-entry list covers HTTP/provider failures (`bad gateway`, `curl error 28`, `service unavailable`).

**Part 3's loop unification was dropped; only the exit code landed.** The brief was to implement `WatchPoller` in `homeboy-triage` and drive it with `watch_loop`. That is not possible as scoped, for two reasons that must be fixed together:

1. **The dependency runs the wrong way.** `WatchPoller`/`watch_loop` are declared in `homeboy-cli`, which *depends on* `homeboy-triage`. Implementing the trait there inverts it. Unifying requires first relocating the loop into `homeboy-core` — five CLI call sites import it today.
2. **The loops differ in kind, not detail.** `watch_loop` polls **one** id with a stateless `is_terminal(&item)`. Triage polls **N** refs, returns only when all have arrived, has a terminal predicate defined relative to the *previous* poll (`state-changed`, `commit-pushed`), and performs a side effect (auto-merge) mid-loop. Covering that needs multi-id polling **and** a `&mut self` poller — a redesign of the shared trait, not the "small generalization" it looks like from outside.

`homeboy-triage/src/watch.rs` now documents both so the next person does not rediscover the dead end. The exit code was the half users could actually observe, so that is what shipped.

---

## Verification

`cargo fmt --all -- --check` clean. `cargo check --lib` exits 0 on all 10 touched crates: `homeboy-error`, `homeboy-engine-primitives`, `homeboy-core`, `homeboy-extension`, `homeboy-upgrade`, `homeboy-release`, `homeboy-rig`, `homeboy-lab-runner`, `homeboy-triage`, `homeboy-cli`.

New tests: shell-quoting parity (2), `FsIndexLock` lifecycle/contention/stale-reclaim (6), duration table (7). `cargo test -p homeboy-engine-primitives --lib shell:: fs_index_lock::` and `-p homeboy-triage --lib watch` all pass locally.

Two tests fail on this branch and **both are pre-existing red on the base commit `d69b32ce8`**, not caused by these changes:

- `measurement::measurement_registry_test::every_gate_layer_decision_...` — fails on `.github/validate-required-gates.sh`, last modified by `79e7a76da` (an ancestor of the base). This PR touches zero files under `.github/`.
- `homeboy-triage tests::targets::rig_target_threads_rig_component_triage_remote_override` — this PR's entire `homeboy-triage` diff is comments; zero files under `crates/homeboy-triage/src/tests/` were changed.

Per the repo's VPS build constraint, no full `cargo build`/`cargo test --workspace` was run locally — CI is the gate.

Closes #11142
