### PR TITLE
Declare Cook terminality instead of inferring it from an open status vocabulary

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
@@ -17,25 +17,27 @@
 //! is the one place the vocabulary is written down, so the three call sites
 //! classify against the same enum instead of three divergent string literals.
 //!
-//! # Why unknown statuses stay terminal
+//! # Terminality is declared, not inferred
 //!
-//! [`CookStatus::is_terminal`] is defined as "not one of the in-flight
-//! states", deliberately keeping the *in-flight* set closed rather than the
-//! terminal set.
+//! Whether a Cook will advance on its own is *not* derived from this
+//! vocabulary. It is [`CookDisposition`], declared by the exit that built the
+//! report.
 //!
-//! The in-flight set is small, internal, and owned by the Cook loop itself.
-//! The terminal set is open: three call sites feed it straight from
-//! `finalization["status"]`, an arbitrary JSON string, defaulting to
-//! `"unknown"` when the field is missing. Making the *terminal* side the
-//! allow-list would mean any status this binary has not been taught is treated
-//! as still-running — so a Cook that genuinely finished would never emit its
-//! terminal notification and the orchestrator would wait forever. Because new
-//! statuses overwhelmingly arrive from finalization, and finalization statuses
-//! are overwhelmingly terminal, the safer default for an unrecognized status
-//! is "the Cook has stopped".
+//! Inferring it from the status string was the original defect. The terminal
+//! side of the vocabulary is open — several exits feed it straight from
+//! `finalization["status"]`, an arbitrary JSON string that defaults to
+//! `"unknown"` when the field is missing — so any inference has to pick a
+//! wrong default for statuses it has not been taught. Guessing "terminal"
+//! fires a completion at the orchestrator for a Cook that is still running;
+//! guessing "in flight" leaves a finished Cook with no completion at all.
 //!
-//! [`CookStatus::Unknown`] preserves the raw string so this classification
-//! never rewrites a status it did not recognize.
+//! There is no need to guess. At every one of those exits the Cook loop has
+//! already decided: it either handed the work to a durable owner that will
+//! carry it forward, or it stopped. Recording that decision removes the
+//! question instead of answering it.
+//!
+//! [`CookStatus::Unknown`] preserves the raw string so a status this binary
+//! does not recognize is never rewritten.
 
 use std::fmt;
 
@@ -167,17 +169,18 @@ impl CookStatus {
         }
     }
 
-    /// Whether the Cook will advance on its own.
+    /// Whether this status *reads* as a Cook that is still progressing.
     ///
-    /// This is the closed set. Everything else — including
-    /// [`CookStatus::Unknown`] — is terminal.
+    /// This is a property of the vocabulary, not the authority on terminality
+    /// — that is [`CookDisposition`], which the producing exit declares. This
+    /// exists so a report can be checked for self-consistency between the
+    /// status it carries and the disposition it declares, and so batch totals
+    /// can bucket a cell by its reported status.
+    ///
+    /// Unlike the terminal side, this set is closed: it is internal to the
+    /// Cook loop and never sourced from finalization JSON.
     pub fn is_in_flight(&self) -> bool {
         matches!(self, Self::Queued | Self::Running | Self::InFlight)
-    }
-
-    /// Whether the Cook will not advance without external action.
-    pub fn is_terminal(&self) -> bool {
-        !self.is_in_flight()
     }
 
     /// Whether this status alone means the operator has nothing to act on.
@@ -199,6 +202,43 @@ impl CookStatus {
 impl fmt::Display for CookStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+/// Whether a Cook will advance on its own, as declared by the exit that
+/// produced the report.
+///
+/// Every Cook exit already knows this. It either handed the work to a durable
+/// owner — a runner daemon or detached staging that owns timeout and provider
+/// rotation from that point on — or it stopped and there is nothing left to
+/// carry the Cook forward. This records that fact so no consumer has to
+/// re-derive it from a status string.
+///
+/// Producing a report requires stating one of these, so an exit added later
+/// cannot inherit a default that happens to be wrong for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CookDisposition {
+    /// The Cook returned, but a durable owner is still carrying the work.
+    /// No terminal notification is due.
+    InFlight,
+    /// The Cook will not advance without external action. This is the
+    /// completion the orchestrator is waiting for.
+    Terminal,
+}
+
+impl CookDisposition {
+    /// Whether the Cook will not advance without external action.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Terminal)
+    }
+
+    /// The durable progress phase label for this disposition.
+    pub fn phase(&self) -> &'static str {
+        match self {
+            Self::InFlight => "in_flight",
+            Self::Terminal => "terminal",
+        }
     }
 }
 
