### PR TITLE
feat(cook): finish intentional no-change outcomes

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
@@ -65,6 +65,8 @@ pub enum CookStatus {
     ReviewReady,
     /// Gates were green but finalization was intentionally not performed.
     GreenNoFinalize,
+    /// A verified provider review intentionally produced no candidate patch.
+    IntentionalNoChange,
     /// Finalization ran and found no changed files.
     NoChanges,
     /// A no-op candidate failed its gates.
@@ -118,6 +120,7 @@ impl CookStatus {
             "completed" => Self::Completed,
             "review_ready" => Self::ReviewReady,
             "green_no_finalize" => Self::GreenNoFinalize,
+            "intentional_no_change" => Self::IntentionalNoChange,
             "no_changes" => Self::NoChanges,
             "no_op_gate_failed" => Self::NoOpGateFailed,
             "gate_failed" => Self::GateFailed,
@@ -148,6 +151,7 @@ impl CookStatus {
             Self::Completed => "completed",
             Self::ReviewReady => "review_ready",
             Self::GreenNoFinalize => "green_no_finalize",
+            Self::IntentionalNoChange => "intentional_no_change",
             Self::NoChanges => "no_changes",
             Self::NoOpGateFailed => "no_op_gate_failed",
             Self::GateFailed => "gate_failed",
@@ -195,6 +199,7 @@ impl CookStatus {
                 | Self::InFlight
                 | Self::ReviewReady
                 | Self::GreenNoFinalize
+                | Self::IntentionalNoChange
         )
     }
 }
@@ -277,6 +282,7 @@ mod tests {
             "completed",
             "review_ready",
             "green_no_finalize",
+            "intentional_no_change",
             "no_changes",
             "gate_failed",
             "awaiting_acceptance",
@@ -342,6 +348,7 @@ mod tests {
             CookStatus::Completed,
             CookStatus::ReviewReady,
             CookStatus::GreenNoFinalize,
+            CookStatus::IntentionalNoChange,
             CookStatus::NoChanges,
             CookStatus::NoOpGateFailed,
             CookStatus::GateFailed,
@@ -375,13 +382,14 @@ mod tests {
     /// Pins the exit-code vocabulary that previously lived as a separate
     /// string list, so it cannot drift from terminality again.
     #[test]
-    fn success_exit_covers_in_flight_plus_the_two_green_terminal_states() {
+    fn success_exit_covers_in_flight_and_candidate_free_terminal_successes() {
         for status in [
             "queued",
             "running",
             "in_flight",
             "review_ready",
             "green_no_finalize",
+            "intentional_no_change",
         ] {
             assert!(
                 CookStatus::from_status(status).is_success_exit(),

--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -65,6 +65,8 @@ pub struct AgentTaskCookLoopReport {
     pub failed_gate_results: Vec<HomeboyGateResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub follow_up_request: Option<AgentTaskRequest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intentional_no_change: Option<AgentTaskIntentionalNoChange>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -73,6 +75,7 @@ pub struct AgentTaskCookLoopReport {
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskCookLoopStatus {
     GreenCompleted,
+    IntentionalNoChange,
     NoChanges,
     NoOpGateFailed,
     RetryRequested,
@@ -97,8 +100,44 @@ pub enum AgentTaskCookLoopQualityClassification {
     LargeOrRiskyPatch,
     VerifiedPatch,
     VerifiedNoOp,
+    IntentionalNoChange,
     Regressing,
     Stagnating,
+}
+
+/// Provider-declared disposition for a review that intentionally produced no
+/// patch. The declaration is accepted only after provider normalization binds
+/// it to a clean, inspected workspace revision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskIntentionalNoChange {
+    pub schema: String,
+    pub verdict: AgentTaskIntentionalNoChangeVerdict,
+    pub inspected_revision: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub next_action: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskIntentionalNoChangeVerdict {
+    Blocked,
+    AlreadySatisfied,
+    /// Legacy `no_change` declarations deserialize as this unambiguous review
+    /// outcome, preserving existing providers while exposing the typed contract.
+    #[serde(alias = "no_change")]
+    InvestigationOnly,
+}
+
+impl std::fmt::Display for AgentTaskIntentionalNoChangeVerdict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Blocked => "blocked",
+            Self::AlreadySatisfied => "already_satisfied",
+            Self::InvestigationOnly => "investigation_only",
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -174,7 +213,18 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         .filter(|gate| gate.status == HomeboyGateStatus::Failed)
         .collect();
     let retry_budget_remaining = options.max_attempts.saturating_sub(options.attempt);
-    let mut quality = classify_cook_loop_quality(&options.promotion_report);
+    let intentional_no_change = (options.promotion_report.status
+        == AgentTaskPromotionStatus::VerifiedNoChanges)
+        .then(|| {
+            options
+                .metadata
+                .get("intentional_no_change")
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok())
+        })
+        .flatten();
+    let mut quality =
+        classify_cook_loop_quality(&options.promotion_report, intentional_no_change.is_some());
     let failure_progression = failure_progression(&options, &failed_gates);
     apply_failure_progression_to_quality(&mut quality, &failure_progression);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
@@ -211,6 +261,8 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         AgentTaskCookLoopStatus::RetryRequested
     } else if options.promotion_report.status == AgentTaskPromotionStatus::NoChangesGateFailed {
         AgentTaskCookLoopStatus::NoOpGateFailed
+    } else if intentional_no_change.is_some() {
+        AgentTaskCookLoopStatus::IntentionalNoChange
     } else if quality.classification == AgentTaskCookLoopQualityClassification::NoChanges {
         AgentTaskCookLoopStatus::NoChanges
     } else if !failed_gates.is_empty() {
@@ -236,13 +288,29 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         failed_gates,
         failed_gate_results,
         follow_up_request,
+        intentional_no_change,
         metadata: report_metadata(options.metadata, &failure_progression),
     }
 }
 
-fn classify_cook_loop_quality(report: &AgentTaskPromotionReport) -> AgentTaskCookLoopQualityReport {
+fn classify_cook_loop_quality(
+    report: &AgentTaskPromotionReport,
+    intentional_no_change: bool,
+) -> AgentTaskCookLoopQualityReport {
     let changed_file_count = report.changed_files.len();
     if changed_file_count == 0 {
+        if intentional_no_change {
+            return AgentTaskCookLoopQualityReport {
+                classification: AgentTaskCookLoopQualityClassification::IntentionalNoChange,
+                summary: "provider intentionally completed review without a candidate patch"
+                    .to_string(),
+                signals: vec![
+                    "changed_files=0".to_string(),
+                    "intentional_no_change=verified".to_string(),
+                ],
+                failure_progression: None,
+            };
+        }
         if report.status == AgentTaskPromotionStatus::VerifiedNoChanges {
             return AgentTaskCookLoopQualityReport {
                 classification: AgentTaskCookLoopQualityClassification::VerifiedNoOp,
@@ -1062,6 +1130,52 @@ mod tests {
 
     #[test]
     fn verified_no_op_completes_and_failed_no_op_is_terminal_failure() {
+        let intentional = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report_with_changed_files(
+                AgentTaskPromotionStatus::VerifiedNoChanges,
+                vec![green_gate()],
+                Vec::new(),
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-intentional-no-change".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: json!({
+                "intentional_no_change": {
+                    "schema": "homeboy/intentional-no-change/v1",
+                    "verdict": "blocked",
+                    "inspected_revision": "abc123",
+                    "next_action": "Add the missing owning-layer contract.",
+                    "source_evidence": ["homeboy://evidence/provider-review"],
+                }
+            }),
+        });
+        assert_eq!(
+            intentional.status,
+            AgentTaskCookLoopStatus::IntentionalNoChange
+        );
+        assert_eq!(
+            intentional.quality.classification,
+            AgentTaskCookLoopQualityClassification::IntentionalNoChange
+        );
+        let declaration = intentional.intentional_no_change.unwrap();
+        assert_eq!(
+            declaration.verdict,
+            AgentTaskIntentionalNoChangeVerdict::Blocked
+        );
+        assert_eq!(
+            declaration.next_action,
+            "Add the missing owning-layer contract."
+        );
+        assert_eq!(
+            declaration.source_evidence,
+            vec!["homeboy://evidence/provider-review"]
+        );
+        assert!(intentional.follow_up_request.is_none());
+
         let verified = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request: source_request(),
             promotion_report: promotion_report_with_changed_files(

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -321,6 +321,7 @@ mod tests {
             disposition: homeboy_core::cook_status::CookDisposition::Terminal,
             attempts: Vec::new(),
             finalization,
+            intentional_no_change: None,
             selected_candidate: None,
             stop_reason: None,
             terminal_phase: None,

--- a/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
@@ -110,8 +110,18 @@ enum IntentionalNoChangeVerdict {
 #[derive(serde::Deserialize)]
 struct IntentionalNoChangeDeclaration {
     schema: String,
-    verdict: String,
+    #[serde(rename = "verdict")]
+    _verdict: IntentionalNoChangeDisposition,
     inspected_revision: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum IntentionalNoChangeDisposition {
+    Blocked,
+    AlreadySatisfied,
+    #[serde(alias = "no_change")]
+    InvestigationOnly,
 }
 
 /// A provider may declare a no-change review only through this versioned result
@@ -132,12 +142,11 @@ fn intentional_no_change_verdict(
     let Ok(declaration) = serde_json::from_value::<IntentionalNoChangeDeclaration>(verdict.clone())
     else {
         return IntentionalNoChangeVerdict::Invalid(
-            "provider declared an intentional no-change verdict without a valid schema, no_change verdict, and inspected workspace revision; changes require recovery review"
+            "provider declared an intentional no-change verdict without a valid schema, supported disposition, and inspected workspace revision; changes require recovery review"
                 .to_string(),
         );
     };
     if declaration.schema != INTENTIONAL_NO_CHANGE_SCHEMA
-        || declaration.verdict != "no_change"
         || declaration.inspected_revision.trim().is_empty()
     {
         return IntentionalNoChangeVerdict::Invalid(

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -472,8 +472,10 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
         "status": "succeeded",
         "intentional_no_change": {
             "schema": "homeboy/intentional-no-change/v1",
-            "verdict": "no_change",
+            "verdict": "investigation_only",
             "inspected_revision": revision,
+            "next_action": "Record the review conclusion with the owning team.",
+            "source_evidence": ["provider://review/transcript"],
         }
     }));
     outcome.status = AgentTaskOutcomeStatus::Succeeded;

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use crate::agent_task_cook_loop::{
     evaluate_cook_loop, AgentTaskCookLoopOptions, AgentTaskCookLoopReport, AgentTaskCookLoopStatus,
+    AgentTaskIntentionalNoChange,
 };
 use crate::agent_task_dispatch_plan::{build_dispatch_plan, validate_single_cook_prompt_source};
 use crate::agent_task_dispatch_service::{self, AgentTaskDispatchCommand};
@@ -115,6 +116,19 @@ fn pre_artifact_interruption_phase(
     } else {
         PreArtifactInterruptionPhase::AfterProviderReturn
     }
+}
+
+fn intentional_no_change_from_aggregate(
+    aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
+) -> Option<AgentTaskIntentionalNoChange> {
+    aggregate.outcomes.iter().find_map(|outcome| {
+        let declaration = outcome
+            .outputs
+            .get("provider_run_result")?
+            .get("intentional_no_change")?
+            .clone();
+        serde_json::from_value::<AgentTaskIntentionalNoChange>(declaration).ok()
+    })
 }
 
 fn pre_artifact_execution_count(record: &agent_task_lifecycle::AgentTaskRunRecord) -> u32 {
@@ -702,6 +716,10 @@ pub struct AgentTaskCookReport {
     pub attempts: Vec<AgentTaskCookAttemptReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finalization: Option<Value>,
+    /// A verified review outcome that intentionally has no candidate to promote
+    /// or finalize.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intentional_no_change: Option<AgentTaskCookIntentionalNoChangeReport>,
     /// Candidate authority is separate from `latest_run_id`, which remains the
     /// chronological invocation/index compatibility field.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -721,6 +739,14 @@ pub struct AgentTaskCookReport {
     /// evidence; operators retrieve that through the listed diagnose command.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_context: Option<AgentTaskCookFailureContext>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookIntentionalNoChangeReport {
+    #[serde(flatten)]
+    pub declaration: AgentTaskIntentionalNoChange,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_form: Option<crate::agent_task_review_dossier::AiFilledReviewForm>,
 }
 
 /// Durable identity and legal recovery surface for a failed Cook.
@@ -2646,6 +2672,7 @@ where
         }
 
         let review_form = review_form_from_aggregate(&aggregate)?;
+        let intentional_no_change = intentional_no_change_from_aggregate(&aggregate);
         let previous_failure_set = attempts
             .last()
             .and_then(|attempt| attempt.feedback.as_ref())
@@ -2663,8 +2690,11 @@ where
             // The form is publication evidence. A no-finalize Cook preserves
             // the verified patch for review without entering finalization.
             require_review_form: !options.no_finalize,
-            review_form,
-            metadata: serde_json::json!({"previous_failure_set": previous_failure_set}),
+            review_form: review_form.clone(),
+            metadata: serde_json::json!({
+                "previous_failure_set": previous_failure_set,
+                "intentional_no_change": intentional_no_change,
+            }),
         });
         let feedback_status = feedback.status;
         let follow_up_request = feedback.follow_up_request.clone();
@@ -2678,6 +2708,34 @@ where
         });
 
         match feedback_status {
+            AgentTaskCookLoopStatus::IntentionalNoChange => {
+                let declaration = feedback
+                    .intentional_no_change
+                    .expect("intentional no-change feedback carries its declaration");
+                let mut report = cook_report(CookReportInput {
+                    cook_id,
+                    status: "intentional_no_change",
+                    disposition: CookDisposition::Terminal,
+                    attempts,
+                    finalization: None,
+                    stop_reason: Some(format!(
+                        "provider completed a verified {} review without a candidate patch; publication was skipped{}",
+                        declaration.verdict,
+                        declaration
+                            .next_action
+                            .is_empty()
+                            .then(String::new)
+                            .unwrap_or_else(|| format!("; next action: {}", declaration.next_action))
+                    )),
+                    exit_code: 0,
+                    invocation_latest_run_id: Some(&run_id),
+                });
+                report.value.intentional_no_change = Some(AgentTaskCookIntentionalNoChangeReport {
+                    declaration,
+                    review_form,
+                });
+                return Ok(report);
+            }
             AgentTaskCookLoopStatus::GreenCompleted => {
                 if options.no_finalize {
                     return Ok(cook_report(CookReportInput {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2505,6 +2505,7 @@ pub(crate) fn cook_report(input: CookReportInput<'_>) -> AgentTaskRunResult<Agen
             disposition,
             attempts,
             finalization,
+            intentional_no_change: None,
             selected_candidate,
             stop_reason,
             terminal_phase: None,


### PR DESCRIPTION
## Summary

- add a first-class terminal `intentional_no_change` Cook status
- normalize blocked, already-satisfied, and investigation-only dispositions
- skip publication for verified no-change outcomes while retaining review/source evidence
- preserve accidental empty-patch rejection and legacy no-change compatibility

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-agents -p homeboy-core`
- `cargo test -p homeboy-agents agent_task_cook_loop::tests::verified_no_op_completes_and_failed_no_op_is_terminal_failure --no-fail-fast`
- `cargo test -p homeboy-agents agent_task_provider::tests::outcome_tests::revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_checkout --no-fail-fast`
- `cargo test -p homeboy-lifecycle-contract cook_status::tests --no-fail-fast`
- `git diff --check`

Closes #11333.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents designed, implemented, and verified the typed no-change Cook outcome. Chris Huber remains responsible for every line.
