### PR TITLE
Fix Cook readers to select substantive candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -776,6 +776,13 @@ pub fn persisted_status(run_id: &str) -> Result<AgentTaskRunRecord> {
     agent_task_lifecycle::persisted_status(run_id)
 }
 
+/// Resolve the durable substantive candidate for a logical Cook reader.
+pub fn select_cook_candidate(
+    cook_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskCookCandidateSelection> {
+    agent_task_lifecycle::select_cook_candidate(cook_id)
+}
+
 pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
     agent_task_lifecycle::run_status(run_id, since_cursor)
 }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -178,15 +178,17 @@ impl TryFrom<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
 }
 
 pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
-    let record = agent_task_lifecycle::status(&args.run_id)?;
+    let target = super::status::resolve_cook_reader_target(&args.run_id)?;
+    let run_id = &target.run_id;
+    let record = agent_task_lifecycle::status(run_id)?;
     // A review that names a target worktree is preparing a promotion handoff.
     // Materialize recovered runner artifacts before rendering its command.
     if args.to_worktree.is_some() {
         agent_task_lifecycle::materialize_recovered_patch_artifact(&record.run_id, None, None)?;
     }
-    let log = agent_task_lifecycle::logs(&args.run_id)?;
-    let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
-    let aggregate_source = completed_run_aggregate_source(&args.run_id).transpose()?;
+    let log = agent_task_lifecycle::logs(run_id)?;
+    let artifacts = agent_task_lifecycle::artifacts(run_id)?;
+    let aggregate_source = completed_run_aggregate_source(run_id).transpose()?;
     let aggregate = aggregate_source
         .as_ref()
         .map(|(aggregate, _path)| aggregate);
@@ -249,8 +251,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
         args.to_worktree.as_deref(),
     );
 
-    Ok((
-        serde_json::json!({
+    let mut value = serde_json::json!({
             "schema": "homeboy/agent-task-review/v1",
             "run_id": record.run_id,
             "state": record.state,
@@ -270,9 +271,35 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
                 "authoritative": "homeboy-agent-task-lifecycle",
                 "chat_state_required": false
             }
-        }),
-        0,
-    ))
+    });
+    if let Some(selection) = target.selection {
+        let latest_attempt_run_id = selection["latest_attempt_run_id"].as_str();
+        if latest_attempt_run_id.is_some_and(|latest| latest != record.run_id) {
+            if let Ok(latest) = agent_task_lifecycle::status(latest_attempt_run_id.unwrap()) {
+                let review_form = completed_run_aggregate_source(&latest.run_id)
+                    .transpose()?
+                    .and_then(|(aggregate, _)| {
+                        aggregate
+                            .selected_outcome()
+                            .or_else(|| {
+                                (aggregate.outcomes.len() == 1)
+                                    .then(|| aggregate.outcomes.first())
+                                    .flatten()
+                            })
+                            .and_then(|outcome| outcome.outputs.get("review_form"))
+                            .cloned()
+                    });
+                value["contributing_attempt"] = serde_json::json!({
+                    "run_id": latest.run_id,
+                    "review_form": review_form,
+                    "verification": latest.metadata.get("latest_promotion"),
+                });
+            }
+        }
+        value["candidate_selection"] = selection;
+    }
+    super::status::bound_full_reader_payload(&mut value);
+    Ok((value, 0))
 }
 
 pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -41,23 +41,55 @@ const COMPACT_TASK_LIMIT: usize = 12;
 const COMPACT_TEXT_LIMIT: usize = 512;
 const FULL_TEXT_LIMIT: usize = 4 * 1024;
 
-pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
-    if args.bridge {
-        let bridge_status = agent_task_service::run_status(&args.run_id, args.since_cursor)?;
-        return Ok((
-            serde_json::to_value(bridge_status).unwrap_or(Value::Null),
-            0,
+/// Cook IDs are logical candidate readers. Exact attempt IDs remain immutable
+/// attempt readers, even when a newer Cook attempt produced no patch.
+pub(super) struct CookReaderTarget {
+    pub(super) run_id: String,
+    pub(super) selection: Option<Value>,
+}
+
+pub(super) fn resolve_cook_reader_target(
+    run_or_cook_id: &str,
+) -> homeboy::core::Result<CookReaderTarget> {
+    if !agent_task_lifecycle::cook_index_exists(run_or_cook_id)? {
+        return Ok(CookReaderTarget {
+            run_id: run_or_cook_id.to_string(),
+            selection: None,
+        });
+    }
+    let selection = agent_task_service_direct::select_cook_candidate(run_or_cook_id)?;
+    if selection.incomplete || selection.run_id.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "cook_id",
+            "candidate selection is incomplete after its bounded recovery window",
+            Some(run_or_cook_id.to_string()),
+            None,
         ));
     }
+    Ok(CookReaderTarget {
+        run_id: selection.run_id.clone(),
+        selection: Some(serde_json::to_value(selection).unwrap_or(Value::Null)),
+    })
+}
 
+pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
+    let target = resolve_cook_reader_target(&args.run_id)?;
+    if args.bridge {
+        let bridge_status = agent_task_service::run_status(&target.run_id, args.since_cursor)?;
+        let mut value = serde_json::to_value(bridge_status).unwrap_or(Value::Null);
+        if let Some(selection) = target.selection {
+            value["candidate_selection"] = selection;
+        }
+        return Ok((value, 0));
+    }
+
+    let run_id = &target.run_id;
     // Terminal inspection is a durable-local read. Reconciliation has its own
     // explicit command so an unavailable runner cannot hold status hostage.
-    let record = match agent_task_service_direct::persisted_status(&args.run_id) {
+    let record = match agent_task_service_direct::persisted_status(run_id) {
         Ok(record) => record,
         Err(error) if is_missing_agent_task_run_metadata_error(&error) => {
-            if let Some(remediation) =
-                agent_task_service::offloaded_status_remediation(&args.run_id)?
-            {
+            if let Some(remediation) = agent_task_service::offloaded_status_remediation(run_id)? {
                 return Ok((remediation, 1));
             }
             return Err(error);
@@ -71,7 +103,7 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
         },
     ));
     // A future durable budget is incompatible, not an absent optional preview.
-    if let Err(error) = agent_task_lifecycle::load_plan(&args.run_id) {
+    if let Err(error) = agent_task_lifecycle::load_plan(run_id) {
         if error
             .message
             .contains("unsupported agent-task execution budget version")
@@ -109,20 +141,26 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
             }
         }
     }
-    enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
-    attach_transport_proxy_recovery_guidance(&mut value, &args.run_id);
+    enrich_with_diagnostic_summary(&mut value, run_id)?;
+    attach_transport_proxy_recovery_guidance(&mut value, run_id);
+    if let Some(selection) = target.selection.as_ref() {
+        value["candidate_selection"] = selection.clone();
+    }
     if args.full {
-        let aggregate = completed_run_aggregate(&args.run_id).and_then(Result::ok);
-        attach_full_status_candidate(&mut value, aggregate.as_ref(), &args.run_id);
+        let aggregate = completed_run_aggregate(run_id).and_then(Result::ok);
+        attach_full_status_candidate(&mut value, aggregate.as_ref(), run_id);
         bound_full_reader_payload(&mut value);
         attach_runner_probe(&mut value, &runner_probe);
-        attach_agent_task_status_actionable(&mut value, &args.run_id);
+        attach_agent_task_status_actionable(&mut value, run_id);
         return Ok((value, 0));
     }
-    let summary = compact_status_summary(&value, &args.run_id);
+    let summary = compact_status_summary(&value, run_id);
     let mut summary = summary;
+    if let Some(selection) = target.selection {
+        summary["candidate_selection"] = selection;
+    }
     attach_runner_probe(&mut summary, &runner_probe);
-    attach_agent_task_status_actionable(&mut summary, &args.run_id);
+    attach_agent_task_status_actionable(&mut summary, run_id);
     Ok((summary, 0))
 }
 
