### PR TITLE
Bound agent-task cancellation acknowledgement

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -132,36 +132,46 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         return Ok(record);
     }
 
-    // Staging is controller-local work, not a runner child. Its terminal
-    // confirmation is required before this parent can become Cancelled.
+    // Staging is controller-local work, not a runner child. Persist the request
+    // and its owner before asking the daemon to stop it; provider shutdown can
+    // take arbitrarily long after the observing CLI has gone away.
     let controller_cancelled = if let Some(controller_job_id) = record
         .metadata
         .get("lab_staging_controller_job_id")
         .and_then(serde_json::Value::as_str)
         .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
     {
+        let cancellation_reason = reason.unwrap_or("agent-task cancellation requested");
+        let metadata = record.ensure_metadata_object();
+        metadata.insert(
+            "controller_job_cancellation".to_string(),
+            json!({
+                "controller_job_id": controller_job_id,
+                "phase": "requesting",
+                "reason": cancellation_reason,
+                "requested_at": now_timestamp(),
+            }),
+        );
+        store::write_record(&record)?;
         // The controller owns every child admitted during staging, including the
         // final runner job. Never bypass it merely because that child identity
         // was already projected onto the parent.
         let controller_job = homeboy_core::daemon::LocalControllerJobClient::connect()?
-            .cancel_and_wait(
-                controller_job_id,
-                reason.unwrap_or("agent-task cancellation requested"),
-            )?;
+            .cancel(&controller_job_id, cancellation_reason)?;
         let metadata = record.ensure_metadata_object();
         metadata.insert(
             "controller_job_cancellation".to_string(),
             json!({
                 "controller_job_id": controller_job.id,
                 "status": controller_job.status,
-                "confirmed": true,
+                "phase": if controller_job.status == homeboy_core::api_jobs::JobStatus::Cancelled { "cancelled" } else { "requested" },
+                "reason": cancellation_reason,
+                "requested_at": now_timestamp(),
             }),
         );
         store::write_record(&record)?;
-        // The controller cancellation projects owned child state. Re-read once
-        // after its terminal confirmation before finalizing this parent.
-        record = store::read_record(&record.run_id)?;
-        if record.state.is_terminal() {
+        if controller_job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
             return Ok(record);
         }
         true
@@ -308,6 +318,88 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
     }
     Ok(record)
+}
+
+/// Reconcile an asynchronously cancelled controller-owned staging job. This is
+/// read-side so a CLI that observed only the acknowledgement still converges the
+/// durable cook record after the provider exits.
+pub(super) fn reconcile_controller_job_cancellation(
+    record: &mut AgentTaskRunRecord,
+) -> Result<bool> {
+    let Some(cancellation) = record
+        .metadata
+        .get("controller_job_cancellation")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Ok(false);
+    };
+    if cancellation
+        .get("phase")
+        .and_then(serde_json::Value::as_str)
+        != Some("requested")
+    {
+        return Ok(false);
+    }
+    let Some(job_id) = cancellation
+        .get("controller_job_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+    else {
+        return Ok(false);
+    };
+
+    let job = match homeboy_core::daemon::LocalControllerJobClient::connect()
+        .and_then(|client| client.status(job_id))
+    {
+        Ok(job) => job,
+        Err(error) => {
+            record.ensure_metadata_object().insert(
+                "controller_job_cancellation_status_error".to_string(),
+                json!({ "checked_at": now_timestamp(), "error": error.message }),
+            );
+            return Ok(true);
+        }
+    };
+    let metadata = record.ensure_metadata_object();
+    metadata.remove("controller_job_cancellation_status_error");
+    if job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
+        metadata.insert(
+            "controller_job_cancellation".to_string(),
+            json!({
+                "controller_job_id": job.id,
+                "status": job.status,
+                "phase": "requested",
+                "last_checked_at": now_timestamp(),
+            }),
+        );
+        return Ok(true);
+    }
+
+    let cancelled_at = now_timestamp();
+    set_run_state(record, AgentTaskRunState::Cancelled);
+    for task in &mut record.tasks {
+        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+            task.state = AgentTaskState::Cancelled;
+        }
+    }
+    let metadata = record.ensure_metadata_object();
+    terminalize_running_provider_executions(metadata, &cancelled_at);
+    metadata.insert("cancelled_at".to_string(), json!(cancelled_at));
+    metadata.insert(
+        "controller_job_cancellation".to_string(),
+        json!({
+            "controller_job_id": job.id,
+            "status": job.status,
+            "phase": "cancelled",
+            "confirmed_at": now_timestamp(),
+        }),
+    );
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
+    record.updated_at = Some(now_timestamp());
+    crate::controller_scratch::finalize_run(&record.run_id)?;
+    homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
+    Ok(true)
 }
 
 /// Outcome of attempting live cancellation of a running run's provider process

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1535,6 +1535,9 @@ pub fn status_with_options(
     if project_persisted_terminal_runner_events(&mut record)? {
         record = store::read_record(&resolved_run_id)?;
     }
+    if super::cancellation::reconcile_controller_job_cancellation(&mut record)? {
+        store::write_record(&record)?;
+    }
     if !record.state.is_terminal() {
         let controller_plan = store::read_controller_plan(&record.run_id)?;
         let controller_plan_path = store::controller_plan_path(&record.run_id)?

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -184,9 +184,9 @@ impl LocalControllerJobClient {
         })
     }
 
