### PR TITLE
fix(issues): stop rendering finding fingerprints as bullet labels

### DIFF
--- a/crates/homeboy-issues/src/render.rs
+++ b/crates/homeboy-issues/src/render.rs
@@ -475,23 +475,38 @@ fn render_normalized_findings_body(
 }
 
 fn render_normalized_finding_line(out: &mut String, finding: &HomeboyFinding) {
-    let label = finding
-        .fingerprint
-        .as_deref()
-        .or(finding.rule.as_deref())
-        .or(finding.location.file.as_deref())
-        .unwrap_or(&finding.tool);
-    let _ = write!(out, "- `{}` — {}", label, finding.message);
-    if let Some(file) = finding.location.file.as_deref() {
-        if label != file {
-            let _ = write!(out, " (`{}", file);
-            if let Some(line) = finding.location.line {
-                let _ = write!(out, ":{}", line);
-            }
-            let _ = write!(out, "`)");
-        }
-    }
-    out.push('\n');
+    let label = finding_display_label(finding);
+    let _ = writeln!(out, "- `{}` — {}", label, finding.message);
+}
+
+/// Human-facing label for one rendered finding bullet.
+///
+/// Location wins over identity. A fingerprint is a dedup key, not a label:
+/// producers are free to compose it from the file, rule, and the whole
+/// normalized message (the audit contract does exactly that), so rendering it
+/// verbatim repeats the file and the message that already follow on the same
+/// line — and any backtick inside it breaks the surrounding code span. Fall
+/// back to the fingerprint only when there is no location and no rule to
+/// identify the finding by.
+fn finding_display_label(finding: &HomeboyFinding) -> String {
+    let label = match finding.location.file.as_deref() {
+        Some(file) => match finding.location.line {
+            Some(line) => format!("{}:{}", file, line),
+            None => file.to_string(),
+        },
+        None => finding
+            .rule
+            .as_deref()
+            .or(finding.fingerprint.as_deref())
+            .unwrap_or(&finding.tool)
+            .to_string(),
+    };
+    sanitize_inline_code(&label)
+}
+
+/// Strip backticks so the label cannot terminate its own code span.
+fn sanitize_inline_code(value: &str) -> String {
+    value.replace('`', "")
 }
 
 fn render_test_cluster_body(

--- a/crates/homeboy-issues/src/render_test.rs
+++ b/crates/homeboy-issues/src/render_test.rs
@@ -160,7 +160,11 @@ fn renders_normalized_lint_findings() {
     assert!(group.body.contains("1 lint finding(s) in this category."));
     assert!(group
         .body
-        .contains("- `lint-1` — trailing whitespace (`src/lib.rs:12`)"));
+        .contains("- `src/lib.rs:12` — trailing whitespace"));
+    assert!(
+        !group.body.contains("lint-1"),
+        "the fingerprint is a dedup key, not a display label"
+    );
 }
 
 #[test]
@@ -309,7 +313,7 @@ fn renders_normalized_test_findings() {
     assert!(group.body.contains("1 test finding(s) in this category."));
     assert!(group
         .body
-        .contains("- `test-1` — expected 200, got 500 (`tests/http.rs:44`)"));
+        .contains("- `tests/http.rs:44` — expected 200, got 500"));
 }
 
 #[test]
