### PR TITLE
Project authoritative terminal Cook status

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1139,6 +1139,34 @@ pub fn record_cook_progress(
     record.ok_or_else(|| Error::internal_unexpected("Cook progress record was unchanged"))
 }
 
+/// Bind the Cook's authoritative command result to its terminal progress
+/// record. Provider and gate state alone cannot establish whether publication
+/// completed, so readers use this positive completion fact rather than a list
+/// of success-status strings.
+pub fn record_cook_terminal_result(
+    run_id: &str,
+    terminal_success: bool,
+    exit_code: i32,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let Some(progress) = record
+            .ensure_metadata_object()
+            .get_mut("cook_progress")
+            .and_then(Value::as_object_mut)
+        else {
+            return false;
+        };
+        if progress.get("phase").and_then(Value::as_str) != Some("terminal") {
+            return false;
+        }
+        progress.insert("terminal_success".to_string(), json!(terminal_success));
+        progress.insert("exit_code".to_string(), json!(exit_code));
+        true
+    })?;
+    record.ok_or_else(|| Error::internal_unexpected("Cook terminal result was unchanged"))
+}
+
 /// Record the provider's terminal result before controller-owned patch
 /// harvesting. Harvesting can fail or be interrupted independently of the
 /// provider execution, so it must not leave this reservation running.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -144,6 +144,13 @@ fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
             .expect("retain terminal progress");
         assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
         assert_eq!(terminal.metadata["cook_progress"]["phase"], "terminal");
+        let terminal =
+            record_cook_terminal_result(run_id, false, 1).expect("record terminal Cook result");
+        assert_eq!(
+            terminal.metadata["cook_progress"]["terminal_success"],
+            false
+        );
+        assert_eq!(terminal.metadata["cook_progress"]["exit_code"], 1);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1786,6 +1786,15 @@ where
         ) {
             return durable_cook_error_report(&failure_options, error);
         }
+        if phase == "terminal" {
+            if let Err(error) = agent_task_lifecycle::record_cook_terminal_result(
+                run_id,
+                result.exit_code == 0,
+                result.exit_code,
+            ) {
+                return durable_cook_error_report(&failure_options, error);
+            }
+        }
     }
     Ok(result)
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -142,6 +142,15 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
         }
     }
     enrich_with_diagnostic_summary(&mut value, run_id)?;
+    if let Some((progress, source_run_id)) = selected_cook_terminal_progress(&target, run_id) {
+        project_owning_cook_terminal_status_from_progress(
+            &mut value,
+            &progress,
+            Some(&source_run_id),
+        );
+    } else {
+        project_owning_cook_terminal_status(&mut value);
+    }
     attach_transport_proxy_recovery_guidance(&mut value, run_id);
     if let Some(selection) = target.selection.as_ref() {
         value["candidate_selection"] = selection.clone();
@@ -152,7 +161,8 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
         bound_full_reader_payload(&mut value);
         attach_runner_probe(&mut value, &runner_probe);
         attach_agent_task_status_actionable(&mut value, run_id);
-        return Ok((value, 0));
+        let exit_code = status_exit_code(&value);
+        return Ok((value, exit_code));
     }
     let summary = compact_status_summary(&value, run_id);
     let mut summary = summary;
@@ -161,7 +171,96 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     }
     attach_runner_probe(&mut summary, &runner_probe);
     attach_agent_task_status_actionable(&mut summary, run_id);
