### PR TITLE
Make runner status observationally read-only

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -292,6 +292,11 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         full: bool,
     },
+    /// Reconcile persisted direct-runner generation state and retire verified drained daemons
+    Reconcile {
+        /// Runner ID
+        id: String,
+    },
     /// Close a runner tunnel and remove its persisted session state
     Disconnect {
         /// Runner ID

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -170,6 +170,7 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             generations,
             full,
         } => map_registry(status_mod::status(id.as_deref(), generations, full)),
+        RunnerCommand::Reconcile { id } => map_registry(status_mod::reconcile(&id)),
         RunnerCommand::Disconnect { id, local_recovery } => {
             map_registry(registry::disconnect(&id, local_recovery))
         }

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -176,6 +176,28 @@ pub(super) fn status(
     ))
 }
 
+pub(super) fn reconcile(id: &str) -> CmdResult<RunnerOutput> {
+    let report = runner::reconcile_status(id)?;
+    let generation_inventory =
+        runner::runner_generation_inventory_for_session(id, report.session.as_ref())?;
+    Ok((
+        RunnerOutput {
+            command: "runner.reconcile".to_string(),
+            id: Some(id.to_string()),
+            extra: RunnerExtra {
+                admission_summary: Some(report.admission_summary(generation_inventory.len())),
+                connection: Some(RunnerConnectionOutput::Status(report.clone())),
+                generation_inventory,
+                operator_hints: runner_status_operator_hints(&report),
+                operator_commands: runner_status_operator_commands(&report),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
 /// Operator-facing hints for read-only probes that hit their bound while this
 /// status was assembled (#10418). Without these an operator cannot distinguish
 /// "the Lab answered and is idle" from "the Lab never answered".
@@ -1375,6 +1397,16 @@ pub(super) fn runner_status_operator_commands(
                 });
             }
         }
+    }
+
+    if session.mode == RunnerTunnelMode::DirectSsh {
+        commands.push(RunnerOperatorCommand {
+            scope: "generation_reconcile",
+            runner_id: report.runner_id.clone(),
+            job_id: None,
+            command: format!("homeboy runner reconcile {}", shell_arg(&report.runner_id)),
+            description: "Persist fresh generation observations and retire only verified drained daemon generations.".to_string(),
+        });
     }
 
     if let Some(warning) = report.stale_daemon.as_ref() {

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -160,6 +160,55 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
 }
 
 #[test]
+fn direct_runner_status_exposes_the_explicit_generation_reconcile_command() {
+    let report = RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: true,
+        state: runner::RunnerSessionState::Connected,
+        session: Some(RunnerSession {
+            runner_id: "homeboy-lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: runner::RunnerSessionRole::Controller,
+            server_id: Some("lab".to_string()),
+            controller_id: Some("controller".to_string()),
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:4000".to_string()),
+            local_port: Some(4000),
+            local_url: Some("http://127.0.0.1:4000".to_string()),
+            tunnel_pid: Some(42),
+            remote_daemon_pid: Some(43),
+            remote_daemon_lease_id: Some("lease-active".to_string()),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "2026-08-03T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }),
+        stale_daemon: None,
+        daemon_freshness: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        stale_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: RunnerActiveJobSource::DirectDaemon.into(),
+        active_job_error: None,
+        active_job_recovery_evidence: None,
+        session_path: "test".to_string(),
+    };
+
+    assert!(runner_status_operator_commands(&report)
+        .iter()
+        .any(|command| {
+            command.scope == "generation_reconcile"
+                && command.command == "homeboy runner reconcile homeboy-lab"
+        }));
+}
+
+#[test]
 fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
     let mut report = RunnerStatusReport {
         runner_id: "homeboy-lab".to_string(),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1398,27 +1398,11 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     // must be reported as disconnected rather than triggering tunnel recovery.
     // Recovery can wait on shared control-plane state and may open a tunnel, so
     // it belongs to explicit connect/admission operations instead.
-    let mut session = read_session_or_live_peer(runner_id)?;
+    let session = read_session_or_live_peer(runner_id)?;
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
-    reconcile_session_metadata_with_observed_daemon(&runner, &mut session, connected)?;
-    // A dead controller tunnel must be reattached or reported as disconnected
-    // before polling every draining local projection.
-    if connected {
-        if let Ok(Some((_, _, client))) = remote_daemon::resolve_ssh_runner(&runner) {
-            super::generation_store::reconcile_with_ssh(runner_id, session.as_ref(), &client)?;
-        } else {
-            super::generation_store::reconcile(runner_id, session.as_ref())?;
-        }
-    }
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
     let local_daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?;
-    // A direct tunnel health response proves this session is safe for new
-    // admission. Keep active jobs on prior generations, but make status and
-    // Cook agree on this freshly verified endpoint.
-    if let (Some(session), Some(_)) = (session.as_ref(), local_daemon_freshness.as_ref()) {
-        super::generation_store::reconcile_admission_session(runner_id, session)?;
-    }
     let mut daemon_freshness =
         local_daemon_freshness.or_else(|| remote_daemon_recovery_freshness(runner_id, &runner));
     let active_job_source = session.as_ref().and_then(active_runner_job_source);
@@ -1477,14 +1461,6 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
             None,
         )
     };
-    let (active_jobs, stale_jobs, direct_daemon_active_jobs, active_job_recovery_evidence) =
-        reconcile_terminal_phantom_activity(
-            runner_id,
-            session.as_ref(),
-            active_jobs,
-            stale_jobs,
-            direct_daemon_active_jobs,
-        );
     if let (Some(freshness), Some(active_jobs)) =
         (daemon_freshness.as_mut(), direct_daemon_active_jobs)
     {
@@ -1522,9 +1498,34 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
         active_job_state,
         active_job_source,
         active_job_error,
-        active_job_recovery_evidence,
+        active_job_recovery_evidence: None,
         session_path: session_path.display().to_string(),
     })