@@ -244,7 +282,7 @@ mod runner_probe_tests {
 
 /// Full recovery output remains a local reader: retain a stable digest for a
 /// large value instead of repeating multi-attempt patches in every projection.
-fn bound_full_reader_payload(value: &mut Value) {
+pub(super) fn bound_full_reader_payload(value: &mut Value) {
     match value {
         Value::String(text) if text.len() > FULL_TEXT_LIMIT => {
             let digest = content_hash::sha256_hex(text.as_bytes());
@@ -667,10 +705,12 @@ pub(super) fn artifacts(args: StatusArgs) -> CmdResult<Value> {
 }
 
 pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
-    let artifacts = agent_task_service::artifacts(&args.run_id)?;
-    let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
+    let target = resolve_cook_reader_target(&args.run_id)?;
+    let run_id = &target.run_id;
+    let artifacts = agent_task_service::artifacts(run_id)?;
+    let aggregate = completed_run_aggregate(run_id).transpose()?;
     let failed_tasks = failed_task_statuses(aggregate.as_ref());
-    let plan = agent_task_lifecycle::load_plan(&args.run_id).ok();
+    let plan = agent_task_lifecycle::load_plan(run_id).ok();
 
     let mut hydrated = Vec::new();
     let mut total = 0;
@@ -706,7 +746,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
             continue;
         }
         hydrated.push(agent_task_service::hydrate_evidence_ref(
-            &args.run_id,
+            run_id,
             &evidence_ref,
             task_id.as_deref(),
             plan.as_ref(),
@@ -716,7 +756,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
 
     let mut value = serde_json::to_value(AgentTaskEvidenceReport {
         schema: "homeboy/agent-task-evidence/v1",
-        run_id: args.run_id.clone(),
+        run_id: run_id.clone(),
         filters: AgentTaskEvidenceFilters {
             kind: args.kind,
             task: args.task,
@@ -727,6 +767,9 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
         evidence: hydrated,
     })
     .unwrap_or(Value::Null);
+    if let Some(selection) = target.selection {
+        value["candidate_selection"] = selection;
+    }
     if !args.full {
         attach_collection_budget(
             &mut value,
@@ -745,10 +788,12 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
 }
 
 pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
+    let target = resolve_cook_reader_target(&args.run_id)?;
+    let run_id = &target.run_id;
     // Keep diagnosis within the same durable-local inspection contract as
     // status and logs; reconciliation is explicitly requested separately.
-    let record = agent_task_service_direct::persisted_status(&args.run_id)?;
-    let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
+    let record = agent_task_service_direct::persisted_status(run_id)?;
+    let aggregate = completed_run_aggregate(run_id).transpose()?;
     let mut hydrated_evidence = Vec::new();
     let mut total_hydrated_evidence = 0;
     let mut nested_reasons = Vec::new();
@@ -793,7 +838,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         .as_ref()
         .map(causal_chain_from_aggregate)
         .unwrap_or_default();
-    let next_commands = diagnose_next_commands(&args.run_id);
+    let next_commands = diagnose_next_commands(run_id);
 
     let mut value = json!({
         "schema": "homeboy/agent-task-diagnose/v1",
@@ -806,17 +851,17 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         "hydrated_evidence_total": total_hydrated_evidence,
         "next_commands": next_commands,
     });
+    if let Some(selection) = target.selection {
+        value["candidate_selection"] = selection;
+    }
     if !args.full {
         attach_collection_budget(
             &mut value,
             "hydrated_evidence",
-            &format!(
-                "homeboy agent-task diagnose {} --full",
-                quote_arg(&args.run_id)
-            ),
+            &format!("homeboy agent-task diagnose {} --full", quote_arg(run_id)),
             &format!(
                 "homeboy agent-task diagnose {} --full --output <path>",
-                quote_arg(&args.run_id)
+                quote_arg(run_id)
             ),
         );
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -146,6 +146,217 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
 }
 
 #[test]
+fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
+    struct PatchExecutor {
+        path: String,
+        run_id: String,
+        size_bytes: u64,
+        sha256: String,
+    }
+
+    struct NoChangeReviewExecutor;
+
+    impl AgentTaskExecutorAdapter for NoChangeReviewExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("intentional no-change gate retry".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: json!({
+                    "review_form": {
+                        "summary": "Retry reviewed the candidate.",
+                        "what_changed": ["No additional patch was needed."],
+                        "compatibility": "No additional compatibility impact.",
+                        "used_for": "Reviewed failed-gate evidence."
+                    }
+                }),
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
+    impl AgentTaskExecutorAdapter for PatchExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("produced patch before failed gate".to_string()),
+                failure_classification: None,
+                artifacts: vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "candidate".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("candidate.patch".to_string()),
+                    label: None,
+                    role: None,
+                    semantic_key: None,
+                    path: Some(self.path.clone()),
+                    url: None,
+                    mime: Some("text/x-diff".to_string()),
+                    size_bytes: Some(self.size_bytes),
+                    sha256: Some(self.sha256.clone()),
+                    metadata: Value::Null,
+                }],
+                typed_artifacts: Vec::new(),
+                evidence_refs: vec![AgentTaskEvidenceRef {
+                    kind: "plan".to_string(),
+                    uri: format!("homeboy://agent-task/run/{}/plan#task=task-a", self.run_id),
+                    label: None,
+                }],
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
+    with_temp_home(|| {
+        let cook_id = "cook-reader-substantive-candidate";
+        let candidate_run_id = "cook-reader-substantive-candidate-attempt-1";
+        let retry_run_id = "cook-reader-substantive-candidate-attempt-2";
+        let patch = tempfile::NamedTempFile::new().expect("candidate patch");
+        let patch_contents = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n";
+        std::fs::write(patch.path(), patch_contents).expect("write candidate patch");
+        run_loaded_plan(
+            test_plan(),
+            Some(candidate_run_id),
+            PatchExecutor {
+                path: patch.path().display().to_string(),
+                run_id: candidate_run_id.to_string(),
+                size_bytes: patch_contents.len() as u64,
+                sha256: homeboy_engine_primitives::content_hash::sha256_hex(
+                    patch_contents.as_bytes(),
+                ),
+            },
+        )
+        .expect("substantive candidate completed");
+        run_loaded_plan(test_plan(), Some(retry_run_id), NoChangeReviewExecutor)
+            .expect("intentional no-change retry completed");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, candidate_run_id)
+            .expect("record substantive candidate");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, retry_run_id)
+            .expect("record latest no-change retry");
+        agent_task_lifecycle::record_promotion(
+            retry_run_id,
+            json!({
+                "status": "gate_failed",
+                "gate_results": [{ "name": "cargo test", "exit_code": 1 }],
+                "provenance": { "gate_retry": "intentional_no_change" }
+            }),
+        )
+        .expect("record retry verification provenance");
+
+        let (status_value, _) = status(StatusArgs {
+            run_id: cook_id.to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: false,
+            no_runner_probe: false,
+        })
+        .expect("Cook status is bounded");
+        let (review_value, _) = review::review(ReviewArgs {
+            run_id: cook_id.to_string(),
+            to_worktree: None,
+            provider_command: None,
+            provider_argv: Vec::new(),
+        })
+        .expect("Cook review is bounded");
+        let (diagnose_value, _) = diagnose(DiagnoseArgs {
+            run_id: cook_id.to_string(),
+            full: false,
+        })
+        .expect("Cook diagnosis is bounded");
+        let (evidence_value, _) = evidence(EvidenceArgs {
+            run_id: cook_id.to_string(),
+            kind: None,
+            task: None,
+            failure_only: true,
+            full: false,
+        })
+        .expect("Cook failure evidence is bounded");
+        let (all_evidence_value, _) = evidence(EvidenceArgs {
+            run_id: cook_id.to_string(),
+            kind: None,
+            task: None,
+            failure_only: false,
+            full: false,
+        })
+        .expect("Cook evidence reads the selected candidate plan");
+
+        for value in [
+            &status_value,
+            &review_value,
+            &diagnose_value,
+            &evidence_value,
+        ] {
+            assert_eq!(value["run_id"], candidate_run_id);
+            assert_eq!(
+                value["candidate_selection"]["latest_attempt_run_id"],
+                retry_run_id
+            );
+            assert_eq!(value["candidate_selection"]["run_id"], candidate_run_id);
+        }
+        assert_eq!(review_value["contributing_attempt"]["run_id"], retry_run_id);
+        assert_eq!(
+            review_value["contributing_attempt"]["review_form"]["summary"],
+            "Retry reviewed the candidate."
+        );
+        assert_eq!(
+            review_value["contributing_attempt"]["verification"]["provenance"]["gate_retry"],
+            "intentional_no_change"
+        );
+        assert_eq!(
+            all_evidence_value["evidence"][0]["content"]["value"]["task_id"], "task-a",
+            "{all_evidence_value:#}"
+        );
+
+        let (bridge_value, _) = status(StatusArgs {
+            run_id: cook_id.to_string(),
+            bridge: true,
+            since_cursor: Some(0),
+            full: false,
+            no_runner_probe: false,
+        })
+        .expect("Cook bridge status selects the candidate");
+        assert_eq!(bridge_value["schema"], "homeboy/agent-task-run-status/v1");
+        assert_eq!(bridge_value["run_id"], candidate_run_id);
+        assert_eq!(
+            bridge_value["candidate_selection"]["run_id"],
+            candidate_run_id
+        );
+
+        let (attempt_status, _) = status(StatusArgs {
+            run_id: retry_run_id.to_string(),
+            bridge: false,
+            since_cursor: None,
+            full: false,
+            no_runner_probe: false,
+        })
+        .expect("exact attempt remains directly addressable");
+        assert_eq!(attempt_status["run_id"], retry_run_id);
+    });
+}
+
+#[test]
 fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema() {
     with_temp_home(|| {
         let root = tempfile::tempdir().expect("worktree root");


### PR DESCRIPTION
## Summary

- resolve Cook-level status, review, diagnose, evidence, and bridge readers through the durable latest substantive candidate
- keep exact attempt IDs directly addressable
- retain the newer no-change attempt's review form and verification provenance without replacing the non-empty candidate
- return bounded candidate-selection diagnostics when lineage is incomplete

Closes #11289.

## Verification

- `cargo test -p homeboy-cli cook_readers_keep_the_substantive_candidate_after_a_no_change_retry --lib`
- `cargo test -p homeboy-agents resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_latest --lib`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

## Compatibility

Direct attempt-ID readers retain their existing behavior. Cook IDs now expose the substantive candidate as the primary run while adding explicit candidate-selection and contributing-attempt provenance.

## AI Assistance

- Tool: OpenCode
- Model: OpenAI `openai/gpt-5.6-sol`
- Used for: parallel codebase investigation, implementation, regression tests, review, and verification with Chris Huber. Chris remains responsible for every line.
