### PR TITLE
Allow recovered Cooks to accept replacement gate proof

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -12,6 +12,9 @@
 use serde_json::Value;
 use std::path::PathBuf;
 
+use homeboy_core::engine::canonical_json::canonical_json_bytes;
+use homeboy_engine_primitives::content_hash;
+
 use crate::agent_task_finalization::{
     finalize_pr_with_backend, preflight_pr_with_backend, validate_publication_intent,
     AgentTaskPrEvidence, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
@@ -225,6 +228,151 @@ pub(crate) fn persisted_promotion_for_attempt(
     restore_gate_feedback_baseline(&record, &mut promotion)?;
     promotion.normalize_gate_outcome();
     Ok(Some(promotion))
+}
+
+/// Records green verification produced after an infrastructure-invalid gate
+/// failure without rewriting the original promotion evidence. The replacement
+/// must describe the exact already-applied candidate, so recovery never
+/// re-applies a patch or silently broadens its verification scope.
+pub fn record_replacement_gate_proof(
+    run_id: &str,
+    mut replacement: AgentTaskPromotionReport,
+    external_authorization: Option<String>,
+) -> Result<AgentTaskPromotionReport> {
+    let original = persisted_promotion_for_attempt(run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "latest_promotion",
+            "replacement gate proof requires a persisted failed promotion",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    if original.status == AgentTaskPromotionStatus::Applied
+        && original.provenance.get("replacement_gate_proof").is_some()
+        && replacement.source == original.source
+        && replacement.target == original.target
+        && replacement.to_worktree == original.to_worktree
+        && replacement.patch_artifact == original.patch_artifact
+        && replacement.changed_files == original.changed_files
+        && replacement.verified_base == original.verified_base
+        && replacement.deterministic_gates == original.deterministic_gates
+        && replacement.command_evidence == original.command_evidence
+    {
+        return Ok(original);
+    }
+    if original.status != AgentTaskPromotionStatus::GateFailed || !original.status.patch_promoted()
+    {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion.status",
+            "replacement gate proof is only valid for an already-applied candidate whose original gates failed",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    if external_authorization
+        .as_deref()
+        .is_none_or(|authorization| authorization.trim().is_empty())
+    {
+        return Err(Error::validation_invalid_argument(
+            "authorize_external_proof",
+            "externally produced replacement gate proof requires explicit operator authorization",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    replacement.normalize_gate_outcome();
+    if replacement.status != AgentTaskPromotionStatus::Applied
+        || replacement.deterministic_gates.is_empty()
+        || replacement.verified_base.is_none()
+        || replacement.deterministic_gates.iter().any(|gate| {
+            gate.command.is_empty()
+                || gate.exit_code != 0
+                || gate.candidate_checkout.is_none()
+                || !replacement
+                    .command_evidence
+                    .iter()
+                    .any(|evidence| evidence.exit_code == 0 && evidence.command == gate.command)
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "replacement_gate_proof",
+            "replacement proof requires every green gate to have matching zero-exit command evidence, plus candidate checkout and verified base",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let same_candidate = replacement.provenance.get("candidate")
+        == original.provenance.get("candidate")
+        && replacement.provenance.get("candidate_checkout")
+            == original.provenance.get("candidate_checkout");
+    if replacement.source.run_id.as_deref() != Some(run_id)
+        || replacement.target != original.target
+        || replacement.to_worktree != original.to_worktree
+        || replacement.patch_artifact != original.patch_artifact
+        || replacement.changed_files != original.changed_files
+        || replacement.verified_base != original.verified_base
+        || !same_candidate
+    {
+        return Err(Error::validation_invalid_argument(
+            "replacement_gate_proof",
+            "replacement proof drifted from the exact failed promotion candidate, base, target, artifact, or scope",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let record = agent_task_lifecycle::status(run_id)?;
+    let original_history_index = record
+        .metadata
+        .get("promotions")
+        .and_then(Value::as_array)
+        .and_then(|promotions| {
+            record
+                .metadata
+                .get("latest_promotion")
+                .and_then(|latest| promotions.iter().rposition(|promotion| promotion == latest))
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "latest_promotion",
+                "replacement gate proof requires the original immutable promotion in history",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let original_history = &record.metadata["promotions"][original_history_index];
+    let original_digest =
+        content_hash::sha256_hex(&canonical_json_bytes(original_history).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize original promotion history".to_string()),
+            )
+        })?);
+    replacement.provenance["replacement_gate_proof"] = serde_json::json!({
+        "schema": "homeboy/agent-task-replacement-gate-proof/v1",
+        "original_history": {
+            "run_id": record.run_id,
+            "metadata_key": "promotions",
+            "index": original_history_index,
+            "status": original.status,
+            "deterministic_gate_count": original.deterministic_gates.len(),
+            "sha256": original_digest,
+        },
+        "reason": "infrastructure_invalid_original_gates",
+        "operator_authorization": external_authorization,
+        "externally_produced": true,
+        // `Inherit` serializes as the default in gate reports; recording the
+        // resolved policy here keeps that valid standard policy explicit.
+        "environment_policy": replacement.deterministic_gates.iter().map(|gate| serde_json::json!({
+            "gate_id": gate.id,
+            "environment": gate.environment,
+        })).collect::<Vec<_>>(),
+    });
+    agent_task_lifecycle::record_promotion(
+        run_id,
+        serde_json::to_value(&replacement)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?,
+    )?;
+    Ok(replacement)
 }
 
 /// Older applied reports lost the post-apply baseline when the final gate
@@ -1883,6 +2031,75 @@ fn cook_review_dossier(
         successful_run_id,
         &terminal_form,
     )?;
+    let mut evidence = vec![
+        AgentTaskReviewEvidence {
+            summary: format!("Task objective: {task_summary}"),
+            url: None,
+        },
+        AgentTaskReviewEvidence {
+            summary: format!(
+                "Verified candidate scope: {changed_file_count} changed file(s): {changed_files}."
+            ),
+            url: None,
+        },
+        AgentTaskReviewEvidence {
+            summary: format!(
+                "Cook deterministic verification: {gate_count} gate(s) completed green."
+            ),
+            url: None,
+        },
+        AgentTaskReviewEvidence {
+            summary: if adoption {
+                "Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.".to_string()
+            } else {
+                "Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.".to_string()
+            },
+            url: None,
+        },
+    ];
+    // Form-only continuations may substitute the implementation promotion for
+    // candidate metadata; the persisted terminal record remains recovery proof.
+    if let Some(replacement) = agent_task_lifecycle::status(successful_run_id)
+        .ok()
+        .and_then(|record| {
+            record
+                .metadata
+                .get("promotions")
+                .and_then(Value::as_array)
+                .and_then(|promotions| {
+                    promotions.iter().rev().find_map(|promotion| {
+                        promotion
+                            .pointer("/provenance/replacement_gate_proof")
+                            .cloned()
+                    })
+                })
+        })
+    {
+        let original_gates = replacement["original_history"]["deterministic_gate_count"]
+            .as_u64()
+            .unwrap_or_default();
+        evidence.extend([
+            AgentTaskReviewEvidence {
+                summary: format!(
+                    "Original infrastructure-invalid verification retained: {original_gates} failed gate record(s); inspect durable gate details."
+                ),
+                // The durable record is operator-only. Keep this reviewer-facing
+                // provenance as text so `enrich_dossier` does not remove it.
+                url: None,
+            },
+            AgentTaskReviewEvidence {
+                summary: format!(
+                    "Replacement candidate-bound verification: {gate_count} gate(s) completed green with matching command evidence."
+                ),
+                url: None,
+            },
+            AgentTaskReviewEvidence {
+                summary: "Explicit operator authorization for external replacement proof was recorded."
+                    .to_string(),
+                url: None,
+            },
+        ]);
+    }
     Ok(AgentTaskReviewDossier {
         schema: "homeboy/agent-task-review-dossier/v1".to_string(),
         summary: lineage.summary,
@@ -1892,32 +2109,7 @@ fn cook_review_dossier(
         // Deterministic evidence: orchestrator-owned. The task objective, scope,
         // gate count, and adoption provenance are factual records, not prose the
         // AI restates.
-        evidence: vec![
-            AgentTaskReviewEvidence {
-                summary: format!("Task objective: {task_summary}"),
-                url: None,
-            },
-            AgentTaskReviewEvidence {
-                summary: format!(
-                    "Verified candidate scope: {changed_file_count} changed file(s): {changed_files}."
-                ),
-                url: None,
-            },
-            AgentTaskReviewEvidence {
-                summary: format!(
-                    "Cook deterministic verification: {gate_count} gate(s) completed green."
-                ),
-                url: None,
-            },
-            AgentTaskReviewEvidence {
-                summary: if adoption {
-                    "Candidate adoption provenance: an immutable candidate was adopted through the recorded Cook workflow and passed the recorded gates.".to_string()
-                } else {
-                    "Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.".to_string()
-                },
-                url: None,
-            },
-        ],
+        evidence,
         changed_public_contracts: Vec::new(),
         public_contract_evidence: None,
         ai_assistance: AgentTaskReviewAiAssistance {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -13,7 +13,7 @@ use super::super::cook_promotion::{
     finalize_or_load_cook_pr_with_backend, moving_base_recovery_for_run,
     moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
     persist_manual_finalization_intent, persist_manual_finalization_receipt,
-    persisted_promotion_for_attempt, recover_cook_pr_with_backend,
+    persisted_promotion_for_attempt, record_replacement_gate_proof, recover_cook_pr_with_backend,
     recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
     CookReportInput, MovingBaseCookRecovery,
 };
@@ -7054,6 +7054,158 @@ fn recovered_cook_finalization_uses_latest_resumed_gate_contract() {
         );
         assert!(!report.to_string().contains("stale-original-contract"));
         assert!(!report.to_string().contains("private stale gate"));
+    });
+}
+
+#[test]
+fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_republishing() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-11290";
+        let run_id = "cook-11290-attempt-1";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+
+        let mut failed = promotion(run_id);
+        failed.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
+        failed.deterministic_gates[0].status = crate::agent_task_gate::AgentTaskGateStatus::Failed;
+        failed.deterministic_gates[0].exit_code = 1;
+        failed.deterministic_gates[0].stderr = "rustup infrastructure failure".to_string();
+        failed.provenance["candidate"] = serde_json::json!({"kind": "git", "fingerprint": {"head": "candidate", "tree": "candidate-tree", "sha256": "candidate-sha"}});
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&failed).unwrap())
+            .expect("record immutable failed evidence");
+
+        let mut replacement = failed.clone();
+        replacement.status = crate::agent_task_promotion::AgentTaskPromotionStatus::Applied;
+        replacement.deterministic_gates[0].status =
+            crate::agent_task_gate::AgentTaskGateStatus::Succeeded;
+        replacement.deterministic_gates[0].exit_code = 0;
+        replacement.deterministic_gates[0].stderr.clear();
+        replacement.command_evidence = vec![
+            crate::agent_task_promotion::AgentTaskPromotionCommandReport {
+                command: vec![
+                    "sh".to_string(),
+                    "-lc".to_string(),
+                    "cargo test --locked agent_task_promotion --lib".to_string(),
+                ],
+                exit_code: 0,
+                stdout: "passed".to_string(),
+                stderr: String::new(),
+                capture: Default::default(),
+            },
+        ];
+        let error = record_replacement_gate_proof(run_id, replacement.clone(), None)
+            .expect_err("external proof requires operator authorization");
+        assert!(error.message.contains("explicit operator authorization"));
+
+        let mut drifted = replacement.clone();
+        drifted.verified_base.as_mut().unwrap().sha = "other-base".to_string();
+        let error = record_replacement_gate_proof(
+            run_id,
+            drifted,
+            Some("Chris approved external proof".to_string()),
+        )
+        .expect_err("base drift is refused");
+        assert!(error.message.contains("drifted"));
+
+        let mut mismatched_evidence = replacement.clone();
+        mismatched_evidence.command_evidence[0].command = vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            "cargo test unrelated".to_string(),
+        ];
+        let error = record_replacement_gate_proof(
+            run_id,
+            mismatched_evidence,
+            Some("Chris approved external proof".to_string()),
+        )
+        .expect_err("each gate needs matching command evidence");
+        assert!(error
+            .message
+            .contains("matching zero-exit command evidence"));
+
+        let replacement_for_replay = replacement.clone();
+        record_replacement_gate_proof(
+            run_id,
+            replacement,
+            Some("Chris approved external proof".to_string()),
+        )
+        .expect("record bound green replacement proof");
+        let replay = record_replacement_gate_proof(
+            run_id,
+            replacement_for_replay,
+            Some("Chris approved external proof".to_string()),
+        )
+        .expect("identical proof replay is idempotent");
+        assert_eq!(
+            replay.status,
+            crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+        );
+        let record = agent_task_lifecycle::status(run_id).expect("read durable evidence");
+        assert_eq!(record.metadata["promotions"].as_array().unwrap().len(), 2);
+        let original_history = &record.metadata["promotions"][0];
+        assert!(original_history["deterministic_gates"][0]["stderr"]
+            .as_str()
+            .unwrap()
+            .contains("rustup infrastructure failure"));
+        let original_reference = &record.metadata["latest_promotion"]["provenance"]
+            ["replacement_gate_proof"]["original_history"];
+        assert_eq!(original_reference["run_id"], run_id);
+        assert_eq!(original_reference["metadata_key"], "promotions");
+        assert_eq!(original_reference["index"], 0);
+        assert_eq!(original_reference["status"], "gate_failed");
+        assert_eq!(original_reference["deterministic_gate_count"], 1);
+        assert_eq!(
+            original_reference["sha256"],
+            homeboy_engine_primitives::content_hash::sha256_hex(
+                &homeboy_core::engine::canonical_json::canonical_json_bytes(original_history)
+                    .expect("serialize original history")
+            )
+        );
+        assert!(
+            record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
+                .get("original")
+                .is_none()
+        );
+        assert_eq!(
+            record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
+                ["environment_policy"][0]["environment"]["mode"],
+            "inherit"
+        );
+
+        let mut backend = CaptureBackend::default();
+        let published = recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut backend)
+            .expect("replacement proof finalizes existing candidate");
+        assert_eq!(published["status"], "review_ready");
+        assert!(backend.created);
+        assert!(backend
+            .body
+            .contains("cargo test --locked agent_task_promotion --lib"));
+        for evidence in [
+            "Original infrastructure-invalid verification retained",
+            "Replacement candidate-bound verification",
+            "Explicit operator authorization for external replacement proof was recorded.",
+        ] {
+            assert!(
+                backend.body.contains(evidence),
+                "missing dossier evidence: {evidence}; body: {}",
+                backend.body
+            );
+        }
+        assert!(!backend.body.contains("Chris approved external proof"));
+        let mut repeated = CaptureBackend::default();
+        assert_eq!(
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut repeated).unwrap(),
+            published
+        );
+        assert!(
+            !repeated.created,
+            "finalization receipt preserves exactly-once publication"
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -431,7 +431,7 @@ pub mod service {
         persist_provider_boundary_replay_evidence, persisted_status, promotion_is_resumable,
         promotion_source, read_plan, rearm_failed_terminal_continuation,
         reconcile_recipe_attempt_for_continuation, reconcile_terminal_artifact_projection,
-        reconstruct_options_with_dispatcher, recover_cook_pr,
+        reconstruct_options_with_dispatcher, record_replacement_gate_proof, recover_cook_pr,
         recover_terminal_transport_proxy_evidence, register_promotion_job_driver,
         resolve_cook_continuation_run_id, resume, resume_cook, resume_cook_batch, retry, run_cook,
         run_cook_batch, run_cook_with_durable_observer, run_loaded_plan, run_next,

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -39,9 +39,10 @@ pub use args::{
     AgentTaskLoopDefineArgs, AgentTaskLoopResumeArgs, AgentTaskLoopStatusArgs, CancelArgs,
     CompileLoopArgs, ContractArgs, ContractFormat, CookContinueArgs, DiagnoseArgs, EvidenceArgs,
     FinalizePrArgs, GateFeedbackArgs, LatestArgs, ListArgs, LogsArgs, PromoteArgs,
-    PromotionProviderArgs, ProvidersArgs, ReconcileRecordsArgs, ReplayProviderBoundaryArgs,
-    RetainedArtifactsArgs, RetainedArtifactsCommand, RetryArgs, ReviewArgs, RunPlanArgs,
-    RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    PromotionProviderArgs, ProvidersArgs, ReconcileRecordsArgs, RecordReplacementGateProofArgs,
+    ReplayProviderBoundaryArgs, RetainedArtifactsArgs, RetainedArtifactsCommand, RetryArgs,
+    ReviewArgs, RunPlanArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs,
+    VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -173,6 +174,9 @@ pub(crate) fn run_with_cook_progress_and_provenance(
             run::promotion_provider(provider_args)
         }
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
+        AgentTaskCommand::RecordReplacementGateProof(args) => {
+            review::record_replacement_gate_proof(args)
+        }
         AgentTaskCommand::Accept(args) => {
             let verdict = if args.verdict == "accepted" {
                 homeboy::agents::agent_tasks::lifecycle::AgentTaskAcceptanceVerdict::Accepted

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -12,8 +12,8 @@ use super::cook::{AgentTaskCookArgs, AgentTaskLoopArgs, PromotionProviderArgs};
 use super::fanout::AgentTaskFanoutArgs;
 use super::lifecycle::{
     AdoptArgs, CancelArgs, DiagnoseArgs, EvidenceArgs, FinalizePrArgs, GateFeedbackArgs, LogsArgs,
-    PromoteArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs, RunArgs, RunPlanArgs,
-    RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs,
+    PromoteArgs, RecordReplacementGateProofArgs, ReplayProviderBoundaryArgs, RetryArgs, ReviewArgs,
+    RunArgs, RunPlanArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs, SubmitArgs,
 };
 
 pub use super::super::auth::{
@@ -103,6 +103,8 @@ pub enum AgentTaskCommand {
     #[command(hide = true)]
     PromotionProvider(PromotionProviderArgs),
     FinalizePr(FinalizePrArgs),
+    /// Attach authorized candidate-bound replacement gate proof after an infrastructure gate failure.
+    RecordReplacementGateProof(RecordReplacementGateProofArgs),
     /// Record an independent, durable acceptance verdict for a candidate.
     Accept(AcceptArgs),
     GateFeedback(GateFeedbackArgs),

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -346,6 +346,17 @@ pub struct FinalizePrArgs {
     pub manual_finalization: bool,
 }
 #[derive(Args, Debug)]
+pub struct RecordReplacementGateProofArgs {
+    /// Durable Cook attempt whose applied candidate has infrastructure-invalid gates.
+    pub run_id: String,
+    /// Complete typed promotion report from the replacement gate executor: inline JSON, `@FILE`, or `-`.
+    #[arg(long, value_name = "JSON|@FILE|-")]
+    pub promotion: String,
+    /// Explicit operator authorization for externally produced proof.
+    #[arg(long, value_name = "TEXT")]
+    pub authorize_external_proof: Option<String>,
+}
+#[derive(Args, Debug)]
 pub struct GateFeedbackArgs {
     /// Promotion report as a JSON spec: inline JSON, `@FILE` to read a file, or
     /// `-` to read stdin. A bare path is NOT accepted — use

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -31,7 +31,10 @@ use homeboy::core::config;
 use homeboy::core::gate::HomeboyGateResult;
 
 use super::super::CmdResult;
-use super::{AdoptArgs, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs, ReviewArgs};
+use super::{
+    AdoptArgs, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
+    RecordReplacementGateProofArgs, ReviewArgs,
+};
 
 #[derive(Args, Debug)]
 pub struct FinalizePrEvidenceArgs {
@@ -534,6 +537,26 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     );
 
     Ok((value, exit_code))
+}
+
+pub(crate) fn record_replacement_gate_proof(
+    args: RecordReplacementGateProofArgs,
+) -> CmdResult<Value> {
+    let replacement = serde_json::from_str(&config::read_json_spec_to_string(&args.promotion)?)
+        .map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                "promotion",
+                format!("replacement gate proof is not a valid promotion report: {error}"),
+                None,
+                None,
+            )
+        })?;
+    let report = agent_task_service::record_replacement_gate_proof(
+        &args.run_id,
+        replacement,
+        args.authorize_external_proof,
+    )?;
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
 }
 
 fn should_persist_manual_preflight_intent(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1948,6 +1948,33 @@ fn retry_force_alias_parses_as_force() {
 }
 
 #[test]
+fn replacement_gate_proof_command_requires_typed_proof_and_operator_authorization() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "record-replacement-gate-proof",
+        "cook-11290-attempt-1",
+        "--promotion",
+        "@replacement.json",
+        "--authorize-external-proof",
+        "Chris approved durable evidence",
+    ])
+    .expect("replacement proof command parses");
+    let Commands::AgentTask(args) = cli.command else {
+        panic!("agent-task command");
+    };
+    let AgentTaskCommand::RecordReplacementGateProof(args) = args.command else {
+        panic!("replacement proof command");
+    };
+    assert_eq!(args.run_id, "cook-11290-attempt-1");
+    assert_eq!(args.promotion, "@replacement.json");
+    assert_eq!(
+        args.authorize_external_proof.as_deref(),
+        Some("Chris approved durable evidence")
+    );
+}
+
+#[test]
 fn resume_command_executes_existing_run() {
     with_temp_home(|| {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-resume-cli")).expect("submitted");

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -68,7 +68,8 @@ pub(super) fn agent_task_resource_behavior(
         | agent_task::AgentTaskCommand::Contract(_)
         | agent_task::AgentTaskCommand::CompileLoop(_)
         | agent_task::AgentTaskCommand::Auth(_)
-        | agent_task::AgentTaskCommand::Accept(_) => AgentTaskResourceBehavior::LocalControl,
+        | agent_task::AgentTaskCommand::Accept(_)
+        | agent_task::AgentTaskCommand::RecordReplacementGateProof(_) => AgentTaskResourceBehavior::LocalControl,
         agent_task::AgentTaskCommand::Cook(cook) if cook.dispatch.core.queue_only => {
             AgentTaskResourceBehavior::LocalControl
         }


### PR DESCRIPTION
## Summary

- add `agent-task record-replacement-gate-proof` for explicitly authorized recovery after infrastructure-invalid Cook gates
- validate exact candidate, base, target, artifact, changed scope, green gate results, matching command evidence, and environment policy
- preserve immutable original failed promotion evidence through bounded history provenance and deterministic digest
- let `finalize-pr --recover` consume accepted replacement proof without provider redispatch or patch reapplication
- distinguish original failure, replacement verification, and operator authorization in reviewer-facing output while keeping authorization text private
- preserve idempotent proof replay and exactly-once PR publication

Closes #11290.

## Verification

- `cargo test -p homeboy-agents replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_republishing --lib`
- `cargo test -p homeboy-cli replacement_gate_proof_command_requires_typed_proof_and_operator_authorization --lib`
- `cargo test -p homeboy-agents agent_task_review_dossier::tests --lib`
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

## Compatibility

The new recovery command and replacement provenance are additive. Existing failed promotion records remain immutable, normal green finalization is unchanged, and candidate/base drift continues to fail closed.

## AI Assistance

- Tool: OpenCode
- Model: OpenAI `openai/gpt-5.6-sol`
- Used for: parallel codebase investigation, recovery-contract design, implementation, security and payload review, regression tests, and verification with Chris Huber. Chris remains responsible for every line.