-    Ok((summary, 0))
+    let exit_code = status_exit_code(&summary);
+    Ok((summary, exit_code))
+}
+
+/// A Cook owns the provider attempt's publication lifecycle. Once it records a
+/// terminal outcome, that outcome is the status headline; the child run state
+/// remains available as `child_run_state` and in `execution_states.provider`.
+fn project_owning_cook_terminal_status(value: &mut Value) {
+    let progress = value.pointer("/metadata/cook_progress").cloned();
+    project_owning_cook_terminal_status_from_progress(value, progress.as_ref(), None);
+}
+
+/// Main's substantive-candidate reader can resolve an earlier patch-producing
+/// attempt while the latest attempt owns the Cook's terminal publication result.
+/// Read that separate lifecycle record so candidate evidence and Cook truth stay
+/// visible together.
+fn selected_cook_terminal_progress(
+    target: &CookReaderTarget,
+    selected_run_id: &str,
+) -> Option<(Value, String)> {
+    let source_run_id = target
+        .selection
+        .as_ref()?
+        .get("latest_attempt_run_id")?
+        .as_str()?
+        .to_string();
+    if source_run_id == selected_run_id {
+        return None;
+    }
+    let record = agent_task_lifecycle::exact_record(&source_run_id).ok()?;
+    let progress = record.metadata.get("cook_progress")?.clone();
+    (progress.get("phase").and_then(Value::as_str) == Some("terminal"))
+        .then_some((progress, source_run_id))
+}
+
+fn project_owning_cook_terminal_status_from_progress(
+    value: &mut Value,
+    progress: Option<&Value>,
+    source_run_id: Option<&str>,
+) {
+    let Some(progress) = progress
+        .filter(|progress| progress.get("phase").and_then(Value::as_str) == Some("terminal"))
+    else {
+        return;
+    };
+    if progress.get("terminal_success").and_then(Value::as_bool) == Some(true) {
+        return;
+    }
+    let Some(status) = progress
+        .get("detail")
+        .and_then(Value::as_str)
+        .filter(|status| !status.trim().is_empty())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let publication = if progress.get("terminal_success").and_then(Value::as_bool) == Some(false) {
+        "blocked"
+    } else {
+        "unknown"
+    };
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    if let Some(run_state) = object.get("state").cloned() {
+        object.insert("child_run_state".to_string(), run_state);
+    }
+    object.insert("state".to_string(), Value::String(status.clone()));
+    let mut cook = json!({
+        "state": status,
+        "phase": "terminal",
+        "publication": publication,
+    });
+    if let Some(source_run_id) = source_run_id {
+        cook["source_run_id"] = json!(source_run_id);
+    }
+    object.insert("cook".to_string(), cook);
+}
+
+fn blocked_owning_cook(value: &Value) -> bool {
+    value.pointer("/cook/phase").and_then(Value::as_str) == Some("terminal")
+        && value.pointer("/cook/publication").and_then(Value::as_str) != Some("completed")
+}
+
+fn status_exit_code(value: &Value) -> i32 {
+    if blocked_owning_cook(value) {
+        1
+    } else {
+        0
+    }
 }
 
 fn attach_full_status_candidate(
@@ -436,7 +535,15 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
         ..Default::default()
     };
 
