### PR TITLE
Pin the adoption fixture's initial branch to main

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1784,7 +1784,12 @@ impl CandidateAdoptionFixture {
             assert!(output.status.success());
             String::from_utf8(output.stdout).unwrap().trim().to_string()
         };
-        git(&source, &["init"]);
+        // The fixture declares `base: "main"`, and promotion verifies that base
+        // exists on origin. Without an explicit initial branch this repo inherits
+        // the host's `init.defaultBranch` — still `master` on stock git — so the
+        // declared base never resolves and every adoption test fails on a machine
+        // that has not opted into `main`.
+        git(&source, &["init", "--initial-branch=main"]);
         git(&source, &["config", "user.email", "agent@example.test"]);
         git(&source, &["config", "user.name", "Agent"]);
         std::fs::write(source.join("lib.rs"), "base\n").unwrap();
@@ -3870,7 +3875,7 @@ fn historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_repla
                 .trim()
                 .to_string()
         };
-        git(&source, &["init"]);
+        git(&source, &["init", "--initial-branch=main"]);
         git(&source, &["config", "user.email", "agent@example.test"]);
         git(&source, &["config", "user.name", "Agent"]);
         std::fs::write(source.join("lib.rs"), "base\n").expect("write base");


### PR DESCRIPTION
Recovers **11 of the 35 tests currently failing on main**.

## Root cause

`CandidateAdoptionFixture` declares `base: "main"` (cook_tests.rs:1658), and promotion verifies that base resolves on origin before running gates:

```rust
git ls-remote --heads origin refs/heads/{base_ref}
```

But the fixture created its repository with a bare `git init`, so the branch it actually got was whatever the **host's** `init.defaultBranch` says. Stock git still defaults to `master`, and nothing in the test environment opts into `main` — so the declared base never resolved:

```
Invalid argument 'base_ref': declared base `main` was not found on
origin before promotion gates
```

The test was depending on host git configuration.

## Why this is clearly the oversight, not the design

Every other git fixture in the crate already pins its initial branch:

| file | |
|---|---|
| `agent_task_candidate_baseline.rs` | `init -b main` (×4) |
| `agent_task_finalization/backend.rs` | `init -b main`, `init --bare -b main` |
| `agent_task_runtime_dependency_graph.rs` | `init -b main` |
| `cook_baseline.rs` | `init -b main` |
| `cook_promotion.rs` | `init --initial-branch=main` (×4) |
| `cook_tests.rs:918` | `init --initial-branch=main` |
| **`cook_tests.rs:1787`, **`cook_tests.rs:3873`** | **`init`** ← these two |

Two sites were missed. This aligns them.

## Verification

Run **single-threaded**, so the result is not a parallelism artifact:

- adoption family: **39 passed, 2 failed** (was failing en masse)
- against the exact 35 names failing on main: **11 now pass**
- `verified_base` now resolves in the promotion report: `base: "main"`

## Not a recent regression

I checked before assuming. The same tests fail identically at **v0.327.1** (two days ago), and at the commit before #11328 — so this is long-standing, and surfaces on main whenever `--changed-since` scope happens to select the agents suite.

## Remaining failures — separate cause, not addressed here

The other 24 fail on a different thing: a missing `aggregate.json`, not base resolution.

```
InternalIoError: .../agent-task-runs/<run>/aggregate.json
No such file or directory (os error 2)
```

Affected: `cook_transport_preparation_failure_*`, `moving_base_recovery_*`, `orphaned_recipe_*`, `cook_report_*`, `post_materialization_failure_families_*`, and others. Worth its own investigation rather than being bundled in.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: reproduced the failures locally, bisected to rule out a recent regression, traced the base-resolution error to the fixture's unpinned initial branch, and measured the recovery. Chris Huber remains responsible for every line.