@@ -226,11 +266,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn only_the_in_flight_states_are_non_terminal() {
+    fn the_in_flight_reading_covers_exactly_the_loop_owned_states() {
         for status in ["queued", "running", "in_flight"] {
             assert!(
-                !CookStatus::from_status(status).is_terminal(),
-                "{status} must not be terminal"
+                CookStatus::from_status(status).is_in_flight(),
+                "{status} must read as in flight"
             );
         }
         for status in [
@@ -245,20 +285,40 @@ mod tests {
             "durable_failure",
         ] {
             assert!(
-                CookStatus::from_status(status).is_terminal(),
-                "{status} must be terminal"
+                !CookStatus::from_status(status).is_in_flight(),
+                "{status} must not read as in flight"
             );
         }
     }
 
-    /// A Cook that finished under a status this binary predates must still
-    /// emit its terminal notification, or the orchestrator waits forever.
+    /// The whole point of declaring disposition: a status this binary has
+    /// never seen carries no claim about whether the Cook is still running.
     #[test]
-    fn an_unknown_status_is_terminal() {
+    fn an_unknown_status_makes_no_claim_about_progress() {
         let status = CookStatus::from_status("some_status_from_a_newer_binary");
         assert!(matches!(status, CookStatus::Unknown(_)));
-        assert!(status.is_terminal());
+        assert!(!status.is_in_flight());
         assert!(!status.is_success_exit());
+    }
+
+    #[test]
+    fn disposition_is_the_authority_on_terminality() {
+        assert!(CookDisposition::Terminal.is_terminal());
+        assert!(!CookDisposition::InFlight.is_terminal());
+        assert_eq!(CookDisposition::Terminal.phase(), "terminal");
+        assert_eq!(CookDisposition::InFlight.phase(), "in_flight");
+    }
+
+    #[test]
+    fn disposition_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CookDisposition::InFlight).expect("serialize"),
+            "\"in_flight\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CookDisposition::Terminal).expect("serialize"),
+            "\"terminal\""
+        );
     }
 
     /// The classification must never rewrite a status it did not recognize.

