### PR TITLE
Derive issue-owned worktrees for Cook

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -111,6 +111,7 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
+                    task_url: None,
                 }),
             },
         );

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -203,6 +203,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
                 dirty: "$.safety.dirty".to_string(),
                 unpushed: "$.safety.unpushed".to_string(),
                 primary: "$.safety.primary".to_string(),
+                task_url: None,
             }),
         },
     );
@@ -304,6 +305,7 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
                 dirty: "$.safety.dirty".to_string(),
                 unpushed: "$.safety.unpushed".to_string(),
                 primary: "$.safety.primary".to_string(),
+                task_url: None,
             }),
         },
     );

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -199,6 +199,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
                 dirty: "$.safety.dirty".to_string(),
                 unpushed: "$.safety.unpushed".to_string(),
                 primary: "$.safety.primary".to_string(),
+                task_url: None,
             }),
         },
     );

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5971,6 +5971,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -306,6 +306,49 @@ mod tests {
         };
         assert!(error.to_string().contains("cannot be used with"));
     }
+
+    #[test]
+    fn cook_accepts_issue_backed_destination_derivation_and_explicit_override() {
+        let derived = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the issue",
+            "--repo",
+            "homeboy",
+            "--task-url",
+            "https://github.com/Extra-Chill/homeboy/issues/11225",
+            "--no-finalize",
+        ])
+        .expect("issue-backed Cook parses without an explicit destination");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = derived.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(derived) = agent_task.command else {
+            panic!("Cook command");
+        };
+        assert_eq!(derived.to_worktree, None);
+
+        let explicit = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the issue",
+            "--to-worktree",
+            "homeboy@existing",
+            "--no-finalize",
+        ])
+        .expect("explicit Cook destination parses");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = explicit.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(explicit) = agent_task.command else {
+            panic!("Cook command");
+        };
+        assert_eq!(explicit.to_worktree.as_deref(), Some("homeboy@existing"));
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -326,11 +369,10 @@ pub struct AgentTaskCookArgs {
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,
     /// Workspace handle the cook edits, verifies, and finalizes into (e.g.
-    /// `repo@branch-slug`). Existing destinations are reused. A missing managed
-    /// destination is created through its configured provider when --repo,
-    /// --base, --head, and --task-url declare explicit intent.
+    /// `repo@branch-slug`). When omitted, --repo plus --task-url derives an
+    /// issue-owned destination through the configured workspace provider.
     #[arg(long, value_name = "HANDLE")]
-    pub to_worktree: String,
+    pub to_worktree: Option<String>,
     #[arg(
         long,
         value_name = "COMMAND",

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -80,6 +80,7 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
 }
 
 pub(crate) fn run_cook(args: AgentTaskCookArgs) -> CmdResult<Value> {
+    let args = resolve_cook_destination(args)?;
     validate_cook_request(&args)?;
     run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
 }
