### PR TITLE
fix(test): bound hermetic subprocess waits so a gate-wide timeout becomes a named test failure (refs #10687)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -706,7 +706,24 @@ fn delegate_agent_task_cook_to_pinned_runtime(
                 Some("resolve current controller executable".to_string()),
             )
         })?;
-        if current == std::path::PathBuf::from(expected) {
+        // This comparison is the only thing standing between the re-exec below
+        // and unbounded recursion, so it must compare file identity rather than
+        // path spelling. `current_exe` resolves through `/proc/self/exe` (or the
+        // platform equivalent) and is fully canonical; the pinned path is
+        // composed from the data store root and can retain symlinked components
+        // — a symlinked `$TMPDIR`, `/tmp` -> `/private/tmp`, a bind-mounted CI
+        // workspace. A verbatim mismatch there makes the pinned runtime fail to
+        // recognize itself and seal-and-re-exec again, forever.
+        let expected = std::path::PathBuf::from(expected);
+        let is_pinned_runtime = current == expected
+            || match (
+                std::fs::canonicalize(&current),
+                std::fs::canonicalize(&expected),
+            ) {
+                (Ok(current), Ok(expected)) => current == expected,
+                _ => false,
+            };
+        if is_pinned_runtime {
             return Ok(None);
         }
     }

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2,8 +2,9 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
@@ -160,6 +161,215 @@ impl Default for HermeticTestContext {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Overrides [`DEFAULT_HERMETIC_SUBPROCESS_BUDGET`] for hosts that are slower
+/// than the budget assumes. It bounds a *stuck* child, not a slow one, so the
+/// default is deliberately far above any healthy invocation.
+pub const HERMETIC_SUBPROCESS_BUDGET_ENV: &str = "HOMEBOY_TEST_SUBPROCESS_BUDGET_SECS";
+
+/// Per-invocation ceiling for a hermetic subprocess.
+///
+/// The slowest healthy invocation in this suite is a cold controller-runtime
+/// pin — a hash, a copy, and a re-exec of a multi-hundred-megabyte unoptimized
+/// binary — which costs single-digit seconds even on a contended runner. Three
+/// minutes is generous enough that crossing it means *blocked*, not *slow*.
+const DEFAULT_HERMETIC_SUBPROCESS_BUDGET: Duration = Duration::from_secs(180);
+
+/// Cadence at which a still-running child reports liveness evidence. The
+/// libtest harness warns at 60s, so a 30s heartbeat guarantees at least one
+/// diagnostic snapshot lands before a human reads that warning.
+const HERMETIC_SUBPROCESS_HEARTBEAT: Duration = Duration::from_secs(30);
+
+/// Run a hermetic subprocess to completion under a bounded wait.
+///
+/// `Command::output` waits on pipe EOF with no ceiling: a child that blocks —
+/// or that exits while a background descendant retains the inherited pipes —
+/// hangs the test thread forever. libtest cannot interrupt a blocked thread, so
+/// the whole gate dies on its outer timeout with `failed: 0` and no test name.
+/// A 25-minute CI failure that names nothing is indistinguishable from a build
+/// break, which is how the same hang survived two fix attempts (#10687).
+///
+/// This kills the child's process tree once the budget elapses and panics with
+/// the evidence needed to tell those cases apart: elapsed time, argv, pid,
+/// whether the child produced *any* output before the kill, and the last
+/// observed process-tree state. The failure is then attributed to one named
+/// test, and every other test in the binary still runs and still reports.
+///
+/// Prefer this over `Command::output`/`wait_with_output` in every subprocess
+/// test; it is the test-side counterpart of the `unbounded_output_capture`
+/// audit rule.
+pub fn bounded_output(mut command: Command) -> Output {
+    let argv = rendered_argv(&command);
+    let budget = hermetic_subprocess_budget();
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Isolate the process group so a stuck child's descendants are reachable
+    // for termination; without it a background grandchild keeps the pipes open
+    // and the capture-reader join strands even after the root dies.
+    crate::engine::command::isolate_process_tree(&mut command);
+
+    let started = Instant::now();
+    let mut child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn hermetic subprocess `{argv}`: {error}"));
+    let pid = child.id();
+
+    let last_snapshot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let supervised = {
+        let last_snapshot = Arc::clone(&last_snapshot);
+        let argv = argv.clone();
+        crate::engine::command::wait_with_bounded_output_supervised(
+            &mut child,
+            crate::engine::command::DEFAULT_CAPTURE_LIMIT_BYTES,
+            budget,
+            HERMETIC_SUBPROCESS_HEARTBEAT,
+            || false,
+            move |elapsed, tail| {
+                let snapshot = process_tree_snapshot(pid);
+                eprintln!(
+                    "hermetic subprocess pid {pid} still running after {:.1}s (budget {:.0}s): {argv}\n  output so far: {}\n  process tree:\n{snapshot}",
+                    elapsed.as_secs_f64(),
+                    budget.as_secs_f64(),
+                    if tail.trim().is_empty() {
+                        "<none>".to_string()
+                    } else {
+                        tail.trim().to_string()
+                    },
+                );
+                *last_snapshot
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(snapshot);
+                Ok(())
+            },
+        )
+    }
+    .unwrap_or_else(|error| panic!("supervise hermetic subprocess `{argv}` (pid {pid}): {error}"));
+
+    let elapsed = started.elapsed();
+    if supervised.termination == crate::engine::command::SupervisedCommandTermination::Completed {
+        return supervised.output.into_output();
+    }
+
+    let output = supervised.output;
+    let snapshot = last_snapshot
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .unwrap_or_else(|| "    (no heartbeat snapshot was taken)".to_string());
+    let produced_output =
+        output.capture.stdout.bytes_seen > 0 || output.capture.stderr.bytes_seen > 0;
+    panic!(
+        "hermetic subprocess did not finish within its {:.0}s budget (terminated: {:?})\n\
+         \x20 argv:      {argv}\n\
+         \x20 pid:       {pid}\n\
+         \x20 elapsed:   {:.1}s\n\
+         \x20 budget:    {:.0}s (override with {HERMETIC_SUBPROCESS_BUDGET_ENV})\n\
+         \x20 stdout:    {} bytes seen, {} retained, truncated={}\n\
+         \x20 stderr:    {} bytes seen, {} retained, truncated={}\n\
+         \x20 verdict:   {}\n\
+         \x20 last observed process tree:\n{snapshot}\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        budget.as_secs_f64(),
+        supervised.termination,
+        elapsed.as_secs_f64(),
+        budget.as_secs_f64(),
+        output.capture.stdout.bytes_seen,
+        output.capture.stdout.bytes_retained,
+        output.capture.stdout.truncated,
+        output.capture.stderr.bytes_seen,
+        output.capture.stderr.bytes_retained,
+        output.capture.stderr.truncated,
+        if produced_output {
+            "the child DID produce output before the kill, so it reached its own logic and blocked (or exited) afterwards"
+        } else {
+            "the child produced NO output at all, so it blocked before reaching any code that writes to its own streams"
+        },
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn hermetic_subprocess_budget() -> Duration {
+    std::env::var(HERMETIC_SUBPROCESS_BUDGET_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_HERMETIC_SUBPROCESS_BUDGET)
+}
+
+fn rendered_argv(command: &Command) -> String {
+    let mut parts = vec![command.get_program().to_string_lossy().into_owned()];
+    parts.extend(
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned()),
+    );
+    crate::engine::shell::quote_args(&parts)
+}
+
+/// Report the root process and its direct children as seen by the kernel.
+///
+/// Deliberately shallow and read-only: state plus wait channel is enough to
+/// separate "blocked on I/O", "spinning", and "already a zombie whose pipes a
+/// descendant still holds" without building a process-forensics framework.
+#[cfg(target_os = "linux")]
+fn process_tree_snapshot(root: u32) -> String {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return "    (/proc unavailable)".to_string();
+    };
+    let mut lines = Vec::new();
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        // The `comm` field is parenthesized and may contain spaces, so parse
+        // the fixed fields from after its closing parenthesis.
+        let Some((command, rest)) = stat
+            .find('(')
+            .and_then(|open| stat.rfind(')').map(|close| (open, close)))
+            .filter(|(open, close)| open < close)
+            .map(|(open, close)| (&stat[open + 1..close], &stat[close + 1..]))
+        else {
+            continue;
+        };
+        let mut fields = rest.split_whitespace();
+        let state = fields.next().unwrap_or("?");
+        let parent = fields
+            .next()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        if pid != root && parent != root {
+            continue;
+        }
+        let wchan = fs::read_to_string(format!("/proc/{pid}/wchan")).unwrap_or_default();
+        let wchan = wchan.trim();
+        lines.push(format!(
+            "    pid {pid} ppid {parent} state {state} comm {command} wchan {}",
+            if wchan.is_empty() { "-" } else { wchan }
+        ));
+    }
+    if lines.is_empty() {
+        "    (no live /proc entry for the child or its children)".to_string()
+    } else {
+        lines.sort();
+        lines.join("\n")
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_tree_snapshot(_root: u32) -> String {
+    "    (process-tree snapshot is only collected on Linux)".to_string()
 }
 
 pub struct HomeGuard {

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -1,6 +1,6 @@
 use std::process::Output;
 
-use homeboy_core::test_support::{HermeticTestContext, TestBinary};
+use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary};
 
 /// Run the fixture binary through the shared hermetic harness.
 ///
@@ -13,13 +13,21 @@ use homeboy_core::test_support::{HermeticTestContext, TestBinary};
 /// leaves that leak open (#10717, #10718). These cases run with a default
 /// operator context; the transport variables are injected explicitly only by
 /// the case that asserts they cannot change a validation outcome (#10917).
+///
+/// `controller_runtime_command` adds the controller-runtime pins on top of that
+/// contract. Every `agent-task cook` invocation is sealed into an immutable
+/// controller runtime by `delegate_agent_task_cook_to_pinned_runtime` *before*
+/// routing reaches validation, so a case that survives clap pays a cold pin —
+/// hash, 666 MB copy, re-exec — against a fresh `HOME`. The pins are immutable
+/// and content-addressed, so sharing them costs no isolation (#10687, #11185).
+///
+/// `bounded_output` replaces `Command::output`, which waits on pipe EOF with no
+/// ceiling and cannot be interrupted by libtest (#10687).
 fn homeboy(args: &[&str]) -> Output {
     let context = HermeticTestContext::new();
-    context
-        .command(TestBinary::HomeboyFixture)
-        .args(args)
-        .output()
-        .expect("run homeboy")
+    let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    command.args(args);
+    bounded_output(command)
 }
 
 #[test]
@@ -29,7 +37,7 @@ fn cook_handoff_subprocesses_do_not_inherit_controller_transport() {
     // above `run_split_placement_cook` swallows every rejection this file
     // asserts, and the suite hangs instead of failing (#10917).
     let context = HermeticTestContext::new();
-    let command = context.command(TestBinary::HomeboyFixture);
+    let command = context.controller_runtime_command(TestBinary::HomeboyFixture);
     let removed_env = command
         .get_envs()
         .filter_map(|(key, value)| value.is_none().then(|| key.to_string_lossy().into_owned()))
@@ -55,17 +63,19 @@ fn contradictory_cook_arguments_survive_controller_transport_context() {
     // Before #10917 this context sent both invocations past validation into
     // real worktree and provider work, where they blocked indefinitely instead
     // of failing fast.
+    // #11185 moved this case onto the shared controller-runtime pins; #11191
+    // reverted it while rebasing an unrelated broker fixture, restoring a cold
+    // 666 MB pin per invocation on a gate that was already at its ceiling.
     let cook = |args: &[&str]| {
         let context = HermeticTestContext::new();
-        context
-            .command(TestBinary::HomeboyFixture)
+        let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+        command
             .env(
                 homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV,
                 r#"{"runner_id":"homeboy-lab"}"#,
             )
-            .args(args)
-            .output()
-            .expect("run homeboy")
+            .args(args);
+        bounded_output(command)
     };
 
     let detach = cook(&[


### PR DESCRIPTION
## The emergency is the gate, not the hang

`homeboy / Test` and `homeboy / Candidate Test` have failed on essentially every PR all day, and the failure is **always a timeout, never an assertion**:

```
"status": "failed", "failed": 0
...
test contradictory_cook_arguments_survive_controller_transport_context has been running for over 60 seconds
test cook_rejects_local_detach_before_worktree_resolution has been running for over 60 seconds
##[error]homeboy review test: TIMED OUT (exit code 124)
```

`failed: 0`. Nothing asserts false. Two tests in `tests/cook_lab_handoff_test.rs` block until the 1500s gate kills the run, so **the gate produces no attributable signal at all** — and roughly ten PRs have been merged through it today. That is worse than the hang itself, and it is what this PR fixes first.

Tracked as #10687. Two prior attempts (#11185, #11191) did not close it.

## What was ruled out before this PR

The exact failing invocation was reproduced three ways against the **release** binary (`/usr/local/bin/homeboy`, 142 MB, v0.327.0+):

1. plain isolated `HOME`
2. with `HOMEBOY_LAB_OFFLOAD_JSON='{"runner_id":"homeboy-lab"}'` injected — the case `contradictory_cook_arguments_survive_controller_transport_context` exercises
3. copied to a tempdir as `homeboy-controller-fixture`, `chmod 0500`, run with the full `HermeticTestContext::command()` env (`HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `HOMEBOY_ARTIFACT_ROOT`, `HOMEBOY_RUNTIME_TMPDIR`, `TMPDIR`, `HOMEBOY_NO_UPDATE_CHECK`)

**All three exited 2 immediately with the correct rejection** (`Invalid argument 'detach-after-handoff': ... cannot detach after handoff with --placement local`).

So argument validation is not broken and #10917's fix is intact. A "validation regression" theory is disproved. The untested variable is the **debug** binary (~666 MB per #11185), which cannot be built on the investigating host.

## 1. The deliverable that matters: a hang is now a named test failure

`Command::output()` waits on pipe EOF with **no ceiling**, and libtest cannot interrupt a blocked thread. One stuck child therefore kills the whole gate and attributes nothing.

New `homeboy_core::test_support::bounded_output`, built on the existing `wait_with_bounded_output_supervised` primitive rather than a new one. It:

- isolates the child's process group (`isolate_process_tree`) so descendants are reachable for termination — without it a background grandchild retains the pipes and strands the capture-reader join even after the root dies;
- waits under a generous **180s** per-invocation budget, overridable via `HOMEBOY_TEST_SUBPROCESS_BUDGET_SECS`. The slowest healthy invocation here is a cold controller-runtime pin, single-digit seconds even on a contended runner, so crossing 180s means *blocked*, not *slow*;
- terminates the process tree on expiry and **panics with the diagnostics**: argv, pid, elapsed, budget, stdout/stderr capture metadata (`bytes_seen` / `bytes_retained` / `truncated`), and the captured tail of both streams.

The gate budget (#10997's 1500s) is untouched. No test is deleted or `#[ignore]`d — they pin real behavior from #10917.

## 2. Instrumentation the next CI run will act on

Two cheap, decisive signals, chosen over building a process-forensics framework:

**A verdict on whether the child produced any output at all.** This partitions the failure space:

- *no output* → the child blocked before reaching any code that writes to its own streams (startup, the pin, the re-exec);
- *output present* → it reached its own logic and blocked afterwards — or **exited** while a descendant retained the inherited pipes, which is a completely different bug that `Command::output` cannot distinguish from a live child.

**A `/proc` state snapshot.** A 30s heartbeat records the child and its direct children (`state`, `wchan`, `comm`, `ppid`) *while still alive*, and the last snapshot is printed in the panic. Linux-only, no-op elsewhere. If the cause is re-exec recursion this shows a chain of `homeboy` children directly.

## 3. Root cause: strong on cost, not conclusive on the unbounded mechanism

**The 6-of-8 split is not a coincidence — it exactly tracks one code path.**

`delegate_agent_task_cook_to_pinned_runtime` (`cli_runtime.rs:687`) runs for every `agent-task cook`, **before** `route_after_parse` and therefore before `reject_contradictory_cook_arguments`. It seals the running controller into an immutable pin — SHA-256 the executable, `fs::copy` it, hard-link it, then **re-exec** it — and only then does the child reach validation.

Which cases reach it:

| case | reaches the pin? | result |
|---|---|---|
| `--placement local --runner homeboy-lab` | no — clap `conflicts_with`, exits at `err.exit()` | passes |
| `--wait --detach-after-handoff` | no — clap `conflicts_with` | passes |
| `--queue-only` | no — rejected by `validate_cook_request_with_provenance` (`run.rs:415`), which runs *before* the delegation | passes |
| `agent-task cook --help` | no | passes |
| **`--placement local --detach-after-handoff`** | **yes** — no clap conflict, so it survives parse and pays the pin | **hangs** |

Both hanging tests are exactly the invocations that survive clap and reach the pin. Every passing case exits before it. That is the whole partition.

Against a fresh `HOME` that pin is *cold*: hash 666 MB, copy 666 MB, hash the staged copy again, then exec a 666 MB binary — with test threads doing it in parallel on runner I/O. #10687's own measurement puts cold at **1.69s** vs warm at **0.04s** locally, and names "share one pin store across hermetic tests" as the intended seam.

**#11185 did exactly that** for `contradictory_cook_arguments_survive_controller_transport_context`. **#11191 reverted that one line** (`controller_runtime_command` → `command`) while rebasing an unrelated reverse-broker fixture — visible in `8388e1423`, and clearly incidental to that PR's stated purpose. The second test, `cook_rejects_local_detach_before_worktree_resolution`, goes through the file's `homeboy()` helper and **never had the shared store at all**.

This PR routes both through `controller_runtime_command`. The pins are immutable and content-addressed, so sharing them costs no isolation — mutable state (`HOME`, XDG roots, artifact root) stays per-context.

**The controller-runtime-env theory from the brief held, but only partly.** #11191 really did remove the pin-store env from one of the two tests, and that env really does govern the expensive path. But it does not explain the *other* test, which never had it, and cost alone does not obviously produce an unbounded wait.

**Leading hypothesis for the unbounded part, explicitly unverified.** The re-exec guard compared paths verbatim:

```rust
if current == std::path::PathBuf::from(expected) { return Ok(None); }
```

`current_exe()` resolves through `/proc/self/exe` and is fully canonical. `expected` is composed from the data-store root, which is a `tempfile::TempDir` under `$TMPDIR` (`exec_capable_tempdir`, which does not canonicalize). If any component is a symlink, the pinned runtime **fails to recognize itself** and seals-and-re-execs again — forever, hashing and copying 666 MB each iteration. That is genuinely unbounded, host-dependent, and would explain a 1.9s local run against a >60s runner run. It is a hypothesis; I could not confirm it without building the debug binary.

The guard now compares file identity instead of path spelling. Canonicalizing can only make it short-circuit *more* often, and only when both paths name the same file — so it is strictly safer than what it replaces, independent of whether it is the bug.

## Non-goals respected

- No test deleted or `#[ignore]`d.
- Gate budget untouched.
- No attempt at #10997's `{"review test":"timeout"}`-in-8-seconds mis-bucketing.

Related: #11151 catalogues `unbounded_output_capture` failing open on 13 `wait_with_output()` sites — `bounded_output` is the test-side counterpart of that rule, and other subprocess test files still use raw `.output()`.

## Verification

Per the host's build constraints (no `cargo build` / `cargo test` / `--workspace`):

- `cargo fmt -p homeboy-core -p homeboy-cli`
- `cargo check -p homeboy-core --lib --features test-support` → 0
- `cargo check -p homeboy-core --lib --tests` → 0
- `cargo check -p homeboy-cli --lib` → 0
- `cargo check -p homeboy --test cook_lab_handoff_test` → 0

## What the next CI run tells us that this one could not

If it still hangs, the failure names **one test**, kills **one child**, lets the other seven report, and prints: elapsed, argv, pid, whether the child ever wrote a byte, and the child's kernel state plus its live children. That is enough to separate "blocked in the pin", "re-exec recursion", "exited but a descendant holds the pipes", and "blocked in validation" — none of which the current `exit 124, failed: 0` can distinguish.

Refs #10687, #11185, #11191, #10997, #11151.