--- a/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
@@ -1,0 +1,338 @@
+//! The Cook status vocabulary and the single classification of terminality.
+//!
+//! # Why this exists
+//!
+//! Cook status was an untyped `String` classified by three independent,
+//! hand-maintained lists inside `agent_task_service/cook.rs`:
+//!
+//! | purpose | vocabulary it recognized |
+//! |---|---|
+//! | batch totals | `queued`, `running`/`in_flight`, `cancelled`, `timed_out` |
+//! | exit code `0` | `queued`, `running`, `in_flight`, `review_ready`, `green_no_finalize` |
+//! | terminality | everything except `queued`, `running`, `in_flight` |
+//!
+//! Three lists over one open vocabulary have to agree by hand, and they did
+//! not: `cancelled` and `timed_out` were known only to the batch list, and
+//! `review_ready`/`green_no_finalize` only to the exit-code list. This module
+//! is the one place the vocabulary is written down, so the three call sites
+//! classify against the same enum instead of three divergent string literals.
+//!
+//! # Why unknown statuses stay terminal
+//!
+//! [`CookStatus::is_terminal`] is defined as "not one of the in-flight
+//! states", deliberately keeping the *in-flight* set closed rather than the
+//! terminal set.
+//!
+//! The in-flight set is small, internal, and owned by the Cook loop itself.
+//! The terminal set is open: three call sites feed it straight from
+//! `finalization["status"]`, an arbitrary JSON string, defaulting to
+//! `"unknown"` when the field is missing. Making the *terminal* side the
+//! allow-list would mean any status this binary has not been taught is treated
+//! as still-running — so a Cook that genuinely finished would never emit its
+//! terminal notification and the orchestrator would wait forever. Because new
+//! statuses overwhelmingly arrive from finalization, and finalization statuses
+//! are overwhelmingly terminal, the safer default for an unrecognized status
+//! is "the Cook has stopped".
+//!
+//! [`CookStatus::Unknown`] preserves the raw string so this classification
+//! never rewrites a status it did not recognize.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A reported Cook status.
+///
+/// Serializes as the bare snake_case string it was parsed from, so the
+/// `homeboy/agent-task-cook/v1` wire format is unchanged and unknown values
+/// round-trip byte-for-byte.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CookStatus {
+    // --- in flight: the Cook will advance on its own ---
+    /// Accepted, not yet started.
+    Queued,
+    /// Executing.
+    Running,
+    /// Executing, reported from a continuation or a detached provider.
+    InFlight,
+
+    // --- terminal: the Cook will not advance without external action ---
+    /// Finished and finalized.
+    Completed,
+    /// Finished with a candidate ready for review.
+    ReviewReady,
+    /// Gates were green but finalization was intentionally not performed.
+    GreenNoFinalize,
+    /// Finalization ran and found no changed files.
+    NoChanges,
+    /// A no-op candidate failed its gates.
+    NoOpGateFailed,
+    /// A deterministic gate failed.
+    GateFailed,
+    /// Waiting on an independent acceptance verdict.
+    AwaitingAcceptance,
+    /// Stopped, but the candidate can still be recovered.
+    CandidateRecoverable,
+    /// Stopped because a dependency was not satisfied.
+    BlockedByDependency,
+    /// Stopped by a blocking claim.
+    Blocked,
+    /// Cancelled by an operator or a supervisor.
+    Cancelled,
+    /// Exceeded its wall-clock budget.
+    TimedOut,
+    /// Ran out of retries.
+    RetriesExhausted,
+    /// Ran out of execution budget.
+    ExecutionBudgetExhausted,
+    /// Stopped by policy.
+    PolicyFailure,
+    /// The provider failed.
+    ProviderFailure,
+    /// Failed with a durable recipe intact.
+    DurableFailure,
+    /// Failed before execution began.
+    PreExecutionFailure,
+    /// Interrupted before artifacts were captured.
+    PreArtifactInterruption,
+    /// Failed without a more specific classification.
+    Failed,
+
+    /// A status this binary does not know.
+    ///
+    /// Classified as terminal — see the module docs. The raw string is kept so
+    /// serialization is lossless.
+    Unknown(String),
+}
+
+impl CookStatus {
+    /// Parse a reported status. Never fails; unrecognized input becomes
+    /// [`CookStatus::Unknown`].
+    pub fn from_status(status: &str) -> Self {
+        match status {
+            "queued" => Self::Queued,
+            "running" => Self::Running,
+            "in_flight" => Self::InFlight,
+            "completed" => Self::Completed,
+            "review_ready" => Self::ReviewReady,
+            "green_no_finalize" => Self::GreenNoFinalize,
+            "no_changes" => Self::NoChanges,
+            "no_op_gate_failed" => Self::NoOpGateFailed,
+            "gate_failed" => Self::GateFailed,
+            "awaiting_acceptance" => Self::AwaitingAcceptance,
+            "candidate_recoverable" => Self::CandidateRecoverable,
+            "blocked_by_dependency" => Self::BlockedByDependency,
+            "blocked" => Self::Blocked,
+            "cancelled" => Self::Cancelled,
+            "timed_out" => Self::TimedOut,
+            "retries_exhausted" => Self::RetriesExhausted,
+            "execution_budget_exhausted" => Self::ExecutionBudgetExhausted,
+            "policy_failure" => Self::PolicyFailure,
+            "provider_failure" => Self::ProviderFailure,
+            "durable_failure" => Self::DurableFailure,
+            "pre_execution_failure" => Self::PreExecutionFailure,
+            "pre_artifact_interruption" => Self::PreArtifactInterruption,
+            "failed" => Self::Failed,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    /// The wire representation.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::InFlight => "in_flight",
+            Self::Completed => "completed",
+            Self::ReviewReady => "review_ready",
+            Self::GreenNoFinalize => "green_no_finalize",
+            Self::NoChanges => "no_changes",
+            Self::NoOpGateFailed => "no_op_gate_failed",
+            Self::GateFailed => "gate_failed",
+            Self::AwaitingAcceptance => "awaiting_acceptance",
+            Self::CandidateRecoverable => "candidate_recoverable",
+            Self::BlockedByDependency => "blocked_by_dependency",
+            Self::Blocked => "blocked",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+            Self::RetriesExhausted => "retries_exhausted",
+            Self::ExecutionBudgetExhausted => "execution_budget_exhausted",
+            Self::PolicyFailure => "policy_failure",
+            Self::ProviderFailure => "provider_failure",
+            Self::DurableFailure => "durable_failure",
+            Self::PreExecutionFailure => "pre_execution_failure",
+            Self::PreArtifactInterruption => "pre_artifact_interruption",
+            Self::Failed => "failed",
+            Self::Unknown(raw) => raw.as_str(),
+        }
+    }
+
+    /// Whether the Cook will advance on its own.
+    ///
+    /// This is the closed set. Everything else — including
+    /// [`CookStatus::Unknown`] — is terminal.
+    pub fn is_in_flight(&self) -> bool {
+        matches!(self, Self::Queued | Self::Running | Self::InFlight)
+    }
+
+    /// Whether the Cook will not advance without external action.
+    pub fn is_terminal(&self) -> bool {
+        !self.is_in_flight()
+    }
+
+    /// Whether this status alone means the operator has nothing to act on.
+    ///
+    /// Callers that also inspect the finalization payload should treat this as
+    /// the status-only half of that decision.
+    pub fn is_success_exit(&self) -> bool {
+        matches!(
+            self,
+            Self::Queued
+                | Self::Running
+                | Self::InFlight
+                | Self::ReviewReady
+                | Self::GreenNoFinalize
+        )
+    }
+}
+
+impl fmt::Display for CookStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for CookStatus {
+    fn from(value: &str) -> Self {
+        Self::from_status(value)
+    }
+}
+
+impl Serialize for CookStatus {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CookStatus {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Ok(Self::from_status(&raw))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_in_flight_states_are_non_terminal() {
+        for status in ["queued", "running", "in_flight"] {
+            assert!(
+                !CookStatus::from_status(status).is_terminal(),
+                "{status} must not be terminal"
+            );
+        }
+        for status in [
+            "completed",
+            "review_ready",
+            "green_no_finalize",
+            "no_changes",
+            "gate_failed",
+            "awaiting_acceptance",
+            "cancelled",
+            "timed_out",
+            "durable_failure",
+        ] {
+            assert!(
+                CookStatus::from_status(status).is_terminal(),
+                "{status} must be terminal"
+            );
+        }
+    }
+
+    /// A Cook that finished under a status this binary predates must still
+    /// emit its terminal notification, or the orchestrator waits forever.
+    #[test]
+    fn an_unknown_status_is_terminal() {
+        let status = CookStatus::from_status("some_status_from_a_newer_binary");
+        assert!(matches!(status, CookStatus::Unknown(_)));
+        assert!(status.is_terminal());
+        assert!(!status.is_success_exit());
+    }
+
+    /// The classification must never rewrite a status it did not recognize.
+    #[test]
+    fn unknown_statuses_round_trip_losslessly() {
+        let raw = "some_status_from_a_newer_binary";
+        let status = CookStatus::from_status(raw);
+        assert_eq!(status.as_str(), raw);
+        let json = serde_json::to_string(&status).expect("serialize");
+        assert_eq!(json, format!("\"{raw}\""));
+        let parsed: CookStatus = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, status);
+    }
+
+    #[test]
+    fn every_known_status_round_trips_through_its_wire_form() {
+        for status in [
+            CookStatus::Queued,
+            CookStatus::Running,
+            CookStatus::InFlight,
+            CookStatus::Completed,
+            CookStatus::ReviewReady,
+            CookStatus::GreenNoFinalize,
+            CookStatus::NoChanges,
+            CookStatus::NoOpGateFailed,
+            CookStatus::GateFailed,
+            CookStatus::AwaitingAcceptance,
+            CookStatus::CandidateRecoverable,
+            CookStatus::BlockedByDependency,
+            CookStatus::Blocked,
+            CookStatus::Cancelled,
+            CookStatus::TimedOut,
+            CookStatus::RetriesExhausted,
+            CookStatus::ExecutionBudgetExhausted,
+            CookStatus::PolicyFailure,
+            CookStatus::ProviderFailure,
+            CookStatus::DurableFailure,
+            CookStatus::PreExecutionFailure,
+            CookStatus::PreArtifactInterruption,
+            CookStatus::Failed,
+        ] {
+            assert_eq!(
+                CookStatus::from_status(status.as_str()),
+                status,
+                "{status} must round-trip"
+            );
+            assert!(
+                !matches!(status, CookStatus::Unknown(_)),
+                "{status} must be a known variant"
+            );
+        }
+    }
+
+    /// Pins the exit-code vocabulary that previously lived as a separate
+    /// string list, so it cannot drift from terminality again.
+    #[test]
+    fn success_exit_covers_in_flight_plus_the_two_green_terminal_states() {
+        for status in [
+            "queued",
+            "running",
+            "in_flight",
+            "review_ready",
+            "green_no_finalize",
+        ] {
+            assert!(
+                CookStatus::from_status(status).is_success_exit(),
+                "{status} must exit 0 on status alone"
+            );
+        }
+        for status in ["failed", "gate_failed", "no_changes", "durable_failure"] {
+            assert!(
+                !CookStatus::from_status(status).is_success_exit(),
+                "{status} must not exit 0 on status alone"
+            );
+        }
+    }
+}

