### PR TITLE
fix(cook): retain base-bound patches after provider failure

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -806,6 +806,9 @@ where
                             );
                         }
                     }
+                    AgentTaskScheduleSupport::preserve_base_bound_patch_after_provider_failure(
+                        &mut outcome,
+                    );
                     let state = AgentTaskScheduleSupport::state_for_outcome(&outcome);
                     events.push(event(
                         &outcome.task_id,

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1035,6 +1035,43 @@ impl AgentTaskScheduleSupport {
         });
     }
 
+    /// A provider can create a durable patch before failing its completion
+    /// contract. Preserve that candidate for a fresh review and gate pass, but
+    /// retain the provider failure classification as the terminal diagnosis.
+    pub(super) fn preserve_base_bound_patch_after_provider_failure(outcome: &mut AgentTaskOutcome) {
+        if matches!(
+            outcome.status,
+            AgentTaskOutcomeStatus::Succeeded
+                | AgentTaskOutcomeStatus::NoOp
+                | AgentTaskOutcomeStatus::Cancelled
+                | AgentTaskOutcomeStatus::Timeout
+                | AgentTaskOutcomeStatus::CandidateRecoverable
+        ) || !outcome
+            .artifacts
+            .iter()
+            .any(|artifact| is_base_bound_patch_candidate(outcome, artifact))
+        {
+            return;
+        }
+
+        let provider_failure = outcome.failure_classification;
+        outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
+        outcome.summary = Some(
+            "provider completion failed after producing a base-bound patch candidate; fresh review and deterministic gates are required before promotion"
+                .to_string(),
+        );
+        outcome.diagnostics.push(AgentTaskDiagnostic {
+            class: "agent_task.provider_failure_recoverable_candidate".to_string(),
+            message: "a non-empty base-bound patch was retained without treating it as verified or promotable"
+                .to_string(),
+            data: serde_json::json!({
+                "provider_failure_classification": provider_failure,
+                "required_validation": ["fresh_review", "deterministic_gates"],
+                "recovery_action": "homeboy agent-task review <run-id>",
+            }),
+        });
+    }
+
     pub(super) fn cancelled_outcome(task_id: String, summary: String) -> AgentTaskOutcome {
         AgentTaskOutcome {
             task_id,
@@ -1178,6 +1215,7 @@ impl AgentTaskScheduleSupport {
                 AgentTaskOutcomeStatus::Succeeded
                     | AgentTaskOutcomeStatus::NoOp
                     | AgentTaskOutcomeStatus::Cancelled
+                    | AgentTaskOutcomeStatus::CandidateRecoverable
             )
             && matches!(
                 outcome.failure_classification,
@@ -1435,6 +1473,7 @@ impl AgentTaskScheduleSupport {
                     | AgentTaskOutcomeStatus::NoOp
                     | AgentTaskOutcomeStatus::Cancelled
                     | AgentTaskOutcomeStatus::Timeout
+                    | AgentTaskOutcomeStatus::CandidateRecoverable
             )
     }
 
@@ -1600,4 +1639,33 @@ impl AgentTaskScheduleSupport {
 
         totals
     }
+}
+
+fn is_base_bound_patch_candidate(outcome: &AgentTaskOutcome, artifact: &AgentTaskArtifact) -> bool {
+    is_actionable_patch_artifact(artifact)
+        && artifact.size_bytes.is_some_and(|size| size > 0)
+        && artifact
+            .sha256
+            .as_deref()
+            .is_some_and(homeboy_engine_primitives::content_hash::is_sha256_hex)
+        && artifact.metadata.get("task_id").and_then(Value::as_str) == Some(&outcome.task_id)
+        && artifact
+            .metadata
+            .get("producer_attempt")
+            .is_some_and(Value::is_u64)
+        && [
+            "run_id",
+            "base_ref",
+            "provider_backend",
+            "repository_identity",
+            "workspace_identity",
+        ]
+        .iter()
+        .all(|key| {
+            artifact
+                .metadata
+                .get(*key)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        })
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -371,6 +371,67 @@ fn policy_denial_is_terminal_even_when_retry_policy_matches_every_failure() {
 }
 
 #[test]
+fn base_bound_patch_survives_policy_denial_and_missing_review_form_for_fresh_review() {
+    let patch = "diff --git a/lib.rs b/lib.rs\n--- a/lib.rs\n+++ b/lib.rs\n@@ -1 +1 @@\n-base\n+candidate\n";
+    let mut denied = outcome(
+        "policy-denied-patch".to_string(),
+        AgentTaskOutcomeStatus::Failed,
+    );
+    denied.failure_classification = Some(AgentTaskFailureClassification::PolicyDenied);
+    denied.artifacts = vec![AgentTaskArtifact {
+        schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: "candidate".to_string(),
+        kind: "patch".to_string(),
+        size_bytes: Some(patch.len() as u64),
+        sha256: Some(homeboy_engine_primitives::content_hash::sha256_hex(
+            patch.as_bytes(),
+        )),
+        metadata: json!({
+            "task_id": "policy-denied-patch",
+            "producer_attempt": 1,
+            "run_id": "run-11280",
+            "base_ref": "base-11280",
+            "provider_backend": "provider",
+            "repository_identity": "repository-11280",
+            "workspace_identity": "workspace-11280",
+        }),
+        ..Default::default()
+    }];
+
+    AgentTaskScheduleSupport::preserve_base_bound_patch_after_provider_failure(&mut denied);
+
+    assert_eq!(denied.status, AgentTaskOutcomeStatus::CandidateRecoverable);
+    assert_eq!(
+        denied.failure_classification,
+        Some(AgentTaskFailureClassification::PolicyDenied)
+    );
+    assert!(denied.outputs.get("review_form").is_none());
+    assert!(denied.diagnostics.iter().any(|diagnostic| {
+        diagnostic.class == "agent_task.provider_failure_recoverable_candidate"
+            && diagnostic.data["recovery_action"] == "homeboy agent-task review <run-id>"
+    }));
+    let outcomes = vec![denied.clone()];
+    assert_eq!(
+        AgentTaskScheduleSupport::aggregate_status(&outcomes),
+        AgentTaskAggregateStatus::PartialRecoverable
+    );
+    let totals = AgentTaskScheduleSupport::totals(1, &outcomes);
+    assert_eq!(totals.candidate_recoverable, 1);
+    assert_eq!(totals.recoverable_candidates, 1);
+    assert_eq!(totals.failed, 0);
+    assert!(!AgentTaskScheduleSupport::should_retry(
+        &denied,
+        1,
+        2,
+        3,
+        3,
+        None,
+        0,
+        &[],
+    ));
+}
+
+#[test]
 fn incomplete_nested_outputs_provider_result_is_detected() {
     // Mirrors a provider wrapper shape: the provider claims
     // top-level success/completed, but `outputs.completed` is false, the reply


### PR DESCRIPTION
Fixes #11280

## Summary
- Preserve a non-empty, SHA-verified patch that is bound to its producing run, task, attempt, base, provider, repository, and workspace when provider completion fails.
- Keep the provider failure classification, require fresh review and deterministic gates, and prevent provider retry/rotation from treating the candidate as verified.
- Surface the supported recovery command: `homeboy agent-task review <run-id>`. Cook continuation and candidate adoption continue through their existing fresh review/gate paths.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents base_bound_patch_survives_policy_denial_and_missing_review_form_for_fresh_review`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes`

## Compatibility
- Existing succeeded, no-op, cancelled, timeout, and already-recoverable outcomes retain their behavior.
- Only canonical, non-empty, base-bound patch artifacts on other terminal provider outcomes become `candidate_recoverable`; they remain unverified and cannot bypass fresh review or deterministic gates.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the scheduler, aggregate, Cook continuation, and adoption paths; implemented the recovery contract and focused tests. Chris Huber remains responsible for every line.