### PR TITLE
Fix derived Lab Cook destination provisioning

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -251,10 +251,11 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
 /// Converge a Cook promotion destination before compiling a task plan. This is
 /// controller-owned so local and Lab dispatch use the same managed checkout.
 pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<Value> {
-    let to_worktree = args
-        .to_worktree
-        .as_deref()
-        .expect("Cook destination is resolved before provisioning");
+    let to_worktree = args.to_worktree.as_deref().ok_or_else(|| {
+        homeboy::core::Error::validation_missing_argument(vec![
+            "--to-worktree is required before provisioning a Cook destination".to_string(),
+        ])
+    })?;
     let direct_path = Path::new(to_worktree);
     if direct_path.is_dir() {
         homeboy::core::worktree_providers::validate_task_worktree_root(direct_path, to_worktree)?;

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -98,6 +98,28 @@ fn cook_derives_issue_destination_and_preserves_explicit_override() {
 }
 
 #[test]
+fn cook_provisioning_rejects_an_unresolved_destination_without_panicking() {
+    with_isolated_home(|_| {
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the issue".to_string(),
+            "--no-finalize".to_string(),
+        ]);
+
+        let error = super::super::run::provision_cook_destination(&args)
+            .expect_err("an unresolved destination must fail closed");
+
+        assert_eq!(
+            error.details["args"][0],
+            "--to-worktree is required before provisioning a Cook destination"
+        );
+    });
+}
+
+#[test]
 fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
     with_isolated_home(|_| {
         let cli = Cli::parse_from([

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1666,9 +1666,10 @@ fn materialize_agent_task_cook_plan(
     else {
         return Ok(None);
     };
-    crate::commands::agent_task::run::validate_cook_request_with_provenance(cook, provenance)?;
-    let provision = crate::commands::agent_task::run::provision_cook_destination(cook)?;
-    let mut plan = crate::commands::agent_task::run::compile_cook_plan(cook, provision)?;
+    let cook = crate::commands::agent_task::run::resolve_cook_destination(cook.clone())?;
+    crate::commands::agent_task::run::validate_cook_request_with_provenance(&cook, provenance)?;
+    let provision = crate::commands::agent_task::run::provision_cook_destination(&cook)?;
+    let mut plan = crate::commands::agent_task::run::compile_cook_plan(&cook, provision)?;
     if let Some(provenance) = provenance {
         crate::commands::agent_task::run::record_cook_argument_provenance(&mut plan, provenance);
     }

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -2306,7 +2306,7 @@ fn explicit_local_cook_does_not_enter_lab_attempt_dispatch() {
 }
 
 #[test]
-fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
+fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path());
@@ -2332,7 +2332,7 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
                 "worktree",
                 "add",
                 "-b",
-                "cook-six-fixture-generic-parity",
+                "fix/issue-11291-homeboy",
                 provider_workspace
                     .to_str()
                     .expect("utf8 provider workspace"),
@@ -2344,9 +2344,9 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
         let provider = provider_dir.path().join("provider");
         let payload = serde_json::json!({
             "worktrees": [{
-                "handle": "blocks-engine@cook-six-fixture-generic-parity",
+                "handle": "homeboy@fix-issue-11291-homeboy",
                 "path": provider_workspace,
-                "branch": "cook-six-fixture-generic-parity",
+                "branch": "fix/issue-11291-homeboy",
                 "safety": { "dirty": false, "unpushed": false, "primary": false }
             }]
         });
@@ -2400,13 +2400,9 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
             "agent-task",
             "cook",
             "--repo",
-            "blocks-engine",
-            "--head",
-            "cook-six-fixture-generic-parity",
+            "homeboy",
             "--task-url",
-            "https://example.com/tasks/cook-six-fixture-generic-parity",
-            "--to-worktree",
-            "blocks-engine@cook-six-fixture-generic-parity",
+            "https://github.com/Extra-Chill/homeboy/issues/11291",
             "--verify",
             "true",
             "--backend",
@@ -2421,6 +2417,10 @@ fn cook_to_worktree_provider_workspace_survives_failed_attempt_and_lab_retry() {
         assert_eq!(
             plan.tasks[0].workspace.root.as_deref(),
             Some(expected_root.as_str())
+        );
+        assert_eq!(
+            plan.tasks[0].metadata["worktree_provision"]["handle"],
+            "homeboy@fix-issue-11291-homeboy"
         );
         agent_task_lifecycle::submit_plan(&plan, Some("failed-run")).expect("submit plan");
         agent_task_lifecycle::record_pre_execution_failure(


### PR DESCRIPTION
## Summary
- resolve issue-owned Cook destinations before Lab plan materialization
- preserve the derived provider worktree through durable retry plans
- replace the unresolved-destination panic with a structured validation error
- cover omitted and explicit destination contracts

Fixes #11291.

## Verification
- `cargo fmt --package homeboy-cli --check`
- `cargo check --package homeboy-cli`
- focused derived-destination, structured-error, and explicit-override tests
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode and a delegated coding agent traced the Lab routing panic, implemented the repair, and ran focused Rust verification. Chris Huber reviewed and remains responsible for the change.