+}
+
+/// Apply the bounded reconciliation that status intentionally only projects.
+/// This is an explicit lifecycle command because it may persist observations,
+/// promote admission, stop a drained daemon, and terminate its local tunnel.
+pub fn reconcile_status(runner_id: &str) -> Result<RunnerStatusReport> {
+    let runner = load(runner_id)?;
+    let mut report = status(runner_id)?;
+    if !report.connected {
+        return Ok(report);
+    }
+
+    reconcile_session_metadata_with_observed_daemon(&runner, &mut report.session, true)?;
+    // Terminal-job settlement was formerly coupled to status. Keep it under
+    // this explicit lifecycle owner so status remains safe to parallelize.
+    reconcile_terminal_jobs(runner_id)?;
+    if let Ok(Some((_, _, client))) = remote_daemon::resolve_ssh_runner(&runner) {
+        super::generation_store::reconcile_with_ssh(runner_id, report.session.as_ref(), &client)?;
+    } else {
+        super::generation_store::reconcile(runner_id, report.session.as_ref())?;
+    }
+    if let (Some(session), Some(_)) = (report.session.as_ref(), report.daemon_freshness.as_ref()) {
+        super::generation_store::reconcile_admission_session(runner_id, session)?;
+    }
+    status(runner_id)
 }
 
 /// Return the persisted controller-side session projection without reconnecting,
