### PR TITLE
Converge Cook runner recovery with controller state

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -201,15 +201,15 @@ pub(crate) fn lab_runner_homeboy_metadata(
 ) -> serde_json::Value {
     let controller_version = homeboy_product_identity::product_version();
     let controller_build_identity = homeboy_product_identity::build_identity().display;
-    let refresh_commands = vec![
-        runner_homeboy_align_to_controller_command(runner_id),
-        format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
-        format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
-    ];
-    let primary_remediation_command =
-        runner_homeboy_primary_remediation_command(runner_id, configured_executable, status);
-    let topology_recovery_command =
-        runner_homeboy_topology_recovery_command(runner_id, configured_executable, status);
+    // Status owns the controller-to-runner convergence target. Reusing its
+    // recovery avoids dispatch telling an operator to reinstall the runner's
+    // already-incompatible configured binary (#11360).
+    let refresh_commands = runner_homeboy_refresh_commands(runner_id, status);
+    let primary_remediation_command = refresh_commands
+        .first()
+        .cloned()
+        .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id));
+    let topology_recovery_command = primary_remediation_command.clone();
     let controller_binary = std::env::current_exe()
         .ok()
         .map(|path| path.display().to_string());
@@ -449,74 +449,8 @@ fn lab_runner_homeboy_version_drift(status: &RunnerStatusReport) -> bool {
     classify_runner_homeboy_version_drift(status) != RunnerHomeboyVersionDrift::None
 }
 
-fn runner_daemon_newer_than_controller(status: &RunnerStatusReport) -> bool {
-    let Some(controller) = parse_version_triplet(homeboy_product_identity::product_version())
-    else {
-        return false;
-    };
-    status
-        .stale_daemon
-        .as_ref()
-        .map(|warning| warning.active_daemon_control_plane_version.as_str())
-        .into_iter()
-        .chain(
-            status
-                .session
-                .as_ref()
-                .map(|session| session.homeboy_version.as_str()),
-        )
-        .filter_map(parse_version_triplet)
-        .any(|runner| runner > controller)
-}
-
-fn runner_homeboy_primary_remediation_command(
-    runner_id: &str,
-    configured_executable: &str,
-    status: &RunnerStatusReport,
-) -> String {
-    if runner_daemon_newer_than_controller(status) {
-        return controller_homeboy_recovery_command();
-    }
-
-    if let Some(command) = runner_configured_binary_select_command(runner_id, configured_executable)
-    {
-        return command;
-    }
-
-    runner_homeboy_refresh_commands(runner_id, status)
-        .into_iter()
-        .next()
-        .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id))
-}
-
-fn runner_homeboy_topology_recovery_command(
-    runner_id: &str,
-    configured_executable: &str,
-    status: &RunnerStatusReport,
-) -> String {
-    if runner_daemon_newer_than_controller(status) {
-        return controller_homeboy_recovery_command();
-    }
-    runner_configured_binary_select_command(runner_id, configured_executable).unwrap_or_else(|| {
-        runner_homeboy_primary_remediation_command(runner_id, configured_executable, status)
-    })
-}
-
-fn runner_configured_binary_select_command(
-    runner_id: &str,
-    configured_executable: &str,
-) -> Option<String> {
-    let configured_executable = configured_executable.trim();
-    if configured_executable.is_empty() || configured_executable == "homeboy" {
-        return None;
-    }
-    Some(format!(
-        "homeboy runner refresh-homeboy {} --select {} --reconnect",
-        shell::quote_arg(runner_id),
-        shell::quote_arg(configured_executable)
-    ))
-}
-
+/// Recover the controller runtime when an independent handoff-stage check
+/// proves that the controller, rather than a runner, must be upgraded.
 pub(crate) fn controller_homeboy_recovery_command() -> String {
     let Ok(exe) = std::env::current_exe() else {
         return "homeboy upgrade".to_string();
@@ -755,15 +689,12 @@ pub(crate) fn stale_runner_homeboy_error(
         });
     let refresh = refresh_commands.join(" && ");
     let mut tried = Vec::new();
-    if runner_daemon_newer_than_controller(status) {
-        tried.push(format!(
-            "Upgrade this local Homeboy controller before retrying Lab offload: {}",
-            runner_homeboy_primary_remediation_command(runner_id, configured_executable, status)
-        ));
-    }
     tried.push(format!(
         "One-command topology recovery: {}",
-        runner_homeboy_topology_recovery_command(runner_id, configured_executable, status)
+        refresh_commands
+            .first()
+            .cloned()
+            .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id))
     ));
     tried.extend([
         format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
@@ -789,7 +720,7 @@ pub(crate) fn runner_homeboy_refresh_commands(
         .as_ref()
         .map(|warning| warning.recovery_commands.clone())
         .unwrap_or_default();
-    if !commands.is_empty() && !runner_id.contains(char::is_whitespace) {
+    if !commands.is_empty() {
         return commands;
     }
     vec![

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -720,16 +720,16 @@ fn minor_version_drift_is_incompatible_and_refused() {
 }
 
 #[test]
-fn newer_runner_than_controller_points_to_local_upgrade_first() {
+fn newer_runner_than_controller_points_to_controller_convergence_first() {
     let status = status_with_runner_version("homeboy-lab", &higher_minor_version());
 
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
-    assert!(metadata["primary_remediation_command"]
-        .as_str()
-        .is_some_and(|command| command.contains("homeboy upgrade")));
-    assert!(metadata["topology_recovery_command"]
-        .as_str()
-        .is_some_and(|command| command.contains("homeboy upgrade")));
+    let expected = format!(
+        "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+        expected_controller_refresh_ref()
+    );
+    assert_eq!(metadata["primary_remediation_command"], expected);
+    assert_eq!(metadata["topology_recovery_command"], expected);
     assert!(metadata["controller_binary"].as_str().is_some());
     assert_eq!(metadata["local_upgrade_command"], "homeboy upgrade");
 
@@ -738,11 +738,11 @@ fn newer_runner_than_controller_points_to_local_upgrade_first() {
     assert!(tried
         .first()
         .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains("homeboy upgrade")));
+        .is_some_and(|hint| hint.contains(&expected)));
 }
 
 #[test]
-fn newer_stale_daemon_control_plane_points_to_local_upgrade_first() {
+fn newer_stale_daemon_control_plane_points_to_controller_convergence_first() {
     let mut status =
         status_with_runner_version("homeboy-lab", homeboy_product_identity::product_version());
     let runner_version = higher_minor_version();
@@ -755,16 +755,20 @@ fn newer_stale_daemon_control_plane_points_to_local_upgrade_first() {
     ));
 
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
-    assert!(metadata["primary_remediation_command"]
-        .as_str()
-        .is_some_and(|command| command.contains("homeboy upgrade")));
+    assert_eq!(
+        metadata["primary_remediation_command"],
+        format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
+        )
+    );
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
     assert!(tried
         .first()
         .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains("homeboy upgrade")));
+        .is_some_and(|hint| hint.contains("refresh-homeboy")));
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("One-command topology recovery"))));
@@ -795,7 +799,7 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
 }
 
 #[test]
