### PR TITLE
fix(test): bound the scheduler suite's spin-waits so a stall names a test

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/cancellation.rs
@@ -41,9 +41,9 @@ mod cancellation_tests {
         let worker_token = token.clone();
 
         let handle = thread::spawn(move || scheduler.run_with_cancellation(plan, worker_token));
-        while running.load(Ordering::SeqCst) == 0 {
-            thread::sleep(Duration::from_millis(1));
-        }
+        wait_until("the first task to start running", || {
+            running.load(Ordering::SeqCst) != 0
+        });
         token.cancel();
         let aggregate = handle.join().expect("scheduler thread");
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -566,9 +566,9 @@ pub(super) mod concurrency_tests {
         let started = Instant::now();
         let aggregate = scheduler.run(plan);
         assert!(started.elapsed() < Duration::from_secs(2));
-        while !finished.load(Ordering::SeqCst) {
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        wait_until("the late-mutating executor to finish", || {
+            finished.load(Ordering::SeqCst)
+        });
         let scratch_root = scratch_roots.lock().expect("scratch roots")[0].clone();
         let run_id = scratch_root
             .ancestors()

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/shared.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/shared.rs
@@ -119,3 +119,33 @@ impl AgentTaskExecutorAdapter for GenericChildRunExecutor {
         }
     }
 }
+
+/// Spin until `ready` reports true, or panic naming the condition.
+///
+/// These suites coordinate with executor threads through atomics, and the
+/// obvious spelling — `while !flag.load(..) { sleep(..) }` — has no exit. When
+/// the executor never reaches the state the test is waiting for, the loop
+/// spins until the 1500s CI budget kills the entire test phase, which reports
+/// `exit 124` with `failed: 0` and no test name. Every gate on every pull
+/// request then says the same uninformative thing, and the suite that actually
+/// broke is invisible (#10687).
+///
+/// Bounding the wait converts that into one named failing test, which is the
+/// same contract `bounded_output` gives hermetic subprocesses (#11234).
+pub(super) fn wait_until(label: &str, ready: impl Fn() -> bool) {
+    // Generous: these waits gate on real thread scheduling and git fixtures,
+    // so the budget only has to be short enough to beat the CI phase timeout.
+    const BUDGET: Duration = Duration::from_secs(60);
+    const POLL: Duration = Duration::from_millis(2);
+
+    let started = Instant::now();
+    while !ready() {
+        assert!(
+            started.elapsed() < BUDGET,
+            "timed out after {:?} waiting for {label}; the scheduler never reached this state, \
+             so the condition is either unreachable or slower than the budget",
+            started.elapsed()
+        );
+        thread::sleep(POLL);
+    }
+}


### PR DESCRIPTION
Refs #10687. Direct follow-up to #11234 — same defect, one layer in.

## What #11234 already bought us

It bounded hermetic **subprocess** waits. The two tests it targeted now pass:

```
test contradictory_cook_arguments_survive_controller_transport_context ... ok
test cook_rejects_local_detach_before_worktree_resolution ... ok
```

But the gate still timed out at 1500s — **and for the first time it told us what was hanging**:

```
test agent_task_scheduler::tests::scheduling_tests::concurrency::concurrency_tests::
     timeout_quarantines_only_its_workspace_without_starving_unrelated_work
     has been running for over 60 seconds
```

That is #11234 working exactly as designed. It converted an anonymous phase timeout into a named suspect.

## The same defect, in-process

`concurrency.rs:569`:
```rust
while !finished.load(Ordering::SeqCst) {
    std::thread::sleep(Duration::from_millis(2));
}
```

No exit. If the executor never reaches the awaited state the loop spins until the 1500s budget kills the whole phase, which reports `exit 124` with `failed: 0` and no test name.

`cancellation.rs:44` has the same shape (`while running.load(..) == 0`).

## Why this matters beyond one test

**Every gate on every PR has been uninformative all day, and ~10 PRs merged through it** — including the consolidation work in #11230/#11231/#11232/#11233. A gate that always fails for an unattributable reason trains everyone to route around it, which is the same failure mode as a gate that always passes (#11093, #10741).

## The change

Adds `wait_until(label, ready)` to the scheduler suite prelude, with a 60s budget, and routes both waits through it. A stall now produces one named failing test carrying the condition it waited for and how long — the same contract `bounded_output` gives subprocesses.

Deliberately left alone: `preview_client/mod.rs:92`, `worker/run.rs:88`, `connection_stop_transport_recovery.rs:744`, `artifact_dom_boxes.rs:167`, `local_exec.rs:358,395`, `test_support.rs:1215`, `reverse_cook_queue_acceptance.rs:35`. Those are server/worker loops that run *until an external stopper flips the flag*, not waits for a condition. Note `preview_client/mod.rs:185` already carries a deadline — that is the correct pattern and the precedent this follows.

## What this does and does not do

It does **not** explain why the scheduler stalls. It makes the stall **attributable**, so the next run points at a specific test with a specific unmet condition instead of killing the phase anonymously.

Verified: `cargo fmt -p homeboy-agents`; `cargo check -p homeboy-agents --lib --tests -j 2` exit 0, no new warnings.

Found during the 2026-08-01 consolidation investigation (#11151). See also #11185, #11191, #10997.