### PR TITLE
fix(cook): attach successful retries to durable lineage

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2056,6 +2056,64 @@ fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
 }
 
 #[test]
+fn approved_empty_provider_failure_retry_stays_attached_and_becomes_continuation_candidate() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-provider-failure-retry";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = format!("{cook_id}-attempt-1");
+        options.max_attempts = 2;
+        super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+        super::super::materialize_initial_cook_attempt(&options)
+            .expect("materialize first attempt");
+
+        let failed = crate::agent_task_service::execution::run_submitted(
+            options.initial_run_id.clone(),
+            ProviderMissingExecutor,
+        )
+        .expect("record provider failure");
+        assert_eq!(failed.exit_code, 1);
+        assert_eq!(
+            agent_task_lifecycle::status(&options.initial_run_id)
+                .expect("failed Cook attempt")
+                .state,
+            agent_task_lifecycle::AgentTaskRunState::Failed
+        );
+
+        // Invoking retry is the explicit operator approval boundary. Its durable
+        // reservation must immediately bind to the owning Cook recipe and index.
+        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("approved provider retry remains Cook-owned");
+        let retry_run_id = retry.record.run_id;
+        let patch_root = tempfile::tempdir().expect("candidate patch root");
+        seed_substantive_candidate_aggregate(
+            &retry_run_id,
+            &options.initial_plan,
+            &patch_root.path().join("candidate.patch"),
+            "diff --git a/fixture.txt b/fixture.txt\n+index 0000000..1111111 100644\n--- a/fixture.txt\n+++ b/fixture.txt\n@@ -0,0 +1 @@\n+fixed\n",
+        );
+
+        let index = agent_task_lifecycle::cook_index(cook_id).expect("Cook retry index");
+        assert_eq!(index.latest_run_id, retry_run_id);
+        assert_eq!(index.attempts.len(), 2);
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("substantive retry is selected");
+        assert_eq!(selection.run_id, retry_run_id);
+        assert_eq!(selection.reason, "latest_substantive_candidate_pointer");
+        assert_eq!(
+            super::super::resolve_cook_continuation_run_id(cook_id)
+                .expect("cook-continue resolves the retry candidate"),
+            retry_run_id
+        );
+        assert_eq!(
+            agent_task_lifecycle::status(&retry_run_id)
+                .expect("successful retry")
+                .state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+    });
+}
+
+#[test]
 fn retryable_pre_provider_retry_propagates_force_after_terminal_successor() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = retryable_pre_provider_cook("cook-forced-terminal-retry", 3);

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -533,14 +533,13 @@ fn reserve_cook_retry_lifecycle(
     }
 }
 
-/// A retryable failure before provider execution has no candidate or execution
-/// evidence to supersede, so its retry remains an append-only Cook attempt.
+/// A manually approved retry of a Cook-owned failure with no candidate evidence
+/// remains an append-only Cook attempt. The durable recipe authenticates source
+/// ownership; the Cook index prevents a failed provider retry from superseding
+/// an already-promotable sibling candidate.
 fn retryable_cook_attempt(
     source: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<Option<CookRetryAttempt>> {
-    if source.metadata["pre_execution_failure"]["retryable"] != serde_json::Value::Bool(true) {
-        return Ok(None);
-    }
     let Some(cook_id) = source.metadata["cook_id"].as_str() else {
         return Ok(None);
     };
@@ -575,6 +574,19 @@ fn retryable_cook_attempt(
             )]),
         ));
     };
+    let retryable_pre_execution_failure =
+        source.metadata["pre_execution_failure"]["retryable"] == serde_json::Value::Bool(true);
+    let failed_provider_without_candidate = source.state
+        == agent_task_lifecycle::AgentTaskRunState::Failed
+        && !retryable_pre_execution_failure
+        && agent_task_lifecycle::select_cook_candidate(cook_id)
+            .ok()
+            .is_some_and(|selection| {
+                selection.run_id == source.run_id && selection.selected_artifact_id.is_none()
+            });
+    if !retryable_pre_execution_failure && !failed_provider_without_candidate {
+        return Ok(None);
+    }
     let mut pending_attempt = None;
     for recipe_attempt in recipe
         .attempts


### PR DESCRIPTION
## Summary
Fix Cook-owned provider-failure retries so an explicitly approved retry is bound to the original Cook and becomes its canonical continuation candidate.

## What changed
- Extended Cook retry eligibility from retryable pre-execution failures to authenticated terminal provider failures with no substantive candidate evidence.
- Reused the existing exactly-once retry reservation and locked recipe/index binding path, preserving budgets, runtime pinning, and unrelated-run safeguards.
- Added a regression covering failed provider run -\> approved retry -\> substantive successful child -\> Cook candidate selection and cook-continue resolution.

## How to test
1. Run `cargo fmt --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo test -p homeboy-agents cook_continue -- --nocapture`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Existing pre-execution retry behavior and missing-record recovery remain unchanged. Generic retries remain generic unless durable recipe membership, Cook identity, failed state, and candidate-empty selection authenticate Cook ownership. Focused tests passed: cargo fmt, the new regression, and 13 existing Cook retry tests.

## Evidence
- Base unchanged since verification: main remains at e089f864df1346b277e39622686e3b3cc7f59484.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/10363
- Task objective: Fix the regression in https://github.com/Extra-Chill/homeboy/issues/10363 in the existing managed worktree.
- Verified candidate scope: 2 changed file(s): crates/homeboy-agents/src/agent\_task\_service/cook\_tests.rs, crates/homeboy-agents/src/agent\_task\_service/execution.rs.
- Verified finalization base: main at e089f864df1346b277e39622686e3b3cc7f59484
- deterministic gate passed: sh -lc cargo fmt --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-agents cook\_continue -- --nocapture (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Investigated lifecycle retry lineage, Cook recipe/index ownership, candidate selection, and continuation resolution before editing. Used AI assistance to trace the existing implementation family, apply the minimal eligibility extension, and add deterministic service coverage.