-fn configured_runner_binary_drift_selects_known_runner_binary() {
+fn configured_runner_binary_drift_still_converges_to_the_controller() {
     let status = status_with_runner_version("homeboy-lab", "0.0.0");
     let configured = "/srv/homeboy-current/target/release/homeboy";
 
@@ -803,7 +807,10 @@ fn configured_runner_binary_drift_selects_known_runner_binary() {
 
     assert_eq!(
         metadata["primary_remediation_command"],
-        "homeboy runner refresh-homeboy homeboy-lab --select /srv/homeboy-current/target/release/homeboy --reconnect"
+        format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
+        )
     );
     assert_eq!(
         metadata["topology_recovery_command"],
@@ -812,9 +819,57 @@ fn configured_runner_binary_drift_selects_known_runner_binary() {
 
     let err = stale_runner_homeboy_error("homeboy-lab", configured, &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried.iter().any(|hint| hint.as_str().is_some_and(|hint| hint.contains(
-        "homeboy runner refresh-homeboy homeboy-lab --select /srv/homeboy-current/target/release/homeboy --reconnect"
-    ))));
+    assert!(tried.iter().any(
+        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
+            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
+            expected_controller_refresh_ref()
+        )))
+    ));
+}
+
+#[test]
+fn cook_metadata_reuses_the_doctor_recovery_action_for_controller_skew() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.327.8".to_string(),
+        "0.327.8".to_string(),
+        Some("homeboy 0.327.8+d444688d3da8".to_string()),
+        Some("homeboy 0.327.8+d444688d3da8".to_string()),
+    )
+    .with_controller_compatibility(
+        "homeboy-lab",
+        "0.327.7".to_string(),
+        "homeboy 0.327.7+e089f864df13".to_string(),
+        true,
+        true,
+        false,
+    );
+    let doctor_action = warning
+        .recovery_actions
+        .first()
+        .cloned()
+        .expect("controller skew has a typed recovery action");
+    let mut status = status_with_runner_version("homeboy-lab", "0.327.8");
+    status.stale_daemon = Some(warning);
+
+    let metadata = lab_runner_homeboy_metadata(
+        "homeboy-lab",
+        "/srv/homeboy-current/target/release/homeboy",
+        &status,
+    );
+
+    assert_eq!(
+        doctor_action.render_command(),
+        "homeboy runner refresh-homeboy homeboy-lab --ref e089f864df13 --reconnect --allow-downgrade"
+    );
+    assert_eq!(
+        metadata["primary_remediation_command"],
+        doctor_action.render_command()
+    );
+    assert_eq!(
+        metadata["refresh_commands"][0],
+        doctor_action.render_command()
+    );
 }
 
 #[test]
@@ -1049,15 +1104,8 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
     assert!(tried
         .first()
         .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains(
-            "homeboy runner refresh-homeboy 'homeboy lab' --select /home/user/Developer/_lab_workspaces/homeboy-post-4583-proof/target/debug/homeboy --reconnect"
-        )));
-    assert!(tried.iter().any(
-        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy 'homeboy lab' --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )))
-    ));
+        .is_some_and(|hint| hint
+            .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref new --reconnect")));
     assert!(tried.iter().any(|hint| hint
         .as_str()
         .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
@@ -1126,14 +1174,7 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
     );
     assert_eq!(
         metadata["refresh_commands"],
-        serde_json::json!([
-            format!(
-                "homeboy runner refresh-homeboy lab --ref {} --reconnect",
-                expected_controller_refresh_ref()
-            ),
-            "homeboy runner disconnect lab",
-            "homeboy runner connect lab"
-        ])
+        serde_json::json!([expected_refresh])
     );
 }
 


### PR DESCRIPTION
## Summary

- reuse runner status as the authoritative controller-to-runner convergence target
- stop Cook admission from recommending the already-installed incompatible runner revision
- assert Cook metadata and runner doctor expose the same typed recovery action

Closes #11360.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner capability_metadata --lib` (32 passed)
- `git diff --check`

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced the divergent remediation builders, implemented the repair, reviewed the diff, and ran targeted verification. Chris Huber remains responsible for every line.