### PR TITLE
fix(cook): preflight effective retry budget

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -27,7 +27,8 @@ use super::cook_baseline::{
     CookFollowUpBaseline, DerivedCookBaselineCapability,
 };
 use super::cook_budget::{
-    budget_remaining, execution_budget_usage, reserve_remediation_budget, ExecutionBudgetUsage,
+    budget_remaining, execution_budget_usage, reserve_remediation_budget,
+    validate_effective_cook_budget, ExecutionBudgetUsage,
 };
 use super::cook_pre_execution::{
     materialize_cook_attempt, materialize_initial_cook_attempt, pre_execution_failure_details,
@@ -1665,6 +1666,29 @@ fn cook_status_is_terminal(status: &str) -> bool {
     !matches!(status, "queued" | "running" | "in_flight")
 }
 
+pub(crate) fn exhausted_budget_guidance(
+    max_attempts: u32,
+    budget: &AgentTaskExecutionBudget,
+    reason: &str,
+    review_form_only: bool,
+) -> String {
+    let remediation = if review_form_only {
+        "review-form remediation"
+    } else {
+        "gate or provider remediation"
+    };
+    format!(
+        "Cook stopped during {remediation} because {reason} was exhausted. Configured budget: --max-attempts {}, --max-provider-executions {}, --max-same-provider-retries {}, --max-provider-rotations {}. Start a new Cook with `--max-attempts {} --max-provider-executions {} --max-same-provider-retries {}`; rotations cannot fund same-provider gate or review-form retries.",
+        max_attempts,
+        budget.max_provider_executions,
+        budget.max_same_provider_retries,
+        budget.max_provider_rotations,
+        max_attempts,
+        max_attempts,
+        max_attempts.saturating_sub(1),
+    )
+}
+
 fn run_cook_with_boundaries_observed<E, S>(
     options: AgentTaskCookServiceOptions,
     executor: E,
@@ -1814,6 +1838,16 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
+    // Validate new Cooks before provider discovery, workspace staging, recipe
+    // persistence, or a detached handoff can spend provider work. Historical
+    // immutable recipes retain their persisted behavior and receive actionable
+    // exhaustion guidance if their legacy budget reaches remediation.
+    if !super::recipe_exists(&options.cook_id)? {
+        validate_effective_cook_budget(
+            options.max_attempts,
+            &options.initial_plan.options.execution_budget,
+        )?;
+    }
     project_initial_finalizing_review_form_contract(&mut options);
     // A configured provider is controller authority. Resolve it before an
     // external runner can spend a provider attempt; explicit transports are
@@ -2819,6 +2853,8 @@ where
                     .as_ref()
                     .expect("budget is initialized from the loaded attempt plan");
                 let budget_scope = follow_up_budget_scope(&source_request, &follow_up_request);
+                let review_form_only =
+                    follow_up_request.inputs["cook_loop"]["review_form_required"] == true;
                 match dispatch_cook_follow_up(
                     &options,
                     executor.clone(),
@@ -2844,8 +2880,11 @@ where
                             status: "execution_budget_exhausted",
                             attempts,
                             finalization: None,
-                            stop_reason: Some(format!(
-                                "provider execution stopped because {reason} was exhausted"
+                            stop_reason: Some(exhausted_budget_guidance(
+                                max_attempts,
+                                budget_limit,
+                                &reason,
+                                review_form_only,
                             )),
                             exit_code: 1,
                             invocation_latest_run_id: Some(&run_id),

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -656,8 +656,11 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     status: "execution_budget_exhausted",
                     attempts: vec![attempt],
                     finalization: None,
-                    stop_reason: Some(format!(
-                        "provider execution stopped because {reason} was exhausted"
+                    stop_reason: Some(super::cook::exhausted_budget_guidance(
+                        options.max_attempts,
+                        &budget,
+                        &reason,
+                        true,
                     )),
                     exit_code: 1,
                     invocation_latest_run_id: Some(record.run_id.as_str()),

--- a/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
@@ -8,6 +8,7 @@
 //! no I/O — which is why they lift cleanly out of the cook orchestration file.
 
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskExecutionBudget, AgentTaskState};
+use homeboy_core::{Error, Result};
 
 use super::cook_pre_execution::provider_rotation_attempts;
 
@@ -28,6 +29,87 @@ impl ExecutionBudgetUsage {
             .provider_rotations
             .saturating_add(other.provider_rotations);
     }
+}
+
+/// The provider-backed portion of a Cook's retry policy. Cook attempts are
+/// orchestration slots; every remediation that reaches a provider also needs a
+/// total execution slot and, for gate and review-form fixes, a same-provider
+/// retry slot. Provider rotation is not a substitute for a form-only retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveCookBudget {
+    pub requested_attempts: u32,
+    pub provider_executions: u32,
+    pub same_provider_remediations: u32,
+    pub provider_rotations: u32,
+}
+
+pub fn effective_cook_budget(
+    max_attempts: u32,
+    budget: &AgentTaskExecutionBudget,
+) -> EffectiveCookBudget {
+    EffectiveCookBudget {
+        requested_attempts: max_attempts.max(1),
+        provider_executions: budget.max_provider_executions,
+        same_provider_remediations: budget.max_same_provider_retries,
+        provider_rotations: budget.max_provider_rotations,
+    }
+}
+
+/// Reject a Cook whose advertised attempt allowance cannot support its
+/// provider-backed remediation contract. This runs before a recipe is written,
+/// preserving immutable-recipe compatibility while preventing expensive work
+/// that could never reach its configured retry allowance.
+pub fn validate_effective_cook_budget(
+    max_attempts: u32,
+    budget: &AgentTaskExecutionBudget,
+) -> Result<EffectiveCookBudget> {
+    let effective = effective_cook_budget(max_attempts, budget);
+    let required_remediations = effective.requested_attempts.saturating_sub(1);
+    let correction = format!(
+        "Start a new Cook with `--max-attempts {} --max-provider-executions {} --max-same-provider-retries {}`.",
+        effective.requested_attempts,
+        effective.requested_attempts,
+        required_remediations,
+    );
+
+    if effective.provider_executions < effective.requested_attempts {
+        return Err(Error::validation_invalid_argument(
+            "max-provider-executions",
+            format!(
+                "Cook requests {} attempts but --max-provider-executions {} can fund only {} provider-backed attempt(s). Effective budget: attempts={}, provider_executions={}, same_provider_remediations={}, provider_rotations={}. {}",
+                effective.requested_attempts,
+                effective.provider_executions,
+                effective.provider_executions,
+                effective.requested_attempts,
+                effective.provider_executions,
+                effective.same_provider_remediations,
+                effective.provider_rotations,
+                correction,
+            ),
+            None,
+            Some(vec![correction]),
+        ));
+    }
+    if effective.same_provider_remediations < required_remediations {
+        return Err(Error::validation_invalid_argument(
+            "max-same-provider-retries",
+            format!(
+                "Cook requests {} attempts but --max-same-provider-retries {} cannot fund {} same-provider remediation(s). Gate fixes and required review-form retries preserve the successful provider identity; --max-provider-rotations {} cannot replace them. Effective budget: attempts={}, provider_executions={}, same_provider_remediations={}, provider_rotations={}. {}",
+                effective.requested_attempts,
+                effective.same_provider_remediations,
+                required_remediations,
+                effective.provider_rotations,
+                effective.requested_attempts,
+                effective.provider_executions,
+                effective.same_provider_remediations,
+                effective.provider_rotations,
+                correction,
+            ),
+            None,
+            Some(vec![correction]),
+        ));
+    }
+    Ok(effective)
 }
 
 pub(crate) fn execution_budget_usage(aggregate: &AgentTaskAggregate) -> ExecutionBudgetUsage {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4669,6 +4669,16 @@ fn repeated_provider_discovery_failures_exhaust_the_adoption_review_allowance() 
             )
             .expect("budget exhaustion is a durable Cook result");
         assert_eq!(exhausted.value.status, "execution_budget_exhausted");
+        assert!(
+            exhausted
+                .value
+                .stop_reason
+                .as_deref()
+                .is_some_and(|reason| reason
+                    .contains("--max-provider-executions 2 --max-same-provider-retries 1")),
+            "form-only remediation exhaustion must provide a copyable correction: {:#?}",
+            exhausted.value.stop_reason
+        );
         assert_eq!(dispatcher.dispatches.load(Ordering::SeqCst), 2);
         let recipe = super::super::load_recipe(&fixture.cook_id).unwrap();
         assert_eq!(recipe.attempts.len(), 3);

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -219,6 +219,52 @@ fn cook_remediation_reserves_the_actual_provider_category_before_launch() {
 }
 
 #[test]
+fn cook_budget_preflight_rejects_unfunded_attempts_and_form_remediation() {
+    let default_provider_budget =
+        crate::agent_task_scheduler::AgentTaskExecutionBudget::new(1, 0, 0);
+    let error = validate_effective_cook_budget(3, &default_provider_budget)
+        .expect_err("three Cook attempts require three provider executions");
+    assert!(
+        error.message.contains("--max-attempts 3"),
+        "{}",
+        error.message
+    );
+    assert!(
+        error
+            .message
+            .contains("--max-provider-executions 3 --max-same-provider-retries 2"),
+        "{}",
+        error.message
+    );
+
+    let rotations_only = crate::agent_task_scheduler::AgentTaskExecutionBudget::new(3, 0, 2);
+    let error = validate_effective_cook_budget(3, &rotations_only)
+        .expect_err("required form remediation cannot rotate providers");
+    assert!(
+        error.message.contains("review-form retries"),
+        "{}",
+        error.message
+    );
+    assert!(
+        error
+            .message
+            .contains("provider-rotations 2 cannot replace"),
+        "{}",
+        error.message
+    );
+
+    assert_eq!(
+        validate_effective_cook_budget(
+            3,
+            &crate::agent_task_scheduler::AgentTaskExecutionBudget::new(3, 2, 0),
+        )
+        .expect("funded Cook budget")
+        .requested_attempts,
+        3
+    );
+}
+
+#[test]
 fn service_run_loaded_plan_persists_durable_lifecycle() {
     with_isolated_home(|_| {
         let result = run_loaded_plan(test_plan(), Some("service-run"), SucceedingExecutor)

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -278,6 +278,47 @@ mod tests {
     }
 
     #[test]
+    fn cook_cli_preflight_explains_the_default_provider_budget_conflict() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--max-attempts",
+            "3",
+            "--no-finalize",
+            "--prompt",
+            "test",
+            "--to-worktree",
+            "repo@branch",
+        ])
+        .expect("parse Cook with the default provider budget");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("Cook command");
+        };
+        let budget = homeboy::agents::agent_task_scheduler::AgentTaskExecutionBudget::new(
+            cook.dispatch.core.attempts,
+            cook.dispatch.core.same_provider_retries,
+            cook.dispatch.core.provider_rotations,
+        );
+
+        let error = homeboy::agents::agent_task_service::validate_effective_cook_budget(
+            cook.max_attempts,
+            &budget,
+        )
+        .expect_err("default provider budget must not silently discard Cook retries");
+        assert!(
+            error
+                .message
+                .contains("--max-provider-executions 3 --max-same-provider-retries 2"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
     fn cook_help_advertises_one_prompt_source_not_wave_inputs() {
         let help = rendered_cook_help();
         assert!(help.contains("--prompt"), "{help}");
@@ -388,9 +429,11 @@ pub struct AgentTaskCookArgs {
     pub provider_argv: Vec<String>,
     #[command(flatten)]
     pub gates: VerifyGateArgs,
-    /// Maximum cook attempts before giving up. Each attempt re-runs the agent
-    /// and gates; a later attempt can recover from a transient failure
-    /// (default 3).
+    /// Maximum Cook attempts before giving up. Each attempt re-runs the agent
+    /// and gates; a later attempt can recover from a transient failure. Set
+    /// --max-provider-executions to at least this value and
+    /// --max-same-provider-retries to at least one less so gate and required
+    /// review-form remediation remain possible (default 3).
     #[arg(long = "max-attempts", default_value_t = 3, value_name = "N")]
     pub max_attempts: u32,
     /// Stop after the work is verified but before opening the pull request,

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -27,7 +27,9 @@ pub struct DispatchCoreArgs {
     pub client_context: Option<String>,
 
     /// Maximum total provider executions per task, including same-provider
-    /// retries and provider rotations. `--attempts 1` runs exactly once.
+    /// retries and provider rotations. For Cook, this must be at least
+    /// --max-attempts; use --max-same-provider-retries for gate and review-form
+    /// remediation. `--attempts 1` runs exactly once.
     #[arg(
         long = "max-provider-executions",
         alias = "attempts",
@@ -36,7 +38,9 @@ pub struct DispatchCoreArgs {
     )]
     pub attempts: u32,
 
-    /// Same-provider retries allowed after the first provider execution.
+    /// Same-provider retries allowed after the first provider execution. Cook
+    /// needs one for each possible gate or required review-form remediation;
+    /// provider rotations cannot replace those retries.
     #[arg(
         long = "max-same-provider-retries",
         alias = "same-provider-retries",
@@ -46,6 +50,8 @@ pub struct DispatchCoreArgs {
     pub same_provider_retries: u32,
 
     /// Cross-provider rotations allowed after the first provider execution.
+    /// Rotations are distinct from same-provider Cook remediation and do not
+    /// satisfy its required review-form retry budget.
     #[arg(
         long = "max-provider-rotations",
         alias = "provider-rotations",


### PR DESCRIPTION
Fixes #9650

## Summary
- Derive and validate the provider-backed Cook retry budget before new Cook dispatches.
- Fail fast with copyable flags when max attempts exceed total provider executions or same-provider remediation capacity.
- Preserve historical immutable recipes and give form-only/gate exhaustion actionable terminal guidance.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents cook_budget_preflight_rejects_unfunded_attempts_and_form_remediation`
- `cargo test -p homeboy-cli cook_cli_preflight_explains_the_default_provider_budget_conflict`
- `cargo test -p homeboy-agents repeated_provider_discovery_failures_exhaust_the_adoption_review_allowance`
- `cargo clippy -p homeboy-agents -p homeboy-cli --tests`

## Compatibility
- Persisted recipe schema is unchanged. Existing immutable recipes bypass new-Cook preflight and retain their continuation behavior; exhausted remediation now reports correction guidance.

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the effective Cook budget preflight, diagnostics, and deterministic tests. Chris Huber is responsible for every line.