### PR TITLE
fix(test): restore Rust test parallelism now the home-root race is fixed

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -372,6 +372,32 @@ fn process_tree_snapshot(_root: u32) -> String {
     "    (process-tree snapshot is only collected on Linux)".to_string()
 }
 
+/// Isolates one test's Homeboy state: config, data, artifact, runtime, and
+/// invocation roots.
+///
+/// # Concurrency contract
+///
+/// This guard repoints `HOME` for the whole process, which is not thread-safe:
+/// `getenv`/`setenv` race, so a reader landing mid-write can observe `HOME` as
+/// *absent* and fail with "HOME environment variable not set on Unix-like
+/// system" on a host where it is plainly set.
+///
+/// `home_lock()` is held for this guard's entire lifetime, but that only
+/// serializes **writers**. Readers never take it — including worker threads a
+/// test spawns inside itself, which is why running the suite with
+/// `--test-threads=1` did not stop the failures: serializing test *functions*
+/// does nothing for threads *within* a test.
+///
+/// The hot resolvers therefore do not read the environment at all. `new()`
+/// registers a process-local override via `paths::set_home_root_override`, and
+/// `paths::homeboy()`, `paths::homeboy_data()`, and the invocation runtime root
+/// read it under a `Mutex` so a concurrent repoint is ordered rather than torn
+/// (#7505, #11266). `set_var("HOME", ..)` is retained alongside it for readers
+/// that still consult `HOME` directly and for subprocesses.
+///
+/// `Drop` clears the override **before** restoring the environment, so no
+/// window exists where the override still names a tempdir it is about to
+/// delete.
 pub struct HomeGuard {
     prior: Option<String>,
     prior_xdg_data_home: Option<String>,

--- a/homeboy.json
+++ b/homeboy.json
@@ -1831,11 +1831,7 @@
     "CARGO_TARGET_DIR": "target"
   },
   "extensions": {
-    "rust": {
-      "settings": {
-        "rust_cargo_test_threads": 1
-      }
-    }
+    "rust": {}
   },
   "hooks": {},
   "id": "homeboy",


### PR DESCRIPTION
Refs #7505, #10097, #9774. Removes the workaround from #11242 now that #11266 fixed the underlying race.

## This PR is deliberately self-proving

Touching `homeboy.json` widens the changed-file test scope, so **this PR's own gate is the wide-scope run that confirms #11266 holds.**

That matters because post-merge runs could not answer it. The only completed post-fix `Test` job on main was **narrow scope — 23 tests**, scoped to changed files in `homeboy-agents`. It reported `0 failed` and zero `HOME environment variable not set`, but 23 tests prove nothing about a concurrency race.

**Read the result this way:**
- **Green** → #11266 holds under full parallelism, and the serialization is correctly gone.
- **Red** → revert *this* PR, not #11266. That fix stands on its own; the serialization can go back on independently.

## Why the workaround was never the fix

`rust_cargo_test_threads = 1` serializes test **functions**. It does nothing for threads a test spawns **inside itself** — and the failing clusters (`cook`, `promotion`, `provider::scheduler`) are exactly the ones that spawn executor threads. It held for two PRs and then stopped:

| PR | setting present | Candidate Test |
|---|---|---|
| #11242 | yes | SUCCESS |
| #11243 | yes | SUCCESS |
| #11245 | yes (verified on merge-base) | FAILURE — 199 |
| #11246 | yes (verified on merge-base) | FAILURE — 199, identical list |

Counts across runs: **126 → 68 → 125 → 199**. Timing-dependent, i.e. a live data race — and every gate in that window was green or red by chance.

## What #11266 changed

`paths::homeboy()`, `paths::homeboy_data()`, and the invocation runtime root now resolve through a `Mutex`-guarded process-local home-root override rather than an unsynchronized `getenv`, so a concurrent repoint is ordered rather than torn. Environment remains the source of truth when no override is registered, so subprocesses are unaffected.

## The cost being recovered

Serialization removed all intra-binary parallelism from the largest crate in the workspace — estimated **400–900s** for `homeboy-agents` against roughly **302s** before.

From the 2026-08-01 consolidation investigation (#11151).