### PR TITLE
fix(gates): compile package artifact test fixtures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -82,6 +82,11 @@ pub struct VerifyGateOptions {
     /// provider can spend an execution budget.
     #[serde(default)]
     pub gate_toolchains: Vec<AgentTaskGateToolchainRequirement>,
+    /// Caller-owned package resources required by deterministic gates. Homeboy
+    /// validates declared paths and records provenance without interpreting the
+    /// package, artifact, or remediation semantics.
+    #[serde(default)]
+    pub gate_package_artifacts: Vec<AgentTaskGatePackageArtifactRequirement>,
     /// Explicit mappings for producer-owned diagnostic sidecars. Homeboy only
     /// consumes declared schemas and paths; producer semantics remain opaque.
     #[serde(default)]
@@ -142,6 +147,36 @@ pub struct AgentTaskGateToolchainRequirement {
     pub probe_arguments: Vec<String>,
 }
 
+/// A caller-declared resource selected by a package or extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGatePackageArtifactRequirement {
+    pub id: String,
+    pub environment: AgentTaskGateArtifactEnvironmentMapping,
+    #[serde(default)]
+    pub required_paths: Vec<AgentTaskGateArtifactPathRequirement>,
+    /// Opaque caller metadata returned with failures and gate provenance.
+    pub remediation: serde_json::Value,
+}
+
+/// An explicit environment mapping for a package resource. `source` reads a
+/// host setting; `default` supplies a stable value when no host setting is used.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateArtifactEnvironmentMapping {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+}
+
+/// A resource path relative to the gate workspace, optionally pinned by SHA-256.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateArtifactPathRequirement {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
 fn default_toolchain_probe_arguments() -> Vec<String> {
     vec!["--version".to_string()]
 }
@@ -198,6 +233,7 @@ impl Default for VerifyGateOptions {
             rerun_completed_gates: false,
             gate_environment: AgentTaskGateEnvironmentPolicy::default(),
             gate_toolchains: Vec::new(),
+            gate_package_artifacts: Vec::new(),
             gate_diagnostic_sidecars: Vec::new(),
             hydrate_dependencies: default_hydrate_dependencies(),
         }
@@ -421,6 +457,27 @@ pub struct AgentTaskGateEnvironment {
     pub preserved: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sanitized: Vec<AgentTaskGateEnvironmentVariable>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub package_artifacts: Vec<AgentTaskGatePackageArtifactProvenance>,
+}
+
+/// Generic provenance for caller-declared package resources.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGatePackageArtifactProvenance {
+    pub id: String,
+    pub environment: String,
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub artifacts: Vec<AgentTaskGateArtifactPathProvenance>,
+    pub remediation: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateArtifactPathProvenance {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -435,6 +492,7 @@ impl AgentTaskGateEnvironment {
             && self.inherited.is_empty()
             && self.preserved.is_empty()
             && self.sanitized.is_empty()
+            && self.package_artifacts.is_empty()
     }
 
     pub(crate) fn replay_policy(&self) -> AgentTaskGateEnvironmentPolicy {
@@ -833,6 +891,7 @@ mod baseline_tests {
             temp.path(),
             Duration::from_millis(20),
             &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
         )
         .expect("bounded gate report");
 
@@ -858,6 +917,7 @@ mod baseline_tests {
             temp.path(),
             Duration::from_millis(20),
             &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
         )
         .expect("bounded gate report");
 
@@ -918,6 +978,7 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir(
         reveal_policy,
         runtime_tmpdir,
         &AgentTaskGateEnvironmentPolicy::default(),
+        &[],
     )
 }
 
@@ -929,6 +990,7 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
     reveal_policy: AgentTaskGateRevealPolicy,
     runtime_tmpdir: Option<&Path>,
     gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
 ) -> Result<AgentTaskGateReport> {
     run_gate_command_with_supervision(
         cwd,
@@ -939,6 +1001,7 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
         runtime_tmpdir,
         None,
         gate_environment,
+        package_artifacts,
     )
 }
 
