### PR TITLE
fix(test): run the Rust gate single-threaded so env writers cannot race readers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -245,13 +245,39 @@ mod tests {
         }
     }
 
+    /// Scopes the process-global artifact-root override to one test.
+    ///
+    /// Two properties matter, and both exist so that a panicking `#[test]`
+    /// cannot fail an unrelated later test on something other than its own
+    /// merits:
+    ///
+    /// 1. The lock is poison-tolerant. A panic inside `test` poisons
+    ///    `ARTIFACT_ROOT_LOCK`, and a plain `.expect(...)` then reports every
+    ///    subsequent test in this module as a `PoisonError` rather than its
+    ///    real result. `homeboy_core::test_support::env_lock` already ignores
+    ///    poison for exactly this reason; match it here.
+    /// 2. The override is cleared from `Drop`, not on the straight-line return
+    ///    path. A panic used to skip the reset and leave the override pointing
+    ///    at an already-deleted `TempDir`, so the next test resolved artifacts
+    ///    under a missing directory.
     fn with_artifact_root<R>(test: impl FnOnce(&Path) -> R) -> R {
-        let _lock = ARTIFACT_ROOT_LOCK.lock().expect("artifact root lock");
+        struct ClearArtifactRootOverride;
+
+        impl Drop for ClearArtifactRootOverride {
+            fn drop(&mut self) {
+                homeboy_core::set_artifact_root_override(None);
+            }
+        }
+
+        let _lock = ARTIFACT_ROOT_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let guard = tempfile::tempdir().expect("artifact root");
         homeboy_core::set_artifact_root_override(Some(guard.path().to_path_buf()));
-        let result = test(guard.path());
-        homeboy_core::set_artifact_root_override(None);
-        result
+        // Declared after `guard` so the override is cleared before the
+        // directory it points at is removed, and before the lock is released.
+        let _clear_override = ClearArtifactRootOverride;
+        test(guard.path())
     }
 
     #[test]

--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -31,6 +31,35 @@ cargo test --lib --features slow-tests collect_refactor_sources_audit_write_uses
 
 Use the slow tier when changing audit detector orchestration, audit fixability planning, or audit-driven refactor planning. These tests remain runnable, but they are not part of the default unit gate because they scan real fixture/checkouts and dominated local suite wall-clock time.
 
+## Process-Global Environment and Test Threads
+
+`homeboy.json` sets the Rust extension's `rust_cargo_test_threads` to `1`, so the
+gate runs `cargo test --workspace -- --test-threads=1`.
+
+This is not a performance choice, it is a correctness one. `HomeGuard`
+(`homeboy_core::test_support`) isolates a test by mutating *process-global*
+environment — `HOME`, `XDG_DATA_HOME`, `HOMEBOY_ARTIFACT_ROOT`,
+`HOMEBOY_RUNTIME_TMPDIR`, the invocation runtime directory — and restoring it on
+`Drop`. The `home_lock` mutex it holds serializes *writers*. It cannot serialize
+*readers*: any test on another thread that reads `HOME`, directly or through
+`paths::homeboy()` and friends, can observe a foreign or missing value while a
+guard's window is open. libtest shares one process across its threads, so there
+is no thread-local escape hatch. (Rust made `std::env::set_var` `unsafe` in the
+2024 edition for this reason.)
+
+One thread per test binary closes that window. Cargo already runs test binaries
+sequentially, so the cost is confined to intra-binary parallelism, and the
+guard-holding tests — the slow ones — were already serialized by the mutex.
+
+The real fix is injectable config and path roots so tests never touch
+process-global environment at all (#7505). Until that lands, do not raise this
+setting, and do not add new ad-hoc `std::env::set_var` helpers in test modules:
+use `HomeGuard`/`with_isolated_home` so the mutation is at least covered by the
+shared lock.
+
+`cargo nextest` does not need this, because it runs each test in its own
+process. It is not what CI uses today.
+
 ## Hermetic CLI Fixtures
 
 Ordinary Rust tests must use `homeboy::test_support::HermeticTestContext` for

--- a/homeboy.json
+++ b/homeboy.json
@@ -1831,7 +1831,11 @@
     "CARGO_TARGET_DIR": "target"
   },
   "extensions": {
-    "rust": {}
+    "rust": {
+      "settings": {
+        "rust_cargo_test_threads": 1
+      }
+    }
   },
   "hooks": {},
   "id": "homeboy",


### PR DESCRIPTION
## Releases have been blocked since v0.327.3

`main`'s `Test` job fails → `Release Quality Policy` fails → `Create GitHub Release` is skipped.

The failure is scope-dependent, which is why it went unnoticed for a while. Green release runs execute a *narrow* scope — run `30718526355` ran `cargo test --workspace --test release_workflow_test`, 45 tests, 0.4s. The red runs widen to full scope: `Rust test scope: Changed files include an inline test support module without test functions; running the full test command.` Only the wide runs are red, and they are the ones that gate a release.

