### PR TITLE
fix(cook): grant gate-fix candidate reads

### DIFF
--- a/crates/homeboy-agents/src/agent_task/policy.rs
+++ b/crates/homeboy-agents/src/agent_task/policy.rs
@@ -36,6 +36,27 @@ impl Default for AgentTaskPolicy {
     }
 }
 
+impl AgentTaskPolicy {
+    /// Permit a remediation provider to inspect its task workspace through its
+    /// runner-owned read tool without granting any write tool.
+    pub(crate) fn grant_workspace_read_tool(&mut self) {
+        self.read = "workspace".to_string();
+        self.tools.tools.insert(
+            "read".to_string(),
+            AgentToolPolicyRule {
+                execution_location: AgentToolExecutionLocation::Runner,
+                timeout_ms: None,
+                reason: Some("inspect the task workspace during remediation".to_string()),
+            },
+        );
+    }
+
+    pub(crate) fn permits_workspace_read_tool(&self) -> bool {
+        self.read == "workspace"
+            && self.tools.execution_location_for("read") == AgentToolExecutionLocation::Runner
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentToolRequest {
     #[serde(default = "agent_tool_request_schema")]

--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -364,6 +364,7 @@ fn build_follow_up_request(
         .root
         .clone()
         .or_else(|| worktree_root_hint(&options.promotion_report));
+    request.policy.grant_workspace_read_tool();
     request.metadata = json!({
         "cook_loop": {
             "kind": "deterministic-gate-feedback",
@@ -448,6 +449,7 @@ fn build_review_form_follow_up_request(
         .root
         .clone()
         .or_else(|| worktree_root_hint(&options.promotion_report));
+    request.policy.grant_workspace_read_tool();
     request.executor.required_capabilities = vec!["structured_outcome".to_string()];
     request.policy.write = "none".to_string();
     request.policy.apply = "none".to_string();
@@ -824,7 +826,7 @@ mod tests {
     use super::*;
     use crate::agent_task::{
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
-        AGENT_TASK_REQUEST_SCHEMA,
+        AgentToolExecutionLocation, AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::agent_task_gate::{AgentTaskGateEnvironment, AgentTaskGateFailureEvidence};
     use crate::agent_task_promotion::{
@@ -869,6 +871,12 @@ mod tests {
             "homeboy://agent-task/run/run-3676"
         );
         assert_eq!(request.workspace.mode, AgentTaskWorkspaceMode::Existing);
+        assert!(request.policy.permits_workspace_read_tool());
+        assert_eq!(
+            request.policy.tools.execution_location_for("read"),
+            AgentToolExecutionLocation::Runner
+        );
+        assert_eq!(request.policy.write, "artifacts_only");
     }
 
     #[test]
@@ -1470,6 +1478,7 @@ mod tests {
         );
         assert_eq!(request.policy.write, "none");
         assert_eq!(request.policy.apply, "none");
+        assert!(request.policy.permits_workspace_read_tool());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1269,6 +1269,13 @@ pub(crate) enum CookFollowUpBudgetScope {
     CandidateAdoptionReview,
 }
 
+fn remediation_tool_policy_error(request: &crate::agent_task::AgentTaskRequest) -> Option<String> {
+    (!request.policy.permits_workspace_read_tool()).then(|| {
+        "Cook remediation policy must grant the runner read access to the task workspace before dispatch"
+            .to_string()
+    })
+}
+
 fn follow_up_budget_scope(
     source_request: &crate::agent_task::AgentTaskRequest,
     follow_up_request: &crate::agent_task::AgentTaskRequest,
@@ -1322,6 +1329,9 @@ pub(crate) fn dispatch_cook_follow_up<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    if let Some(reason) = remediation_tool_policy_error(&follow_up_request) {
+        return Ok(CookFollowUpDispatch::PolicyFailure { reason });
+    }
     let recipe = super::load_recipe(cook_id)?;
     let related_attempts = recipe.attempts.iter().filter(|recipe_attempt| {
         recipe_attempt.plan.tasks.len() == 1

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -57,6 +57,44 @@ fn test_review_form_outputs() -> Value {
     serde_json::json!({ "review_form": test_review_form() })
 }
 
+#[test]
+fn remediation_policy_rejects_denied_workspace_read_before_dispatch() {
+    let mut request = AgentTaskRequest {
+        schema: crate::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+        task_id: "gate-fix".to_string(),
+        group_key: None,
+        parent_plan_id: None,
+        executor: AgentTaskExecutor {
+            backend: "fixture".to_string(),
+            selector: None,
+            runtime_selection: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            model: None,
+            config: Value::Null,
+        },
+        instructions: "Fix the failing gate.".to_string(),
+        inputs: Value::Null,
+        source_refs: Vec::new(),
+        workspace: AgentTaskWorkspace::default(),
+        component_contracts: Vec::new(),
+        policy: AgentTaskPolicy::default(),
+        limits: AgentTaskLimits::default(),
+        expected_artifacts: Vec::new(),
+        artifact_declarations: Vec::new(),
+        output_declarations: Vec::new(),
+        metadata: Value::Null,
+    };
+
+    assert_eq!(
+        remediation_tool_policy_error(&request).as_deref(),
+        Some("Cook remediation policy must grant the runner read access to the task workspace before dispatch")
+    );
+
+    request.policy.grant_workspace_read_tool();
+    assert!(remediation_tool_policy_error(&request).is_none());
+}
+
 fn seed_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
     use crate::agent_task::{AgentTaskOutcome, AgentTaskOutcomeStatus};
     use crate::agent_task_scheduler::{
@@ -1212,6 +1250,11 @@ impl AgentTaskExecutorAdapter for ReviewFormOnlyExecutor {
         request: crate::agent_task::AgentTaskRequest,
         _context: crate::agent_task_scheduler::AgentTaskExecutionContext,
     ) -> crate::agent_task::AgentTaskOutcome {
+        assert!(
+            request.policy.permits_workspace_read_tool(),
+            "the form-only remediation must be able to inspect the authenticated candidate"
+        );
+        assert_eq!(request.policy.write, "none");
         crate::agent_task::AgentTaskOutcome {
             schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             task_id: request.task_id,


### PR DESCRIPTION
## Summary

- grant gate-fix and review-form follow-ups runner-owned read access to the task workspace
- keep write access scoped by existing policy
- validate required remediation reads before reserving provider budget
- add regression coverage for policy failure and successful follow-up construction

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents remediation_policy_rejects_denied_workspace_read_before_dispatch`
- `cargo test -p homeboy-agents red_gate_creates_follow_up_request_with_failure_evidence_and_diff`
- `cargo test -p homeboy-agents green_change_without_review_form_requests_another_attempt`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes`
- `cargo check -p homeboy-agents`
- `git diff --check`

Closes #11331.

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode general coding subagents diagnosed, implemented, and verified this remediation policy fix. Chris Huber remains responsible for every line.
