### PR TITLE
Fix runner recovery for unreachable idle daemon leases

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -91,6 +91,13 @@ pub fn classify(args: &[String]) -> CommandCapability {
         [command, subcommand, ..] if command == "runner" && subcommand == "status" => {
             CommandCapability::ReadOnly
         }
+        [command, subcommand, rest @ ..]
+            if command == "runner"
+                && subcommand == "doctor"
+                && !rest.iter().any(|arg| arg == "--repair") =>
+        {
+            CommandCapability::ReadOnly
+        }
         [command, subcommand, ..]
             if matches!(
                 (command.as_str(), subcommand.as_str()),
@@ -118,6 +125,14 @@ mod tests {
             args(&["homeboy", "self", "identity"]),
             args(&["homeboy", "self", "status"]),
             args(&["homeboy", "status"]),
+            args(&[
+                "homeboy",
+                "runner",
+                "doctor",
+                "lab",
+                "--scope",
+                "lab-offload",
+            ]),
             args(&["homeboy", "agent-task", "retry", "--help"]),
             args(&[
                 "homeboy",

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -76,6 +76,7 @@ pub fn run(args: DeferredWorkloadArgs) -> CmdResult<serde_json::Value> {
 }
 
 pub fn ensure_worker() -> homeboy::core::Result<()> {
+    let _start_lock = deferred_workload::acquire_worker_start_lock()?;
     ensure_worker_with(deferred_workload::worker_is_live, || {
         let executable = std::env::current_exe().map_err(|error| {
             homeboy::core::Error::internal_io(
@@ -115,6 +116,27 @@ pub fn ensure_worker() -> homeboy::core::Result<()> {
                 Some("spawn deferred workload worker".to_string()),
             )
         })?;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if deferred_workload::worker_status()?
+                .as_ref()
+                .is_some_and(deferred_workload::worker_is_live)
+            {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        if deferred_workload::records()?.iter().any(|record| {
+            matches!(
+                record.state,
+                deferred_workload::DeferredWorkloadState::Deferred
+                    | deferred_workload::DeferredWorkloadState::Claimed
+            )
+        }) {
+            return Err(homeboy::core::Error::internal_unexpected(
+                "deferred workload worker did not publish live ownership within 5 seconds",
+            ));
+        }
         Ok(())
     })
 }
@@ -158,6 +180,7 @@ fn run_worker(startup_token: &str) -> homeboy::core::Result<()> {
     };
     std::env::set_var("HOMEBOY_DEFERRED_WORKLOAD_OWNER", startup_token);
     let owner = startup_token.to_string();
+    deferred_workload::write_worker_status(&owner, "starting", "probing runner readiness")?;
     deferred_workload::append_worker_log(format!("worker started owner={owner}"))?;
     run_worker_while_holding_lock(
         &lock,

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -10,8 +10,8 @@ use homeboy::agents::agent_tasks::provider::{
 use homeboy::core::engine::shell;
 use homeboy::core::server::{self, Server, SshClient};
 use homeboy::runner::runners::{
-    self as runner, daemon_repair_codes, Runner, RunnerKind, RunnerToolRegistry, RunnerToolSpec,
-    RunnerTunnelMode,
+    self as runner, daemon_repair_codes, Runner, RunnerKind, RunnerSession, RunnerToolRegistry,
+    RunnerToolSpec, RunnerTunnelMode,
 };
 use serde::Serialize;
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -1298,6 +1298,110 @@ pub fn connected_daemon_exec_checks_with_timeout(
     )]
 }
 
+/// Observe the already-published daemon session without creating a daemon job
+/// or invoking runner status reconciliation. The persisted session liveness
+/// check has already matched this lease and PID; this request is a bounded
+/// final health observation for the doctor report.
+pub fn connected_daemon_health_checks_with_timeout(
+    runner_id: &str,
+    session: &RunnerSession,
+    timeout: std::time::Duration,
+) -> Vec<RunnerCheck> {
+    if session.mode != RunnerTunnelMode::DirectSsh {
+        return Vec::new();
+    }
+    let Some(local_url) = session.local_url.as_deref() else {
+        return Vec::new();
+    };
+    let mut details = BTreeMap::new();
+    details.insert("url".to_string(), local_url.to_string());
+    if timeout.is_zero() {
+        details.insert(
+            "reason_code".to_string(),
+            "runner_doctor.overall_timeout".to_string(),
+        );
+        return vec![checks::error(
+            "daemon.exec",
+            "Connected runner daemon health probe was skipped because the diagnostic deadline was exhausted".to_string(),
+            None,
+            details,
+        )];
+    }
+    let response = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .build()
+        .and_then(|client| {
+            client
+                .get(format!("{}/health", local_url.trim_end_matches('/')))
+                .send()
+        });
+    match response {
+        Ok(response) if response.status().is_success() => {
+            let body = response.json::<serde_json::Value>().unwrap_or_default();
+            let lease = body
+                .pointer("/data/freshness/lease_id")
+                .and_then(serde_json::Value::as_str);
+            let pid = body
+                .pointer("/data/pid")
+                .and_then(serde_json::Value::as_u64);
+            let lease_matches = lease == session.remote_daemon_lease_id.as_deref();
+            let pid_matches = pid == session.remote_daemon_pid.map(u64::from);
+            if lease_matches && pid_matches {
+                return vec![checks::ok(
+                    "daemon.exec",
+                    "Connected runner daemon health and session identity are valid".to_string(),
+                    None,
+                )];
+            }
+            details.insert(
+                "observed_lease".to_string(),
+                lease.unwrap_or("unavailable").to_string(),
+            );
+            details.insert(
+                "observed_pid".to_string(),
+                pid.map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "unavailable".to_string()),
+            );
+            vec![checks::error(
+                "daemon.exec",
+                "Connected runner daemon health identity does not match the controller session"
+                    .to_string(),
+                Some(format!(
+                    "Reconnect runner `{runner_id}` only after inspecting the endpoint mismatch"
+                )),
+                details,
+            )]
+        }
+        Ok(response) => {
+            details.insert("status".to_string(), response.status().as_u16().to_string());
+            vec![checks::error(
+                "daemon.exec",
+                "Connected runner daemon health probe returned an error".to_string(),
+                None,
+                details,
+            )]
+        }
+        Err(error) => {
+            details.insert("error".to_string(), error.to_string());
+            details.insert(
+                "reason_code".to_string(),
+                if error.is_timeout() {
+                    "runner_doctor.daemon_timeout"
+                } else {
+                    "runner_doctor.daemon_request_failed"
+                }
+                .to_string(),
+            );
+            vec![checks::error(
+                "daemon.exec",
+                "Connected runner daemon did not answer the bounded health probe".to_string(),
+                None,
+                details,
+            )]
+        }
+    }
+}
+
 pub(super) fn daemon_exec_check(
     runner_id: &str,
     workspace_root: &str,

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -8,28 +8,32 @@ pub fn report(
     client: &SshClient,
     options: &RunnerDoctorOptions,
 ) -> RunnerDoctorOutput {
+    let _probe_limits = client.scoped_probe_limits(
+        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(60),
+        "runner doctor",
+    );
+    let persisted_status = runner::diagnostic_status(runner_id).ok();
     if options.scope == RunnerDoctorScope::LabOffload {
-        match runner::status(runner_id) {
-            Ok(status) if !status.connected => {
-                return disconnected_report(runner_id, runner, server, status.daemon_freshness);
+        match persisted_status.as_ref() {
+            Some(status) if !status.connected => {
+                return disconnected_report(
+                    runner_id,
+                    runner,
+                    server,
+                    status.daemon_freshness.clone(),
+                );
             }
-            Err(_) => {
+            None => {
                 return disconnected_report(runner_id, runner, server, None);
             }
-            Ok(_) => {}
+            Some(_) => {}
         }
     }
     let workspace_root = runner
         .workspace_root
         .clone()
         .unwrap_or_else(|| ".".to_string());
-    let _probe_limits = (options.scope == RunnerDoctorScope::LabOffload).then(|| {
-        client.scoped_probe_limits(
-            std::time::Duration::from_secs(5),
-            std::time::Duration::from_secs(60),
-            "runner doctor",
-        )
-    });
     let artifact_root = default_artifact_root(client);
     let mut checks = Vec::new();
     let mut tools = BTreeMap::new();
@@ -224,11 +228,13 @@ pub fn report(
         .remaining_probe_budget()
         .unwrap_or(std::time::Duration::from_secs(5))
         .min(std::time::Duration::from_secs(5));
-    let daemon_checks = probes::connected_daemon_exec_checks_with_timeout(
-        runner_id,
-        &workspace_root,
-        daemon_timeout,
-    );
+    let daemon_checks = persisted_status
+        .as_ref()
+        .and_then(|status| status.session.as_ref())
+        .map(|session| {
+            probes::connected_daemon_health_checks_with_timeout(runner_id, session, daemon_timeout)
+        })
+        .unwrap_or_default();
     let daemon_timed_out = daemon_checks.iter().any(|check| {
         matches!(
             check.details.get("reason_code").map(String::as_str),

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -2,6 +2,59 @@ use super::super::*;
 use types::RunnerDoctorStatus;
 
 #[test]
+fn healthy_session_health_probe_is_observational() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("addr");
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        let mut buffer = [0; 4096];
+        std::io::Read::read(&mut stream, &mut buffer).expect("read request");
+        let body =
+            r#"{"success":true,"data":{"freshness":{"lease_id":"lease-doctor"},"pid":4242}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(), body
+        );
+        std::io::Write::write_all(&mut stream, response.as_bytes()).expect("write response");
+    });
+    let session = RunnerSession {
+        runner_id: "homeboy-lab".to_string(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: homeboy::runner::runners::RunnerSessionRole::Controller,
+        server_id: Some("lab".to_string()),
+        controller_id: Some("controller".to_string()),
+        broker_url: None,
+        remote_daemon_address: Some("127.0.0.1:4000".to_string()),
+        local_port: Some(addr.port()),
+        local_url: Some(format!("http://{addr}")),
+        tunnel_pid: Some(1234),
+        remote_daemon_pid: Some(4242),
+        remote_daemon_lease_id: Some("lease-doctor".to_string()),
+        homeboy_version: "test".to_string(),
+        homeboy_build_identity: Some("homeboy test+doctor".to_string()),
+        connected_at: "2026-08-03T00:00:00Z".to_string(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: None,
+    };
+    let before = serde_json::to_value(&session).expect("session snapshot");
+
+    let checks = probes::connected_daemon_health_checks_with_timeout(
+        "homeboy-lab",
+        &session,
+        std::time::Duration::from_secs(1),
+    );
+
+    assert_eq!(checks.len(), 1);
+    assert_eq!(checks[0].status, RunnerDoctorStatus::Ok);
+    assert_eq!(
+        serde_json::to_value(&session).expect("session after"),
+        before
+    );
+}
+
+#[test]
 fn daemon_exec_probe_reports_structured_failure() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
     let addr = listener.local_addr().expect("addr");

--- a/crates/homeboy-core/src/deferred_workload.rs
+++ b/crates/homeboy-core/src/deferred_workload.rs
@@ -98,6 +98,12 @@ pub struct DeferredWorkloadWorkerLock {
     _root: File,
 }
 
+/// Short-lived admission lock for deciding whether a worker process needs to
+/// be spawned. The lifetime worker lock still owns readiness and dispatch.
+pub struct DeferredWorkloadWorkerStartLock {
+    _file: File,
+}
+
 pub fn defer(input: DeferredWorkloadInput) -> Result<DeferredWorkload> {
     if input
         .job_overrides
@@ -330,6 +336,35 @@ pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
             )),
         )),
     }
+}
+
+pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
+    let root = crate::paths::homeboy()?;
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create deferred workload root {}", root.display())),
+        )
+    })?;
+    let path = root.join("deferred-workload-worker-start.lock");
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
+        })?;
+    file.lock_exclusive().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "acquire deferred workload start lock {}",
+                path.display()
+            )),
+        )
+    })?;
+    Ok(DeferredWorkloadWorkerStartLock { _file: file })
 }
 
 pub fn worker_status() -> Result<Option<DeferredWorkloadWorkerStatus>> {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -407,13 +407,51 @@ fn connect_with_orphan_adoption_and_live_lease(
     // A controller can lose its local tunnel after B became admission owner.
     // Rehydrate B from the durable ledger rather than treating the legacy
     // record (which may still name draining A) as the reconnect target.
-    let previous_session =
+    let mut previous_session =
         super::generation_store::admission_session(runner_id, previous_session.as_ref())?
             .or(previous_session);
-    let pending_replacement = super::generation_store::pending_replacement(runner_id)?;
+    let mut pending_replacement = super::generation_store::pending_replacement(runner_id)?;
+    let mut replacement_operation_id = None;
+    if let Some(pending) = pending_replacement.as_ref() {
+        if let Ok(mut observed) = remote_daemon_status(&client, homeboy) {
+            probe_remote_daemon_endpoint(&client, &mut observed);
+            let exact = observed.daemon.as_ref().is_some_and(|daemon| {
+                daemon.lease_id == pending.remote_daemon_lease_id
+                    && daemon.pid == pending.remote_daemon_pid
+                    && pending.remote_daemon_address.as_deref() == Some(daemon.address.as_str())
+            });
+            let exact_dead =
+                exact && observed.stale_reason_code == Some(DaemonStaleReasonCode::PidDead);
+            let authoritatively_superseded = !exact
+                && observed.fresh
+                && observed.endpoint_probe_error.is_none()
+                && observed.daemon.as_ref().is_some_and(|daemon| {
+                    daemon
+                        .lease_id
+                        .as_deref()
+                        .is_some_and(|lease| !lease.is_empty())
+                        && daemon.pid.is_some()
+                        && parse_loopback_daemon_addr(&daemon.address).is_ok()
+                });
+            let exact_unhealthy_idle =
+                exact && observed.endpoint_probe_error.is_some() && observed.active_jobs == 0;
+            if exact_dead || authoritatively_superseded || exact_unhealthy_idle {
+                if exact_unhealthy_idle {
+                    previous_session = Some(pending.clone());
+                }
+                replacement_operation_id = Some(
+                    super::generation_store::retire_pending_replacement(runner_id)?,
+                );
+                pending_replacement = None;
+            }
+        }
+    }
     // This write precedes every remote mutation. A retry reuses the same key
     // even when the SSH command completed but its response was lost.
-    let replacement_operation_id = super::generation_store::replacement_operation(runner_id)?;
+    let replacement_operation_id = match replacement_operation_id {
+        Some(operation_id) => operation_id,
+        None => super::generation_store::replacement_operation(runner_id)?,
+    };
 
     let mut leaseless_recovery = None;
     let mut state_loss_recovery = None;
@@ -743,6 +781,26 @@ fn connect_with_orphan_adoption_and_live_lease(
         attach_state_loss_recovery(&mut report, state_loss_recovery);
         return Ok((report, exit_code));
     };
+
+    // Ordinary ensure-running and exact-owner replacement also cross the
+    // mutation boundary. Persist the returned immutable coordinates before
+    // opening a tunnel so health or endpoint-identity failure can never strand
+    // an unpublished daemon generation.
+    if pending_replacement.is_none()
+        && super::generation_store::replacement_operation_replay(runner_id)?.is_some()
+    {
+        super::generation_store::record_pending_replacement(
+            runner_id,
+            &pending_replacement_session(
+                runner_id,
+                &server_id,
+                &daemon,
+                &version,
+                &configured_build_identity,
+                recovery_evidence.as_ref(),
+            )?,
+        )?;
+    }
 
     let expected_version = daemon.version.clone().unwrap_or(version.clone());
     let expected_identity = daemon
@@ -1493,6 +1551,18 @@ pub fn persisted_status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_recovery_evidence: None,
         session_path: session_path.display().to_string(),
     })
