### PR TITLE
Fix recursive live-lease adoption recovery guidance

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -811,7 +811,13 @@ pub(super) fn remote_daemon_connect_action_for_runner(
         {
             return Ok(RemoteDaemonConnectAction::ReplaceIdleStale);
         }
-        return reattach_only_if_same_lease(previous_session, daemon, runner_id, status);
+        return reattach_only_if_same_lease(
+            previous_session,
+            daemon,
+            runner_id,
+            status,
+            live_lease_expectation,
+        );
     }
 
     let healthy = status.fresh && status.reachable;
@@ -868,6 +874,7 @@ pub(super) fn remote_daemon_connect_action_for_runner(
                     status,
                     expected_identity,
                     runner_id,
+                    live_lease_expectation,
                 ));
             }
         } else if live_lease_expectation
@@ -885,6 +892,7 @@ pub(super) fn remote_daemon_connect_action_for_runner(
                 status,
                 expected_identity,
                 runner_id,
+                live_lease_expectation,
             ));
         }
         return Ok(RemoteDaemonConnectAction::Reattach);
@@ -898,6 +906,7 @@ fn reattach_only_if_same_lease(
     daemon: &RemoteDaemon,
     runner_id: &str,
     status: &RemoteDaemonStatus,
+    live_lease_expectation: Option<(&str, u32)>,
 ) -> std::result::Result<RemoteDaemonConnectAction, String> {
     let persisted_lease = previous_session
         .filter(|session| {
@@ -915,6 +924,7 @@ fn reattach_only_if_same_lease(
             status,
             "not evaluated for stale daemon",
             runner_id,
+            live_lease_expectation,
         ))
     }
 }
