### PR TITLE
fix(paths): resolve the home root through a lock, not a racing getenv

### DIFF
--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -50,7 +50,6 @@
 //! (`<workload-id>/daemon/daemon.sock` ≈ 40 bytes) underneath.
 
 use crate::error::{Error, Result};
-#[cfg(windows)]
 use crate::paths;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -152,15 +151,22 @@ fn cache_fallback_root() -> Result<PathBuf> {
         if let Some(xdg_cache) = non_empty_env("XDG_CACHE_HOME") {
             return Ok(PathBuf::from(xdg_cache).join("homeboy").join("inv"));
         }
-        let home = env::var("HOME").map_err(|_| {
-            Error::internal_unexpected(
-                "HOME environment variable not set on Unix-like system".to_string(),
-            )
-        })?;
-        Ok(PathBuf::from(home)
-            .join(".cache")
-            .join("homeboy")
-            .join("inv"))
+        // Resolve through `paths`, which prefers the process-local home-root
+        // override over an unsynchronized `getenv` (#7505). `homeboy()` returns
+        // `<home>/.config/homeboy`, so step back to the home root rather than
+        // re-reading `HOME` here and reintroducing the race this fixes.
+        let config_root = paths::homeboy()?;
+        let home = config_root
+            .parent()
+            .and_then(Path::parent)
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "could not derive a home root from config directory {}",
+                    config_root.display()
+                ))
+            })?
+            .to_path_buf();
+        Ok(home.join(".cache").join("homeboy").join("inv"))
     }
 }
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -466,6 +466,13 @@ impl HomeGuard {
         // exec-capable root.
         let context = HermeticTestContext::new();
         std::env::set_var("HOME", context.home());
+        // `set_var` above stays for the readers that still consult `HOME`
+        // directly and for anything reading it after this process forks. The
+        // override is what makes the *hot* resolvers — `paths::homeboy()`,
+        // `paths::homeboy_data()`, and the invocation runtime root — race-free:
+        // they read it under a lock instead of racing this `setenv` from
+        // worker threads a test spawns inside itself (#7505).
+        crate::paths::set_home_root_override(Some(context.home().to_path_buf()));
         // Preserve the legacy in-process defaults while the subprocess context
         // uses explicit paths. These tests exercise fallback path resolution.
         std::env::set_var("XDG_DATA_HOME", context.home().join(".local").join("share"));
@@ -759,6 +766,10 @@ pub fn exec_capable_tempdir() -> TempDir {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        // Clear the override before restoring `HOME` so no window exists where
+        // the override still points at this guard's tempdir — which `Drop` is
+        // about to delete — while the environment already names the next root.
+        crate::paths::set_home_root_override(None);
         match &self.prior {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -22,6 +22,58 @@ fn artifact_root_override() -> &'static Mutex<Option<PathBuf>> {
     OVERRIDE.get_or_init(|| Mutex::new(None))
 }
 
+fn home_root_override() -> &'static Mutex<Option<PathBuf>> {
+    static OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+    OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+/// Set a process-local home-root override that outranks `$HOME`.
+///
+/// `getenv`/`setenv` are not thread-safe. A caller that mutates `HOME` while
+/// another thread resolves a path does not merely race on the *value* — the
+/// reader can observe the variable as absent mid-write, and `homeboy()` then
+/// fails with "HOME environment variable not set on Unix-like system" on a
+/// machine where `HOME` is plainly set. Rust made `std::env::set_var` unsafe in
+/// the 2024 edition for exactly this reason.
+///
+/// The hermetic test harness is the only mutator in practice: it repoints
+/// `HOME` per test so each one owns its config, data, and artifact state.
+/// Serializing those mutations behind a lock cannot fix it, because the
+/// *readers* never take that lock — including worker threads a test spawns
+/// inside itself, which is why serial execution alone left the failures in
+/// place (#7505, #10097, #9774).
+///
+/// Routing the hot resolvers through a `Mutex` replaces an unsynchronized
+/// `getenv` with a properly synchronized read, so a concurrent repoint is
+/// ordered rather than torn. Environment remains the source of truth when no
+/// override is registered, so subprocesses — which read their own environment
+/// and are configured explicitly by the harness — are unaffected.
+pub fn set_home_root_override(path: Option<PathBuf>) {
+    let mut guard = home_root_override()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = path;
+}
+
+/// Resolved home root: the process-local override when set, else `$HOME`.
+#[cfg(not(windows))]
+fn resolved_home_root() -> Result<PathBuf> {
+    let override_path = {
+        let guard = home_root_override()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.clone()
+    };
+    if let Some(path) = override_path {
+        return Ok(path);
+    }
+    env::var("HOME").map(PathBuf::from).map_err(|_| {
+        Error::internal_unexpected(
+            "HOME environment variable not set on Unix-like system".to_string(),
+        )
+    })
+}
+
 /// Set a process-local artifact root override.
 ///
 /// This is intentionally process-scoped so CLI flags can outrank environment
@@ -82,12 +134,7 @@ pub fn homeboy() -> Result<PathBuf> {
 
     #[cfg(not(windows))]
     {
-        let home = env::var("HOME").map_err(|_| {
-            Error::internal_unexpected(
-                "HOME environment variable not set on Unix-like system".to_string(),
-            )
-        })?;
-        Ok(PathBuf::from(home)
+        Ok(resolved_home_root()?
             .join(".config")
             .join(homeboy_product_identity::PRODUCT_IDENTITY.config_dirname))
     }
@@ -123,6 +170,24 @@ pub fn homeboy_data() -> Result<PathBuf> {
 
     #[cfg(not(windows))]
     {
+        // A registered override outranks `XDG_DATA_HOME` deliberately. The
+        // harness that sets it also points `XDG_DATA_HOME` at
+        // `<home>/.local/share`, so the resolved path is identical — but
+        // reading the override avoids a second unsynchronized `getenv` on the
+        // same hot path.
+        let override_home = {
+            let guard = home_root_override()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard.clone()
+        };
+        if let Some(home) = override_home {
+            return Ok(home
+                .join(".local")
+                .join("share")
+                .join(homeboy_product_identity::PRODUCT_IDENTITY.data_dirname));
+        }
+
         if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
             if !xdg_data_home.trim().is_empty() {
                 return Ok(PathBuf::from(xdg_data_home)
@@ -130,12 +195,7 @@ pub fn homeboy_data() -> Result<PathBuf> {
             }
         }
 
-        let home = env::var("HOME").map_err(|_| {
-            Error::internal_unexpected(
-                "HOME environment variable not set on Unix-like system".to_string(),
-            )
-        })?;
-        Ok(PathBuf::from(home)
+        Ok(resolved_home_root()?
             .join(".local")
             .join("share")
             .join(homeboy_product_identity::PRODUCT_IDENTITY.data_dirname))
@@ -1145,6 +1205,85 @@ mod formatter_visibility {
                 .map(|s| s.as_str())
                 .collect::<Vec<_>>()
                 .join("\n  ")
+        );
+    }
+}
+
+#[cfg(test)]
+mod home_root_override_tests {
+    use super::*;
+
+    /// The override must beat `$HOME`, so a harness can repoint the home root
+    /// without a `setenv` that other threads race.
+    #[test]
+    fn an_override_outranks_the_environment() {
+        set_home_root_override(Some(PathBuf::from("/tmp/homeboy-override-root")));
+        let resolved = homeboy().expect("config root");
+        set_home_root_override(None);
+
+        assert!(
+            resolved.starts_with("/tmp/homeboy-override-root"),
+            "override must win over $HOME, got {}",
+            resolved.display()
+        );
+    }
+
+    /// Clearing the override must fall back to the environment rather than
+    /// stick at the last override — otherwise a dropped guard would leave every
+    /// later resolution pointing at a deleted tempdir.
+    #[test]
+    fn clearing_the_override_restores_environment_resolution() {
+        set_home_root_override(Some(PathBuf::from("/tmp/homeboy-override-root")));
+        set_home_root_override(None);
+
+        let resolved = homeboy().expect("config root");
+        assert!(
+            !resolved.starts_with("/tmp/homeboy-override-root"),
+            "cleared override must not persist, got {}",
+            resolved.display()
+        );
+    }
+
+    /// The defect this exists for: threads spawned *inside* a test read the
+    /// home root while the harness repoints it. `--test-threads=1` does not
+    /// serialize those, and `getenv`/`setenv` are not thread-safe, so the
+    /// reader could observe `HOME` as absent and fail with "HOME environment
+    /// variable not set on Unix-like system" on a host where it is plainly set.
+    ///
+    /// Reading through the override is a `Mutex` read, so a concurrent repoint
+    /// is ordered rather than torn. This asserts every reader resolves *some*
+    /// valid root — never an error — while the root is repointed underneath.
+    #[test]
+    fn concurrent_readers_never_observe_a_missing_home_root() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let readers: Vec<_> = (0..4)
+            .map(|_| {
+                let stop = Arc::clone(&stop);
+                std::thread::spawn(move || {
+                    let mut failures = 0usize;
+                    while !stop.load(Ordering::SeqCst) {
+                        if homeboy().is_err() || homeboy_data().is_err() {
+                            failures += 1;
+                        }
+                    }
+                    failures
+                })
+            })
+            .collect();
+
+        for i in 0..500 {
+            set_home_root_override(Some(PathBuf::from(format!("/tmp/homeboy-root-{i}"))));
+        }
+        stop.store(true, Ordering::SeqCst);
+        set_home_root_override(None);
+
+        let failures: usize = readers.into_iter().map(|h| h.join().expect("reader")).sum();
+        assert_eq!(
+            failures, 0,
+            "readers must never fail to resolve a home root while it is repointed"
         );
     }
 }


### PR DESCRIPTION
Refs #7505, #10097, #9774. Follow-up to #11242 and #11243.

## The bug

The hermetic harness repoints `HOME` per test. `getenv`/`setenv` are **not thread-safe**, so a reader landing mid-write can observe `HOME` as *absent* and fail with `HOME environment variable not set on Unix-like system` — on a host where it is plainly set. Rust made `std::env::set_var` unsafe in the 2024 edition for precisely this.

## Why the previous two attempts did not close it

**`home_lock()` is held correctly** — `HomeGuard::new` takes it and stores it as `_guard` for the guard's full lifetime. That was verified, and it is not the problem. It serializes **writers**; the **readers never take it**.

**`--test-threads=1` (#11242) serializes test *functions*, not threads a test spawns *inside itself*** — and the failing clusters (`cook`, `promotion`, `provider::scheduler`) are exactly the ones that spawn executor threads. It went green for two PRs, then stopped:

| PR | setting present | Candidate Test |
|---|---|---|
| #11242 | yes | SUCCESS |
| #11243 | yes | SUCCESS |
| #11245 | yes (verified on merge-base) | FAILURE — 199 |
| #11246 | yes (verified on merge-base) | FAILURE — 199, identical list |

Counts across runs: **126 → 68 → 125 → 199**. Timing-dependent — a data race.

## The fix

All the failures funnel through **three** resolvers, not the 2,072 `with_isolated_home` call sites. The writers are many; the readers that break are few:

- `paths::homeboy()`
- `paths::homeboy_data()`
- `engine::invocation::runtime` cache root

Adds a process-local home-root override to `homeboy-paths`, mirroring `set_artifact_root_override` **already in that crate**, and routes those three through it. Reading the override is a `Mutex` read, so a concurrent repoint is **ordered rather than torn**.

Environment stays the source of truth when no override is registered, so subprocesses — which read their own environment and are configured explicitly by `HermeticTestContext::command()` — are unaffected. `set_var("HOME", ..)` is retained for readers that still consult `HOME` directly, so nothing else changes behaviour.

`Drop` clears the override **before** restoring the environment, so no window exists where the override still names a tempdir it is about to delete.

## Why not nextest

#11243 established it is blocked upstream anyway: `homeboy-extensions`' result parser passes only a `cargo-test` adapter matching `test result:` lines, so nextest's `Summary [ ... ] N tests run` yields `test_counts: None` → `Unmeasured(NoStructuredCounts)` → `"failed"` regardless of outcome.

But more fundamentally, nextest **isolates around** the race; this **removes** it — with no toolchain dependency on every runner and dev machine, no result-adapter work, no `rust_nextest_fallback` silent-revert trap, and it fixes the behaviour for anything embedding homeboy too.

## Verification

Three new tests in `homeboy-paths`, all passing locally, including one that spawns four reader threads while the root is repointed 500 times and asserts **zero** resolution failures — the exact shape `--test-threads=1` cannot protect.

`cargo check --lib` clean on `homeboy-paths` and `homeboy-core`; `--lib --tests` clean on `homeboy-core`.

**The decisive test is this PR's own Candidate Test** — the 21 `HOME environment variable not set` failures should be gone. If they are, #11242's `rust_cargo_test_threads = 1` can come back off in a follow-up and restore parallelism.

From the 2026-08-01 consolidation investigation (#11151).