+}
+
+/// Bounded, observation-only doctor projection. Unlike `status`, this never
+/// reconciles jobs, generations, sessions, or tunnels, but a disconnected
+/// session still receives remote lease recovery evidence when SSH is available.
+pub fn diagnostic_status(runner_id: &str) -> Result<RunnerStatusReport> {
+    let mut report = persisted_status(runner_id)?;
+    if !report.connected {
+        let runner = load(runner_id)?;
+        report.daemon_freshness = remote_daemon_recovery_freshness(runner_id, &runner);
+    }
+    Ok(report)
 }
 
 /// Recover only this controller's lost direct SSH projection. The remote daemon

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -599,6 +599,7 @@ pub(super) enum RemoteDaemonConnectAction {
     Reattach,
     Start,
     ReplaceIdleStale,
+    ReplaceUnhealthyExactOwner,
 }
 
 pub(super) fn ensure_remote_daemon(
@@ -654,7 +655,8 @@ pub(super) fn ensure_remote_daemon(
             journal_ensure_running_replay(runner_id, homeboy, replacement_operation_id)?;
             return remote_daemon_ensure_running(client, homeboy, replacement_operation_id);
         }
-        RemoteDaemonConnectAction::ReplaceIdleStale => {
+        RemoteDaemonConnectAction::ReplaceIdleStale
+        | RemoteDaemonConnectAction::ReplaceUnhealthyExactOwner => {
             // Prove idempotent replacement support before stopping A. Otherwise
             // a controller response loss could leave no recoverable owner.
             negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
@@ -779,6 +781,37 @@ pub(super) fn remote_daemon_connect_action_for_runner(
     if parse_loopback_daemon_addr(&daemon.address).is_err() {
         return Err(format!(
             "reachable remote daemon did not report a loopback address; refusing to replace or persist a session{}",
+            active_job_recovery_guidance(status.active_jobs)
+        ));
+    }
+    if let Some(endpoint_error) = status.endpoint_probe_error.as_deref() {
+        let exact_owner = previous_session.is_some_and(|session| {
+            session.mode == RunnerTunnelMode::DirectSsh
+                && session.role == RunnerSessionRole::Controller
+                && session.remote_daemon_lease_id.as_deref() == daemon.lease_id.as_deref()
+                && session.remote_daemon_pid == daemon.pid
+                && session.remote_daemon_address.as_deref() == Some(daemon.address.as_str())
+                && session.homeboy_build_identity.as_deref().map(str::trim)
+                    == Some(expected_identity.trim())
+        });
+        if exact_owner && status.fresh && status.active_jobs == 0 {
+            return Ok(RemoteDaemonConnectAction::ReplaceUnhealthyExactOwner);
+        }
+        if live_lease_expectation == daemon.lease_id.as_deref().zip(daemon.pid) {
+            return Err(lease_reconciliation_failure(
+                previous_session
+                    .and_then(|session| session.remote_daemon_lease_id.as_deref())
+                    .unwrap_or("none or corrupt"),
+                daemon.lease_id.as_deref().expect("checked above"),
+                daemon,
+                status,
+                expected_identity,
+                runner_id,
+                live_lease_expectation,
+            ));
+        }
+        return Err(format!(
+            "remote daemon listener is unhealthy ({endpoint_error}); refusing replacement because exact lease/PID/address/build ownership with authoritatively zero active jobs was not proven{}",
             active_job_recovery_guidance(status.active_jobs)
         ));
     }
@@ -1414,7 +1447,7 @@ pub(super) fn remote_daemon_force_stop(
     lease_id: &str,
 ) -> std::result::Result<(), String> {
     let command = format!(
-        "{} daemon stop --force --lease-id {}",
+        "{} daemon stop --lease-id {}",
         shell::quote_arg(homeboy),
         shell::quote_arg(lease_id),
     );

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -77,6 +77,52 @@ fn tunnel_only_failure_reattaches_the_persisted_daemon() {
 }
 
 #[test]
+fn live_exact_owner_with_dead_listener_selects_bounded_replacement() {
+    let session = direct_ssh_session("lease-listener-dead");
+    let mut status = remote_daemon_status_for_test(
+        true,
+        true,
+        0,
+        "lease-listener-dead",
+        session.remote_daemon_pid.expect("pid"),
+    );
+    status.endpoint_probe_error = Some("curl timed out".to_string());
+
+    assert_eq!(
+        remote_daemon_connect_action_with_controller_identity(
+            Some(&session),
+            &status,
+            session.homeboy_build_identity.as_deref().expect("identity"),
+        )
+        .expect("exact idle recovery"),
+        RemoteDaemonConnectAction::ReplaceUnhealthyExactOwner
+    );
+}
+
+#[test]
+fn dead_listener_with_active_jobs_or_ambiguous_coordinates_fails_closed() {
+    let session = direct_ssh_session("lease-listener-dead");
+    let mut active = remote_daemon_status_for_test(
+        true,
+        true,
+        1,
+        "lease-listener-dead",
+        session.remote_daemon_pid.expect("pid"),
+    );
+    active.endpoint_probe_error = Some("curl timed out".to_string());
+    assert!(remote_daemon_connect_action(Some(&session), &active)
+        .expect_err("active work is protected")
+        .contains("active job"));
+
+    let mut drifted = active;
+    drifted.active_jobs = 0;
+    drifted.daemon.as_mut().expect("daemon").pid = Some(9999);
+    assert!(remote_daemon_connect_action(Some(&session), &drifted)
+        .expect_err("PID drift is ambiguous")
+        .contains("not proven"));
+}
+
+#[test]
 fn repeated_tunnel_flaps_continue_to_select_the_same_active_daemon() {
     let mut session = direct_ssh_session("lease-active");
     let status = remote_daemon_status_for_test(true, true, 2, "lease-active", 4242);
@@ -1746,7 +1792,7 @@ fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_ow
             assert_eq!(daemon.build_identity.as_deref(), Some(configured_identity));
             assert_eq!(
                 std::fs::read_to_string(argv_path).expect("read command argv"),
-                "daemon\nstatus\ndaemon\nstop\n--force\n--lease-id\nlease-old\ndaemon\nensure-running\n--addr\n127.0.0.1:0\ndaemon\nstatus\n"
+                "daemon\nstatus\ndaemon\nstop\n--lease-id\nlease-old\ndaemon\nensure-running\n--addr\n127.0.0.1:0\ndaemon\nstatus\n"
             );
         },
     );

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -1196,45 +1196,26 @@ fn refresh_disconnect_refuses_remote_lease_drift_after_promotion_started() {
 }
 
 #[test]
-fn refresh_disconnect_accepts_local_tunnel_rotation_and_uses_the_current_tunnel() {
+fn refresh_disconnect_retains_a_rotated_tunnel_without_ssh_authority() {
     test_support::with_isolated_home(|_| {
         crate::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false).expect("create runner");
-        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
-        let address = listener.local_addr().expect("address");
-        let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener
-                .accept()
-                .expect("identity request through rotated tunnel");
-            let mut request = [0; 4096];
-            let length = stream.read(&mut request).expect("read identity request");
-            let request = String::from_utf8(request[..length].to_vec()).expect("request text");
-            let nonce = request
-                .split("nonce=")
-                .nth(1)
-                .and_then(|value| value.split_whitespace().next())
-                .expect("identity nonce");
-            let body = format!(
-                r#"{{"protocol":"homeboy.daemon.endpoint-identity.v1","nonce":"{nonce}","daemon":{{"schema":"homeboy.daemon.session_lease.v1","lease_id":"lease-stable","pid":4242}}}}"#
-            );
-            stream.write_all(format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes()).expect("identity response");
-        });
         let recorded = direct_ssh_session("lease-stable");
         let mut rotated = recorded.clone();
-        rotated.local_port = Some(address.port());
-        rotated.local_url = Some(format!("http://{address}"));
+        rotated.local_port = Some(49153);
+        rotated.local_url = Some("http://127.0.0.1:49153".to_string());
         rotated.tunnel_pid = None;
         rotated.connected_at = "2026-07-15T23:00:00Z".to_string();
         rotated.homeboy_build_identity = Some("homeboy test+rotated".to_string());
         write_session(&rotated).expect("record rotated tunnel");
 
-        let error = disconnect_with_session("homeboy-lab", Some(&recorded), false)
-            .expect_err("a local fixture cannot authorize the required SSH re-probe");
-        server.join().expect("server");
-        assert!(error.message.contains("unresolved daemon generations"));
-        assert!(error
-            .details
-            .to_string()
-            .contains("runner is not SSH-backed"));
+        let report = disconnect_with_session("homeboy-lab", Some(&recorded), false)
+            .expect("missing SSH authority is reported as a partial disconnect");
+        assert!(report.partial);
+        assert!(!report.disconnected);
+        assert!(report
+            .remote_error
+            .as_deref()
+            .is_some_and(|error| error.contains("requires an SSH authority")));
         assert!(read_session("homeboy-lab").expect("read session").is_some());
     });
 }

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -121,6 +121,18 @@ pub(crate) fn disconnect_with_session(
         }
     }
     if let Some(session) = &mut session {
+        if session.mode != RunnerTunnelMode::DirectSsh {
+            remove_session(runner_id)?;
+            return Ok(RunnerDisconnectReport {
+                runner_id: runner_id.to_string(),
+                disconnected: true,
+                partial: false,
+                remote_error: None,
+                local_recovery_command: None,
+                session: Some(session.clone()),
+                session_path: session_path(runner_id)?.display().to_string(),
+            });
+        }
         // Retained generations are historical routing evidence, not authority
         // to mutate every port they once used. Resolve one current daemon via
         // SSH and clean up stale local tunnel processes only after its stop.

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -48,7 +48,10 @@ struct ReplacementOperation {
     kind: Option<String>,
 }
 
-fn write_durable_json<T: serde::Serialize>(path: &std::path::Path, value: &T) -> Result<()> {
+pub(crate) fn write_durable_json<T: serde::Serialize>(
+    path: &std::path::Path,
+    value: &T,
+) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| Error::internal_unexpected("journal has no parent"))?;
@@ -480,6 +483,36 @@ pub(crate) fn record_replacement_operation_replay(
 pub(crate) fn record_pending_replacement(runner_id: &str, session: &RunnerSession) -> Result<()> {
     with_registry_lock(runner_id, || {
         write_durable_json(&pending_replacement_path(runner_id)?, session)
+    })
+}
+
+/// Retire an interrupted replacement only after the caller has re-probed the
+/// remote lease and proved that these recorded coordinates are no longer a
+/// publishable daemon. A later attempt receives a new operation identity.
+pub(crate) fn retire_pending_replacement(runner_id: &str) -> Result<String> {
+    with_registry_lock(runner_id, || {
+        let operation_id = uuid::Uuid::new_v4().to_string();
+        // Publish the successor receipt before releasing the old coordinates.
+        // A crash can therefore leave both records, but never neither record.
+        write_durable_json(
+            &replacement_operation_path(runner_id)?,
+            &ReplacementOperation {
+                runner_id: runner_id.to_string(),
+                operation_id: operation_id.clone(),
+                replay_command: None,
+                kind: None,
+            },
+        )?;
+        let pending_path = pending_replacement_path(runner_id)?;
+        if pending_path.exists() {
+            std::fs::remove_file(&pending_path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", pending_path.display())),
+                )
+            })?;
+        }
+        Ok(operation_id)
     })
 }
 
@@ -1449,6 +1482,32 @@ mod tests {
             last_seen_at: None,
             leaseless_recovery_evidence: None,
         }
+    }
+
+    #[test]
+    fn retiring_an_unpublishable_replacement_releases_its_endpoint_and_operation_identity() {
+        test_support::with_isolated_home(|_| {
+            let first_operation = replacement_operation("runner-a").expect("operation");
+            record_replacement_operation_replay("runner-a", "ensure-running", "replay")
+                .expect("replay journal");
+            record_pending_replacement("runner-a", &session("lease-dead", "127.0.0.1", None))
+                .expect("pending coordinates");
+
+            let next_operation =
+                retire_pending_replacement("runner-a").expect("retire dead pending replacement");
+
+            assert!(pending_replacement("runner-a")
+                .expect("read pending")
+                .is_none());
+            assert!(replacement_operation_replay("runner-a")
+                .expect("read replay")
+                .is_none());
+            assert_ne!(next_operation, first_operation);
+            assert_eq!(
+                replacement_operation("runner-a").expect("new operation"),
+                next_operation
+            );
+        });
     }
 
     #[derive(Default)]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -643,6 +643,14 @@ pub fn refresh_homeboy_binary(
                     previous_homeboy_path.as_deref(),
                 )
                 .map(|_| ())