--- a/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
@@ -8,15 +8,18 @@
 //! `ArtifactRef` (`from_record`, `to_artifact_ref`, `From<ArtifactRef>`) live
 //! in `homeboy-core` as free functions, so this crate stays observation-free.
 //!
-//! Two distinct lifecycle vocabularies live here and do not overlap. `lifecycle`
-//! is the workload *phase* lifecycle (`LifecyclePhaseKind`).
+//! Three distinct lifecycle vocabularies live here and do not overlap.
+//! `lifecycle` is the workload *phase* lifecycle (`LifecyclePhaseKind`).
 //! `run_lifecycle_record` is a run *state machine* (`RunExecutionState`,
 //! `CleanupState`, `FinalizationState`, `ArtifactRetentionStatus`). The latter
 //! was its own `homeboy-run-lifecycle-contract` crate until it was merged here;
 //! the two share no types, and `homeboy-core` already imported that crate under
 //! the module name `run_lifecycle_record`, which is the name it keeps.
+//! `cook_status` is the Cook *report* vocabulary (`CookStatus`) and owns the
+//! single definition of Cook terminality.
 
 pub mod artifact_contract;
+pub mod cook_status;
 pub mod lifecycle;
 pub mod rig_snapshot;
 pub mod run_lifecycle_record;
@@ -25,6 +28,7 @@ pub mod timeline;
 pub use artifact_contract::{
     ArtifactContract, ArtifactRecord, ArtifactViewerLink, ARTIFACT_CONTRACT_SCHEMA,
 };
+pub use cook_status::CookStatus;
 pub use lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
     LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef,

--- a/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/lib.rs
@@ -15,8 +15,9 @@
 //! was its own `homeboy-run-lifecycle-contract` crate until it was merged here;
 //! the two share no types, and `homeboy-core` already imported that crate under
 //! the module name `run_lifecycle_record`, which is the name it keeps.
-//! `cook_status` is the Cook *report* vocabulary (`CookStatus`) and owns the
-//! single definition of Cook terminality.
+//! `cook_status` is the Cook *report* vocabulary (`CookStatus`) plus
+//! `CookDisposition`, the declared answer to whether a Cook will advance on
+//! its own.
 
 pub mod artifact_contract;
 pub mod cook_status;
@@ -28,7 +29,7 @@ pub mod timeline;
 pub use artifact_contract::{
     ArtifactContract, ArtifactRecord, ArtifactViewerLink, ARTIFACT_CONTRACT_SCHEMA,
 };