@@ -2870,6 +2871,33 @@ mod indexed_inspection_tests {
         assert!(!body.contains("recover_dead_direct_tunnel"));
         assert!(!body.contains("connect("));
         assert!(!body.contains("SshClient"));
+    }
+}
+
+#[cfg(test)]
+mod status_read_purity_tests {
+    #[test]
+    fn status_has_no_lifecycle_mutation_path() {
+        let source = include_str!("connection.rs");
+        let start = source.find("pub fn status(").expect("status exists");
+        let end = start
+            + source[start..]
+                .find("pub fn reconcile_status(")
+                .expect("explicit reconciliation follows status");
+        let status = &source[start..end];
+
+        for mutation in [
+            "reconcile_session_metadata_with_observed_daemon",
+            "generation_store::reconcile",
+            "generation_store::reconcile_admission_session",
+            "write_session(",
+            "adopt",
+        ] {
+            assert!(
+                !status.contains(mutation),
+                "status must not invoke lifecycle mutation `{mutation}`"
+            );
+        }
     }
 }
 

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -1551,6 +1551,51 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_status_projections_preserve_stale_direct_generation_state_without_operations() {
+        test_support::with_isolated_home(|_| {
+            let draining = session("lease-draining", "daemon-draining", Some(101));
+            let active = session("lease-active", "daemon-active", Some(202));
+            record_job("runner-a", &draining, "draining-job").expect("record draining job");
+            activate(
+                "runner-a",
+                &draining,
+                "lease-active".to_string(),
+                active.clone(),
+                &["draining-job".to_string()],
+            )
+            .expect("activate current generation");
+            let registry_path = path("runner-a").expect("registry path");
+            let before = std::fs::read(&registry_path).expect("snapshot durable state");
+            let operations = std::sync::Arc::new(FakeEndpointOperations::default());
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+
+            let observers = (0..2)
+                .map(|_| {
+                    let barrier = std::sync::Arc::clone(&barrier);
+                    let active = active.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        status_projection("runner-a", Some(&active)).expect("status projection")
+                    })
+                })
+                .collect::<Vec<_>>();
+            barrier.wait();
+            for observer in observers {
+                let projection = observer.join().expect("status observer");
+                assert_eq!(projection.len(), 2);
+            }
+
+            assert_eq!(
+                std::fs::read(registry_path).expect("read durable state"),
+                before
+            );
+            assert!(operations.terminal_reconciled_leases.borrow().is_empty());
+            assert!(operations.stopped_leases.borrow().is_empty());
+            assert!(operations.terminated_pids.borrow().is_empty());
+        });
+    }
+
+    #[test]
     fn endpoint_fallback_retires_only_the_authoritatively_idle_draining_generation() {
         test_support::with_isolated_home(|_| {
             let a = session("lease-a", "daemon-a", Some(101));

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -148,9 +148,10 @@ pub(crate) use connection::disconnect_with_force;
 pub use connection::{
     close_reconnected_job_log_owner, connect, connect_reverse, connect_with_live_lease_adoption,
     connect_with_orphan_adoption, diagnostic_status, disconnect, disconnect_local_recovery,
-    persisted_status, persisted_statuses, reconcile_terminal_jobs, reconnect_job_log_owner,
-    reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
-    runner_artifact_content, status, statuses, statuses_indexed, submit_reverse_broker_job,
+    persisted_status, persisted_statuses, reconcile_status, reconcile_terminal_jobs,
+    reconnect_job_log_owner, reverse_broker_artifact, reverse_broker_artifact_content,
+    reverse_broker_reconcile, runner_artifact_content, status, statuses, statuses_indexed,
+    submit_reverse_broker_job,
 };
 pub(crate) use connection::{
     configured_runner_homeboy_build_identity, local_live_session, status_for_admission,

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -40,7 +40,7 @@ pub use crate::{
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability,
     promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts,
     promote_runner_exec_summaries, promoted_output, prune_homeboy_binary_cache, prune_workspaces,
-    pull_workspace, refresh_homeboy_binary, refresh_mirrored_daemon_evidence,
+    pull_workspace, reconcile_status, refresh_homeboy_binary, refresh_mirrored_daemon_evidence,
     reportable_artifact_evidence_path, resolve_default_lab_runner, run_reverse_worker,
     runner_artifact_store_token, runner_dev_sync, runner_exec_failure_error,
     runner_exec_structured_summary, runner_generation_inventory,


### PR DESCRIPTION
## Summary

- make runner status observationally read-only
- move reconciliation, terminal settlement, and generation repair behind explicit `runner reconcile`
- prove concurrent compact/full observations preserve stale direct-SSH state byte-for-byte without lifecycle operations

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner concurrent_status_projections_preserve_stale_direct_generation_state_without_operations --lib`
- `cargo test -p homeboy-cli runner_status --lib`
- `git diff --check`

Closes #11262.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents implemented, reviewed, and verified this change. Chris Huber remains responsible for every line.