@@ -951,6 +1014,7 @@ pub(crate) fn run_gate_command_with_supervision(
     runtime_tmpdir: Option<&Path>,
     supervision: Option<&GateSupervision>,
     gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
 ) -> Result<AgentTaskGateReport> {
     let command_vec = vec!["sh".to_string(), "-lc".to_string(), command.to_string()];
     let mut process = Command::new(&command_vec[0]);
@@ -959,7 +1023,10 @@ pub(crate) fn run_gate_command_with_supervision(
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let selected_environment = selected_gate_environment(gate_environment, runtime_tmpdir)?;
+    let (gate_environment, package_artifacts) =
+        validate_package_artifacts(cwd, gate_environment, package_artifacts)?;
+    let mut selected_environment = selected_gate_environment(&gate_environment, runtime_tmpdir)?;
+    selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
     if supervision.is_some() {
         if !homeboy_core::engine::command::supports_process_tree_isolation() {
@@ -1064,6 +1131,7 @@ pub(crate) fn run_gate_command_with_timeout(
     runtime_tmpdir: &Path,
     timeout: Duration,
     gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
 ) -> Result<AgentTaskGateReport> {
     let command_vec = vec!["sh".to_string(), "-lc".to_string(), command.to_string()];
     let mut process = Command::new("sh");
@@ -1072,7 +1140,11 @@ pub(crate) fn run_gate_command_with_timeout(
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let selected_environment = selected_gate_environment(gate_environment, Some(runtime_tmpdir))?;
+    let (gate_environment, package_artifacts) =
+        validate_package_artifacts(cwd, gate_environment, package_artifacts)?;
+    let mut selected_environment =
+        selected_gate_environment(&gate_environment, Some(runtime_tmpdir))?;
+    selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
     homeboy_core::engine::command::isolate_process_tree(&mut process);
     let mut child = process.spawn().map_err(|error| {
@@ -1282,10 +1354,12 @@ pub(crate) fn preflight_gate_toolchains(
     cwd: &Path,
     policy: &AgentTaskGateEnvironmentPolicy,
     requirements: &[AgentTaskGateToolchainRequirement],
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
     runtime_tmpdir: Option<&Path>,
     timeout: Duration,
 ) -> Result<()> {
-    let selected_environment = selected_gate_environment(policy, runtime_tmpdir)?;
+    let (policy, _) = validate_package_artifacts(cwd, policy, package_artifacts)?;
+    let selected_environment = selected_gate_environment(&policy, runtime_tmpdir)?;
     // The deadline covers declared probe execution. Controller scheduling before
     // the first child starts cannot make an otherwise successful probe fail.
     let mut started = None;
@@ -1370,6 +1444,129 @@ pub(crate) fn preflight_gate_toolchains(
         }
     }
     Ok(())
+}
+
+fn validate_package_artifacts(
+    cwd: &Path,
+    policy: &AgentTaskGateEnvironmentPolicy,
+    requirements: &[AgentTaskGatePackageArtifactRequirement],
+) -> Result<(
+    AgentTaskGateEnvironmentPolicy,
+    Vec<AgentTaskGatePackageArtifactProvenance>,
+)> {
+    let mut policy = policy.clone();
+    let mut provenance = Vec::with_capacity(requirements.len());
+    for requirement in requirements {
+        if requirement.id.trim().is_empty()
+            || requirement.environment.name.trim().is_empty()
+            || requirement.required_paths.is_empty()
+            || requirement.remediation.is_null()
+        {
+            return Err(package_artifact_error(
+                requirement,
+                "each declaration requires an id, environment mapping, required path, and remediation metadata",
+                Vec::new(),
+            ));
+        }
+        let mapping = &requirement.environment;
+        if mapping.source.is_some() == mapping.default.is_some() {
+            return Err(package_artifact_error(
+                requirement,
+                "environment mapping requires exactly one of source or default",
+                Vec::new(),
+            ));
+        }
+        if (mapping.name == "HOME" && policy.isolate_home)
+            || (XDG_ENV_VARS.contains(&mapping.name.as_str()) && policy.isolate_xdg)
+        {
+            return Err(package_artifact_error(
+                requirement,
+                "environment mapping conflicts with the declared HOME/XDG isolation policy",
+                Vec::new(),
+            ));
+        }
+        let value = match (&mapping.source, &mapping.default) {
+            (Some(source), None) => preserved_environment_value(source)?,
+            (None, Some(default)) if !default.is_empty() => default.clone(),
+            _ => {
+                return Err(package_artifact_error(
+                    requirement,
+                    "environment mapping resolved to an empty value",
+                    Vec::new(),
+                ));
+            }
+        };
+        policy.variables.insert(mapping.name.clone(), value.clone());
+        let mut artifacts = Vec::with_capacity(requirement.required_paths.len());
+        let mut missing = Vec::new();
+        for artifact in &requirement.required_paths {
+            let path = Path::new(&artifact.path);
+            if path.is_absolute() || artifact.path.trim().is_empty() || artifact.path.contains("..")
+            {
+                missing.push(artifact.path.clone());
+                continue;
+            }
+            let path = cwd.join(path);
+            if !path.exists() {
+                missing.push(artifact.path.clone());
+                continue;
+            }
+            if let Some(expected) = &artifact.sha256 {
+                let bytes = fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+                let actual = format!("sha256:{:x}", Sha256::digest(bytes));
+                if expected != &actual {
+                    missing.push(artifact.path.clone());
+                    continue;
+                }
+            }
+            artifacts.push(AgentTaskGateArtifactPathProvenance {
+                path: artifact.path.clone(),
+                sha256: artifact.sha256.clone(),
+            });
+        }
+        if !missing.is_empty() {
+            return Err(package_artifact_error(
+                requirement,
+                "required artifact paths are unavailable or do not match their declared digest",
+                missing,
+            ));
+        }
+        provenance.push(AgentTaskGatePackageArtifactProvenance {
+            id: requirement.id.clone(),
+            environment: mapping.name.clone(),
+            value,
+            source: mapping.source.clone(),
+            artifacts,
+            remediation: requirement.remediation.clone(),
+        });
+    }
+    Ok((policy, provenance))
+}
+
+fn package_artifact_error(
+    requirement: &AgentTaskGatePackageArtifactRequirement,
+    message: &str,
+    invalid_paths: Vec<String>,
+) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "gate_package_artifacts",
+        format!(
+            "package artifact readiness for `{}` failed: {message}",
+            requirement.id
+        ),
+        Some(requirement.id.clone()),
+        None,
+    );
+    error.retryable = Some(true);
+    error.details["package_artifact_readiness"] = json!({
+        "id": requirement.id,
+        "environment": requirement.environment,
+        "invalid_paths": invalid_paths,
+        "remediation": requirement.remediation,
+    });
+    error
 }
 
 fn toolchain_preflight_error(
@@ -1634,6 +1831,7 @@ mod tests {
             None,
             Some(&supervision),
             &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
         )
         .is_err());
         let pid = child_pid
@@ -1670,6 +1868,7 @@ mod tests {
             None,
             Some(&supervision),
             &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
         )
         .expect("gate");
         assert!(tails
@@ -1706,6 +1905,7 @@ mod tests {
             None,
             Some(&supervision),
             &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
         )
         .expect("private gate");
         let tails = tails.lock().expect("tails");
@@ -2073,6 +2273,7 @@ mod tests {
             AgentTaskGateRevealPolicy::FullEvidence,
             None,
             &policy,
+            &[],
         )
         .expect("gate report");
 
@@ -2084,6 +2285,88 @@ mod tests {
         assert_eq!(report.environment.inherited.len(), 1);
         assert_eq!(report.environment.inherited[0].name, "DECLARED_INPUT");
         assert_eq!(report.environment.inherited[0].value, "kept");
+    }
+
+    #[test]
+    fn declared_package_artifact_maps_resource_preserves_isolation_and_records_provenance() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let artifact = workspace.path().join("fixtures/ready.bin");
+        fs::create_dir_all(artifact.parent().expect("artifact parent")).expect("artifact parent");
+        fs::write(&artifact, b"neutral fixture").expect("artifact");
+        let digest = format!("sha256:{:x}", Sha256::digest(b"neutral fixture"));
+        let requirement = AgentTaskGatePackageArtifactRequirement {
+            id: "fixture-resource".to_string(),
+            environment: AgentTaskGateArtifactEnvironmentMapping {
+                name: "FIXTURE_RESOURCE_ROOT".to_string(),
+                source: None,
+                default: Some("fixtures".to_string()),
+            },
+            required_paths: vec![AgentTaskGateArtifactPathRequirement {
+                path: "fixtures/ready.bin".to_string(),
+                sha256: Some(digest),
+            }],
+            remediation: json!({"action": "refresh_fixture_resource"}),
+        };
+
+        let report = run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
+            workspace.path(),
+            1,
+            "test \"$FIXTURE_RESOURCE_ROOT\" = fixtures && test \"$HOME\" != fixtures",
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            None,
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[requirement],
+        )
+        .expect("declared resource is gate-ready");
+
+        assert_eq!(report.status, AgentTaskGateStatus::Succeeded);
+        assert_eq!(report.environment.package_artifacts.len(), 1);
+        assert_eq!(
+            report.environment.package_artifacts[0].id,
+            "fixture-resource"
+        );
+        assert_eq!(
+            report.environment.package_artifacts[0].artifacts[0].path,
+            "fixtures/ready.bin"
+        );
+    }
+
+    #[test]
+    fn missing_declared_package_artifact_stops_preflight_with_caller_remediation() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let requirement = AgentTaskGatePackageArtifactRequirement {
+            id: "fixture-resource".to_string(),
+            environment: AgentTaskGateArtifactEnvironmentMapping {
+                name: "FIXTURE_RESOURCE_ROOT".to_string(),
+                source: None,
+                default: Some("fixtures".to_string()),
+            },
+            required_paths: vec![AgentTaskGateArtifactPathRequirement {
+                path: "fixtures/missing.bin".to_string(),
+                sha256: None,
+            }],
+            remediation: json!({"action": "refresh_fixture_resource"}),
+        };
+
+        let error = preflight_gate_toolchains(
+            workspace.path(),
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
+            &[requirement],
+            None,
+            Duration::from_secs(1),
+        )
+        .expect_err("missing resource must stop provider preflight");
+
+        assert_eq!(
+            error.details["package_artifact_readiness"]["invalid_paths"],
+            json!(["fixtures/missing.bin"])
+        );
+        assert_eq!(
+            error.details["package_artifact_readiness"]["remediation"]["action"],
+            "refresh_fixture_resource"
+        );
     }
 
     /// Toolchain preflight is declared, never inferred. A gate command is a
@@ -2172,6 +2455,7 @@ mod tests {
                 command: "cargo".to_string(),
                 probe_arguments: vec!["--version".to_string()],
             }],
+            &[],
             None,
             Duration::from_secs(10),
         );
@@ -2210,6 +2494,7 @@ mod tests {
                 command: "other-tool".to_string(),
                 probe_arguments: vec!["initialize".to_string()],
             }],
