### PR TITLE
Classify inherited failures in normal Cook gates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -393,6 +393,20 @@ pub struct AgentTaskGateBaselineComparison {
     pub exit_code: i32,
     pub failure_fingerprint: String,
     pub matches_candidate_failure: bool,
+    #[serde(default)]
+    pub result: AgentTaskGateDifferentialResult,
+}
+
+/// The durable outcome of replaying a candidate gate against its immutable base.
+/// `InheritedRed` is deliberately distinct from a passing gate.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskGateDifferentialResult {
+    BaselineRed,
+    CandidateRegression,
+    CandidateImprovement,
+    #[default]
+    Inconclusive,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -769,6 +783,7 @@ impl AgentTaskGateReport {
             .inputs(PlanValues::new().json("command", &self.command))
             .output_value("exit_code", serde_json::json!(self.exit_code))
             .output_value("accepted_inherited_failure", serde_json::json!(true))
+            .output_value("baseline_red", serde_json::json!(true))
             .gate_result(gate_result)
             .build();
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -22,9 +22,9 @@ use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::{Error, Result};
 
 use super::cook_baseline::{
-    cook_attempt_harvest_context, materialize_follow_up_baseline,
-    materialize_initial_candidate_baseline, re_materialize_follow_up_baseline,
-    CookFollowUpBaseline, DerivedCookBaselineCapability,
+    compare_gate_failures_to_verified_base, cook_attempt_harvest_context,
+    materialize_follow_up_baseline, materialize_initial_candidate_baseline,
+    re_materialize_follow_up_baseline, CookFollowUpBaseline, DerivedCookBaselineCapability,
 };
 use super::cook_budget::{
     budget_remaining, execution_budget_usage, reserve_remediation_budget,
@@ -1954,7 +1954,9 @@ where
     // A detached transport may own workspace materialization on the runner.
     // Its initial handoff has no controller-local source path to validate yet;
     // requiring one here turns an accepted detached retry into a local failure.
-    if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
+    if cook_attempt_needs_execution(&options.initial_run_id)
+        && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
+    {
         validate_cook_workspace(&options)?;
     }
     validate_cook_candidate_group(&options.initial_plan)?;
@@ -2112,22 +2114,7 @@ where
             Some(plan) => plan,
             None => agent_task_lifecycle::load_plan(&run_id)?,
         };
-        let needs_execution = agent_task_lifecycle::status(&run_id)
-            .map(|record| {
-                (!matches!(
-                    record.state,
-                    agent_task_lifecycle::AgentTaskRunState::Succeeded
-                        | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-                        | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-                        | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-                        | agent_task_lifecycle::AgentTaskRunState::Failed
-                        | agent_task_lifecycle::AgentTaskRunState::Cancelled
-                ) || retryable_pre_execution_failure(&record))
-                    && !record.lab_handoff.as_ref().is_some_and(|handoff| {
-                        handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
-                    })
-            })
-            .unwrap_or(true);
+        let needs_execution = cook_attempt_needs_execution(&run_id);
         if needs_execution {
             report_cook_progress(
                 durable_observer,
@@ -2588,7 +2575,7 @@ where
             attempt,
             None,
         )?;
-        let promotion = match side_effects.promote(&options, &run_id) {
+        let mut promotion = match side_effects.promote(&options, &run_id) {
             Ok(report) => report,
             Err(_error) => {
                 attempts.push(AgentTaskCookAttemptReport {
@@ -2611,6 +2598,40 @@ where
                 }));
             }
         };
+        if promotion.status.gate_failed() {
+            let base_sha = promotion
+                .verified_base
+                .as_ref()
+                .map(|base| base.sha.clone())
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "promotion.verified_base",
+                        "gate-failed Cook promotion has no immutable verified base for differential verification",
+                        None,
+                        None,
+                    )
+                })?;
+            let repository_root = promotion.target.path.clone().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "promotion.target.path",
+                    "gate-failed Cook promotion has no candidate repository path for differential verification",
+                    None,
+                    None,
+                )
+            })?;
+            compare_gate_failures_to_verified_base(
+                &mut promotion,
+                std::path::Path::new(&repository_root),
+                &base_sha,
+                options.gates.gate_timeout(),
+                |_compared, _total| Ok(()),
+            )?;
+            agent_task_lifecycle::record_promotion(
+                &run_id,
+                serde_json::to_value(&promotion)
+                    .map_err(|error| Error::internal_json(error.to_string(), None))?,
+            )?;
+        }
 
         let review_form = review_form_from_aggregate(&aggregate)?;
         let previous_failure_set = attempts
