### PR TITLE
Predict full baseline drift from changed-scope lint

### DIFF
--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -158,6 +158,125 @@ exit 1
 }
 
 #[test]
+fn changed_scope_baseline_verdict_matches_an_identical_merge_tree() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let run_git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(source.path())
+                .output()
+                .expect("git command");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["config", "user.email", "homeboy@example.com"]);
+        run_git(&["config", "user.name", "Homeboy Test"]);
+        std::fs::write(source.path().join("legacy.php"), "<?php // base\n").expect("base source");
+        std::fs::write(source.path().join("untouched.php"), "<?php // debt\n")
+            .expect("untouched debt source");
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "base"]);
+        run_git(&["branch", "baseline"]);
+        std::fs::write(source.path().join("legacy.php"), "<?php // candidate\n")
+            .expect("candidate source");
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "candidate"]);
+        run_git(&["branch", "merge-candidate"]);
+
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+if [ -n "$HOMEBOY_LINT_GLOB" ]; then
+  printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 0
+else
+  printf '[{"tool":"phpcs","message":"known","fingerprint":"known","file":"untouched.php"},{"tool":"phpstan","message":"relocated","fingerprint":"relocated","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  exit 1
+fi
+"#,
+        );
+        let known = homeboy_core::finding::HomeboyFinding::builder("phpcs", "known")
+            .fingerprint("known")
+            .build();
+        crate::lint::baseline::save_baseline(source.path(), "fixture", &[known])
+            .expect("save baseline");
+
+        let mut pr_args = lint_args();
+        pr_args.changed_since = Some("baseline".to_string());
+        pr_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        let pr_result = run_main_lint_workflow(
+            &component,
+            source.path(),
+            pr_args,
+            &RunDir::create().expect("PR run dir"),
+        )
+        .expect("PR workflow result");
+
+        let merge_tree = std::process::Command::new("git")
+            .args(["rev-parse", "merge-candidate^{tree}"])
+            .current_dir(source.path())
+            .output()
+            .expect("merge tree");
+        let head_tree = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD^{tree}"])
+            .current_dir(source.path())
+            .output()
+            .expect("head tree");
+        assert_eq!(
+            head_tree.stdout, merge_tree.stdout,
+            "trees must be identical"
+        );
+
+        let merge_result = run_main_lint_workflow(
+            &component,
+            source.path(),
+            lint_args(),
+            &RunDir::create().expect("merge run dir"),
+        )
+        .expect("merge workflow result");
+
+        assert_eq!(pr_result.status, "failed");
+        assert_eq!(merge_result.status, "failed");
+        assert_eq!(
+            pr_result
+                .baseline_comparison
+                .as_ref()
+                .expect("PR baseline comparison")
+                .new_items
+                .iter()
+                .map(|item| item.fingerprint.as_str())
+                .collect::<Vec<_>>(),
+            merge_result
+                .baseline_comparison
+                .as_ref()
+                .expect("merge baseline comparison")
+                .new_items
+                .iter()
+                .map(|item| item.fingerprint.as_str())
+                .collect::<Vec<_>>(),
+            "the PR gate must predict the full-scope verdict for the same tree"
+        );
+        assert_eq!(
+            pr_result
+                .baseline_comparison
+                .as_ref()
+                .expect("PR baseline comparison")
+                .new_items
+                .len(),
+            1,
+            "the untouched baseline finding remains accepted"
+        );
+    });
+}
+
+#[test]
 fn runner_failure_without_findings_is_an_infrastructure_error_without_autofix() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -39,6 +39,12 @@ struct ScopedLintOutput {
     child_run_dirs: Vec<RunDir>,
 }
 
+struct FullCandidateBaseline {
+    findings: Vec<HomeboyFinding>,
+    hard_error: bool,
+    exit_code: i32,
+}
+
 /// Run the main lint workflow.
 ///
 /// Handles changed-file scoping, autofix planning, lint runner execution,