+            &[],
             None,
             Duration::from_secs(10),
         )
@@ -2259,6 +2544,7 @@ mod tests {
                 command: tool.display().to_string(),
                 probe_arguments: vec!["initialize".to_string()],
             }],
+            &[],
             Some(runtime_tmpdir.path()),
             Duration::from_secs(10),
         )
@@ -2294,6 +2580,7 @@ mod tests {
                 command: tool.display().to_string(),
                 probe_arguments: Vec::new(),
             }],
+            &[],
             None,
             Duration::from_millis(500),
         )
@@ -2335,6 +2622,7 @@ mod tests {
                 command: tool.display().to_string(),
                 probe_arguments: Vec::new(),
             }],
+            &[],
             None,
             Duration::from_millis(100),
         )
@@ -2376,6 +2664,7 @@ mod tests {
                     probe_arguments: Vec::new(),
                 },
             ],
+            &[],
             None,
             Duration::from_secs(10),
         )
@@ -2419,6 +2708,7 @@ mod tests {
                 command: tool.display().to_string(),
                 probe_arguments: Vec::new(),
             }],
+            &[],
             None,
             Duration::from_secs(10),
         )

--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -370,6 +370,7 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
         reveal_policy: AgentTaskGateRevealPolicy,
         _runtime_tmpdir: &Path,
         _gate_environment: &crate::agent_task_gate::AgentTaskGateEnvironmentPolicy,