@@ -3008,6 +3029,25 @@ fn bind_dispatch_workspace_attestations(plan: &mut AgentTaskPlan) -> Result<()> 
         }
     }
     Ok(())
+}
+
+fn cook_attempt_needs_execution(run_id: &str) -> bool {
+    agent_task_lifecycle::status(run_id)
+        .map(|record| {
+            (!matches!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Succeeded
+                    | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+                    | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
+                    | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+                    | agent_task_lifecycle::AgentTaskRunState::Failed
+                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
+            ) || retryable_pre_execution_failure(&record))
+                && !record.lab_handoff.as_ref().is_some_and(|handoff| {
+                    handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+                })
+        })
+        .unwrap_or(true)
 }
 
 /// Re-resolve the declared Cook target before a provider can run. Durable

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -21,10 +21,6 @@ use crate::agent_task_cook_loop::{
 use crate::agent_task_finalization::{
     AgentTaskPrFinalizationBackend, RealAgentTaskPrFinalizationBackend,
 };
-use crate::agent_task_gate::{
-    failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateBaselineComparison,
-    AgentTaskGateStatus,
-};
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::resolve_candidate_revision;
 use crate::agent_task_promotion::{
@@ -507,11 +503,18 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 None,
             )
         })?;
-    compare_adoption_gate_failures_to_base(
+    super::cook_baseline::compare_gate_failures_to_verified_base(
         &mut promotion,
         &source_worktree,
         &candidate_base_sha,
-        &record.run_id,
+        options.gates.gate_timeout(),
+        |compared, total| {
+            agent_task_lifecycle::checkpoint_candidate_adoption(
+                &record.run_id,
+                "baseline_verification",
+                &format!("baseline gate {compared}/{total}"),
+            )
+        },
     )?;
     if agent_task_lifecycle::candidate_adoption_cancel_requested(&record.run_id)? {
         return Err(Error::validation_invalid_argument(
@@ -876,133 +879,6 @@ fn reusable_applied_adoption_promotion(
         )
         .map(|_| promotion),
     )
-}
-
-/// Candidate adoption can prove that an otherwise-red broad command is
-/// inherited only by executing the identical command at the recorded base.
-/// A changed failure fingerprint is deliberately still a hard gate failure.
-fn compare_adoption_gate_failures_to_base(
-    promotion: &mut AgentTaskPromotionReport,
-    source_worktree: &std::path::Path,
-    task_base_sha: &str,
-    run_id: &str,
-) -> Result<()> {
-    if !promotion.status.gate_failed() {
-        return Ok(());
-    }
-    let baseline_root = tempfile::tempdir().map_err(|error| {
-        Error::internal_io(
-            error.to_string(),
-            Some("create candidate-adoption gate baseline".to_string()),
-        )
-    })?;
-    let baseline_path = baseline_root.path().join("base");
-    let output = std::process::Command::new("git")
-        .args(["worktree", "add", "--detach"])
-        .arg(&baseline_path)
-        .arg(task_base_sha)
-        .current_dir(source_worktree)
-        .output()
-        .map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("materialize candidate-adoption gate baseline".to_string()),
-            )
-        })?;
-    if !output.status.success() {
-        return Err(Error::internal_io(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
-            Some("materialize immutable candidate-adoption gate baseline".to_string()),
-        ));
-    }
-    let baseline_result = (|| -> Result<bool> {
-        // Match promotion's dependency and isolated-runtime setup before the
-        // base command is allowed to serve as comparison evidence.
-        homeboy_core::hygiene::materialize_worktree_dependencies(&baseline_path)?;
-        let mut all_failures_inherited = true;
-        let failed_gate_count = promotion
-            .deterministic_gates
-            .iter()
-            .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
-            .count();
-        if failed_gate_count == 0 {
-            return Ok(false);
-        }
-        let mut compared = 0;
-        for (index, gate) in promotion.deterministic_gates.iter_mut().enumerate() {
-            if gate.status != AgentTaskGateStatus::Failed {
-                continue;
-            }
-            compared += 1;
-            agent_task_lifecycle::checkpoint_candidate_adoption(
-                run_id,
-                "baseline_verification",
-                &format!("baseline gate {compared}/{failed_gate_count}"),
-            )?;
-            let command = gate.command.last().cloned().unwrap_or_default();
-            let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
-            let baseline = match (|| {
-                let baseline_runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
-                    &baseline_run_dir,
-                    &homeboy_core::engine::invocation::InvocationRequirements::default(),
-                )?;
-                run_gate_command_with_timeout(
-                    &baseline_path,
-                    index + 1,
-                    &command,
-                    gate.visibility,
-                    gate.reveal_policy,
-                    &baseline_runtime.context().tmp_dir,
-                    std::time::Duration::from_secs(5 * 60),
-                    &gate.environment.replay_policy(),
-                )
-            })() {
-                Ok(baseline) => baseline,
-                Err(error) => {
-                    baseline_run_dir.finish(false);
-                    return Err(error);
-                }
-            };
-            let candidate_fingerprint = failure_fingerprint(&gate.stdout, &gate.stderr);
-            let baseline_fingerprint = failure_fingerprint(&baseline.stdout, &baseline.stderr);
-            let matches = baseline.status == AgentTaskGateStatus::Failed
-                && candidate_fingerprint == baseline_fingerprint;
-            gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
-                base_ref: task_base_sha.to_string(),
-                exit_code: baseline.exit_code,
-                failure_fingerprint: baseline_fingerprint,
-                matches_candidate_failure: matches,
-            });
-            all_failures_inherited &= matches;
-            if matches {
-                gate.accept_inherited_failure();
-            }
-            baseline_run_dir.finish(true);
-        }
-        Ok(all_failures_inherited)
-    })();
-    let cleanup = std::process::Command::new("git")
-        .args(["worktree", "remove", "--force"])
-        .arg(&baseline_path)
-        .current_dir(source_worktree)
-        .status()
-        .map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some("remove candidate-adoption gate baseline".to_string()),
-            )
-        })?;
-    if !cleanup.success() {
-        return Err(Error::internal_io(
-            "git worktree remove failed".to_string(),
-            Some("remove candidate-adoption gate baseline".to_string()),
-        ));
-    }
-    let all_failures_inherited = baseline_result?;
-    if all_failures_inherited {
-        promotion.normalize_gate_outcome();
-    }
-    Ok(())
 }
 
 pub(crate) fn candidate_adoption_source(

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -13,6 +13,10 @@ use serde_json::Value;
 use std::path::PathBuf;
 use std::process::Command;
 
+use crate::agent_task_gate::{
+    failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateBaselineComparison,
+    AgentTaskGateDifferentialResult, AgentTaskGateStatus,
+};
 use crate::agent_task_promotion::{normalize_promotion_patch, AgentTaskPromotionReport};
 use crate::agent_task_scheduler::AgentTaskPlan;
 use homeboy_core::{Error, Result};
@@ -270,6 +274,172 @@ pub(crate) fn materialize_follow_up_baseline(
     materialize_follow_up_baseline_at(promotion, None, source_run_id, bound_task_id)
 }
 
+/// Replay unresolved failed gates against the immutable verified base. This is
+/// controller work, not provider remediation: callers persist the resulting
+/// promotion before evaluating Cook feedback.
+pub(crate) fn compare_gate_failures_to_verified_base(
+    promotion: &mut AgentTaskPromotionReport,
+    repository_root: &std::path::Path,
+    base_sha: &str,
+    timeout: std::time::Duration,
+    mut checkpoint: impl FnMut(usize, usize) -> Result<()>,
+) -> Result<()> {
+    if !promotion.status.gate_failed() {
+        return Ok(());
+    }
+    let unresolved = promotion
+        .deterministic_gates
+        .iter()
+        .filter(|gate| {
+            gate.status == AgentTaskGateStatus::Failed && gate.baseline_comparison.is_none()
+        })
+        .count();
+    if unresolved == 0 {
+        return Ok(());
+    }
+    let baseline_root = tempfile::tempdir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create Cook gate baseline".to_string()),
+        )
+    })?;
+    let baseline_path = baseline_root.path().join("base");
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&baseline_path)
+        .arg(base_sha)
+        .current_dir(repository_root)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("materialize Cook gate baseline".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::internal_io(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            Some("materialize immutable Cook gate baseline".to_string()),
+        ));
+    }
+    let comparison = (|| -> Result<()> {
+        homeboy_core::hygiene::materialize_worktree_dependencies(&baseline_path)?;
+        let mut compared = 0;
+        for (index, gate) in promotion.deterministic_gates.iter_mut().enumerate() {
+            if gate.status != AgentTaskGateStatus::Failed || gate.baseline_comparison.is_some() {
+                continue;
+            }
+            compared += 1;
+            checkpoint(compared, unresolved)?;
+            let command = gate.command.last().cloned().unwrap_or_default();
+            let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
+            let baseline = (|| {
+                let runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
+                    &baseline_run_dir,
+                    &homeboy_core::engine::invocation::InvocationRequirements::default(),
+                )?;
+                run_gate_command_with_timeout(
+                    &baseline_path,
+                    index + 1,
+                    &command,
+                    gate.visibility,
+                    gate.reveal_policy,
+                    &runtime.context().tmp_dir,
+                    timeout,
+                    &gate.environment.replay_policy(),
+                )
+            })();
+            let result: Result<()> = match baseline {
+                Ok(baseline) if baseline.exit_code == 124 => {
+                    gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                        base_ref: base_sha.to_string(),
+                        exit_code: baseline.exit_code,
+                        failure_fingerprint: failure_fingerprint(
+                            &baseline.stdout,
+                            &baseline.stderr,
+                        ),
+                        matches_candidate_failure: false,
+                        result: AgentTaskGateDifferentialResult::Inconclusive,
+                    });
+                    Ok(())
+                }
+                Ok(baseline) if baseline.status == AgentTaskGateStatus::Failed => {
+                    let matches = failure_fingerprint(&gate.stdout, &gate.stderr)
+                        == failure_fingerprint(&baseline.stdout, &baseline.stderr);
+                    gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                        base_ref: base_sha.to_string(),
+                        exit_code: baseline.exit_code,
+                        failure_fingerprint: failure_fingerprint(
+                            &baseline.stdout,
+                            &baseline.stderr,
+                        ),
+                        matches_candidate_failure: matches,
+                        result: if matches {
+                            AgentTaskGateDifferentialResult::BaselineRed
+                        } else {
+                            AgentTaskGateDifferentialResult::CandidateRegression
+                        },
+                    });
+                    if matches {
+                        gate.accept_inherited_failure();
+                    }
+                    Ok(())
+                }
+                Ok(baseline) => {
+                    gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                        base_ref: base_sha.to_string(),
+                        exit_code: baseline.exit_code,
+                        failure_fingerprint: failure_fingerprint(
+                            &baseline.stdout,
+                            &baseline.stderr,
+                        ),
+                        matches_candidate_failure: false,
+                        result: AgentTaskGateDifferentialResult::CandidateRegression,
+                    });
+                    Ok(())
+                }
+                Err(error) => {
+                    gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                        base_ref: base_sha.to_string(),
+                        exit_code: 124,
+                        failure_fingerprint: String::new(),
+                        matches_candidate_failure: false,
+                        result: AgentTaskGateDifferentialResult::Inconclusive,
+                    });
+                    // Preserve the inconclusive evidence and leave the candidate
+                    // gate red. A baseline execution failure must never convert a
+                    // candidate failure into an infrastructure error that loses
+                    // its durable comparison result.
+                    let _ = error;
+                    Ok(())
+                }
+            };
+            baseline_run_dir.finish(result.is_ok());
+            result?;
+        }
+        promotion.normalize_gate_outcome();
+        Ok(())
+    })();
+    let cleanup = std::process::Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(&baseline_path)
+        .current_dir(repository_root)
+        .status()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("remove Cook gate baseline".to_string()),
+            )
+        })?;
+    if !cleanup.success() {
+        return Err(Error::internal_io(
+            "git worktree remove failed".to_string(),
+            Some("remove Cook gate baseline".to_string()),
+        ));
+    }
+    comparison
+}
+
 /// Re-materialize a follow-up baseline worktree at a specific path that was
 /// previously created by [`materialize_follow_up_baseline`] but has since been
 /// reaped (e.g. by tmp cleanup, disk-pressure cleanup, or `git worktree prune`).