@@ -250,12 +251,13 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
 /// Converge a Cook promotion destination before compiling a task plan. This is
 /// controller-owned so local and Lab dispatch use the same managed checkout.
 pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<Value> {
-    let direct_path = Path::new(&args.to_worktree);
+    let to_worktree = args
+        .to_worktree
+        .as_deref()
+        .expect("Cook destination is resolved before provisioning");
+    let direct_path = Path::new(to_worktree);
     if direct_path.is_dir() {
-        homeboy::core::worktree_providers::validate_task_worktree_root(
-            direct_path,
-            &args.to_worktree,
-        )?;
+        homeboy::core::worktree_providers::validate_task_worktree_root(direct_path, to_worktree)?;
         let path = std::fs::canonicalize(direct_path).map_err(|error| {
             homeboy::core::Error::internal_io(
                 error.to_string(),
@@ -265,13 +267,11 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         return Ok(serde_json::json!({
             "action": "existing",
             "kind": "direct_task_worktree",
-            "handle": args.to_worktree,
+            "handle": to_worktree,
             "path": path,
         }));
     }
-    if let Some(record) =
-        homeboy::core::worktree::resolve_workspace_ref_if_present(&args.to_worktree)?
-    {
+    if let Some(record) = homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)? {
         if record.state() != &homeboy::core::worktree::TaskWorktreeState::Active {
             return Err(homeboy::core::Error::validation_invalid_argument(
                 "to_worktree",
@@ -279,27 +279,27 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                     "Homeboy workspace `{}` is no longer active",
                     record.handle()
                 ),
-                Some(args.to_worktree.clone()),
+                Some(to_worktree.to_string()),
                 None,
             ));
         }
         let path = PathBuf::from(record.path());
-        homeboy::core::worktree_providers::validate_task_worktree_root(&path, &args.to_worktree)?;
+        homeboy::core::worktree_providers::validate_task_worktree_root(&path, to_worktree)?;
         return Ok(
-            serde_json::json!({ "action": "existing", "kind": record.source_kind(), "handle": args.to_worktree, "path": path }),
+            serde_json::json!({ "action": "existing", "kind": record.source_kind(), "handle": to_worktree, "path": path }),
         );
     }
 
     let config = defaults::load_config();
     match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-        &args.to_worktree,
+        to_worktree,
         &config,
         None,
     ) {
         Ok(resolution) => {
             homeboy::core::worktree_providers::validate_task_worktree_root(
                 Path::new(&resolution.worktree.path),
-                &args.to_worktree,
+                to_worktree,
             )?;
             return Ok(
                 serde_json::json!({ "action": "existing", "kind": "provider", "provider": resolution.provider_id, "handle": resolution.worktree.handle, "path": resolution.worktree.path, "branch": resolution.worktree.branch }),
@@ -332,7 +332,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     })?;
     provision_apply_enabled_worktree_provider_from_config(
         &WorktreeProviderCreateIntent {
-            handle: args.to_worktree.clone(),
+            handle: to_worktree.to_string(),
             repo,
             base: args.base.clone(),
             head,
@@ -350,6 +350,95 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             "branch": provision.resolution.worktree.branch,
         })
     })
+}
+
+pub(crate) fn resolve_cook_destination(
+    mut args: AgentTaskCookArgs,
+) -> homeboy::core::Result<AgentTaskCookArgs> {
+    if args.to_worktree.is_some() {
+        return Ok(args);
+    }
+    let repo = args.dispatch.repo.as_deref().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--repo <repo> is required when --to-worktree is omitted".to_string(),
+        ])
+    })?;
+    let task_url = args.dispatch.task_url.as_deref().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--task-url <url> is required when --to-worktree is omitted".to_string(),
+        ])
+    })?;
+    let config = defaults::load_config();
+    // DMC's provider mapping currently exposes safety and handle metadata but
+    // not task ownership. In that mode the canonical handle is still resolved
+    // first; its ensure operation must reject a different task-owned worktree.
+    args.to_worktree = Some(match homeboy::core::worktree_providers::find_apply_enabled_worktree_provider_by_task_url_from_config(task_url, &config) {
+        Ok(Some(resolution)) => resolution.worktree.handle,
+        Ok(None) => format!("{repo}@{}", slugify_cook_branch(&derived_cook_branch(task_url)?)),
+        Err(mut error) => {
+            if let Some(handles) = error.message.strip_prefix(&format!("multiple active apply-enabled worktrees are owned by `{task_url}`: ")) {
+                error.details["recovery"] = serde_json::json!(handles.split(", ").map(|handle| format!("homeboy agent-task cook --to-worktree {handle}")).collect::<Vec<_>>());
+            }
+            return Err(error);
+        }
+    });
+    if args.head.is_none() {
+        args.head = Some(derived_cook_branch(task_url)?);
+    }
+    Ok(args)
+}
+
+fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
+    let issue = task_url
+        .trim()
+        .split(|character| matches!(character, '?' | '#'))
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/');
+    let Some((repository, number)) = issue.rsplit_once("/issues/") else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "task_url",
+            "--task-url must be a GitHub issue URL when --to-worktree is omitted",
+            Some(task_url.to_string()),
+            None,
+        ));
+    };
+    let number = number.split('/').next().unwrap_or_default();
+    if number.is_empty() || !number.chars().all(|character| character.is_ascii_digit()) {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "task_url",
+            "--task-url must end in a numeric GitHub issue number when --to-worktree is omitted",
+            Some(task_url.to_string()),
+            None,
+        ));
+    }
+    let mut segments = repository.trim_end_matches('/').rsplit('/');
+    let repo = segments.next().unwrap_or_default();
+    let owner = segments.next().unwrap_or_default();
+    if owner.is_empty() || repo.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "task_url",
+            "--task-url must include a GitHub owner and repo when --to-worktree is omitted",
+            Some(task_url.to_string()),
+            None,
+        ));
+    }
+    Ok(format!("fix/issue-{number}-{}", slugify_cook_branch(repo)))
+}
+
+fn slugify_cook_branch(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_dash = false;
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    slug.trim_matches('-').to_string()
 }
 
 pub(crate) fn record_cook_provision(plan: &mut AgentTaskPlan, provision: Value) {
@@ -507,6 +596,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    let args = resolve_cook_destination(args)?;
     validate_cook_request_with_provenance(&args, provenance)?;
     // Deterministic gates exist to make *publication* safe: a green gate is the
     // proof a cook may commit, push, and open a PR. A `--no-finalize` cook does
@@ -618,7 +708,7 @@ where
             cook_id,
             initial_run_id: run_id,
             initial_plan,
-            to_worktree: args.to_worktree,
+            to_worktree: args.to_worktree.expect("Cook destination is resolved"),
             source_worktree_path,
             provider_command: args.provider_command,
             provider_invocation: (!args.provider_argv.is_empty()).then(|| CommandInvocation {
@@ -807,7 +897,7 @@ pub(crate) fn compile_cook_plan(
         // after provider execution. Keep the compiled task durable and let
         // promotion report its established controlled policy failure.
         Err(error)
-            if request.workspace.as_deref() == Some(args.to_worktree.as_str())
+            if request.workspace.as_deref() == args.to_worktree.as_deref()
                 && error.message.contains(
                     "neither an existing directory nor a resolvable managed worktree handle",
                 ) =>

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -41,6 +41,63 @@ fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
 }
 
 #[test]
+fn cook_derives_issue_destination_and_preserves_explicit_override() {
+    with_isolated_home(|_| {
+        let derived = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the issue".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--task-url".to_string(),
+            "https://github.com/Extra-Chill/homeboy/issues/11225".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("derive Cook destination");
+        assert_eq!(
+            derived.to_worktree.as_deref(),
+            Some("homeboy@fix-issue-11225-homeboy")
+        );
+        assert_eq!(derived.head.as_deref(), Some("fix/issue-11225-homeboy"));
+
+        let suffixed = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the issue".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--task-url".to_string(),
+            "https://github.com/Extra-Chill/homeboy/issues/11225?source=cook#details".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("derive Cook destination from suffixed issue URL");
+        assert_eq!(suffixed.to_worktree, derived.to_worktree);
+        assert_eq!(suffixed.head, derived.head);
+
+        let explicit = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the issue".to_string(),
+            "--to-worktree".to_string(),
+            "homeboy@caller-selected".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("preserve explicit destination");
+        assert_eq!(
+            explicit.to_worktree.as_deref(),
+            Some("homeboy@caller-selected")
+        );
+        assert_eq!(explicit.head, None);
+    });
+}
+
+#[test]
 fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
     with_isolated_home(|_| {
         let cli = Cli::parse_from([
@@ -314,6 +371,7 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },
@@ -417,6 +475,7 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },
@@ -488,6 +547,7 @@ fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_meta
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -200,7 +200,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 attempt_run_id: Some("cook-missing-provider-attempt-1-controller".to_string()),
                 attempt_plan: None,
                 goal: Some("cook fixture".to_string()),
-                to_worktree: target.display().to_string(),
+                to_worktree: Some(target.display().to_string()),
                 provider_command: None,
                 provider_argv: vec![
                     "sh".to_string(),
@@ -505,6 +505,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },
@@ -570,7 +571,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 attempt_run_id: None,
                 attempt_plan: None,
                 goal: None,
-                to_worktree: "fixture@promoted".to_string(),
+                to_worktree: Some("fixture@promoted".to_string()),
                 provider_command: None,
                 provider_argv: vec!["sh".to_string(), provider.display().to_string()],
                 gates: VerifyGateArgs {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -2388,6 +2388,7 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     },
                 ),
             },

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -442,6 +442,10 @@ pub struct WorktreeProviderListResultMapping {
     pub dirty: String,
     pub unpushed: String,
     pub primary: String,
+    /// Optional task/issue URL recorded for the managed worktree. This lets
+    /// callers safely reuse an existing destination by its tracker ownership.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -154,6 +154,7 @@ pub struct WorktreeProviderHandle {
     pub handle: String,
     pub path: String,
     pub branch: String,
+    pub task_url: Option<String>,
     pub safety: WorktreeProviderHandleSafety,
 }
 
@@ -360,6 +361,58 @@ pub fn resolve_apply_enabled_worktree_provider_from_config(
         gate_feedback_baseline,
         None,
     )
+}
+
+/// Find the sole apply-enabled provider worktree owned by a tracker URL.
+/// Providers must map `task_url` to participate, preserving existing provider
+/// configurations that only support handle-based lookup.
+pub fn find_apply_enabled_worktree_provider_by_task_url_from_config(
+    task_url: &str,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderResolution>> {
+    let mut matches = Vec::new();
+    for (provider_id, provider) in &config.worktree_providers {
+        if !provider.enabled
+            || !provider.apply_enabled
+            || provider
+                .list_result_mapping
+                .as_ref()
+                .and_then(|mapping| mapping.task_url.as_ref())
+                .is_none()
+        {
+            continue;
+        }
+        let Some(command) = provider.commands.list.as_ref() else {
+            continue;
+        };
+        for worktree in run_provider_list_command(provider_id, provider, command)? {
+            if worktree.task_url.as_deref() == Some(task_url) {
+                validate_provider_handle(provider_id, &worktree, None, None)?;
+                matches.push(WorktreeProviderResolution {
+                    provider_id: provider_id.clone(),
+                    worktree,
+                });
+            }
+        }
+    }
+    matches.sort_by(|left, right| left.worktree.handle.cmp(&right.worktree.handle));
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => Err(Error::validation_invalid_argument(
+            "task_url",
+            format!(
+                "multiple active apply-enabled worktrees are owned by `{task_url}`: {}",
+                matches
+                    .iter()
+                    .map(|resolution| resolution.worktree.handle.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Some(task_url.to_string()),
+            None,
+        )),
+    }
 }
 
 /// A clean immutable candidate may be its own destination before Homeboy's
@@ -1197,6 +1250,12 @@ fn map_provider_list_result(
                 handle: required_string(provider_id, index, "handle", &mapping.handle, item)?,
                 path: required_string(provider_id, index, "path", &mapping.path, item)?,
                 branch: required_string(provider_id, index, "branch", &mapping.branch, item)?,
+                task_url: mapping
+                    .task_url
+                    .as_deref()
+                    .map(|path| optional_string(provider_id, index, "task_url", path, item))
+                    .transpose()?
+                    .flatten(),
                 // Safety flags are advisory hints a provider raises to BLOCK an
                 // unsafe destination (dirty/unpushed/primary => refuse). A
                 // provider that does not report one is making no claim of
@@ -1231,6 +1290,26 @@ fn required_string(
         .as_str()
         .map(ToString::to_string)
         .ok_or_else(|| mapping_error(provider_id, field, path, "must resolve to a string"))
+}
+
+/// Task ownership is optional per row even when a provider supports exposing
+/// it. A provider list can legitimately include unmanaged worktrees.
+fn optional_string(
+    provider_id: &str,
+    index: usize,
+    field: &str,
+    path: &str,
+    item: &Value,
+) -> Result<Option<String>> {
+    match optional_jsonpath_value(provider_id, &format!("items[{index}].{field}"), path, item)? {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| {
+                mapping_error(provider_id, field, path, "must resolve to a string or null")
+            }),
+    }
 }
 
 fn required_bool(
@@ -2293,6 +2372,7 @@ mod tests {
                 handle: "fixture@release".to_string(),
                 path: temp.path().display().to_string(),
                 branch: "main".to_string(),
+                task_url: None,
                 safety: WorktreeProviderHandleSafety {
                     dirty: false,
                     unpushed: false,
@@ -2448,6 +2528,7 @@ mod tests {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
+                    task_url: None,
                 }),
             },
         );
@@ -2537,6 +2618,7 @@ mod tests {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
+                    task_url: None,
                 }),
             },
         );
@@ -3354,6 +3436,7 @@ mod tests {
             handle: "fixture@cook-target".to_string(),
             path: workspace.path().display().to_string(),
             branch: "cook-target".to_string(),
+            task_url: None,
             safety: WorktreeProviderHandleSafety {
                 dirty: true,
                 unpushed: false,
@@ -3507,6 +3590,7 @@ mod tests {
                     dirty: "$.state.dirty".to_string(),
                     unpushed: "$.state.unpushed".to_string(),
                     primary: "$.state.primary".to_string(),
+                    task_url: None,
                 },
             ),
             (
@@ -3522,6 +3606,7 @@ mod tests {
                     dirty: "$.dirty".to_string(),
                     unpushed: "$.unpushed".to_string(),
                     primary: "$.primary".to_string(),
+                    task_url: None,
                 },
             ),
         ];
@@ -3535,6 +3620,69 @@ mod tests {
             .expect("configured envelope resolves");
             assert_eq!(handle.path, workspace.path().display().to_string());
         }
+    }
+
+    #[test]
+    fn finds_one_task_owned_worktree_and_rejects_ambiguous_ownership() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "issue-42");
+        let task_url = "https://github.com/example/project/issues/42";
+        let mapping = WorktreeProviderListResultMapping {
+            items: "$.worktrees".to_string(),
+            handle: "$.handle".to_string(),
+            path: "$.path".to_string(),
+            branch: "$.branch".to_string(),
+            dirty: "$.safety.dirty".to_string(),
+            unpushed: "$.safety.unpushed".to_string(),
+            primary: "$.safety.primary".to_string(),
+            task_url: Some("$.task_url".to_string()),
+        };
+        let item = |handle: &str| {
+            json!({
+                "handle": handle,
+                "path": workspace.path(),
+                "branch": "issue-42",
+                "task_url": task_url,
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            })
+        };
+        let mut provider = list_provider(
+            fake_list_provider_script(
+                json!({ "worktrees": [item("project@fix-issue-42-project")] }),
+            ),
+            mapping.clone(),
+        );
+        provider.apply_enabled = true;
+        let config = config_with_provider(provider);
+        let found = find_apply_enabled_worktree_provider_by_task_url_from_config(task_url, &config)
+            .expect("task lookup")
+            .expect("task worktree");
+        assert_eq!(found.worktree.handle, "project@fix-issue-42-project");
+
+        let mapped = map_provider_list_result(
+            "fixture",
+            &mapping,
+            &json!({ "worktrees": [
+                { "handle": "project@unowned", "path": workspace.path(), "branch": "issue-42", "task_url": null, "safety": { "dirty": false, "unpushed": false, "primary": false } },
+                { "handle": "project@legacy", "path": workspace.path(), "branch": "issue-42", "safety": { "dirty": false, "unpushed": false, "primary": false } }
+            ] }),
+        )
+        .expect("mixed task ownership maps");
+        assert!(mapped.iter().all(|worktree| worktree.task_url.is_none()));
+
+        let mut provider = list_provider(
+            fake_list_provider_script(
+                json!({ "worktrees": [item("project@first"), item("project@second")] }),
+            ),
+            mapping,
+        );
+        provider.apply_enabled = true;
+        let error = find_apply_enabled_worktree_provider_by_task_url_from_config(
+            task_url,
+            &config_with_provider(provider),
+        )
+        .expect_err("duplicate ownership must be explicit");
+        assert!(error.message.contains("project@first, project@second"));
     }
 
     #[test]
