### PR TITLE
fix(deferred-workload): preserve singleton lock identity

### DIFF
--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -1,5 +1,4 @@
 use clap::{Args, Subcommand};
-use fs4::fs_std::FileExt;
 use homeboy::core::deferred_workload;
 use serde::Serialize;
 use std::collections::BTreeSet;
@@ -154,14 +153,14 @@ fn restart_worker_if_pending_with(
 }
 
 fn run_worker(startup_token: &str) -> homeboy::core::Result<()> {
-    let lock = deferred_workload::worker_lock()?;
-    if lock.try_lock_exclusive().is_err() {
+    let Some(lock) = deferred_workload::try_acquire_worker_lock()? else {
         return Ok(());
-    }
+    };
     std::env::set_var("HOMEBOY_DEFERRED_WORKLOAD_OWNER", startup_token);
     let owner = startup_token.to_string();
     deferred_workload::append_worker_log(format!("worker started owner={owner}"))?;
-    run_worker_with(
+    run_worker_while_holding_lock(
+        &lock,
         &owner,
         || {
             let readiness = crate::runner::runners::lab_runner_readiness()?;
@@ -184,6 +183,21 @@ fn run_worker(startup_token: &str) -> homeboy::core::Result<()> {
         deferred_workload_now_ms,
         thread::sleep,
     )
+}
+
+fn run_worker_while_holding_lock(
+    _lock: &deferred_workload::DeferredWorkloadWorkerLock,
+    owner: &str,
+    readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
+    dispatch: impl FnMut(
+        &deferred_workload::DeferredWorkload,
+        &str,
+        &str,
+    ) -> homeboy::core::Result<bool>,
+    now: impl Fn() -> u64,
+    sleep: impl FnMut(Duration),
+) -> homeboy::core::Result<()> {
+    run_worker_with(owner, readiness, dispatch, now, sleep)
 }
 
 pub(crate) fn run_worker_with(

--- a/crates/homeboy-core/src/deferred_workload.rs
+++ b/crates/homeboy-core/src/deferred_workload.rs
@@ -91,6 +91,13 @@ pub struct DeferredWorkloadWorkerStatus {
     pub detail: String,
 }
 
+/// The exclusive worker ownership guard. The directory file is deliberately
+/// retained for the complete worker lifetime: advisory locks belong to its
+/// inode, not to the pathname used to open it.
+pub struct DeferredWorkloadWorkerLock {
+    _root: File,
+}
+
 pub fn defer(input: DeferredWorkloadInput) -> Result<DeferredWorkload> {
     if input
         .job_overrides
@@ -289,16 +296,40 @@ pub fn records() -> Result<Vec<DeferredWorkload>> {
     read_store(&store_path()?)
 }
 
-pub fn worker_lock() -> Result<File> {
-    let path = store_path()?.with_extension("worker.lock");
-    OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .open(&path)
-        .map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
-        })
+pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
+    let root = crate::paths::homeboy()?;
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create deferred workload root {}", root.display())),
+        )
+    })?;
+    let root = fs::canonicalize(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "canonicalize deferred workload root {}",
+                root.display()
+            )),
+        )
+    })?;
+    let file = File::open(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("open deferred workload root {}", root.display())),
+        )
+    })?;
+    match file.try_lock_exclusive() {
+        Ok(true) => Ok(Some(DeferredWorkloadWorkerLock { _root: file })),
+        Ok(false) => Ok(None),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "acquire deferred workload worker lock {}",
+                root.display()
+            )),
+        )),
+    }
 }
 
 pub fn worker_status() -> Result<Option<DeferredWorkloadWorkerStatus>> {
@@ -321,12 +352,11 @@ pub fn worker_is_live(status: &DeferredWorkloadWorkerStatus) -> bool {
     if status.owner_token.is_empty() {
         return false;
     }
-    let Ok(lock) = worker_lock() else {
+    let Ok(lock) = try_acquire_worker_lock() else {
         return false;
     };
     // A status file is advisory. The singleton lock is the authority.
-    if lock.try_lock_exclusive().is_ok() {
-        let _ = lock.unlock();
+    if lock.is_some() {
         return false;
     }
     worker_identity_is_live(
@@ -537,6 +567,9 @@ fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     fn input() -> DeferredWorkloadInput {
         DeferredWorkloadInput {
@@ -700,6 +733,108 @@ mod tests {
             |_, _| crate::process::ProcessIdentityState::IdentityMismatch,
             |_, _| true,
         ));
+    }
+
+    #[test]
+    fn worker_lock_survives_replacement_of_the_legacy_adjacent_lock_file() {
+        crate::test_support::with_isolated_home(|_| {
+            let owner = try_acquire_worker_lock()
+                .expect("acquire worker lock")
+                .expect("first worker owns lock");
+            let legacy_lock = store_path()
+                .expect("store path")
+                .with_extension("worker.lock");
+            std::fs::write(&legacy_lock, b"old lock inode").expect("write old lock file");
+            let replacement = legacy_lock.with_extension("replacement");
+            std::fs::write(&replacement, b"replacement lock inode")
+                .expect("write replacement lock file");
+            std::fs::rename(&replacement, &legacy_lock).expect("replace legacy lock file");
+
+            assert!(
+                try_acquire_worker_lock()
+                    .expect("check competing worker")
+                    .is_none(),
+                "replacing the old lock pathname must not create a second owner"
+            );
+            drop(owner);
+        });
+    }
+
+    #[test]
+    fn worker_lock_contenders_reach_readiness_once_across_processes() {
+        let child_id = std::env::var("HOMEBOY_WORKER_LOCK_TEST_CHILD").ok();
+        if let Some(child_id) = child_id {
+            let root =
+                PathBuf::from(std::env::var("HOMEBOY_WORKER_LOCK_TEST_ROOT").expect("test root"));
+            std::fs::write(root.join(format!("ready-{child_id}")), b"ready")
+                .expect("announce child readiness");
+            while !root.join("start").exists() {
+                thread::sleep(Duration::from_millis(5));
+            }
+            if let Some(_owner) = try_acquire_worker_lock().expect("acquire worker lock") {
+                std::fs::write(root.join(format!("readiness-{child_id}")), b"polled")
+                    .expect("record readiness polling");
+                thread::sleep(Duration::from_millis(250));
+            } else {
+                std::fs::write(root.join(format!("exited-{child_id}")), b"lost")
+                    .expect("record losing contender");
+            }
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("temporary root");
+        let home = temp.path().join("home");
+        let marker_root = temp.path().join("markers");
+        std::fs::create_dir_all(&marker_root).expect("create marker root");
+        let test_name = "deferred_workload::tests::worker_lock_contenders_reach_readiness_once_across_processes";
+        let mut children = Vec::new();
+        for child_id in 0..8 {
+            children.push(
+                Command::new(std::env::current_exe().expect("test executable"))
+                    .args(["--exact", test_name, "--nocapture"])
+                    .env("HOME", &home)
+                    .env("HOMEBOY_WORKER_LOCK_TEST_ROOT", &marker_root)
+                    .env("HOMEBOY_WORKER_LOCK_TEST_CHILD", child_id.to_string())
+                    .spawn()
+                    .expect("spawn worker contender"),
+            );
+        }
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while std::fs::read_dir(&marker_root)
+            .expect("read marker root")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("ready-"))
+            .count()
+            < children.len()
+        {
+            assert!(Instant::now() < deadline, "worker contenders did not start");
+            thread::sleep(Duration::from_millis(10));
+        }
+        std::fs::write(marker_root.join("start"), b"start").expect("release contenders");
+        for mut child in children {
+            assert!(child.wait().expect("wait for contender").success());
+        }
+        let entries = std::fs::read_dir(&marker_root)
+            .expect("read marker root")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|name| name.starts_with("readiness-"))
+                .count(),
+            1,
+            "only the owner may reach readiness polling"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|name| name.starts_with("exited-"))
+                .count(),
+            7,
+            "every losing contender exits before readiness polling"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Enforced deferred-workload singleton ownership with a durable lock on the canonical Homeboy root, preventing duplicate workers from reaching readiness polling.

## What changed
- Replaced the replaceable adjacent worker lock-file identity with an exclusive lock held on the canonical Homeboy root directory.
- Made the lock guard explicit across the complete worker polling lifetime; contenders return before \`worker started\` logging or runner probes.
- Updated worker liveness checks to use the same authoritative ownership mechanism.
- Added deterministic eight-process contention coverage proving exactly one readiness entrant and seven pre-poll exits.
- Added regression coverage showing replacement of the legacy adjacent lock pathname cannot create a second owner.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo test -p homeboy-cli deferred_workload -- --nocapture`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
The durable deferred queue and startup behavior are unchanged. Lock ownership is now independent of runtime binary path and adjacent state-file replacement. Existing stale legacy lock files are ignored safely. No SSH probe-budget behavior was changed.

## Evidence
- Base unchanged since verification: main remains at fd5bae5cdc621c926fe1c2d0831626ffbbff4549.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/11263
- Task objective: Fix https://github.com/Extra-Chill/homeboy/issues/11263 in the existing managed worktree.
- Verified candidate scope: 2 changed file(s): crates/homeboy-cli/src/commands/deferred\_workload.rs, crates/homeboy-core/src/deferred\_workload.rs.
- Verified finalization base: main at fd5bae5cdc621c926fe1c2d0831626ffbbff4549
- deterministic gate passed: sh -lc cargo fmt --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-cli deferred\_workload -- --nocapture (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Investigated existing worker, status, and locking contracts before editing; identified inode drift from the adjacent lock-file identity and strengthened ownership at the shared canonical-root layer. Used AI-assisted codebase and issue analysis, then ran \`cargo fmt --check\`, focused core worker-lock tests, and focused CLI deferred-workload tests.
