### PR TITLE
fix(cook): continue from latest failed attempt

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1175,9 +1175,9 @@ pub fn reconstruct_adoption_options(
     reconstruct_recipe_options(recipe, None, false, false)
 }
 
-/// Resolve a Cook identifier to the durable attempt whose controller runtime
-/// owns continuation. Both the CLI re-exec boundary and the Cook handler use
-/// this so an upgraded controller cannot select different attempts.
+/// Resolve a Cook identifier to its latest durable attempt. Candidate selection
+/// is promotion authority, not continuation authority: a failed gate-feedback
+/// attempt must remain the source of the next retry.
 pub fn resolve_cook_continuation_run_id(cook_or_attempt_id: &str) -> Result<String> {
     let recipe = match load_recipe(cook_or_attempt_id) {
         // A Cook ID can also be its original attempt's run ID. In that case the
@@ -1188,53 +1188,29 @@ pub fn resolve_cook_continuation_run_id(cook_or_attempt_id: &str) -> Result<Stri
             return Ok(cook_or_attempt_id.to_string());
         }
     };
-    if !agent_task_lifecycle::cook_index_exists(&recipe.cook_id)? {
-        let attempts = recipe
+    let run_id = if agent_task_lifecycle::cook_index_exists(&recipe.cook_id)? {
+        agent_task_lifecycle::cook_index(&recipe.cook_id)?.latest_run_id
+    } else {
+        recipe
             .attempts
-            .iter()
-            .map(|attempt| agent_task_lifecycle::AgentTaskCookIndexAttempt {
-                attempt: attempt.attempt,
-                run_id: attempt.run_id.clone(),
-                recorded_at: String::new(),
-            })
-            .collect();
-        let selection =
-            agent_task_lifecycle::select_cook_candidate_from_attempts(&recipe.cook_id, attempts)?;
-        if selection.incomplete {
-            return Err(Error::validation_invalid_argument(
-                "cook_id",
-                "candidate selection is incomplete after its bounded recovery window",
-                Some(recipe.cook_id.clone()),
-                None,
-            ));
-        }
-        return Ok(selection.run_id);
-    }
-    let selection = agent_task_lifecycle::select_cook_candidate(&recipe.cook_id)?;
-    if selection.incomplete {
+            .last()
+            .expect("validated recipe has an attempt")
+            .run_id
+            .clone()
+    };
+    if !recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == run_id)
+    {
         return Err(Error::validation_invalid_argument(
             "cook_id",
-            "candidate selection is incomplete after its bounded recovery window",
+            "Cook index latest attempt is not declared by the durable recipe",
             Some(recipe.cook_id.clone()),
             None,
         ));
     }
-    Ok(Some(selection.run_id)
-        .filter(|run_id| !run_id.is_empty())
-        .filter(|run_id| {
-            recipe
-                .attempts
-                .iter()
-                .any(|attempt| attempt.run_id == *run_id)
-        })
-        .unwrap_or_else(|| {
-            recipe
-                .attempts
-                .last()
-                .expect("validated recipe has an attempt")
-                .run_id
-                .clone()
-        }))
+    Ok(run_id)
 }
 
 /// Adoption accepts historical policy, but a remediation retry still needs the

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5027,71 +5027,75 @@ fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empt
 }
 
 #[test]
