### PR TITLE
fix(cli): consolidate the changed-scope, mutation, and presentation vocabularies

### DIFF
--- a/crates/homeboy-cli/src/commands/api/mod.rs
+++ b/crates/homeboy-cli/src/commands/api/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use homeboy::core::server::api;
 
+use super::utils::args::MutationArgs;
 use super::CmdResult;
 
 pub mod auth;
@@ -31,9 +32,10 @@ pub(crate) enum ApiCommand {
         project_id: String,
         /// API endpoint
         endpoint: String,
-        /// Confirm the mutating request should be sent.
-        #[arg(long)]
-        apply: bool,
+        // Confirm the mutating request should be sent. Shared plan-default
+        // mutation group (#11139) — `--apply` sends, bare plans.
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -47,9 +49,10 @@ pub(crate) enum ApiCommand {
         project_id: String,
         /// API endpoint
         endpoint: String,
-        /// Confirm the mutating request should be sent.
-        #[arg(long)]
-        apply: bool,
+        // Confirm the mutating request should be sent. Shared plan-default
+        // mutation group (#11139) — `--apply` sends, bare plans.
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -63,9 +66,10 @@ pub(crate) enum ApiCommand {
         project_id: String,
         /// API endpoint
         endpoint: String,
-        /// Confirm the mutating request should be sent.
-        #[arg(long)]
-        apply: bool,
+        // Confirm the mutating request should be sent. Shared plan-default
+        // mutation group (#11139) — `--apply` sends, bare plans.
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -79,9 +83,10 @@ pub(crate) enum ApiCommand {
         project_id: String,
         /// API endpoint
         endpoint: String,
-        /// Confirm the mutating request should be sent.
-        #[arg(long)]
-        apply: bool,
+        // Confirm the mutating request should be sent. Shared plan-default
+        // mutation group (#11139) — `--apply` sends, bare plans.
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
 }
 
@@ -116,11 +121,11 @@ fn run_project(args: ApiArgs) -> CmdResult<api::ApiOutput> {
 }
 
 pub(crate) fn require_apply_for_mutation(args: &ApiArgs) -> homeboy::core::Result<()> {
-    let Some((command, endpoint, apply)) = mutating_command(&args.command) else {
+    let Some((command, endpoint, mutation)) = mutating_command(&args.command) else {
         return Ok(());
     };
 
-    if *apply {
+    if mutation.is_apply() {
         return Ok(());
     }
 
@@ -138,21 +143,21 @@ pub(crate) fn require_apply_for_mutation(args: &ApiArgs) -> homeboy::core::Resul
     ))
 }
 
-fn mutating_command(command: &ApiCommand) -> Option<(&'static str, &str, &bool)> {
+fn mutating_command(command: &ApiCommand) -> Option<(&'static str, &str, &MutationArgs)> {
     match command {
         ApiCommand::Auth(_) | ApiCommand::Http(_) | ApiCommand::Get { .. } => None,
         ApiCommand::Post {
-            endpoint, apply, ..
-        } => Some(("post", endpoint, apply)),
+            endpoint, mutation, ..
+        } => Some(("post", endpoint, mutation)),
         ApiCommand::Put {
-            endpoint, apply, ..
-        } => Some(("put", endpoint, apply)),
+            endpoint, mutation, ..
+        } => Some(("put", endpoint, mutation)),
         ApiCommand::Patch {
-            endpoint, apply, ..
-        } => Some(("patch", endpoint, apply)),
+            endpoint, mutation, ..
+        } => Some(("patch", endpoint, mutation)),
         ApiCommand::Delete {
-            endpoint, apply, ..
-        } => Some(("delete", endpoint, apply)),
+            endpoint, mutation, ..
+        } => Some(("delete", endpoint, mutation)),
     }
 }
 