+            })
+            .map_err(|error| {
+                durable_refresh_partial_error_if_needed(
+                    error,
+                    &plan.runner_id,
+                    previous_homeboy_path.as_deref(),
+                    options.force,
+                )
             });
         }
         let (report, connect_exit_code) = match connect_with_orphan_adoption(
@@ -688,7 +696,15 @@ pub fn refresh_homeboy_binary(
                         }
                         Ok(())
                     },
-                );
+                )
+                .map_err(|error| {
+                    durable_refresh_partial_error_if_needed(
+                        error,
+                        &plan.runner_id,
+                        previous_homeboy_path.as_deref(),
+                        options.force,
+                    )
+                });
             }
         };
         let daemon_identity_verification = (connect_exit_code == 0)
@@ -707,7 +723,12 @@ pub fn refresh_homeboy_binary(
                 previous_homeboy_path.as_deref(),
                 options.force,
             ) {
-                return Err(reconnect_rollback_error(&report, rollback_error));
+                return Err(reconnect_rollback_error(
+                    &report,
+                    rollback_error,
+                    previous_homeboy_path.as_deref(),
+                    options.force,
+                ));
             }
             return Ok((
                 HomeboyBinaryRefreshOutput {
@@ -757,7 +778,12 @@ pub fn refresh_homeboy_binary(
                     previous_homeboy_path.as_deref(),
                     options.force,
                 ) {
-                    return Err(reconnect_rollback_error(&report, rollback_error));
+                    return Err(reconnect_rollback_error(
+                        &report,
+                        rollback_error,
+                        previous_homeboy_path.as_deref(),
+                        options.force,
+                    ));
                 }
                 return Ok((
                     HomeboyBinaryRefreshOutput {
@@ -791,6 +817,9 @@ pub fn refresh_homeboy_binary(
         interrupted_job_ids = Vec::new();
     }
 
+    if daemon_refreshed {
+        clear_refresh_partial_state(&plan.runner_id)?;
+    }
     Ok((
         HomeboyBinaryRefreshOutput {
             variant: "refresh_homeboy",
@@ -1936,7 +1965,12 @@ where
     Err(primary_error)
 }
 
-fn reconnect_rollback_error(report: &super::RunnerConnectReport, rollback_error: Error) -> Error {
+fn reconnect_rollback_error(
+    report: &super::RunnerConnectReport,
+    rollback_error: Error,
+    previous_homeboy_path: Option<&str>,
+    force: bool,
+) -> Error {
     let primary_error = Error::validation_invalid_argument(
         "reconnect",
         report
@@ -1957,7 +1991,81 @@ fn reconnect_rollback_error(report: &super::RunnerConnectReport, rollback_error:
         "message": rollback_error.message,
         "details": rollback_error.details,
     });
+    durable_refresh_partial_error(error, &report.runner_id, previous_homeboy_path, force)
+}
+
+fn durable_refresh_partial_error(
+    mut error: Error,
+    runner_id: &str,
+    previous_homeboy_path: Option<&str>,
+    force: bool,
+) -> Error {
+    let previous = previous_homeboy_path.unwrap_or("homeboy");
+    let continuation_command = format!(
+        "homeboy runner refresh-homeboy {} --select {} --reconnect{}",
+        quote_arg(runner_id),
+        quote_arg(previous),
+        if force { " --force" } else { "" },
+    );
+    let state = serde_json::json!({
+        "schema": "homeboy/runner-refresh-partial/v1",
+        "runner_id": runner_id,
+        "status": "rollback_incomplete",
+        "previous_binary_path": previous,
+        "continuation_command": continuation_command,
+        "recorded_at": chrono::Utc::now().to_rfc3339(),
+    });
+    let path = refresh_partial_state_path(runner_id);
+    match path.and_then(|path| {
+        super::generation_store::write_durable_json(&path, &state)?;
+        Ok(path)
+    }) {
+        Ok(path) => {
+            error.details["partial_state"] = state;
+            error.details["partial_state_path"] =
+                serde_json::Value::String(path.display().to_string());
+            error.details["continuation_command"] = serde_json::Value::String(continuation_command);
+        }
+        Err(write_error) => {
+            error.message = format!(
+                "{}; additionally failed to persist rollback continuation state: {}",
+                error.message, write_error.message
+            );
+        }
+    }
     error
+}
+
+fn refresh_partial_state_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(homeboy_core::paths::runner_sessions_dir()?
+        .join(homeboy_core::paths::sanitize_path_segment(runner_id))
+        .join("refresh-partial.json"))
+}
+
+fn clear_refresh_partial_state(runner_id: &str) -> Result<()> {
+    let path = refresh_partial_state_path(runner_id)?;
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("remove {}", path.display())),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn durable_refresh_partial_error_if_needed(
+    error: Error,
+    runner_id: &str,
+    previous_homeboy_path: Option<&str>,
+    force: bool,
+) -> Error {
+    if error.details.get("rollback_error").is_some() {
+        durable_refresh_partial_error(error, runner_id, previous_homeboy_path, force)
+    } else {
+        error
+    }
 }
 
 fn error_context(error: &Error) -> String {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -1314,6 +1314,53 @@ fn rollback_failure_keeps_the_primary_refresh_error() {
 }
 
 #[test]
+fn rollback_failure_persists_one_exact_previous_binary_continuation() {
+    test_support::with_isolated_home(|_| {
+        let error = durable_refresh_partial_error(
+            Error::internal_unexpected("rollback reconnect failed"),
+            "lab runner",
+            Some("/stable builds/homeboy"),
+            true,
+        );
+        let path = error.details["partial_state_path"]
+            .as_str()
+            .expect("partial state path");
+        let state: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).expect("durable partial state"))
+                .expect("partial state JSON");
+
+        assert_eq!(state["status"], "rollback_incomplete");
+        assert_eq!(state["previous_binary_path"], "/stable builds/homeboy");
+        assert_eq!(
+            state["continuation_command"],
+            "homeboy runner refresh-homeboy 'lab runner' --select '/stable builds/homeboy' --reconnect --force"
+        );
+        assert_eq!(
+            error.details["continuation_command"],
+            state["continuation_command"]
+        );
+    });
+}
+
+#[test]
+fn successful_rollback_does_not_publish_partial_state() {
+    test_support::with_isolated_home(|_| {
+        let primary = rollback_refresh_error_with::<(), _>(
+            Error::internal_unexpected("candidate connect failed"),
+            || Ok(()),
+        )
+        .expect_err("primary failure remains visible");
+        let error =
+            durable_refresh_partial_error_if_needed(primary, "lab", Some("/stable/homeboy"), false);
+
+        assert!(error.details.get("partial_state").is_none());
+        assert!(!refresh_partial_state_path("lab")
+            .expect("partial path")
+            .exists());
+    });
+}
+
+#[test]
 fn default_target_dir_is_ref_scoped() {
     assert_eq!(
         default_target_dir("/runner/ws/", "origin/main"),

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -147,10 +147,10 @@ pub(crate) use connection::daemon_endpoint_identity;
 pub(crate) use connection::disconnect_with_force;
 pub use connection::{
     close_reconnected_job_log_owner, connect, connect_reverse, connect_with_live_lease_adoption,
-    connect_with_orphan_adoption, disconnect, disconnect_local_recovery, persisted_status,
-    persisted_statuses, reconcile_terminal_jobs, reconnect_job_log_owner, reverse_broker_artifact,
-    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
-    statuses, statuses_indexed, submit_reverse_broker_job,
+    connect_with_orphan_adoption, diagnostic_status, disconnect, disconnect_local_recovery,
+    persisted_status, persisted_statuses, reconcile_terminal_jobs, reconnect_job_log_owner,
+    reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
+    runner_artifact_content, status, statuses, statuses_indexed, submit_reverse_broker_job,
 };
 pub(crate) use connection::{
     configured_runner_homeboy_build_identity, local_live_session, status_for_admission,

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -27,11 +27,11 @@ pub use crate::{
     BROKER_TOKEN_ENV, BROKER_TOKEN_HEADER,
 };
 pub use crate::{
-    connect_reverse, disconnect, disconnect_local_recovery, download_remote_artifact,
-    evaluate_lab_runner_capabilities_for_runner, exec, execute_lab_offload,
-    hydrate_prepared_workspace_source_snapshot, is_remote_runner_artifact_path,
-    is_reportable_artifact_evidence_path, is_retrievable_runner_artifact,
-    lab_offload_changed_since_ref, lab_offload_metadata,
+    connect_reverse, diagnostic_status, disconnect, disconnect_local_recovery,
+    download_remote_artifact, evaluate_lab_runner_capabilities_for_runner, exec,
+    execute_lab_offload, hydrate_prepared_workspace_source_snapshot,
+    is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
+    is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, lab_runner_readiness, list_workspaces,
     mirror_connected_runner_run, mirrored_runner_job_identity, persisted_status,
     persisted_statuses, plan_homeboy_binary_refresh, plan_managed_runner_source_sync,

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -146,7 +146,10 @@ homeboy runner doctor <runner-id> --scope lab-offload
 homeboy runner doctor <runner-id> --scope lab-offload --repair
 ```
 
-Diagnoses a local or configured SSH runner without mutating it. Use `local`,
+Diagnoses a local or configured SSH runner without mutating it. A connected
+session is read once from controller state and checked through a bounded
+`/health` request; doctor does not reconcile generations, create an exec job,
+replace the session, or tear down its tunnel. Use `local`,
 `localhost`, or `self` to inspect this machine without creating a runner record.
 The JSON payload uses `command: "runner.doctor"` and includes `runner_id`,
 `status`, `capabilities`, and warning/error details when a capability probe fails.
@@ -160,7 +163,7 @@ operator lifecycle actions. They do not currently expose dry-run contracts; use
 
 Use `--scope lab-offload` before serious Lab evidence runs. It adds checks for
 the configured runner Homeboy command, bare `homeboy` PATH resolution, preferred
-runner binaries, connected daemon exec readiness, and Sample Runtime runner-path
+runner binaries, connected daemon health readiness, and Sample Runtime runner-path
 freshness signals. When Homeboy can identify a safe exact recovery command, the
 check includes that remediation instead of leaving the operator to infer it from
 logs.
@@ -209,6 +212,12 @@ Without it, the JSON output includes follow-up `disconnect`, `connect`, and
 status` also reports controller, configured executable, active daemon version,
 build identity, drift signals, and refresh commands under
 `selected_lab_runner.runner_homeboy`.
+
+Reconnect rollback restores the exact previously selected binary and publishes
+its session. If any rollback phase fails, Homeboy retains
+`runner-sessions/<runner-id>/refresh-partial.json`; the error names that path and
+one `refresh-homeboy --select <previous-path> --reconnect` continuation command.
+Do not delete the receipt as a recovery step.
 
 When a configured SSH runner is disconnected, `refresh-homeboy` automatically
 uses its configured SSH server transport to run the same managed build/select
@@ -380,6 +389,15 @@ can use the daemon session instead of ad-hoc SSH command execution. The JSON
 payload uses `command: "runner.connect"` and reports connection state such as
 the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
 
+Reconnect distinguishes a healthy endpoint from a lost local tunnel, a live
+exact-owner PID whose recorded listener no longer answers, a dead PID with a
+retained lease, and an endpoint whose lease/PID identity differs from the
+controller record. Only the exact lease, PID, loopback address, configured build,
+and authoritatively zero durable jobs permit automatic unhealthy-listener
+replacement. The lease-bound stop rechecks the startup ownership token and job
+store before every signal. Active work, PID/lease drift, and ambiguous listener
+ownership remain fail-closed.
+
 When a controller session was lost while a remote daemon lease is dead and its
 durable jobs remain, inspect the remote `homeboy daemon status` first. Recovery
 requires the explicit exact-lease form shown above. It verifies the recorded PID
@@ -404,6 +422,12 @@ If replacement startup fails, the receipt retains the reconciled evidence and th
 same exact lease, PID, and endpoint inputs resume only replacement startup on
 retry. Different replay inputs fail closed, and a zero-active-job invocation
 without a matching receipt remains invalid.
+
+Every daemon returned by a replacement operation is journaled before tunnel
+health and endpoint identity checks. A retry authenticates and publishes those
+exact coordinates. If the recorded PID has died, a newer lease has superseded
+it, or the exact idle replacement listener is unhealthy, the stale journal is
+retired under the runner lock so it cannot pin a dead endpoint.
 
 When `daemon status` reports `stale_reason_code: lease_missing`, active jobs,
 and unavailable recovery evidence, run the explicit daemon reconciliation on the


### PR DESCRIPTION
## Summary

- recover exact-owner, authoritatively idle daemon failures through a bounded replacement path
- reconcile interrupted pending-replacement journals instead of pinning dead endpoints
- keep runner doctor observational for healthy sessions and bound remote probes
- make refresh rollback restore the exact prior binary/session or retain actionable partial state
- coordinate deferred-workload readiness probes without weakening active-job or ownership fences

Closes #11260.

## Verification

Run after rebasing onto current `main`, with isolated `HOME`/XDG directories and explicit Rust and Node toolchains:

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p homeboy-lab-runner connection::tests -- --test-threads=1`
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests -- --test-threads=1`
- `cargo test -p homeboy-cli commands::runner::doctor -- --test-threads=1`
- `cargo test -p homeboy-core deferred_workload -- --test-threads=1`
- `cargo test -p homeboy-cli deferred_workload -- --test-threads=1`

The broad `homeboy-lab-runner` suite has eight unrelated execution/broker fixture failures. The same eight failures were reproduced with the same isolated environment on a fresh `origin/main` worktree; this PR introduces no additional broad-suite failures.

## Compatibility

Active jobs, ambiguous ownership, PID drift, and build-identity mismatch remain fail-closed. Behavior changes only when Homeboy proves the exact daemon owner is idle or when doctor can inspect an existing healthy session without mutation.

## AI Assistance

- Tool: OpenCode
- Model: OpenAI `openai/gpt-5.6-sol`
- Used for: investigated the live daemon, tunnel, session, and worker failure chain; implemented the recovery candidate; repaired test regressions; compared broad failures against fresh `main`; and ran isolated issue-bounded verification with Chris Huber.
