### PR TITLE
Gate hot-controller fallback independently of placement

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/placement.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/placement.rs
@@ -31,6 +31,13 @@ impl Default for Placement {
 }
 
 impl Placement {
+    /// Explicit operator authorization to execute on the controller despite
+    /// resource admission. This is distinct from permitting a local fallback
+    /// after a Lab attempt.
+    pub const fn is_explicit_local_override(self) -> bool {
+        matches!(self, Self::Local)
+    }
+
     /// Explicitly permit controller execution when an intended Lab offload
     /// cannot proceed. `Auto` retains the existing default routing behavior.
     pub const fn allows_local_fallback(self) -> bool {
@@ -97,6 +104,22 @@ mod tests {
                 placement.allows_local_fallback(),
                 allows_fallback,
                 "{placement:?} allows_local_fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn only_local_is_an_explicit_controller_override() {
+        for (placement, explicit_local_override) in [
+            (Placement::Auto, false),
+            (Placement::Local, true),
+            (Placement::Lab, false),
+            (Placement::LabOrLocal, false),
+        ] {
+            assert_eq!(
+                placement.is_explicit_local_override(),
+                explicit_local_override,
+                "{placement:?} explicit local override"
             );
         }
     }

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1412,7 +1412,7 @@ fn preflight_hot_command(
                     } else {
                         warning.as_ref()
                     },
-                    matches!(cli.placement, crate::cli_surface::Placement::Local),
+                    cli.placement.is_explicit_local_override(),
                     lab_readiness.as_ref(),
                     runner_hosted,
                 );
@@ -1427,7 +1427,7 @@ fn preflight_hot_command(
             if let Some(warning) = warning.as_ref() {
                 if let Some(err) = resource_policy::non_interactive_preflight_error(
                     warning,
-                    !matches!(cli.placement, crate::cli_surface::Placement::Auto) || runner_hosted,
+                    cli.placement.is_explicit_local_override() || runner_hosted,
                     is_interactive_shell(),
                     resource_policy::rerun_command(
                         hot_command,

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -3151,6 +3151,59 @@ fn lab_or_local_placement_still_falls_back_without_a_runner() {
     );
 }
 
+#[test]
+fn cold_lab_or_local_records_an_admitted_local_fallback() {
+    let source = tempfile::tempdir().expect("source workspace");
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab-or-local",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@wave",
+        "--verify",
+        "true",
+        "--prompt",
+        "fall back locally when admitted",
+    ]);
+
+    let decision = placement_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
+        .expect("cold controller may select local fallback");
+
+    assert!(decision.permits_local_execution());
+    assert!(decision.fallback.local_allowed);
+    assert!(!decision.override_authorization.authorized);
+}
+
+#[test]
+fn explicit_local_placement_records_audited_override_authorization() {
+    let source = tempfile::tempdir().expect("source workspace");
+    let cli = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "local",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@wave",
+        "--verify",
+        "true",
+        "--prompt",
+        "run locally with operator authorization",
+    ]);
+
+    let decision = placement_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
+        .expect("explicit local placement resolves");
+
+    assert!(decision.permits_local_execution());
+    assert!(decision.override_authorization.authorized);
+    assert_eq!(
+        decision.override_authorization.authority.as_deref(),
+        Some("operator --placement local")
+    );
+}
+
 /// Batch fanout is the documented one-command path for a wave, so it resolves
 /// Lab placement through the same contract as a single cook.
 #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -1410,6 +1410,40 @@ mod tests {
     }
 
     #[test]
+    fn hot_lab_or_local_requires_admission_before_local_fallback() {
+        let _lock = env_lock();
+        let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
+        let placement = crate::cli_surface::Placement::LabOrLocal;
+        let disconnected = LabRunnerReadiness {
+            state: crate::runner::runners::LabRunnerReadinessState::Disconnected,
+            selected_runner_id: None,
+            available_runner_ids: Vec::new(),
+            reasons: vec!["runner is disconnected".to_string()],
+            remediation_commands: vec!["homeboy runner connect homeboy-lab".to_string()],
+        };
+        let warning = evaluate_with_runner_hint(
+            lab_supported_hot("agent-task cook/run-plan/retry --run"),
+            &resources(ResourceRecommendation::Hot),
+            Some(&disconnected),
+        )
+        .expect("hot controller warns");
+
+        let error = non_interactive_preflight_error(
+            &warning,
+            placement.is_explicit_local_override(),
+            false,
+            None,
+            false,
+        )
+        .expect("hot lab-or-local must stop before routing can dispatch a provider");
+
+        assert!(error.message.contains("homeboy runner connect homeboy-lab"));
+        assert!(error
+            .message
+            .contains("explicit, authorized `--placement local` override"));
+    }
+
+    #[test]
     fn runner_hosted_exec_does_not_fail_non_interactive_preflight() {
         let _lock = env_lock();
         let _guard = EnvVarGuard::set(crate::runner::RUNNER_HOSTED_EXEC_ENV, "1");


### PR DESCRIPTION
Closes #11226.

## Summary

- distinguish permission to fall back locally from explicit hot-controller override authorization
- treat only `--placement local` as the audited resource-admission override
- prevent `lab-or-local` from dispatching locally when Lab is disconnected and the controller is hot
- retain admitted fallback on a cold controller and preserve explicit local override evidence

## Verification

- focused `lab_or_local` CLI routing tests
- explicit local override authorization test
- placement contract test
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol traced the hot fallback through placement and resource preflight, implemented the typed override distinction, added deterministic admission/routing coverage, ran focused tests, and drafted this PR. Chris Huber remains responsible for every line.