### PR TITLE
Keep the gate temp root short and non-symlink

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1125,24 +1125,49 @@ impl SelectedGateEnvironment {
     }
 }
 
+/// Resolve the real directory every gate process receives as its temporary
+/// root.
+///
+/// Two independent constraints apply, and canonicalizing satisfies only one of
+/// them:
+///
+/// 1. **Socket budget (#10829).** `InvocationGuard` deliberately exports a
+///    short symlink alias (`<runtime-root>/<short>.t`) and validates it with
+///    `enforce_path_budget`, so gate workloads can bind `AF_UNIX` sockets
+///    under `$TMPDIR`. The managed directory behind that alias is ~125 bytes —
+///    already past the 108-byte Linux `sun_path` capacity before a socket name
+///    is appended. Resolving the alias away discards the very budget the
+///    invocation layer validated.
+/// 2. **Non-symlink root (#11265).** Security-sensitive child tools reject a
+///    symlinked temp root outright, before writing anything into it.
+///
+/// A real `tmp` subdirectory created *through* the alias satisfies both: the
+/// path stays short, the leaf is a genuine directory rather than a symlink,
+/// and the bytes still land in managed runtime-temp storage rather than on the
+/// invocation root's volume (#11125).
+///
+/// Isolated `HOME`/XDG directories hang off this same root, so they inherit
+/// both properties instead of re-deriving them.
+fn gate_temp_root(runtime_tmpdir: &Path) -> Result<PathBuf> {
+    let root = runtime_tmpdir.join("tmp");
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "create isolated gate temp directory {}",
+                root.display()
+            )),
+        )
+    })?;
+    Ok(root)
+}
+
 fn selected_gate_environment(
     policy: &AgentTaskGateEnvironmentPolicy,
     runtime_tmpdir: Option<&Path>,
 ) -> Result<SelectedGateEnvironment> {
-    let canonical_runtime_tmpdir = runtime_tmpdir
-        .map(|path| {
-            fs::canonicalize(path).map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some(format!(
-                        "canonicalize isolated gate temp directory {}",
-                        path.display()
-                    )),
-                )
-            })
-        })
-        .transpose()?;
-    let runtime_tmpdir = canonical_runtime_tmpdir.as_deref();
+    let gate_tmpdir = runtime_tmpdir.map(gate_temp_root).transpose()?;
+    let runtime_tmpdir = gate_tmpdir.as_deref();
     let mut report = AgentTaskGateEnvironment {
         mode: policy.mode,
         ..AgentTaskGateEnvironment::default()
@@ -1718,12 +1743,7 @@ mod tests {
         )
         .expect("gate report");
 
-        let expected = scratch
-            .path()
-            .canonicalize()
-            .expect("canonical scratch")
-            .display()
-            .to_string();
+        let expected = scratch.path().join("tmp").display().to_string();
         assert_eq!(report.stdout, format!("{expected}:{expected}:{expected}"));
     }
 
