### PR TITLE
Bound and paginate agent-task discovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -4,7 +4,7 @@
 use crate::agent_task::{AgentTaskRequest, AgentTaskSourceRef};
 use crate::agent_task_lifecycle::{self, AgentTaskRecordHealthSummary, AgentTaskRunRecord};
 use crate::agent_task_scheduler::AgentTaskState;
-use homeboy_core::Result;
+use homeboy_core::{Error, Result};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,12 +18,21 @@ pub enum AgentTaskDiscoveryFilter {
 /// this carries the operator-facing `--limit` cap shared by the `list`/`active`
 /// list surfaces so a large run history stays scannable, matching the
 /// pagination affordance other list commands expose (#5681).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AgentTaskDiscoveryOptions {
     /// Maximum number of runs to return, applied after filtering/sorting.
     /// `None` returns every matching run. Ignored for the `latest` filter,
     /// which is always a single run.
     pub limit: Option<usize>,
+    /// Zero-based offset into the filtered, newest-first result set.
+    pub cursor: usize,
+    pub repo: Option<String>,
+    pub workspace: Option<String>,
+    pub task_url: Option<String>,
+    pub submitted_after: Option<String>,
+    pub state: Option<String>,
+    pub placement: Option<String>,
+    pub parent_id: Option<String>,
 }
 
 /// Number of minutes a `Running` record may go without an `updated_at`
@@ -49,6 +58,9 @@ pub struct AgentTaskDiscoveryReport {
     /// `true` when `total > count` because the `--limit` cap truncated results.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
+    /// Offset to pass as `--cursor` for the next distinct page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<usize>,
     pub runs: Vec<AgentTaskDiscoveryRun>,
     /// Bounded health evidence for malformed, legacy, conflicting, or
     /// quarantined lifecycle rows omitted from the typed run projection.
@@ -240,29 +252,37 @@ fn discovery_report(
             )
         });
     }
+    let submitted_after = options
+        .submitted_after
+        .as_deref()
+        .map(parse_submitted_after)
+        .transpose()?;
+    records.retain(|record| matches_discovery_options(record, &options, submitted_after.as_ref()));
     if filter == AgentTaskDiscoveryFilter::Latest {
         records.truncate(1);
     }
-
     let total = records.len();
+
+    let now = chrono::Utc::now();
+    let liveness_summary = is_active.then(|| liveness_summary_for_records(&records, now));
 
     // `latest` is always a single run; only `all`/`active` honor a limit cap.
     let effective_limit = match filter {
         AgentTaskDiscoveryFilter::Latest => None,
         _ => options.limit,
     };
-    if let Some(limit) = effective_limit {
-        records.truncate(limit);
-    }
+    let cursor = options.cursor.min(total);
+    let end = effective_limit
+        .map(|limit| cursor.saturating_add(limit).min(total))
+        .unwrap_or(total);
+    let records = records.drain(cursor..end).collect::<Vec<_>>();
 
-    let now = chrono::Utc::now();
     let runs: Vec<_> = records
         .into_iter()
         .map(|record| discovery_run(record, is_active, now))
         .collect();
 
