### PR TITLE
docs(test): record why CI cannot adopt cargo-nextest yet, and keep #11242's serialization

### DIFF
--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -1,12 +1,17 @@
 # Test Tiers
 
-The default Rust gate is the bounded unit suite:
+The commands in this section are the **local** edit-loop tiers. CI does not run
+any of them: the CI gate is `cargo test`, for the reasons in
+[Process-per-test isolation](#process-per-test-isolation-cargo-nextest). Read
+that section before assuming a local nextest pass predicts a CI pass.
+
+The default Rust tier is the bounded unit suite:
 
 ```sh
 cargo nextest run --profile default --lib
 ```
 
-CI uses the non-fail-fast profile so one run reports the full failure set:
+The non-fail-fast profile reports the full failure set in one run:
 
 ```sh
 cargo nextest run --profile ci --lib
@@ -51,14 +56,139 @@ One thread per test binary closes that window. Cargo already runs test binaries
 sequentially, so the cost is confined to intra-binary parallelism, and the
 guard-holding tests — the slow ones — were already serialized by the mutex.
 
-The real fix is injectable config and path roots so tests never touch
-process-global environment at all (#7505). Until that lands, do not raise this
-setting, and do not add new ad-hoc `std::env::set_var` helpers in test modules:
-use `HomeGuard`/`with_isolated_home` so the mutation is at least covered by the
+This is a workaround, not a fix. It buys correctness with every bit of
+intra-binary parallelism the gate had, and it does nothing about the underlying
+design: the tests still mutate process-global state. The structural fix is
+injectable config and path roots so tests never touch process-global environment
+at all (#7505), across roughly 2,072 `with_isolated_home` call sites. The
+mechanical fix that retires the same defect class without touching those call
+sites is process-per-test execution, below.
+
+Until one of those lands, do not raise this setting, and do not add new ad-hoc
+`std::env::set_var` helpers in test modules: use
+`HomeGuard`/`with_isolated_home` so the mutation is at least covered by the
 shared lock.
 
-`cargo nextest` does not need this, because it runs each test in its own
-process. It is not what CI uses today.
+## Process-per-test isolation (cargo-nextest)
+
+`cargo nextest` runs **one process per test**. A process-global `set_var` is
+then global to a single test, so the reader/writer window described above cannot
+open at all: there is no shared `HOME` for a second test to read. That retires
+the whole defect class by construction rather than working around it, and it
+does so without giving up intra-binary parallelism, which is the entire cost of
+`rust_cargo_test_threads = 1`.
+
+**CI does not run nextest, and cannot be switched to it from this repository
+alone.** Selecting it here today would produce a red `Test` gate on a fully
+passing suite. Three gaps must close first, and two of them live in repositories
+this one does not control. They are listed in the order they must land.
+
+### 1. Result parsing — `homeboy-extensions`
+
+This is the gap that makes a premature flip *red* rather than merely useless.
+
+`test_run_status` (`crates/homeboy-extension/src/test/run.rs`) treats absent
+counts as a failure, deliberately: `test_measurement` maps `None` to
+`Measurement::unreported()`, which assesses to
+`Unmeasured(NoStructuredCounts)`, and `Unknown` collapses to `"failed"`. An
+unmeasured gate has never been allowed to render green (#10685).
+
+Counts reach that function from `homeboy-extensions`:
+`rust/scripts/parse-test-results.sh` invokes the shared adapter set with exactly
+one adapter, `cargo-test`, and that adapter matches only lines beginning
+`test result:`. Core's fallback text parser
+(`crates/homeboy-extension/src/test/parsing.rs`) is PHPUnit-shaped —
+`Tests:`/`Failures:`/`Errors:` — with a `passed=<n> failed=<n>` key-value
+fallback. `cargo nextest run` emits neither; its summary is
+`Summary [ 1.234s] N tests run: N passed, M skipped`. Nothing matches, so
+`test_counts` is `None` and the phase reports `failed` regardless of outcome.
+
+`rust.json` declares no `test.result_parse` spec, and a component cannot supply
+one — `result_parse` is read from the extension manifest via `load_extension`,
+not from `homeboy.json`. So there is no in-repo lever. `homeboy-extensions`
+needs a `nextest` result adapter (and matching failure-name extraction in
+`rust/scripts/parse-test-failures.py`, which is also `test result:`-shaped)
+before the runner can be flipped anywhere.
+
+Note that core already parses nextest *durations*
+(`crates/homeboy-extension/src/test/durations/mod.rs` reads the nextest
+`Summary` line). Durations are advisory and do not feed `test_counts`, so that
+existing support does not satisfy the measurement invariant.
+
+### 2. Install — `homeboy-action` for the PR gate, this repo for the release gate
+
+The two `Test` gates have different shapes:
+
+- **Release** (`.github/workflows/release.yml`, `gate-test`) is a normal
+  step-based job in this repository. An install step —
+  `taiki-e/install-action` with `tool: cargo-nextest`, which fetches a prebuilt
+  binary in seconds rather than paying a `cargo install` build — can be added
+  here directly.
+- **PR** (`.github/workflows/ci.yml`, job `homeboy`) calls the reusable workflow
+  `Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2`. A caller cannot
+  inject steps into a reusable workflow, and that workflow exposes no
+  pre-command hook. `homeboy-action` contains no reference to `nextest` and its
+  `auto-setup` does not install it. The PR gate therefore cannot get nextest
+  without a change in `homeboy-action`.
+
+Homeboy has no `pre:test` hook either — `homeboy.json` hooks are limited to
+`pre:version:bump`, `post:version:bump`, `post:release`, and `post:deploy`
+(`crates/homeboy-core/src/engine/hooks.rs`) — so there is no runner-driven
+install path that would cover both gates.
+
+Until an install exists on a given gate, leave `rust_nextest_fallback` at its
+default `true` for that gate. The setting is a trap only when it is the *whole*
+story: a silent fallback to `cargo test` with no thread cap would leave the race
+unguarded. It is safe here precisely because `rust_cargo_test_threads = 1` is
+still set, and that setting applies **only** when the resolved runner is
+`cargo`, which is exactly the fallback path. Where nextest *is* installed, set
+`HOMEBOY_RUST_NEXTEST_FALLBACK=0` on that job so a missing binary exits 127 with
+the install diagnostic instead of quietly reverting — otherwise a no-op is
+indistinguishable from success.
+
+### 3. Profile selection — this repo
+
+`.config/nextest.toml` already defines tuned `default`, `ci`, and `quick`
+profiles, but the extension runner builds `cargo nextest run --manifest-path …`
+plus scope args and never passes `--profile`. Nextest defaults to the `default`
+profile unless `NEXTEST_PROFILE` is set, so the `ci` profile is **not** selected
+today and would not be selected by an install alone.
+
+That matters: `ci` sets `fail-fast = false`. Without it, nextest inherits
+fail-fast and reproduces the exact complaint that motivated #11242 — cargo
+aborting the remainder of the workspace so most of the suite never executes. Any
+job that runs nextest should set `NEXTEST_PROFILE: ci`.
+
+The timeout interaction is favourable and needs no budget change. `default` is
+`period = 30s, terminate-after = 4` and `ci` is `period = 60s,
+terminate-after = 2`; both **kill** a test at 120s. Against the 2700s phase
+budget (`HOMEBOY_TEST_TIMEOUT_SECONDS`) and the action's 3000s outer backstop,
+that converts a hung test from a 2700s phase stall into a bounded, named,
+120s test failure — the same win #11234 and #11235 delivered by hand, but
+automatic. Do not change the 2700s budget to accommodate it.
+
+The one behavioural risk to measure on the first real run: a test that
+legitimately takes over 120s becomes a failure rather than a slow pass. The
+deliberately slow tier is already excluded from the gate behind
+`--features slow-tests`, so the exposure should be small, but it is unverified.
+
+### Landing order
+
+1. `homeboy-extensions`: add a `nextest` result adapter and nextest failure-name
+   parsing, and release the extension. Homeboy resolves extensions at the latest
+   published release, so this propagates to CI on its own.
+2. `homeboy-action`: install `cargo-nextest` in the reusable CI workflow's
+   `candidate`/`baseline` jobs, so the PR gate has the binary.
+3. This repo: add the install to `gate-test` in `release.yml`, set
+   `NEXTEST_PROFILE: ci` and `HOMEBOY_RUST_NEXTEST_FALLBACK: '0'` on every job
+   that has the binary, then set `extensions.rust.settings.rust_test_runner` to
+   `nextest` in `homeboy.json`.
+4. Only once a run demonstrably reports `Running cargo nextest...` with parsed,
+   non-null test counts, drop `rust_cargo_test_threads`. Removing it earlier
+   would leave the race unguarded on any path that fell back to `cargo test`.
+
+Steps 1 and 2 are independent and can land in either order; step 3 must not
+precede step 1.
 
 ## Hermetic CLI Fixtures
 


### PR DESCRIPTION
## Summary

I was asked to enable `cargo-nextest` in CI to retire the process-global env defect class, and to remove #11242's serialization once nextest was proven to run.

**I could not enable it, and shipping the flip would have turned the `Test` gate red on a fully passing suite.** This PR ships the investigation instead: `homeboy.json` and every workflow file are byte-identical, #11242's serialization stays, and `docs/internals/test-tiers.md` now records the three gaps, the evidence for each, and the exact order they must land.

It also fixes a live doc defect: the top of that file advertised `cargo nextest run --profile ci --lib` as what "CI uses", which has never been true and contradicted the section 40 lines below it.

## What #11242 bought, and what it cost

#11242 set `extensions.rust.settings.rust_cargo_test_threads = 1`, serializing the whole workspace run. It unblocked the pipeline and v0.327.5 shipped.

The cost is all intra-binary parallelism. `homeboy-agents` is 302s today; serial is an honest 400–900s. Cargo already ran test binaries sequentially, so this is confined to within-binary threading — but that is where the suite's parallelism lived.

## Why nextest is the structural fix

`HomeGuard` mutates process-global env (`HOME`, `XDG_DATA_HOME`, `HOMEBOY_ARTIFACT_ROOT`, `HOMEBOY_RUNTIME_TMPDIR`, the invocation runtime dir) and restores on `Drop`. The `home_lock` mutex is held correctly for the guard's full lifetime — that is not the bug. The bug is that a mutex serializes **writers**, and readers never take it. Any test on another libtest thread reading `HOME`, directly or via `paths::homeboy()`, can land inside a guard's window and see a foreign or missing value. Hence `HOME environment variable not set on Unix-like system` dominating 68–126 failures.

A writer lock cannot fix a reader/writer race. A shared-read/exclusive-write lock deadlocks, because the guard holder reads the same env while holding the write side and `std` locks are not reentrant. libtest shares one process across threads, so there is no thread-local escape.

`cargo nextest` runs **one process per test**. A process-global `set_var` is then global to exactly one test — there is no shared `HOME` for a second test to read, so the window cannot open. It dissolves the class by construction, keeps parallelism, and requires none of the ~2,072 `with_isolated_home` call-site changes that the real fix (#7505) needs.

That reasoning is sound. The blocker is elsewhere.

## How I tried to prove it runs — and what I found instead

### Gap 1 — result parsing (`homeboy-extensions`). This is the one that makes a flip *red*, not merely useless.

`test_run_status` (`crates/homeboy-extension/src/test/run.rs`) maps absent counts to `Measurement::unreported()` → `Unmeasured(NoStructuredCounts)` → `Unknown` → `"failed"`, deliberately, so an unmeasured gate never renders green (#10685).

Counts come from `homeboy-extensions/rust/scripts/parse-test-results.sh`, which passes exactly **one** adapter — `cargo-test` — and that adapter matches only lines starting `test result:`. Core's fallback text parser (`crates/homeboy-extension/src/test/parsing.rs`) is PHPUnit-shaped (`Tests:`/`Failures:`/`Errors:`) plus a `passed=<n> failed=<n>` key-value form.

`cargo nextest run` emits none of those. Its summary is:

```
     Summary [   1.234s] 11400 tests run: 11400 passed, 0 skipped
```

Nothing matches → `test_counts` is `None` → the phase reports `failed` **regardless of test outcome**. This is precisely the `test_counts:null` / "test phase failed without structured counts" signature.

There is no in-repo lever: `result_parse` is read from the extension manifest via `load_extension`, not from `homeboy.json`, and `rust.json` declares no `test.result_parse` spec. Core's existing nextest *duration* parsing (`test/durations/mod.rs` reads the nextest `Summary` line) is advisory and does not feed `test_counts`.

### Gap 2 — install. Only half is reachable from this repo.

| Gate | Shape | Installable here? |
|---|---|---|
| Release `Test` (`release.yml` → `gate-test`) | step-based job in this repo | **Yes** — `taiki-e/install-action` with `tool: cargo-nextest`, prebuilt, seconds |
| PR `Test` (`ci.yml` → job `homeboy`) | `uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2` | **No** |

A caller cannot inject steps into a reusable workflow; that workflow exposes no pre-command hook; and `homeboy-action` has **zero** references to nextest (verified via code search at `v2`) — `auto-setup` does not install it. Homeboy has no `pre:test` hook either (hooks are `pre:/post:version:bump`, `post:release`, `post:deploy` only), so there is no runner-driven install covering both gates.

### Gap 3 — profile selection. In-repo, but an install alone would not fix it.

`.config/nextest.toml` already has tuned `default`/`ci`/`quick` profiles, but the extension builds `cargo nextest run --manifest-path …` + scope args and **never passes `--profile`**, and nothing sets `NEXTEST_PROFILE`. So the `ci` profile is not selected. Without it nextest inherits fail-fast and reproduces the exact complaint behind #11242 — the run aborting so most of the suite never executes. Any job running nextest needs `NEXTEST_PROFILE: ci`.

**Budget interaction (no change needed, and it's a win):** `default` is `period=30s, terminate-after=4`; `ci` is `period=60s, terminate-after=2`. Both **kill** at 120s. Against the 2700s phase budget and the action's 3000s outer backstop, that converts a hung test from a 2700s phase stall into a bounded, named, 120s test failure — the same win #11234/#11235 delivered by hand, but automatic. The 2700s budget is untouched. The one risk to measure on the first real run: a legitimately >120s test becomes a failure; the deliberately slow tier is already excluded behind `--features slow-tests`, so exposure should be small but is unverified.

## Did serialization come off?

**No.** `rust_cargo_test_threads = 1` stays, and `homeboy.json` is unchanged.

I also did not set `rust_nextest_fallback = false`. It is the right setting *wherever we assert nextest is installed*, and the doc records it as such — but globally it hard-fails every PR at exit 127, including this one, since the PR gate has no install. Left at its default `true`, the fallback lands on `cargo test`, and `rust_cargo_test_threads` applies **only** when the resolved runner is `cargo` — exactly the fallback path. So #11242's protection covers the fallback precisely, and "neither protection active" is unreachable.

Removing the serialization now would leave the race unguarded on every path in exchange for nothing.

## Landing order (documented in the file)

1. **`homeboy-extensions`** — add a `nextest` result adapter and nextest failure-name parsing (`rust/scripts/parse-test-failures.py` is also `test result:`-shaped), then release. Homeboy resolves extensions at the latest published release, so it propagates to CI automatically.
2. **`homeboy-action`** — install `cargo-nextest` in the reusable CI workflow's `candidate`/`baseline` jobs so the PR gate has the binary.
3. **This repo** — add the install to `gate-test`, set `NEXTEST_PROFILE: ci` and `HOMEBOY_RUST_NEXTEST_FALLBACK: '0'` on every job that has the binary, then flip `rust_test_runner` to `nextest`.
4. Only once a run demonstrably logs `Running cargo nextest...` **with parsed, non-null test counts**, drop `rust_cargo_test_threads`.

Steps 1 and 2 are independent; step 3 must not precede step 1.

## Constraints

No test deleted, ignored, or weakened. 2700s budget unchanged. `homeboy-extensions` not edited. Documentation-only diff.

Refs #7505, #10097, #9774, #11151, #10685. Follows #11242, #11234, #11235.