@@ -176,7 +181,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ApiCommand::Post {
             project_id,
             endpoint,
-            apply: _,
+            mutation: _,
             body,
             form,
         } => (
@@ -189,7 +194,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ApiCommand::Put {
             project_id,
             endpoint,
-            apply: _,
+            mutation: _,
             body,
             form,
         } => (
@@ -202,7 +207,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ApiCommand::Patch {
             project_id,
             endpoint,
-            apply: _,
+            mutation: _,
             body,
             form,
         } => (
@@ -215,7 +220,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ApiCommand::Delete {
             project_id,
             endpoint,
-            apply: _,
+            mutation: _,
         } => (project_id, "DELETE", endpoint.clone(), None, "json"),
         ApiCommand::Auth(_) | ApiCommand::Http(_) => {
             unreachable!("nested API commands are routed before project API input construction")

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -12,7 +12,7 @@ use homeboy::core::observation::{
 
 use super::source_command::resolve_source_context;
 use super::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
+    BaselineArgs, ChangedSinceArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::CmdResult;
@@ -49,12 +49,17 @@ pub struct AuditArgs {
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
 
-    /// Only audit files changed since a git ref (branch, tag, or SHA).
-    #[arg(long)]
-    pub changed_since: Option<String>,
-
-    #[arg(skip)]
-    pub precomputed_changed_files: Option<Vec<String>>,
+    // Only audit files changed since a git ref. Shared changed-scope group
+    // (#11140) — the same declaration `lint`, `test`, `build`, `review`, and
+    // `refactor` flatten.
+    //
+    // NOTE (divergence, unchanged): `lab_contract()` below makes
+    // `audit --changed-since` local-only, while `lint --changed-since` stays
+    // a Lab-portable release gate. Both now read the identical field, so the
+    // asymmetry is a visible policy choice rather than a side effect of two
+    // independent flag declarations.
+    #[command(flatten)]
+    pub changed: ChangedSinceArgs,
 
     // The `--summary` alias keeps one compact-output convention working across
     // the `review` umbrella and every phase subcommand. `review/mod.rs` already
@@ -72,7 +77,7 @@ pub struct AuditArgs {
 
 impl AuditArgs {
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
-        if self.changed_since.is_some() {
+        if self.changed.changed_since.is_some() {
             return Some(LabCommandContract::local_only(
                 AUDIT_LAB_LABEL,
                 AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON,
@@ -152,8 +157,8 @@ pub fn run(args: AuditArgs) -> CmdResult<AuditCommandOutput> {
             ignore_baseline: args.baseline_args.ignore_baseline,
             ratchet: args.baseline_args.ratchet,
         },
-        changed_since: args.changed_since,
-        precomputed_changed_files: args.precomputed_changed_files,
+        changed_since: args.changed.changed_since,
+        precomputed_changed_files: args.changed.precomputed_changed_files,
         json_summary: args.json_summary,
         include_fixability: args.fixability,
     });
@@ -300,7 +305,7 @@ fn audit_observation_command(component_id: &str, args: &AuditArgs) -> String {
     for extension in &args.extension_override.extensions {
         parts.push(format!("--extension={extension}"));
     }
-    if let Some(changed_since) = &args.changed_since {
+    if let Some(changed_since) = args.changed.changed_since() {
         parts.push(format!("--changed-since={changed_since}"));
     }
     if args.json_summary {
@@ -325,7 +330,7 @@ fn audit_observation_initial_metadata(source_path: &str, args: &AuditArgs) -> se
             "ignore_baseline": args.baseline_args.ignore_baseline,
             "ratchet": args.baseline_args.ratchet,
         },
-        "changed_since": args.changed_since,
+        "changed_since": args.changed.changed_since,
         "json_summary": args.json_summary,
         "fixability": args.fixability,
     })
@@ -554,8 +559,10 @@ mod tests {
                 ignore_baseline: false,
                 ratchet: false,
             },
-            changed_since: Some("origin/main".to_string()),
-            precomputed_changed_files: None,
+            changed: ChangedSinceArgs {
+                changed_since: Some("origin/main".to_string()),
+                precomputed_changed_files: None,
+            },
             json_summary: true,
             fixability: false,
         }
@@ -713,7 +720,7 @@ mod tests {
         .expect("audit should parse --extension override");
 
         assert_eq!(cli.audit.extension_override.extensions, vec!["rust"]);
-        assert_eq!(cli.audit.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(cli.audit.changed.changed_since(), Some("origin/main"));
         assert_eq!(cli.audit.profile, "pr");
     }
 
@@ -973,8 +980,7 @@ mod tests {
                     ignore_baseline: true,
                     ratchet: false,
                 },
-                changed_since: None,
-                precomputed_changed_files: None,
+                changed: ChangedSinceArgs::default(),
                 json_summary: false,
                 fixability: false,
             };

--- a/crates/homeboy-cli/src/commands/build.rs
+++ b/crates/homeboy-cli/src/commands/build.rs
@@ -6,7 +6,7 @@ use homeboy::core::scope::{self, Scope};
 use homeboy_extension::build;
 use homeboy_extension::ExtensionCapability;
 
-use crate::commands::utils::args::ScopeArgs;
+use crate::commands::utils::args::{ChangedSinceArgs, ScopeArgs};
 use crate::commands::utils::resolve::resolve_project_components;
 use crate::commands::CmdResult;
 
@@ -34,9 +34,12 @@ pub struct BuildArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
 
-    /// Ask the build provider to resolve the build scope from files changed since this git ref
-    #[arg(long)]
-    pub changed_since: Option<String>,
+    // Ask the build provider to resolve the build scope from files changed
+    // since a git ref. Declared once in the shared changed-scope group so
+    // `build --changed-since` cannot drift from the other five commands
+    // that speak the same contract (#11140).
+    #[command(flatten)]
+    pub changed: ChangedSinceArgs,
 }
 
 pub fn run(args: BuildArgs) -> CmdResult<build::BuildResult> {
@@ -46,7 +49,7 @@ pub fn run(args: BuildArgs) -> CmdResult<build::BuildResult> {
     // component records through the same changed-since runner with the same
     // `--changed-since` argument, so funnel them through one helper.
     let run_components = |components: &[component::Component]| {
-        build::run_components_with_changed_since(components, args.changed_since.as_deref())
+        build::run_components_with_changed_since(components, args.changed.changed_since())
     };
 
     // JSON takes precedence
@@ -77,7 +80,7 @@ pub fn run(args: BuildArgs) -> CmdResult<build::BuildResult> {
         ))?;
         return build::run_component_with_changed_since(
             &ctx.component,
-            args.changed_since.as_deref(),
+            args.changed.changed_since(),
         );
     }
 
@@ -175,9 +178,9 @@ pub fn run(args: BuildArgs) -> CmdResult<build::BuildResult> {
 
     // Single target_id: treat as component ID
     if let Some(ref path) = args.scope.path {
-        build::run_with_path_changed_since(target_id, path, args.changed_since.as_deref())
+        build::run_with_path_changed_since(target_id, path, args.changed.changed_since())
     } else {
-        build::run_changed_since(target_id, args.changed_since.as_deref())
+        build::run_changed_since(target_id, args.changed.changed_since())
     }
 }
 
@@ -230,7 +233,7 @@ mod tests {
         assert_eq!(json.json.as_deref(), Some(r#"{"componentIds":["a"]}"#));
 
         let changed = parse(&["build", "my-comp", "--changed-since", "origin/main"]);
-        assert_eq!(changed.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(changed.changed.changed_since(), Some("origin/main"));
 
         let cwd = parse(&["build"]);
         assert!(cwd.target_id.is_none());

--- a/crates/homeboy-cli/src/commands/component.rs
+++ b/crates/homeboy-cli/src/commands/component.rs
@@ -7,6 +7,7 @@ use homeboy::core::component::{self, Component};
 use homeboy::core::project::{self, Project};
 use homeboy::core::EntityCrudOutput;
 
+use super::utils::args::MutationArgs;
 use super::{CmdResult, DynamicSetArgs};
 
 mod env;
@@ -170,9 +171,10 @@ enum ComponentCommand {
     Reconcile {
         /// Component ID
         id: String,
-        /// Apply a safe discovered repair instead of reporting only
-        #[arg(long)]
-        apply: bool,
+        // Apply a safe discovered repair instead of reporting only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
     /// Report or remove declared reconstructable artifacts for a component
     Artifacts {
@@ -181,9 +183,10 @@ enum ComponentCommand {
         /// Discover component from a directory's homeboy.json instead of the registry
         #[arg(long)]
         path: Option<String>,
-        /// Remove reported artifact paths instead of dry-run reporting only
-        #[arg(long)]
-        apply: bool,
+        // Remove reported artifact paths instead of dry-run reporting only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
 }
 
@@ -357,9 +360,9 @@ pub fn run(args: ComponentArgs) -> CmdResult<ComponentOutput> {
             source.as_deref(),
             skip_dependencies,
         ),
-        ComponentCommand::Reconcile { id, apply } => reconcile(&id, apply),
-        ComponentCommand::Artifacts { id, path, apply } => {
-            artifacts(id.as_deref(), path.as_deref(), apply)
+        ComponentCommand::Reconcile { id, mutation } => reconcile(&id, mutation.is_apply()),
+        ComponentCommand::Artifacts { id, path, mutation } => {
+            artifacts(id.as_deref(), path.as_deref(), mutation.is_apply())
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/db.rs
+++ b/crates/homeboy-cli/src/commands/db.rs
@@ -1,6 +1,8 @@
 use clap::{Args, Subcommand};
 use serde::{Serialize, Serializer};
 
+use super::utils::args::MutationArgs;
+
 use homeboy::core::db::{self, DbResult, DbTunnelResult};
 use homeboy::core::engine::text;
 use homeboy::core::observation::store::{self, ObservationDbStatus};
@@ -68,9 +70,10 @@ enum DbCommand {
     DeleteRow {
         /// Project ID
         project_id: String,
-        /// Apply the destructive mutation. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the destructive mutation. Without this flag, prints a plan
+        // only. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// Table name and row ID
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -79,9 +82,10 @@ enum DbCommand {
     DropTable {
         /// Project ID
         project_id: String,
-        /// Apply the destructive mutation. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the destructive mutation. Without this flag, prints a plan
+        // only. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// Table name
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -174,14 +178,14 @@ pub fn run(args: DbArgs) -> CmdResult<DbOutput> {
         ),
         DbCommand::DeleteRow {
             project_id,
-            apply,
+            mutation,
             args,
-        } => delete_row(&project_id, &args, apply),
+        } => delete_row(&project_id, &args, mutation.is_apply()),
         DbCommand::DropTable {
             project_id,
-            apply,
+            mutation,
             args,
-        } => drop_table(&project_id, &args, apply),
+        } => drop_table(&project_id, &args, mutation.is_apply()),
         DbCommand::Tunnel {
             project_id,
             local_port,

--- a/crates/homeboy-cli/src/commands/file/args.rs
+++ b/crates/homeboy-cli/src/commands/file/args.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 
+use crate::commands::utils::args::MutationArgs;
 use homeboy::core::server::transfer::TransferConfig;
 
 /// Inspect and modify remote project files.
@@ -41,9 +42,10 @@ pub(crate) enum FileCommand {
         project_id: String,
         /// Remote file path
         path: String,
-        /// Apply the destructive write. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the destructive write. Without this flag, prints a plan only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
     /// Create a directory
     Mkdir {
@@ -51,9 +53,10 @@ pub(crate) enum FileCommand {
         project_id: String,
         /// Remote directory path
         path: String,
-        /// Apply the directory creation. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the directory creation. Without this flag, prints a plan only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
     /// Delete a file or directory
     Delete {
@@ -64,9 +67,10 @@ pub(crate) enum FileCommand {
         /// Delete directories recursively
         #[arg(short, long)]
         recursive: bool,
-        /// Apply the destructive delete. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the destructive delete. Without this flag, prints a plan only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
     /// Rename or move a file
     Rename {
@@ -76,9 +80,10 @@ pub(crate) enum FileCommand {
         old_path: String,
         /// New path
         new_path: String,
-        /// Apply the rename/move. Without this flag, prints a plan only.
-        #[arg(long)]
-        apply: bool,
+        // Apply the rename/move. Without this flag, prints a plan only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
     },
     /// Find files by name pattern
     Find {

--- a/crates/homeboy-cli/src/commands/file/mod.rs
+++ b/crates/homeboy-cli/src/commands/file/mod.rs
@@ -50,35 +50,35 @@ pub fn run(args: FileArgs) -> CmdResult<FileCommandOutput> {
         FileCommand::Write {
             project_id,
             path,
-            apply,
+            mutation,
         } => {
-            let (out, code) = write(&project_id, &path, apply)?;
+            let (out, code) = write(&project_id, &path, mutation.is_apply())?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Mkdir {
             project_id,
             path,
-            apply,
+            mutation,
         } => {
-            let (out, code) = mkdir(&project_id, &path, apply)?;
+            let (out, code) = mkdir(&project_id, &path, mutation.is_apply())?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Delete {
             project_id,
             path,
             recursive,
-            apply,
+            mutation,
         } => {
-            let (out, code) = delete(&project_id, &path, recursive, apply)?;
+            let (out, code) = delete(&project_id, &path, recursive, mutation.is_apply())?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Rename {
             project_id,
             old_path,
             new_path,
-            apply,
+            mutation,
         } => {
-            let (out, code) = rename(&project_id, &old_path, &new_path, apply)?;
+            let (out, code) = rename(&project_id, &old_path, &new_path, mutation.is_apply())?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Find {

--- a/crates/homeboy-cli/src/commands/fleet.rs
+++ b/crates/homeboy-cli/src/commands/fleet.rs
@@ -9,6 +9,7 @@ use homeboy::core::plan::HomeboyPlan;
 use homeboy::core::project::Project;
 use homeboy::core::EntityCrudOutput;
 
+use super::utils::args::MutationArgs;
 use super::{adapter, CmdResult, DynamicSetArgs};
 use crate::command_contract::{CommandJsonFamily, CommandOutputFileMode, LabCommandContract};
 
@@ -23,12 +24,12 @@ pub struct FleetArgs {
 impl FleetArgs {
     pub fn is_hot_resource_command(&self) -> bool {
         matches!(
-            self.command,
+            &self.command,
             FleetCommand::Exec {
                 check: false,
-                apply: true,
+                mutation,
                 ..
-            }
+            } if mutation.is_apply()
         )
     }
 }
@@ -128,9 +129,10 @@ enum FleetCommand {
         #[arg(long)]
         check: bool,
 
-        /// Confirm the command should execute over SSH on every project in the fleet
-        #[arg(long)]
-        apply: bool,
+        // Confirm the command should execute over SSH on every project in
+        // the fleet. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Override the SSH user for this execution (instead of each server's configured user)
         #[arg(long)]
@@ -190,9 +192,9 @@ pub fn run(args: FleetArgs) -> CmdResult<FleetOutput> {
             id,
             command,
             check,
-            apply,
+            mutation,
             user,
-        } => exec(&id, command, check, apply, user),
+        } => exec(&id, command, check, mutation.is_apply(), user),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/git/args.rs
+++ b/crates/homeboy-cli/src/commands/git/args.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use crate::commands::utils::args::MutationArgs;
+
 #[derive(Args)]
 pub(super) struct ComponentPathArgs {
     /// Workspace path to discover the component from a portable homeboy.json
@@ -345,9 +347,10 @@ pub(super) enum PrCommand {
         #[arg(long)]
         update_branches: bool,
 
-        /// Merge green, clean PRs. Without this flag the command is read-only.
-        #[arg(long)]
-        apply: bool,
+        // Merge green, clean PRs. Without this flag the command is
+        // read-only. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Merge method: merge, squash, or rebase.
         #[arg(long, default_value = "squash")]

--- a/crates/homeboy-cli/src/commands/git/pr.rs
+++ b/crates/homeboy-cli/src/commands/git/pr.rs
@@ -160,7 +160,7 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             component_id,
             refs,
             update_branches,
-            apply,
+            mutation,
             merge_method,
             path_args,
         } => {
@@ -175,7 +175,7 @@ pub(super) fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                 PrFleetOptions {
                     refs,
                     update_branches,
-                    apply,
+                    apply: mutation.is_apply(),
                     merge_method,
                     path,
                 },

--- a/crates/homeboy-cli/src/commands/infra/runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/runtime.rs
@@ -2,6 +2,7 @@ use clap::{Args, Subcommand};
 use homeboy::core::controller_runtime::ControllerRuntimeRetentionOverrides;
 use serde::Serialize;
 
+use crate::commands::utils::args::MutationArgs;
 use crate::commands::CmdResult;
 
 #[derive(Args)]
@@ -34,9 +35,10 @@ enum RuntimeCommand {
     PromotionTakeover,
     /// Plan or apply pruning for unreferenced immutable controller runtimes.
     ControllerPrune {
-        /// Delete pins not retained by nonterminal durable runs or the active generation.
-        #[arg(long)]
-        apply: bool,
+        // Delete pins not retained by nonterminal durable runs or the active
+        // generation. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Purge every unreferenced pin, ignoring the configured controller
         /// runtime retention window. Destructive: prefer the configured window.
@@ -121,9 +123,9 @@ pub fn run(args: RuntimeArgs) -> CmdResult<RuntimeOutput> {
         } => refresh_runtime_package(&runtime_id, &source, revision.as_deref()),
         RuntimeCommand::PromotionTakeover => promotion_takeover(),
         RuntimeCommand::ControllerPrune {
-            apply,
+            mutation,
             ignore_retention,
-        } => controller_prune(apply, ignore_retention),
+        } => controller_prune(mutation.is_apply(), ignore_retention),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/issues.rs
+++ b/crates/homeboy-cli/src/commands/issues.rs
@@ -19,6 +19,7 @@ use homeboy::issues::{
 };
 
 use super::parse_key_val;
+use super::utils::args::MutationArgs;
 use super::CmdResult;
 
 #[derive(Args, Clone)]
@@ -89,9 +90,10 @@ pub(crate) enum IssuesCommand {
         #[arg(long, default_value_t = 200)]
         list_limit: usize,
 
-        /// Actually perform the reconcile actions. Default is dry-run.
-        #[arg(long)]
-        apply: bool,
+        // Actually perform the reconcile actions. Default is dry-run.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Workspace path to discover the component from a portable
         /// homeboy.json (CI runners, ad-hoc clones).
@@ -133,9 +135,10 @@ pub(crate) enum IssuesCommand {
         #[arg(long, default_value_t = 200)]
         list_limit: usize,
 
-        /// Actually perform the reconcile actions. Default is dry-run.
-        #[arg(long)]
-        apply: bool,
+        // Actually perform the reconcile actions. Default is dry-run.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Workspace path to discover the component from a portable
         /// homeboy.json (CI runners, ad-hoc clones).
@@ -262,7 +265,7 @@ pub fn run(args: IssuesArgs) -> CmdResult<IssuesCommandOutput> {
             run_url,
             no_refresh_closed,
             list_limit,
-            apply,
+            mutation,
             path,
         } => {
             let (output, exit) = run_reconcile_command(ReconcileCommandRequest {
@@ -272,7 +275,7 @@ pub fn run(args: IssuesArgs) -> CmdResult<IssuesCommandOutput> {
                 run_url,
                 no_refresh_closed,
                 list_limit,
-                apply,
+                apply: mutation.is_apply(),
                 path,
             })?;
             Ok((IssuesCommandOutput::Reconcile(output), exit))
@@ -284,7 +287,7 @@ pub fn run(args: IssuesArgs) -> CmdResult<IssuesCommandOutput> {
             run_url,
             no_refresh_closed,
             list_limit,
-            apply,
+            mutation,
             path,
         } => {
             let output = run_reconcile_run(
@@ -294,7 +297,7 @@ pub fn run(args: IssuesArgs) -> CmdResult<IssuesCommandOutput> {
                 run_url,
                 no_refresh_closed,
                 list_limit,
-                apply,
+                mutation.is_apply(),
                 path,
             )?;
             let exit = if output.totals.failures > 0 { 1 } else { 0 };

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -32,7 +32,8 @@ use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, L
 
 use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, LintSniffArgs, PositionalComponentArgs, SettingArgs,
+    BaselineArgs, ChangedScopeArgs, ExtensionOverrideArgs, LintSniffArgs, PositionalComponentArgs,
+    SettingArgs,
 };
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::CmdResult;
@@ -59,22 +60,17 @@ pub struct LintArgs {
     #[arg(long)]
     pub glob: Option<String>,
 
-    /// Lint modified files in the working tree (file-scoped, not hunk-scoped)
-    #[arg(long, conflicts_with = "changed_since")]
-    pub changed_only: bool,
-
-    /// Lint only files changed since a git ref (branch, tag, or SHA) — CI-friendly
-    #[arg(long, conflicts_with = "changed_only")]
-    pub changed_since: Option<String>,
-
-    #[arg(skip)]
-    pub precomputed_changed_files: Option<Vec<String>>,
+    // Changed-file scoping. Shared changed-scope group (#11140) — one
+    // declaration for `--changed-since`, `--changed-only`, the
+    // caller-injected changeset, and the hidden Lab handoff payload. The
+    // `--changed-since`/`--changed-only` conflict is owned by the group, so
+    // the two hand-written `conflicts_with` attributes that used to point at
+    // each other are gone.
+    #[command(flatten)]
+    pub changed: ChangedScopeArgs,
 
     #[arg(skip)]
     pub force_main_workflow: bool,
-
-    #[arg(long, hide = true, value_name = "JSON")]
-    pub lab_changed_files_json: Option<String>,
 
     /// Run using env from a single extension-declared CI lint job.
     #[arg(long, value_name = "ID", conflicts_with = "fix")]
@@ -112,8 +108,7 @@ pub struct LintArgs {
 impl LintArgs {
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         if self.is_full_workspace_run()
-            || self.changed_since.is_some()
-            || self.changed_only
+            || self.changed.is_scoped()
             || self.file.is_some()
             || self.glob.is_some()
         {
@@ -132,10 +127,7 @@ impl LintArgs {
     }
 
     pub fn is_full_workspace_run(&self) -> bool {
-        self.changed_since.is_none()
-            && !self.changed_only
-            && self.file.is_none()
-            && self.glob.is_none()
+        self.changed.is_full_scope() && self.file.is_none() && self.glob.is_none()
     }
 
     pub(crate) fn should_use_self_check_dispatch(&self) -> bool {
@@ -153,8 +145,6 @@ impl LintArgs {
             && !self.baseline_args.baseline
             && !self.baseline_args.ignore_baseline
             && !self.baseline_args.ratchet
-            && self.precomputed_changed_files.is_none()
-            && self.lab_changed_files_json.is_none()
     }
 
     /// Positional component id targeted by this run, if any (the
@@ -267,9 +257,9 @@ pub fn run(args: LintArgs) -> CmdResult<LintCommandOutput> {
             summary: args.summary,
             file: args.file.clone(),
             glob: args.glob.clone(),
-            changed_only: args.changed_only,
-            changed_since: args.changed_since.clone(),
-            precomputed_changed_files: changed_files_from_args(&args)?,
+            changed_only: args.changed.changed_only,
+            changed_since: args.changed.changed_since().map(str::to_string),
+            precomputed_changed_files: args.changed.resolve()?,
             sniff_filters: args.sniff_filters.to_lint_sniff_filters(),
             category: args.category.clone(),
             ci_env: ci_profile::ci_job_env(ci_job.as_ref()),
@@ -309,27 +299,6 @@ fn attach_lint_actionable(output: &mut LintCommandOutput, run_id: Option<String>
             "homeboy-lint",
         ));
     }
-}
-
-fn changed_files_from_args(args: &LintArgs) -> homeboy::core::Result<Option<Vec<String>>> {
-    if args.precomputed_changed_files.is_some() {
-        return Ok(args.precomputed_changed_files.clone());
-    }
-    args.lab_changed_files_json
-        .as_deref()
-        .map(parse_lab_changed_files_json)
-        .transpose()
-}
-
-fn parse_lab_changed_files_json(raw: &str) -> homeboy::core::Result<Vec<String>> {
-    serde_json::from_str(raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "lab_changed_files_json",
-            format!("invalid Lab changed-file payload: {error}"),
-            None,
-            None,
-        )
-    })
 }
 
 struct LintObservationAdapter {
@@ -464,12 +433,12 @@ fn lint_command_label(component_id: &str, args: &LintArgs) -> String {
         parts.push("--glob".to_string());
         parts.push(glob.clone());
     }
-    if args.changed_only {
+    if args.changed.changed_only {
         parts.push("--changed-only".to_string());
     }
-    if let Some(changed_since) = &args.changed_since {
+    if let Some(changed_since) = args.changed.changed_since() {
         parts.push("--changed-since".to_string());
-        parts.push(changed_since.clone());
+        parts.push(changed_since.to_string());
     }
     if args.force {
         parts.push("--force".to_string());
@@ -493,7 +462,7 @@ fn run_fix(
     component_label: String,
     settings: Vec<(String, serde_json::Value)>,
 ) -> CmdResult<LintCommandOutput> {
-    let selected_files = if args.changed_only {
+    let selected_files = if args.changed.changed_only {
         let changes = git::get_uncommitted_changes(&ctx.component.local_path)?;
         let mut files = Vec::new();
         files.extend(changes.staged);
@@ -519,7 +488,7 @@ fn run_fix(
         lint_options,
         true,
     );
-    request.changed_since = args.changed_since.clone();
+    request.changed_since = args.changed.changed_since().map(str::to_string);
     request.force = args.force;
 
     let run = collect_refactor_sources(request)?;
@@ -560,7 +529,7 @@ mod tests {
         .expect("lint should parse --extension override");
 
         assert_eq!(cli.lint.extension_override.extensions, vec!["fixture-lint"]);
-        assert_eq!(cli.lint.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(cli.lint.changed.changed_since(), Some("origin/main"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/refactor.rs
+++ b/crates/homeboy-cli/src/commands/refactor.rs
@@ -9,7 +9,8 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use super::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs, WriteModeArgs,
+    BaselineArgs, ChangedSinceArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
+    WriteModeArgs,
 };
 use crate::commands::CmdResult;
 
@@ -42,9 +43,10 @@ pub struct RefactorArgs {
     #[arg(long = "all")]
     all: bool,
 
-    /// Only include files changed since a git ref (branch, tag, or SHA)
-    #[arg(long)]
-    changed_since: Option<String>,
+    // Only include files changed since a git ref. Shared changed-scope
+    // group (#11140).
+    #[command(flatten)]
+    changed: ChangedSinceArgs,
 
     /// Restrict audit-generated fixes to these fix kinds (repeatable)
     #[arg(long = "only", value_name = "kind")]
@@ -314,7 +316,7 @@ pub fn run(args: RefactorArgs) -> CmdResult<RefactorOutput> {
             &args.extension_override.extensions,
             &args.from,
             args.all,
-            args.changed_since.as_deref(),
+            args.changed.changed_since(),
             &args.only,
             &args.exclude,
             &args.setting_args.setting,

--- a/crates/homeboy-cli/src/commands/report.rs
+++ b/crates/homeboy-cli/src/commands/report.rs
@@ -72,26 +72,50 @@ pub struct ReportOutput {
     pub report_compare: Option<ReportCompareReport>,
 }
 
+/// The markdown format value every `report` subcommand compares against.
+pub const MARKDOWN_FORMAT: &str = "markdown";
+
+impl ReportCommand {
+    /// The `--format` value this subcommand was invoked with.
+    ///
+    /// Every `report` subcommand declares its own `--format`, so the
+    /// markdown check used to be written out six times — once per variant —
+    /// in `is_markdown_mode` (#11138). Reading the value through one
+    /// accessor means a seventh subcommand only has to be added here.
+    ///
+    /// The six declarations still carry three *different* `value_parser`
+    /// sets, which this deliberately does not reconcile:
+    ///
+    /// - `failure-digest`, `performance-digest`: `["markdown"]`
+    /// - `bench-coverage`, `browser-evidence-compare`, `compare`:
+    ///   `["markdown", "json"]`
+    /// - `matrix-artifacts`: **no `value_parser` at all**, so it accepts
+    ///   any string and silently falls through to the JSON envelope for
+    ///   anything that is not exactly `markdown`.
+    ///
+    /// Narrowing `matrix-artifacts` would reject values it accepts today,
+    /// and widening the two markdown-only reports would accept values they
+    /// reject today. Both are behavior changes, so they are left for a
+    /// separate issue.
+    pub fn format(&self) -> &str {
+        match self {
+            ReportCommand::FailureDigest(args) => &args.format,
+            ReportCommand::PerformanceDigest(args) => &args.format,
+            ReportCommand::BenchCoverage(args) => &args.format,
+            ReportCommand::BrowserEvidenceCompare(args) => &args.format,
+            ReportCommand::MatrixArtifacts(args) => &args.format,
+            ReportCommand::Compare(args) => &args.format,
+        }
+    }
+
+    /// True when this invocation renders markdown directly.
+    pub fn is_markdown(&self) -> bool {
+        self.format() == MARKDOWN_FORMAT
+    }
+}
+
 pub fn is_markdown_mode(args: &ReportArgs) -> bool {
-    matches!(
-        &args.command,
-        ReportCommand::FailureDigest(failure_args) if failure_args.format == "markdown"
-    ) || matches!(
-        &args.command,
-        ReportCommand::PerformanceDigest(performance_args) if performance_args.format == "markdown"
-    ) || matches!(
-        &args.command,
-        ReportCommand::BenchCoverage(coverage_args) if coverage_args.format == "markdown"
-    ) || matches!(
-        &args.command,
-        ReportCommand::BrowserEvidenceCompare(compare_args) if compare_args.format == "markdown"
-    ) || matches!(
-        &args.command,
-        ReportCommand::MatrixArtifacts(matrix_args) if matrix_args.format == "markdown"
-    ) || matches!(
-        &args.command,
-        ReportCommand::Compare(compare_args) if compare_args.format == "markdown"
-    )
+    args.command.is_markdown()
 }
 
 pub fn run_markdown(args: ReportArgs) -> CmdResult<String> {

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -32,7 +32,10 @@ use serde_json::Value;
 use std::path::Path;
 
 use super::parse_key_val;
-use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs};
+use super::utils::args::{
+    BaselineArgs, ChangedScopeArgs, ChangedSinceArgs, ExtensionOverrideArgs, LabChangedScopeArgs,
+    PositionalComponentArgs,
+};
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::{audit, audit_baseline, build, ci, lint, test, CmdResult};
 use crate::command_contract::{LabCommandContract, REVIEW_LAB_LABEL};
@@ -57,17 +60,16 @@ pub struct ReviewArgs {
     #[command(flatten)]
     pub extension_override: ExtensionOverrideArgs,
 
-    /// Run audit + lint + test only against files changed since this git ref
-    /// (branch, tag, or SHA). CI-friendly — mirrors the per-stage flag.
-    #[arg(long, value_name = "REF", conflicts_with = "changed_only")]
-    pub changed_since: Option<String>,
-
-    /// Run only against files modified in the working tree
-    /// (staged, unstaged, untracked). Only the lint stage scopes natively;
-    /// audit and test run on the full component with a hint noting the
-    /// limitation. Use `--changed-since` for full umbrella scoping.
-    #[arg(long, conflicts_with = "changed_since")]
-    pub changed_only: bool,
+    // Changed-file scoping for the whole umbrella. Shared changed-scope
+    // group (#11140) — the identical declaration each phase subcommand
+    // flattens, so `review --changed-since` and `review lint --changed-since`
+    // can no longer drift apart.
+    //
+    // Only the lint stage scopes `--changed-only` natively; audit and test
+    // run on the full component with a hint noting the limitation. Use
+    // `--changed-since` for full umbrella scoping.
+    #[command(flatten)]
+    pub changed: ChangedScopeArgs,
 
     /// Show compact summary instead of full per-stage output
     #[arg(long)]
@@ -95,9 +97,6 @@ pub struct ReviewArgs {
 
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
-
-    #[arg(long, hide = true, value_name = "JSON")]
-    pub lab_changed_files_json: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -162,11 +161,13 @@ impl ReviewArgs {
     pub(crate) fn lab_changed_scope_component_args(&self) -> Option<&PositionalComponentArgs> {
         match self.command.as_ref() {
             Some(ReviewCommand::Lint(args))
-                if args.changed_only && args.changed_since.is_none() =>
+                if args.changed.changed_only && args.changed.changed_since().is_none() =>
             {
                 Some(&args.comp)
             }
-            None if self.changed_only && self.changed_since.is_none() => Some(&self.comp),
+            None if self.changed.changed_only && self.changed.changed_since().is_none() => {
+                Some(&self.comp)
+            }
             _ => None,
         }
     }
@@ -192,7 +193,7 @@ impl ReviewArgs {
                 )),
             };
         }
-        if self.changed_since.is_some() || self.changed_only {
+        if self.changed.changed_since().is_some() || self.changed.changed_only {
             Some(LabCommandContract::local_only(
                 REVIEW_LAB_LABEL,
                 REVIEW_SCOPED_LAB_UNSUPPORTED_REASON,
@@ -373,7 +374,7 @@ pub fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
     let quality_plan = build_quality_plan(QualityPlanOptions::review(&component_label));
 
     if let Some(0) = changed_file_count {
-        let scope_label = if let Some(ref r) = args.changed_since {
+        let scope_label = if let Some(r) = args.changed.changed_since() {
             format!("since {}", r)
         } else {
             "in working tree".to_string()
@@ -400,7 +401,7 @@ pub fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
                 )),
                 observation: observation_metadata,
                 scope: scope.clone(),
-                changed_since: args.changed_since.clone(),
+                changed_since: args.changed.changed_since().map(str::to_string),
                 changed_file_count: Some(0),
                 head_ref: review::git_ref(&source_path, "HEAD").unwrap_or_default(),
                 hints: vec![message],
@@ -549,7 +550,7 @@ pub fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
         }
     };
 
-    if args.changed_only {
+    if args.changed.changed_only {
         top_hints.push(
             "--changed-only scopes lint only; audit and test ran on the full component".to_string(),
         );
@@ -562,7 +563,7 @@ pub fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
             plan: quality_plan,
             observation: observation_metadata,
             scope,
-            changed_since: args.changed_since.clone(),
+            changed_since: args.changed.changed_since().map(str::to_string),
             changed_file_count,
             head_ref: review::git_ref(&source_path, "HEAD").unwrap_or_default(),
             hints: top_hints,
@@ -663,16 +664,18 @@ fn manual_release_owned_mutations(
         return Vec::new();
     };
     let baseline = args
-        .changed_since
-        .as_deref()
-        .or(args.changed_only.then_some("HEAD"));
+        .changed
+        .changed_since()
+        .or(args.changed.changed_only.then_some("HEAD"));
     let Some(baseline) = baseline else {
         return Vec::new();
     };
 
     let mutations = changed_files
         .iter()
-        .filter_map(|file| version_mutation_at(source_path, baseline, file, args.changed_only))
+        .filter_map(|file| {
+            version_mutation_at(source_path, baseline, file, args.changed.changed_only)
+        })
         .collect::<Vec<_>>();
     version::detect_manual_release_owned_mutations(component, &mutations, None)
 }
@@ -724,9 +727,9 @@ fn preflight_review_scope(
     args: &ReviewArgs,
     source_path: &str,
 ) -> homeboy::core::Result<ReviewExecutionContext> {
-    let scope = if args.changed_since.is_some() {
+    let scope = if args.changed.changed_since().is_some() {
         "changed-since"
-    } else if args.changed_only {
+    } else if args.changed.changed_only {
         "changed-only"
     } else {
         "full"
@@ -736,12 +739,9 @@ fn preflight_review_scope(
     // Probe once at the umbrella level so review can short-circuit before
     // extension setup, include a stable changed-file count in its artifact,
     // and pass the same resolved scope to each internal stage.
-    let precomputed_changed_files = match (&args.changed_since, args.changed_only) {
-        _ if args.lab_changed_files_json.is_some() => args
-            .lab_changed_files_json
-            .as_deref()
-            .map(parse_lab_changed_files_json)
-            .transpose()?,
+    let precomputed_changed_files = match (args.changed.changed_since(), args.changed.changed_only)
+    {
+        _ if args.changed.lab.lab_changed_files_json.is_some() => args.changed.resolve()?,
         (Some(git_ref), _) => Some(git::get_files_changed_since(source_path, git_ref)?),
         (_, true) => Some(git::get_dirty_files(source_path)?),
         _ => None,
@@ -803,9 +803,9 @@ pub fn write_artifact_to_file(
 }
 
 fn scope_flag_suffix(args: &ReviewArgs, include_changed_only: bool) -> String {
-    if let Some(ref r) = args.changed_since {
+    if let Some(r) = args.changed.changed_since() {
         format!(" --changed-since={}", r)
-    } else if args.changed_only && include_changed_only {
+    } else if args.changed.changed_only && include_changed_only {
         " --changed-only".to_string()
     } else {
         String::new()
@@ -824,10 +824,12 @@ fn build_audit_args(
         exclude: Vec::new(),
         profile: selected_audit_profile(args, review_context),
         baseline_args: args.baseline_args.clone(),
-        changed_since: args.changed_since.clone(),
-        precomputed_changed_files: review_context
-            .precomputed_changed_files()
-            .map(<[String]>::to_vec),
+        changed: ChangedSinceArgs {
+            changed_since: args.changed.changed_since().map(str::to_string),
+            precomputed_changed_files: review_context
+                .precomputed_changed_files()
+                .map(<[String]>::to_vec),
+        },
         json_summary: args.summary,
         fixability: false,
     }
@@ -835,7 +837,9 @@ fn build_audit_args(
 
 fn selected_audit_profile(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> String {
     args.audit_profile.clone().unwrap_or_else(|| {
-        if args.changed_since.is_some() || review_context.precomputed_changed_files().is_some() {
+        if args.changed.changed_since().is_some()
+            || review_context.precomputed_changed_files().is_some()
+        {
             "pr".to_string()
         } else {
             "full".to_string()
@@ -849,11 +853,18 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
         summary: args.summary,
         file: None,
         glob: None,
-        changed_only: args.changed_only,
-        changed_since: args.changed_since.clone(),
-        precomputed_changed_files: review_context
-            .precomputed_changed_files()
-            .map(<[String]>::to_vec),
+        changed: ChangedScopeArgs {
+            lab: LabChangedScopeArgs {
+                since: ChangedSinceArgs {
+                    changed_since: args.changed.changed_since().map(str::to_string),
+                    precomputed_changed_files: review_context
+                        .precomputed_changed_files()
+                        .map(<[String]>::to_vec),
+                },
+                lab_changed_files_json: None,
+            },
+            changed_only: args.changed.changed_only,
+        },
         force_main_workflow: true,
         ci_job: None,
         sniff_filters: Default::default(),
@@ -863,7 +874,6 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
         extension_override: args.extension_override.clone(),
         setting_args: Default::default(),
         baseline_args: args.baseline_args.clone(),
-        lab_changed_files_json: None,
         json_summary: args.summary,
     }
 }
@@ -880,28 +890,21 @@ fn build_test_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
         drift: false,
         write: false,
         since: "HEAD~10".to_string(),
-        changed_since: args.changed_since.clone(),
-        precomputed_changed_files: review_context
-            .precomputed_changed_files()
-            .map(<[String]>::to_vec),
+        changed: LabChangedScopeArgs {
+            since: ChangedSinceArgs {
+                changed_since: args.changed.changed_since().map(str::to_string),
+                precomputed_changed_files: review_context
+                    .precomputed_changed_files()
+                    .map(<[String]>::to_vec),
+            },
+            lab_changed_files_json: None,
+        },
         ci_job: None,
         setting_args: Default::default(),
         args: Vec::new(),
-        lab_changed_files_json: None,
         json_summary: args.summary,
         restore_checkout: true,
     }
-}
-
-fn parse_lab_changed_files_json(raw: &str) -> homeboy::core::Result<Vec<String>> {
-    serde_json::from_str(raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "lab_changed_files_json",
-            format!("invalid Lab changed-file payload: {error}"),
-            None,
-            None,
-        )
-    })
 }
 
 fn audit_finding_count(output: &AuditCommandOutput) -> usize {
@@ -994,8 +997,8 @@ mod tests {
     fn parses_changed_since() {
         let cli = TestCli::try_parse_from(["test", "my-comp", "--changed-since", "trunk"])
             .expect("should parse");
-        assert_eq!(cli.review.changed_since.as_deref(), Some("trunk"));
-        assert!(!cli.review.changed_only);
+        assert_eq!(cli.review.changed.changed_since(), Some("trunk"));
+        assert!(!cli.review.changed.changed_only);
         assert_eq!(cli.review.comp.component.as_deref(), Some("my-comp"));
     }
 
@@ -1015,14 +1018,14 @@ mod tests {
             cli.review.extension_override.extensions,
             vec!["fixture-review"]
         );
-        assert_eq!(cli.review.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(cli.review.changed.changed_since(), Some("origin/main"));
     }
 
     #[test]
     fn parses_changed_only() {
         let cli = TestCli::try_parse_from(["test", "--changed-only"]).expect("should parse");
-        assert!(cli.review.changed_only);
-        assert!(cli.review.changed_since.is_none());
+        assert!(cli.review.changed.changed_only);
+        assert!(cli.review.changed.changed_since().is_none());
     }
 
     #[test]
@@ -1191,15 +1194,22 @@ mod tests {
                 path: None,
             },
             extension_override: ExtensionOverrideArgs::default(),
-            changed_since: Some("trunk".to_string()),
-            changed_only: false,
+            changed: ChangedScopeArgs {
+                lab: LabChangedScopeArgs {
+                    since: ChangedSinceArgs {
+                        changed_since: Some("trunk".to_string()),
+                        precomputed_changed_files: None,
+                    },
+                    lab_changed_files_json: None,
+                },
+                changed_only: false,
+            },
             summary: false,
             ci_profile: None,
             audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
-            lab_changed_files_json: None,
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-since=trunk");
         assert_eq!(scope_flag_suffix(&args, false), " --changed-since=trunk");
@@ -1215,15 +1225,22 @@ mod tests {
                 path: None,
             },
             extension_override: ExtensionOverrideArgs::default(),
-            changed_since: None,
-            changed_only: true,
+            changed: ChangedScopeArgs {
+                lab: LabChangedScopeArgs {
+                    since: ChangedSinceArgs {
+                        changed_since: None,
+                        precomputed_changed_files: None,
+                    },
+                    lab_changed_files_json: None,
+                },
+                changed_only: true,
+            },
             summary: false,
             ci_profile: None,
             audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
-            lab_changed_files_json: None,
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-only");
         // audit/test do not support --changed-only, so the suffix is empty
@@ -1241,15 +1258,22 @@ mod tests {
                 path: None,
             },
             extension_override: ExtensionOverrideArgs::default(),
-            changed_since: None,
-            changed_only: false,
+            changed: ChangedScopeArgs {
+                lab: LabChangedScopeArgs {
+                    since: ChangedSinceArgs {
+                        changed_since: None,
+                        precomputed_changed_files: None,
+                    },
+                    lab_changed_files_json: None,
+                },
+                changed_only: false,
+            },
             summary: false,
             ci_profile: None,
             audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
-            lab_changed_files_json: None,
         };
         assert_eq!(scope_flag_suffix(&args, true), "");
         assert_eq!(scope_flag_suffix(&args, false), "");
@@ -1258,7 +1282,7 @@ mod tests {
     #[test]
     fn changed_since_review_uses_pr_audit_profile() {
         let mut args = review_args_fixture();
-        args.changed_since = Some("origin/main".to_string());
+        args.changed.lab.since.changed_since = Some("origin/main".to_string());
         let review_context = ReviewExecutionContext {
             scope: "changed since origin/main".to_string(),
             changed_file_count: Some(1),
@@ -1283,7 +1307,7 @@ mod tests {
     #[test]
     fn scoped_review_lint_args_do_not_use_self_check_dispatch() {
         let mut args = review_args_fixture();
-        args.changed_since = Some("origin/main".to_string());
+        args.changed.lab.since.changed_since = Some("origin/main".to_string());
         let review_context = ReviewExecutionContext {
             scope: "changed-since".to_string(),
             changed_file_count: Some(1),
@@ -1292,9 +1316,14 @@ mod tests {
 
         let lint_args = build_lint_args(&args, &review_context);
 
-        assert_eq!(lint_args.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(lint_args.changed.changed_since(), Some("origin/main"));
         assert_eq!(
-            lint_args.precomputed_changed_files.as_deref(),
+            lint_args
+                .changed
+                .lab
+                .since
+                .precomputed_changed_files
+                .as_deref(),
             Some(&["src/lib.rs".to_string()][..])
         );
         assert!(
@@ -1357,7 +1386,7 @@ mod tests {
     #[test]
     fn review_audit_profile_override_takes_precedence() {
         let mut args = review_args_fixture();
-        args.changed_since = Some("origin/main".to_string());
+        args.changed.lab.since.changed_since = Some("origin/main".to_string());
         args.audit_profile = Some("architecture".to_string());
         let review_context = ReviewExecutionContext {
             scope: "changed since origin/main".to_string(),
@@ -1402,15 +1431,22 @@ mod tests {
                 path: None,
             },
             extension_override: ExtensionOverrideArgs::default(),
-            changed_since: None,
-            changed_only: false,
+            changed: ChangedScopeArgs {
+                lab: LabChangedScopeArgs {
+                    since: ChangedSinceArgs {
+                        changed_since: None,
+                        precomputed_changed_files: None,
+                    },
+                    lab_changed_files_json: None,
+                },
+                changed_only: false,
+            },
             summary: false,
             ci_profile: None,
             audit_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
-            lab_changed_files_json: None,
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -147,10 +147,10 @@ fn review_observation_command(component_id: &str, args: &ReviewArgs) -> String {
         "review".to_string(),
         component_id.to_string(),
     ];
-    if let Some(changed_since) = args.changed_since.as_ref() {
+    if let Some(changed_since) = args.changed.changed_since() {
         parts.push(format!("--changed-since={changed_since}"));
     }
-    if args.changed_only {
+    if args.changed.changed_only {
         parts.push("--changed-only".to_string());
     }
     if args.summary {
@@ -172,8 +172,8 @@ pub(super) fn review_observation_initial_metadata(
         "schema": "homeboy/review-observation/v1",
         "component_label": component_label,
         "scope": scope,
-        "changed_since": args.changed_since,
-        "changed_only": args.changed_only,
+        "changed_since": args.changed.changed_since(),
+        "changed_only": args.changed.changed_only,
         "summary": args.summary,
         "ci_profile": args.ci_profile,
         "report": args.report,
@@ -245,7 +245,8 @@ fn stage_run_id<T: serde::Serialize>(output: &T) -> Option<String> {
 mod tests {
     use super::*;
     use crate::commands::utils::args::{
-        BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs,
+        BaselineArgs, ChangedScopeArgs, ChangedSinceArgs, ExtensionOverrideArgs,
+        LabChangedScopeArgs, PositionalComponentArgs,
     };
     use homeboy_review::review::{build_artifact, ReviewSummary};
 
@@ -258,15 +259,22 @@ mod tests {
                 path: None,
             },
             extension_override: ExtensionOverrideArgs::default(),
-            changed_since: Some("origin/main".to_string()),
-            changed_only: false,
+            changed: ChangedScopeArgs {
+                lab: LabChangedScopeArgs {
+                    since: ChangedSinceArgs {
+                        changed_since: Some("origin/main".to_string()),
+                        precomputed_changed_files: None,
+                    },
+                    lab_changed_files_json: None,
+                },
+                changed_only: false,
+            },
             summary: true,
             ci_profile: None,
             audit_profile: None,
             report: Some("pr-comment".to_string()),
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
-            lab_changed_files_json: None,
         }
     }
 

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -7,6 +7,7 @@ use super::doctor;
 use super::lifecycle;
 use super::refresh_plan;
 use super::workspace;
+use crate::commands::utils::args::MutationArgs;
 
 #[derive(Args)]
 pub struct RunnerArgs {
@@ -367,9 +368,10 @@ pub(super) enum RunnerCommand {
         /// Runner ID
         runner_id: String,
 
-        /// Delete eligible slots. Omit for inventory only.
-        #[arg(long)]
-        apply: bool,
+        // Delete eligible slots. Omit for inventory only.
+        // Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Minimum slot age before an unselected slot is eligible.
         /// Defaults to the shared runner age floor

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -216,12 +216,12 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
         })),
         RunnerCommand::CachePrune {
             runner_id,
-            apply,
+            mutation,
             min_age_hours,
         } => map_cache_prune(runner::prune_homeboy_binary_cache(
             &runner_id,
             runner::RunnerBinaryCachePruneOptions {
-                apply,
+                apply: mutation.is_apply(),
                 // One named age floor shared with `homeboy cleanup --include
                 // runner-binary-caches` (#10316).
                 min_age_hours: min_age_hours

--- a/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Subcommand, ValueEnum};
 use serde::Serialize;
 
+use crate::commands::utils::args::MutationArgs;
 use homeboy::core::cleanup;
 use homeboy::runner::runners::{
     self as runner, RunnerWorkspaceApplyOutput, RunnerWorkspaceListOutput,
@@ -124,9 +125,10 @@ pub(super) enum RunnerWorkspaceCommand {
         /// Runner ID
         runner_id: String,
 
-        /// Delete the previewed orphaned workspaces. Without this flag, the command is a dry run.
-        #[arg(long)]
-        apply: bool,
+        // Delete the previewed orphaned workspaces. Without this flag, the
+        // command is a dry run. Shared plan-default mutation group (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
 
         /// Minimum workspace age before it can be considered orphaned.
         /// Defaults to the shared runner age floor
@@ -229,7 +231,7 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
         }
         RunnerWorkspaceCommand::Prune {
             runner_id,
-            apply,
+            mutation,
             min_age_hours,
             limit,
             passes,
@@ -240,7 +242,7 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
         } => runner::prune_workspaces(
             &runner_id,
             runner::RunnerWorkspacePruneOptions {
-                apply,
+                apply: mutation.is_apply(),
                 // One named age floor shared with `homeboy cleanup --include
                 // remote-lab-workspaces`, which used to carry its own literal
                 // `24` beside this command's `default_value_t = 24` (#10316).

--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -29,6 +29,7 @@ use super::types::{
 };
 use super::CmdResult;
 use crate::commands::cleanup::RUNNER_DOWNLOADS_METADATA;
+use crate::commands::utils::args::MutationArgs;
 
 pub fn get(artifact: ArtifactRecord, output: Option<PathBuf>) -> CmdResult<RunsOutput> {
     let download = runs_service::download_remote_artifact(artifact, output)?;
@@ -426,7 +427,7 @@ pub fn cleanup_downloads(args: RunsArtifactCleanupDownloadsArgs) -> CmdResult<Ru
     // deliberately unexposed (#10564).
     let policy = resolve_cleanup_policy(CleanupPolicyOverrides::default())?;
     let outcome = runs_service::cleanup_runner_downloads(RunnerDownloadCleanupOptions {
-        apply: args.apply,
+        apply: args.mutation.is_apply(),
         runner: args.runner,
         run_id: args.run_id,
         limit: policy.scan_limit(),
@@ -440,8 +441,9 @@ pub fn cleanup_downloads(args: RunsArtifactCleanupDownloadsArgs) -> CmdResult<Ru
             command: "runs.artifact.cleanup-downloads",
             cleanup_category: RUNNER_DOWNLOADS_METADATA.category,
             canonical_cleanup_command: RUNNER_DOWNLOADS_METADATA
-                .canonical_cleanup_command(args.apply),
-            specialist_cleanup_command: RUNNER_DOWNLOADS_METADATA.specialist_command(args.apply),
+                .canonical_cleanup_command(args.mutation.is_apply()),
+            specialist_cleanup_command: RUNNER_DOWNLOADS_METADATA
+                .specialist_command(args.mutation.is_apply()),
             dry_run: outcome.dry_run,
             retention: policy,
             root: outcome.root.display().to_string(),
@@ -473,7 +475,7 @@ pub fn cleanup_persisted(args: RunsArtifactCleanupPersistedArgs) -> CmdResult<Ru
         ..CleanupPolicyOverrides::default()
     })?;
     let outcome = runs_service::cleanup_persisted_artifacts(PersistedArtifactCleanupOptions {
-        apply: args.apply,
+        apply: args.mutation.is_apply(),
         older_than_days: policy.terminal_run_days,
         run_id: args.run_id,
         kind: args.kind,
@@ -985,7 +987,7 @@ mod tests {
             fs::write(run_dir.join("report.json"), b"{}").expect("report");
 
             let dry = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
-                apply: false,
+                mutation: MutationArgs::from(false),
                 runner: Some("local".to_string()),
                 run_id: Some("run-1".to_string()),
             })
@@ -1045,7 +1047,7 @@ mod tests {
             // nothing: the narrowing filter selects a candidate, it does not
             // waive the age floor.
             let applied = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
-                apply: true,
+                mutation: MutationArgs::from(true),
                 runner: Some("local".to_string()),
                 run_id: Some("run-1".to_string()),
             })
@@ -1094,7 +1096,7 @@ mod tests {
             // The retention contract never reaps evidence while its run owns an
             // active lease, even when the age threshold is zero.
             let active = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
-                apply: true,
+                mutation: MutationArgs::from(true),
                 older_than_days: Some(0),
                 run_id: Some(run.id.clone()),
                 kind: None,
@@ -1118,7 +1120,7 @@ mod tests {
                 .expect("finish run");
 
             let dry = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
-                apply: false,
+                mutation: MutationArgs::from(false),
                 older_than_days: Some(0),
                 run_id: Some(run.id.clone()),
                 kind: None,
@@ -1140,7 +1142,7 @@ mod tests {
             assert!(store.get_artifact(&artifact.id).expect("get").is_some());
 
             let applied = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
-                apply: true,
+                mutation: MutationArgs::from(true),
                 older_than_days: Some(0),
                 run_id: Some(run.id.clone()),
                 kind: None,
@@ -1165,7 +1167,7 @@ mod tests {
     #[test]
     fn cleanup_downloads_requires_runner_for_run_filter() {
         let result = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
-            apply: false,
+            mutation: MutationArgs::from(false),
             runner: None,
             run_id: Some("run-1".to_string()),
         });
@@ -1184,7 +1186,7 @@ mod tests {
             (Some("/tmp/outside".to_string()), None),
         ] {
             let result = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
-                apply: false,
+                mutation: MutationArgs::from(false),
                 runner,
                 run_id,
             });

--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -29,7 +29,6 @@ use super::types::{
 };
 use super::CmdResult;
 use crate::commands::cleanup::RUNNER_DOWNLOADS_METADATA;
-use crate::commands::utils::args::MutationArgs;
 
 pub fn get(artifact: ArtifactRecord, output: Option<PathBuf>) -> CmdResult<RunsOutput> {
     let download = runs_service::download_remote_artifact(artifact, output)?;
@@ -521,6 +520,8 @@ mod tests {
 
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
+
+    use crate::commands::utils::args::MutationArgs;
 
     use super::*;
 

--- a/crates/homeboy-cli/src/commands/runs/types.rs
+++ b/crates/homeboy-cli/src/commands/runs/types.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 
+use crate::commands::utils::args::MutationArgs;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
@@ -708,9 +709,10 @@ pub use capture_types::*;
 
 #[derive(Args, Clone, Default)]
 pub struct RunsArtifactCleanupDownloadsArgs {
-    /// Delete the planned cached downloads. Without this flag, only reports the plan.
-    #[arg(long)]
-    pub apply: bool,
+    // Delete the planned cached downloads. Without this flag, only reports
+    // the plan. Shared plan-default mutation group (#11139).
+    #[command(flatten)]
+    pub mutation: MutationArgs,
     /// Limit cleanup to one runner id under the local runner artifact cache.
     #[arg(long)]
     pub runner: Option<String>,
@@ -750,9 +752,11 @@ pub struct RunsArtifactCleanupDownloadsOutput {
 
 #[derive(Args, Clone)]
 pub struct RunsArtifactCleanupPersistedArgs {
-    /// Delete planned artifact files/directories and their DB rows. Without this flag, only reports the plan.
-    #[arg(long)]
-    pub apply: bool,
+    // Delete planned artifact files/directories and their DB rows. Without
+    // this flag, only reports the plan. Shared plan-default mutation group
+    // (#11139).
+    #[command(flatten)]
+    pub mutation: MutationArgs,
     /// Only include artifacts older than this many days.
     /// Defaults to the configured `retention.terminal_run_days`.
     #[arg(long)]

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -8,6 +8,7 @@ use homeboy::runner::runners::{self as runner, Runner, RunnerKind, RunnerStatusR
 use homeboy_upgrade::self_status::{self, ControllerRuntimeInput, RunnerRuntimeInput};
 use serde_json::Value;
 
+use crate::commands::utils::args::MutationArgs;
 use crate::commands::{docs, resources, CmdResult};
 
 #[derive(Args)]
@@ -44,9 +45,10 @@ pub struct SelfDoctorArgs {}
 
 #[derive(Args)]
 pub struct SelfCleanupRuntimeTmpArgs {
-    /// Delete planned temp entries. Without this flag, only reports the plan.
-    #[arg(long)]
-    pub apply: bool,
+    // Delete planned temp entries. Without this flag, only reports the plan.
+    // Shared plan-default mutation group (#11139).
+    #[command(flatten)]
+    pub mutation: MutationArgs,
     /// Only include entries older than this many days.
     /// Defaults to the configured `retention.runtime_tmp_days`.
     #[arg(long)]
@@ -147,7 +149,7 @@ pub fn run(args: SelfArgs) -> CmdResult<Value> {
             })?;
             let output = engine::temp::cleanup_runtime_tmp_bounded(
                 engine::temp::RuntimeTempCleanupOptions {
-                    apply: args.apply,
+                    apply: args.mutation.is_apply(),
                     older_than_days: policy.runtime_tmp_days,
                     managed_older_than_days: None,
                     prefix: args.prefix.as_deref(),
@@ -288,7 +290,7 @@ mod tests {
         assert_eq!(cli.args.run_max_bytes, None);
         assert_eq!(cli.args.run_max_count, None);
         assert_eq!(cli.args.prefix, None);
-        assert!(!cli.args.apply);
+        assert!(!cli.args.mutation.is_apply());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -28,8 +28,8 @@ use std::path::{Component, Path, PathBuf};
 
 use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
-    filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, PassthroughCommand,
-    PositionalComponentArgs, SettingArgs,
+    filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, LabChangedScopeArgs,
+    PassthroughCommand, PositionalComponentArgs, SettingArgs,
 };
 use super::utils::response::actionable_metadata_value_for_run_ref;
 use super::CmdResult;
@@ -76,15 +76,12 @@ pub struct TestArgs {
     #[arg(long, value_name = "REF", default_value = "HEAD~10")]
     pub since: String,
 
-    /// Limit test execution to files changed since this git ref (PR impact scope)
-    #[arg(long, value_name = "REF")]
-    pub changed_since: Option<String>,
-
-    #[arg(skip)]
-    pub precomputed_changed_files: Option<Vec<String>>,
-
-    #[arg(long, hide = true, value_name = "JSON")]
-    pub lab_changed_files_json: Option<String>,
+    // Limit test execution to files changed since a git ref (PR impact
+    // scope). Shared changed-scope group (#11140) — one declaration for
+    // `--changed-since`, the caller-injected changeset, and the hidden Lab
+    // handoff payload.
+    #[command(flatten)]
+    pub changed: LabChangedScopeArgs,
 
     /// Run using env and passthrough args from a single extension-declared CI test job.
     #[arg(long, value_name = "ID", conflicts_with = "drift")]
@@ -128,9 +125,7 @@ impl TestArgs {
             && !self.analyze
             && !self.drift
             && !self.write
-            && self.changed_since.is_none()
-            && self.precomputed_changed_files.is_none()
-            && self.lab_changed_files_json.is_none()
+            && !self.changed.is_scoped()
             && self.ci_job.is_none()
             && cli_passthrough_args.is_empty()
             && !self.setting_args.has_overrides()
@@ -274,8 +269,8 @@ pub fn run(args: TestArgs) -> CmdResult<TestCommandOutput> {
                 ignore_baseline: args.baseline_args.ignore_baseline,
                 ratchet: args.baseline_args.ratchet,
             },
-            changed_since: args.changed_since.clone(),
-            precomputed_changed_files: changed_files_from_args(&args)?,
+            changed_since: args.changed.changed_since().map(str::to_string),
+            precomputed_changed_files: args.changed.resolve()?,
             json_summary: args.json_summary,
             restore_checkout: args.restore_checkout,
             ci_env: test_runner_ci_env(ci_job.as_ref())
@@ -334,27 +329,6 @@ fn attach_test_actionable(output: &mut TestCommandOutput, run_id: Option<String>
             "homeboy-test",
         ));
     }
-}
-
-fn changed_files_from_args(args: &TestArgs) -> homeboy::core::Result<Option<Vec<String>>> {
-    if args.precomputed_changed_files.is_some() {
-        return Ok(args.precomputed_changed_files.clone());
-    }
-    args.lab_changed_files_json
-        .as_deref()
-        .map(parse_lab_changed_files_json)
-        .transpose()
-}
-
-fn parse_lab_changed_files_json(raw: &str) -> homeboy::core::Result<Vec<String>> {
-    serde_json::from_str(raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_argument(
-            "lab_changed_files_json",
-            format!("invalid Lab changed-file payload: {error}"),
-            None,
-            None,
-        )
-    })
 }
 
 fn ci_job_passthrough_args(job: Option<&CiResolvedJob>) -> Vec<String> {
@@ -1078,7 +1052,7 @@ fn test_observation_command(component_id: &str, args: &TestArgs) -> String {
     if args.drift {
         parts.push("--drift".to_string());
     }
-    if let Some(changed_since) = &args.changed_since {
+    if let Some(changed_since) = args.changed.changed_since() {
         parts.push(format!("--changed-since={changed_since}"));
     }
     if args.json_summary {
@@ -1110,7 +1084,7 @@ fn test_observation_initial_metadata(
             "ignore_baseline": args.baseline_args.ignore_baseline,
             "ratchet": args.baseline_args.ratchet,
         },
-        "changed_since": args.changed_since,
+        "changed_since": args.changed.changed_since(),
         "since": args.since,
         "json_summary": args.json_summary,
         "passthrough_args": filter_homeboy_flags(&args.args),
@@ -1981,7 +1955,7 @@ mod tests {
         .expect("test should parse --extension override");
 
         assert_eq!(cli.test.extension_override.extensions, vec!["fixture-test"]);
-        assert_eq!(cli.test.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(cli.test.changed.changed_since(), Some("origin/main"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -1219,23 +1219,219 @@ impl LintSniffArgs {
 }
 
 // ============================================================================
-// WriteModeArgs: --write (dry-run by default)
+// Mutation vocabulary: MutationArgs / WriteModeArgs / DryRunArgs
 // ============================================================================
+//
+// Homeboy speaks three different mutation vocabularies, and the *default
+// polarity* is unknowable without reading each command (#11139):
+//
+//   --apply     the default is PLAN;    passing the flag EXECUTES.
+//   --write     the default is PLAN;    passing the flag EXECUTES.
+//   --dry-run   the default is EXECUTE; passing the flag PREVIEWS.
+//
+// This governs destructive operations, so the polarity of any single
+// command is deliberately NOT changed here. [`MutationArgs`] gives the
+// plan-default family one declaration and one predicate; the other two
+// groups keep their existing meaning and are documented so the asymmetry
+// is legible rather than implicit.
+//
+// Commands that carry BOTH vocabularies at once are the sharpest edge and
+// are intentionally left alone by this group: `deploy` (`--dry-run`
+// previews, `--apply` confirms dangerous modes), `release` (a flattened
+// `DryRunArgs` *and* its own `--apply`), `harvest`, and the `agent-task`
+// reconcile args. Folding those into one group cannot be done without
+// deciding a polarity, which is a behavior change.
 
+/// Which side of the plan/execute boundary a run lands on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutationMode {
+    /// Report the plan; mutate nothing.
+    Plan,
+    /// Execute the mutation.
+    Apply,
+}
+
+/// The plan-default mutation switch: `--apply` executes, bare is a plan.
+///
+/// Modeled directly on `worktree cleanup`, which already declares exactly
+/// this pair — `--apply` to execute plus a `--dry-run` that conflicts with
+/// it and names the plan-only default.
+///
+/// `--dry-run` here is **not** an inverting alias of `--apply`. It is an
+/// explicit spelling of the default the command already had, so an
+/// operator script written against the `--dry-run` vocabulary keeps
+/// meaning "do not mutate" on an `--apply`-style command instead of
+/// failing with `unexpected argument`. Adding it cannot flip a default:
+/// the only field that authorizes a mutation is still `apply`.
+#[derive(Args, Debug, Clone, Default)]
+pub struct MutationArgs {
+    /// Execute the mutation. Without this flag the command reports a plan only.
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Explicitly request the plan-only default. Never mutates.
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+}
+
+impl MutationArgs {
+    /// True when the operator authorized the mutation.
+    pub fn is_apply(&self) -> bool {
+        self.apply
+    }
+
+    /// True when this run must not mutate anything.
+    ///
+    /// The plan-only default means this is simply `!apply`; `--dry-run`
+    /// makes that default explicit rather than adding a second way to
+    /// suppress a mutation.
+    pub fn is_dry_run(&self) -> bool {
+        !self.apply
+    }
+
+    /// The resolved plan/execute mode.
+    pub fn mode(&self) -> MutationMode {
+        if self.apply {
+            MutationMode::Apply
+        } else {
+            MutationMode::Plan
+        }
+    }
+}
+
+impl From<bool> for MutationArgs {
+    /// Build the group from a bare `apply` bool, for call sites that still
+    /// thread the primitive through helper functions.
+    fn from(apply: bool) -> Self {
+        Self {
+            apply,
+            dry_run: !apply,
+        }
+    }
+}
+
+/// Plan-default mutation switch spelled `--write`.
+///
+/// Same polarity as [`MutationArgs`] under a different name. Consumer:
+/// `refactor`.
 #[derive(Args, Debug, Clone, Default)]
 pub struct WriteModeArgs {
     #[arg(long)]
     pub write: bool,
 }
 
-// ============================================================================
-// DryRunArgs: --dry-run (execute by default)
-// ============================================================================
+impl WriteModeArgs {
+    /// True when the operator authorized the mutation.
+    pub fn is_apply(&self) -> bool {
+        self.write
+    }
 
+    /// The resolved plan/execute mode.
+    pub fn mode(&self) -> MutationMode {
+        if self.write {
+            MutationMode::Apply
+        } else {
+            MutationMode::Plan
+        }
+    }
+}
+
+/// Execute-default mutation switch: bare executes, `--dry-run` previews.
+///
+/// **Opposite polarity to [`MutationArgs`] and [`WriteModeArgs`].** This is
+/// the group whose default actually mutates, which is why it is not merged
+/// into `MutationArgs` — doing so would silently repolarize every consumer.
+/// Consumer: `release`.
 #[derive(Args, Debug, Clone, Default)]
 pub struct DryRunArgs {
     #[arg(long)]
     pub dry_run: bool,
+}
+
+impl DryRunArgs {
+    /// True when this run must not mutate anything.
+    pub fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    /// The resolved plan/execute mode.
+    pub fn mode(&self) -> MutationMode {
+        if self.dry_run {
+            MutationMode::Plan
+        } else {
+            MutationMode::Apply
+        }
+    }
+}
+
+#[cfg(test)]
+mod mutation_args_tests {
+    use super::{DryRunArgs, MutationArgs, MutationMode, WriteModeArgs};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct MutationCli {
+        #[command(flatten)]
+        mutation: MutationArgs,
+    }
+
+    fn parse(args: &[&str]) -> MutationArgs {
+        MutationCli::try_parse_from(args)
+            .expect("mutation args should parse")
+            .mutation
+    }
+
+    #[test]
+    fn bare_invocation_plans() {
+        let args = parse(&["mutating"]);
+        assert!(!args.is_apply());
+        assert!(args.is_dry_run());
+        assert_eq!(args.mode(), MutationMode::Plan);
+    }
+
+    #[test]
+    fn apply_executes() {
+        let args = parse(&["mutating", "--apply"]);
+        assert!(args.is_apply());
+        assert!(!args.is_dry_run());
+        assert_eq!(args.mode(), MutationMode::Apply);
+    }
+
+    #[test]
+    fn dry_run_is_the_default_spelled_out_and_never_executes() {
+        let args = parse(&["mutating", "--dry-run"]);
+        assert!(!args.is_apply());
+        assert!(args.is_dry_run());
+        assert_eq!(args.mode(), MutationMode::Plan);
+        assert_eq!(args.mode(), parse(&["mutating"]).mode());
+    }
+
+    #[test]
+    fn apply_and_dry_run_cannot_be_combined() {
+        assert!(MutationCli::try_parse_from(["mutating", "--apply", "--dry-run"]).is_err());
+        assert!(MutationCli::try_parse_from(["mutating", "--dry-run", "--apply"]).is_err());
+    }
+
+    #[test]
+    fn write_mode_shares_the_plan_default_polarity() {
+        assert_eq!(WriteModeArgs::default().mode(), MutationMode::Plan);
+        assert_eq!(WriteModeArgs { write: true }.mode(), MutationMode::Apply);
+    }
+
+    #[test]
+    fn dry_run_args_has_the_opposite_polarity() {
+        // The invariant this whole group exists to make visible: a bare
+        // DryRunArgs command MUTATES, while a bare MutationArgs command
+        // does not. Nothing in this change reconciles the two.
+        assert_eq!(DryRunArgs::default().mode(), MutationMode::Apply);
+        assert_eq!(MutationArgs::default().mode(), MutationMode::Plan);
+    }
+
+    #[test]
+    fn from_bool_round_trips_helper_threaded_apply_flags() {
+        assert_eq!(MutationArgs::from(true).mode(), MutationMode::Apply);
+        assert_eq!(MutationArgs::from(false).mode(), MutationMode::Plan);
+    }
 }
 
 // ============================================================================

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -1219,6 +1219,168 @@ impl LintSniffArgs {
 }
 
 // ============================================================================
+// PresentationArgs: --format + --detail
+// ============================================================================
+
+/// How a command should render its result.
+///
+/// `--json` means three unrelated things across the CLI today (#11138) and
+/// this enum owns only the first of them — the *output format* sense:
+///
+/// 1. **Output format** (a bool): `bench --json`, `runs show --json`,
+///    `runs proof --json`, `runs dossier --json`.
+/// 2. **A JSON request body** (a string): `api http --json '<body>'`.
+/// 3. **A bulk input spec** (a string): `git --json`, `deploy --json`,
+///    `build --json`, and `DynamicSetArgs --json` — *"JSON input spec for
+///    bulk operations. Use `-` for stdin"*.
+///
+/// Senses 2 and 3 are inputs, not presentation, so they are deliberately
+/// out of this group's scope. Renaming the input-spec flag to `--spec`
+/// with `--json` kept as an alias is the natural follow-up, but it is a
+/// separate change: `--json` there takes a value, so it cannot be folded
+/// into a presentation flag without removing a spelling.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    /// Let the command pick its documented default presentation.
+    #[default]
+    Auto,
+    /// Structured JSON envelope.
+    Json,
+    /// Rendered markdown.
+    Markdown,
+    /// Plain human-readable text.
+    Text,
+}
+
+/// How much of the result to render.
+///
+/// The CLI currently spells this eight different ways (#11138):
+/// `--json-summary` (audit, lint, test, bench, trace), `--summary`
+/// (review — and lint declares *both*), `--full` (status, plus agent-task
+/// in six places), `--compact` (runner), `--format` (report, in six
+/// declarations across three different `value_parser` sets), the
+/// `--report markdown` / `--report pr-comment` pair, and the global
+/// `--output <PATH>`.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DetailLevel {
+    /// Compact machine-readable summary.
+    Summary,
+    /// The command's documented default detail.
+    #[default]
+    Full,
+}
+
+/// The canonical presentation vocabulary: `--format` + `--detail`.
+///
+/// This group names the contract once so new commands have one obvious
+/// spelling to reach for. It is deliberately **additive**: no existing
+/// `--json` / `--json-summary` / `--summary` / `--full` / `--compact`
+/// flag is removed or re-pointed by introducing it.
+///
+/// Folding the existing flags into this group cannot be done with clap
+/// aliases, which is why it is not attempted here. An alias must have the
+/// same arity as the flag it aliases, and every current spelling is a
+/// *boolean* while `--format` and `--detail` take values. Making
+/// `--json` an alias of `--format` would change its arity, and dropping
+/// the boolean would remove a spelling that CI wrappers and operator
+/// scripts depend on. Migration therefore has to be per-command and
+/// staged, not mechanical.
+#[derive(Args, Debug, Clone, Default)]
+pub struct PresentationArgs {
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Auto)]
+    pub format: OutputFormat,
+
+    /// How much of the result to render.
+    #[arg(long, value_enum, default_value_t = DetailLevel::Full)]
+    pub detail: DetailLevel,
+}
+
+impl PresentationArgs {
+    /// True when the caller explicitly asked for JSON.
+    pub fn is_json(&self) -> bool {
+        matches!(self.format, OutputFormat::Json)
+    }
+
+    /// True when the caller explicitly asked for markdown.
+    pub fn is_markdown(&self) -> bool {
+        matches!(self.format, OutputFormat::Markdown)
+    }
+
+    /// True when the caller asked for the compact summary.
+    pub fn is_summary(&self) -> bool {
+        matches!(self.detail, DetailLevel::Summary)
+    }
+
+    /// True when the command should pick its own default presentation.
+    pub fn is_auto_format(&self) -> bool {
+        matches!(self.format, OutputFormat::Auto)
+    }
+}
+
+#[cfg(test)]
+mod presentation_args_tests {
+    use super::{DetailLevel, OutputFormat, PresentationArgs};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct PresentationCli {
+        #[command(flatten)]
+        presentation: PresentationArgs,
+    }
+
+    fn parse(args: &[&str]) -> PresentationArgs {
+        PresentationCli::try_parse_from(args)
+            .expect("presentation args should parse")
+            .presentation
+    }
+
+    #[test]
+    fn defaults_are_auto_and_full() {
+        let args = parse(&["rendered"]);
+        assert_eq!(args.format, OutputFormat::Auto);
+        assert_eq!(args.detail, DetailLevel::Full);
+        assert!(args.is_auto_format());
+        assert!(!args.is_summary());
+    }
+
+    #[test]
+    fn every_documented_format_value_parses() {
+        for (flag, expected) in [
+            ("auto", OutputFormat::Auto),
+            ("json", OutputFormat::Json),
+            ("markdown", OutputFormat::Markdown),
+            ("text", OutputFormat::Text),
+        ] {
+            assert_eq!(parse(&["rendered", "--format", flag]).format, expected);
+        }
+    }
+
+    #[test]
+    fn every_documented_detail_value_parses() {
+        assert!(parse(&["rendered", "--detail", "summary"]).is_summary());
+        assert!(!parse(&["rendered", "--detail", "full"]).is_summary());
+    }
+
+    #[test]
+    fn unknown_values_are_rejected() {
+        assert!(PresentationCli::try_parse_from(["rendered", "--format", "yaml"]).is_err());
+        assert!(PresentationCli::try_parse_from(["rendered", "--detail", "verbose"]).is_err());
+    }
+
+    #[test]
+    fn format_predicates_are_mutually_exclusive() {
+        let json = parse(&["rendered", "--format=json"]);
+        assert!(json.is_json());
+        assert!(!json.is_markdown());
+
+        let markdown = parse(&["rendered", "--format=markdown"]);
+        assert!(markdown.is_markdown());
+        assert!(!markdown.is_json());
+    }
+}
+
+// ============================================================================
 // Mutation vocabulary: MutationArgs / WriteModeArgs / DryRunArgs
 // ============================================================================
 //

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -919,6 +919,269 @@ pub struct BaselineArgs {
 }
 
 // ============================================================================
+// ChangedSinceArgs / LabChangedScopeArgs / ChangedScopeArgs: changed-file scope
+// ============================================================================
+
+/// The `--changed-since` scope contract, declared once.
+///
+/// Six commands (`audit`, `lint`, `test`, `build`, `review`, `refactor`)
+/// each declared this flag independently, with three different doc comments,
+/// two different `value_name`s, and — in `lint`/`review` — hand-written
+/// `conflicts_with` pairs pointing at each other (#11140). The
+/// `#[arg(skip)] precomputed_changed_files` escape hatch that lets a caller
+/// (`review`, the Lab handoff) inject an already-computed changeset was
+/// repeated three times verbatim, and two byte-identical
+/// `changed_files_from_args` helpers lived in `lint.rs` and `test.rs`.
+///
+/// The group is layered rather than flat so that flattening it never *adds*
+/// a flag to a command that did not already accept it:
+///
+/// - [`ChangedSinceArgs`] — `--changed-since` plus the skip escape hatch.
+///   Flattened by `audit`, `build`, `refactor`.
+/// - [`LabChangedScopeArgs`] — adds the hidden `--lab-changed-files-json`
+///   handoff payload. Flattened by `test`.
+/// - [`ChangedScopeArgs`] — adds `--changed-only` working-tree scoping.
+///   Flattened by `lint` and `review`.
+///
+/// ## Known divergence (surfaced, deliberately not changed)
+///
+/// `audit --changed-since` disables Lab offload entirely (see
+/// `AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON` in `commands/audit.rs`) while
+/// `lint --changed-since` treats the same scoping as a Lab-portable release
+/// gate. Both spellings resolve to the identical field on the same shared
+/// group now, so the divergence lives entirely in each command's
+/// `lab_contract()` where it is visible. Whether audit's carve-out is still
+/// warranted is a behavior decision for a separate issue — this group only
+/// makes the asymmetry legible.
+#[derive(Args, Debug, Clone, Default)]
+pub struct ChangedSinceArgs {
+    /// Only operate on files changed since this git ref (branch, tag, or SHA).
+    #[arg(long, value_name = "REF")]
+    pub changed_since: Option<String>,
+
+    /// Caller-injected changeset. Not a CLI surface — `review` and the Lab
+    /// handoff populate this so a downstream phase reuses one `git diff`
+    /// instead of recomputing it per stage.
+    #[arg(skip)]
+    pub precomputed_changed_files: Option<Vec<String>>,
+}
+
+impl ChangedSinceArgs {
+    /// The requested git base ref, if any.
+    pub fn changed_since(&self) -> Option<&str> {
+        self.changed_since.as_deref()
+    }
+
+    /// True when the run is scoped to a changed-file set.
+    pub fn is_scoped(&self) -> bool {
+        self.changed_since.is_some() || self.precomputed_changed_files.is_some()
+    }
+
+    /// Resolve the effective changed-file list for this run.
+    ///
+    /// A caller-injected changeset always wins; there is no Lab payload at
+    /// this layer.
+    pub fn resolve(&self) -> homeboy::core::Result<Option<Vec<String>>> {
+        Ok(self.precomputed_changed_files.clone())
+    }
+}
+
+/// [`ChangedSinceArgs`] plus the hidden Lab changed-file handoff payload.
+#[derive(Args, Debug, Clone, Default)]
+pub struct LabChangedScopeArgs {
+    #[command(flatten)]
+    pub since: ChangedSinceArgs,
+
+    /// Serialized changed-file list handed across the Lab boundary.
+    #[arg(long, hide = true, value_name = "JSON")]
+    pub lab_changed_files_json: Option<String>,
+}
+
+impl LabChangedScopeArgs {
+    /// The requested git base ref, if any.
+    pub fn changed_since(&self) -> Option<&str> {
+        self.since.changed_since()
+    }
+
+    /// True when the run is scoped to a changed-file set.
+    pub fn is_scoped(&self) -> bool {
+        self.since.is_scoped() || self.lab_changed_files_json.is_some()
+    }
+
+    /// Resolve the effective changed-file list for this run.
+    ///
+    /// Precedence: caller-injected changeset, then the Lab handoff payload.
+    /// This replaces the two byte-identical `changed_files_from_args`
+    /// helpers that lived in `lint.rs` and `test.rs`.
+    pub fn resolve(&self) -> homeboy::core::Result<Option<Vec<String>>> {
+        if self.since.precomputed_changed_files.is_some() {
+            return Ok(self.since.precomputed_changed_files.clone());
+        }
+        self.lab_changed_files_json
+            .as_deref()
+            .map(parse_lab_changed_files_json)
+            .transpose()
+    }
+}
+
+/// [`LabChangedScopeArgs`] plus working-tree (`--changed-only`) scoping.
+#[derive(Args, Debug, Clone, Default)]
+pub struct ChangedScopeArgs {
+    #[command(flatten)]
+    pub lab: LabChangedScopeArgs,
+
+    /// Operate only on files modified in the working tree
+    /// (staged, unstaged, untracked). File-scoped, not hunk-scoped.
+    #[arg(long, conflicts_with = "changed_since")]
+    pub changed_only: bool,
+}
+
+impl ChangedScopeArgs {
+    /// The requested git base ref, if any.
+    pub fn changed_since(&self) -> Option<&str> {
+        self.lab.changed_since()
+    }
+
+    /// True when the run is scoped to a changed-file set by any mechanism.
+    pub fn is_scoped(&self) -> bool {
+        self.lab.is_scoped() || self.changed_only
+    }
+
+    /// True when nothing narrowed the run — the full component is in scope.
+    pub fn is_full_scope(&self) -> bool {
+        !self.is_scoped()
+    }
+
+    /// Resolve the effective changed-file list for this run.
+    pub fn resolve(&self) -> homeboy::core::Result<Option<Vec<String>>> {
+        self.lab.resolve()
+    }
+}
+
+/// Parse a Lab changed-file handoff payload.
+///
+/// Previously copied verbatim into `lint.rs`, `test.rs`, and
+/// `review/mod.rs`.
+pub fn parse_lab_changed_files_json(raw: &str) -> homeboy::core::Result<Vec<String>> {
+    serde_json::from_str(raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "lab_changed_files_json",
+            format!("invalid Lab changed-file payload: {error}"),
+            None,
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod changed_scope_tests {
+    use super::{ChangedScopeArgs, ChangedSinceArgs, LabChangedScopeArgs};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct SinceCli {
+        #[command(flatten)]
+        changed: ChangedSinceArgs,
+    }
+
+    #[derive(Parser)]
+    struct LabCli {
+        #[command(flatten)]
+        changed: LabChangedScopeArgs,
+    }
+
+    #[derive(Parser)]
+    struct ScopeCli {
+        #[command(flatten)]
+        changed: ChangedScopeArgs,
+    }
+
+    #[test]
+    fn changed_since_parses_split_and_inline_forms() {
+        let split = SinceCli::try_parse_from(["scoped", "--changed-since", "origin/main"])
+            .expect("split form parses");
+        assert_eq!(split.changed.changed_since(), Some("origin/main"));
+
+        let inline = SinceCli::try_parse_from(["scoped", "--changed-since=origin/main"])
+            .expect("inline form parses");
+        assert_eq!(inline.changed.changed_since(), Some("origin/main"));
+    }
+
+    #[test]
+    fn base_group_exposes_no_extra_flags() {
+        assert!(SinceCli::try_parse_from(["scoped", "--changed-only"]).is_err());
+        assert!(SinceCli::try_parse_from(["scoped", "--lab-changed-files-json", "[]"]).is_err());
+    }
+
+    #[test]
+    fn lab_group_exposes_the_hidden_payload_but_not_changed_only() {
+        assert!(LabCli::try_parse_from(["scoped", "--lab-changed-files-json", "[]"]).is_ok());
+        assert!(LabCli::try_parse_from(["scoped", "--changed-only"]).is_err());
+    }
+
+    #[test]
+    fn changed_since_and_changed_only_conflict_in_both_orders() {
+        assert!(
+            ScopeCli::try_parse_from(["scoped", "--changed-since", "main", "--changed-only"])
+                .is_err()
+        );
+        assert!(
+            ScopeCli::try_parse_from(["scoped", "--changed-only", "--changed-since", "main"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_precomputed_over_lab_payload() {
+        let mut args = LabChangedScopeArgs {
+            lab_changed_files_json: Some(r#"["from-lab.rs"]"#.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            args.resolve().expect("lab payload resolves"),
+            Some(vec!["from-lab.rs".to_string()])
+        );
+
+        args.since.precomputed_changed_files = Some(vec!["injected.rs".to_string()]);
+        assert_eq!(
+            args.resolve().expect("precomputed wins"),
+            Some(vec!["injected.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_a_malformed_lab_payload() {
+        let args = LabChangedScopeArgs {
+            lab_changed_files_json: Some("not-json".to_string()),
+            ..Default::default()
+        };
+        let error = args.resolve().expect_err("malformed payload should fail");
+        assert_eq!(
+            error.code,
+            homeboy::core::ErrorCode::ValidationInvalidArgument
+        );
+    }
+
+    #[test]
+    fn scope_predicates_track_every_narrowing_mechanism() {
+        let full = ChangedScopeArgs::default();
+        assert!(full.is_full_scope());
+        assert!(!full.is_scoped());
+
+        let changed_only = ChangedScopeArgs {
+            changed_only: true,
+            ..Default::default()
+        };
+        assert!(changed_only.is_scoped());
+        assert!(!changed_only.is_full_scope());
+
+        let mut since = ChangedScopeArgs::default();
+        since.lab.since.changed_since = Some("origin/main".to_string());
+        assert!(since.is_scoped());
+    }
+}
+
+// ============================================================================
 // LintSniffArgs: --errors-only + --sniffs + --exclude-sniffs
 // ============================================================================
 

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -15,6 +15,7 @@ use homeboy::core::worktree::{
 
 use crate::command_contract::{LabCommandContract, WORKTREE_CLEANUP_LAB_LABEL};
 
+use super::utils::args::MutationArgs;
 use super::CmdResult;
 
 #[derive(Args)]
@@ -115,15 +116,15 @@ enum WorktreeCommand {
     },
     /// Remove cleanup-eligible task worktrees after safety checks
     Cleanup {
-        /// Remove planned worktrees and artifacts after safety checks. Without this flag, only reports the plan.
-        #[arg(long, conflicts_with = "dry_run")]
-        apply: bool,
+        // Remove planned worktrees and artifacts after safety checks.
+        // Without --apply, only reports the plan; --dry-run names that
+        // default explicitly. This pair is the precedent the shared
+        // plan-default mutation group was modeled on (#11139).
+        #[command(flatten)]
+        mutation: MutationArgs,
         /// Allow dirty/unpushed worktree removal; hard gates still apply
         #[arg(long)]
         force: bool,
-        /// Deprecated plan-only alias retained for one release; bare cleanup also reports the plan.
-        #[arg(long, conflicts_with = "apply")]
-        dry_run: bool,
         /// Also remove declared rebuildable artifacts from the Homeboy checkout that built this binary.
         #[arg(long)]
         cleanup_artifacts: bool,
@@ -264,13 +265,14 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             allow_unmerged_branch,
         })?),
         WorktreeCommand::Cleanup {
-            apply,
+            mutation,
             force,
-            dry_run: deprecated_dry_run,
             cleanup_artifacts,
             cleanup_branches,
             allow_unmerged_branches,
         } => {
+            let apply = mutation.is_apply();
+            let deprecated_dry_run = mutation.dry_run;
             let dry_run = cleanup_is_dry_run(apply);
             let worktrees = worktree::cleanup(WorktreeCleanupOptions {
                 force,
@@ -339,8 +341,7 @@ mod tests {
             panic!("expected worktree command");
         };
         let WorktreeCommand::Cleanup {
-            apply,
-            dry_run,
+            mutation,
             cleanup_artifacts,
             ..
         } = args.command
@@ -348,9 +349,9 @@ mod tests {
             panic!("expected worktree cleanup command");
         };
 
-        assert!(!apply);
-        assert!(!dry_run);
-        assert!(cleanup_is_dry_run(apply));
+        assert!(!mutation.apply);
+        assert!(!mutation.dry_run);
+        assert!(cleanup_is_dry_run(mutation.is_apply()));
         assert!(!cleanup_artifacts);
     }
 
@@ -368,7 +369,7 @@ mod tests {
             panic!("expected worktree command");
         };
         let WorktreeCommand::Cleanup {
-            apply,
+            mutation,
             cleanup_artifacts,
             ..
         } = args.command
@@ -376,8 +377,8 @@ mod tests {
             panic!("expected worktree cleanup command");
         };
 
-        assert!(apply);
-        assert!(!cleanup_is_dry_run(apply));
+        assert!(mutation.apply);
+        assert!(!cleanup_is_dry_run(mutation.is_apply()));
         assert!(cleanup_artifacts);
     }
 
@@ -388,13 +389,13 @@ mod tests {
         let Commands::Worktree(args) = cli.command else {
             panic!("expected worktree command");
         };
-        let WorktreeCommand::Cleanup { apply, dry_run, .. } = args.command else {
+        let WorktreeCommand::Cleanup { mutation, .. } = args.command else {
             panic!("expected worktree cleanup command");
         };
 
-        assert!(!apply);
-        assert!(dry_run);
-        assert!(cleanup_is_dry_run(apply));
+        assert!(!mutation.apply);
+        assert!(mutation.dry_run);
+        assert!(cleanup_is_dry_run(mutation.is_apply()));
     }
 
     #[test]
@@ -404,11 +405,11 @@ mod tests {
         let Commands::Worktree(args) = cli.command else {
             panic!("expected worktree command");
         };
-        let WorktreeCommand::Cleanup { dry_run, .. } = args.command else {
+        let WorktreeCommand::Cleanup { mutation, .. } = args.command else {
             panic!("expected worktree cleanup command");
         };
 
-        assert_eq!(dry_run.then_some("--dry-run"), Some("--dry-run"));
+        assert_eq!(mutation.dry_run.then_some("--dry-run"), Some("--dry-run"));
     }
 
     #[test]

--- a/tests/commands/api_test.rs
+++ b/tests/commands/api_test.rs
@@ -1,3 +1,5 @@
+use crate::commands::utils::args::MutationArgs;
+
 use super::{require_apply_for_mutation, ApiArgs, ApiCommand};
 
 #[test]
@@ -6,28 +8,28 @@ fn api_mutating_commands_require_apply() {
         ApiCommand::Post {
             project_id: "site".to_string(),
             endpoint: "/wp/v2/posts".to_string(),
-            apply: false,
+            mutation: MutationArgs::from(false),
             body: None,
             form: Vec::new(),
         },
         ApiCommand::Put {
             project_id: "site".to_string(),
             endpoint: "/wp/v2/posts/1".to_string(),
-            apply: false,
+            mutation: MutationArgs::from(false),
             body: None,
             form: Vec::new(),
         },
         ApiCommand::Patch {
             project_id: "site".to_string(),
             endpoint: "/wp/v2/posts/1".to_string(),
-            apply: false,
+            mutation: MutationArgs::from(false),
             body: None,
             form: Vec::new(),
         },
         ApiCommand::Delete {
             project_id: "site".to_string(),
             endpoint: "/wp/v2/posts/1".to_string(),
-            apply: false,
+            mutation: MutationArgs::from(false),
         },
     ] {
         let err = require_apply_for_mutation(&ApiArgs { command })
@@ -53,7 +55,7 @@ fn api_get_and_applied_mutations_pass_apply_guard() {
         command: ApiCommand::Post {
             project_id: "site".to_string(),
             endpoint: "/wp/v2/posts".to_string(),
-            apply: true,
+            mutation: MutationArgs::from(true),
             body: None,
             form: Vec::new(),
         },

--- a/tests/commands/file_test.rs
+++ b/tests/commands/file_test.rs
@@ -1,5 +1,6 @@
 use super::args::{EditArgs, FileModifications, LineOperations, PatternOperations};
 use super::{run, FileArgs, FileCommand, FileCommandOutput};
+use crate::commands::utils::args::MutationArgs;
 use crate::test_support::with_isolated_home;
 use std::path::Path;
 
@@ -72,7 +73,7 @@ fn file_delete_without_apply_returns_plan_and_preserves_file() {
                 project_id: project_id.to_string(),
                 path: "sample.txt".to_string(),
                 recursive: false,
-                apply: false,
+                mutation: MutationArgs::from(false),
             },
         })
     });
@@ -105,7 +106,7 @@ fn file_mkdir_without_apply_returns_plan_and_preserves_filesystem() {
             command: FileCommand::Mkdir {
                 project_id: project_id.to_string(),
                 path: "new-dir".to_string(),
-                apply: false,
+                mutation: MutationArgs::from(false),
             },
         })
     });
@@ -141,7 +142,7 @@ fn file_rename_without_apply_returns_plan_and_preserves_filesystem() {
                 project_id: project_id.to_string(),
                 old_path: "old.txt".to_string(),
                 new_path: "new.txt".to_string(),
-                apply: false,
+                mutation: MutationArgs::from(false),
             },
         })
     });

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use crate::commands::test::{run as run_test, TestArgs};
 use crate::commands::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
+    BaselineArgs, ExtensionOverrideArgs, LabChangedScopeArgs, PositionalComponentArgs, SettingArgs,
 };
 use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
 use homeboy_core::engine::run_dir::RunDir;
@@ -36,9 +36,7 @@ fn test_command_args(root: &Path) -> TestArgs {
         drift: false,
         write: false,
         since: "HEAD~10".to_string(),
-        changed_since: None,
-        precomputed_changed_files: None,
-        lab_changed_files_json: None,
+        changed: LabChangedScopeArgs::default(),
         ci_job: None,
         setting_args: SettingArgs::default(),
         args: Vec::new(),
@@ -588,8 +586,8 @@ fn changed_wordpress_php_smoke_test_executes_with_generic_result_adapter() {
         init_git_repo(dir.path());
 
         let mut args = test_command_args(dir.path());
-        args.changed_since = Some("HEAD".to_string());
-        args.precomputed_changed_files = Some(vec![
+        args.changed.since.changed_since = Some("HEAD".to_string());
+        args.changed.since.precomputed_changed_files = Some(vec![
             "src/patterns.php".to_string(),
             "tests/patterns/patterns-ability-smoke.php".to_string(),
         ]);
@@ -669,8 +667,8 @@ fn changed_nested_extension_js_smokes_use_component_relative_exclusive_route() {
         init_git_repo(repo.path());
 
         let mut args = test_command_args(&extension_root);
-        args.changed_since = Some("HEAD".to_string());
-        args.precomputed_changed_files = Some(vec![
+        args.changed.since.changed_since = Some("HEAD".to_string());
+        args.changed.since.precomputed_changed_files = Some(vec![
             "wordpress/tests/wp-codebox-database-service-smoke.mjs".to_string(),
             "wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs".to_string(),
             "wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs".to_string(),
@@ -734,8 +732,9 @@ fn successful_selected_test_without_result_evidence_fails_closed() {
             .expect("extension script should be executable");
 
         let mut args = test_command_args(dir.path());
-        args.changed_since = Some("origin/main".to_string());
-        args.precomputed_changed_files = Some(vec!["tests/generic-smoke.php".to_string()]);
+        args.changed.since.changed_since = Some("origin/main".to_string());
+        args.changed.since.precomputed_changed_files =
+            Some(vec!["tests/generic-smoke.php".to_string()]);
         let (output, exit_code) = run_test(args).expect("extension test should run");
 
         assert_eq!(exit_code, 1);

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -1,7 +1,8 @@
 use homeboy::commands::lint::{run as run_lint, LintArgs};
 use homeboy::commands::test::{run as run_test, TestArgs};
 use homeboy::commands::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, LintSniffArgs, PositionalComponentArgs, SettingArgs,
+    BaselineArgs, ChangedScopeArgs, ExtensionOverrideArgs, LabChangedScopeArgs, LintSniffArgs,
+    PositionalComponentArgs, SettingArgs,
 };
 use std::fs;
 use std::path::Path;
@@ -40,11 +41,8 @@ fn lint_args(root: &Path) -> LintArgs {
         summary: false,
         file: None,
         glob: None,
-        changed_only: false,
-        changed_since: None,
-        precomputed_changed_files: None,
+        changed: ChangedScopeArgs::default(),
         force_main_workflow: false,
-        lab_changed_files_json: None,
         ci_job: None,
         sniff_filters: LintSniffArgs::default(),
         category: None,
@@ -68,9 +66,7 @@ fn test_args(root: &Path) -> TestArgs {
         drift: false,
         write: false,
         since: "HEAD~10".to_string(),
-        changed_since: None,
-        precomputed_changed_files: None,
-        lab_changed_files_json: None,
+        changed: LabChangedScopeArgs::default(),
         ci_job: None,
         setting_args: SettingArgs::default(),
         args: Vec::new(),


### PR DESCRIPTION
Consolidates three overloaded CLI vocabularies found during the 2026-08-01 consolidation investigation (#11151).

**Governing rule followed throughout: add spellings, never remove one.** No flag was renamed, removed, or repolarized. `cargo fmt` clean; `cargo check -p homeboy-cli --lib --tests` exits 0.

---

## 1. `--changed-since` declared six times — `Closes #11140`

Six independent declarations (`audit`, `lint`, `test`, `build`, `review`, `refactor`) with three different doc comments and two different `value_name`s. Plus `--changed-only` twice, each with a hand-written `conflicts_with` pointing at the other; the hidden `--lab-changed-files-json` three times verbatim; the `#[arg(skip)] precomputed_changed_files` escape hatch three times; and two byte-identical `changed_files_from_args` helpers (`lint.rs`, `test.rs`) plus three copies of `parse_lab_changed_files_json`.

`commands/utils/args.rs`'s own header already said commands should *"compose these via `#[command(flatten)]` instead of redeclaring the same flags independently."*

The group is **layered** so flattening never adds a flag to a command that did not already accept it — the CLI surface is byte-for-byte unchanged:

| Group | Flags | Flattened into |
|---|---|---|
| `ChangedSinceArgs` | `--changed-since` + skip escape hatch | audit, build, refactor |
| `LabChangedScopeArgs` | + hidden `--lab-changed-files-json` | test |
| `ChangedScopeArgs` | + `--changed-only` | lint, review |

One `resolve()` replaces both `changed_files_from_args` helpers and all three `parse_lab_changed_files_json` copies, with identical precedence (caller-injected changeset beats the Lab handoff payload).

### The audit/lint Lab-offload divergence — reproduced, surfaced, NOT changed

It reproduces exactly as described. `audit --changed-since` returns `LabCommandContract::local_only(...)` via `AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON` — Lab offload disabled outright. `lint --changed-since` returns `LabCommandContract::portable(...).release_gate()` — identical scoping treated as a Lab-portable release gate.

Both now read the **same field on the same shared group**, so the asymmetry lives visibly in each command's `lab_contract()` instead of emerging from two unrelated flag declarations. It is documented on the group and at the audit call site. Whether audit's carve-out is still warranted is a behavior decision for a separate issue — **this PR does not change it.**

---

## 2. Three mutation vocabularies — `Refs #11139`

The default polarity is unknowable without reading each command:

```
--apply     default is PLAN;    the flag EXECUTES
--write     default is PLAN;    the flag EXECUTES
--dry-run   default is EXECUTE; the flag PREVIEWS
```

The two shared groups were near-dead — `WriteModeArgs` had one consumer (`refactor`), `DryRunArgs` one (`release`) — while ~40 inline `apply: bool` / `dry_run: bool` fields were hand-declared across the tree.

Adds `MutationArgs` for the plan-default family, flattened into: `api` (×4), `file` (×4), `component` (×2), `issues` (×2), `db` (×2), `git pr fleet`, `fleet exec`, `runner cache-prune`, `runner workspace prune`, `infra runtime controller-prune`, `runs artifact cleanup-downloads`, `runs artifact cleanup-persisted`, `self cleanup-runtime-tmp`, `worktree cleanup`.

### The polarity hazard — nothing was repolarized

**No command's default changed.** The only field that authorizes a mutation is still `apply`, and every consumer reads it through `is_apply()` — the identical bool it read before.

`MutationArgs` is modeled on `worktree cleanup`, which **already declared exactly this pair by hand**: `--apply` to execute, plus a `--dry-run` that conflicts with it and names the plan-only default.

`--dry-run` is therefore **not an inverting alias of `--apply`.** It is an explicit spelling of the default the command already had, so a script written against the `--dry-run` vocabulary keeps meaning *"do not mutate"* instead of failing with `unexpected argument`. It cannot flip a default because it never sets `apply`. A unit test pins the invariant: a bare `DryRunArgs` command **mutates**, a bare `MutationArgs` command **does not**.

### Deliberately left alone (folding them in requires deciding a polarity)

- **`deploy`** — carries both: `--dry-run` previews, `--apply` confirms dangerous modes.
- **`release`** — carries both: a flattened `DryRunArgs` *and* its own `--apply`. **A fourth dual-vocabulary command not in the original issue.**
- **`harvest`** — carries both, plus `--check`.
- **`agent-task`** `ActiveArgs`/`ReconcileArgs` — both, with `requires`/`conflicts_with` entanglement.
- **`runs resources --apply`** — gated by `requires = "cleanup_root"`.
- **`cleanup --apply`** — declared in `crates/contracts/`, another PR's lane.

Hence `Refs`, not `Closes`.

---

## 3. `--json` means three different things — `Refs #11138`

1. **Output format** (bool) — `bench`, `runs show`, `runs proof`, `runs dossier`
2. **A JSON request body** (string) — `api http --json '<body>'`
3. **A bulk input spec** (string) — `git`, `deploy`, `build`, `DynamicSetArgs`: *"JSON input spec for bulk operations. Use `-` for stdin"*

Plus eight verbosity spellings: `--json-summary` (audit, lint, test, bench, trace), `--summary` (review — **lint declares both**), `--full` (status + agent-task ×6), `--compact` (runner), `--format` (report ×6), `--report markdown` vs `--report pr-comment`, and the global `--output <PATH>`.

Adds `PresentationArgs` — `--format {auto,json,markdown,text}` + `--detail {summary,full}` — as the canonical vocabulary, with all three `--json` senses and all eight verbosity spellings documented on the group. Collapses `report.rs`'s **six-times-repeated** markdown check into one `ReportCommand::format()` accessor.

### Why the existing flags are not aliased onto the new group

The issue asks for them as `visible_alias`es. **That is not expressible in clap**: an alias must have the same arity as the flag it aliases, and every current spelling is a *boolean* while `--format`/`--detail` take values. Making `--json` an alias of `--format` changes its arity; dropping the boolean removes a spelling CI wrappers depend on. Per the aliases-only rule this stops at naming the vocabulary. Renaming the input-spec `--json` to `--spec` is deferred for the same reason — it takes a value.

Also surfaced, not changed: the six `report --format` declarations carry three different `value_parser` sets, and **`matrix_artifacts.rs` has no `value_parser` at all** — it accepts any string and silently falls through to the JSON envelope for anything that is not exactly `markdown`.

---

## Verification

- `cargo fmt -p homeboy-cli --check` clean; `cargo check -p homeboy-cli --lib --tests` exit 0, no new warnings (11 before, 11 after).
- The `--tests` check caught four out-of-tree `#[path]` test modules that a `--lib`-only check misses: `tests/core/extension/component_script_test.rs`, `tests/self_checks_test.rs`, `tests/commands/api_test.rs`, `tests/commands/file_test.rs`.
- New unit tests over `try_parse_from` cover: every old `--changed-since` spelling (split + inline), the base group rejecting `--changed-only`/`--lab-changed-files-json`, the conflict in both orders, `resolve()` precedence and malformed-payload rejection, every `--format`/`--detail` value, and the mutation polarity invariant.
- Manually audited every `MutationArgs` site for a sibling `dry_run` in the same variant — none collide (the nearby `dry_run` fields are all in different variants or in `Serialize` output structs).
- Per the VPS build constraint no binary was built, so `homeboy <cmd> --help` was not run. clap's `debug_assert` runs on any `Cli::try_parse_from` from the root, and the suite has many such tests, so CI validates the assembled tree.

**Follow-up:** the checked-in CLI reference under `docs/reference/cli/` is now stale for the added `--dry-run` flags. It is a generator, not a gate (`cli_reference_docs_regenerate_on_demand` asserts nothing without `HOMEBOY_WRITE_CLI_REFERENCE`, and `checked_in_contract_matches_reference_docs` compares two checked-in artifacts to each other), so nothing fails. Regenerate with `HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib cli_surface::reference_docs`.

Touched no files under `crates/contracts/`, `command_contract/`, or `resource_policy/` — clear of the three sibling PRs.