Run `30749573516` (main @ `aea1dd300`, i.e. after #11234 and #11235) reports **68 named failures, all in one binary**:

```
error: test failed, to rerun pass `-p homeboy-agents --lib`
test result: FAILED. 1188 passed; 68 failed; 2 ignored; finished in 302.14s
```

Cargo aborts the workspace run there, so **~8.8k of the ~11.4k workspace tests have not executed at all** in recent memory. That is separate from this PR but worth stating plainly (see "What remains").

## Root cause: the mutex serializes writers, not readers

`HomeGuard` (`crates/homeboy-core/src/test_support.rs`) isolates a test by mutating **process-global** environment — `HOME`, `XDG_DATA_HOME`, `HOMEBOY_ARTIFACT_ROOT`, `HOMEBOY_RUNTIME_TMPDIR`, the invocation runtime dir — and restoring it on `Drop`.

The mutex is held correctly. `HomeGuard::new` takes `home_lock()` and stores it as `_guard`, so it is held for the guard's entire lifetime. **That is not the bug.**

The bug is that **readers do not take the lock.** Any test running on another libtest thread that reads `HOME` — directly, or indirectly through `paths::homeboy()` and friends — can land inside a guard's `set_var`/`remove_var` window and observe a foreign or missing value. That is exactly the 12 `HOME environment variable not set on Unix-like system` failures. Rust made `std::env::set_var` `unsafe` in the 2024 edition for this precise reason.

**A reader-side lock cannot fix it.** Making readers take the read side of an `RwLock` deadlocks the common case: the guard holder itself reads the same env while holding the write side, and `std` locks are not reentrant. libtest also shares one process across its threads, so there is no thread-local escape hatch.

The non-`HOME` signatures are the same defect wearing a different hat:

* `re_linking_does_not_duplicate_evidence_refs` failing `left: 4, right: 2` is a shared artifact root. `HomeGuard` calls `set_artifact_root_override(None)` on **both** construction and drop, so it clears an override another thread's test is actively relying on.
* `homeboy-agents` carries **85 ad-hoc `std::env::set_var`/`remove_var` sites** in test modules (`agent_task_gate.rs` sets `HOME` and `PATH` directly, `agent_task_promotion/promote.rs` sets `HOMEBOY_RUNTIME_TMPDIR`, …) that never take `home_lock()` at all. Those race guards in both directions.

This is #7505 / #10097 / #9774. The correct long-term fix is injectable config/path roots so tests never touch process-global env — 2,072 `with_isolated_home` call sites. **Not this PR.**

## The lever

`homeboy.json` now sets the Rust extension's `rust_cargo_test_threads` to `1`:

```json
"extensions": {
  "rust": { "settings": { "rust_cargo_test_threads": 1 } }
}
```

The setting exists for exactly this case. Its own description in `homeboy-extensions/rust/rust.json` reads: *"Set to 1 for suites that mutate process-global environment and need deterministic serial execution."* `test-runner.sh` turns it into `cargo test --workspace -- --test-threads=1`.

**Why this and not something narrower.** I looked for a per-crate lever and there isn't one:

* The cargo invocation is built by `homeboy-extensions/rust/scripts/test-runner.sh` — a **separate repo this PR cannot edit**, and one with no PR CI.
* Cargo has no per-package `--test-threads`. `RUST_TEST_THREADS` is read by libtest at process start, and `.cargo/config.toml` `[env]` is workspace-global, so neither can be scoped to one crate either.
* `cargo nextest` **would** fix the class outright — process-per-test makes global env mutation harmless while keeping full parallelism, and `.config/nextest.toml` already exists. But nextest is **not installed on the runner**, and `rust_nextest_fallback` defaults to `true`, so selecting it would silently fall back to `cargo test` and change nothing. Installing it is a larger change (drops doctests, and the configured `slow-timeout` would terminate legitimately slow tests). Worth a follow-up; not the way to unblock a release today.

## Runtime cost

Honest estimate, and the part I could not measure directly:

* Cargo already runs test binaries **sequentially**, so this only removes *intra-binary* parallelism.
* In `homeboy-agents`, ~46% of tests take an isolated home and were **already serialized** by `home_lock()` — and those are the slow ones (git operations, subprocess spawns; 302s for 1256 tests is 240ms average). So the marginal cost is well below the naive 4x a 4-vCPU runner implies. **400–900s** for that binary versus 302s today is my estimate.
* Narrow-scope runs — which is what most releases actually execute — are effectively unaffected.
* The residual risk is on the full-scope run, and it is **not primarily this change**: those ~8.8k never-executed tests now get to run for the first time regardless of thread count. If full scope exceeds the 2700s budget, the next moves are per-crate test jobs or #7505 — not raising this setting back.

The 2700s budget is unchanged.

## Secondary: the PoisonError cascade

`with_artifact_root` in `agent_task_executor_evidence.rs` used `.expect("artifact root lock")` and reset the override on the straight-line return path only. So a single panicking test both poisoned `ARTIFACT_ROOT_LOCK` *and* left the override pointing at an already-deleted `TempDir`, and later tests reported `PoisonError` or a missing directory instead of their own result.

Now it is poison-tolerant (matching `env_lock()`, which already does `unwrap_or_else(|e| e.into_inner())`) and clears the override from `Drop`. Serial execution does not remove this cascade — it just makes it sequential — so the fix is still load-bearing.

## What remains

* **All 68 should go**, since every one of them is in the single binary being serialized and every signature traces to concurrent global-env mutation. I cannot prove that without a CI run; the VPS cannot run this suite.
* The failures that would **not** be fixed by serialization are any that are order-dependent rather than concurrency-dependent — a test that only passes because some other test left state behind. Serial execution exposes those instead of hiding them. If any survive, that is the honest signal and they should be fixed on their merits, not by restoring parallelism.
* **The bigger unknown is not this change.** Cargo has been aborting at `homeboy-agents`, so `homeboy-core` (1967 tests), `homeboy-cli` (1786) and `homeboy-lab-runner` (1574) lib tests have not run. Once the gate gets past `homeboy-agents` they will, and they may surface their own failures and their own wall time.
* #7505 is still the real fix. This buys the release pipeline back; it does not pay the debt.

## Verification

`cargo fmt --all --check` clean; `cargo check -p homeboy-agents --lib --tests` exits 0. Per this VPS's constraints the suite itself was not run locally — CI is the gate.

Refs #7505, #10097, #9774, #10687, #11151. Follows #11234, #11235.