-fn cook_alias_continuation_uses_the_candidate_selected_after_adoption_and_gate_feedback() {
+fn cook_alias_continuation_starts_from_failed_gate_feedback_attempt() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("candidate artifacts");
         let cook_id = "cook-alias-selected-attempt";
         // Attempt one deliberately shares the Cook ID, matching the durable
-        // identity shape that previously bypassed candidate selection.
+        // identity shape that previously bypassed continuation selection.
         let original_run_id = cook_id;
-        let adoption_run_id = "cook-alias-selected-attempt-attempt-2-adoption";
-        let gate_feedback_run_id = "cook-alias-selected-attempt-attempt-3-gate-feedback";
+        let gate_feedback_run_id = "cook-alias-selected-attempt-attempt-2-gate-feedback";
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.max_attempts = 3;
         options.initial_run_id = original_run_id.to_string();
         super::super::persist_initial_recipe(&options).expect("persist recipe");
-        super::super::record_recipe_attempt(cook_id, 2, adoption_run_id, &options.initial_plan)
-            .expect("persist adoption recipe attempt");
         super::super::record_recipe_attempt(
             cook_id,
-            3,
+            2,
             gate_feedback_run_id,
             &options.initial_plan,
         )
         .expect("persist gate-feedback recipe attempt");
-        for (attempt, run_id) in [
-            (1, original_run_id),
-            (2, adoption_run_id),
-            (3, gate_feedback_run_id),
-        ] {
+        for (attempt, run_id) in [(1, original_run_id), (2, gate_feedback_run_id)] {
             agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
                 .expect("persist lifecycle record");
             agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
                 .expect("persist Cook attempt");
         }
         let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
-        for (run_id, name) in [
-            (original_run_id, "original.patch"),
-            (adoption_run_id, "adoption.patch"),
-            (gate_feedback_run_id, "gate-feedback.patch"),
-        ] {
-            seed_substantive_candidate_aggregate(
-                run_id,
-                &options.initial_plan,
-                &temp.path().join(name),
-                patch,
-            );
-        }
+        seed_substantive_candidate_aggregate(
+            original_run_id,
+            &options.initial_plan,
+            &temp.path().join("original.patch"),
+            patch,
+        );
+        seed_review_form_aggregate(gate_feedback_run_id, &options.initial_plan);
+        let mut gate_feedback = promotion(gate_feedback_run_id);
+        gate_feedback.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
+        gate_feedback.deterministic_gates[0].status =
+            crate::agent_task_gate::AgentTaskGateStatus::Failed;
+        gate_feedback.deterministic_gates[0].exit_code = 1;
+        agent_task_lifecycle::record_promotion(
+            gate_feedback_run_id,
+            serde_json::to_value(gate_feedback).expect("serialize failed gate-feedback evidence"),
+        )
+        .expect("persist failed gate-feedback evidence");
 
         let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
-            .expect("select advanced durable candidate");
-        assert_eq!(selection.run_id, gate_feedback_run_id);
-        assert_eq!(selection.attempt, 3);
+            .expect("select earlier substantive candidate for promotion");
+        assert_eq!(selection.run_id, original_run_id);
+        assert_eq!(selection.attempt, 1);
         assert_eq!(selection.reason, "latest_substantive_candidate_pointer");
 
-        let selected_run_id = super::super::resolve_cook_continuation_run_id(cook_id)
-            .expect("Cook alias resolves selected candidate");
-        assert_eq!(selected_run_id, gate_feedback_run_id);
+        let continuation_run_id = super::super::resolve_cook_continuation_run_id(cook_id)
+            .expect("Cook alias resolves latest failed gate-feedback attempt");
+        assert_eq!(continuation_run_id, gate_feedback_run_id);
         assert_eq!(
-            super::super::resolve_cook_continuation_run_id(adoption_run_id)
+            super::super::resolve_cook_continuation_run_id(gate_feedback_run_id)
                 .expect("exact distinct attempt remains addressable"),
-            adoption_run_id
+            gate_feedback_run_id
         );
         let recipe = super::super::load_recipe(cook_id).expect("load recipe");
-        let record =
-            super::super::reconcile_recipe_attempt_for_continuation(&recipe, &selected_run_id)
-                .expect("selected candidate passes strict Cook identity fence");
-        assert_eq!(record.run_id, gate_feedback_run_id);
-        super::super::validate_recipe_attempt_record(&recipe, &selected_run_id, &record)
+        assert_eq!(
+            resumable_cook_run_id(&recipe, cook_id, &continuation_run_id, 2, false),
+            None,
+            "continuation resumes attempt 2 so the remaining budget reaches attempt 3"
+        );
+        assert!(agent_task_lifecycle::cook_attempt_run_id(cook_id, 3)
+            .starts_with(&format!("{cook_id}-attempt-3-")));
+        let record = agent_task_lifecycle::status(&continuation_run_id)
+            .expect("failed gate-feedback attempt remains inspectable");
+        super::super::validate_recipe_attempt_record(&recipe, &continuation_run_id, &record)
             .expect("matching Cook metadata passes the identity fence");
         let mut cross_cook_record = record;
         cross_cook_record.ensure_metadata_object().insert(
@@ -5100,7 +5104,7 @@ fn cook_alias_continuation_uses_the_candidate_selected_after_adoption_and_gate_f
         );
         let error = super::super::validate_recipe_attempt_record(
             &recipe,
-            &selected_run_id,
+            &continuation_run_id,
             &cross_cook_record,
         )
         .expect_err("cross-Cook metadata must fail the identity fence");


### PR DESCRIPTION
## Summary

- resolve Cook alias continuation from the recipe-bound latest run rather than the promotable candidate
- validate the selected attempt against the Cook's immutable attempt list
- preserve exact attempt-ID inspection and cross-Cook rejection
- add substantive attempt 1, failed attempt 2, and attempt-3 continuation coverage

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents cook_alias_continuation_starts_from_failed_gate_feedback_attempt --lib`
- `cargo check -p homeboy-agents`
- `git diff --check`

Closes #11335.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents reproduced, repaired, and verified Cook alias continuation. Chris Huber remains responsible for every line.
