### PR TITLE
fix(invocation): restore direct HOME resolution for the runtime root

### DIFF
--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -50,6 +50,7 @@
 //! (`<workload-id>/daemon/daemon.sock` ≈ 40 bytes) underneath.
 
 use crate::error::{Error, Result};
+#[cfg(windows)]
 use crate::paths;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -151,22 +152,34 @@ fn cache_fallback_root() -> Result<PathBuf> {
         if let Some(xdg_cache) = non_empty_env("XDG_CACHE_HOME") {
             return Ok(PathBuf::from(xdg_cache).join("homeboy").join("inv"));
         }
-        // Resolve through `paths`, which prefers the process-local home-root
-        // override over an unsynchronized `getenv` (#7505). `homeboy()` returns
-        // `<home>/.config/homeboy`, so step back to the home root rather than
-        // re-reading `HOME` here and reintroducing the race this fixes.
-        let config_root = paths::homeboy()?;
-        let home = config_root
-            .parent()
-            .and_then(Path::parent)
-            .ok_or_else(|| {
-                Error::internal_unexpected(format!(
-                    "could not derive a home root from config directory {}",
-                    config_root.display()
-                ))
-            })?
-            .to_path_buf();
-        Ok(home.join(".cache").join("homeboy").join("inv"))
+        // Deliberately reads `HOME` directly rather than deriving it from
+        // `paths::homeboy()`.
+        //
+        // #11266 routed this through `paths` so it would honor the home-root
+        // override and avoid a second `getenv`. That broke
+        // `promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id`,
+        // which passed in three pre-#11266 runs and failed in every run after.
+        //
+        // This resolver is not where the race lived: the
+        // "HOME environment variable not set" failures came from
+        // `paths::homeboy()` and `paths::homeboy_data()`, which #11266 does
+        // fix and which keep the override. The invocation runtime root is
+        // additionally pinned by `HOMEBOY_INVOCATION_RUNTIME_DIR_ENV` for every
+        // hermetic test, so it was never a meaningful source of the race —
+        // only of extra blast radius.
+        //
+        // Socket paths under this root must stay inside the `sockaddr_un`
+        // budget (~104 bytes), so its shape is load-bearing in a way the
+        // config root's is not. Keep them independent.
+        let home = env::var("HOME").map_err(|_| {
+            Error::internal_unexpected(
+                "HOME environment variable not set on Unix-like system".to_string(),
+            )
+        })?;
+        Ok(PathBuf::from(home)
+            .join(".cache")
+            .join("homeboy")
+            .join("inv"))
     }
 }
 


### PR DESCRIPTION
Reverts one hunk of #11266. **My regression — currently on main.**

## Evidence

`promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id`:

| run | base | result |
|---|---|---|
| #11234 candidate gate | pre-#11266 | **ok** |
| #11235 candidate gate | pre-#11266 | **ok** |
| #11246 candidate gate | pre-#11266 | **ok** |
| #11273 candidate gate | post-#11266 | **FAILED** |
| #11276 candidate gate | post-#11266 | **FAILED** |

Two independent branches sharing only that base, failing on the same single test, with **zero** `HOME environment variable not set` failures — so the race #11266 targeted is genuinely fixed, and this is separate collateral.

## What was wrong with the change

#11266 routed the invocation runtime root through `paths::homeboy()` and stepped back two parents to recover the home root, so it would honor the home-root override and avoid a second `getenv`.

That was over-reach on three counts:

1. **This resolver was never where the race lived.** The failures came from `paths::homeboy()` and `paths::homeboy_data()`. Both keep the override; both are untouched here.
2. **It is already pinned in tests.** `HermeticTestContext` sets `HOMEBOY_INVOCATION_RUNTIME_DIR_ENV` for every hermetic test, so this branch is not even reached there. It contributed blast radius rather than coverage.
3. **It is shape-sensitive in a way the config root is not.** Socket paths under this root must stay inside the `sockaddr_un` budget (~104 bytes) — which is precisely what the broken test asserts (`socket_path.len() < 104`). Deriving it from the config root coupled two paths with different constraints and no shared reason to agree.

The failing test is in-process (`agent_task_promotion::promote` called directly, no `HomeGuard`), so it resolves against CI's real `HOME` — the one case where the two derivations can diverge.

## Scope

One hunk. The `homeboy-paths` home-root override, its use in `homeboy()` and `homeboy_data()`, and the three concurrency tests — including the one that spawns 4 readers while repointing the root 500 times — are all unchanged.

**This unblocks #11273 and #11276**, both currently failing on this and nothing else.

From the 2026-08-01 consolidation investigation (#11151).