-    if classify_candidates(value).state().is_available() {
+    if blocked_owning_cook(value) {
+        metadata.next_actions.push(
+            CommandNextAction::new(
+                "diagnose blocked Cook",
+                format!("homeboy agent-task diagnose {run_id} --full"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        );
+    } else if classify_candidates(value).state().is_available() {
         let review_command = format!("homeboy agent-task review {run_id}");
         metadata.next_actions.push(
             CommandNextAction::new("review run", review_command)
@@ -2371,6 +2478,8 @@ fn compact_status_summary_with_aggregate(
         "schema": "homeboy/agent-task-status-summary/v1",
         "run_id": record.get("run_id").cloned().unwrap_or_else(|| json!(run_id)),
         "state": record.get("state").cloned().unwrap_or(Value::Null),
+        "child_run_state": record.get("child_run_state").cloned().unwrap_or(Value::Null),
+        "cook": record.get("cook").cloned().unwrap_or(Value::Null),
         "timestamps": compact_fields(record, &["created_at", "updated_at", "started_at", "completed_at"]),
         "work_summary": work_summary,
         "canonical_candidate": canonical_candidate_projection(canonical_candidate),
@@ -3530,6 +3639,202 @@ mod tests {
             .any(
                 |action| action["command"] == "homeboy agent-task review agent-task-durable-patch"
             ));
+    }
+
+    #[test]
+    fn terminal_cook_gate_failure_overrides_successful_provider_status() {
+        let mut status = blocked_cook_status_fixture("gate_failed", "gate_failed", "not_attempted");
+
+        project_owning_cook_terminal_status(&mut status);
+        let mut status = compact_status_summary(&status, "cook-attempt-1");
+        attach_agent_task_status_actionable(&mut status, "cook-attempt-1");
+        let rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+            crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+            &status,
+        )
+        .expect("status summary");
+
+        assert_eq!(status["state"], "gate_failed");
+        assert_eq!(status["child_run_state"], "succeeded");
+        assert_eq!(
+            status["execution_states"]["provider"][0]["state"],
+            "succeeded"
+        );
+        assert_eq!(status["execution_states"]["gate"]["state"], "failed");
+        assert_eq!(status["cook"]["publication"], "blocked");
+        assert_eq!(status_exit_code(&status), 1);
+        assert!(rendered.contains("Status: gate_failed"));
+        assert!(rendered.contains("Cook: gate_failed (publication blocked)"));
+        assert!(rendered.contains("Next: homeboy agent-task diagnose cook-attempt-1 --full"));
+        assert!(!rendered.contains("Next: homeboy agent-task review"));
+        assert!(
+            status[ACTIONABLE_METADATA_KEY]["next_actions"]
+                .as_array()
+                .expect("next actions")
+                .iter()
+                .any(|action| action["command"]
+                    == "homeboy agent-task diagnose cook-attempt-1 --full")
+        );
+        assert!(!status[ACTIONABLE_METADATA_KEY]["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .any(|action| action["command"] == "homeboy agent-task review cook-attempt-1"));
+    }
+
+    #[test]
+    fn terminal_cook_finalization_failure_overrides_successful_provider_status() {
+        let mut status =
+            blocked_cook_status_fixture("finalization_failed", "applied", "finalization_failed");
+
+        project_owning_cook_terminal_status(&mut status);
+        attach_agent_task_status_actionable(&mut status, "cook-attempt-1");
+
+        assert_eq!(status["state"], "finalization_failed");
+        assert_eq!(status["child_run_state"], "succeeded");
+        assert_eq!(
+            status["execution_states"]["provider"][0]["state"],
+            "succeeded"
+        );
+        assert_eq!(status["execution_states"]["promotion"]["state"], "applied");
+        assert_eq!(
+            status["execution_states"]["finalization"]["state"],
+            "finalization_failed"
+        );
+        assert_eq!(status_exit_code(&status), 1);
+        assert!(
+            status[ACTIONABLE_METADATA_KEY]["next_actions"]
+                .as_array()
+                .expect("next actions")
+                .iter()
+                .any(|action| action["command"]
+                    == "homeboy agent-task diagnose cook-attempt-1 --full")
+        );
+    }
+
+    #[test]
+    fn terminal_cook_budget_exhaustion_overrides_successful_provider_status() {
+        let mut status = blocked_cook_status_fixture(
+            "execution_budget_exhausted",
+            "gate_failed",
+            "not_attempted",
+        );
+
+        project_owning_cook_terminal_status(&mut status);
+        let mut status = compact_status_summary(&status, "cook-attempt-1");
+        attach_agent_task_status_actionable(&mut status, "cook-attempt-1");
+
+        assert_eq!(status["state"], "execution_budget_exhausted");
+        assert_eq!(status["child_run_state"], "succeeded");
+        assert_eq!(
+            status["execution_states"]["provider"][0]["state"],
+            "succeeded"
+        );
+        assert_eq!(status["execution_states"]["gate"]["state"], "failed");
+        assert_eq!(status_exit_code(&status), 1);
+        assert!(
+            status[ACTIONABLE_METADATA_KEY]["next_actions"]
+                .as_array()
+                .expect("next actions")
+                .iter()
+                .any(|action| action["command"]
+                    == "homeboy agent-task diagnose cook-attempt-1 --full")
+        );
+    }
+
+    #[test]
+    fn successful_terminal_cook_result_keeps_the_child_status_and_actions() {
+        let mut status = json!({
+            "run_id": "cook-attempt-1",
+            "state": "succeeded",
+            "metadata": {
+                "cook_progress": {
+                    "phase": "terminal",
+                    "detail": "future_success_status",
+                    "terminal_success": true,
+                    "exit_code": 0
+                }
+            }
+        });
+
+        project_owning_cook_terminal_status(&mut status);
+
+        assert_eq!(status["state"], "succeeded");
+        assert!(status.get("cook").is_none());
+        assert_eq!(status_exit_code(&status), 0);
+    }
+
+    #[test]
+    fn green_and_review_ready_terminal_cooks_keep_successful_status_actions() {
+        for terminal_status in ["green_no_finalize", "review_ready"] {
+            let mut status = json!({
+                "run_id": "cook-attempt-1",
+                "state": "succeeded",
+                "tasks": [],
+                "metadata": {
+                    "cook_progress": {
+                        "phase": "terminal",
+                        "detail": terminal_status,
+                        "terminal_success": true,
+                        "exit_code": 0
+                    },
+                    "latest_promotion": {
+                        "status": "applied",
+                        "patch_artifact": { "id": "patch" }
+                    }
+                }
+            });
+
+            project_owning_cook_terminal_status(&mut status);
+            let mut status = compact_status_summary(&status, "cook-attempt-1");
+            attach_agent_task_status_actionable(&mut status, "cook-attempt-1");
+            let rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+                crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+                &status,
+            )
+            .expect("status summary");
+
+            assert_eq!(status["state"], "succeeded", "{terminal_status}");
+            assert!(status["cook"].is_null(), "{terminal_status}");
+            assert_eq!(status_exit_code(&status), 0, "{terminal_status}");
+            assert!(rendered.contains("Next: homeboy agent-task review cook-attempt-1"));
+            assert!(status[ACTIONABLE_METADATA_KEY]["next_actions"]
+                .as_array()
+                .expect("next actions")
+                .iter()
+                .any(|action| action["command"] == "homeboy agent-task review cook-attempt-1"));
+        }
+    }
+
+    fn blocked_cook_status_fixture(
+        cook_status: &str,
+        promotion_status: &str,
+        finalization_status: &str,
+    ) -> Value {
+        json!({
+            "run_id": "cook-attempt-1",
+            "state": "succeeded",
+            "tasks": [],
+            "metadata": {
+                "cook_progress": {
+                    "phase": "terminal",
+                    "detail": cook_status,
+                    "terminal_success": false,
+                    "exit_code": 1
+                },
+                "latest_promotion": {
+                    "status": promotion_status,
+                    "patch_artifact": { "id": "patch" }
+                },
+                "cook_finalization": { "status": finalization_status }
+            },
+            "execution_states": {
+                "provider": [{ "task_id": "cook", "state": "succeeded" }],
+                "gate": { "state": if promotion_status == "gate_failed" { "failed" } else { "passed" } },
+                "promotion": { "state": promotion_status },
+                "finalization": { "state": finalization_status }
+            }
+        })
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -145,7 +145,7 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     if let Some((progress, source_run_id)) = selected_cook_terminal_progress(&target, run_id) {
         project_owning_cook_terminal_status_from_progress(
             &mut value,
-            &progress,
+            Some(&progress),
             Some(&source_run_id),
         );
     } else {
@@ -200,7 +200,7 @@ fn selected_cook_terminal_progress(
     if source_run_id == selected_run_id {
         return None;
     }
-    let record = agent_task_lifecycle::exact_record(&source_run_id).ok()?;
+    let record = agent_task_service_direct::persisted_status(&source_run_id).ok()?;
     let progress = record.metadata.get("cook_progress")?.clone();
     (progress.get("phase").and_then(Value::as_str) == Some("terminal"))
         .then_some((progress, source_run_id))

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -108,12 +108,14 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
     let tasks_attempted = status_attempted_task_count(payload);
     let metrics = code_production_metrics(payload);
-    let state = effective_run_state(
-        raw_state,
-        tasks_attempted,
-        metrics.candidate_state,
-        metrics.candidate_scan_degraded,
-    );
+    let state = string_value(payload, &["cook", "state"]).unwrap_or_else(|| {
+        effective_run_state(
+            raw_state,
+            tasks_attempted,
+            metrics.candidate_state,
+            metrics.candidate_scan_degraded,
+        )
+    });
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
@@ -129,7 +131,13 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
     lines.push(format!("Artifacts: {artifact_count}"));
-    if metrics.candidate_state.is_available() {
+    if let Some(cook_status) = string_value(payload, &["cook", "state"]) {
+        let publication = string_value(payload, &["cook", "publication"])
+            .map(|publication| format!("publication {publication}"))
+            .unwrap_or_else(|| "publication outcome unknown".to_string());
+        lines.push(format!("Cook: {cook_status} ({publication})"));
+        lines.push(format!("Next: homeboy agent-task diagnose {run_id} --full"));
+    } else if metrics.candidate_state.is_available() {
         if let Some(path) = aggregate_path {
             lines.push(format!("Aggregate: {path}"));
         }


### PR DESCRIPTION
## Summary

- persist authoritative terminal Cook success and exit status
- project Cook blockers above successful child-provider state in human and JSON status
- preserve substantive candidate evidence while reporting latest-attempt terminal truth

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::agent_task::status::tests --lib` (19 passed)
- `cargo test -p homeboy-agents cook_progress_is_durable_across_active_and_terminal_lifecycle_states --lib`
- `git diff --check`

Closes #9652.

## AI Assistance

OpenAI gpt-5.6-sol and gpt-5.6-terra via OpenCode general coding subagents implemented, integrated with latest main, reviewed, and verified this change. Chris Huber remains responsible for every line.