@@ -458,4 +462,91 @@ fn normalized_audit_findings_render_fixability_tiers() {
     assert!(group.body.contains("Total fixable: 5"));
     assert!(group.body.contains("Automated: 3"));
     assert!(group.body.contains("Manual-only: 2"));
+}
+
+#[test]
+fn normalized_finding_bullets_do_not_repeat_the_fingerprint() {
+    // Regression for the `core-agnostic-source` issue bodies: the audit
+    // contract composes its fingerprint as
+    // `file:kind:convention:normalized_message`, so rendering the fingerprint
+    // as the bullet label repeated the file and the whole message on the same
+    // line — and the backticks the message carries terminated the label's own
+    // code span, garbling every bullet after it.
+    let file = "crates/homeboy-agents/src/artifacts.rs";
+    let message = "Core boundary leak (core-agnostic-source) configured ecosystem term \
+                   `node` appears at line 148 in behavioral context `collect_artifacts`";
+    let fingerprint = format!(
+        "{}:core_boundary_leak:core_boundary_leak:core-agnostic-source:{}",
+        file,
+        message.replace("line 148", "line <line>")
+    );
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "findings": [
+                {
+                    "tool": "audit",
+                    "rule": "core_boundary_leak",
+                    "category": "core_boundary_leak:core-agnostic-source",
+                    "message": message,
+                    "fingerprint": fingerprint,
+                    "file": file
+                }
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("audit", output, &IssueRenderContext::default()).unwrap();
+    let group = rendered
+        .groups
+        .get("core_boundary_leak:core-agnostic-source")
+        .unwrap();
+    let bullet = group
+        .body
+        .lines()
+        .find(|line| line.starts_with("- `"))
+        .expect("a finding bullet is rendered");
+
+    assert_eq!(bullet, format!("- `{}` — {}", file, message));
+    assert_eq!(
+        bullet.matches(file).count(),
+        1,
+        "the file must appear once per bullet"
+    );
+    assert_eq!(
+        bullet.matches("behavioral context").count(),
+        1,
+        "the message must appear once per bullet"
+    );
+    assert!(
+        !bullet.contains("<line>"),
+        "the fingerprint's line placeholder must not leak into the body"
+    );
+}
+
+#[test]
+fn normalized_finding_label_strips_backticks() {
+    // A label that carries a backtick would close its own code span.
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "findings": [
+                {
+                    "tool": "lint",
+                    "category": "style",
+                    "message": "bad quoting",
+                    "fingerprint": "weird`fingerprint"
+                }
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+    let group = rendered.groups.get("style").unwrap();
+
+    assert!(group.body.contains("- `weirdfingerprint` — bad quoting"));
 }


### PR DESCRIPTION
Reported in #11298 — the duplication within each finding bullet.

## What's wrong

`render_normalized_finding_line` used `finding.fingerprint` as the display label:

```rust
let label = finding.fingerprint.as_deref()   // <-- takes priority
    .or(finding.rule.as_deref())
    .or(finding.location.file.as_deref())
    .unwrap_or(&finding.tool);
write!(out, "- `{}` — {}", label, finding.message);
// ...then appends (`file`) when label != file
```

But the audit contract composes its fingerprint as `file:kind:convention:normalized_description` (`crates/contracts/homeboy-audit-contract/src/finding.rs:118`). So every bullet emitted:

- the **file** twice — inside the fingerprint, and again in the trailing `` (`file`) ``
- the **description** twice — once with line numbers scrubbed to `<line>` inside the fingerprint, once verbatim as the message
- the **category** three times — issue title, `##` heading, and the `Core boundary leak (core-agnostic-source)` prefix the detector bakes into the description

On #11298 that is ~300 of 537 characters per bullet, across 409 findings.

## It also broke the markdown

Descriptions quote identifiers in backticks (`` `node` ``, `` `fn_name` ``). Wrapping that in backticks terminates the code span early. Verified against GitHub's own `/markdown` API:

```html
<li><code>a.rs:kind:conv:desc with </code>node<code>at line &lt;line&gt; in ctx</code>fn_x`` — desc with <code>node</code> at line 148 in ctx `fn_x` (`a.rs`)</li>
```

`node` escapes the span, `<line>` gets HTML-escaped, and the doubled backtick opens a span that never closes — so the remainder of the line renders with raw backticks visible. Every bullet in that issue is malformed.

## The fix

Location wins over identity: `file:line` → `file` → `rule` → `fingerprint` → `tool`, with backticks stripped from whatever is chosen. The trailing `(file)` suffix becomes redundant and is dropped.

```
- `crates/homeboy-agents/src/agent_task_controller_service/artifacts.rs` — Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line 148 in behavioral context `collect_required_artifacts_from_declarations`
```

537 → ~235 characters, and it renders.

## Safety

Nothing parses these bullets back out. `reconcile.rs` keys off the `<!-- homeboy:issues-reconcile-key=... -->` HTML comment and the issue title only, so the fingerprint carries zero machine value in the body. This is presentation-only; grouping, dedup, and reconcile identity are untouched.

## Tests

- Updated `renders_normalized_lint_findings` and `renders_normalized_test_findings` for the new label, plus a negative assertion that the fingerprint no longer leaks into the body.
- Added `normalized_finding_bullets_do_not_repeat_the_fingerprint`, which reproduces the exact #11298 shape and asserts the file and message each appear once and `<line>` never reaches the body.
- Added `normalized_finding_label_strips_backticks`.
- The legacy (non-normalized) lint path is untouched, so `renders_lint_output_grouped_by_category` is unchanged.

Verified locally with `cargo check -p homeboy-issues --tests` (clean); test execution left to CI per this host's build policy.

## Follow-up

`audit_contract::Finding` has no `line` field at all — `convention, severity, file, description, suggestion, kind`. Line numbers exist only as prose inside the description, and the fingerprint deliberately scrubs them, so audit labels can only ever reach `file`, never `file:line`. Filed separately.