+        _package_artifacts: &[crate::agent_task_gate::AgentTaskGatePackageArtifactRequirement],
     ) -> Result<AgentTaskGateReport> {
         self.verify(cwd, index, command, visibility, reveal_policy)
     }
@@ -582,6 +583,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
         reveal_policy: AgentTaskGateRevealPolicy,
         runtime_tmpdir: &Path,
         gate_environment: &crate::agent_task_gate::AgentTaskGateEnvironmentPolicy,
+        package_artifacts: &[crate::agent_task_gate::AgentTaskGatePackageArtifactRequirement],
     ) -> Result<AgentTaskGateReport> {
         crate::agent_task_gate::run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
             cwd,
@@ -591,6 +593,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
             reveal_policy,
             Some(runtime_tmpdir),
             gate_environment,
+            package_artifacts,
         )
     }
 }

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1830,6 +1830,7 @@ fn run_promotion_gate(
         worktree_path,
         &options.gates.gate_environment,
         &options.gates.required_toolchains(),
+        &options.gates.gate_package_artifacts,
         Some(&runtime_tmpdir.context().tmp_dir),
         options.gates.gate_timeout(),
     ) {
@@ -1850,6 +1851,7 @@ fn run_promotion_gate(
             Some(&runtime_tmpdir.context().tmp_dir),
             Some(supervision),
             &options.gates.gate_environment,
+            &options.gates.gate_package_artifacts,
         )
     } else {
         provider.verify_with_runtime_tmpdir(
@@ -1860,6 +1862,7 @@ fn run_promotion_gate(
             reveal_policy,
             &runtime_tmpdir.context().tmp_dir,
             &options.gates.gate_environment,
+            &options.gates.gate_package_artifacts,
         )
     };
     let mut result = result;

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2031,26 +2031,27 @@ where
         &options.ai_tool,
     );
     let required_toolchains = options.gates.required_toolchains();