@@ -505,6 +675,10 @@ fn parent_snapshot_from_transport(raw: &str) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task_gate::{
+        AgentTaskGateEnvironment, AgentTaskGateRevealPolicy, AgentTaskGateStatus,
+    };
+    use homeboy_core::gate::HomeboyGateVisibility;
     use sha2::{Digest, Sha256};
 
     #[test]
@@ -525,6 +699,102 @@ mod tests {
                 ["snapshot_hash"],
             "abc"
         );
+    }
+
+    #[test]
+    fn differential_gate_comparison_classifies_inherited_regression_and_inconclusive() {
+        for (name, command, candidate_output, timeout, expected, accepted) in [
+            (
+                "inherited",
+                "printf 'same\\n' >&2; exit 1",
+                "same\n",
+                std::time::Duration::from_secs(1),
+                AgentTaskGateDifferentialResult::BaselineRed,
+                true,
+            ),
+            (
+                "regression",
+                "cat state >&2; exit 1",
+                "candidate\n",
+                std::time::Duration::from_secs(1),
+                AgentTaskGateDifferentialResult::CandidateRegression,
+                false,
+            ),
+            (
+                "inconclusive",
+                "sleep 1; exit 1",
+                "candidate\n",
+                std::time::Duration::from_millis(10),
+                AgentTaskGateDifferentialResult::Inconclusive,
+                false,
+            ),
+        ] {
+            let temp = tempfile::tempdir().expect("repository");
+            git_output(temp.path(), &["init", "-b", "main"]).expect("init");
+            git_output(temp.path(), &["config", "user.name", "Homeboy Test"]).expect("name");
+            git_output(temp.path(), &["config", "user.email", "test@example.test"]).expect("email");
+            std::fs::write(temp.path().join("state"), "base\n").expect("base state");
+            git_output(temp.path(), &["add", "state"]).expect("add");
+            git_output(temp.path(), &["commit", "-m", "base"]).expect("commit");
+            let base = git_output(temp.path(), &["rev-parse", "HEAD"]).expect("base sha");
+            std::fs::write(temp.path().join("state"), "candidate\n").expect("candidate state");
+            let mut promotion: AgentTaskPromotionReport =
+                serde_json::from_value(serde_json::json!({
+                    "schema": "homeboy/agent-task-promotion-report/v1",
+                    "status": "gate_failed",
+                    "source": {"kind": "aggregate", "task_id": "task"},
+                    "to_worktree": "fixture",
+                    "target": {"worktree": "fixture", "path": temp.path()},
+                    "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
+                    "deterministic_gates": [],
+                    "operator_notification": {"status": "blocked", "message": "red"}
+                }))
+                .expect("promotion");
+            let mut gate = crate::agent_task_gate::AgentTaskGateReport::new(
+                name,
+                vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+                1,
+                "",
+                candidate_output,
+                None,
+                HomeboyGateVisibility::Visible,
+                AgentTaskGateRevealPolicy::FullEvidence,
+                AgentTaskGateEnvironment::default(),
+            );
+            gate.status = AgentTaskGateStatus::Failed;
+            promotion.deterministic_gates.push(gate);
+
+            let result = compare_gate_failures_to_verified_base(
+                &mut promotion,
+                temp.path(),
+                &base,
+                timeout,
+                |_compared, _total| Ok(()),
+            );
+
+            result.expect("baseline comparison");
+            assert_eq!(
+                promotion.deterministic_gates[0]
+                    .baseline_comparison
+                    .as_ref()
+                    .expect("comparison")
+                    .result,
+                expected
+            );
+            assert_eq!(
+                promotion.deterministic_gates[0].status
+                    == AgentTaskGateStatus::AcceptedInheritedFailure,
+                accepted
+            );
+            assert_eq!(
+                promotion.status,
+                if accepted {
+                    crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+                } else {
+                    crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
+                }
+            );
+        }
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6091,6 +6091,7 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
             exit_code: 1,
             failure_fingerprint: "inherited failure".to_string(),
             matches_candidate_failure: true,
+            result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
         });
     accepted.normalize_gate_outcome();
 