@@ -2100,10 +2120,7 @@ mod tests {
         let workspace = tempfile::tempdir().expect("workspace");
         let runtime_tmpdir = tempfile::tempdir().expect("runtime tmpdir");
         let bin = tempfile::tempdir().expect("bin");
-        let canonical_runtime_tmpdir = runtime_tmpdir
-            .path()
-            .canonicalize()
-            .expect("canonical runtime tmpdir");
+        let gate_tmpdir = runtime_tmpdir.path().join("tmp");
 
         // Fails unless every temp-dir variable points at the invocation temp
         // dir. An unset variable compares as empty and exits non-zero too.
@@ -2112,7 +2129,7 @@ mod tests {
             &tool,
             format!(
                 "#!/bin/sh\n[ \"$TMPDIR\" = '{dir}' ] || exit 3\n[ \"$TEMP\" = '{dir}' ] || exit 4\n[ \"$TMP\" = '{dir}' ] || exit 5\nexit 0\n",
-                dir = canonical_runtime_tmpdir.display()
+                dir = gate_tmpdir.display()
             ),
         )
         .expect("tool");
@@ -2141,12 +2158,7 @@ mod tests {
         )
         .expect("gate environment");
 
-        let expected = runtime_tmpdir
-            .path()
-            .canonicalize()
-            .expect("canonical runtime tmpdir")
-            .display()
-            .to_string();
+        let expected = runtime_tmpdir.path().join("tmp").display().to_string();
         for name in TMPDIR_ENV_VARS {
             assert_eq!(
                 selected.values.get(*name),
@@ -2156,9 +2168,16 @@ mod tests {
         }
     }
 
+    /// A symlinked invocation temp alias must yield sandbox paths that are
+    /// simultaneously **short** and **non-symlink**.
+    ///
+    /// Resolving the alias away (canonicalizing) would satisfy the non-symlink
+    /// half while discarding the `sockaddr_un` budget the invocation layer
+    /// validated on the alias, so this asserts the exported paths stay *under
+    /// the alias* rather than under its canonical target.
     #[cfg(unix)]
     #[test]
-    fn gate_environment_resolves_symlinked_invocation_tmpdir() {
+    fn gate_environment_exports_a_real_directory_beneath_the_invocation_tmp_alias() {
         let runtime_tmpdir = tempfile::tempdir().expect("runtime tmpdir");
         let alias_root = tempfile::tempdir().expect("alias root");
         let alias = alias_root.path().join("runtime-tmp-alias");
@@ -2167,18 +2186,24 @@ mod tests {
         let selected =
             selected_gate_environment(&AgentTaskGateEnvironmentPolicy::default(), Some(&alias))
                 .expect("gate environment");
-        let expected_root = runtime_tmpdir
-            .path()
-            .canonicalize()
-            .expect("canonical temp root");
+        let expected_root = alias.join("tmp");
 
         for name in TMPDIR_ENV_VARS {
             assert_eq!(
                 selected.values.get(*name).map(PathBuf::from),
                 Some(expected_root.clone()),
-                "{name} must resolve past the invocation temp alias"
+                "{name} must stay beneath the short invocation temp alias"
             );
         }
+
+        // The exported root is reached *through* the alias, but is itself a
+        // real directory — the property security-sensitive child tools check.
+        assert!(!fs::symlink_metadata(&expected_root)
+            .expect("gate temp root metadata")
+            .file_type()
+            .is_symlink());
+        assert!(expected_root.is_dir());
+
         for variable in &selected.report.sanitized {
             let path = PathBuf::from(&variable.value);
             assert!(path.starts_with(&expected_root));


### PR DESCRIPTION
## Summary

Fixes red `main`. The `Test` gate has been failing on
`promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id`
with:

```
called `Result::unwrap()` on an `Err` value: Error { kind: InvalidInput,
message: "path must be shorter than SUN_LEN" }
```

## Root cause

Two merged PRs asserted opposite invariants on the same value.

- **#10829** made `InvocationGuard` export a **short symlink alias**
  (`<runtime-root>/<short>.t`) as `TMPDIR`, validated by
  `enforce_path_budget`, so gate workloads can bind `AF_UNIX` sockets.
- **#11267** (closes #11265) added `fs::canonicalize()` in
  `selected_gate_environment`, so gates receive the **real long path** —
  because SSI rejects a symlinked artifact-workspace root.

The arithmetic makes this categorical, not marginal:

| path | bytes |
|---|---|
| short alias `/tmp/hb-1001/9438c493c9.t` | 25 |
| alias + `/gate.sock` | 35 |
| canonical `~/.local/share/homeboy/runtime/tmp/homeboy-invocation-tmp-<uuid>-<nanos>` | **125** |
| Linux `SUN_PATH_CAPACITY` | 108 |

The canonical path exceeds the socket budget *before any socket name is
appended*, so every gate workload binding a Unix socket under `$TMPDIR`
was broken. Homeboy was validating `enforce_path_budget` on the alias and
then handing out a different, unvalidated path.

## Fix

Export a real `tmp` subdirectory created *through* the alias, rather than
canonicalizing.

`isolate_home` / `isolate_xdg` already exported `<root>/gate-home` and
`<root>/gate-xdg/*` — real directories reached through the alias. Only
`TMPDIR`/`TEMP`/`TMP` was ever the raw symlink, so this is the surgical
change that reconciles both invariants:

- **short** (~29 bytes) — socket budget restored, #10829 holds
- **non-symlink leaf** — the property #11265's child tools check, so SSI
  stays fixed
- **bytes stay in managed runtime-temp storage** — no #11125 / #10732
  disk-pressure regression
- preflight and execution share one helper, so they still agree on a
  single directory (#10245)

## Test changes

`gate_environment_resolves_symlinked_invocation_tmpdir` pinned the
canonicalization, so it is retargeted (and renamed to
`gate_environment_exports_a_real_directory_beneath_the_invocation_tmp_alias`)
to assert the combined property: exported paths stay **under the alias**
*and* the leaf is a real directory. Asserting "stays under the alias" is
what keeps the socket budget from silently regressing again.

## Verification

- `cargo check -p homeboy-agents --lib --tests` — clean
- `cargo test -p homeboy-agents --lib agent_task_gate::tests -- --test-threads=1` — **25 passed, 0 failed**
- `cargo fmt`

The integration test itself needs the `homeboy` binary, so it is left to
CI per the repo's build policy.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: traced red `main` to the #10829/#11267 conflict via CI observation
  artifacts, established the path-budget arithmetic, implemented the fix and
  retargeted the pinning test. Chris Huber remains responsible for every line.