@@ -3558,6 +3706,7 @@ mod tests {
                 dirty: "$.dirty".to_string(),
                 unpushed: "$.unpushed".to_string(),
                 primary: "$.primary".to_string(),
+                task_url: None,
             };
             *match field {
                 "items" => &mut mapping.items,
@@ -3792,6 +3941,7 @@ mod tests {
             dirty: "$.safety.dirty".to_string(),
             unpushed: "$.safety.unpushed".to_string(),
             primary: "$.safety.primary".to_string(),
+            task_url: None,
         }
     }
 

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -135,6 +135,7 @@ mod lab_source_path_tests {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
+                        task_url: None,
                     }),
                 },
             );

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -628,6 +628,7 @@ mod tests {
                     handle: "release-fixture".to_string(),
                     path: "/workspace".to_string(),
                     branch: "main".to_string(),
+                    task_url: None,
                     safety: WorktreeProviderHandleSafety {
                         dirty: false,
                         unpushed: false,
@@ -723,6 +724,7 @@ mod tests {
                             dirty: "$.safety.dirty".to_string(),
                             unpushed: "$.safety.unpushed".to_string(),
                             primary: "$.safety.primary".to_string(),
+                            task_url: None,
                         },
                     ),
                 },


### PR DESCRIPTION
Closes #11225.

## Summary

- make `--to-worktree` an explicit override instead of mandatory ceremony
- derive a deterministic issue-owned branch and handle from `--repo` plus `--task-url`
- reuse a sole provider-reported task-owned destination and fail clearly on ambiguous ownership
- preserve generic provider ownership boundaries and DMC freshness/primary safety through the existing ensure path
- tolerate mixed provider rows with missing or null optional task ownership metadata

## Verification

- `cargo test --workspace --no-run`
- focused Homeboy CLI Cook derivation tests
- focused worktree-provider ownership tests
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol analyzed the failed Cook workflow, implemented conditional destination derivation and provider ownership mapping, hardened optional metadata behavior, ran workspace compilation and focused tests, and drafted this PR. Chris Huber remains responsible for every line.