### PR TITLE
fix(issues): only a complete audit run may close issues on absence

### DIFF
--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -591,6 +591,14 @@ mod tests {
         code_audit::AuditRunWorkflowResult {
             output: AuditCommandOutput::Full {
                 passed: false,
+                measurement: code_audit::AuditMeasurement::new(
+                    code_audit::AuditProfile::Full,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                ),
                 result: code_audit::CodeAuditResult {
                     component_id: "homeboy".to_string(),
                     source_path: home.to_string_lossy().to_string(),

--- a/crates/homeboy-cli/src/commands/issues.rs
+++ b/crates/homeboy-cli/src/commands/issues.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::code_audit::FindingConfidence;
 use homeboy::issues::{
-    apply_plan, build_findings_from_native_output, reconcile_scoped, GithubTracker,
+    apply_plan, build_findings_from_native_output, reconcile_measured, GithubTracker,
     IssueRenderContext, ReconcileConfig, ReconcileFindingsInput, ReconcilePlan, ReconcileResult,
     Tracker,
 };
@@ -322,7 +322,21 @@ fn run_reconcile_command(
         request.run_url,
     )?;
     let command_label = findings_input.command.clone();
+    let complete_measurement = findings_input.complete_measurement;
+    let measurement_narrowed_by = findings_input.measurement_narrowed_by.clone();
     let groups = into_issue_groups(findings_input, &request.component_id);
+
+    if !complete_measurement {
+        eprintln!(
+            "[issues] {} run was narrowed ({}); absent categories will not be closed",
+            command_label,
+            if measurement_narrowed_by.is_empty() {
+                "reason not declared".to_string()
+            } else {
+                measurement_narrowed_by.join(", ")
+            }
+        );
+    }
 
     let config = build_reconcile_config(request.no_refresh_closed);
 
@@ -333,12 +347,13 @@ fn run_reconcile_command(
     let existing = tracker_impl.list_issues(&command_label, request.list_limit)?;
 
     // Pure decision.
-    let plan = reconcile_scoped(
+    let plan = reconcile_measured(
         &groups,
         &existing,
         &config,
         &command_label,
         &request.component_id,
+        complete_measurement,
     );
     let plan_lines = render_plan_lines(&plan);
     let plan_summary = summarize_plan(&plan);
@@ -802,7 +817,30 @@ fn parse_findings_value(value: Value) -> homeboy::core::Result<ReconcileFindings
         }
     }
 
-    Ok(ReconcileFindingsInput { command, groups })
+    // A hand-authored findings file may declare narrowed coverage the same way
+    // a native envelope does; absent, it is treated as a complete measurement.
+    let complete_measurement = obj
+        .get("complete_measurement")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let measurement_narrowed_by = obj
+        .get("measurement_narrowed_by")
+        .and_then(|v| v.as_array())
+        .map(|reasons| {
+            reasons
+                .iter()
+                .filter_map(|reason| reason.as_str())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ReconcileFindingsInput {
+        command,
+        groups,
+        complete_measurement,
+        measurement_narrowed_by,
+    })
 }
 
 fn parse_confidence(raw: &str) -> Option<FindingConfidence> {

--- a/crates/homeboy-code-audit/src/lib.rs
+++ b/crates/homeboy-code-audit/src/lib.rs
@@ -86,7 +86,7 @@ pub(crate) use execution_plan::{
 pub use findings::{homeboy_finding_from_audit, Finding, FindingConfidence, Severity};
 pub use fingerprint::FileFingerprint;
 pub use homeboy_engine_primitives::test_path::is_test_path;
-pub use report::AuditCommandOutput;
+pub use report::{AuditCommandOutput, AuditMeasurement};
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 
 pub use entry::{

--- a/crates/homeboy-code-audit/src/report.rs
+++ b/crates/homeboy-code-audit/src/report.rs
@@ -33,6 +33,9 @@ pub struct AuditSummaryOutput {
     pub top_findings: Vec<HomeboyFinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixability: Option<AuditFixability>,
+    /// Coverage declaration — see [`AuditMeasurement`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measurement: Option<AuditMeasurement>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changed_since: Option<AuditChangedSinceSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,6 +84,63 @@ pub struct AuditChangedSinceSummary {
     pub contextual_findings: usize,
 }
 
+/// What this audit run actually measured.
+///
+/// Consumers that retire findings on absence — issue reconciliation above all —
+/// must not read "this run reported no findings in category X" as "category X
+/// is clean". A `pr` profile runs seven detector families; `core_boundary_leaks`
+/// and `source_policy` are deliberately excluded from it (see
+/// [`crate::AuditProfile::includes_detector`]), so a PR-profile run *cannot*
+/// emit those categories no matter how much debt the tree carries. Kind/label
+/// filters and `--changed-since` narrow the surface the same way.
+///
+/// `complete` is therefore the only safe licence to close on absence: it is true
+/// only for an unfiltered whole-tree run.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AuditMeasurement {
+    /// Profile the run executed under (`full`, `pr`, `architecture`).
+    pub profile: String,
+    /// True when the run measured every detector across the whole tree.
+    pub complete: bool,
+    /// Why the measurement was narrowed, when it was.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub narrowed_by: Vec<String>,
+}
+
+impl AuditMeasurement {
+    /// Build the coverage declaration for one audit run.
+    pub fn new(
+        profile: crate::AuditProfile,
+        changed_since: bool,
+        only_kinds: bool,
+        exclude_kinds: bool,
+        only_labels: bool,
+        exclude_labels: bool,
+    ) -> Self {
+        let mut narrowed_by = Vec::new();
+        if profile != crate::AuditProfile::Full {
+            narrowed_by.push(format!("profile={}", profile.as_str()));
+        }
+        for (narrowed, reason) in [
+            (changed_since, "changed-since"),
+            (only_kinds, "only-kinds"),
+            (exclude_kinds, "exclude-kinds"),
+            (only_labels, "only-labels"),
+            (exclude_labels, "exclude-labels"),
+        ] {
+            if narrowed {
+                narrowed_by.push(reason.to_string());
+            }
+        }
+
+        Self {
+            profile: profile.as_str().to_string(),
+            complete: narrowed_by.is_empty(),
+            narrowed_by,
+        }
+    }
+}
+
 /// Baseline filtering counters for compact audit summaries.
 ///
 /// `total_findings` on [`AuditSummaryOutput`] is the current findings count.
@@ -109,6 +169,8 @@ pub enum AuditCommandOutput {
         passed: bool,
         #[serde(flatten)]
         result: CodeAuditResult,
+        /// Coverage declaration — see [`AuditMeasurement`].
+        measurement: AuditMeasurement,
         #[serde(skip_serializing_if = "Option::is_none")]
         fixability: Option<AuditFixability>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -144,6 +206,8 @@ pub enum AuditCommandOutput {
         #[serde(flatten)]
         result: CodeAuditResult,
         baseline_comparison: baseline::BaselineComparison,
+        /// Coverage declaration — see [`AuditMeasurement`].
+        measurement: AuditMeasurement,
         #[serde(skip_serializing_if = "Option::is_none")]
         changed_since: Option<AuditChangedSinceSummary>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -226,6 +290,7 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
         finding_groups,
         top_findings,
         fixability: None,
+        measurement: None,
         changed_since: None,
         baseline_filtering: None,
         unbaselined_findings: Vec::new(),

--- a/crates/homeboy-code-audit/src/report_test.rs
+++ b/crates/homeboy-code-audit/src/report_test.rs
@@ -464,3 +464,81 @@ fn test_from_main_workflow() {
     assert_eq!(exit_code, 3);
     assert!(matches!(output, AuditCommandOutput::Summary(_)));
 }
+
+#[test]
+fn measurement_is_complete_only_for_an_unfiltered_full_run() {
+    let complete = crate::report::AuditMeasurement::new(
+        crate::AuditProfile::Full,
+        false,
+        false,
+        false,
+        false,
+        false,
+    );
+
+    assert!(complete.complete);
+    assert_eq!(complete.profile, "full");
+    assert!(complete.narrowed_by.is_empty());
+}
+
+#[test]
+fn pr_profile_declares_a_narrowed_measurement() {
+    // `AuditProfile::Pr` runs seven detector families. `core_boundary_leaks`
+    // and `source_policy` are deliberately not among them, so a PR-profile run
+    // cannot emit those categories however much debt the tree carries. It must
+    // never be read as authority that they are clean. See homeboy #11298.
+    let narrowed = crate::report::AuditMeasurement::new(
+        crate::AuditProfile::Pr,
+        false,
+        false,
+        false,
+        false,
+        false,
+    );
+
+    assert!(!narrowed.complete);
+    assert_eq!(narrowed.profile, "pr");
+    assert_eq!(narrowed.narrowed_by, vec!["profile=pr".to_string()]);
+}
+
+#[test]
+fn every_narrowing_flag_is_recorded_and_defeats_completeness() {
+    let narrowed = crate::report::AuditMeasurement::new(
+        crate::AuditProfile::Full,
+        true,
+        true,
+        true,
+        true,
+        true,
+    );
+
+    assert!(!narrowed.complete);
+    assert_eq!(
+        narrowed.narrowed_by,
+        vec![
+            "changed-since".to_string(),
+            "only-kinds".to_string(),
+            "exclude-kinds".to_string(),
+            "only-labels".to_string(),
+            "exclude-labels".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn changed_since_alone_narrows_a_full_profile_run() {
+    // Whole-tree detectors still run, but only over the changed scope, so the
+    // run cannot speak for categories outside the diff.
+    let narrowed = crate::report::AuditMeasurement::new(
+        crate::AuditProfile::Full,
+        true,
+        false,
+        false,
+        false,
+        false,
+    );
+
+    assert!(!narrowed.complete);
+    assert_eq!(narrowed.profile, "full");
+    assert_eq!(narrowed.narrowed_by, vec!["changed-since".to_string()]);
+}

--- a/crates/homeboy-code-audit/src/run.rs
+++ b/crates/homeboy-code-audit/src/run.rs
@@ -42,10 +42,27 @@ pub struct AuditRunWorkflowResult {
     pub timing: AuditTiming,
 }
 
+/// Coverage declaration for this run — see [`report::AuditMeasurement`].
+///
+/// Threaded into every emitted envelope so downstream consumers can tell a
+/// clean category from an unmeasured one.
+fn measurement_for(args: &AuditRunWorkflowArgs) -> report::AuditMeasurement {
+    report::AuditMeasurement::new(
+        args.profile,
+        args.changed_since.is_some(),
+        !args.only_kinds.is_empty(),
+        !args.exclude_kinds.is_empty(),
+        !args.only_labels.is_empty(),
+        !args.exclude_labels.is_empty(),
+    )
+}
+
 /// Run the main audit workflow.
 pub fn run_main_audit_workflow(
     args: AuditRunWorkflowArgs,
 ) -> homeboy_error::Result<AuditRunWorkflowResult> {
+    let measurement = measurement_for(&args);
+
     // Run audit — scoped or full
     let result = run_audit(&args)?;
 
@@ -72,6 +89,7 @@ pub fn run_main_audit_workflow(
                         findings: vec![],
                         duplicate_groups: vec![],
                     },
+                    measurement,
                     fixability: None,
                     extension_phase_timings: Vec::new(),
                     actionable: None,
@@ -360,6 +378,7 @@ fn run_comparison_workflow(
         let findings = result.findings.clone();
         let summary = timing.time_phase("report_assembly", || {
             let mut summary = report::build_audit_summary(&result, exit_code);
+            summary.measurement = Some(measurement_for(args));
             summary.fixability = compute_fixability_if_requested(&result, analysis, args);
             summary
         });
@@ -378,6 +397,7 @@ fn run_comparison_workflow(
             output: AuditCommandOutput::Full {
                 passed: exit_code == 0,
                 result,
+                measurement: measurement_for(args),
                 fixability,
                 extension_phase_timings: Vec::new(),
                 actionable: None,
@@ -549,6 +569,7 @@ fn build_comparison_output(
                 &existing_baseline,
             ));
             summary.unbaselined_findings = report::build_unbaselined_finding_summary(&comparison);
+            summary.measurement = Some(measurement_for(args));
             summary
         });
         Ok(AuditRunWorkflowResult {
@@ -568,6 +589,7 @@ fn build_comparison_output(
                 passed: exit_code == 0,
                 result,
                 baseline_comparison: comparison,
+                measurement: measurement_for(args),
                 changed_since: changed_since_summary,
                 summary: None,
                 fixability,

--- a/crates/homeboy-issues/src/lib.rs
+++ b/crates/homeboy-issues/src/lib.rs
@@ -45,7 +45,7 @@ pub use plan::{
     IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
     TrackedIssueState,
 };
-pub use reconcile::{reconcile, reconcile_scoped};
+pub use reconcile::{reconcile, reconcile_measured, reconcile_scoped};
 pub use render::{
     build_findings_from_native_output, IssueRenderContext, ReconcileFindingsInput,
     RenderedIssueGroup,

--- a/crates/homeboy-issues/src/reconcile.rs
+++ b/crates/homeboy-issues/src/reconcile.rs
@@ -24,7 +24,7 @@ pub fn reconcile(
     existing: &[TrackedIssue],
     config: &ReconcileConfig,
 ) -> ReconcilePlan {
-    reconcile_with_scope(groups, existing, config, None)
+    reconcile_with_scope(groups, existing, config, None, true)
 }
 
 /// Reconcile within an explicit `(command, component)` scope.
@@ -41,7 +41,44 @@ pub fn reconcile_scoped(
     command: &str,
     component_id: &str,
 ) -> ReconcilePlan {
-    reconcile_with_scope(groups, existing, config, Some((command, component_id)))
+    reconcile_with_scope(
+        groups,
+        existing,
+        config,
+        Some((command, component_id)),
+        true,
+    )
+}
+
+/// Reconcile within a scope whose measurement may have been narrowed.
+///
+/// `complete_measurement` is the producing run's own declaration that it
+/// examined its whole surface. When it is false the reconciler still files and
+/// updates, but it will not retire a category that is merely absent — absence
+/// from a narrowed run is not evidence the findings are gone.
+///
+/// This is not hypothetical. `release.yml` runs `review audit --profile=pr`,
+/// and `AuditProfile::Pr` executes seven detector families; `core_boundary_leaks`
+/// and `source_policy` are deliberately excluded from it. A PR-profile run
+/// therefore *cannot* emit those categories at any debt level, and treating that
+/// silence as a fix closed 23 tracking issues — 409 findings in one of them — as
+/// "All findings have been resolved" 29 minutes after a full-tree sweep filed
+/// them. See homeboy #11298.
+pub fn reconcile_measured(
+    groups: &[IssueGroup],
+    existing: &[TrackedIssue],
+    config: &ReconcileConfig,
+    command: &str,
+    component_id: &str,
+    complete_measurement: bool,
+) -> ReconcilePlan {
+    reconcile_with_scope(
+        groups,
+        existing,
+        config,
+        Some((command, component_id)),
+        complete_measurement,
+    )
 }
 
 fn reconcile_with_scope(
@@ -49,6 +86,7 @@ fn reconcile_with_scope(
     existing: &[TrackedIssue],
     config: &ReconcileConfig,
     scope: Option<(&str, &str)>,
+    complete_measurement: bool,
 ) -> ReconcilePlan {
     // Index existing issues by (command, component, category). New issues carry
     // a stable hidden body key; legacy action-created issues fall back to the
@@ -204,7 +242,9 @@ fn reconcile_with_scope(
         push_file_new(&mut actions, group);
     }
 
-    if let Some((command, component_id)) = scope {
+    // Only a run that measured its whole surface may retire a category on
+    // absence. A narrowed run reports silence for everything it did not look at.
+    if let (Some((command, component_id)), true) = (scope, complete_measurement) {
         close_absent_open_issues(
             &mut actions,
             &by_category,
@@ -1019,6 +1059,72 @@ mod tests {
                 keep: 10,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn narrowed_measurement_never_closes_absent_categories() {
+        // Regression for homeboy #11298. `release.yml` runs
+        // `review audit --profile=pr`, and `AuditProfile::Pr` does not execute
+        // the `core_boundary_leaks` or `source_policy` detector families at all.
+        // Their absence from its output is structural, not evidence of a fix —
+        // yet it closed 23 full-tree tracking issues as "All findings have been
+        // resolved", one of them carrying 409 findings.
+        let existing = vec![
+            issue(11298, "core boundary leak", TrackedIssueState::Open, 409),
+            issue(11300, "dead code", TrackedIssueState::Open, 147),
+        ];
+
+        let plan = reconcile_measured(
+            &[],
+            &existing,
+            &cfg(),
+            "audit",
+            "sample-plugin",
+            false, // narrowed run: profile=pr
+        );
+
+        assert!(
+            plan.actions.is_empty(),
+            "a narrowed run must not retire categories it never measured, got {:?}",
+            plan.actions
+        );
+    }
+
+    #[test]
+    fn narrowed_measurement_still_files_and_updates_what_it_did_measure() {
+        // Coverage gating is about closing, not about going silent: a narrowed
+        // run must still report the findings it actually produced.
+        let existing = vec![issue(
+            11298,
+            "core boundary leak",
+            TrackedIssueState::Open,
+            409,
+        )];
+        let groups = vec![group("structural", 3)];
+
+        let plan = reconcile_measured(&groups, &existing, &cfg(), "audit", "sample-plugin", false);
+
+        assert_eq!(plan.actions.len(), 1);
+        assert!(
+            matches!(&plan.actions[0], ReconcileAction::FileNew { title, .. }
+                if title == "audit: structural in sample-plugin (3)"),
+            "got {:?}",
+            plan.actions[0]
+        );
+    }
+
+    #[test]
+    fn complete_measurement_still_closes_absent_categories() {
+        // The full-tree sweep keeps its authority to retire resolved debt.
+        let existing = vec![issue(11300, "dead code", TrackedIssueState::Open, 147)];
+
+        let plan = reconcile_measured(&[], &existing, &cfg(), "audit", "sample-plugin", true);
+
+        assert_eq!(plan.actions.len(), 1);
+        assert!(matches!(
+            &plan.actions[0],
+            ReconcileAction::Close { number: 11300, .. }
         ));
     }
 

--- a/crates/homeboy-issues/src/render.rs
+++ b/crates/homeboy-issues/src/render.rs
@@ -14,11 +14,38 @@ use homeboy_code_audit::FindingConfidence;
 use homeboy_core::finding::HomeboyFinding;
 
 /// Canonical input shape consumed by `homeboy runs findings reconcile`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconcileFindingsInput {
     pub command: String,
     #[serde(default)]
     pub groups: BTreeMap<String, RenderedIssueGroup>,
+    /// Whether the producing run measured its whole surface.
+    ///
+    /// Only a complete measurement may retire a category on absence. See
+    /// [`ReconcileFindingsInput::complete_measurement`] and the reconciler's
+    /// `close_absent_open_issues`.
+    #[serde(default = "default_complete_measurement")]
+    pub complete_measurement: bool,
+    /// Human-readable reasons the measurement was narrowed, when it was.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub measurement_narrowed_by: Vec<String>,
+}
+
+/// Producers that predate the coverage declaration are treated as complete so
+/// lint and test keep their existing close-on-absence behavior.
+fn default_complete_measurement() -> bool {
+    true
+}
+
+impl Default for ReconcileFindingsInput {
+    fn default() -> Self {
+        Self {
+            command: String::new(),
+            groups: BTreeMap::new(),
+            complete_measurement: true,
+            measurement_narrowed_by: Vec::new(),
+        }
+    }
 }
 
 /// One rendered category row in the reconcile input.
@@ -47,6 +74,14 @@ impl ReconcileFindingsInput {
         for (category, group) in other.groups {
             self.groups.insert(category, group);
         }
+        // Coverage is the weakest link: merging a narrowed run into a complete
+        // one yields a narrowed union, never a complete one.
+        self.complete_measurement &= other.complete_measurement;
+        for reason in other.measurement_narrowed_by {
+            if !self.measurement_narrowed_by.contains(&reason) {
+                self.measurement_narrowed_by.push(reason);
+            }
+        }
     }
 }
 
@@ -70,10 +105,45 @@ pub fn build_findings_from_native_output(
     }
 }
 
+/// Read the audit run's coverage declaration out of its envelope.
+///
+/// `measurement` is emitted at the envelope root by `audit`/`audit.compared`
+/// and under `summary` by `audit.summary`. An envelope without it predates the
+/// declaration and is treated as complete, preserving prior behavior.
+fn audit_measurement(data: &Value) -> (bool, Vec<String>) {
+    let Some(measurement) = data
+        .get("measurement")
+        .or_else(|| data.pointer("/summary/measurement"))
+    else {
+        return (true, Vec::new());
+    };
+    let complete = measurement
+        .get("complete")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let narrowed_by = measurement
+        .get("narrowed_by")
+        .and_then(Value::as_array)
+        .map(|reasons| {
+            reasons
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    (complete, narrowed_by)
+}
+
 fn render_audit(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let (complete_measurement, measurement_narrowed_by) = audit_measurement(data);
     let normalized_findings = normalized_findings(data);
     if !normalized_findings.is_empty() {
-        return render_normalized_findings("audit", normalized_findings, Some(data), context);
+        let mut input =
+            render_normalized_findings("audit", normalized_findings, Some(data), context);
+        input.complete_measurement = complete_measurement;
+        input.measurement_narrowed_by = measurement_narrowed_by;
+        return input;
     }
 
     let mut by_kind: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
@@ -113,6 +183,8 @@ fn render_audit(data: &Value, context: &IssueRenderContext) -> ReconcileFindings
     ReconcileFindingsInput {
         command: "audit".to_string(),
         groups,
+        complete_measurement,
+        measurement_narrowed_by,
     }
 }
 
@@ -247,6 +319,7 @@ fn render_lint(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsI
     ReconcileFindingsInput {
         command: "lint".to_string(),
         groups,
+        ..Default::default()
     }
 }
 
@@ -353,6 +426,7 @@ fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsI
     ReconcileFindingsInput {
         command: "test".to_string(),
         groups,
+        ..Default::default()
     }
 }
 
@@ -416,6 +490,7 @@ fn render_normalized_findings(
     ReconcileFindingsInput {
         command: command.to_string(),
         groups,
+        ..Default::default()
     }
 }
 

--- a/crates/homeboy-issues/src/render_test.rs
+++ b/crates/homeboy-issues/src/render_test.rs
@@ -550,3 +550,104 @@ fn normalized_finding_label_strips_backticks() {
 
     assert!(group.body.contains("- `weirdfingerprint` — bad quoting"));
 }
+
+#[test]
+fn audit_envelope_measurement_marks_narrowed_runs() {
+    // A `--profile=pr` audit declares narrowed coverage; the reconcile input
+    // must carry that through so the reconciler will not close on absence.
+    let output = json!({
+        "data": {
+            "command": "audit",
+            "passed": false,
+            "measurement": {
+                "profile": "pr",
+                "complete": false,
+                "narrowed_by": ["profile=pr", "changed-since"]
+            },
+            "findings": [
+                {"tool": "audit", "rule": "structural", "category": "structural",
+                 "message": "module is oversized", "file": "src/a.rs"}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("audit", output, &IssueRenderContext::default()).unwrap();
+
+    assert!(!rendered.complete_measurement);
+    assert_eq!(
+        rendered.measurement_narrowed_by,
+        vec!["profile=pr".to_string(), "changed-since".to_string()]
+    );
+}
+
+#[test]
+fn audit_envelope_measurement_marks_full_runs_complete() {
+    let output = json!({
+        "data": {
+            "command": "audit",
+            "passed": false,
+            "measurement": {"profile": "full", "complete": true},
+            "findings": [
+                {"tool": "audit", "rule": "dead_code", "category": "dead_code",
+                 "message": "unreferenced export", "file": "src/a.rs"}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("audit", output, &IssueRenderContext::default()).unwrap();
+
+    assert!(rendered.complete_measurement);
+    assert!(rendered.measurement_narrowed_by.is_empty());
+}
+
+#[test]
+fn envelope_without_measurement_is_treated_as_complete() {
+    // Envelopes produced before the coverage declaration existed must keep
+    // their prior close-on-absence behavior rather than silently stop closing.
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "findings": [
+                {"tool": "lint", "category": "style", "message": "trailing whitespace",
+                 "file": "src/lib.rs", "line": 12}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    assert!(rendered.complete_measurement);
+}
+
+#[test]
+fn merging_a_narrowed_run_narrows_the_result() {
+    // Coverage is the weakest link across merged inputs.
+    let mut complete = build_findings_from_native_output(
+        "audit",
+        json!({"data": {"measurement": {"profile": "full", "complete": true},
+               "findings": [{"tool": "audit", "category": "A", "message": "one"}]}}),
+        &IssueRenderContext::default(),
+    )
+    .unwrap();
+    let narrowed = build_findings_from_native_output(
+        "audit",
+        json!({"data": {"measurement": {"profile": "pr", "complete": false,
+               "narrowed_by": ["profile=pr"]},
+               "findings": [{"tool": "audit", "category": "B", "message": "two"}]}}),
+        &IssueRenderContext::default(),
+    )
+    .unwrap();
+
+    assert!(complete.complete_measurement);
+    complete.merge(narrowed);
+
+    assert!(!complete.complete_measurement);
+    assert_eq!(
+        complete.measurement_narrowed_by,
+        vec!["profile=pr".to_string()]
+    );
+}

--- a/crates/homeboy-review/src/review/artifact_findings.rs
+++ b/crates/homeboy-review/src/review/artifact_findings.rs
@@ -87,6 +87,14 @@ mod tests {
         let output = AuditCommandOutput::Full {
             passed: false,
             result: audit_result(vec![audit_finding("src/lib.rs", "missing method")]),
+            measurement: homeboy_code_audit::AuditMeasurement::new(
+                homeboy_code_audit::AuditProfile::Full,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
             fixability: None,
             extension_phase_timings: Vec::new(),
             actionable: None,
@@ -106,6 +114,14 @@ mod tests {
         let output = AuditCommandOutput::Compared {
             passed: false,
             result: audit_result(vec![audit_finding("src/main.rs", "naming drift")]),
+            measurement: homeboy_code_audit::AuditMeasurement::new(
+                homeboy_code_audit::AuditProfile::Full,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
             baseline_comparison: BaselineComparison {
                 new_items: Vec::new(),
                 resolved_fingerprints: Vec::new(),
@@ -140,6 +156,7 @@ mod tests {
             finding_groups: Vec::new(),
             top_findings: vec![top_finding.clone()],
             fixability: None,
+            measurement: None,
             changed_since: None,
             baseline_filtering: None,
             unbaselined_findings: Vec::new(),

--- a/crates/homeboy-review/src/review/render.rs
+++ b/crates/homeboy-review/src/review/render.rs
@@ -637,6 +637,14 @@ mod tests {
         AuditCommandOutput::Full {
             passed: result.findings.is_empty(),
             result,
+            measurement: homeboy_code_audit::AuditMeasurement::new(
+                homeboy_code_audit::AuditProfile::Full,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
             fixability: None,
             extension_phase_timings: Vec::new(),
             actionable: None,


### PR DESCRIPTION
## The bug

The reconciler retires a category whenever it is missing from the latest command output. Nothing checks whether the run *looked* for it.

`crates/homeboy-issues/src/reconcile.rs` → `close_absent_open_issues`:

```rust
if seen_keys.contains(&(issue_command, issue_component, category)) { continue; }
// ...otherwise
comment: close_resolved_comment(&category.replace('_', " ")),
```

Two workflows share that namespace with very different coverage:

| | workflow | scope |
|---|---|---|
| files the issues | `audit-debt.yml` (scheduled) | `review audit --profile=full` — whole tree |
| closes them | `release.yml` → `gate-audit` (every push to main) | `review audit --profile=pr --changed-since <before>` |

`AuditProfile::Pr` runs seven detector families:

```rust
Self::Pr => matches!(family.id,
    "structural" | "layer_ownership" | "test_topology" | "test_wiring"
    | "docs" | "command_status_contracts" | "thin_command_adapter"),
```

`core_boundary_leaks` and `source_policy` are **deliberately** not among them — `execution_plan.rs` carries a long comment explaining why they must stay out. So a PR-profile run *cannot* emit those categories at any level of debt. Their absence is structural.

The reconciler read it as a fix.

## What it did

2026-08-03: the scheduled sweep (run 30806460795) filed 23 tracking issues at 11:00:28. The release audit (run 30808964627, Audit job 11:28:39–11:30:42) closed all 23 between 11:29:52 and 11:30:37, each with:

> All **core boundary leak:core-agnostic-source** findings have been resolved. Closing automatically.

409 findings, on #11298. The same thing happened on 08-01 (`skeleton duplication` 164 → 163, `intra method duplication` 171 → 172). The categories get refiled by each sweep and retired by the next push to main, so no burndown has ever been visible and every one of them is recorded in the tracker as `COMPLETED`.

This is a measurement-integrity bug, not a cosmetic one: CI is asserting resolution it never observed.

## The fix

Audit runs now declare what they measured.

```rust
pub struct AuditMeasurement {
    pub profile: String,       // full | pr | architecture
    pub complete: bool,        // true only for an unfiltered whole-tree run
    pub narrowed_by: Vec<String>,
}
```

`complete` is false if the profile is not `full`, or `--changed-since` was used, or any of `--only-kinds` / `--exclude-kinds` / `--only-labels` / `--exclude-labels` was set. It rides on the `audit`, `audit.compared`, and `audit.summary` envelopes, so it reaches the reconciler through the existing `--from-output` path with no change required in `homeboy-action`.

`reconcile_measured` gates close-on-absence on that declaration. A narrowed run still files new issues and updates existing ones with everything it actually found — it just may not retire a category it never looked at. `ReconcileFindingsInput::merge` takes the weakest link, so merging a narrowed input into a complete one yields a narrowed union.

The full-tree sweep keeps its authority to close resolved debt, which is where that authority belongs.

## Compatibility

Envelopes without `measurement` default to complete, so `lint` and `test` — which do run their whole surface — keep their existing close-on-absence behavior. `reconcile` and `reconcile_scoped` keep their signatures and pass `true`.

## Tests

`homeboy-issues`:
- `narrowed_measurement_never_closes_absent_categories` — reproduces the #11298 shape; a narrowed run over the two real issue numbers must produce zero actions
- `narrowed_measurement_still_files_and_updates_what_it_did_measure` — gating closing must not make narrowed runs go silent
- `complete_measurement_still_closes_absent_categories` — the sweep keeps its authority
- four render tests covering the declaration round-tripping out of the envelope, the missing-field default, and merge semantics

`homeboy-code-audit`: four tests pinning `AuditMeasurement::new`, including `pr_profile_declares_a_narrowed_measurement` and `changed_since_alone_narrows_a_full_profile_run`.

Verified locally with `cargo check --workspace --tests` (clean) and `cargo clippy -p homeboy-issues -p homeboy-code-audit --tests` (no new findings; the `large size difference between variants` warning on `AuditCommandOutput` pre-exists on main). Test execution left to CI per this host's build policy.

## Scope

This fixes the mechanism, not the findings. Whether the 409 `core-agnostic-source` findings are real is a separate question — filed separately. Adjacent to but distinct from #10509, which is about over-*reporting* in PR scope rather than over-*closing*.

Refs #11298