@@ -79,6 +85,39 @@ pub fn run_main_lint_workflow(
     // read differently to an operator and to the PR comment.
     if let Some(ref plan) = scoped_plan {
         if plan.runs.is_empty() {
+            let full_candidate =
+                should_verify_full_candidate_baseline(source_path, &args, scoped_plan.as_ref())
+                    .then(|| run_full_candidate_baseline(component, &args))
+                    .transpose()?;
+            if let Some(candidate) = full_candidate {
+                let (baseline_comparison, baseline_exit_override) =
+                    process_baseline(source_path, &args, &candidate.findings)?;
+                let exit_code = if candidate.hard_error {
+                    candidate.exit_code
+                } else {
+                    baseline_exit_override.unwrap_or(0)
+                };
+                return Ok(LintRunWorkflowResult {
+                    status: if exit_code == 0 { "passed" } else { "failed" }.to_string(),
+                    component: args.component_label,
+                    exit_code,
+                    harness_error: false,
+                    infrastructure_failure: false,
+                    autofix: None,
+                    hints: None,
+                    baseline_comparison,
+                    formatting_findings: None,
+                    findings: None,
+                    producer_summaries: Vec::new(),
+                    summary: if args.json_summary {
+                        Some(build_lint_summary(&[], &[], exit_code))
+                    } else {
+                        None
+                    },
+                    self_check_capture: None,
+                    extension_phase_timings: Vec::new(),
+                });
+            }
             let hints = (plan.changed_files_considered > 0).then(|| {
                 vec![format!(
                     "Lint ran no scopes: {} changed file(s) were considered and none matched any \
@@ -211,6 +250,14 @@ pub fn run_main_lint_workflow(
         lint_findings.extend(route_findings);
         producer_summaries.extend(route_producers);
     }
+    // Changed-file routes intentionally omit untouched debt from their output.
+    // Before accepting that scoped result against a baseline, run the same
+    // candidate tree without a route so fingerprint changes remain predictable
+    // after a fast-forward or merge commit with the identical tree.
+    let full_candidate =
+        should_verify_full_candidate_baseline(source_path, &args, scoped_plan.as_ref())
+            .then(|| run_full_candidate_baseline(component, &args))
+            .transpose()?;
     let formatting_findings =
         extract_formatting_findings(&output.stdout, &output.stderr, source_path);
 
@@ -225,8 +272,14 @@ pub fn run_main_lint_workflow(
     let lint_exit_code = normalize_producer_exit_code(runner_exit_code, &producer_summaries);
 
     // Baseline lifecycle
-    let (baseline_comparison, baseline_exit_override) =
-        process_baseline(source_path, &args, &lint_findings)?;
+    let (baseline_comparison, baseline_exit_override) = process_baseline(
+        source_path,
+        &args,
+        full_candidate
+            .as_ref()
+            .map(|candidate| candidate.findings.as_slice())
+            .unwrap_or(&lint_findings),
+    )?;
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
@@ -236,6 +289,9 @@ pub fn run_main_lint_workflow(
             && producer.metadata.contains_key("failure")
     });
     let hard_error = output.exit_code >= 2
+        || full_candidate
+            .as_ref()
+            .is_some_and(|candidate| candidate.hard_error)
         || harness_error
         || producer_summaries
             .iter()
@@ -317,6 +373,70 @@ pub fn run_main_lint_workflow(
         producer_summaries,
         self_check_capture: None,
         extension_phase_timings: output.extension_phase_timings,
+    })
+}
+
+fn should_verify_full_candidate_baseline(
+    source_path: &Path,
+    args: &LintRunWorkflowArgs,
+    scoped_plan: Option<&super::types::ScopedLintPlan>,
+) -> bool {
+    scoped_plan.is_some()
+        && args.file.is_none()
+        && args.glob.is_none()
+        && args.category.is_none()
+        && !args.sniff_filters.errors_only
+        && args.sniff_filters.sniffs.is_none()
+        && args.sniff_filters.exclude_sniffs.is_none()
+        && !args.baseline_flags.baseline
+        && !args.baseline_flags.ignore_baseline
+        && lint_baseline::load_baseline(source_path).is_some()
+}
+
+fn run_full_candidate_baseline(
+    component: &Component,
+    args: &LintRunWorkflowArgs,
+) -> homeboy_core::Result<FullCandidateBaseline> {
+    let full_run_dir = RunDir::create()?;
+    let runner = build_lint_runner(
+        component,
+        args.path_override.clone(),
+        &args.settings,
+        true,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        &full_run_dir,
+    )?;
+    let runner = args
+        .ci_env
+        .iter()
+        .fold(runner, |runner, (key, value)| runner.env(key, value));
+    let output = runner
+        .env_if(
+            args.changed_since.is_some(),
+            "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
+            "1",
+        )
+        .passthrough(false)
+        .run()?;
+    let findings_file = full_run_dir.step_file(run_dir::files::LINT_FINDINGS);
+    if crate::lint::declares_lint_findings_sidecar(component) && !findings_file.is_file() {
+        full_run_dir.finish(false);
+        return Err(missing_findings_evidence_error(&findings_file));
+    }
+    let findings = lint_baseline::parse_findings_file(&findings_file)?;
+    full_run_dir.finish(output.success);
+
+    Ok(FullCandidateBaseline {
+        findings,
+        hard_error: output.exit_code >= 2,
+        exit_code: output.exit_code,
     })
 }
 


### PR DESCRIPTION
## Summary

- run full candidate baseline reconciliation for unfiltered changed-scope lint
- keep explicitly filtered lint commands targeted
- prove an identical PR-head/merge tree receives the same baseline verdict

Closes #11361.

## Verification

- `cargo fmt --check`
- identical candidate-tree regression passes
- `cargo test -p homeboy-extension lint::run::tests -- --test-threads=1`: 38 passed; existing unrelated `successful_zero_finding_routes_initialize_and_clean_evidence` isolation failure remains

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced the changed/full scope mismatch, implemented the repair, reviewed the diff, and ran targeted verification. Chris Huber remains responsible for every line.