-    /// Requests cancellation and returns only after the daemon confirms the
-    /// owned controller work reached `Cancelled`.
-    pub fn cancel_and_wait(&self, job_id: &str, reason: &str) -> Result<crate::api_jobs::Job> {
+    /// Persist a cancellation request and return the daemon's current job
+    /// projection. The controller continues provider shutdown asynchronously.
+    pub fn cancel(&self, job_id: &str, reason: &str) -> Result<crate::api_jobs::Job> {
         let response = self
             .client
             .post(format!("{}/controller/jobs/{job_id}/cancel", self.endpoint))
@@ -208,7 +208,7 @@ impl LocalControllerJobClient {
             || value.get("success").and_then(serde_json::Value::as_bool) != Some(true)
         {
             return Err(Error::internal_unexpected(format!(
-                "local controller job `{job_id}` cancellation was not confirmed: {value}"
+                "local controller job `{job_id}` cancellation was not accepted: {value}"
             )));
         }
         let job: crate::api_jobs::Job =
@@ -221,12 +221,6 @@ impl LocalControllerJobClient {
                     Some("parse local controller job".to_string()),
                 )
             })?;
-        if job.status != JobStatus::Cancelled {
-            return Err(Error::internal_unexpected(format!(
-                "local controller job `{job_id}` remains {} after cancellation",
-                job.status.daemon_status_label()
-            )));
-        }
         Ok(job)
     }
 
@@ -2819,52 +2813,13 @@ fn cancel_controller_job(
     {
         let _ = runtime.cancel.send(());
     }
-    if job.status == JobStatus::Cancelled {
-        return Ok(json!({ "job": job }));
-    }
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let job = job_store.get(job_id)?;
-        match job.status {
-            JobStatus::Cancelled => return Ok(json!({ "job": job })),
-            JobStatus::Failed => {
-                return Err(Error::validation_invalid_argument(
-                    "job_id",
-                    "controller job cancellation failed; inspect the durable job events",
-                    Some(job_id.to_string()),
-                    None,
-                ));
-            }
-            JobStatus::Succeeded => {
-                return Err(Error::validation_invalid_argument(
-                    "job_id",
-                    "controller job completed before cancellation could stop it",
-                    Some(job_id.to_string()),
-                    None,
-                ));
-            }
-            JobStatus::Queued | JobStatus::Running if Instant::now() < deadline => {
-                std::thread::sleep(Duration::from_millis(5));
-            }
-            JobStatus::Queued | JobStatus::Running => {
-                let _ = job_store.append_event(
-                    job_id,
-                    crate::api_jobs::JobEventKind::Error,
-                    Some(
-                        "controller job cancellation did not complete before the daemon timeout"
-                            .to_string(),
-                    ),
-                    Some(json!({ "phase": "cancellation_timeout" })),
-                );
-                return Err(Error::validation_invalid_argument(
-                    "job_id",
-                    "controller job cancellation is still pending; inspect the durable job events",
-                    Some(job_id.to_string()),
-                    None,
-                ));
-            }
-        }
-    }
+    Ok(json!({
+        "job": job,
+        "cancellation": {
+            "accepted": true,
+            "phase": if job.status == JobStatus::Cancelled { "cancelled" } else { "requested" },
+        },
+    }))
 }
 
 fn controller_job_id_from_path(path: &str, suffix: &str) -> Result<Uuid> {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -786,6 +786,88 @@ fn generic_cancel_rejects_running_controller_work_without_touching_its_driver() 
 }
 
 #[test]
