### PR TITLE
Use latest resumed promotion evidence for Cook finalization

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1182,6 +1182,11 @@ pub(crate) fn cook_finalization_options(
         })?;
     let mut review_dossier = cook_review_dossier(options, promotion, successful_run_id)?;
     review_dossier.overrides = overrides;
+    let targeted_checks_run = review_dossier
+        .how_to_test
+        .iter()
+        .map(|step| step.command.clone())
+        .collect();
     Ok(AgentTaskPrFinalizationOptions {
         path: path.clone(),
         run_id: successful_run_id.to_string(),
@@ -1204,7 +1209,7 @@ pub(crate) fn cook_finalization_options(
             ai_model: options.ai_model.clone(),
             source_relationship: AgentTaskPrSourceRelationship::default(),
             verification: AgentTaskPrVerification {
-                targeted_checks_run: options.gates.verify.clone(),
+                targeted_checks_run,
                 targeted_checks_unavailable: None,
                 ci_expected: vec!["Homeboy CI after push".to_string()],
                 manual_reviewer_check: None,
@@ -1842,34 +1847,31 @@ fn cook_review_dossier(
         })
         .unwrap_or("No single-line task objective was retained in durable task evidence.");
     let adoption = promotion.provenance.get("adoption").is_some();
-    let how_to_test = options
-        .gates
-        .verify
+    let how_to_test = verification_promotion
+        .deterministic_gates
         .iter()
-        .map(|command| {
-            let matched = verification_promotion.has_visible_passed_gate_for_command(command);
-            if !matched {
-                return Err(Error::validation_invalid_argument(
-                    "verification",
-                    "Cook cannot publish a test command without matching successful visible durable gate evidence",
-                    Some(command.clone()),
-                    None,
-                ));
-            }
-            if !crate::agent_task_review_dossier::reviewer_runnable_command(command) {
-                return Err(Error::validation_invalid_argument(
-                    "verification",
-                    "Cook cannot publish a test command containing an operator-only reference",
-                    Some(command.clone()),
-                    None,
-                ));
-            }
-            Ok(AgentTaskReviewTestStep {
+        .filter_map(|gate| {
+            let [shell, flag, command] = gate.command.as_slice() else {
+                return None;
+            };
+            (shell == "sh"
+                && flag == "-lc"
+                && verification_promotion.has_visible_passed_gate_for_command(command)
+                && crate::agent_task_review_dossier::reviewer_runnable_command(command))
+            .then(|| AgentTaskReviewTestStep {
                 command: command.clone(),
                 expected: "passes as recorded by Cook's deterministic gate".to_string(),
             })
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Vec<_>>();
+    if how_to_test.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "verification",
+            "Cook cannot publish a test command without matching successful visible durable gate evidence bound to the promoted candidate",
+            None,
+            None,
+        ));
+    }
 
     // A form-only follow-up owns reviewer metadata, not the candidate it carries
     // forward. Resolve the persisted Cook lineage so that follow-up prose cannot

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6947,6 +6947,49 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
 }
 
 #[test]
+fn recovered_cook_finalization_uses_latest_resumed_gate_contract() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-8307";
+        let run_id = "cook-8307-attempt-2";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test stale-original-contract".to_string()],
+            private_verify: vec!["private stale gate".to_string()],
+            ..Default::default()
+        };
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+
+        let mut resumed = promotion(run_id);
+        resumed.deterministic_gates[0].command = vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            "cargo test resumed-gate-contract".to_string(),
+        ];
+        resumed.gate_results[0].name = "cargo test resumed-gate-contract".to_string();
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(resumed).unwrap())
+            .expect("record latest applied promotion");
+
+        let report =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), true, &mut CaptureBackend::default())
+                .expect("recovered preflight");
+        assert_eq!(
+            report["review_dossier"]["how_to_test"][0]["command"],
+            "cargo test resumed-gate-contract"
+        );
+        assert_eq!(
+            report["verification"]["targeted_checks_run"],
+            serde_json::json!(["cargo test resumed-gate-contract"])
+        );
+        assert!(!report.to_string().contains("stale-original-contract"));
+        assert!(!report.to_string().contains("private stale gate"));
+    });
+}
+
+#[test]
 fn cook_rejects_test_claim_without_matching_durable_gate() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "cook-8058-mismatch";

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -520,7 +520,11 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     };
 
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
-    if args.manual_finalization && args.preflight && report.status == "validated" {
+    if should_persist_manual_preflight_intent(
+        args.preflight,
+        &report.status,
+        report.manual_finalization,
+    ) {
         agent_task_service::persist_manual_finalization_intent(&handoff_run_id, &report)?;
     }
     value["handoff"] = finalization_handoff(
@@ -530,6 +534,14 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     );
 
     Ok((value, exit_code))
+}
+
+fn should_persist_manual_preflight_intent(
+    preflight: bool,
+    status: &str,
+    manual_finalization: bool,
+) -> bool {
+    preflight && status == "validated" && manual_finalization
 }
 
 fn validate_finalize_inputs(args: &FinalizePrArgs) -> homeboy::core::Result<()> {
@@ -2174,6 +2186,20 @@ mod tests {
             handoff["next_actions"][0],
             "PR was not opened; inspect finalization status and git/PR errors"
         );
+    }
+
+    #[test]
+    fn durable_run_manual_preflight_does_not_persist_manual_intent() {
+        assert!(!should_persist_manual_preflight_intent(
+            true,
+            "validated",
+            false,
+        ));
+        assert!(should_persist_manual_preflight_intent(
+            true,
+            "validated",
+            true,
+        ));
     }
 
     fn provider_fixture(id: &str, backend: &str) -> AgentTaskExecutorProvider {


### PR DESCRIPTION
## Summary
Fix recovered Cook finalization so reviewer checks come from the latest applied promotion's visible, passed, candidate-bound deterministic gates, not immutable recipe gates.

## What changed
- Derived review dossier commands and targeted checks from persisted promotion gate evidence; private and stale recipe gates are excluded.
- Rejected recovery when no reviewer-runnable candidate-bound visible gate exists.
- Persisted manual preflight intent only when the finalization report remains manual.
- Added focused regressions for resumed gate contracts and durable-run manual preflight intent.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo test -p homeboy-agents recovered_cook_finalization_uses_latest_resumed_gate_contract`; expect passes as recorded by Cook's deterministic gate.
3. Run `cargo test -p homeboy-cli durable_run_manual_preflight_does_not_persist_manual_intent`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
No public API change. Recovery now fails closed without reviewer-runnable candidate-bound visible gate evidence. Verified with both requested focused tests, cargo fmt, and diff checks. Commit ed1fb9819 is local; push and PR creation were blocked by the environment's homeboy-blocked origin transport.

## Evidence
- Base unchanged since verification: main remains at c496620b75cb01ed1845a2913c792379e5664d58.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/8307
- Task objective: Fix reopened issue #8307 on current origin/main using the reproduction at https://github.com/Extra-Chill/homeboy/issues/8307#issuecomment-5160290188. Root cause: recovered finalization loads latest applied promotion but rebuilds how\_to\_test and targeted\_checks\_run from immutable original recipe gates. Derive reviewer-runnable checks solely from candidate-bound visible passed deterministic gates on the latest applied promotion; reject absence; preserve private gate secrecy and exactly-once commit/push/PR behavior. Also fix durable-run manual preflight so it persists manual intent only when the finalization report remains manual. Add focused tests named recovered\_cook\_finalization\_uses\_latest\_resumed\_gate\_contract and durable\_run\_manual\_preflight\_does\_not\_persist\_manual\_intent. Commit, push, and open a PR with required AI disclosure.
- Verified candidate scope: 3 changed file(s): crates/homeboy-agents/src/agent\_task\_service/cook\_promotion.rs, crates/homeboy-agents/src/agent\_task\_service/cook\_tests.rs, crates/homeboy-cli/src/commands/agent\_task/review.rs.
- Verified finalization base: main at c496620b75cb01ed1845a2913c792379e5664d58
- deterministic gate passed: sh -lc cargo fmt --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-agents recovered\_cook\_finalization\_uses\_latest\_resumed\_gate\_contract (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-cli durable\_run\_manual\_preflight\_does\_not\_persist\_manual\_intent (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected nearby recovery predicates and finalization contracts, implemented the smallest promotion-bound derivation, preserved candidate-binding and gate visibility checks, and validated the focused regressions with AI assistance disclosure prepared for the PR.