-pub use cook_status::CookStatus;
+pub use cook_status::{CookDisposition, CookStatus};
 pub use lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
     LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef,

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -316,6 +316,9 @@ mod tests {
             history_run_ids: Vec::new(),
             invocation_run_ids: Vec::new(),
             status: status.to_string(),
+            // These tests all build terminal payloads; the notification only
+            // fires for a terminal disposition in the first place.
+            disposition: homeboy_core::cook_status::CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization,
             selected_candidate: None,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -19,7 +19,7 @@ use crate::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::cook_status::CookStatus;
+use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::{Error, Result};
 
 use super::cook_baseline::{
@@ -135,6 +135,7 @@ fn pre_artifact_interruption_report(
     let mut report = cook_report(CookReportInput {
         cook_id,
         status: "pre_artifact_interruption",
+        disposition: CookDisposition::Terminal,
         attempts,
         finalization: None,
         stop_reason: Some(reason),
@@ -692,6 +693,12 @@ pub struct AgentTaskCookReport {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub invocation_run_ids: Vec<String>,
     pub status: String,
+    /// Whether the Cook will advance on its own, declared by the exit that
+    /// produced this report rather than inferred from `status`.
+    ///
+    /// Consumers waiting on completion should read this instead of
+    /// pattern-matching `status`, which is an open vocabulary.
+    pub disposition: CookDisposition,
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finalization: Option<Value>,
@@ -1658,16 +1665,6 @@ fn cook_component(options: &AgentTaskCookServiceOptions) -> Option<String> {
         .find_map(|contract| contract.slug.clone())
 }
 
-/// Whether a reported cook status means the cook will not advance on its own.
-///
-/// Delegates to [`CookStatus`], which is the single definition of the Cook
-/// status vocabulary and of terminality. It is shared by the durable progress
-/// phase label, the terminal notification, the batch totals, and the exit
-/// code, so a new status cannot make any of them silently disagree.
-fn cook_status_is_terminal(status: &str) -> bool {
-    CookStatus::from_status(status).is_terminal()
-}
-
 pub(crate) fn exhausted_budget_guidance(
     max_attempts: u32,
     budget: &AgentTaskExecutionBudget,
@@ -1733,7 +1730,7 @@ where
         allow_historical_terminal,
     );
     if let Ok(result) = &result {
-        if cook_status_is_terminal(&result.value.status) {
+        if result.value.disposition.is_terminal() {
             crate::agent_task_notify::cook_terminal(
                 &result.value,
                 cook_component(&notification_options).as_deref(),
@@ -1773,11 +1770,7 @@ where
             .last()
             .map(|attempt| attempt.attempt)
             .unwrap_or(1);
-        let phase = if cook_status_is_terminal(&result.value.status) {
-            "terminal"
-        } else {
-            "in_flight"
-        };
+        let phase = result.value.disposition.phase();
         if let Err(error) = report_cook_progress(
             durable_observer,
             &result.value.cook_id,
@@ -1803,6 +1796,7 @@ fn durable_cook_error_report(
         let mut report = cook_report(CookReportInput {
             cook_id: options.cook_id.clone(),
             status: "durable_failure",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: Some(
@@ -2360,6 +2354,7 @@ where
                     return Ok(cook_report(CookReportInput {
                         cook_id,
                         status: "retries_exhausted",
+                        disposition: CookDisposition::Terminal,
                         attempts,
                         finalization: None,
                         stop_reason: Some(error.to_string()),
@@ -2414,6 +2409,7 @@ where
             return Ok(cook_report(CookReportInput {
                 cook_id,
                 status: "in_flight",
+                disposition: CookDisposition::InFlight,
                 attempts,
                 finalization: None,
                 stop_reason: Some("provider attempt accepted by the runner daemon".to_string()),
@@ -2508,6 +2504,7 @@ where
             return Ok(cook_report(CookReportInput {
                 cook_id,
                 status: "policy_failure",
+                disposition: CookDisposition::Terminal,
                 attempts,
                 finalization: None,
                 stop_reason: Some(
@@ -2538,6 +2535,7 @@ where
             return Ok(cook_report(CookReportInput {
                 cook_id,
                 status: "provider_failure",
+                disposition: CookDisposition::Terminal,
                 attempts,
                 finalization: None,
                 stop_reason: Some(format!(
@@ -2574,6 +2572,7 @@ where
             return Ok(cook_report(CookReportInput {
                 cook_id,
                 status: &status,
+                disposition: CookDisposition::Terminal,
                 attempts,
                 finalization: Some(finalization),
                 stop_reason: None,
@@ -2605,6 +2604,7 @@ where
                 return Ok(cook_report(CookReportInput {
                     cook_id,
                     status: "policy_failure",
+                    disposition: CookDisposition::Terminal,
                     attempts,
                     finalization: None,
                     stop_reason: Some(recovery),
@@ -2652,6 +2652,7 @@ where
                     return Ok(cook_report(CookReportInput {
                         cook_id,
                         status: "green_no_finalize",
+                        disposition: CookDisposition::Terminal,
                         attempts,
                         finalization: None,
                         stop_reason: Some(
@@ -2769,6 +2770,7 @@ where
                         return Ok(cook_report(CookReportInput {
                             cook_id,
                             status: "awaiting_acceptance",
+                            disposition: CookDisposition::Terminal,
                             attempts,
                             finalization: Some(serde_json::json!({
                                 "status": "awaiting_acceptance",
@@ -2800,6 +2802,7 @@ where
                 return Ok(cook_report(CookReportInput {
                     cook_id,
                     status: &final_status,
+                    disposition: CookDisposition::Terminal,
                     attempts,
                     finalization: Some(finalization),
                     stop_reason,
@@ -2811,6 +2814,7 @@ where
                 return Ok(cook_report(CookReportInput {
                     cook_id,
                     status: "no_changes",
+                    disposition: CookDisposition::Terminal,
                     attempts,
                     finalization: None,
                     stop_reason: Some(
@@ -2826,6 +2830,7 @@ where
                 return Ok(cook_report(CookReportInput {
                     cook_id,
                     status: "no_op_gate_failed",
+                    disposition: CookDisposition::Terminal,
                     attempts,
                     finalization: None,
                     stop_reason: Some(
@@ -2842,6 +2847,7 @@ where
                     return Ok(cook_report(CookReportInput {
                         cook_id,
                         status: "policy_failure",
+                        disposition: CookDisposition::Terminal,
                         attempts,
                         finalization: None,
                         stop_reason: Some(
@@ -2880,6 +2886,7 @@ where
                         return Ok(cook_report(CookReportInput {
                             cook_id,
                             status: "execution_budget_exhausted",
+                            disposition: CookDisposition::Terminal,
                             attempts,
                             finalization: None,
                             stop_reason: Some(exhausted_budget_guidance(
@@ -2896,6 +2903,7 @@ where
                         return Ok(cook_report(CookReportInput {
                             cook_id,
                             status: "policy_failure",
+                            disposition: CookDisposition::Terminal,
                             attempts,
                             finalization: None,
                             stop_reason: Some(reason),
@@ -2909,6 +2917,7 @@ where
                 return Ok(cook_report(CookReportInput {
                     cook_id,
                     status: "retries_exhausted",
+                    disposition: CookDisposition::Terminal,
                     attempts,
                     finalization: None,
                     stop_reason: Some(
@@ -2925,6 +2934,7 @@ where
     Ok(cook_report(CookReportInput {
         cook_id,
         status: "retries_exhausted",
+        disposition: CookDisposition::Terminal,
         attempts,
         finalization: None,
         stop_reason: Some("cook attempt budget exhausted".to_string()),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -19,6 +19,7 @@ use crate::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 use homeboy_core::command_invocation::CommandInvocation;
+use homeboy_core::cook_status::CookStatus;
 use homeboy_core::{Error, Result};
 
 use super::cook_baseline::{
@@ -1045,11 +1046,11 @@ fn cook_batch_result(
     let total = cooks.len();
     let mut totals = crate::agent_task_batch::AgentTaskBatchTotals::default();
     for cell in &cooks {
-        match cell.status.as_str() {
-            "queued" => totals.queued += 1,
-            "running" | "in_flight" => totals.running += 1,
-            "cancelled" => totals.cancelled += 1,
-            "timed_out" => totals.timed_out += 1,
+        match CookStatus::from_status(&cell.status) {
+            CookStatus::Queued => totals.queued += 1,
+            CookStatus::Running | CookStatus::InFlight => totals.running += 1,
+            CookStatus::Cancelled => totals.cancelled += 1,
+            CookStatus::TimedOut => totals.timed_out += 1,
             _ if cell.exit_code == 0 => totals.succeeded += 1,
             _ => totals.failed += 1,
         }
@@ -1217,8 +1218,8 @@ fn cook_report_exit_code(report: &AgentTaskCookReport) -> i32 {
     // A review-ready or already-finalized cook is a success; anything the cook
     // could not carry to a green, finalized state is a non-zero resume result
     // the operator must still act on.
-    match report.status.as_str() {
-        "queued" | "running" | "in_flight" | "review_ready" | "green_no_finalize" => 0,
+    match CookStatus::from_status(&report.status) {
+        status if status.is_success_exit() => 0,
         _ => {
             if report
                 .finalization
@@ -1659,11 +1660,12 @@ fn cook_component(options: &AgentTaskCookServiceOptions) -> Option<String> {
 
 /// Whether a reported cook status means the cook will not advance on its own.
 ///
-/// The single definition, shared by the durable progress phase label and the
-/// terminal notification, so a new in-flight status cannot make one of them
-/// silently disagree with the other.
+/// Delegates to [`CookStatus`], which is the single definition of the Cook
+/// status vocabulary and of terminality. It is shared by the durable progress
+/// phase label, the terminal notification, the batch totals, and the exit
+/// code, so a new status cannot make any of them silently disagree.
 fn cook_status_is_terminal(status: &str) -> bool {
-    !matches!(status, "queued" | "running" | "in_flight")
+    CookStatus::from_status(status).is_terminal()
 }
 
 pub(crate) fn exhausted_budget_guidance(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -31,6 +31,7 @@ use crate::agent_task_promotion::{
     promote_with_checkpoint, AgentTaskPromotionOptions, AgentTaskPromotionReport,
 };
 use crate::agent_task_provider::ExtensionProviderAgentTaskExecutor;
+use homeboy_core::cook_status::CookDisposition;
 use homeboy_core::{Error, Result};
 
 use super::cook::{
@@ -335,6 +336,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             return Ok(cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
                 status: &result.status,
+                disposition: CookDisposition::Terminal,
                 attempts: vec![AgentTaskCookAttemptReport {
                     attempt: 1,
                     run_id: record.run_id.clone(),
@@ -379,6 +381,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: &status,
+            disposition: CookDisposition::Terminal,
             attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 1,
                 run_id: record.run_id.clone(),
@@ -569,6 +572,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             let report = cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
                 status: "policy_failure",
+                disposition: CookDisposition::Terminal,
                 attempts: vec![attempt],
                 finalization: None,
                 stop_reason: Some(
@@ -654,6 +658,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 let report = cook_report(CookReportInput {
                     cook_id: cook_id.to_string(),
                     status: "execution_budget_exhausted",
+                    disposition: CookDisposition::Terminal,
                     attempts: vec![attempt],
                     finalization: None,
                     stop_reason: Some(super::cook::exhausted_budget_guidance(
@@ -676,6 +681,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 let report = cook_report(CookReportInput {
                     cook_id: cook_id.to_string(),
                     status: "policy_failure",
+                    disposition: CookDisposition::Terminal,
                     attempts: vec![attempt],
                     finalization: None,
                     stop_reason: Some(reason.clone()),
@@ -696,6 +702,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "gate_failed",
+            disposition: CookDisposition::Terminal,
             attempts: vec![attempt],
             finalization: None,
             stop_reason: Some(
@@ -710,6 +717,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "green_no_finalize",
+            disposition: CookDisposition::Terminal,
             attempts: vec![attempt],
             finalization: None,
             stop_reason: Some(
@@ -750,6 +758,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     Ok(cook_report(CookReportInput {
         cook_id: cook_id.to_string(),
         status: &status,
+        disposition: CookDisposition::Terminal,
         attempts: vec![attempt],
         finalization: Some(finalization),
         stop_reason: None,

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 use crate::agent_task::AgentTaskExecutor;
 use crate::agent_task_lifecycle;
 use crate::agent_task_scheduler::AgentTaskPlan;
+use homeboy_core::cook_status::CookDisposition;
 use homeboy_core::{Error, Result};
 
 use super::cook::{
@@ -172,6 +173,7 @@ pub(crate) fn pre_execution_failure_report(
     let mut report = cook_report(CookReportInput {
         cook_id,
         status: "pre_execution_failure",
+        disposition: CookDisposition::Terminal,
         attempts,
         finalization: None,
         stop_reason: Some(format!(

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -12,6 +12,7 @@
 use serde_json::Value;
 use std::path::PathBuf;
 
+use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use homeboy_engine_primitives::content_hash;
 
@@ -644,6 +645,7 @@ pub(crate) fn moving_base_recovery_report(
     let mut report = cook_report(CookReportInput {
         cook_id,
         status: "candidate_recoverable",
+        disposition: CookDisposition::Terminal,
         attempts,
         finalization: None,
         stop_reason,
@@ -2405,6 +2407,12 @@ fn review_form_for_finalization(
 pub(crate) struct CookReportInput<'a> {
     pub cook_id: String,
     pub status: &'a str,
+    /// Whether this exit handed the work to a durable owner or stopped.
+    ///
+    /// Required, and deliberately not defaulted: this is the fact the
+    /// orchestrator's completion depends on, and the exit building the report
+    /// is the only place that knows it.
+    pub disposition: CookDisposition,
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     pub finalization: Option<Value>,
     pub stop_reason: Option<String>,
@@ -2419,12 +2427,21 @@ pub(crate) fn cook_report(input: CookReportInput<'_>) -> AgentTaskRunResult<Agen
     let CookReportInput {
         cook_id,
         status,
+        disposition,
         attempts,
         finalization,
         stop_reason,
         exit_code,
         invocation_latest_run_id,
     } = input;
+    // Defense in depth, not a second source of truth: `disposition` remains
+    // authoritative in release builds. This only catches an exit whose
+    // declared disposition contradicts the status it reports, which is a
+    // producer bug rather than a condition to recover from.
+    debug_assert!(
+        !CookStatus::from_status(status).is_in_flight() || disposition == CookDisposition::InFlight,
+        "cook exit reported in-flight status {status:?} but declared {disposition:?}"
+    );
     let history_run_ids = agent_task_lifecycle::cook_index(&cook_id)
         .map(|index| {
             index
@@ -2483,6 +2500,7 @@ pub(crate) fn cook_report(input: CookReportInput<'_>) -> AgentTaskRunResult<Agen
             history_run_ids,
             invocation_run_ids,
             status: status.to_string(),
+            disposition,
             attempts,
             finalization,
             selected_candidate,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5187,6 +5187,59 @@ fn cook_index_serialization_remains_compatible_with_indexes_without_a_candidate_
     assert!(serialized.get("latest_substantive_candidate").is_none());
 }
 
+/// Terminality must survive a status this binary has never seen.
+///
+/// The previous implementation inferred it from the status string, so a Cook
+/// reporting an unrecognized status — which is reachable, because several
+/// exits pass `finalization["status"]` straight through and fall back to
+/// `"unknown"` — was classified by whichever way that inference happened to
+/// guess. The declared disposition is what the orchestrator's completion
+/// depends on, so it must not consult the vocabulary at all.
+#[test]
+fn terminality_is_declared_by_the_exit_not_read_from_the_status_string() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-disposition-authority";
+        let unrecognized = "some_status_from_a_newer_binary";
+
+        let terminal = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: unrecognized,
+            disposition: CookDisposition::Terminal,
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 1,
+            invocation_latest_run_id: None,
+        });
+        assert!(terminal.value.disposition.is_terminal());
+        assert_eq!(terminal.value.disposition.phase(), "terminal");
+        // The unrecognized status is reported verbatim, never rewritten.
+        assert_eq!(terminal.value.status, unrecognized);
+
+        // The one exit that hands work to a durable owner stays non-terminal,
+        // so no completion is announced while that owner is still working.
+        let in_flight = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "in_flight",
+            disposition: CookDisposition::InFlight,
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: Some("provider attempt accepted by the runner daemon".to_string()),
+            exit_code: 0,
+            invocation_latest_run_id: None,
+        });
+        assert!(!in_flight.value.disposition.is_terminal());
+        assert_eq!(in_flight.value.disposition.phase(), "in_flight");
+
+        // Consumers reading the serialized report get the same answer without
+        // having to pattern-match the open status vocabulary.
+        let serialized = serde_json::to_value(&terminal.value).expect("serialize cook report");
+        assert_eq!(serialized["disposition"], "terminal");
+        let serialized = serde_json::to_value(&in_flight.value).expect("serialize cook report");
+        assert_eq!(serialized["disposition"], "in_flight");
+    });
+}
+
 #[test]
 fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run_id() {
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -5225,6 +5278,7 @@ fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run
         let report = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "completed",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: None,
@@ -5339,6 +5393,7 @@ fn resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_lates
         let report = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "execution_budget_exhausted",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: Some(
@@ -5393,6 +5448,7 @@ fn resume_promoted_patch_guidance_keeps_the_exhausted_zero_byte_attempt_as_lates
         let unproven = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "execution_budget_exhausted",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: None,
@@ -7993,6 +8049,7 @@ fn cook_report_latest_run_id_prefers_invocation_over_stale_cook_index() {
         let report = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "execution_budget_exhausted",
+            disposition: CookDisposition::Terminal,
             attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 2,
                 run_id: fresh_run_id.clone(),
@@ -8146,6 +8203,7 @@ fn selected_candidate_provenance_flags_cross_invocation_selection() {
         let cross_invocation = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "completed",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: None,
@@ -8165,6 +8223,7 @@ fn selected_candidate_provenance_flags_cross_invocation_selection() {
         let in_invocation = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "completed",
+            disposition: CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization: None,
             stop_reason: None,
@@ -8208,6 +8267,7 @@ fn post_materialization_failure_families_expose_only_durable_identity_and_legal_
             let report = cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
                 status,
+                disposition: CookDisposition::Terminal,
                 attempts: Vec::new(),
                 finalization: None,
                 stop_reason: Some(
@@ -8389,6 +8449,7 @@ fn cook_report_invocation_run_ids_populated_for_policy_failure() {
         let report = cook_report(CookReportInput {
             cook_id: "cook-test".to_string(),
             status: "policy_failure",
+            disposition: CookDisposition::Terminal,
             attempts: vec![AgentTaskCookAttemptReport {
                 attempt: 1,
                 run_id: fresh_run_id.clone(),

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -77,6 +77,7 @@ pub mod content_diff;
 pub mod context;
 pub mod controller_pin_reference;
 pub mod controller_runtime;
+pub use homeboy_lifecycle_contract::cook_status;
 pub mod daemon;
 pub mod deferred_workload;
 pub mod deps;


### PR DESCRIPTION
Refs #11117. Two commits: the first single-sources the vocabulary, the second removes the inference entirely.

## What I found

The issue's headline claim does not reproduce. **`continuation_pending` never reaches `cook_status_is_terminal`** — it is built in `homeboy-cli/.../agent_task/run.rs:194` by `cook_continuation_pending()`, which returns a raw `serde_json::Value`, not an `AgentTaskCookReport`.

The real defect was larger: **three independent classification lists over one open vocabulary, in one file, that had to agree by hand and didn't.**

| `cook.rs` | purpose | recognized |
|---|---|---|
| 1049 | batch totals | `queued`, `running`/`in_flight`, `cancelled`, `timed_out` |
| 1221 | exit code `0` | `queued`, `running`, `in_flight`, **`review_ready`**, **`green_no_finalize`** |
| 1666 | terminality | everything except `queued`, `running`, `in_flight` |

`cancelled`/`timed_out` were known only to the batch list; `review_ready`/`green_no_finalize` only to the exit-code list. The vocabulary was written down nowhere — I recovered it from every producer.

## Commit 1 — single-source the vocabulary

`CookStatus` in `homeboy-lifecycle-contract` is now the one place the Cook status vocabulary is declared, and all three call sites classify against it.

## Commit 2 — stop inferring terminality (the deeper fix)

Terminality decides two things: whether the orchestrator is told the Cook completed, and the durable progress phase label. Both read it from the status string — and the terminal side of that vocabulary is **open**. Five exits pass `finalization["status"]` straight through, defaulting to `"unknown"` when the field is absent (`cook.rs:2792`, `cook_adoption.rs:377`, `cook_adoption.rs:746`, …).

Any inference over an open vocabulary must pick a default for statuses it was never taught, and **both defaults are wrong in a different direction**:

- guess *terminal* → announce a completion for a Cook that is still running
- guess *in-flight* → a finished Cook never reports completion, orchestrator waits forever

There is nothing to guess. Every exit already knows: it either handed the work to a durable owner that will carry it forward — a runner daemon or detached staging owning timeout and provider rotation from that point — or it stopped.

`CookDisposition` records that decision. `cook_status_is_terminal` is deleted.

It is a **required** field on `CookReportInput`, deliberately not defaulted, so all 28 exits state which they are and an exit added later cannot inherit a default that is wrong for it. The compiler surfaced every site.

Of the 28 exits, **exactly one is in flight**: the runner-handoff path at `cook.rs:2412`. All five dynamic exits are post-finalization and terminal — one deserializes a type literally named `CandidateAdoptionTerminalResult`.

### No second source of truth

`CookStatus::is_terminal` is gone. `is_in_flight` remains as a property of the vocabulary, used to bucket batch totals and to `debug_assert` that an exit's declared disposition does not contradict the status it reports — a producer bug caught in tests, with no inference in release builds.

### Additive on the wire

The report gains `disposition`, so consumers waiting on completion no longer have to pattern-match the open status vocabulary either. `AgentTaskCookReport` is `Serialize`-only and never deserialized, so this is purely additive. `CookStatus` serializes as the bare snake_case string it parsed, and unknown values round-trip byte-for-byte.

## Verification

- `cargo test -p homeboy-lifecycle-contract --lib cook_status` — **7 passed**
- `cargo test -p homeboy-agents --lib agent_task_notify` — **11 passed**, incl. `terminal_kind_follows_the_exit_code_not_the_open_status_vocabulary`
- `cargo test -p homeboy-agents --lib -- batch_` — **16 passed**
- `cargo check -p homeboy-agents --lib --tests` and `-p homeboy-cli --lib` — clean

**Before/after on the whole touched subsystem**, single-threaded, this branch vs the same branch stashed:

```
before: 165 passed; 32 failed
after:  166 passed; 32 failed     (+1 = the new test)
diff of failing test names: IDENTICAL
```

All 27 unique pre-existing failures are unchanged and unrelated (they fail identically on clean `origin/main`).

New test `terminality_is_declared_by_the_exit_not_read_from_the_status_string` pins the invariant: a Cook reporting a status this binary has never seen is still classified by its declared disposition, and the status is reported verbatim rather than rewritten.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: traced the reported symptom to a non-reproducing claim, recovered the vocabulary from every producer, identified the three divergent lists, enumerated all 28 exits to establish exactly one is non-terminal, and implemented the declared disposition. Chris Huber remains responsible for every line.