-    let liveness_summary = is_active.then(|| liveness_summary(&runs));
-    let truncated = runs.len() < total;
+    let truncated = end < total;
 
     Ok(AgentTaskDiscoveryReport {
         schema: "homeboy/agent-task-discovery/v1",
@@ -275,6 +295,7 @@ fn discovery_report(
         total,
         limit: effective_limit,
         truncated,
+        next_cursor: truncated.then_some(end),
         runs,
         record_health,
         liveness_summary,
@@ -282,17 +303,103 @@ fn discovery_report(
     })
 }
 
-fn liveness_summary(runs: &[AgentTaskDiscoveryRun]) -> AgentTaskLivenessSummary {
+fn matches_discovery_options(
+    record: &AgentTaskRunRecord,
+    options: &AgentTaskDiscoveryOptions,
+    submitted_after: Option<&chrono::DateTime<chrono::Utc>>,
+) -> bool {
+    if options
+        .state
+        .as_deref()
+        .is_some_and(|state| format!("{:?}", record.state).eq_ignore_ascii_case(state) == false)
+        || submitted_after.is_some_and(|after| {
+            chrono::DateTime::parse_from_rfc3339(&record.submitted_at)
+                .map(|submitted| submitted.with_timezone(&chrono::Utc) <= *after)
+                .unwrap_or(true)
+        })
+        || options.placement.as_deref().is_some_and(|placement| {
+            let source = run_source(record);
+            !matches!(
+                (placement, source.as_str()),
+                ("local", "local") | ("remote", "remote")
+            ) && !(placement == "runner" && source.starts_with("runner:"))
+        })
+    {
+        return false;
+    }
+
+    if options.repo.is_none()
+        && options.workspace.is_none()
+        && options.task_url.is_none()
+        && options.parent_id.is_none()
+    {
+        return true;
+    }
+
+    let plan = agent_task_lifecycle::load_controller_plan(&record.run_id).ok();
+    let first_task = plan.as_ref().and_then(|plan| plan.tasks.first());
+    let repo = plan
+        .as_ref()
+        .and_then(|plan| plan.group_key.as_deref())
+        .or_else(|| first_task.and_then(|task| task.group_key.as_deref()))
+        .or_else(|| first_task.and_then(|task| task.workspace.component_id.as_deref()))
+        .or_else(|| first_task.and_then(|task| task.workspace.slug.as_deref()));
+    let remote_workspace = metadata_string(&record.metadata, "remote_workspace");
+    let workspace = first_task
+        .and_then(|task| task.workspace.root.as_deref())
+        .or(remote_workspace.as_deref());
+    let sourced_task_url = first_task.and_then(task_source_url);
+    let task_url = first_task
+        .and_then(|task| task.workspace.task_url.as_deref())
+        .or(sourced_task_url.as_deref());
+    let parent_matches = first_task
+        .map(|task| task.parent_plan_id.as_deref() == options.parent_id.as_deref())
+        .unwrap_or(false);
+
+    options
+        .repo
+        .as_deref()
+        .is_none_or(|value| repo == Some(value))
+        && options
+            .workspace
+            .as_deref()
+            .is_none_or(|value| workspace == Some(value))
+        && options
+            .task_url
+            .as_deref()
+            .is_none_or(|value| task_url == Some(value))
+        && options.parent_id.as_deref().is_none_or(|_| parent_matches)
+}
+
+fn parse_submitted_after(value: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "submitted-after",
+                "must be a valid RFC3339 timestamp",
+                Some(value.to_string()),
+                Some(vec![
+                    "Example: --submitted-after 2026-08-03T10:00:00Z".to_string()
+                ]),
+            )
+        })
+}
+
+fn liveness_summary_for_records(
+    records: &[AgentTaskRunRecord],
+    now: chrono::DateTime<chrono::Utc>,
+) -> AgentTaskLivenessSummary {
     let mut summary = AgentTaskLivenessSummary {
         reconcile_command: "homeboy agent-task active --reconcile --dry-run",
         ..Default::default()
     };
-    for run in runs {
-        match run.liveness {
-            Some(AgentTaskLiveness::Active) | None => summary.active += 1,
-            Some(AgentTaskLiveness::Stale) => summary.stale += 1,
-            Some(AgentTaskLiveness::Suspect) => summary.suspect += 1,
-            Some(AgentTaskLiveness::Unreconciled) => summary.unreconciled += 1,
+    for record in records {
+        match classify_liveness(record, age_minutes(record.updated_at.as_deref(), now), now) {
+            AgentTaskLiveness::Active => summary.active += 1,
+            AgentTaskLiveness::Stale => summary.stale += 1,
+            AgentTaskLiveness::Suspect => summary.suspect += 1,
+            AgentTaskLiveness::Unreconciled => summary.unreconciled += 1,
         }
     }
     summary
@@ -310,8 +417,18 @@ fn classify_liveness(
         if agent_task_lifecycle::has_expired_pending_runner_submission_intent(record, now) {
             return AgentTaskLiveness::Unreconciled;
         }
-        // Queued runs are genuinely pending work unless their controller-owned
-        // Lab handoff exceeded its durable acceptance deadline.
+        // A queued record with no queued/running task and an expired heartbeat
+        // cannot be claimed by a worker. Keep it visible for reconciliation,
+        // but never project this historical ghost as active work.
+        let has_pending_task = record
+            .tasks
+            .iter()
+            .any(|task| matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running));
+        if !has_pending_task
+            && last_update_age_minutes.is_some_and(|age| age >= STALE_UPDATE_THRESHOLD_MINUTES)
+        {
+            return AgentTaskLiveness::Stale;
+        }
         return AgentTaskLiveness::Active;
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -876,6 +876,7 @@ fn discovery_active_classifies_liveness_and_source() {
             record.metadata = serde_json::json!({
                 "runner_id": "homeboy-lab",
                 "runner_job_id": "job-xyz",
+                "stale_running": true,
             });
         })
         .expect("stale runner-backed record stored");
@@ -1117,7 +1118,10 @@ fn discovery_limit_caps_list_and_reports_total() {
 
         let report = discover_runs_with_options(
             AgentTaskDiscoveryFilter::All,
-            AgentTaskDiscoveryOptions { limit: Some(2) },
+            AgentTaskDiscoveryOptions {
+                limit: Some(2),
+                ..Default::default()
+            },
         )
         .expect("listed with limit");
 
@@ -1126,6 +1130,122 @@ fn discovery_limit_caps_list_and_reports_total() {
         assert_eq!(report.limit, Some(2));
         assert!(report.truncated);
         assert_eq!(report.runs.len(), 2);
+    });
+}
+
+#[test]
+fn discovery_998_record_history_pages_without_repeating_or_losing_records() {
+    with_isolated_home(|_| {
+        for index in 0..998 {
+            agent_task_lifecycle::submit_plan(
+                &discovery_plan(),
+                Some(&format!("run-page-{index:04}")),
+            )
+            .expect("submitted");
+        }
+
+        let first = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                limit: Some(20),
+                state: Some("queued".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("first page");
+        let second = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                limit: Some(20),
+                cursor: first.next_cursor.expect("continuation"),
+                state: Some("queued".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("second page");
+        let exhaustive = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                state: Some("queued".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("full history");
+
+        assert_eq!(first.total, 998);
+        assert_eq!(first.count, 20);
+        assert_eq!(first.next_cursor, Some(20));
+        assert!(first.truncated);
+        assert_eq!(second.total, 998);
+        assert_eq!(second.count, 20);
+        assert_ne!(first.runs[0].run_id, second.runs[0].run_id);
+        assert_eq!(exhaustive.count, 998);
+        assert!(!exhaustive.truncated);
+        assert_eq!(exhaustive.next_cursor, None);
+    });
+}
+
+#[test]
+fn discovery_filters_by_cook_identity_and_omits_stale_queued_ghosts_from_active() {
+    with_isolated_home(|_| {
+        let mut matching = discovery_plan();
+        matching.group_key = Some("matching-repo".to_string());
+        matching.tasks[0].workspace.root = Some("/work/matching".to_string());
+        matching.tasks[0].workspace.task_url =
+            Some("https://example.test/issues/11086".to_string());
+        matching.tasks[0].parent_plan_id = Some("batch-11086".to_string());
+        agent_task_lifecycle::submit_plan(&matching, Some("run-matching")).expect("matching run");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-other")).expect("other run");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-queued-ghost"))
+            .expect("ghost run");
+        agent_task_lifecycle::rewrite_record_for_test("run-queued-ghost", |record| {
+            record.tasks[0].state = AgentTaskState::Succeeded;
+            record.updated_at = Some("2000-01-01T00:00:00+00:00".to_string());
+        })
+        .expect("age ghost");
+
+        let filtered = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                repo: Some("matching-repo".to_string()),
+                workspace: Some("/work/matching".to_string()),
+                task_url: Some("https://example.test/issues/11086".to_string()),
+                parent_id: Some("batch-11086".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("filtered discovery");
+        let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active discovery");
+
+        assert_eq!(filtered.runs.len(), 1);
+        assert_eq!(filtered.runs[0].run_id, "run-matching");
+        let ghost = active
+            .runs
+            .iter()
+            .find(|run| run.run_id == "run-queued-ghost")
+            .expect("stale ghost remains reconcilable");
+        assert_eq!(ghost.liveness, Some(AgentTaskLiveness::Stale));
+        assert_eq!(active.liveness_summary.expect("summary").stale, 1);
+    });
+}
+
+#[test]
+fn discovery_rejects_invalid_submitted_after_timestamps() {
+    with_isolated_home(|_| {
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-invalid-timestamp-filter"))
+            .expect("submitted");
+
+        let error = discover_runs_with_options(
+            AgentTaskDiscoveryFilter::All,
+            AgentTaskDiscoveryOptions {
+                submitted_after: Some("yesterday".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("invalid timestamp is rejected");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("RFC3339"));
     });
 }
 
@@ -1139,7 +1259,10 @@ fn discovery_latest_ignores_limit() {
 
         let report = discover_runs_with_options(
             AgentTaskDiscoveryFilter::Latest,
-            AgentTaskDiscoveryOptions { limit: Some(5) },
+            AgentTaskDiscoveryOptions {
+                limit: Some(5),
+                ..Default::default()
+            },
         )
         .expect("latest listed");
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -141,6 +141,25 @@ pub struct CookContinueArgs {
 pub struct ListArgs {
     #[arg(long = "limit", value_name = "N", conflicts_with = "full")]
     pub limit: Option<usize>,
+    /// Continue at this zero-based offset. Reuse every filter from the prior page.
+    #[arg(long, value_name = "N", conflicts_with = "full")]
+    pub cursor: Option<usize>,
+    #[arg(long)]
+    pub repo: Option<String>,
+    #[arg(long)]
+    pub worktree: Option<String>,
+    #[arg(long = "task-url")]
+    pub task_url: Option<String>,
+    /// RFC3339 submission timestamp; excludes older records.
+    #[arg(long = "submitted-after", value_name = "RFC3339")]
+    pub submitted_after: Option<String>,
+    #[arg(long, value_parser = ["queued", "running", "succeeded", "failed", "cancelled"])]
+    pub state: Option<String>,
+    /// Filter by recorded execution placement, not the global routing policy.
+    #[arg(long = "run-placement", value_parser = ["local", "remote", "runner"])]
+    pub run_placement: Option<String>,
+    #[arg(long = "parent-id")]
+    pub parent_id: Option<String>,
     /// Return every matching record. This is intentionally explicit because
     /// discovery defaults to a finite agent-facing page.
     #[arg(long)]
@@ -183,6 +202,14 @@ impl From<ListArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ListArgs) -> Self {
         Self {
             limit: (!args.full).then(|| args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+            cursor: args.cursor.unwrap_or_default(),
+            repo: args.repo,
+            workspace: args.worktree,
+            task_url: args.task_url,
+            submitted_after: args.submitted_after,
+            state: args.state,
+            placement: args.run_placement,
+            parent_id: args.parent_id,
         }
     }
 }
@@ -190,6 +217,7 @@ impl From<ActiveArgs> for AgentTaskDiscoveryOptions {
     fn from(args: ActiveArgs) -> Self {
         Self {
             limit: (!args.full).then(|| args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+            ..Default::default()
         }
     }
 }
@@ -197,6 +225,7 @@ impl From<LatestArgs> for AgentTaskDiscoveryOptions {
     fn from(args: LatestArgs) -> Self {
         Self {
             limit: Some(args.limit.unwrap_or(DEFAULT_DISCOVERY_LIMIT)),
+            ..Default::default()
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -313,12 +313,6 @@ pub(super) fn list_runs(
 ) -> CmdResult<Value> {
     let report = agent_task_service_direct::discover_runs_with_options(filter, options)?;
     let mut value = serde_json::to_value(report).unwrap_or(Value::Null);
-    attach_collection_budget(
-        &mut value,
-        "runs",
-        "homeboy agent-task list --full",
-        "homeboy agent-task list --full --output <path>",
-    );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }
@@ -348,12 +342,6 @@ pub(super) fn list_active(
             json!("run the per-run `commands.reconcile` preview, then repeat it with `--apply` after reviewing authoritative provider state"),
         );
     }
-    attach_collection_budget(
-        &mut value,
-        "runs",
-        "homeboy agent-task active --full",
-        "homeboy agent-task active --full --output <path>",
-    );
     attach_agent_task_discovery_actionable(&mut value);
     Ok((value, 0))
 }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -39,7 +39,7 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
 | `prompts save\|list\|show\|remove` | Manage markdown prompts in Homeboy-owned storage. |
 
-`agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `agent-task reconcile <run-id>` is the recovery path emitted by status and activity: it previews only that run by default, refreshes runner/provider state before classification, and requires `--apply` to mutate it. If ownership or provider state changes before apply, it reports a no-op. `agent-task active --reconcile` is an explicit fleet operation: it previews every candidate by default and requires `--apply` to reconcile the displayed set.
+`agent-task list`, `agent-task active`, and `agent-task latest` accept `--limit <n>` to cap discovery output. `list` defaults to 20 newest rows and returns `next_cursor` when another page exists; repeat the same filters with `--cursor <next_cursor>`. `list --full` returns every matching row. Filter list discovery by `--task-url`, `--repo`, `--worktree`, `--submitted-after`, `--state`, `--run-placement`, or `--parent-id`. `agent-task reconcile <run-id>` is the recovery path emitted by status and activity: it previews only that run by default, refreshes runner/provider state before classification, and requires `--apply` to mutate it. If ownership or provider state changes before apply, it reports a no-op. `agent-task active --reconcile` is an explicit fleet operation: it previews every candidate by default and requires `--apply` to reconcile the displayed set.
 
 ### Resource Behavior
 


### PR DESCRIPTION
## Summary

- make default agent-task history bounded and cursor-paginatable
- make `--full` genuinely exhaustive and add identity/state/time filters
- classify expired queued ghosts as stale instead of active

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_service::tests::discovery --lib -- --test-threads=1` (12 passed)
- `cargo check -p homeboy-cli`
- `cargo run --quiet -- agent-task list --help`
- `git diff --check`

Closes #11086.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents implemented, reviewed, and verified this change. Chris Huber remains responsible for every line.