@@ -6129,6 +6130,122 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
         .unwrap()
         .commit = "other-candidate".to_string();
     assert!(!wrong_candidate.has_visible_passed_gate_for_command(command));
+}
+
+#[test]
+fn normal_cook_finalizes_an_inherited_gate_failure_without_provider_retry() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("repository");
+        let root = temp.path();
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.name", "Homeboy Test"],
+            vec!["config", "user.email", "test@example.test"],
+        ] {
+            git_output(root, &args).expect("git setup");
+        }
+        std::fs::write(root.join("failure"), "inherited\n").unwrap();
+        std::fs::write(root.join("candidate"), "base\n").unwrap();
+        git_output(root, &["add", "."]).unwrap();
+        git_output(root, &["commit", "-m", "base"]).unwrap();
+        let base = git_output(root, &["rev-parse", "HEAD"]).unwrap();
+        std::fs::write(root.join("candidate"), "provider-produced\n").unwrap();
+        git_output(root, &["add", "candidate"]).unwrap();
+        git_output(root, &["commit", "-m", "provider candidate"]).unwrap();
+
+        let cook_id = "cook-normal-inherited";
+        let run_id = format!("{cook_id}-run");
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.clone();
+        options.no_finalize = false;
+        options.to_worktree = root.display().to_string();
+        options.source_worktree_path = Some(root.to_path_buf());
+        options.max_attempts = 1;
+        options.gates.verify = vec!["cat failure >&2; exit 1".to_string()];
+        options.initial_plan.options.execution_budget =
+            crate::agent_task_scheduler::AgentTaskExecutionBudget::new(1, 0, 0);
+        persist_initial_recipe(&options).unwrap();
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&run_id)).unwrap();
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &run_id).unwrap();
+        seed_review_form_aggregate(&run_id, &options.initial_plan);
+        agent_task_lifecycle::rewrite_record_for_test(&run_id, |record| {
+            record.metadata["provider_executions_consumed"] = serde_json::json!(1);
+        })
+        .unwrap();
+        let gate = crate::agent_task_gate::AgentTaskGateReport::new(
+            "verify-1",
+            vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                options.gates.verify[0].clone(),
+            ],
+            1,
+            "",
+            "inherited\n",
+            None,
+            homeboy_core::gate::HomeboyGateVisibility::Visible,
+            crate::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence,
+            crate::agent_task_gate::AgentTaskGateEnvironment::default(),
+        );
+        let promotion: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "gate_failed",
+            "source": {"kind": "aggregate", "task_id": "provider", "run_id": run_id},
+            "to_worktree": root,
+            "target": {"worktree": root, "path": root},
+            "patch_artifact": {"id": "provider-patch", "kind": "patch", "path": "provider.patch"},
+            "changed_files": ["candidate"],
+            "deterministic_gates": [gate],
+            "verified_base": {"base": "main", "sha": base},
+            "provenance": {"worktree_path": root},
+            "operator_notification": {"status": "blocked", "message": "gate failed"}
+        }))
+        .unwrap();
+        agent_task_lifecycle::record_promotion(&run_id, serde_json::to_value(promotion).unwrap())
+            .unwrap();
+        let finalized = Arc::new(AtomicUsize::new(0));
+        let finalization_count = Arc::clone(&finalized);
+        let expected_base = base.clone();
+        let expected_run_id = run_id.clone();
+        let result = run_cook_with_finalizer(
+            options,
+            UnusedExecutor,
+            move |_, received_run, promotion| {
+                finalization_count.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(received_run, expected_run_id);
+                assert_eq!(promotion.verified_base.as_ref().unwrap().sha, expected_base);
+                assert_eq!(
+                    promotion.deterministic_gates[0]
+                        .baseline_comparison
+                        .as_ref()
+                        .unwrap()
+                        .result,
+                    crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed
+                );
+                Ok(serde_json::json!({"status": "review_ready"}))
+            },
+        )
+        .unwrap();
+        assert_eq!(result.value.status, "review_ready", "{:#?}", result.value);
+        assert_eq!(finalized.load(Ordering::SeqCst), 1);
+        let record = agent_task_lifecycle::status(&run_id).unwrap();
+        assert_eq!(record.metadata["provider_executions_consumed"], 1);
+        let persisted = persisted_promotion_for_attempt(&run_id).unwrap().unwrap();
+        assert_eq!(persisted.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(persisted.deterministic_gates[0].exit_code, 1);
+        assert_eq!(
+            persisted.deterministic_gates[0].status,
+            crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+        );
+        assert_eq!(
+            persisted.deterministic_gates[0]
+                .baseline_comparison
+                .as_ref()
+                .unwrap()
+                .base_ref,
+            base
+        );
+    });
 }
 
 #[test]
@@ -6951,6 +7068,7 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
                 exit_code: 1,
                 failure_fingerprint: "inherited failure".to_string(),
                 matches_candidate_failure: true,
+                result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
             });
         adopted.operator_notification =
             crate::agent_task_promotion::AgentTaskPromotionNotification {


### PR DESCRIPTION
## Summary

- share immutable-base gate comparison between adoption and normal Cook
- classify inherited red, candidate regression/improvement, and inconclusive baseline execution visibly
- let accepted inherited failures finalize without spending another provider execution

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents normal_cook_finalizes_an_inherited_gate_failure_without_provider_retry --lib`
- `cargo test -p homeboy-agents differential_gate_comparison_classifies_inherited_regression_and_inconclusive --lib`
- `cargo test -p homeboy-agents accepted_inherited_failure_completes_without_hiding_a_regression --lib`
- `git diff --check`

Closes #11287.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents implemented, independently debugged, reviewed, and verified this change. Chris Huber remains responsible for every line.