-    let preflight = required_toolchains
-        .is_empty()
-        .then_some(Ok(()))
-        .unwrap_or_else(|| {
-            let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "workspace",
-                    "Cook requires a workspace before gate toolchain preflight",
-                    Some(options.to_worktree.clone()),
-                    None,
-                )
-            })?;
-            crate::agent_task_gate::preflight_gate_toolchains(
-                gate_workspace,
-                &options.gates.gate_environment,
-                &required_toolchains,
+    let preflight = (required_toolchains.is_empty()
+        && options.gates.gate_package_artifacts.is_empty())
+    .then_some(Ok(()))
+    .unwrap_or_else(|| {
+        let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "workspace",
+                "Cook requires a workspace before gate toolchain preflight",
+                Some(options.to_worktree.clone()),
                 None,
-                options.gates.gate_timeout(),
             )
-        });
+        })?;
+        crate::agent_task_gate::preflight_gate_toolchains(
+            gate_workspace,
+            &options.gates.gate_environment,
+            &required_toolchains,
+            &options.gates.gate_package_artifacts,
+            None,
+            options.gates.gate_timeout(),
+        )
+    });
     if let Err(error) = preflight {
         let error = with_pre_execution_phase(error, "gate_toolchain_preflight");
         record_pre_execution_failure(

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -347,6 +347,7 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                     &runtime.context().tmp_dir,
                     timeout,
                     &gate.environment.replay_policy(),
+                    &[],
                 )
             })();
             let result: Result<()> = match baseline {

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -267,9 +267,11 @@ pub mod review_dossier {
 /// Gate report contracts, visibility, and reveal policies.
 pub mod gate {
     pub use super::super::agent_task_gate::{
+        AgentTaskGateArtifactEnvironmentMapping, AgentTaskGateArtifactPathRequirement,
         AgentTaskGateEnvironment, AgentTaskGateEnvironmentMode, AgentTaskGateEnvironmentPolicy,
         AgentTaskGateEnvironmentVariable, AgentTaskGateExecutionPolicy,
-        AgentTaskGateFailureEvidence, AgentTaskGateReport, AgentTaskGateRevealPolicy,
+        AgentTaskGateFailureEvidence, AgentTaskGatePackageArtifactProvenance,
+        AgentTaskGatePackageArtifactRequirement, AgentTaskGateReport, AgentTaskGateRevealPolicy,
         AgentTaskGateStatus, AgentTaskGateToolchainRequirement, AgentTaskGateVisibility,
         VerifyGateOptions, AGENT_TASK_GATE_REPORT_SCHEMA,
     };

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 use homeboy::agents::agent_task_scheduler::AgentTaskCandidateCompletionPolicy;
 use homeboy::agents::agent_tasks::gate::{
     AgentTaskGateEnvironmentMode, AgentTaskGateEnvironmentPolicy, AgentTaskGateExecutionPolicy,
-    AgentTaskGateRevealPolicy, AgentTaskGateToolchainRequirement, VerifyGateOptions,
+    AgentTaskGatePackageArtifactRequirement, AgentTaskGateRevealPolicy,
+    AgentTaskGateToolchainRequirement, VerifyGateOptions,
 };
 
 use super::super::super::super::agent_task_dispatch::DispatchArgs;
@@ -78,6 +79,11 @@ pub struct VerifyGateArgs {
     /// `COMMAND --version` in the final isolated gate environment. Repeatable.
     #[arg(long = "gate-toolchain", value_name = "COMMAND")]
     pub gate_toolchains: Vec<String>,
+    /// Caller-declared package resource readiness as a JSON object. The object
+    /// defines its environment mapping, required paths or digests, and opaque
+    /// remediation metadata. Repeat for multiple resources.
+    #[arg(long = "gate-package-artifact", value_name = "JSON", value_parser = parse_gate_package_artifact)]
+    pub gate_package_artifacts: Vec<AgentTaskGatePackageArtifactRequirement>,
     /// Run gates with an isolated `$HOME` so gate side effects do not touch the
     /// operator's home directory (default true).
     #[arg(
@@ -137,10 +143,18 @@ impl From<VerifyGateArgs> for VerifyGateOptions {
                     probe_arguments: vec!["--version".to_string()],
                 })
                 .collect(),
+            gate_package_artifacts: args.gate_package_artifacts,
             gate_diagnostic_sidecars: Vec::new(),
             hydrate_dependencies: true,
         }
     }
+}
+
+fn parse_gate_package_artifact(
+    value: &str,
+) -> Result<AgentTaskGatePackageArtifactRequirement, String> {
+    serde_json::from_str(value)
+        .map_err(|error| format!("invalid gate package artifact declaration: {error}"))
 }
 
 fn parse_gate_environment(value: &str) -> Result<(String, String), String> {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3230,6 +3230,7 @@ fi
             secret_env: vec!["AI_PROVIDER_OPENAI_CODEX_TOKEN".to_string()],
             provider_config: Some(r#"{"runtime":"opencode"}"#.to_string()),
             gates: super::super::args::VerifyGateArgs {
+                gate_package_artifacts: Vec::new(),
                 verify: vec!["cargo test --lib".to_string()],
                 private_verify: Vec::new(),
                 private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1770,6 +1770,9 @@ struct BatchCookSpec {
     gate_environment: AgentTaskGateEnvironmentPolicy,
     #[serde(default)]
     gate_toolchains: Vec<homeboy::agents::agent_tasks::gate::AgentTaskGateToolchainRequirement>,
+    #[serde(default)]
+    gate_package_artifacts:
+        Vec<homeboy::agents::agent_tasks::gate::AgentTaskGatePackageArtifactRequirement>,
     #[serde(default = "default_max_attempts")]
     max_attempts: u32,
     #[serde(default)]
@@ -1915,6 +1918,7 @@ impl BatchCookSpec {
                     rerun_completed_gates: self.rerun_completed_gates,
                     gate_environment: self.gate_environment.clone(),
                     gate_toolchains: self.gate_toolchains.clone(),
+                    gate_package_artifacts: self.gate_package_artifacts.clone(),
                     gate_diagnostic_sidecars: Vec::new(),
                     hydrate_dependencies: true,
                 },
@@ -2075,6 +2079,8 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
             rerun_completed_gates: args.gates.rerun_completed_gates,
             gate_environment: VerifyGateOptions::from(args.gates.clone()).gate_environment,
             gate_toolchains: VerifyGateOptions::from(args.gates.clone()).gate_toolchains,
+            gate_package_artifacts: VerifyGateOptions::from(args.gates.clone())
+                .gate_package_artifacts,
             max_attempts: default_max_attempts(),
             no_finalize: false,
             base: args.base.clone(),

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -425,6 +425,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                         .to_string(),
                 ],
                 gates: VerifyGateArgs {
+                    gate_package_artifacts: Vec::new(),
                     verify: vec!["cargo test --lib".to_string()],
                     private_verify: Vec::new(),
                     private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
@@ -791,6 +792,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 provider_command: None,
                 provider_argv: vec!["sh".to_string(), provider.display().to_string()],
                 gates: VerifyGateArgs {
+                    gate_package_artifacts: Vec::new(),
                     verify: vec!["true".to_string()],
                     private_verify: Vec::new(),
                     private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,


### PR DESCRIPTION
## Summary
- initialize the new generic package-artifact declarations field in three test-only `VerifyGateArgs` fixtures
- repair the workspace test-target compile failure merged with #11351

## Verification
- `cargo fmt --check`
- `cargo check --workspace --tests --locked`
- `cargo test -p homeboy-agents --lib declared_package_artifact` (2 passed)
- `git diff --check`

Follow-up to #11351, which was merged by another actor before this CI repair commit landed.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode reproduced the CI failure and updated the affected neutral test fixtures. Chris Huber remains responsible for every line.