### PR TITLE
fix(audit): match source-policy terms against lexical projections

### DIFF
--- a/crates/contracts/homeboy-audit-contract/src/lib.rs
+++ b/crates/contracts/homeboy-audit-contract/src/lib.rs
@@ -56,7 +56,7 @@ pub use remote_execution::{ArtifactPortabilityConfig, RemoteExecutionSafetyConfi
 pub use source_policy::{
     ConventionTagGlob, CoreBoundaryLeakConfig, MutatingResourceAccessConfig, RequestedDetectorRule,
     RequestedDetectorRuleBody, RequiredRegexScope, SourcePolicyMatchMode, SourcePolicyRule,
-    SourcePolicyRuleBody, SourcePolicyTerm,
+    SourcePolicyRuleBody, SourcePolicyTerm, SourcePolicyTermContext,
 };
 pub use test_wiring::{TestWiringConfig, TestWiringPolicy};
 pub use thin_command_adapter::{ThinCommandAdapterConfig, ThinCommandAdapterMarkerGroup};
@@ -284,6 +284,7 @@ mod tests {
                 exclude_path_contains: Vec::new(),
                 allow_line_contains: Vec::new(),
                 ignore_line_prefixes: Vec::new(),
+                scan_comments: false,
                 ignore_after_line_equals: Vec::new(),
                 example_path_contains: Vec::new(),
                 example_classification: None,
@@ -295,6 +296,7 @@ mod tests {
                         label: None,
                         match_mode: None,
                         detect_split: false,
+                        context: None,
                     }],
                     default_match: SourcePolicyMatchMode::Token,
                     case_insensitive: true,
@@ -489,6 +491,7 @@ mod tests {
             exclude_path_contains: Vec::new(),
             allow_line_contains: Vec::new(),
             ignore_line_prefixes: Vec::new(),
+            scan_comments: false,
             ignore_after_line_equals: Vec::new(),
             example_path_contains: Vec::new(),
             example_classification: None,
@@ -500,6 +503,7 @@ mod tests {
                     label: None,
                     match_mode: None,
                     detect_split: false,
+                    context: None,
                 }],
                 default_match: SourcePolicyMatchMode::Token,
                 case_insensitive: true,

--- a/crates/contracts/homeboy-audit-contract/src/source_policy.rs
+++ b/crates/contracts/homeboy-audit-contract/src/source_policy.rs
@@ -84,6 +84,7 @@ impl CoreBoundaryLeakConfig {
             } else {
                 self.ignore_line_prefixes.clone()
             },
+            scan_comments: false,
             ignore_after_line_equals: Vec::new(),
             example_path_contains: self.example_path_contains.clone(),
             example_classification: None,
@@ -124,6 +125,7 @@ fn core_boundary_term(term: &str) -> Option<SourcePolicyTerm> {
         label: None,
         match_mode: Some(match_mode),
         detect_split: false,
+        context: None,
     })
 }
 
