### PR TITLE
fix(lab): bundle complete partial clone snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -234,9 +234,8 @@ pub(super) fn materialize_git_from_controller_bundle(
 }
 
 /// Materialize a controller Git workspace as its exact captured commit, then
-/// apply its filtered working-tree contents. Prefer the runner's configured
-/// remote so partial controller clones never need to hydrate historical
-/// promisor objects. An unpublished commit falls back to a controller bundle.
+/// apply its filtered working-tree contents. The controller completes and
+/// transfers the object closure; a Lab must never contact the source remote.
 pub(super) fn materialize_git_snapshot_from_controller_bundle(
     runner: &Runner,
     local_path: &Path,
@@ -247,83 +246,21 @@ pub(super) fn materialize_git_snapshot_from_controller_bundle(
     let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
         .ok()
         .filter(|branch| branch != "HEAD");
-    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"]).ok();
-    if let Some(remote_url) = remote_url.as_deref().filter(|url| !url.trim().is_empty()) {
-        match materialize_git(
-            runner,
-            remote_path,
-            remote_url,
-            &head,
-            branch.as_deref(),
-            None,
-            &[],
-            false,
-        ) {
-            Ok(()) => {
-                materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
-                return Ok(None);
-            }
-            Err(runner_error) => {
-                return materialize_git_snapshot_from_controller_bundle_fallback(
-                    runner,
-                    local_path,
-                    remote_path,
-                    excludes,
-                    &head,
-                    branch.as_deref(),
-                    remote_url,
-                    Some(runner_error),
-                );
-            }
-        }
-    }
-    materialize_git_snapshot_from_controller_bundle_fallback(
+    let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| "homeboy-controller-bundle".to_string());
+    let provenance = materialize_git_from_controller_bundle(
         runner,
         local_path,
         remote_path,
-        excludes,
         &head,
         branch.as_deref(),
-        "homeboy-controller-bundle",
-        None,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn materialize_git_snapshot_from_controller_bundle_fallback(
-    runner: &Runner,
-    local_path: &Path,
-    remote_path: &str,
-    excludes: &[String],
-    head: &str,
-    branch: Option<&str>,
-    remote_url: &str,
-    runner_error: Option<Error>,
-) -> Result<Option<ControllerGitBundleProvenance>> {
-    let result = materialize_git_from_controller_bundle(
-        runner,
-        local_path,
-        remote_path,
-        head,
-        branch,
-        remote_url,
+        &remote_url,
         None,
         &[],
         false,
-    );
-    let provenance = match result {
-        Ok(provenance) => provenance,
-        Err(bundle_error) => {
-            let runner_diagnostic = runner_error.map_or_else(
-                || "runner-side exact-SHA materialization was unavailable because the source has no origin remote".to_string(),
-                |error| error.message,
-            );
-            return Err(Error::internal_unexpected(format!(
-                "could not materialize exact Git commit `{head}`: runner-side checkout failed: {runner_diagnostic}; controller bundle fallback failed: {}",
-                bundle_error.message
-            )));
-        }
-    };
+    )?;
     materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
     Ok(Some(provenance))
 }
@@ -336,6 +273,7 @@ fn sha256_file(path: &Path) -> Result<String> {
 /// promisor remote itself. The controller is the only participant allowed to
 /// use the source checkout's authenticated transport.
 fn hydrate_controller_bundle_objects(local_path: &Path, refs: &[String]) -> Result<()> {
+    repair_controller_bundle_commit_closure(local_path, refs)?;
     let mut object_list = Command::new("git")
         // A stale commit graph can name promisor objects that do not exist in
         // the local database. Walk the repaired closure from real objects so
@@ -409,6 +347,20 @@ fn hydrate_controller_bundle_objects(local_path: &Path, refs: &[String]) -> Resu
         );
     }
 
+    if let Some(remote) = promisor_remote(local_path)? {
+        let missing = missing_promisor_objects(local_path, refs)?;
+        if !missing.is_empty() {
+            return Err(controller_object_closure_error(
+                "hydrate git bundle objects completed with required promisor objects still unavailable",
+                None,
+                local_path,
+                &remote,
+                refs,
+                &missing,
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -474,9 +426,14 @@ fn refetch_controller_bundle_commits(
     // `incomplete_refs` was derived from explicit missing-object probe output
     // in a promisor-configured checkout. The transport result itself stays out
     // of provenance: it may contain credentials or remote implementation data.
+    let missing = missing_promisor_objects(local_path, refs).unwrap_or_default();
     Err(controller_object_closure_error(
         "refetch controller git bundle commits failed while required promisor objects remained unavailable",
         output.status.code(),
+        local_path,
+        remote,
+        refs,
+        &missing,
     ))
 }
 
@@ -487,21 +444,50 @@ fn controller_bundle_failure(
     exit_status: Option<i32>,
 ) -> Result<()> {
     match has_reported_missing_promisor_objects(local_path, refs) {
-        Ok(true) => Err(controller_object_closure_error(
-            format!("{action} failed while required promisor objects remained unavailable"),
-            exit_status,
-        )),
+        Ok(true) => {
+            let remote = promisor_remote(local_path)?.unwrap_or_default();
+            let missing = missing_promisor_objects(local_path, refs)?;
+            Err(controller_object_closure_error(
+                format!("{action} failed while required promisor objects remained unavailable"),
+                exit_status,
+                local_path,
+                &remote,
+                refs,
+                &missing,
+            ))
+        }
         // Preserve the operation that actually failed. A probe failure is not
         // evidence that this checkout has a missing promisor-object closure.
         Ok(false) | Err(_) => Err(git_command_failure(action, exit_status)),
     }
 }
 
-fn controller_object_closure_error(message: impl Into<String>, exit_status: Option<i32>) -> Error {
-    let mut error = Error::internal_unexpected(message);
+fn controller_object_closure_error(
+    message: impl Into<String>,
+    exit_status: Option<i32>,
+    local_path: &Path,
+    remote: &str,
+    refs: &[String],
+    missing: &[String],
+) -> Error {
+    let repair_command = format!(
+        "git -C {} fetch --no-tags --filter=blob:none {} {}",
+        shell::quote_arg(&local_path.display().to_string()),
+        shell::quote_arg(remote),
+        refs.iter()
+            .map(|git_ref| shell::quote_arg(git_ref))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    let mut error = Error::internal_unexpected(format!(
+        "{}; repair the controller checkout with `{repair_command}`",
+        message.into()
+    ));
     error.details = serde_json::json!({
         "reason": "controller_git_object_closure_unavailable",
         "git_exit_status": exit_status,
+        "missing_object_ids": missing,
+        "repair_command": repair_command,
     });
     error
 }
@@ -531,10 +517,20 @@ pub(super) fn ref_has_missing_objects(local_path: &Path, git_ref: &str) -> Resul
 /// missing object. A non-zero Git exit is not proof of an incomplete object
 /// closure: it can be caused by invalid refs, permissions, or corruption.
 fn has_reported_missing_promisor_objects(local_path: &Path, refs: &[String]) -> Result<bool> {
+    Ok(!missing_promisor_objects(local_path, refs)?.is_empty())
+}
+
+const MISSING_PROMISOR_OBJECT_DIAGNOSTIC_LIMIT: usize = 8;
+
+/// Return a bounded list of missing promised objects without allowing Git to
+/// hydrate them. The list is diagnostic only; closure hydration remains the
+/// controller's responsibility.
+fn missing_promisor_objects(local_path: &Path, refs: &[String]) -> Result<Vec<String>> {
     if promisor_remote(local_path)?.is_none() {
-        return Ok(false);
+        return Ok(Vec::new());
     }
 
+    let mut missing = Vec::new();
     for git_ref in refs {
         let output = Command::new("git")
             .args([
@@ -563,15 +559,18 @@ fn has_reported_missing_promisor_objects(local_path: &Path, refs: &[String]) -> 
             ));
         }
 
-        if String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .any(|line| line.starts_with('?'))
-        {
-            return Ok(true);
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let Some(object_id) = line.strip_prefix('?') else {
+                continue;
+            };
+            if missing.len() == MISSING_PROMISOR_OBJECT_DIAGNOSTIC_LIMIT {
+                return Ok(missing);
+            }
+            missing.push(object_id.to_string());
         }
     }
 
-    Ok(false)
+    Ok(missing)
 }
 
 fn promisor_remote(local_path: &Path) -> Result<Option<String>> {

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -175,29 +175,7 @@ pub fn sync_workspace(
                         materialization_plan.controller_git_bundle = provenance;
                         (None, None)
                     }
-                    Err(_) => {
-                        rollback_materialized_workspace(&runner, workspace_root, &remote_path);
-                        if let Err(snapshot_error) = materialize_snapshot_with_scratch(
-                            &runner,
-                            &local_path,
-                            &remote_path,
-                            &excludes,
-                            Some(scratch),
-                        ) {
-                            rollback_materialized_workspace(&runner, workspace_root, &remote_path);
-                            return Err(snapshot_error);
-                        }
-                        materialization_plan.snapshot_transfer =
-                            Some(super::types::SnapshotTransferStats {
-                                reused: ByteFileCounts::default(),
-                                transferred: stats.clone(),
-                                final_size: stats.clone(),
-                            });
-                        (
-                            None,
-                            Some("snapshot_git_checkout_and_controller_bundle_failed".to_string()),
-                        )
-                    }
+                    Err(error) => return Err(error),
                 }
             } else if options.mode == RunnerWorkspaceSyncMode::SnapshotGit {
                 match materialize_snapshot_git(

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -304,7 +304,7 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
 }
 
 #[test]
-fn snapshot_git_falls_back_to_filesystem_snapshot_when_git_closure_is_unavailable() {
+fn snapshot_git_fails_before_handoff_when_controller_closure_is_unavailable() {
     let _path_guard = PATH_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -370,43 +370,19 @@ fn snapshot_git_falls_back_to_filesystem_snapshot_when_git_closure_is_unavailabl
         );
         std::env::set_var("PATH", original_path);
 
-        let (synced, exit_code) = result.expect("filesystem fallback");
-        assert_eq!(exit_code, 0);
-        assert_eq!(
-            synced
-                .materialization_plan
-                .actual_materialization_mode
-                .as_deref(),
-            Some("filesystem_snapshot")
+        let error = result.expect_err("closure failure must stop Lab handoff");
+        assert!(
+            error.message.contains("list git bundle objects"),
+            "{error:?}"
         );
-        assert!(synced.materialization_plan.controller_git_bundle.is_none());
-        assert_eq!(
-            synced.materialization_plan.fallback_reason.as_deref(),
-            Some("snapshot_git_checkout_and_controller_bundle_failed")
-        );
-        let remote = Path::new(&synced.remote_path);
-        assert_eq!(
-            fs::read_to_string(remote.join("dirty.txt")).unwrap(),
-            "dirty\n"
-        );
-        assert!(!remote.join(".git").exists());
-        let component = std::process::Command::new("sh")
-            .args(["-c", "test -f components/demo/component.txt && pwd"])
-            .current_dir(remote)
-            .output()
-            .expect("execute from remote component workspace");
-        assert!(component.status.success());
-        let metadata: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(remote.join(".homeboy/runner-workspace.json")).expect("metadata"),
-        )
-        .expect("parse metadata");
-        assert_eq!(
-            metadata["actual_materialization_mode"],
-            "filesystem_snapshot"
-        );
-        assert_eq!(
-            metadata["fallback_reason"],
-            "snapshot_git_checkout_and_controller_bundle_failed"
+        let workspaces_root = runner_root.path().join("_lab_workspaces");
+        assert!(
+            !workspaces_root.exists()
+                || fs::read_dir(workspaces_root)
+                    .expect("read workspaces root")
+                    .next()
+                    .is_none(),
+            "failed controller hydration must not hand off a fallback workspace"
         );
     });
 }
@@ -1257,7 +1233,7 @@ fn snapshot_git_sync_falls_back_for_unpublished_commit_and_preserves_dirty_overl
 }
 
 #[test]
-fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
+fn snapshot_git_hydrates_partial_clone_on_controller_without_lab_remote_access() {
     let _path_guard = PATH_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -1311,8 +1287,6 @@ fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
                 ".",
             ],
         );
-        let source_branch = git_output(source.path(), &["rev-parse", "--abbrev-ref", "HEAD"])
-            .expect("source branch");
         assert!(
             git_output(
                 source.path(),
@@ -1336,9 +1310,14 @@ fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
 
         let shim_root = tempfile::tempdir().expect("git shim root");
         let shim = shim_root.path().join("git");
+        let lab_remote_access = shim_root.path().join("lab-remote-accessed");
+        let origin_url = format!("file://{}", origin.path().display());
         fs::write(
             &shim,
-            "#!/bin/sh\nfor arg in \"$@\"; do [ \"$arg\" = \"rev-list\" ] && { echo 'git bundle closure enumeration invoked' >&2; exit 91; }; done\nexec /usr/bin/git \"$@\"\n",
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = clone ]; then for arg in \"$@\"; do [ \"$arg\" = {origin_url:?} ] && {{ : > {}; exit 91; }}; done; fi\nexec /usr/bin/git \"$@\"\n",
+                lab_remote_access.display(),
+            ),
         )
         .expect("write git shim");
         #[cfg(unix)]
@@ -1356,24 +1335,27 @@ fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
             "lab-local-partial-snapshot",
             RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
                 ..Default::default()
             },
         )
-        .expect("filesystem snapshot must not enumerate a Git bundle closure");
+        .expect("controller must hydrate and bundle the partial clone");
         std::env::set_var("PATH", original_path);
 
         let remote = Path::new(&output.remote_path);
         assert_eq!(exit_code, 0);
-        assert!(output.materialization_plan.controller_git_bundle.is_none());
+        assert!(
+            output.materialization_plan.controller_git_bundle.is_some(),
+            "snapshot-git handoff must retain controller bundle provenance"
+        );
         assert_eq!(
             output
                 .materialization_plan
                 .actual_materialization_mode
                 .as_deref(),
-            Some("filesystem_snapshot")
+            Some("snapshot-git")
         );
-        assert!(!remote.join(".git").exists());
+        assert!(remote.join(".git").exists());
         assert_eq!(
             fs::read_to_string(remote.join("file.txt")).unwrap(),
             "dirty\n"
@@ -1387,31 +1369,36 @@ fn filesystem_snapshot_of_dirty_partial_clone_avoids_git_bundle_closure() {
             output.current_workspace.source_commit.as_deref(),
             Some(head.as_str())
         );
-        assert_eq!(
-            output.current_workspace.source_ref.as_deref(),
-            Some(source_branch.as_str())
-        );
         let metadata: serde_json::Value = serde_json::from_str(
             &fs::read_to_string(remote.join(".homeboy/runner-workspace.json"))
                 .expect("read workspace metadata"),
         )
         .expect("parse workspace metadata");
-        assert_eq!(
-            metadata["actual_materialization_mode"],
-            "filesystem_snapshot"
-        );
+        assert_eq!(metadata["actual_materialization_mode"], "snapshot-git");
         assert_eq!(
             metadata["source_remote_url"],
             format!("file://{}", origin.path().display())
         );
         assert!(
-            git_output(
+            !git_output(
                 source.path(),
                 &["rev-list", "--objects", "--missing=print", "HEAD"]
             )
-            .expect("inspect controller after runner checkout")
+            .expect("inspect hydrated controller")
             .contains(&format!("?{base_blob}")),
-            "runner-side materialization must not hydrate controller promisor objects"
+            "controller must hydrate every promised snapshot object before handoff"
+        );
+        assert!(
+            !lab_remote_access.exists(),
+            "Lab materializer must not contact the promisor remote"
+        );
+        assert!(
+            git_output(
+                remote,
+                &["config", "--get-regexp", r"^remote\..*\.promisor$"]
+            )
+            .is_err(),
+            "Lab checkout must not inherit promisor remote configuration"
         );
     });
 }


### PR DESCRIPTION
## Summary

- always transfer controller-created Git bundles for snapshot-git materialization
- hydrate and verify the selected object closure on the controller before handoff
- prevent Lab-side promisor remote access and filesystem fallback after closure failure
- return bounded missing-object diagnostics and a controller repair command

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner snapshot_git_hydrates_partial_clone_on_controller_without_lab_remote_access --lib`
- `cargo test -p homeboy-lab-runner snapshot_git_fails_before_handoff_when_controller_closure_is_unavailable --lib`
- `cargo check -p homeboy-lab-runner`
- `git diff --check`

Closes #11337.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents reproduced, implemented, and verified controller-owned partial-clone hydration. Chris Huber remains responsible for every line.
