### PR TITLE
Make policy denials terminal and interruption recovery durable

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1421,6 +1421,7 @@ impl AgentTaskScheduleSupport {
             && retry_budget_total
                 .map(|budget| retry_budget_used < budget)
                 .unwrap_or(true)
+            && outcome.failure_classification != Some(AgentTaskFailureClassification::PolicyDenied)
             && (retryable_failure_classifications.is_empty()
                 || outcome
                     .failure_classification

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -344,6 +344,33 @@ fn incomplete_empty_executor_result_fails_when_retries_are_unavailable() {
 }
 
 #[test]
+fn policy_denial_is_terminal_even_when_retry_policy_matches_every_failure() {
+    let mut denied = outcome("policy-denied".to_string(), AgentTaskOutcomeStatus::Failed);
+    denied.failure_classification = Some(AgentTaskFailureClassification::PolicyDenied);
+
+    assert!(!AgentTaskScheduleSupport::should_retry(
+        &denied,
+        1,
+        2,
+        3,
+        3,
+        None,
+        0,
+        &[],
+    ));
+    assert!(!AgentTaskScheduleSupport::should_retry(
+        &denied,
+        1,
+        2,
+        3,
+        3,
+        None,
+        0,
+        &[AgentTaskFailureClassification::PolicyDenied],
+    ));
+}
+
+#[test]
 fn incomplete_nested_outputs_provider_result_is_detected() {
     // Mirrors a provider wrapper shape: the provider claims
     // top-level success/completed, but `outputs.completed` is false, the reply


### PR DESCRIPTION
## Summary
- prevent `PolicyDenied` outcomes from consuming scheduler retry budgets
- keep denials terminal under unrestricted and explicitly matching retry policies
- materialize pre-artifact interruption successors before publishing their durable claim
- reuse an already-recorded successor identity after restart

## Verification
- `cargo test -p homeboy-agents policy_denial_is_terminal_even_when_retry_policy_matches_every_failure`
- `cargo test -p homeboy-agents revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_checkout`
- `cargo test -p homeboy-agents pre_artifact_interruption_claim_is_restart_and_concurrent_controller_idempotent`
- `cargo fmt --check`
- `git diff --check`

The broader scheduler slice passed 81/85 tests. Four existing lifecycle/scratch tests failed both parallel and serial due missing durable run records or deferred cleanup, outside these changes.

Closes #11237
Closes #11248

## AI assistance
OpenAI gpt-5.6-sol via OpenCode implemented the retry and durable interruption-recovery repairs with regression coverage. Chris Huber reviewed the result and remains responsible for every line.