@@ -158,6 +160,13 @@ pub struct SourcePolicyRule {
     /// Trimmed line prefixes skipped before matching, such as comment prefixes.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore_line_prefixes: Vec<String>,
+    /// Match inside comments as well as code.
+    ///
+    /// Off by default: a term in a comment describes behavior, it does not
+    /// implement it (#6857). Turn it on for policies that are genuinely about
+    /// comment text, such as banned TODO markers or licence headers.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub scan_comments: bool,
     /// Exact trimmed lines after which the rest of the file is ignored.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore_after_line_equals: Vec<String>,
@@ -207,6 +216,28 @@ pub struct SourcePolicyTerm {
     /// variable indirection, or character-code arithmetic.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub detect_split: bool,
+    /// Which lexical region of the source this term is trusted in.
+    ///
+    /// Defaults to [`SourcePolicyTermContext::Code`], which matches anywhere
+    /// outside comments. Terms whose bare word is ordinary programming
+    /// vocabulary — `node`, `playground`, `brew` — produce mostly noise there,
+    /// because a local named `node` is a graph node, not Node.js. Scoping such
+    /// a term to [`SourcePolicyTermContext::StringLiteral`] keeps it detecting
+    /// the shape that actually leaks (a command name, a filename, an error
+    /// substring) without deleting it from the policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<SourcePolicyTermContext>,
+}
+
+/// Lexical region a source-policy term is matched against.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourcePolicyTermContext {
+    /// Anywhere in the file except comments. The default.
+    #[default]
+    Code,
+    /// Only inside string literals.
+    StringLiteral,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/homeboy-code-audit/src/detectors/mod.rs
+++ b/crates/homeboy-code-audit/src/detectors/mod.rs
@@ -20,6 +20,7 @@ pub(super) mod repeated_literal_shape;
 pub(super) mod requested_detectors;
 pub(super) mod shared_scaffolding;
 pub(super) mod source_policy;
+pub(super) mod source_text;
 pub(super) mod test_coverage;
 pub(super) mod test_topology;
 pub(super) mod test_vacuity;

--- a/crates/homeboy-code-audit/src/detectors/source_policy.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_policy.rs
@@ -6,11 +6,13 @@ use std::str::FromStr;
 
 use homeboy_audit_contract::{
     AuditConfig, SourcePolicyMatchMode, SourcePolicyRule, SourcePolicyRuleBody, SourcePolicyTerm,
+    SourcePolicyTermContext,
 };
 
 use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use super::source_text::SourceMasks;
 
 pub(crate) fn run(fingerprints: &[&FileFingerprint], rules: &[SourcePolicyRule]) -> Vec<Finding> {
     if rules.is_empty() {
@@ -159,6 +161,11 @@ fn run_forbidden_terms(
 
     let mut findings = Vec::new();
     for fp in eligible_files(rule, fingerprints) {
+        // Scan each file once into comment-stripped and string-only
+        // projections. Matching against raw lines cannot tell a leak from prose
+        // describing one, which is what made this detector ~80% noise (#11330).
+        let masks = (!rule.scan_comments).then(|| SourceMasks::new(&fp.content, fp.language));
+
         for (index, line) in fp.content.lines().enumerate() {
             let trimmed = line.trim_start();
             if rule
@@ -168,6 +175,8 @@ fn run_forbidden_terms(
             {
                 break;
             }
+            // Allow/ignore markers are authored against the source as written,
+            // so they read the raw line even when matching reads a projection.
             if rule
                 .allow_line_contains
                 .iter()
@@ -180,8 +189,17 @@ fn run_forbidden_terms(
                 continue;
             }
 
+            let code = masks.as_ref().map_or(line, |masks| masks.code(index));
+            let strings = masks.as_ref().map(|masks| masks.strings(index));
+
             for matcher in &matchers {
-                if matcher.matches(line) {
+                let haystack = match matcher.context {
+                    SourcePolicyTermContext::Code => code,
+                    // Without projections (scan_comments) there is no string
+                    // mask to narrow to, so the term reads the whole line.
+                    SourcePolicyTermContext::StringLiteral => strings.unwrap_or(line),
+                };
+                if matcher.matches(haystack) {
                     findings.push(finding_for_match(rule, fp, index, &matcher.label));
                 }
             }
@@ -259,6 +277,8 @@ fn finding_for_match(
 
 struct TermMatcher {
     label: String,
+    /// Lexical region this term is matched against.
+    context: SourcePolicyTermContext,
     regex: Regex,
     /// Matches the term reassembled from adjacent string-literal fragments.
     /// Populated only when the term opts in with `detect_split`.
@@ -292,6 +312,7 @@ impl TermMatcher {
 
         Regex::new(&pattern).ok().map(|regex| Self {
             label: term.label.clone().unwrap_or_else(|| value.to_string()),
+            context: term.context.unwrap_or_default(),
             regex,
             split_regex,
         })
@@ -428,6 +449,7 @@ mod tests {
             exclude_path_contains: vec!["src/core/generated/".to_string()],
             allow_line_contains: vec!["homeboy-audit: allow-source-policy".to_string()],
             ignore_line_prefixes: vec!["//".to_string()],
+            scan_comments: false,
             ignore_after_line_equals: vec!["#[cfg(test)]".to_string()],
             example_path_contains: vec!["/fixtures/".to_string()],
             example_classification: None,
@@ -442,12 +464,14 @@ mod tests {
                         label: None,
                         match_mode: None,
                         detect_split: false,
+                        context: None,
                     },
                     SourcePolicyTerm {
                         value: "florp-run".to_string(),
                         label: None,
                         match_mode: Some(SourcePolicyMatchMode::Literal),
                         detect_split: false,
+                        context: None,
                     },
                 ],
                 default_match: SourcePolicyMatchMode::Token,
@@ -524,6 +548,7 @@ mod tests { const SAMPLE: &str = "florpstack"; }
                 label: Some("numbered widget".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Regex),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Token,
             case_insensitive: false,
@@ -544,6 +569,7 @@ mod tests { const SAMPLE: &str = "florpstack"; }
                 label: None,
                 match_mode: Some(SourcePolicyMatchMode::Literal),
                 detect_split,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Literal,
             case_insensitive: true,
@@ -626,6 +652,7 @@ mod tests { const SAMPLE: &str = "florpstack"; }
                 label: Some("FLORP_TOKEN".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Regex),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Token,
             case_insensitive: true,
@@ -655,6 +682,7 @@ mod tests { const SAMPLE: &str = "florpstack"; }
                 label: Some("florp diagnostic code".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Regex),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Token,
             case_insensitive: true,
@@ -685,6 +713,7 @@ mod tests { const SAMPLE: &str = "florpstack"; }
                 label: None,
                 match_mode: Some(SourcePolicyMatchMode::Token),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Token,
             case_insensitive: true,
@@ -732,6 +761,7 @@ fn dispatch() {
                 label: Some("command-layer dependency".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Literal),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Literal,
             case_insensitive: false,
@@ -762,12 +792,14 @@ fn dispatch() {
                     label: None,
                     match_mode: Some(SourcePolicyMatchMode::Token),
                     detect_split: false,
+                    context: None,
                 },
                 SourcePolicyTerm {
                     value: "widget-package.json".to_string(),
                     label: None,
                     match_mode: Some(SourcePolicyMatchMode::Literal),
                     detect_split: false,
+                    context: None,
                 },
             ],
             default_match: SourcePolicyMatchMode::Token,
@@ -808,6 +840,7 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
                 label: Some("direct process execution".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Regex),
                 detect_split: false,
+                context: None,
             }],
             default_match: SourcePolicyMatchMode::Regex,
             case_insensitive: false,
@@ -1028,3 +1061,7 @@ fn dispatch() {
         assert!(findings.is_empty());
     }
 }
+
+#[cfg(test)]
+#[path = "source_policy_context_test.rs"]
+mod source_policy_context_test;

--- a/crates/homeboy-code-audit/src/detectors/source_policy_context_test.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_policy_context_test.rs
@@ -1,0 +1,204 @@
+//! Regression coverage for homeboy #11330.
+//!
+//! Each case below is a verbatim line from the `core-agnostic-source` findings
+//! in #11298, resolved at the audited SHA `76c6c50cd`. They are reproduced here
+//! rather than paraphrased so the fix is pinned to the evidence that motivated
+//! it.
+
+use homeboy_audit_contract::{
+    SourcePolicyMatchMode, SourcePolicyRule, SourcePolicyRuleBody, SourcePolicyTerm,
+    SourcePolicyTermContext,
+};
+
+use super::super::conventions::Language;
+use super::super::findings::Finding;
+use super::super::fingerprint::FileFingerprint;
+use super::run;
+
+fn fp(content: &str) -> FileFingerprint {
+    FileFingerprint {
+        relative_path: "crates/homeboy-agents/src/thing.rs".to_string(),
+        language: Language::Rust,
+        content: content.to_string(),
+        ..Default::default()
+    }
+}
+
+/// The real rule shape from `homeboy.json`: token match, case-insensitive,
+/// scanning `crates/`.
+fn rule(terms: Vec<SourcePolicyTerm>) -> SourcePolicyRule {
+    SourcePolicyRule {
+        id: "core-agnostic-source".to_string(),
+        kind: "core_boundary_leak".to_string(),
+        severity: "warning".to_string(),
+        convention: "core_boundary_leak:core-agnostic-source".to_string(),
+        language: None,
+        file_extensions: Vec::new(),
+        include_path_contains: vec!["crates/".to_string()],
+        exclude_path_contains: Vec::new(),
+        allow_line_contains: Vec::new(),
+        ignore_line_prefixes: Vec::new(),
+        scan_comments: false,
+        ignore_after_line_equals: Vec::new(),
+        example_path_contains: Vec::new(),
+        example_classification: None,
+        description: "term `{term}` at line {line}".to_string(),
+        suggestion: "move it".to_string(),
+        rule: SourcePolicyRuleBody::ForbiddenTerms {
+            terms,
+            default_match: SourcePolicyMatchMode::Token,
+            case_insensitive: true,
+        },
+    }
+}
+
+fn term(value: &str, context: Option<SourcePolicyTermContext>) -> SourcePolicyTerm {
+    SourcePolicyTerm {
+        value: value.to_string(),
+        label: None,
+        match_mode: None,
+        detect_split: false,
+        context,
+    }
+}
+
+fn findings(content: &str, terms: Vec<SourcePolicyTerm>) -> Vec<Finding> {
+    let fp = fp(content);
+    run(&[&fp], &[rule(terms)])
+}
+
+// ---------------------------------------------------------------- comments
+
+#[test]
+fn doc_comment_prose_is_not_a_leak() {
+    // reference_docs.rs:290 and :304 in #11298.
+    let content = "\
+/// Globals are deliberately excluded: they are identical on every node and are
+/// Records every visible command node under `path` that has no help text.
+fn documented_positionals() {}
+";
+
+    assert!(
+        findings(content, vec![term("node", None)]).is_empty(),
+        "prose about nodes is not a Node.js dependency"
+    );
+}
+
+#[test]
+fn module_comment_command_examples_are_not_leaks() {
+    // reference_docs.rs:26 and descriptors.rs:9/:11 in #11298.
+    let content = "\
+//! HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli --lib
+/// rustfmt resolves the module tree by parsing and does not expand
+/// `cargo fmt --all` -- fifteen subtrees, 33 files, drifting unformatted.
+fn styled() {}
+";
+
+    let terms = vec![term("cargo", None), term("rustfmt", None)];
+    assert!(
+        findings(content, terms).is_empty(),
+        "a comment showing how to run a tool does not invoke it"
+    );
+}
+
+#[test]
+fn a_leak_on_a_line_that_also_carries_a_comment_is_still_reported() {
+    // Masking comments must not become a way to hide a real leak.
+    let content = "fn dispatch() { run(\"composer\"); } // see the composer docs\n";
+
+    let found = findings(content, vec![term("composer", None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+}
+
+#[test]
+fn scan_comments_opts_back_in() {
+    let content = "/// mentions composer\n";
+    let mut rule = rule(vec![term("composer", None)]);
+    rule.scan_comments = true;
+    let fp = fp(content);
+
+    assert_eq!(run(&[&fp], &[rule]).len(), 1);
+}
+
+// ----------------------------------------------------------- term contexts
+
+#[test]
+fn string_literal_context_ignores_identifiers_named_like_the_term() {
+    // artifacts.rs:148, agent_task_dependency_actions.rs:100/:228, and
+    // agent_task_dependency_graph.rs:102/:197 in #11298 — every one of them a
+    // graph node, not Node.js.
+    let content = "\
+fn collect() {
+    let mut node = declaration;
+    let head = required_node_value(node, \"head\", downstream_id)?;
+    let ids = upstream.iter().map(|node| (node.id.clone(), 0usize));
+}
+";
+
+    let terms = vec![term("node", Some(SourcePolicyTermContext::StringLiteral))];
+    assert!(
+        findings(content, terms).is_empty(),
+        "a local named `node` is not an ecosystem dependency"
+    );
+}
+
+#[test]
+fn string_literal_context_still_reports_the_term_as_data() {
+    // agent_task_gate_executor.rs:162 in #11298 — a real hit that must survive.
+    let content = "fn gate_argv() -> Vec<String> { vec![\"node\".to_string()] }\n";
+
+    let terms = vec![term("node", Some(SourcePolicyTermContext::StringLiteral))];
+    let found = findings(content, terms);
+
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert!(found[0].description.contains("node"));
+}
+
+#[test]
+fn code_context_remains_the_default_and_still_sees_identifiers() {
+    // Narrowing is opt-in per term; unscoped terms keep full strength so that
+    // a core function named `wordpress_*` is still a finding.
+    let content = "fn wordpress_plugin_path() -> String { String::new() }\n";
+
+    let found = findings(content, vec![term("wordpress", None)]);
+    assert_eq!(found.len(), 1, "{found:?}");
+}
+
+#[test]
+fn string_literal_context_reports_the_correct_line() {
+    let content = "fn f() {\n    let x = 1;\n    run(\"node\");\n}\n";
+
+    let terms = vec![term("node", Some(SourcePolicyTermContext::StringLiteral))];
+    let found = findings(content, terms);
+
+    assert_eq!(found.len(), 1);
+    assert!(
+        found[0].description.contains("line 3"),
+        "masking must preserve line numbers: {}",
+        found[0].description
+    );
+}
+
+// -------------------------------------------------------------- allowlists
+
+#[test]
+fn allow_line_contains_reads_the_source_as_written() {
+    // The Cargo build-script protocol string is unavoidable in any Rust build
+    // script, so it is allowlisted rather than detected.
+    let content = "    println!(\"cargo:rerun-if-changed={}\", path.display());\n";
+
+    let mut rule = rule(vec![term("cargo", None)]);
+    rule.allow_line_contains = vec!["cargo:rerun-if-changed".to_string()];
+    let fp = fp(content);
+
+    assert!(run(&[&fp], &[rule]).is_empty());
+}
+
+#[test]
+fn the_cargo_directive_is_a_finding_without_the_allowlist() {
+    // Pin that the allowlist is what silences it — not the comment mask, which
+    // would be the wrong reason and would hide real string-literal leaks.
+    let content = "    println!(\"cargo:rerun-if-changed={}\", path.display());\n";
+
+    assert_eq!(findings(content, vec![term("cargo", None)]).len(), 1);
+}

--- a/crates/homeboy-code-audit/src/detectors/source_text.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_text.rs
@@ -1,0 +1,304 @@
+//! Lexical projections of source text for term-matching detectors.
+//!
+//! A term-matching detector that reads raw lines cannot tell the difference
+//! between behavior and prose about behavior. `/// runs on every node` and
+//! `run("node")` are the same bytes to a substring search, but only one of them
+//! is a boundary leak. #6857 named this for the whole detector family; the
+//! `core-agnostic-source` policy reported ~80% false positives because of it.
+//!
+//! [`SourceMasks`] scans a file once and returns two same-shaped projections of
+//! every line, with the excluded regions blanked to spaces so byte offsets, line
+//! numbers, and token boundaries all survive:
+//!
+//! - [`SourceMasks::code`] — comments removed, everything else kept. What the
+//!   file *does*.
+//! - [`SourceMasks::strings`] — only string-literal spans kept. What the file
+//!   *names*. Ecosystem knowledge that leaks into core does so as data — command
+//!   names, filenames, error substrings — so a term whose bare word is ordinary
+//!   vocabulary (`node`, `playground`) can be scoped to this projection and stop
+//!   matching local variables without losing the leaks that matter.
+//!
+//! This is a lexer, not a parser: it tracks comments, strings, and escapes, and
+//! deliberately does not resolve macros, heredocs, or preprocessor conditionals.
+
+use super::conventions::Language;
+
+/// Punctuation preserved in the string projection so that seam patterns
+/// (`"car", "go"`) still see the join between two adjacent literals.
+const SEAM_PUNCTUATION: [char; 2] = [',', '+'];
+
+/// Comment-stripped and string-only projections of one file, line by line.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SourceMasks {
+    code: Vec<String>,
+    strings: Vec<String>,
+}
+
+impl SourceMasks {
+    /// Scan `content` under `language`'s lexical rules.
+    pub(crate) fn new(content: &str, language: Language) -> Self {
+        Scanner::new(content, language).run()
+    }
+
+    /// Line with comment spans blanked. Index is 0-based.
+    pub(crate) fn code(&self, line_index: usize) -> &str {
+        self.code.get(line_index).map(String::as_str).unwrap_or("")
+    }
+
+    /// Line with everything but string-literal spans blanked. Index is 0-based.
+    pub(crate) fn strings(&self, line_index: usize) -> &str {
+        self.strings
+            .get(line_index)
+            .map(String::as_str)
+            .unwrap_or("")
+    }
+}
+
+/// Which lexical region the scanner is currently inside.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    Code,
+    LineComment,
+    /// Rust block comments nest; the depth is carried so `/* /* */ */` closes
+    /// once rather than leaking the rest of the file into a comment.
+    BlockComment(u32),
+    /// A quoted string. The delimiter distinguishes `"` / `'` / JS backticks.
+    Quoted(char),
+    /// A Rust raw string: `r"..."`, `r#"..."#`, `r##"..."##`. No escapes apply,
+    /// and it closes only on a quote followed by the opening hash count.
+    RawString(usize),
+}
+
+struct Scanner<'a> {
+    chars: Vec<char>,
+    language: Language,
+    content: &'a str,
+}
+
+impl<'a> Scanner<'a> {
+    fn new(content: &'a str, language: Language) -> Self {
+        Self {
+            chars: content.chars().collect(),
+            language,
+            content,
+        }
+    }
+
+    /// True when `#` starts a line comment in this language.
+    fn hash_comments(&self) -> bool {
+        matches!(self.language, Language::Php | Language::Unknown)
+    }
+
+    /// True when backticks delimit template literals in this language.
+    fn template_literals(&self) -> bool {
+        matches!(self.language, Language::JavaScript | Language::TypeScript)
+    }
+
+    /// True when `r"..."` / `r#"..."#` raw strings apply.
+    fn raw_strings(&self) -> bool {
+        matches!(self.language, Language::Rust)
+    }
+
+    fn run(self) -> SourceMasks {
+        let mut code_line = String::new();
+        let mut string_line = String::new();
+        let mut masks = SourceMasks::default();
+        let mut state = State::Code;
+        let mut index = 0usize;
+
+        while index < self.chars.len() {
+            let ch = self.chars[index];
+
+            if ch == '\n' {
+                masks.code.push(std::mem::take(&mut code_line));
+                masks.strings.push(std::mem::take(&mut string_line));
+                // A line comment ends at the newline; every other state spans it.
+                if state == State::LineComment {
+                    state = State::Code;
+                }
+                index += 1;
+                continue;
+            }
+
+            let (next_state, consumed, class) = self.step(state, index);
+            for offset in 0..consumed {
+                let ch = self.chars[index + offset];
+                code_line.push(match class {
+                    Class::Comment => blank(ch),
+                    _ => ch,
+                });
+                string_line.push(match class {
+                    Class::String => ch,
+                    _ if SEAM_PUNCTUATION.contains(&ch) => ch,
+                    _ => blank(ch),
+                });
+            }
+            state = next_state;
+            index += consumed;
+        }
+
+        masks.code.push(code_line);
+        masks.strings.push(string_line);
+        masks
+    }
+
+    /// Classify the run of characters starting at `index`.
+    ///
+    /// Returns the state to continue in, how many characters were consumed, and
+    /// how they should be projected.
+    fn step(&self, state: State, index: usize) -> (State, usize, Class) {
+        match state {
+            State::LineComment => (State::LineComment, 1, Class::Comment),
+            State::BlockComment(depth) => self.step_block_comment(depth, index),
+            State::Quoted(delimiter) => self.step_quoted(delimiter, index),
+            State::RawString(hashes) => self.step_raw_string(hashes, index),
+            State::Code => self.step_code(index),
+        }
+    }
+
+    fn step_block_comment(&self, depth: u32, index: usize) -> (State, usize, Class) {
+        if self.matches_at(index, "*/") {
+            let next = if depth <= 1 {
+                State::Code
+            } else {
+                State::BlockComment(depth - 1)
+            };
+            return (next, 2, Class::Comment);
+        }
+        // Only Rust nests; elsewhere an inner `/*` is just comment text.
+        if self.raw_strings() && self.matches_at(index, "/*") {
+            return (State::BlockComment(depth + 1), 2, Class::Comment);
+        }
+        (State::BlockComment(depth), 1, Class::Comment)
+    }
+
+    fn step_quoted(&self, delimiter: char, index: usize) -> (State, usize, Class) {
+        let ch = self.chars[index];
+        if ch == '\\' && index + 1 < self.chars.len() {
+            return (State::Quoted(delimiter), 2, Class::String);
+        }
+        if ch == delimiter {
+            return (State::Code, 1, Class::String);
+        }
+        (State::Quoted(delimiter), 1, Class::String)
+    }
+
+    fn step_raw_string(&self, hashes: usize, index: usize) -> (State, usize, Class) {
+        if self.chars[index] == '"' && self.hash_run(index + 1) >= hashes {
+            return (State::Code, 1 + hashes, Class::String);
+        }
+        (State::RawString(hashes), 1, Class::String)
+    }
+
+    fn step_code(&self, index: usize) -> (State, usize, Class) {
+        let ch = self.chars[index];
+
+        if self.matches_at(index, "//") {
+            return (State::LineComment, 2, Class::Comment);
+        }
+        if self.matches_at(index, "/*") {
+            return (State::BlockComment(1), 2, Class::Comment);
+        }
+        if ch == '#' && self.hash_comments() {
+            return (State::LineComment, 1, Class::Comment);
+        }
+        if self.raw_strings() && (ch == 'r' || ch == 'b') {
+            if let Some((hashes, consumed)) = self.raw_string_opener(index) {
+                return (State::RawString(hashes), consumed, Class::String);
+            }
+        }
+        if ch == '"' {
+            return (State::Quoted('"'), 1, Class::String);
+        }
+        if ch == '`' && self.template_literals() {
+            return (State::Quoted('`'), 1, Class::String);
+        }
+        if ch == '\'' && self.single_quote_opens_a_literal(index) {
+            return (State::Quoted('\''), 1, Class::String);
+        }
+        (State::Code, 1, Class::Code)
+    }
+
+    /// Recognize `r"`, `r#"`, `br##"`, … and report the hash count and the
+    /// width of the opener.
+    fn raw_string_opener(&self, index: usize) -> Option<(usize, usize)> {
+        let mut cursor = index;
+        if self.chars.get(cursor) == Some(&'b') {
+            cursor += 1;
+        }
+        if self.chars.get(cursor) != Some(&'r') {
+            return None;
+        }
+        cursor += 1;
+        let hashes = self.hash_run(cursor);
+        cursor += hashes;
+        if self.chars.get(cursor) != Some(&'"') {
+            return None;
+        }
+        Some((hashes, cursor + 1 - index))
+    }
+
+    fn hash_run(&self, start: usize) -> usize {
+        let mut count = 0;
+        while self.chars.get(start + count) == Some(&'#') {
+            count += 1;
+        }
+        count
+    }
+
+    /// Distinguish a Rust char literal from a lifetime.
+    ///
+    /// `'a` in `&'a str` and `Foo<'_>` is not a string; treating it as one
+    /// would swallow source up to the next apostrophe. A char literal is
+    /// `'x'` or an escape like `'\n'`, so require a closing quote within the
+    /// short window one can occupy.
+    fn single_quote_opens_a_literal(&self, index: usize) -> bool {
+        if !self.raw_strings() {
+            // PHP and JS use `'` for ordinary strings.
+            return true;
+        }
+        match self.chars.get(index + 1) {
+            Some('\\') => true,
+            Some(_) => self.chars.get(index + 2) == Some(&'\''),
+            None => false,
+        }
+    }
+
+    fn matches_at(&self, index: usize, needle: &str) -> bool {
+        needle
+            .chars()
+            .enumerate()
+            .all(|(offset, expected)| self.chars.get(index + offset) == Some(&expected))
+    }
+}
+
+/// How a consumed run of characters projects into each mask.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Class {
+    Code,
+    Comment,
+    String,
+}
+
+/// Blank a character while preserving tabs, so column math and indentation-
+/// sensitive rendering survive masking.
+fn blank(ch: char) -> char {
+    if ch == '\t' {
+        '\t'
+    } else {
+        ' '
+    }
+}
+
+impl std::fmt::Debug for Scanner<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Scanner")
+            .field("language", &self.language)
+            .field("len", &self.content.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[path = "source_text_test.rs"]
+mod source_text_test;

--- a/crates/homeboy-code-audit/src/detectors/source_text_test.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_text_test.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+fn masks(content: &str) -> SourceMasks {
+    SourceMasks::new(content, Language::Rust)
+}
+
+#[test]
+fn line_comments_are_removed_from_the_code_projection() {
+    let masks = masks("let node = 1; // runs on every node\n");
+
+    assert_eq!(masks.code(0).trim_end(), "let node = 1;");
+    assert!(!masks.code(0).contains("runs on every"));
+}
+
+#[test]
+fn doc_comments_are_removed() {
+    // The dominant false-positive shape in homeboy #11298.
+    let masks = masks("/// Globals are identical on every node and are excluded.\nfn f() {}\n");
+
+    assert!(masks.code(0).trim().is_empty());
+    assert_eq!(masks.code(1), "fn f() {}");
+}
+
+#[test]
+fn inner_doc_comments_are_removed() {
+    let masks = masks("//! HOMEBOY_WRITE_CLI_REFERENCE=1 cargo test -p homeboy-cli\n");
+
+    assert!(masks.code(0).trim().is_empty());
+}
+
+#[test]
+fn block_comments_span_lines_and_nest() {
+    let masks = masks("a /* one\n two /* inner */ still comment */ b\n");
+
+    assert_eq!(masks.code(0).trim_end(), "a");
+    assert!(!masks.code(1).contains("inner"));
+    assert!(!masks.code(1).contains("still comment"));
+    assert!(masks.code(1).contains('b'));
+}
+
+#[test]
+fn masking_preserves_column_positions() {
+    // Findings report a line and a context; blanking rather than deleting keeps
+    // any column-derived reporting honest.
+    let source = "let x = 1; // cargo\n";
+    let masks = masks(source);
+
+    assert_eq!(masks.code(0).chars().count(), source.trim_end().len());
+    assert!(masks.code(0).starts_with("let x = 1; "));
+}
+
+#[test]
+fn comment_markers_inside_strings_do_not_start_a_comment() {
+    // The classic masker bug: a URL is not a comment.
+    let masks = masks("let url = \"https://example.com/node\"; let after = 2;\n");
+
+    assert!(masks.code(0).contains("after = 2"));
+    assert!(masks.code(0).contains("https://example.com/node"));
+}
+
+#[test]
+fn quote_inside_a_comment_does_not_open_a_string() {
+    let masks = masks("// it's fine\nlet real = \"kept\";\n");
+
+    assert!(masks.code(0).trim().is_empty());
+    assert!(masks.code(1).contains("kept"));
+}
+
+#[test]
+fn escaped_quotes_do_not_end_a_string() {
+    let masks = masks("let s = \"a\\\"b\"; let after = 1;\n");
+
+    assert!(masks.code(0).contains("after = 1"));
+    assert!(masks.strings(0).contains("a\\\"b"));
+}
+
+#[test]
+fn rust_raw_strings_are_string_spans() {
+    let masks = masks("let s = r#\"a \"quoted\" node\"#; let after = 1;\n");
+
+    assert!(masks.strings(0).contains("quoted"));
+    assert!(masks.code(0).contains("after = 1"));
+}
+
+#[test]
+fn rust_lifetimes_are_not_char_literals() {
+    // `'a` must not open a string and swallow the rest of the line.
+    let masks = masks("fn f<'a>(x: &'a str) -> &'a str { x }\n");
+
+    assert!(masks.code(0).contains("-> &'a str { x }"));
+    assert!(
+        masks.strings(0).trim().is_empty(),
+        "lifetimes are code, not strings: {:?}",
+        masks.strings(0)
+    );
+}
+
+#[test]
+fn rust_char_literals_are_string_spans() {
+    let masks = masks("let c = 'x'; let n = '\\n';\n");
+
+    assert!(masks.strings(0).contains('x'));
+    assert!(masks.code(0).contains("let c ="));
+}
+
+#[test]
+fn string_projection_keeps_only_literals() {
+    let masks = masks("run_tool(\"florp-run\", node);\n");
+
+    assert!(masks.strings(0).contains("florp-run"));
+    assert!(
+        !masks.strings(0).contains("run_tool"),
+        "identifiers must not appear in the string projection: {:?}",
+        masks.strings(0)
+    );
+    assert!(
+        !masks.strings(0).contains("node"),
+        "a local variable is not a string literal: {:?}",
+        masks.strings(0)
+    );
+}
+
+#[test]
+fn string_projection_preserves_seam_punctuation() {
+    // `detect_split` looks for `"car", "go"`; blanking the comma would hide it.
+    let masks = masks("let joined = [\"car\", \"go\"].concat();\n");
+
+    assert!(masks.strings(0).contains("\"car\", \"go\""));
+}
+
+#[test]
+fn php_hash_comments_are_removed() {
+    let masks = SourceMasks::new("$x = 1; # uses composer\n", Language::Php);
+
+    assert_eq!(masks.code(0).trim_end(), "$x = 1;");
+}
+
+#[test]
+fn php_single_quoted_strings_are_string_spans() {
+    let masks = SourceMasks::new("$cmd = 'composer install';\n", Language::Php);
+
+    assert!(masks.strings(0).contains("composer install"));
+}
+
+#[test]
+fn javascript_template_literals_are_string_spans() {
+    let masks = SourceMasks::new("const c = `npm ci`;\n", Language::JavaScript);
+
+    assert!(masks.strings(0).contains("npm ci"));
+}
+
+#[test]
+fn javascript_does_not_nest_block_comments() {
+    // Only Rust nests; in JS the first `*/` closes the comment.
+    let masks = SourceMasks::new("/* /* */ const after = 1;\n", Language::JavaScript);
+
+    assert!(masks.code(0).contains("const after = 1"));
+}
+
+#[test]
+fn out_of_range_lines_are_empty_rather_than_panicking() {
+    let masks = masks("fn f() {}\n");
+
+    assert_eq!(masks.code(99), "");
+    assert_eq!(masks.strings(99), "");
+}
+
+#[test]
+fn unterminated_block_comment_does_not_panic() {
+    let masks = masks("fn f() {} /* never closed\nstill comment\n");
+
+    assert!(masks.code(0).contains("fn f() {}"));
+    assert!(masks.code(1).trim().is_empty());
+}

--- a/homeboy.json
+++ b/homeboy.json
@@ -120,6 +120,7 @@
       {
         "allow_line_contains": [
           "audit-allow-cargo-secondary-key",
+          "cargo:rerun-if-changed",
           "clippy::",
           "Extra-Chill/homeboy",
           "target/release/homeboy"
@@ -326,7 +327,8 @@
             "value": "python3"
           },
           {
-            "value": "node"
+            "value": "node",
+            "context": "string_literal"
           },
           {
             "value": "opencode"


### PR DESCRIPTION
Fixes #11330.

## What was actually wrong

Neither cause is the term list.

**1. Comments were being scanned.** #6857's fix (`06d9e355a`, 2026-07-24) added comment-prefix skipping to `CoreBoundaryLeakConfig::to_source_policy_rules()` — the *preset*. The rule producing the 409 findings on #11298 is not the preset; it is a generic `source_policies` entry in `homeboy.json` with `id: core-agnostic-source`, and it has no `ignore_line_prefixes`. The fix never reached it.

I confirmed the audit ran a from-source binary at the audited SHA (`Built from source: homeboy 0.327.8+76c6c50cdc1a`), so this is not a stale-binary artifact.

A per-config opt-in was the wrong shape regardless: every component that writes a source policy walks into the same trap, silently.

**2. The engine could not tell a name from a mention.** `node` matches a local variable as readily as `Command::new("node")`. Line-prefix skipping also only handles *whole-line* comments — a term in a trailing comment still matched.

## The fix

`SourceMasks` (`detectors/source_text.rs`) scans each file once into two same-shaped projections, with excluded regions blanked to spaces so line numbers, columns, and token boundaries all survive:

- `code` — comments removed. What the file *does*.
- `strings` — only string-literal spans. What the file *names*.

It is a lexer, not a parser: nested block comments (Rust nests, JS does not), raw strings `r#"..."#`, escapes, PHP `#` comments, JS template literals, and — the classic trap — Rust char literals distinguished from lifetimes, so `&'a str` does not swallow the line. Seam punctuation is preserved in the string projection so `detect_split` still sees `"car", "go"`.

Two config surfaces:

- `SourcePolicyRule::scan_comments` (default **false**) — comment masking is now the engine's default for every source policy, with an opt-in for policies genuinely about comment text (banned TODO markers, licence headers).
- `SourcePolicyTerm::context` (default `code`) — `string_literal` scopes a term to data. Ecosystem knowledge that leaks into core does so as command names, filenames, and error substrings.

## Config change, deliberately minimal

```diff
   "allow_line_contains": [
     "audit-allow-cargo-secondary-key",
+    "cargo:rerun-if-changed",
...
   {
-    "value": "node"
+    "value": "node",
+    "context": "string_literal"
   },
```

**No term removed.** `nodejs` and `node_modules` keep full strength, so Node.js detection is not weakened — and `node` still fires on `Command::new("node")`, the `"node"` gate argv, and `.nvm/versions/node`.

I measured the other ordinary-word candidates (`playground`, `brew`, `yarn`, `cellar`, `gemini`, `claude`) rather than assuming: scoping them changes the count by **zero** on this tree. That is risk with no benefit, so they stay at full strength.

`rust` also stays at full strength deliberately. Its remaining hits are `Language::Rust` in core — real ecosystem knowledge, and precisely the subject of #6855. Narrowing it would have hidden a true positive.

The Cargo directive is allowlisted rather than detected because `println!("cargo:rerun-if-changed=")` is the build-script protocol; no Rust build script can omit it. There is a test pinning that it is the *allowlist* silencing it and not the comment mask, so the allowlist cannot rot into hiding real string-literal leaks.

## Measured effect

Replaying the real rule (real terms, real excludes, real match modes) over the real tree:

| stage | matches |
|---|---|
| baseline (today) | 605 |
| + comment mask | 335 (−270) |
| + `node` string-literal scope | 300 (−35) |
| + Cargo directive allowlist | **293** |

**51% reduction.** Raw match count, before the fingerprint dedup that produces the number on the issue — the ratio is the meaningful figure, not the absolute.

Per term, `node` goes 74 → 13 and every survivor is a genuine Node.js reference.

## Tests

- `source_text_test.rs` — 19 tests on the lexer: doc/inner-doc/block/nested comments, `//` inside a URL, quote inside a comment, escaped quotes, raw strings, **lifetimes vs char literals**, PHP `#`, JS template literals, JS non-nesting, column preservation, seam punctuation, unterminated comment, out-of-range lines.
- `source_policy_context_test.rs` — every case is a verbatim line from #11298 at the audited SHA, reproduced rather than paraphrased. Includes the two invariants that keep this from becoming a mask for real problems: a leak on a line that *also* carries a comment is still reported, and an unscoped term still matches identifiers so `fn wordpress_plugin_path()` remains a finding.

Verified `cargo check --workspace --tests` clean and `cargo clippy` clean on the touched crates. The 19 lexer tests were additionally run standalone under `rustc --test` (all pass) since this host cannot run the crate's test binary — `homeboy-code-audit`'s dev-dependencies pull in `homeboy-core`. Full execution left to CI.

## Note

`CoreBoundaryLeakConfig::to_source_policy_rules()` still sets `ignore_line_prefixes` to comment prefixes. That is now redundant with engine-level masking but harmless, and I left it rather than widen the blast radius of this change.