@@ -926,7 +936,44 @@ fn lease_reconciliation_failure(
     status: &RemoteDaemonStatus,
     expected_identity: &str,
     runner_id: &str,
+    live_lease_expectation: Option<(&str, u32)>,
 ) -> String {
+    if live_lease_expectation == daemon.lease_id.as_deref().zip(daemon.pid) {
+        let (blocker, action) = if let Some(error) = status.endpoint_probe_error.as_deref() {
+            (
+                format!("the endpoint identity/jobs probe failed: {error}"),
+                "Restore endpoint identity/jobs availability",
+            )
+        } else if daemon
+            .build_identity
+            .as_deref()
+            .is_none_or(|identity| identity.trim().is_empty())
+        {
+            (
+                "the reachable endpoint did not provide a build identity".to_string(),
+                "Restore endpoint build identity reporting",
+            )
+        } else if daemon.build_identity.as_deref().map(str::trim) != Some(expected_identity.trim())
+        {
+            (
+                format!(
+                    "live build identity `{}` does not match configured identity `{expected_identity}`",
+                    daemon.build_identity.as_deref().expect("checked above")
+                ),
+                "Use a controller configured for the live identity or restore the endpoint to the configured identity",
+            )
+        } else {
+            (
+                "the required endpoint identity proof is unavailable".to_string(),
+                "Restore the required endpoint identity proof",
+            )
+        };
+        return format!(
+            "explicit live lease adoption matched lease `{actual_lease}` and PID {}, but {blocker}; refusing to persist a session. No session state was changed. {action}, then verify it with `homeboy runner status {} --json` before retrying adoption.",
+            daemon.pid.expect("matching expectation requires PID"),
+            shell::quote_arg(runner_id),
+        );
+    }
     format!(
         "live remote daemon lease `{actual_lease}` differs from persisted session lease `{expected_lease}`; refusing to adopt or replace it because runner ownership is not proven (fresh={}, reachable={}, live identity `{}`, configured identity `{}`, endpoint probe `{}`). No session state was changed. Run `homeboy runner connect {} --adopt-live-lease {} --expected-live-pid {}` to explicitly adopt this observed lease/PID/build after revalidation. This is operator-confirmed recovery within the trusted remote SSH UID boundary; it never stops or replaces a daemon, and later lease drift fails closed. Run `homeboy runner status {} --json` to inspect it.",
         status.fresh,

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -167,6 +167,47 @@ fn explicit_live_lease_adoption_accepts_an_exact_reachable_stale_daemon() {
 }
 
 #[test]
+fn explicit_live_lease_adoption_with_endpoint_timeout_reports_the_probe_blocker() {
+    let session = direct_ssh_session("lease-recorded");
+    let mut status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);
+    status.daemon.as_mut().expect("daemon").build_identity =
+        Some("homeboy test+configured".to_string());
+    status.endpoint_probe_error = Some("timed out after 2 seconds".to_string());
+
+    let error = remote_daemon::remote_daemon_connect_action_for_runner(
+        Some(&session),
+        &status,
+        "homeboy test+configured",
+        "runner-a",
+        Some(("lease-live", 4646)),
+    )
+    .expect_err("endpoint timeout must fail closed");
+
+    assert!(error.contains("endpoint identity/jobs probe failed: timed out after 2 seconds"));
+    assert!(error.contains("homeboy runner status runner-a --json"));
+    assert!(!error.contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
+}
+
+#[test]
+fn explicit_live_lease_adoption_with_unavailable_identity_reports_the_identity_blocker() {
+    let session = direct_ssh_session("lease-recorded");
+    let status = remote_daemon_status_for_test(true, true, 0, "lease-live", 4646);
+
+    let error = remote_daemon::remote_daemon_connect_action_for_runner(
+        Some(&session),
+        &status,
+        "homeboy test+configured",
+        "runner-a",
+        Some(("lease-live", 4646)),
+    )
+    .expect_err("unavailable identity must fail closed");
+
+    assert!(error.contains("reachable endpoint did not provide a build identity"));
+    assert!(error.contains("homeboy runner status runner-a --json"));
+    assert!(!error.contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
+}
+
+#[test]
 fn stale_active_mismatched_daemon_never_reattaches_or_adopts() {
     let session = direct_ssh_session("lease-recorded");
     let mut status = remote_daemon_status_for_test(false, true, 1, "lease-live", 4646);
@@ -181,8 +222,9 @@ fn stale_active_mismatched_daemon_never_reattaches_or_adopts() {
     )
     .expect_err("stale active daemon must preserve the persisted session");
 
-    assert!(error.contains("persisted session lease `lease-recorded`"));
-    assert!(error.contains("live remote daemon lease `lease-live`"));
+    assert!(error.contains("endpoint identity/jobs probe failed: identity probe failed"));
+    assert!(error.contains("homeboy runner status runner-a --json"));
+    assert!(!error.contains("--adopt-live-lease lease-live --expected-live-pid 4646"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #9414 by preserving fail-closed live lease adoption checks while replacing recursive advice with the exact endpoint/identity predicate and a convergent status-first action.

## What changed
- Exact --adopt-live-lease/--expected-live-pid failures now report endpoint timeout, missing identity, or configured-identity mismatch without recommending the command already running.
- Kept lease, PID, build, endpoint, and jobs admission behavior unchanged.
- Added regression coverage for endpoint timeout and unavailable identity, asserting no self-recommendation.
- Committed as eefec047a.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo test -p homeboy-lab-runner explicit_live_lease_adoption`; expect passes as recorded by Cook's deterministic gate.
3. Run `cargo test -p homeboy-lab-runner stale_active_mismatched_daemon_never_reattaches_or_adopts`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Diagnostic-only change for failed exact adoption attempts; successful adoption and all fail-closed identity checks are unchanged. Focused tests and formatting pass. Two unrelated existing disconnect fixtures fail independently. Push and PR creation were blocked because origin's push URL is intentionally configured as homeboy-blocked.

## Evidence
- Base unchanged since verification: main remains at c496620b75cb01ed1845a2913c792379e5664d58.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/9414
- Task objective: Fix reopened issue #9414 on current origin/main. Preserve fail-closed lease/PID/build/endpoint identity checks. When connect was already invoked with matching --adopt-live-lease and --expected-live-pid but adoption fails because endpoint identity/jobs probing or configured identity proof is unavailable/mismatched, report the actual blocking predicate and a convergent operator action; never recommend the exact command currently executing. Add regression tests for exact lease/PID with endpoint timeout or unavailable identity and assert no recursive self-recommendation. Keep the smallest generic change. Inspect issue comment https://github.com/Extra-Chill/homeboy/issues/9414#issuecomment-5160060191. Commit, push, and open a PR with required AI disclosure.
- Verified candidate scope: 2 changed file(s): crates/homeboy-lab-runner/src/connection/remote\_daemon.rs, crates/homeboy-lab-runner/src/connection/tests/session.rs.
- Verified finalization base: main at c496620b75cb01ed1845a2913c792379e5664d58
- deterministic gate passed: sh -lc cargo fmt --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-lab-runner explicit\_live\_lease\_adoption (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-lab-runner stale\_active\_mismatched\_daemon\_never\_reattaches\_or\_adopts (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Inspected issue comment evidence and adjacent runner reconciliation predicates, made the smallest formatter-path change, added focused regressions, ran verification, and attempted push/PR creation with AI disclosure.