+fn cancelling_running_controller_job_acknowledges_before_blocked_shutdown_finishes() {
+    let _home = HomeGuard::new();
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let (cancellation_release, cancellation_rx) = mpsc::channel();
+    controller_job_driver::register_controller_job_driver(Arc::new(BlockingControllerDriver {
+        job_type: "test.bounded-cancellation",
+        started: started_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+        cancellation_release,
+        executions: Arc::new(AtomicUsize::new(0)),
+        cancellations: Arc::new(AtomicUsize::new(0)),
+    }))
+    .expect("register bounded cancellation driver");
+    let submitted = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.bounded-cancellation", "version": 1, "idempotency_key": "bounded-cancel", "request": {}
+        })),
+        &store,
+    );
+    let job_id = uuid::Uuid::parse_str(
+        submitted.body["body"]["job"]["id"]
+            .as_str()
+            .expect("job id"),
+    )
+    .expect("valid job id");
+    assert_eq!(
+        route_with_body(
+            "POST",
+            &format!("/controller/jobs/{job_id}/start"),
+            None,
+            &store
+        )
+        .status_code,
+        200
+    );
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("driver started");
+
+    let started = Instant::now();
+    let acknowledgement = route_with_body(
+        "POST",
+        &format!("/controller/jobs/{job_id}/cancel"),
+        Some(serde_json::json!({ "reason": "observing client disappeared" })),
+        &store,
+    );
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert_eq!(acknowledgement.status_code, 200);
+    assert_eq!(
+        acknowledgement.body["body"]["cancellation"]["accepted"],
+        true
+    );
+    assert_eq!(
+        acknowledgement.body["body"]["cancellation"]["phase"],
+        "requested"
+    );
+    assert_eq!(
+        store.get(job_id).expect("pending job").status,
+        JobStatus::Running
+    );
+
+    release_tx
+        .send(())
+        .expect("release blocked provider shutdown");
+    cancellation_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("driver cancellation released provider work");
+    for _ in 0..200 {
+        if store.get(job_id).expect("job").status == JobStatus::Cancelled {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    panic!("controller job did not reconcile to cancelled after provider shutdown");
+}
+
+#[test]
 fn controller_terminal_persistence_retries_the_result_without_reexecuting_after_restart() {
     let _home = HomeGuard::new();
     let path = crate::paths::daemon_jobs_file().expect("jobs path");
@@ -1053,7 +1135,14 @@ fn controller_job_cancel_failure_is_diagnostic_and_non_cancelled() {
         None,
         &store,
     );
-    assert_eq!(cancelled.status_code, 400);
+    assert_eq!(cancelled.status_code, 200);
+    assert_eq!(cancelled.body["body"]["cancellation"]["accepted"], true);
+    for _ in 0..200 {
+        if store.get(job_id).expect("job").status == JobStatus::Failed {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
     assert_eq!(store.get(job_id).expect("job").status, JobStatus::Failed);
     assert!(store.events(job_id).expect("events").iter().any(|event| {
         event


### PR DESCRIPTION
## Summary

- persist controller-owned cancellation intent before signalling shutdown
- acknowledge cancellation without waiting indefinitely for provider termination
- reconcile durable Cook state from controller job status

Closes #11363.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- bounded acknowledgement regression
- asynchronous failure reconciliation regression
- stale-running cancellation regression

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced the blocking cancellation path, implemented the repair, reviewed the diff, and ran targeted verification. Chris Huber remains responsible for every line.