### PR TITLE
Add distributed workspace reconciliation fencing

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -389,6 +389,9 @@ pub fn build_dispatch_plan_with_provider_requirements(
         "runtime_dependency_graph": runtime_dependency_graph_evidence,
     });
 
+    plan.workspace_identity = workspace_target
+        .as_ref()
+        .and_then(|target| target.workspace_identity.clone());
     Ok(plan)
 }
 
@@ -524,7 +527,7 @@ fn resolve_dispatch_workspace(
                 None,
             ));
         }
-        return Ok(Some(DispatchWorkspaceTarget::workspace_ref(record)));
+        return DispatchWorkspaceTarget::workspace_ref(record).map(Some);
     }
 
     let resolution = worktree_providers::resolve_worktree_provider(workspace).map_err(|error| {
@@ -577,6 +580,7 @@ pub(crate) struct DispatchWorkspaceTarget {
     component_id: Option<String>,
     branch: Option<String>,
     base_ref: Option<String>,
+    workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
     pub(crate) metadata: Value,
 }
 
@@ -593,6 +597,7 @@ impl DispatchWorkspaceTarget {
             component_id: None,
             branch: None,
             base_ref: None,
+            workspace_identity: None,
             metadata: serde_json::json!({
                 "kind": kind,
                 "root": root.display().to_string(),
@@ -600,9 +605,9 @@ impl DispatchWorkspaceTarget {
         }
     }
 
-    fn workspace_ref(record: worktree::WorkspaceRefRecord) -> Self {
-        match record {
-            worktree::WorkspaceRefRecord::Task(record) => Self::record(record),
+    fn workspace_ref(record: worktree::WorkspaceRefRecord) -> Result<Self> {
+        Ok(match record {
+            worktree::WorkspaceRefRecord::Task(record) => Self::record(record)?,
             worktree::WorkspaceRefRecord::Adopted(record) => {
                 let root = std::path::PathBuf::from(&record.path);
                 Self {
@@ -612,6 +617,7 @@ impl DispatchWorkspaceTarget {
                     component_id: None,
                     branch: None,
                     base_ref: None,
+                    workspace_identity: None,
                     metadata: serde_json::json!({
                         "kind": "adopted-workspace",
                         "handle": record.handle,
@@ -621,18 +627,20 @@ impl DispatchWorkspaceTarget {
                     }),
                 }
             }
-        }
+        })
     }
 
-    fn record(record: worktree::TaskWorktreeRecord) -> Self {
+    fn record(record: worktree::TaskWorktreeRecord) -> Result<Self> {
         let root = std::path::PathBuf::from(&record.worktree_path);
-        Self {
+        let workspace_identity = record.effective_workspace_identity()?;
+        Ok(Self {
             root,
             slug: Some(record.component_id.clone()),
             kind: Some("homeboy-worktree".to_string()),
             component_id: Some(record.component_id.clone()),
             branch: Some(record.branch.clone()),
             base_ref: Some(record.base_ref.clone()),
+            workspace_identity: Some(workspace_identity),
             metadata: serde_json::json!({
                 "kind": "homeboy-worktree",
                 "id": record.id,
@@ -643,7 +651,7 @@ impl DispatchWorkspaceTarget {
                 "source_checkout": record.source_checkout,
                 "task_url": record.task_url,
             }),
-        }
+        })
     }
 
     fn provider(resolution: worktree_providers::WorktreeProviderResolution) -> Self {
@@ -655,6 +663,7 @@ impl DispatchWorkspaceTarget {
             component_id: None,
             branch: Some(resolution.worktree.branch.clone()),
             base_ref: None,
+            workspace_identity: None,
             metadata: serde_json::json!({
                 "kind": "worktree-provider",
                 "provider_id": resolution.provider_id,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -43,6 +43,9 @@ pub(crate) fn aggregate_evidence_refs(
             .flat_map(AgentTaskLatestExecutorEvidence::refs),
     );
     dedup_evidence_refs(&mut refs);
+    // Failure-specific evidence is the primary actionable record for a
+    // pre-dispatch failure, ahead of generic executor context.
+    refs.sort_by_key(|reference| reference.kind != "lab-offload-pre-dispatch-failure");
     refs
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -180,6 +180,12 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
         candidate_adoption: None,
         adoption_run_id: None,
         acceptance: None,
+        // Reconstructed legacy records have no durable admission fence. Do not
+        // invent workspace ownership from a plan-only projection.
+        workspace_identity: None,
+        workspace_lifecycle_revision: 0,
+        workspace_owner_lease: None,
+        workspace_claim: None,
         metadata: json!({
             "lifecycle_reconstruction": {
                 "source": "observation_status_and_durable_plan",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -330,7 +330,7 @@ pub fn run_owes_candidate_follow_up(run_id: &str) -> Result<bool> {
                 .metadata
                 .pointer("/artifact_projection/status")
                 .and_then(Value::as_str)
-                == Some("pending")),
+                .is_some_and(|status| matches!(status, "pending" | "failed"))),
         Err(_) => Ok(false),
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -290,6 +290,10 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             None,
         ));
     }
+    // The accepted handoff is the controller-side attachment authority. Capture
+    // the exact durable run binding here so later attachment writes cannot be
+    // authorized by a substituted workspace claim.
+    require_record_workspace_owner(&record)?;
     if let Some(accepted) = record.lab_handoff.as_ref().filter(|handoff| {
         handoff.state == AgentTaskLabHandoffState::Accepted
             && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
@@ -409,7 +413,12 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             accepted_at.clone(),
         )
     });
-    record.lab_handoff = Some(pending_handoff.accepted(input.runner_job_id, accepted_at.clone()));
+    let mut accepted_handoff = pending_handoff.accepted(input.runner_job_id, accepted_at.clone());
+    accepted_handoff.workspace_identity = record.workspace_identity.clone();
+    accepted_handoff.workspace_lifecycle_revision = record.workspace_lifecycle_revision;
+    accepted_handoff.workspace_owner_lease = record.workspace_owner_lease.clone();
+    accepted_handoff.workspace_claim = record.workspace_claim.clone();
+    record.lab_handoff = Some(accepted_handoff);
     let metadata = record.ensure_metadata_object();
     metadata.insert("kind".to_string(), json!("lab_offload_detached_handoff"));
     if let Some(intent) = metadata.get_mut("runner_submission_intent") {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -512,10 +512,32 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
+    let mut normalized_plan = plan.clone();
+    if normalized_plan.workspace_identity.is_none() {
+        normalized_plan.workspace_identity = identity_for_plan(&normalized_plan)?;
+    }
     let run_id = requested_run_id
         .map(sanitize_run_id)
         .unwrap_or_else(default_run_id);
-    let plan_path = store::write_plan(&run_id, plan)?;
+    if let Some(identity) = normalized_plan.workspace_identity.clone() {
+        normalized_plan.workspace_owner_lease =
+            Some(register_local_workspace_owner(identity, &run_id)?);
+        normalized_plan.workspace_lifecycle_revision = normalized_plan
+            .workspace_owner_lease
+            .as_ref()
+            .expect("registered owner lease")
+            .lifecycle_revision;
+    }
+    let plan = &normalized_plan;
+    let plan_path = match store::write_plan(&run_id, plan) {
+        Ok(path) => path,
+        Err(error) => {
+            if let Some(lease) = plan.workspace_owner_lease.as_ref() {
+                let _ = release_local_workspace_owner(lease);
+            }
+            return Err(error);
+        }
+    };
 
     let mut metadata = json!({
         "task_count": plan.tasks.len(),
@@ -590,6 +612,10 @@ where
         candidate_adoption: None,
         adoption_run_id: None,
         acceptance: None,
+        workspace_identity: plan.workspace_identity.clone(),
+        workspace_lifecycle_revision: plan.workspace_lifecycle_revision,
+        workspace_owner_lease: plan.workspace_owner_lease.clone(),
+        workspace_claim: None,
         metadata,
     };
     let mut preserved_controller_runtime = None;
@@ -643,7 +669,15 @@ where
                 record.lab_handoff = existing.lab_handoff;
             }
         }
+        // A replay of the same run retains its fenced ownership. A different
+        // claim is never silently substituted after ownership was established.
+        if existing.workspace_identity == record.workspace_identity
+            && existing.workspace_lifecycle_revision == record.workspace_lifecycle_revision
+        {
+            record.workspace_owner_lease = existing.workspace_owner_lease;
+        }
     }
+    require_record_workspace_owner(&record)?;
     store::write_record(&record)?;
 
     // The queue is durable independently of this foreground controller. Status
@@ -1057,6 +1091,7 @@ pub fn reserve_provider_execution(
     attempt: u32,
 ) -> Result<ProviderExecutionReservation> {
     let run_id = sanitize_run_id(run_id);
+    require_record_workspace_owner(&store::read_record(&run_id)?)?;
     let execution_key = format!("{}:{attempt}", task.task_id);
     let mut reservation = ProviderExecutionReservation::AlreadyReserved;
     store::mutate_record(&run_id, |record| {
@@ -2342,6 +2377,25 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     let run_id = record.run_id.clone();
     let aggregate = snapshot.aggregate;
     let latest_executor_evidence = record.latest_executor_evidence.as_ref();
+    let mut evidence_refs = aggregate_evidence_refs(aggregate.as_ref(), latest_executor_evidence);
+    if aggregate.is_none()
+        && (record.metadata.get("kind").and_then(Value::as_str)
+            == Some("lab_offload_pre_dispatch_failure")
+            || record
+                .tasks
+                .iter()
+                .any(|task| task.task_id == "agent-task-predispatch"))
+    {
+        evidence_refs.insert(
+            0,
+            AgentTaskEvidenceRef {
+                kind: "lab-offload-pre-dispatch-failure".to_string(),
+                uri: format!("homeboy://agent-task/run/{run_id}/logs"),
+                label: Some("Lab offload pre-dispatch failure".to_string()),
+            },
+        );
+        dedup_evidence_refs(&mut evidence_refs);
+    }
     Ok(AgentTaskRunArtifacts {
         schema: schemas::RUN_ARTIFACTS.to_string(),
         run_id,
@@ -2350,7 +2404,7 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
             .map(crate::agent_task_artifacts::reviewer_facing_aggregate)
             .map(|aggregate| aggregate_artifacts(Some(&aggregate)))
             .unwrap_or_default(),
-        evidence_refs: aggregate_evidence_refs(aggregate.as_ref(), latest_executor_evidence),
+        evidence_refs,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -53,6 +53,7 @@ mod records;
 pub mod runner_continuation;
 mod runner_exec;
 mod workspace_authority;
+mod workspace_claims;
 
 pub(crate) use acceptance_verifier::revalidate_durable_attestation;
 #[cfg(any(test, feature = "test-support"))]
@@ -87,6 +88,7 @@ pub use runner_continuation::{
 };
 pub use runner_exec::*;
 pub use workspace_authority::*;
+pub use workspace_claims::*;
 
 pub(crate) use conversion::*;
 pub(crate) use lifecycle_record_ops::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/private_attachment.rs
@@ -202,7 +202,22 @@ pub fn persist_private_run_attachment<T: Serialize + DeserializeOwned + Clone + 
 ) -> Result<PrivateRunAttachment<T>> {
     let run_id = validated_run_id(run_id)?;
     // Prove the authoritative lifecycle exists before creating side data.
-    store::read_record(&run_id)?;
+    let record = store::read_record(&run_id)?;
+    super::require_record_workspace_owner(&record)?;
+    if let Some(handoff) = record.lab_handoff.as_ref() {
+        if handoff.state == super::AgentTaskLabHandoffState::Accepted
+            && (handoff.workspace_identity != record.workspace_identity
+                || handoff.workspace_lifecycle_revision != record.workspace_lifecycle_revision
+                || handoff.workspace_owner_lease != record.workspace_owner_lease)
+        {
+            return Err(Error::validation_invalid_argument(
+                "workspace_claim_binding",
+                "accepted Lab handoff binding does not match the durable run",
+                Some(run_id),
+                None,
+            ));
+        }
+    }
     let path = attachment_path(&run_id, kind)?;
     let attachment = PrivateRunAttachment {
         schema: PRIVATE_RUN_ATTACHMENT_SCHEMA.to_string(),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -120,6 +120,14 @@ pub struct AgentTaskRunRecord {
     /// promotion, and gate state. It is the only acceptance authority.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceptance: Option<AgentTaskAcceptanceRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
+    #[serde(default)]
+    pub workspace_lifecycle_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim: Option<homeboy_core::workspace_claim::WorkspaceClaim>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -308,6 +316,14 @@ pub struct AgentTaskLabHandoff {
     pub accepted_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expired_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_identity: Option<homeboy_core::workspace_claim::WorkspaceIdentity>,
+    #[serde(default)]
+    pub workspace_lifecycle_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim: Option<homeboy_core::workspace_claim::WorkspaceClaim>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -664,6 +680,10 @@ impl AgentTaskLabHandoff {
             acceptance_deadline_at: Some(acceptance_deadline_at),
             accepted_at: None,
             expired_at: None,
+            workspace_identity: None,
+            workspace_lifecycle_revision: 0,
+            workspace_owner_lease: None,
+            workspace_claim: None,
         }
     }
 
@@ -679,6 +699,10 @@ impl AgentTaskLabHandoff {
             acceptance_deadline_at: self.acceptance_deadline_at.clone(),
             accepted_at: Some(accepted_at),
             expired_at: None,
+            workspace_identity: self.workspace_identity.clone(),
+            workspace_lifecycle_revision: self.workspace_lifecycle_revision,
+            workspace_owner_lease: self.workspace_owner_lease.clone(),
+            workspace_claim: self.workspace_claim.clone(),
         }
     }
 
@@ -694,6 +718,10 @@ impl AgentTaskLabHandoff {
             acceptance_deadline_at: self.acceptance_deadline_at.clone(),
             accepted_at: None,
             expired_at: Some(expired_at),
+            workspace_identity: self.workspace_identity.clone(),
+            workspace_lifecycle_revision: self.workspace_lifecycle_revision,
+            workspace_owner_lease: self.workspace_owner_lease.clone(),
+            workspace_claim: self.workspace_claim.clone(),
         }
     }
 
@@ -793,6 +821,10 @@ impl AgentTaskLabHandoff {
                         .and_then(optional_timestamp),
                     accepted_at: Some(accepted_at),
                     expired_at: None,
+                    workspace_identity: None,
+                    workspace_lifecycle_revision: 0,
+                    workspace_owner_lease: None,
+                    workspace_claim: None,
                 })
             }
             "expired"
@@ -810,6 +842,10 @@ impl AgentTaskLabHandoff {
                     acceptance_deadline_at: None,
                     accepted_at: None,
                     expired_at: required_timestamp(acceptance.get("expired_at")),
+                    workspace_identity: None,
+                    workspace_lifecycle_revision: 0,
+                    workspace_owner_lease: None,
+                    workspace_claim: None,
                 })
             }
             _ => None,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -16,6 +16,7 @@ use homeboy_core::api_jobs::{
     Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLogSnapshot,
 };
 use homeboy_core::error::{Error, Result};
+use homeboy_core::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
 
 /// Result of reconciling a runner job across its known daemon generations.
 ///
@@ -31,6 +32,72 @@ pub enum RunnerJobReconciliation {
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
+    /// `false` is a fail-closed declaration for older providers. Ordinary jobs
+    /// do not call these methods and retain their existing compatibility.
+    fn supports_workspace_claims(&self) -> bool {
+        false
+    }
+
+    /// Explicit capability gate for terminal historical inspection. Older
+    /// providers fail closed rather than turning an unavailable probe into
+    /// absent-job evidence.
+    fn supports_terminal_workspace_authority(&self) -> bool {
+        false
+    }
+
+    /// Configured remote authorities which must participate in a workspace
+    /// claim. The default keeps older providers compatible for local-only runs.
+    fn workspace_claim_runner_ids(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
+    /// Every configured direct or reverse runner authority which must attest a
+    /// terminal workspace. Implementations may use a stricter set than claims.
+    fn terminal_workspace_authority_runner_ids(&self) -> Result<Vec<String>> {
+        self.workspace_claim_runner_ids()
+    }
+
+    fn acquire_workspace_claim(
+        &self,
+        _runner_id: &str,
+        _workspace: WorkspaceIdentity,
+        _lifecycle_revision: u64,
+    ) -> Result<WorkspaceClaim> {
+        Err(Error::validation_invalid_argument(
+            "workspace_claim",
+            "runner does not advertise workspace claim capability",
+            None,
+            None,
+        ))
+    }
+
+    fn validate_workspace_claim(&self, _runner_id: &str, _claim: &WorkspaceClaim) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn release_workspace_claim(&self, _runner_id: &str, _claim: &WorkspaceClaim) -> Result<()> {
+        Err(Error::validation_invalid_argument(
+            "workspace_claim",
+            "runner does not advertise workspace claim capability",
+            None,
+            None,
+        ))
+    }
+
+    /// Token-free inventory for bounded write-ahead-intent recovery. `Ok(true)`
+    /// means the authority confirms no live claim or owner for this identity.
+    fn workspace_claim_authority_is_clear(
+        &self,
+        _runner_id: &str,
+        _workspace: &WorkspaceIdentity,
+    ) -> Result<bool> {
+        Err(Error::validation_invalid_argument(
+            "workspace_claim",
+            "runner does not advertise workspace claim authority inventory",
+            None,
+            None,
+        ))
+    }
     /// Durable snapshot (job + event log) for a runner job.
     fn runner_job_log_snapshot(
         &self,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1535,6 +1535,10 @@ fn detached_runner_failure_transitions_parent_and_task_terminal() {
         candidate_adoption: None,
         adoption_run_id: None,
         acceptance: None,
+        workspace_identity: None,
+        workspace_lifecycle_revision: 0,
+        workspace_owner_lease: None,
+        workspace_claim: None,
         metadata: json!({ "runner_id": "homeboy-lab", "runner_job_id": "job-123" }),
     };
     record.tasks[0].state = AgentTaskState::Running;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -141,6 +141,8 @@ pub(super) fn replay_request(run_id: &str, command: &[String]) -> RemoteRunnerJo
         require_paths: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: Some(json!({
             "submission_key": format!("agent-task:v1:homeboy-lab:{run_id}"),
             "durable_run_id": run_id,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1955,6 +1955,10 @@ fn malformed_typed_pending_handoff_is_health_malformed_and_unreconciled() {
                 acceptance_deadline_at: None,
                 accepted_at: None,
                 expired_at: None,
+                workspace_identity: None,
+                workspace_lifecycle_revision: 0,
+                workspace_owner_lease: None,
+                workspace_claim: None,
             });
         })
         .expect_err("validated test rewrite rejects malformed typed handoff");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -197,6 +197,7 @@ pub fn resolve_workspace_terminal_authority(
         .map_err(|error| {
             Error::internal_json(error.to_string(), Some(path.display().to_string()))
         })?;
+    let substituted_job = job_id.is_some_and(|job_id| job_id != receipt.runner_job_id);
     let valid = receipt.schema == WORKSPACE_TERMINAL_AUTHORITY_SCHEMA
         && receipt.run_id == run_id
         && receipt.runner_id == runner_id
@@ -204,6 +205,12 @@ pub fn resolve_workspace_terminal_authority(
         && !receipt.runner_job_id.is_empty()
         && job_id.is_none_or(|job_id| job_id == receipt.runner_job_id);
     valid.then_some(receipt).map(Some).ok_or_else(|| {
+        // A substituted job identity is a conflicting authority assertion.
+        // Freeze cleanup so later compaction cannot make the workspace appear
+        // safely addressable after a failed exact-binding check.
+        if substituted_job {
+            let _ = begin_workspace_terminal_authority_release(run_id, runner_id, remote_workspace);
+        }
         Error::validation_invalid_argument(
             "workspace_terminal_authority",
             "workspace terminal authority receipt is malformed or contradicts workspace ownership",

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1,0 +1,1801 @@
+//! Local controller authority for portable agent-task workspace claims.
+
+use super::runner_continuation::with_runner_continuation;
+use super::*;
+use homeboy_core::engine::local_files::write_json_file_owner_only;
+use homeboy_core::workspace_claim::{
+    WorkspaceClaim, WorkspaceClaimBinding, WorkspaceClaimStore, WorkspaceIdentity,
+    WorkspaceOwnerLease, MAX_WORKSPACE_CLAIM_TTL_MS,
+};
+use homeboy_core::worktree::{
+    authority_set_fingerprint, TaskWorktreeRecord, TerminalWorkspaceAuthorityObservation,
+    TerminalWorkspaceAuthorityProof, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
+    TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub const LOCAL_WORKSPACE_CLAIM_TTL_MS: u64 = MAX_WORKSPACE_CLAIM_TTL_MS;
+pub const LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS: u64 = MAX_WORKSPACE_CLAIM_TTL_MS;
+const COMMIT_SAFETY_MARGIN_MS: u64 = 1_000;
+
+fn commit_budget_ms(now_ms: u64, claims: impl Iterator<Item = u64>) -> u64 {
+    claims
+        .map(|expires_at_ms| expires_at_ms.saturating_sub(now_ms))
+        .min()
+        .unwrap_or(0)
+        .saturating_sub(COMMIT_SAFETY_MARGIN_MS)
+}
+
+/// A refusal retains the reason and any earlier observations, allowing callers
+/// to present durable evidence without treating an uncertain probe as terminal.
+#[derive(Debug, Clone)]
+pub enum TerminalWorkspaceAuthorityResolution {
+    Proven(TerminalWorkspaceAuthorityProof),
+    Refused {
+        reason: String,
+        observations: Vec<TerminalWorkspaceAuthorityObservation>,
+    },
+}
+
+/// Resolve historical authority outside the task-worktree registry lease. The
+/// manifest is the request binding; controller state and runner snapshots are
+/// evidence, never a wall-clock mutation fence.
+pub fn resolve_terminal_workspace_authority(
+    record: &TaskWorktreeRecord,
+) -> Result<TerminalWorkspaceAuthorityResolution> {
+    let workspace = record.effective_workspace_identity()?;
+    let authority_set = match configured_terminal_authorities() {
+        Ok(authorities) => authorities,
+        Err(reason) => {
+            return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+                reason,
+                observations: Vec::new(),
+            })
+        }
+    };
+    if let Some(proof) = &record.terminal_workspace_authority {
+        if proof.exact_for(record, record.run_id.as_deref())
+            && proof.authority_set == authority_set
+            && proof.authority_set_fingerprint == authority_set_fingerprint(&authority_set)
+        {
+            return Ok(TerminalWorkspaceAuthorityResolution::Proven(proof.clone()));
+        }
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason:
+                "cached terminal authority receipt is malformed or binds another manifest revision"
+                    .into(),
+            observations: Vec::new(),
+        });
+    }
+    let Some(run_id) = record.run_id.as_deref() else {
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason: "no-run-id task worktree requires an existing exact terminal authority receipt"
+                .into(),
+            observations: Vec::new(),
+        });
+    };
+    let controller = match store::read_record(run_id) {
+        Ok(record) => record,
+        Err(_) => {
+            return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+                reason: "durable controller run is missing".into(),
+                observations: Vec::new(),
+            })
+        }
+    };
+    if !controller.state.is_terminal() || !controller.run_state_projections_agree() {
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason: "durable controller run is active or has conflicting state projection".into(),
+            observations: Vec::new(),
+        });
+    }
+    if controller
+        .lab_handoff
+        .as_ref()
+        .is_some_and(|handoff| handoff.state == AgentTaskLabHandoffState::Pending)
+    {
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason: "controller handoff remains pending".into(),
+            observations: Vec::new(),
+        });
+    }
+    if controller
+        .workspace_owner_lease
+        .as_ref()
+        .is_some_and(|lease| validate_local_workspace_owner(lease).unwrap_or(true))
+    {
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason: "controller still has a live local workspace owner lease".into(),
+            observations: Vec::new(),
+        });
+    }
+    let mut observations = vec![TerminalWorkspaceAuthorityObservation {
+        authority: "controller".into(),
+        capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
+        capability_version: 1,
+        status: "terminal".into(),
+        evidence: format!(
+            "{:?}@{}",
+            controller.state, controller.workspace_lifecycle_revision
+        ),
+        run_id: Some(run_id.into()),
+        runner_job_id: None,
+    }];
+    let accepted = controller
+        .lab_handoff
+        .as_ref()
+        .filter(|handoff| handoff.state == AgentTaskLabHandoffState::Accepted);
+    if let Some(handoff) = accepted {
+        let Some(job_id) = handoff
+            .runner_job_id
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+        else {
+            return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+                reason: "accepted handoff has no exact runner job identity".into(),
+                observations,
+            });
+        };
+        if !with_runner_continuation(|provider| provider.supports_terminal_workspace_authority())
+            || !with_runner_continuation(|provider| provider.runner_exists(&handoff.runner_id))
+            || !with_runner_continuation(|provider| {
+                provider.is_runner_connected(&handoff.runner_id)
+            })
+        {
+            return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+                reason: "accepted runner is old, missing, or unreachable".into(),
+                observations,
+            });
+        }
+        match with_runner_continuation(|provider| {
+            provider.reconcile_runner_job(&handoff.runner_id, job_id)
+        }) {
+            RunnerJobReconciliation::Snapshot(snapshot) if snapshot.job.status.is_terminal() => {
+                observations.push(TerminalWorkspaceAuthorityObservation {
+                    authority: handoff.runner_id.clone(),
+                    capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
+                    capability_version: 1,
+                    status: "terminal".into(),
+                    evidence: format!("{}:{:?}", job_id, snapshot.job.status),
+                    run_id: Some(run_id.into()),
+                    runner_job_id: Some(job_id.into()),
+                })
+            }
+            RunnerJobReconciliation::ConfirmedAbsent {
+                checked_generations,
+            } if checked_generations > 0 => {
+                observations.push(TerminalWorkspaceAuthorityObservation {
+                    authority: handoff.runner_id.clone(),
+                    capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
+                    capability_version: 1,
+                    status: "absent_terminal".into(),
+                    evidence: format!(
+                        "{} absent across {} generations",
+                        job_id, checked_generations
+                    ),
+                    run_id: Some(run_id.into()),
+                    runner_job_id: Some(job_id.into()),
+                })
+            }
+            _ => return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+                reason:
+                    "accepted runner job is active, unknown, or has incomplete terminal evidence"
+                        .into(),
+                observations,
+            }),
+        }
+    }
+    // This protocol has one durable accepted-handoff binding. A configured
+    // authority with no such binding cannot truthfully attest terminality, so
+    // refuse rather than manufacture an "absent" receipt.
+    if authority_set.iter().any(|authority| {
+        authority != "controller"
+            && !observations
+                .iter()
+                .any(|observation| observation.authority == *authority)
+    }) {
+        return Ok(TerminalWorkspaceAuthorityResolution::Refused {
+            reason: "configured terminal authority has no accepted exact runner job binding".into(),
+            observations,
+        });
+    }
+    Ok(TerminalWorkspaceAuthorityResolution::Proven(
+        TerminalWorkspaceAuthorityProof {
+            schema: TERMINAL_WORKSPACE_AUTHORITY_SCHEMA.into(),
+            capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
+            capability_version: 1,
+            workspace,
+            task_worktree_id: record.id.clone(),
+            manifest_revision: record.lifecycle_revision,
+            run_id: Some(run_id.into()),
+            controller_state: format!("{:?}", controller.state),
+            controller_version: controller.workspace_lifecycle_revision,
+            accepted_runner_id: accepted.map(|handoff| handoff.runner_id.clone()),
+            accepted_runner_job_id: accepted.and_then(|handoff| handoff.runner_job_id.clone()),
+            authority_set_fingerprint: authority_set_fingerprint(&authority_set),
+            authority_set,
+            observations,
+            issued_evidence: vec![format!("controller-run:{run_id}")],
+        },
+    ))
+}
+
+fn configured_terminal_authorities() -> std::result::Result<Vec<String>, String> {
+    let runner_ids = with_runner_continuation(|provider| {
+        let ids = provider.terminal_workspace_authority_runner_ids()?;
+        if !ids.is_empty() && !provider.supports_terminal_workspace_authority() {
+            return Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "configured runner does not support terminal workspace authority",
+                None,
+                None,
+            ));
+        }
+        for runner_id in &ids {
+            if runner_id.trim().is_empty()
+                || runner_id == "controller"
+                || !provider.runner_exists(runner_id)
+                || !provider.is_runner_connected(runner_id)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "terminal_workspace_authority",
+                    "configured terminal workspace authority is missing or unreachable",
+                    Some(runner_id.clone()),
+                    None,
+                ));
+            }
+        }
+        Ok(ids)
+    })
+    .map_err(|error| error.message)?;
+    let mut authorities = vec!["controller".to_string()];
+    authorities.extend(runner_ids);
+    authorities.sort();
+    if authorities.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err("configured terminal workspace authorities are not unique".into());
+    }
+    Ok(authorities)
+}
+
+/// The complete authority set for a workspace mutation. Each remote component
+/// has its own opaque token; callers must validate and release every component.
+#[derive(Debug, Clone)]
+pub struct CompositeWorkspaceClaim {
+    pub workspace: WorkspaceIdentity,
+    /// Controller-owned identity for this composition operation. It is not an
+    /// authority epoch: each component retains the epoch its own store issued.
+    pub generation: u64,
+    /// Monotonic controller-side deadline. It starts before any component is
+    /// acquired and is intentionally independent of runner wall clocks.
+    pub commit_deadline: std::time::Instant,
+    pub local: WorkspaceClaim,
+    pub local_released: bool,
+    pub runners: Vec<CompositeWorkspaceClaimComponent>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompositeWorkspaceClaimComponent {
+    pub runner_id: String,
+    pub claim: WorkspaceClaim,
+    pub released: bool,
+}
+
+/// Evidence for a component which remained live after an acquisition rollback.
+#[derive(Debug, Clone)]
+pub struct CompositeWorkspaceClaimRollbackFailure {
+    pub component: String,
+    pub error: Error,
+}
+
+/// An acquisition failure preserves its original error and, when rollback was
+/// incomplete, the exact claim receipt the caller must retry releasing.
+#[derive(Debug, Clone)]
+pub struct CompositeWorkspaceClaimAcquisitionFailure {
+    pub primary: Error,
+    pub rollback_failures: Vec<CompositeWorkspaceClaimRollbackFailure>,
+    pub cleanup: Option<CompositeWorkspaceClaim>,
+}
+
+pub const PENDING_COMPOSITE_WORKSPACE_CLEANUP_SCHEMA: &str =
+    "homeboy/pending-composite-workspace-cleanup/v1";
+pub const COMPOSITE_ACQUISITION_INTENT_SCHEMA: &str = "homeboy/composite-acquisition-intent/v1";
+
+#[cfg(test)]
+static FAIL_NEXT_PENDING_COMPOSITE_CLEANUP_WRITE: AtomicBool = AtomicBool::new(false);
+
+/// A token-free write-ahead marker for one workspace reconciliation. It is
+/// retained while the process owns the composite claim so a crash cannot turn
+/// an acquired fence into an untracked one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CompositeAcquisitionIntent {
+    schema: String,
+    recovery_id: String,
+    workspace: WorkspaceIdentity,
+    started_at_ms: u64,
+    requested_ttl_ms: u64,
+    state: String,
+}
+
+/// Owner-only recovery state for a failed composite acquisition or release.
+/// This deliberately contains the exact opaque receipts needed to replay an
+/// idempotent release; only summaries leave the lifecycle boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingCompositeWorkspaceCleanup {
+    pub schema: String,
+    pub recovery_id: String,
+    pub created_at: String,
+    pub workspace: WorkspaceIdentity,
+    pub generation: u64,
+    pub local: WorkspaceClaim,
+    pub local_released: bool,
+    pub runners: Vec<PendingCompositeWorkspaceCleanupComponent>,
+    pub attempt_count: u32,
+    pub last_error: PendingCompositeWorkspaceCleanupError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingCompositeWorkspaceCleanupComponent {
+    pub runner_id: String,
+    pub claim: WorkspaceClaim,
+    pub released: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingCompositeWorkspaceCleanupError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct QuarantinedCompositeWorkspaceCleanup {
+    recovery_id: String,
+    workspace: Option<WorkspaceIdentity>,
+    reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum CompositeWorkspaceCleanupStatus {
+    Released,
+    Pending {
+        recovery_id: String,
+        attempt_count: u32,
+        failures: Vec<String>,
+    },
+    Quarantined {
+        recovery_id: String,
+        reason: String,
+    },
+}
+
+impl CompositeWorkspaceCleanupStatus {
+    pub fn recovery_ref(&self) -> Option<&str> {
+        match self {
+            Self::Released => None,
+            Self::Pending { recovery_id, .. } | Self::Quarantined { recovery_id, .. } => {
+                Some(recovery_id)
+            }
+        }
+    }
+
+    pub fn public_summary(&self) -> String {
+        match self {
+            Self::Released => "composite cleanup released".into(),
+            Self::Pending {
+                recovery_id,
+                attempt_count,
+                ..
+            } => format!(
+                "composite cleanup remains pending (recovery_ref={recovery_id}, attempts={attempt_count})"
+            ),
+            Self::Quarantined { recovery_id, reason } => format!(
+                "composite cleanup is quarantined (recovery_ref={recovery_id}): {reason}"
+            ),
+        }
+    }
+}
+
+impl From<Error> for CompositeWorkspaceClaimAcquisitionFailure {
+    fn from(primary: Error) -> Self {
+        Self {
+            primary,
+            rollback_failures: Vec::new(),
+            cleanup: None,
+        }
+    }
+}
+
+struct CompositeWorkspaceClaimAcquisitionGuard {
+    workspace: WorkspaceIdentity,
+    generation: u64,
+    acquired_at: std::time::Instant,
+    acquired_at_ms: u64,
+    local: WorkspaceClaim,
+    runners: Vec<CompositeWorkspaceClaimComponent>,
+}
+
+impl CompositeWorkspaceClaimAcquisitionGuard {
+    fn new(workspace: WorkspaceIdentity, generation: u64, local: WorkspaceClaim) -> Self {
+        Self {
+            workspace,
+            generation,
+            acquired_at: std::time::Instant::now(),
+            acquired_at_ms: now_ms(),
+            local,
+            runners: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> CompositeWorkspaceClaim {
+        let budget_ms = commit_budget_ms(
+            self.acquired_at_ms,
+            std::iter::once(self.local.expires_at_ms).chain(
+                self.runners
+                    .iter()
+                    .map(|component| component.claim.expires_at_ms),
+            ),
+        );
+        CompositeWorkspaceClaim {
+            workspace: self.workspace,
+            generation: self.generation,
+            commit_deadline: self.acquired_at + std::time::Duration::from_millis(budget_ms),
+            local: self.local,
+            local_released: false,
+            runners: self.runners,
+        }
+    }
+
+    fn fail(mut self, mut primary: Error) -> CompositeWorkspaceClaimAcquisitionFailure {
+        let mut rollback_failures = Vec::new();
+        if let Err(error) = release_local_workspace_claim(&self.local) {
+            rollback_failures.push(CompositeWorkspaceClaimRollbackFailure {
+                component: "local".into(),
+                error,
+            });
+        } else {
+            // A retained receipt must describe only components that still need
+            // cleanup, so successful releases are recorded before returning it.
+            // `local_released` is populated below on the constructed receipt.
+        }
+        let local_released = rollback_failures
+            .iter()
+            .all(|failure| failure.component != "local");
+        for component in &mut self.runners {
+            if let Err(error) = with_runner_continuation(|provider| {
+                provider.release_workspace_claim(&component.runner_id, &component.claim)
+            }) {
+                rollback_failures.push(CompositeWorkspaceClaimRollbackFailure {
+                    component: component.runner_id.clone(),
+                    error,
+                });
+            } else {
+                component.released = true;
+            }
+        }
+        if !rollback_failures.is_empty() {
+            primary.retryable = Some(true);
+            primary.details["workspace_claim_composite_rollback"] =
+                serde_json::json!(rollback_failures
+                    .iter()
+                    .map(|failure| serde_json::json!({
+                        "component": failure.component,
+                        "code": failure.error.code.as_str(),
+                        "message": failure.error.message,
+                    }))
+                    .collect::<Vec<_>>());
+        }
+        CompositeWorkspaceClaimAcquisitionFailure {
+            primary,
+            cleanup: (!rollback_failures.is_empty()).then(|| CompositeWorkspaceClaim {
+                workspace: self.workspace,
+                generation: self.generation,
+                commit_deadline: self.acquired_at,
+                local: self.local,
+                local_released,
+                runners: self.runners,
+            }),
+            rollback_failures,
+        }
+    }
+}
+
+pub fn acquire_composite_workspace_claim(
+    workspace: WorkspaceIdentity,
+    generation: u64,
+) -> std::result::Result<CompositeWorkspaceClaim, CompositeWorkspaceClaimAcquisitionFailure> {
+    // Recovery is bounded and does not let an unrelated unreachable authority
+    // prevent a distinct workspace from being reconciled.
+    let _ = retry_pending_composite_workspace_cleanups(32);
+    if let Some(status) = composite_acquisition_intent_for_workspace(&workspace) {
+        let mut failure = CompositeWorkspaceClaimAcquisitionFailure::from(composite_error(
+            "workspace has unresolved composite acquisition intent",
+            Vec::new(),
+        ));
+        failure.primary.retryable = Some(true);
+        failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
+            "status": status.public_summary(),
+            "recovery_ref": status.recovery_ref(),
+        });
+        return Err(failure);
+    }
+    if let Some(status) = pending_composite_cleanup_for_workspace(&workspace) {
+        let mut failure = CompositeWorkspaceClaimAcquisitionFailure::from(composite_error(
+            "workspace has unresolved composite cleanup",
+            Vec::new(),
+        ));
+        failure.primary.retryable = Some(true);
+        failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
+            "status": status.public_summary(),
+            "recovery_ref": status.recovery_ref(),
+        });
+        return Err(failure);
+    }
+    let intent = CompositeAcquisitionIntent {
+        schema: COMPOSITE_ACQUISITION_INTENT_SCHEMA.into(),
+        recovery_id: uuid::Uuid::new_v4().to_string(),
+        workspace: workspace.clone(),
+        started_at_ms: now_ms(),
+        requested_ttl_ms: LOCAL_WORKSPACE_CLAIM_TTL_MS,
+        state: "acquiring".into(),
+    };
+    if let Err(error) =
+        homeboy_core::config::with_config_lock(|| write_composite_acquisition_intent(&intent))
+    {
+        return Err(CompositeWorkspaceClaimAcquisitionFailure::from(error));
+    }
+    match acquire_composite_workspace_claim_unrecovered(workspace, generation) {
+        Ok(claim) => {
+            let mut active = intent;
+            active.state = "active".into();
+            if let Err(error) = homeboy_core::config::with_config_lock(|| {
+                write_composite_acquisition_intent(&active)
+            }) {
+                let status = persist_and_retry_composite_workspace_cleanup(claim, &error);
+                let mut failure = CompositeWorkspaceClaimAcquisitionFailure::from(error);
+                failure.primary.retryable = Some(true);
+                failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
+                    "status": status.public_summary(),
+                    "recovery_ref": status.recovery_ref(),
+                });
+                return Err(failure);
+            }
+            Ok(claim)
+        }
+        Err(mut failure) => {
+            if let Some(cleanup) = failure.cleanup.take() {
+                let status =
+                    persist_and_retry_composite_workspace_cleanup(cleanup, &failure.primary);
+                failure.primary.retryable = Some(true);
+                failure.primary.details["workspace_claim_composite_cleanup"] = serde_json::json!({
+                    "status": status.public_summary(),
+                    "recovery_ref": status.recovery_ref(),
+                });
+            } else {
+                // Every acquired component was released, so the intent is no
+                // longer a crash-recovery obligation.
+                let _ = homeboy_core::config::with_config_lock(|| {
+                    remove_composite_acquisition_intent(&intent.workspace)
+                });
+            }
+            Err(failure)
+        }
+    }
+}
+
+fn acquire_composite_workspace_claim_unrecovered(
+    workspace: WorkspaceIdentity,
+    generation: u64,
+) -> std::result::Result<CompositeWorkspaceClaim, CompositeWorkspaceClaimAcquisitionFailure> {
+    workspace.verify()?;
+    let local = acquire_local_workspace_claim(workspace.clone(), generation)?;
+    let mut guard =
+        CompositeWorkspaceClaimAcquisitionGuard::new(workspace.clone(), generation, local);
+    let runner_ids =
+        match with_runner_continuation(|provider| provider.workspace_claim_runner_ids()) {
+            Ok(runner_ids) => runner_ids,
+            Err(error) => return Err(guard.fail(error)),
+        };
+    let mut unique_runner_ids = std::collections::BTreeSet::new();
+    for runner_id in &runner_ids {
+        if runner_id.trim().is_empty() || runner_id != runner_id.trim() || runner_id == "controller"
+        {
+            return Err(guard.fail(Error::validation_invalid_argument(
+                "workspace_claim_runner_ids",
+                "configured workspace claim runner id is malformed",
+                Some(runner_id.clone()),
+                None,
+            )));
+        }
+        if !unique_runner_ids.insert(runner_id) {
+            return Err(guard.fail(Error::validation_invalid_argument(
+                "workspace_claim_runner_ids",
+                "configured workspace claim runner ids are not unique",
+                Some(runner_id.clone()),
+                None,
+            )));
+        }
+    }
+    if !runner_ids.is_empty()
+        && !with_runner_continuation(|provider| provider.supports_workspace_claims())
+    {
+        return Err(guard.fail(composite_error(
+            "workspace claim provider does not support configured remote authorities",
+            Vec::new(),
+        )));
+    }
+    for runner_id in runner_ids {
+        let acquired = match with_runner_continuation(|provider| {
+            provider.acquire_workspace_claim(&runner_id, workspace.clone(), generation)
+        }) {
+            Ok(claim) => claim,
+            Err(error) => return Err(guard.fail(error)),
+        };
+        match acquired {
+            claim if claim.workspace == workspace => {
+                guard.runners.push(CompositeWorkspaceClaimComponent {
+                    runner_id,
+                    claim,
+                    released: false,
+                });
+            }
+            _ => {
+                return Err(guard.fail(Error::validation_invalid_argument(
+                    "workspace_claim",
+                    "runner returned a workspace claim for another workspace",
+                    Some(runner_id),
+                    None,
+                )));
+            }
+        }
+    }
+    Ok(guard.finish())
+}
+
+/// This is deliberately offline: remote validation belongs before acquiring
+/// the registry lease. The retained components are checked by exact shape,
+/// token, identity and the monotonic acquisition budget only.
+pub fn composite_workspace_claim_ready_to_commit(claim: &CompositeWorkspaceClaim) -> bool {
+    if std::time::Instant::now() >= claim.commit_deadline
+        || claim.local.workspace != claim.workspace
+        || claim.local.verify_shape(0).is_err()
+    {
+        return false;
+    }
+    claim.runners.iter().all(|component| {
+        !component.runner_id.trim().is_empty()
+            && component.claim.workspace == claim.workspace
+            && component.claim.verify_shape(0).is_ok()
+    })
+}
+
+pub fn validate_composite_workspace_claim(claim: &CompositeWorkspaceClaim) -> Result<bool> {
+    claim.workspace.verify()?;
+    if claim.local.workspace != claim.workspace || !validate_local_workspace_claim(&claim.local)? {
+        return Ok(false);
+    }
+    for component in &claim.runners {
+        if component.runner_id.trim().is_empty()
+            || component.claim.workspace != claim.workspace
+            || !with_runner_continuation(|provider| {
+                provider.validate_workspace_claim(&component.runner_id, &component.claim)
+            })?
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+pub enum CompositeWorkspaceClaimRelease {
+    Released,
+    Partial { failures: Vec<String> },
+}
+
+pub fn release_composite_workspace_claim(
+    claim: &mut CompositeWorkspaceClaim,
+) -> Result<CompositeWorkspaceClaimRelease> {
+    let mut failures = Vec::new();
+    // Release the primary inventory authority first; retries skip evidence of a
+    // successful release and fan out only to unresolved remote components.
+    if !claim.local_released {
+        match release_local_workspace_claim(&claim.local) {
+            Ok(()) => claim.local_released = true,
+            Err(error) => failures.push(format!("local: {}", error.message)),
+        }
+    }
+    for component in &mut claim.runners {
+        if component.released {
+            continue;
+        }
+        if let Err(error) = with_runner_continuation(|provider| {
+            provider.release_workspace_claim(&component.runner_id, &component.claim)
+        }) {
+            failures.push(format!("{}: {}", component.runner_id, error.message));
+        } else {
+            component.released = true;
+        }
+    }
+    if failures.is_empty() {
+        homeboy_core::config::with_config_lock(|| {
+            remove_composite_acquisition_intent(&claim.workspace)
+        })?;
+        Ok(CompositeWorkspaceClaimRelease::Released)
+    } else {
+        Ok(CompositeWorkspaceClaimRelease::Partial { failures })
+    }
+}
+
+/// Persist an exact composite receipt before retrying its idempotent release.
+/// The returned status is safe to surface to users: opaque tokens remain only
+/// in the owner-only receipt.
+pub fn persist_and_retry_composite_workspace_cleanup(
+    claim: CompositeWorkspaceClaim,
+    error: &Error,
+) -> CompositeWorkspaceCleanupStatus {
+    let pending = PendingCompositeWorkspaceCleanup {
+        schema: PENDING_COMPOSITE_WORKSPACE_CLEANUP_SCHEMA.into(),
+        recovery_id: uuid::Uuid::new_v4().to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        workspace: claim.workspace,
+        generation: claim.generation,
+        local: claim.local,
+        local_released: claim.local_released,
+        runners: claim
+            .runners
+            .into_iter()
+            .map(|component| PendingCompositeWorkspaceCleanupComponent {
+                runner_id: component.runner_id,
+                claim: component.claim,
+                released: component.released,
+            })
+            .collect(),
+        attempt_count: 0,
+        last_error: PendingCompositeWorkspaceCleanupError {
+            code: error.code.as_str().into(),
+            message: error.message.clone(),
+        },
+    };
+    let recovery_id = pending.recovery_id.clone();
+    if let Err(error) =
+        homeboy_core::config::with_config_lock(|| write_pending_composite_cleanup(&pending))
+    {
+        return CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id,
+            reason: format!("could not persist cleanup receipt: {}", error.message),
+        };
+    }
+    // The exact receipt is durable now; removing the token-free intent cannot
+    // reopen acquisition because the receipt itself remains identity-scoped.
+    if let Err(error) = homeboy_core::config::with_config_lock(|| {
+        remove_composite_acquisition_intent(&pending.workspace)
+    }) {
+        return CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id,
+            reason: format!(
+                "could not finalize cleanup receipt replacement: {}",
+                error.message
+            ),
+        };
+    }
+    retry_pending_composite_workspace_cleanup(&pending.recovery_id).unwrap_or_else(|error| {
+        CompositeWorkspaceCleanupStatus::Pending {
+            recovery_id: pending.recovery_id,
+            attempt_count: pending.attempt_count,
+            failures: vec![error.message],
+        }
+    })
+}
+
+/// Explicit lifecycle recovery API. Every pending receipt is replayed at most
+/// `limit` times; completed receipts are removed atomically after all component
+/// releases have reported success.
+pub fn retry_pending_composite_workspace_cleanups(
+    limit: usize,
+) -> Result<Vec<CompositeWorkspaceCleanupStatus>> {
+    let entries = read_pending_composite_cleanups()?;
+    entries
+        .into_iter()
+        .take(limit)
+        .map(|(_, pending)| retry_pending_composite_workspace_cleanup(&pending.recovery_id))
+        .collect()
+}
+
+fn retry_pending_composite_workspace_cleanup(
+    recovery_id: &str,
+) -> Result<CompositeWorkspaceCleanupStatus> {
+    homeboy_core::config::with_config_lock(|| {
+        let Some((path, mut pending)) = read_pending_composite_cleanups()?
+            .into_iter()
+            .find(|(_, pending)| pending.recovery_id == recovery_id)
+        else {
+            return Ok(CompositeWorkspaceCleanupStatus::Released);
+        };
+        let mut claim = CompositeWorkspaceClaim {
+            workspace: pending.workspace.clone(),
+            generation: pending.generation,
+            // A cleanup receipt is never committed, so its old commit deadline
+            // is irrelevant to an idempotent release.
+            commit_deadline: std::time::Instant::now(),
+            local: pending.local.clone(),
+            local_released: pending.local_released,
+            runners: pending
+                .runners
+                .iter()
+                .map(|component| CompositeWorkspaceClaimComponent {
+                    runner_id: component.runner_id.clone(),
+                    claim: component.claim.clone(),
+                    released: component.released,
+                })
+                .collect(),
+        };
+        match release_composite_workspace_claim(&mut claim)? {
+            CompositeWorkspaceClaimRelease::Released => {
+                fs::remove_file(path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some("pending composite cleanup".into()))
+                })?;
+                Ok(CompositeWorkspaceCleanupStatus::Released)
+            }
+            CompositeWorkspaceClaimRelease::Partial { failures } => {
+                pending.local_released = claim.local_released;
+                pending.runners = claim
+                    .runners
+                    .into_iter()
+                    .map(|component| PendingCompositeWorkspaceCleanupComponent {
+                        runner_id: component.runner_id,
+                        claim: component.claim,
+                        released: component.released,
+                    })
+                    .collect();
+                pending.attempt_count = pending.attempt_count.saturating_add(1);
+                pending.last_error = PendingCompositeWorkspaceCleanupError {
+                    code: "workspace_claim_composite".into(),
+                    message: failures.join("; "),
+                };
+                write_pending_composite_cleanup(&pending)?;
+                Ok(CompositeWorkspaceCleanupStatus::Pending {
+                    recovery_id: pending.recovery_id,
+                    attempt_count: pending.attempt_count,
+                    failures,
+                })
+            }
+        }
+    })
+}
+
+fn pending_composite_cleanup_for_workspace(
+    workspace: &WorkspaceIdentity,
+) -> Option<CompositeWorkspaceCleanupStatus> {
+    match read_pending_composite_cleanups() {
+        Ok(entries) => entries
+            .into_iter()
+            .find_map(|(_, pending)| {
+                (pending.workspace == *workspace).then_some(
+                    CompositeWorkspaceCleanupStatus::Pending {
+                        recovery_id: pending.recovery_id,
+                        attempt_count: pending.attempt_count,
+                        failures: vec![pending.last_error.message],
+                    },
+                )
+            })
+            .or_else(|| quarantined_composite_cleanup_for_workspace(workspace)),
+        Err(error) => Some(CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id: "unknown".into(),
+            reason: error.message,
+        }),
+    }
+}
+
+fn pending_composite_cleanup_dir() -> Result<std::path::PathBuf> {
+    Ok(paths::homeboy_data()?.join("agent-task-composite-workspace-cleanups"))
+}
+
+fn composite_acquisition_intent_dir() -> Result<std::path::PathBuf> {
+    Ok(paths::homeboy_data()?.join("agent-task-composite-acquisition-intents"))
+}
+
+fn composite_acquisition_intent_path(workspace: &WorkspaceIdentity) -> Result<std::path::PathBuf> {
+    let mut digest = Sha256::new();
+    digest.update(workspace.schema.as_bytes());
+    digest.update([0]);
+    digest.update(workspace.kind.as_bytes());
+    digest.update([0]);
+    digest.update(workspace.locator.as_bytes());
+    Ok(composite_acquisition_intent_dir()?.join(format!("{:x}.json", digest.finalize())))
+}
+
+fn write_composite_acquisition_intent(intent: &CompositeAcquisitionIntent) -> Result<()> {
+    if intent.schema != COMPOSITE_ACQUISITION_INTENT_SCHEMA
+        || intent.recovery_id.trim().is_empty()
+        || intent.requested_ttl_ms == 0
+        || intent.requested_ttl_ms > MAX_WORKSPACE_CLAIM_TTL_MS
+        || !matches!(intent.state.as_str(), "acquiring" | "active")
+    {
+        return Err(composite_error(
+            "composite acquisition intent is malformed",
+            Vec::new(),
+        ));
+    }
+    intent.workspace.verify()?;
+    write_json_file_owner_only(
+        &composite_acquisition_intent_path(&intent.workspace)?,
+        intent,
+    )
+}
+
+fn remove_composite_acquisition_intent(workspace: &WorkspaceIdentity) -> Result<()> {
+    let path = composite_acquisition_intent_path(workspace)?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(path.display().to_string()),
+        )),
+    }
+}
+
+fn composite_acquisition_intent_for_workspace(
+    workspace: &WorkspaceIdentity,
+) -> Option<CompositeWorkspaceCleanupStatus> {
+    let path = composite_acquisition_intent_path(workspace).ok()?;
+    if !path.exists() {
+        return None;
+    }
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return Some(CompositeWorkspaceCleanupStatus::Quarantined {
+                recovery_id: "unknown".into(),
+                reason: format!("could not read composite acquisition intent: {error}"),
+            })
+        }
+    };
+    let intent: CompositeAcquisitionIntent = match serde_json::from_slice(&bytes) {
+        Ok(intent) => intent,
+        Err(_) => {
+            return Some(CompositeWorkspaceCleanupStatus::Quarantined {
+                recovery_id: "unknown".into(),
+                reason: "composite acquisition intent is malformed".into(),
+            })
+        }
+    };
+    if intent.schema != COMPOSITE_ACQUISITION_INTENT_SCHEMA
+        || intent.workspace != *workspace
+        || intent.recovery_id.trim().is_empty()
+        || intent.requested_ttl_ms == 0
+        || intent.requested_ttl_ms > MAX_WORKSPACE_CLAIM_TTL_MS
+        || !matches!(intent.state.as_str(), "acquiring" | "active")
+    {
+        return Some(CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id: intent.recovery_id,
+            reason: "composite acquisition intent is malformed".into(),
+        });
+    }
+    let conservative_expiry = intent
+        .started_at_ms
+        .saturating_add(MAX_WORKSPACE_CLAIM_TTL_MS);
+    if now_ms() < conservative_expiry {
+        return Some(CompositeWorkspaceCleanupStatus::Pending {
+            recovery_id: intent.recovery_id,
+            attempt_count: 0,
+            failures: vec![
+                "composite acquisition intent is within the maximum component TTL".into(),
+            ],
+        });
+    }
+    // A token-free marker may be cleared only with a complete local and remote
+    // authority inventory. Any unavailable inventory remains a quarantine.
+    let clear = store()
+        .and_then(|store| {
+            store
+                .has_live_authority(workspace, now_ms())
+                .map(|live| !live)
+        })
+        .and_then(|local_clear| {
+            if !local_clear {
+                return Ok(false);
+            }
+            with_runner_continuation(|provider| {
+                provider
+                    .workspace_claim_runner_ids()
+                    .and_then(|runner_ids| {
+                        if !runner_ids.is_empty() && !provider.supports_workspace_claims() {
+                            return Ok(false);
+                        }
+                        runner_ids.into_iter().try_fold(true, |clear, runner_id| {
+                            provider
+                                .workspace_claim_authority_is_clear(&runner_id, workspace)
+                                .map(|remote_clear| clear && remote_clear)
+                        })
+                    })
+            })
+        });
+    match clear {
+        Ok(true) if remove_composite_acquisition_intent(workspace).is_ok() => None,
+        Ok(_) => Some(CompositeWorkspaceCleanupStatus::Pending {
+            recovery_id: intent.recovery_id,
+            attempt_count: 0,
+            failures: vec![
+                "complete authority inventory still reports a live claim or owner".into(),
+            ],
+        }),
+        Err(error) => Some(CompositeWorkspaceCleanupStatus::Quarantined {
+            recovery_id: intent.recovery_id,
+            reason: format!(
+                "complete authority inventory is unavailable: {}",
+                error.message
+            ),
+        }),
+    }
+}
+
+fn pending_composite_cleanup_path(recovery_id: &str) -> Result<std::path::PathBuf> {
+    Ok(pending_composite_cleanup_dir()?.join(format!("{recovery_id}.json")))
+}
+
+fn write_pending_composite_cleanup(pending: &PendingCompositeWorkspaceCleanup) -> Result<()> {
+    #[cfg(test)]
+    if FAIL_NEXT_PENDING_COMPOSITE_CLEANUP_WRITE.swap(false, Ordering::SeqCst) {
+        return Err(Error::internal_io(
+            "injected pending composite cleanup receipt write failure",
+            None,
+        ));
+    }
+    verify_pending_composite_cleanup(pending)?;
+    let path = pending_composite_cleanup_path(&pending.recovery_id)?;
+    write_json_file_owner_only(&path, pending)
+}
+
+fn read_pending_composite_cleanups(
+) -> Result<Vec<(std::path::PathBuf, PendingCompositeWorkspaceCleanup)>> {
+    let directory = pending_composite_cleanup_dir()?;
+    if !directory.exists() {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&directory).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+    })? {
+        let path = entry
+            .map_err(|error| Error::internal_io(error.to_string(), None))?
+            .path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            || path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".quarantine.json"))
+        {
+            continue;
+        }
+        let bytes = fs::read(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+        match serde_json::from_slice::<PendingCompositeWorkspaceCleanup>(&bytes)
+            .map_err(|error| {
+                Error::internal_json(error.to_string(), Some(path.display().to_string()))
+            })
+            .and_then(|pending| {
+                verify_pending_composite_cleanup(&pending)?;
+                Ok(pending)
+            }) {
+            Ok(pending) => entries.push((path, pending)),
+            Err(error) => quarantine_pending_composite_cleanup(&path, &bytes, error.message)?,
+        }
+    }
+    Ok(entries)
+}
+
+fn quarantine_pending_composite_cleanup(
+    path: &std::path::Path,
+    bytes: &[u8],
+    reason: String,
+) -> Result<()> {
+    let recovery_id = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let workspace = serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|value| value.get("workspace").cloned())
+        .and_then(|value| serde_json::from_value(value).ok());
+    let quarantine = QuarantinedCompositeWorkspaceCleanup {
+        recovery_id: recovery_id.clone(),
+        workspace,
+        reason,
+    };
+    let quarantine_path = path.with_file_name(format!("{recovery_id}.quarantine.json"));
+    write_json_file_owner_only(&quarantine_path, &quarantine)?;
+    fs::remove_file(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+}
+
+fn quarantined_composite_cleanup_for_workspace(
+    workspace: &WorkspaceIdentity,
+) -> Option<CompositeWorkspaceCleanupStatus> {
+    let directory = pending_composite_cleanup_dir().ok()?;
+    let entries = fs::read_dir(directory).ok()?;
+    entries.filter_map(|entry| entry.ok()).find_map(|entry| {
+        let path = entry.path();
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".quarantine.json"))
+            .then_some(())?;
+        let quarantine: QuarantinedCompositeWorkspaceCleanup =
+            serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+        (quarantine.workspace.as_ref() == Some(workspace)).then_some(
+            CompositeWorkspaceCleanupStatus::Quarantined {
+                recovery_id: quarantine.recovery_id,
+                reason: quarantine.reason,
+            },
+        )
+    })
+}
+
+fn verify_pending_composite_cleanup(pending: &PendingCompositeWorkspaceCleanup) -> Result<()> {
+    pending.workspace.verify()?;
+    if pending.schema != PENDING_COMPOSITE_WORKSPACE_CLEANUP_SCHEMA
+        || pending.recovery_id.trim().is_empty()
+        || pending.generation == 0
+        || pending.local.workspace != pending.workspace
+    {
+        return Err(composite_error(
+            "pending composite cleanup receipt is malformed",
+            Vec::new(),
+        ));
+    }
+    pending.local.verify_shape(0)?;
+    for component in &pending.runners {
+        if component.runner_id.trim().is_empty() || component.claim.workspace != pending.workspace {
+            return Err(composite_error(
+                "pending composite cleanup component is malformed",
+                Vec::new(),
+            ));
+        }
+        component.claim.verify_shape(0)?;
+    }
+    Ok(())
+}
+
+fn composite_error(message: &str, failures: Vec<String>) -> Error {
+    Error::validation_invalid_argument(
+        "workspace_claim_composite",
+        message,
+        None,
+        (!failures.is_empty()).then(|| failures),
+    )
+}
+
+fn store() -> Result<WorkspaceClaimStore> {
+    Ok(WorkspaceClaimStore::new(
+        paths::homeboy_data()?.join("agent-task-workspace-claims"),
+    ))
+}
+
+/// Return the durable controller binding for a workspace-owning run. Callers
+/// serialize this unchanged across the direct daemon boundary.
+pub fn workspace_claim_binding(run_id: &str) -> Result<Option<WorkspaceClaimBinding>> {
+    let record = store::read_record(run_id)?;
+    require_record_workspace_owner(&record)?;
+    Ok(record
+        .workspace_identity
+        .zip(record.workspace_claim)
+        .map(|(workspace, claim)| WorkspaceClaimBinding {
+            workspace,
+            lifecycle_revision: record.workspace_lifecycle_revision,
+            claim: Some(claim),
+        }))
+}
+
+/// Legacy generic runner runs have a durable run id but no agent-task record.
+/// They remain unbound; an existing workspace-owning record still fails closed.
+pub fn workspace_claim_binding_if_present(run_id: &str) -> Result<Option<WorkspaceClaimBinding>> {
+    match store::read_record(run_id) {
+        Ok(_) => workspace_claim_binding(run_id),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Direct daemons issue their own durable lease in their authority store. The
+/// controller supplies only the stable workspace and owner identities.
+pub fn workspace_owner_registration_if_present(
+    run_id: &str,
+) -> Result<Option<(WorkspaceIdentity, String)>> {
+    match store::read_record(run_id) {
+        Ok(record) => {
+            require_record_workspace_owner(&record)?;
+            Ok(record
+                .workspace_identity
+                .map(|workspace| (workspace, record.run_id)))
+        }
+        Err(_) => Ok(None),
+    }
+}
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// Inventory is local-controller evidence only. Runner authority composition is
+/// deliberately delegated to `RunnerContinuationProvider` in a later layer.
+pub fn local_workspace_authority_inventory() -> Result<Vec<AgentTaskRunRecord>> {
+    store::read_records().map(|records| {
+        records
+            .into_iter()
+            .filter(|record| {
+                !record.state.is_terminal()
+                    && record
+                        .workspace_owner_lease
+                        .as_ref()
+                        .is_some_and(|lease| validate_local_workspace_owner(lease).unwrap_or(false))
+            })
+            .collect()
+    })
+}
+
+pub fn acquire_local_workspace_claim(
+    workspace: WorkspaceIdentity,
+    _lifecycle_revision: u64,
+) -> Result<WorkspaceClaim> {
+    store()?.acquire(workspace, LOCAL_WORKSPACE_CLAIM_TTL_MS, now_ms())
+}
+
+pub fn validate_local_workspace_claim(claim: &WorkspaceClaim) -> Result<bool> {
+    store()?.validate(claim, now_ms())
+}
+
+pub fn release_local_workspace_claim(claim: &WorkspaceClaim) -> Result<()> {
+    store()?.release(claim, now_ms())
+}
+
+pub(crate) fn register_local_workspace_owner(
+    workspace: WorkspaceIdentity,
+    run_id: &str,
+) -> Result<WorkspaceOwnerLease> {
+    store()?.register_owner(
+        workspace,
+        run_id,
+        LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS,
+        now_ms(),
+    )
+}
+
+pub(crate) fn renew_local_workspace_owner(
+    lease: &WorkspaceOwnerLease,
+) -> Result<WorkspaceOwnerLease> {
+    store()?.renew_owner(lease, LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS, now_ms())
+}
+
+pub(crate) fn validate_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Result<bool> {
+    store()?.validate_owner(lease, now_ms())
+}
+
+pub(crate) fn release_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Result<()> {
+    store()?.release_owner(lease, now_ms())
+}
+
+pub(crate) fn renew_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
+    if record.state.is_terminal() {
+        return Ok(());
+    }
+    let Some(lease) = record.workspace_owner_lease.as_ref() else {
+        return Ok(());
+    };
+    let renewed = renew_local_workspace_owner(lease)?;
+    record.workspace_lifecycle_revision = renewed.lifecycle_revision;
+    record.workspace_owner_lease = Some(renewed);
+    Ok(())
+}
+
+pub(crate) fn ensure_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
+    let Some(identity) = record.workspace_identity.clone() else {
+        return Ok(());
+    };
+    identity.verify()?;
+    if let Some(lease) = record.workspace_owner_lease.as_ref() {
+        if lease.workspace == identity
+            && lease.owner_id == record.run_id
+            && lease.lifecycle_revision == record.workspace_lifecycle_revision
+            && validate_local_workspace_owner(lease)?
+        {
+            return Ok(());
+        }
+    }
+    record.workspace_owner_lease = Some(register_local_workspace_owner(identity, &record.run_id)?);
+    record.workspace_lifecycle_revision = record
+        .workspace_owner_lease
+        .as_ref()
+        .expect("registered owner lease")
+        .lifecycle_revision;
+    Ok(())
+}
+
+pub(crate) fn require_record_workspace_owner(record: &AgentTaskRunRecord) -> Result<()> {
+    let Some(identity) = record.workspace_identity.as_ref() else {
+        return Ok(());
+    };
+    identity.verify()?;
+    let lease = record.workspace_owner_lease.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "workspace-owning agent-task record has no durable owner lease",
+            Some(record.run_id.clone()),
+            None,
+        )
+    })?;
+    if lease.workspace != *identity
+        || lease.owner_id != record.run_id
+        || lease.lifecycle_revision != record.workspace_lifecycle_revision
+        || !validate_local_workspace_owner(lease)?
+    {
+        return Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "workspace owner lease is stale, malformed, or no longer owned by this controller",
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn release_terminal_record_workspace_owner(record: &AgentTaskRunRecord) -> Result<()> {
+    if record.state.is_terminal() {
+        if let Some(lease) = record.workspace_owner_lease.as_ref() {
+            release_local_workspace_owner(lease)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn identity_for_plan(plan: &AgentTaskPlan) -> Result<Option<WorkspaceIdentity>> {
+    // Task-worktree identity is assigned by the workspace resolver before the
+    // plan is submitted. Other modes have no portable physical allocation here.
+    let _ = plan;
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::workspace_claim::{WorkspaceClaimProtocol, WORKSPACE_CLAIM_SCHEMA};
+    use std::collections::BTreeSet;
+    use std::sync::{Arc, Mutex};
+
+    struct ClaimProvider {
+        runner_ids: Result<Vec<String>>,
+        fail_acquire_for: Option<String>,
+        fail_release_once_for: Mutex<BTreeSet<String>>,
+        fail_release_always_for: Arc<Mutex<BTreeSet<String>>>,
+        live: Arc<Mutex<BTreeSet<String>>>,
+        released: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl ClaimProvider {
+        fn claim(workspace: WorkspaceIdentity, runner_id: &str) -> WorkspaceClaim {
+            WorkspaceClaim {
+                schema: WORKSPACE_CLAIM_SCHEMA.into(),
+                protocol: WorkspaceClaimProtocol::current(),
+                workspace,
+                lifecycle_revision: 1,
+                token: format!("{runner_id}-claim"),
+                expires_at_ms: now_ms() + 60_000,
+            }
+        }
+    }
+
+    impl RunnerContinuationProvider for ClaimProvider {
+        fn supports_workspace_claims(&self) -> bool {
+            true
+        }
+
+        fn workspace_claim_runner_ids(&self) -> Result<Vec<String>> {
+            self.runner_ids.clone()
+        }
+
+        fn acquire_workspace_claim(
+            &self,
+            runner_id: &str,
+            workspace: WorkspaceIdentity,
+            _lifecycle_revision: u64,
+        ) -> Result<WorkspaceClaim> {
+            if self.fail_acquire_for.as_deref() == Some(runner_id)
+                && workspace.locator == "workspace-claim-rollback"
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "injected acquisition failure for {runner_id}"
+                )));
+            }
+            self.live
+                .lock()
+                .expect("live claims")
+                .insert(runner_id.into());
+            Ok(Self::claim(workspace, runner_id))
+        }
+
+        fn release_workspace_claim(&self, runner_id: &str, _claim: &WorkspaceClaim) -> Result<()> {
+            self.released
+                .lock()
+                .expect("release log")
+                .push(runner_id.into());
+            if self
+                .fail_release_once_for
+                .lock()
+                .expect("release faults")
+                .remove(runner_id)
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "injected release failure for {runner_id}"
+                )));
+            }
+            if self
+                .fail_release_always_for
+                .lock()
+                .expect("release faults")
+                .contains(runner_id)
+            {
+                return Err(Error::internal_unexpected(format!(
+                    "injected persistent release failure for {runner_id}"
+                )));
+            }
+            self.live.lock().expect("live claims").remove(runner_id);
+            Ok(())
+        }
+
+        fn runner_job_log_snapshot(
+            &self,
+            _runner_id: &str,
+            _job_id: &str,
+        ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+            Err(Error::internal_unexpected(
+                "not used by workspace claim tests",
+            ))
+        }
+
+        fn is_runner_connected(&self, _runner_id: &str) -> bool {
+            true
+        }
+
+        fn runner_exists(&self, _runner_id: &str) -> bool {
+            true
+        }
+
+        fn run_continuation_exec(
+            &self,
+            _runner_id: &str,
+            _cwd: &str,
+            _command: &[String],
+            _run_id: &str,
+        ) -> Result<i32> {
+            Err(Error::internal_unexpected(
+                "not used by workspace claim tests",
+            ))
+        }
+
+        fn submit_reverse_broker_job(
+            &self,
+            _runner_id: &str,
+            _request: homeboy_core::api_jobs::RemoteRunnerJobRequest,
+        ) -> Result<homeboy_core::api_jobs::Job> {
+            Err(Error::internal_unexpected(
+                "not used by workspace claim tests",
+            ))
+        }
+    }
+
+    fn workspace() -> WorkspaceIdentity {
+        WorkspaceIdentity::new("test", "workspace-claim-rollback").expect("workspace")
+    }
+
+    fn install_claim_provider(provider: ClaimProvider) -> RunnerContinuationTestGuard {
+        super::super::tests::ensure_runner_continuation_provider_reset_hook();
+        RunnerContinuationTestGuard::install(Box::new(provider))
+    }
+
+    fn provider(runner_ids: Result<Vec<String>>) -> (ClaimProvider, Arc<Mutex<BTreeSet<String>>>) {
+        let live = Arc::new(Mutex::new(BTreeSet::new()));
+        (
+            ClaimProvider {
+                runner_ids,
+                fail_acquire_for: None,
+                fail_release_once_for: Mutex::new(BTreeSet::new()),
+                fail_release_always_for: Arc::new(Mutex::new(BTreeSet::new())),
+                live: live.clone(),
+                released: Arc::new(Mutex::new(Vec::new())),
+            },
+            live,
+        )
+    }
+
+    #[test]
+    fn commit_budget_uses_shortest_authority_expiry() {
+        // The explicit `now_ms` is a fake monotonic-clock injection seam: no
+        // wall clock or sleep is needed to exercise expiry while waiting.
+        assert_eq!(commit_budget_ms(10_000, [310_000, 10_500].into_iter()), 0);
+        assert_eq!(
+            commit_budget_ms(10_000, [310_000, 12_500].into_iter()),
+            1_500
+        );
+    }
+
+    #[test]
+    fn enumeration_failure_after_local_acquisition_releases_the_local_claim() {
+        with_isolated_home(|_| {
+            let (provider, live) = provider(Err(Error::internal_unexpected(
+                "injected enumeration failure",
+            )));
+            let _provider = install_claim_provider(provider);
+            let workspace = workspace();
+
+            let failure = acquire_composite_workspace_claim(workspace.clone(), 1)
+                .expect_err("enumeration must fail");
+
+            assert_eq!(failure.primary.message, "injected enumeration failure");
+            assert!(failure.rollback_failures.is_empty());
+            assert!(failure.cleanup.is_none());
+            assert!(live.lock().expect("live claims").is_empty());
+            let claim = acquire_local_workspace_claim(workspace, 1).expect("local claim released");
+            release_local_workspace_claim(&claim).expect("release verification claim");
+        });
+    }
+
+    #[test]
+    fn malformed_and_duplicate_runner_ids_release_the_local_claim() {
+        for runner_ids in [vec![" ".into()], vec!["runner-a".into(), "runner-a".into()]] {
+            with_isolated_home(|_| {
+                let (provider, live) = provider(Ok(runner_ids));
+                let _provider = install_claim_provider(provider);
+                let failure = acquire_composite_workspace_claim(workspace(), 1)
+                    .expect_err("invalid runner IDs must fail");
+                assert!(failure.primary.message.contains("runner id"));
+                assert!(failure.cleanup.is_none());
+                assert!(live.lock().expect("live claims").is_empty());
+                let claim =
+                    acquire_local_workspace_claim(workspace(), 1).expect("local claim released");
+                release_local_workspace_claim(&claim).expect("release verification claim");
+            });
+        }
+    }
+
+    #[test]
+    fn later_remote_failure_releases_local_and_prior_remote_claims() {
+        with_isolated_home(|_| {
+            let (mut provider, live) = provider(Ok(vec!["runner-a".into(), "runner-b".into()]));
+            provider.fail_acquire_for = Some("runner-b".into());
+            let _provider = install_claim_provider(provider);
+
+            let failure = acquire_composite_workspace_claim(workspace(), 1)
+                .expect_err("second remote acquisition must fail");
+
+            assert_eq!(
+                failure.primary.message,
+                "injected acquisition failure for runner-b"
+            );
+            assert!(failure.rollback_failures.is_empty());
+            assert!(failure.cleanup.is_none());
+            assert!(live.lock().expect("live claims").is_empty());
+            let claim =
+                acquire_local_workspace_claim(workspace(), 1).expect("local claim released");
+            release_local_workspace_claim(&claim).expect("release verification claim");
+        });
+    }
+
+    #[test]
+    fn failed_remote_rollback_persists_and_retries_a_durable_cleanup_receipt() {
+        with_isolated_home(|_| {
+            let (mut provider, live) = provider(Ok(vec!["runner-a".into(), "runner-b".into()]));
+            provider.fail_acquire_for = Some("runner-b".into());
+            let faults = provider.fail_release_always_for.clone();
+            faults.lock().expect("faults").insert("runner-a".into());
+            let _provider = install_claim_provider(provider);
+
+            let failure = acquire_composite_workspace_claim(workspace(), 1)
+                .expect_err("second remote acquisition must fail");
+
+            assert_eq!(
+                failure.primary.message,
+                "injected acquisition failure for runner-b"
+            );
+            assert_eq!(failure.rollback_failures.len(), 1);
+            assert_eq!(failure.rollback_failures[0].component, "runner-a");
+            assert_eq!(
+                failure.primary.details["workspace_claim_composite_rollback"][0]["message"],
+                "injected persistent release failure for runner-a"
+            );
+            assert!(
+                failure.cleanup.is_none(),
+                "receipt is lifecycle-owned after persistence"
+            );
+            let recovery_ref = failure.primary.details["workspace_claim_composite_cleanup"]
+                ["recovery_ref"]
+                .as_str()
+                .expect("redacted recovery reference");
+            assert!(!recovery_ref.contains("runner-a-claim"));
+            assert!(matches!(
+                pending_composite_cleanup_for_workspace(&workspace()),
+                Some(CompositeWorkspaceCleanupStatus::Pending { .. })
+            ));
+            let blocked = acquire_composite_workspace_claim(workspace(), 2)
+                .expect_err("same workspace must fail closed while cleanup is pending");
+            assert_eq!(blocked.primary.retryable, Some(true));
+            faults.lock().expect("faults").clear();
+            let retry = retry_pending_composite_workspace_cleanups(1).expect("restart retry");
+            assert!(matches!(
+                retry.as_slice(),
+                [CompositeWorkspaceCleanupStatus::Released]
+            ));
+            let mut unrelated = acquire_composite_workspace_claim(
+                WorkspaceIdentity::new("test", "unrelated-workspace-claim").expect("identity"),
+                1,
+            )
+            .expect("unrelated workspace can proceed");
+            assert!(matches!(
+                release_composite_workspace_claim(&mut unrelated).expect("unrelated release"),
+                CompositeWorkspaceClaimRelease::Released
+            ));
+            // A fresh lifecycle call can replay the persisted receipt without
+            // retaining any process-local composite token map.
+            assert!(retry_pending_composite_workspace_cleanups(1)
+                .expect("idempotent retry")
+                .is_empty());
+            assert!(live.lock().expect("live claims").is_empty());
+        });
+    }
+
+    #[test]
+    fn malformed_pending_receipt_is_quarantined_and_blocks_only_its_identity() {
+        with_isolated_home(|_| {
+            let workspace = workspace();
+            let local = acquire_local_workspace_claim(workspace.clone(), 1).expect("local claim");
+            let recovery_id = "malformed-receipt".to_string();
+            let mut pending = PendingCompositeWorkspaceCleanup {
+                schema: PENDING_COMPOSITE_WORKSPACE_CLEANUP_SCHEMA.into(),
+                recovery_id: recovery_id.clone(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                workspace: workspace.clone(),
+                generation: 1,
+                local: local.clone(),
+                local_released: false,
+                runners: Vec::new(),
+                attempt_count: 0,
+                last_error: PendingCompositeWorkspaceCleanupError {
+                    code: "test".into(),
+                    message: "test fixture".into(),
+                },
+            };
+            pending.local.token.clear();
+            let path = pending_composite_cleanup_path(&recovery_id).expect("receipt path");
+            fs::create_dir_all(path.parent().expect("receipt directory"))
+                .expect("receipt directory");
+            fs::write(&path, serde_json::to_vec(&pending).expect("receipt json"))
+                .expect("corrupt receipt");
+
+            let blocked = acquire_composite_workspace_claim(workspace.clone(), 2)
+                .expect_err("malformed receipt must fail closed");
+            assert!(
+                blocked.primary.details["workspace_claim_composite_cleanup"]["status"]
+                    .as_str()
+                    .expect("status")
+                    .contains(&recovery_id)
+            );
+            assert!(path
+                .with_file_name(format!("{recovery_id}.quarantine.json"))
+                .exists());
+
+            release_local_workspace_claim(&local).expect("fixture release");
+        });
+    }
+
+    #[test]
+    fn write_ahead_intent_blocks_only_its_identity_until_authority_is_proven_clear() {
+        with_isolated_home(|_| {
+            let (provider, _) = provider(Ok(Vec::new()));
+            let _provider = install_claim_provider(provider);
+            let workspace = workspace();
+            let mut intent = CompositeAcquisitionIntent {
+                schema: COMPOSITE_ACQUISITION_INTENT_SCHEMA.into(),
+                recovery_id: "intent-recovery".into(),
+                workspace: workspace.clone(),
+                started_at_ms: now_ms(),
+                requested_ttl_ms: LOCAL_WORKSPACE_CLAIM_TTL_MS,
+                state: "acquiring".into(),
+            };
+            write_composite_acquisition_intent(&intent).expect("write token-free intent");
+            assert!(matches!(
+                composite_acquisition_intent_for_workspace(&workspace),
+                Some(CompositeWorkspaceCleanupStatus::Pending { .. })
+            ));
+            let mut unrelated = acquire_composite_workspace_claim(
+                WorkspaceIdentity::new("test", "unrelated-intent").expect("identity"),
+                1,
+            )
+            .expect("unrelated identity remains available");
+            assert!(matches!(
+                release_composite_workspace_claim(&mut unrelated).expect("release unrelated"),
+                CompositeWorkspaceClaimRelease::Released
+            ));
+
+            intent.started_at_ms = now_ms().saturating_sub(MAX_WORKSPACE_CLAIM_TTL_MS + 1);
+            write_composite_acquisition_intent(&intent).expect("age intent beyond ttl");
+            let live = acquire_local_workspace_claim(workspace.clone(), 1).expect("live authority");
+            assert!(matches!(
+                composite_acquisition_intent_for_workspace(&workspace),
+                Some(CompositeWorkspaceCleanupStatus::Pending { .. })
+            ));
+            release_local_workspace_claim(&live).expect("release live authority");
+            assert!(composite_acquisition_intent_for_workspace(&workspace).is_none());
+
+            let mut claim = acquire_composite_workspace_claim(workspace.clone(), 1)
+                .expect("clear intent permits acquisition");
+            assert!(composite_acquisition_intent_path(&workspace)
+                .expect("intent path")
+                .exists());
+            assert!(matches!(
+                release_composite_workspace_claim(&mut claim).expect("release claim"),
+                CompositeWorkspaceClaimRelease::Released
+            ));
+            assert!(!composite_acquisition_intent_path(&workspace)
+                .expect("intent path")
+                .exists());
+        });
+    }
+
+    #[test]
+    fn malformed_write_ahead_intent_quarantines_its_identity() {
+        with_isolated_home(|_| {
+            let workspace = workspace();
+            let path = composite_acquisition_intent_path(&workspace).expect("intent path");
+            fs::create_dir_all(path.parent().expect("intent directory")).expect("intent directory");
+            fs::write(&path, b"not json").expect("malformed intent");
+            assert!(matches!(
+                composite_acquisition_intent_for_workspace(&workspace),
+                Some(CompositeWorkspaceCleanupStatus::Quarantined { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn failed_pending_receipt_write_preserves_the_write_ahead_intent() {
+        with_isolated_home(|_| {
+            let (mut provider, _) = provider(Ok(vec!["runner-a".into(), "runner-b".into()]));
+            provider.fail_acquire_for = Some("runner-b".into());
+            provider
+                .fail_release_always_for
+                .lock()
+                .expect("faults")
+                .insert("runner-a".into());
+            let faults = provider.fail_release_always_for.clone();
+            let _provider = install_claim_provider(provider);
+            FAIL_NEXT_PENDING_COMPOSITE_CLEANUP_WRITE.store(true, Ordering::SeqCst);
+
+            let failure = acquire_composite_workspace_claim(workspace(), 1)
+                .expect_err("incomplete rollback must fail");
+            assert!(
+                failure.primary.details["workspace_claim_composite_cleanup"]["status"]
+                    .as_str()
+                    .expect("public status")
+                    .contains("quarantined")
+            );
+            assert!(composite_acquisition_intent_path(&workspace())
+                .expect("intent path")
+                .exists());
+            assert!(acquire_composite_workspace_claim(workspace(), 2).is_err());
+
+            let mut unrelated = acquire_composite_workspace_claim(
+                WorkspaceIdentity::new("test", "unrelated-write-failure").expect("identity"),
+                1,
+            )
+            .expect("unrelated identity remains available");
+            // The injected runner failure is global to this test provider; the
+            // unrelated acquisition above proves identity isolation.
+            faults.lock().expect("faults").clear();
+            assert!(matches!(
+                release_composite_workspace_claim(&mut unrelated).expect("release unrelated"),
+                CompositeWorkspaceClaimRelease::Released
+            ));
+        });
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -10,6 +10,7 @@ use crate::agent_task::{AgentTaskComponentContract, AgentTaskOutcome, AgentTaskR
 use homeboy_core::plan::{
     HomeboyPlan, PlanArtifact, PlanKind, PlanStep, PlanStepDependencyKind, PlanStepStatus,
 };
+use homeboy_core::workspace_claim::{WorkspaceIdentity, WorkspaceOwnerLease};
 
 mod plan {
     use super::*;
@@ -28,6 +29,9 @@ mod plan {
         pub artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
         pub options: AgentTaskScheduleOptions,
         pub metadata: Value,
+        pub workspace_identity: Option<WorkspaceIdentity>,
+        pub workspace_lifecycle_revision: u64,
+        pub workspace_owner_lease: Option<WorkspaceOwnerLease>,
         pub homeboy_plan: HomeboyPlan,
     }
 
@@ -43,6 +47,9 @@ mod plan {
                 artifact_outputs: HashMap::new(),
                 options: AgentTaskScheduleOptions::default(),
                 metadata: Value::Null,
+                workspace_identity: None,
+                workspace_lifecycle_revision: 0,
+                workspace_owner_lease: None,
                 homeboy_plan: HomeboyPlan::default(),
             };
             plan.rebuild_homeboy_plan();
@@ -120,6 +127,9 @@ mod plan {
                 artifact_outputs,
                 options,
                 metadata,
+                workspace_identity: None,
+                workspace_lifecycle_revision: 0,
+                workspace_owner_lease: None,
                 homeboy_plan,
             }
         }
@@ -135,7 +145,13 @@ mod plan {
                 }
             }
             self.rebuild_homeboy_plan();
-            Self::from_homeboy_plan(self.homeboy_plan)
+            let mut canonical = Self::from_homeboy_plan(self.homeboy_plan);
+            // Workspace authority is plan-level durable state, not a step input.
+            // Keep it through the generic Homeboy-plan normalization projection.
+            canonical.workspace_identity = self.workspace_identity;
+            canonical.workspace_lifecycle_revision = self.workspace_lifecycle_revision;
+            canonical.workspace_owner_lease = self.workspace_owner_lease;
+            canonical
         }
 
         fn to_homeboy_plan(&self) -> HomeboyPlan {
@@ -256,6 +272,12 @@ mod plan {
         options: AgentTaskScheduleOptions,
         #[serde(default, skip_serializing_if = "Value::is_null")]
         metadata: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_identity: Option<WorkspaceIdentity>,
+        #[serde(default)]
+        workspace_lifecycle_revision: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_owner_lease: Option<WorkspaceOwnerLease>,
     }
 
     impl AgentTaskPlanJson {
@@ -279,6 +301,9 @@ mod plan {
                 artifact_outputs: self.artifact_outputs,
                 options: self.options,
                 metadata: self.metadata,
+                workspace_identity: self.workspace_identity,
+                workspace_lifecycle_revision: self.workspace_lifecycle_revision,
+                workspace_owner_lease: self.workspace_owner_lease,
                 homeboy_plan: HomeboyPlan::default(),
             };
             plan.rebuild_homeboy_plan();
@@ -298,6 +323,9 @@ mod plan {
                 artifact_outputs: plan.artifact_outputs.clone(),
                 options: plan.options.clone(),
                 metadata: plan.metadata.clone(),
+                workspace_identity: plan.workspace_identity.clone(),
+                workspace_lifecycle_revision: plan.workspace_lifecycle_revision,
+                workspace_owner_lease: plan.workspace_owner_lease.clone(),
             }
         }
     }

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -229,8 +229,14 @@ fn write_record_with_aggregate(
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<()> {
-    let committed = write_record_with_aggregate_without_workspace_authority(record, aggregate)?;
+    let mut record = record.clone();
+    // Every durable scheduler/provider/controller heartbeat passes through this
+    // write boundary. Renew before persisting so the record carries the exact
+    // store-issued epoch rather than an optimistic local timestamp.
+    super::renew_record_workspace_owner(&mut record)?;
+    let committed = write_record_with_aggregate_without_workspace_authority(&record, aggregate)?;
     super::workspace_authority::persist_terminal_from_record(&committed)
+        .and_then(|_| super::release_terminal_record_workspace_owner(&committed))
 }
 
 fn write_record_with_aggregate_without_workspace_authority(
@@ -568,6 +574,21 @@ pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
             problem,
             Some(format!("validate agent-task Lab handoff {}", run.id)),
         ));
+    }
+    if let Some(identity) = record.workspace_identity.as_ref() {
+        identity.verify()?;
+        if record.workspace_owner_lease.as_ref().is_some_and(|lease| {
+            lease.workspace != *identity
+                || lease.lifecycle_revision != record.workspace_lifecycle_revision
+                || lease.owner_id != record.run_id
+        }) {
+            return Err(Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                "agent-task workspace owner lease contradicts durable identity or lifecycle revision",
+                Some(run.id.clone()),
+                None,
+            ));
+        }
     }
     Ok(record)
 }

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -85,6 +85,14 @@ pub struct RemoteRunnerJobRequest {
     pub lab_runner_workload: Option<LabRunnerWorkload>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<RunnerJobLifecycleMetadata>,
+    /// Exact reconciliation authority required to mutate this workspace. It is
+    /// absent for ordinary runner jobs, preserving the original wire contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    /// Exact active-work authority for portable workspace jobs. Unlike a
+    /// reconciliation fence this remains live while the worker executes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
 }
@@ -95,6 +103,14 @@ impl RemoteRunnerJobRequest {
     /// must never be handed a job that would make this boundary fail open.
     pub fn requires_execution_context(&self) -> bool {
         !self.extension_env_providers.is_empty()
+    }
+
+    pub fn requires_workspace_claim_protocol(&self) -> bool {
+        self.workspace_claim_binding.is_some()
+    }
+
+    pub fn requires_workspace_owner_lease_protocol(&self) -> bool {
+        self.workspace_owner_lease.is_some()
     }
 
     /// A caller-owned identity makes a retried POST safe across a lost response.
@@ -137,6 +153,8 @@ impl RemoteRunnerJobRequest {
             "require_paths": request.require_paths,
             "extension_env_providers": request.extension_env_providers,
             "runner_workload": request.lab_runner_workload,
+            "workspace_claim_binding": request.workspace_claim_binding,
+            "workspace_owner_lease": request.workspace_owner_lease,
             "command_assets": request
                 .metadata
                 .as_ref()
@@ -425,6 +443,12 @@ pub struct RemoteRunnerJobClaim {
     /// Echoed by compatible workers and verified before they execute a claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_protocol: Option<crate::runner_job_execution_context::RunnerJobExecutionProtocol>,
+    /// Echoed only for workspace-owning jobs. A worker must reject a missing or
+    /// malformed value before it materializes the claimed workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_protocol: Option<crate::workspace_claim::WorkspaceClaimProtocol>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease_protocol: Option<crate::workspace_claim::WorkspaceOwnerLeaseProtocol>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -597,6 +621,36 @@ fn execution_context_id_from_evidence(stored: &StoredJob) -> Result<Option<Strin
 }
 
 impl JobStore {
+    pub fn remote_runner_workspace_claim_binding(
+        &self,
+        job_id: Uuid,
+    ) -> Result<Option<crate::workspace_claim::WorkspaceClaimBinding>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        Ok(stored
+            .remote_runner
+            .as_ref()
+            .and_then(|remote| remote.request.workspace_claim_binding.clone()))
+    }
+
+    pub fn remote_runner_workspace_owner_lease(
+        &self,
+        job_id: Uuid,
+    ) -> Result<Option<crate::workspace_claim::WorkspaceOwnerLease>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        Ok(stored
+            .remote_runner
+            .as_ref()
+            .and_then(|remote| remote.request.workspace_owner_lease.clone()))
+    }
+
     pub fn lookup_remote_runner_submission(
         &self,
         submission_key: &str,
@@ -635,6 +689,12 @@ impl JobStore {
             ));
         }
         request.validate_command_assets()?;
+        if let Some(binding) = request.workspace_claim_binding.as_ref() {
+            binding.verify()?;
+        }
+        if let Some(lease) = request.workspace_owner_lease.as_ref() {
+            lease.verify_shape(timestamp_ms())?;
+        }
         let secret_env_plan = request.normalize();
         reject_inline_durable_secret_env(&request, &secret_env_plan)?;
         super::with_runner_job_preparation(|p| {
@@ -858,6 +918,33 @@ impl JobStore {
             &crate::runner_job_execution_context::RunnerJobExecutionProtocol,
         >,
     ) -> Result<Option<RemoteRunnerJobClaim>> {
+        self.claim_remote_runner_job_with_protocols(
+            runner_id,
+            project_id,
+            lease_ms,
+            concurrency_limit,
+            execution_protocol,
+            Some(&crate::workspace_claim::WorkspaceClaimProtocol::current()),
+            Some(&crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current()),
+        )
+    }
+
+    /// Claim a reverse-runner job only when every optional authority carried by
+    /// the job was explicitly negotiated by the worker.
+    pub fn claim_remote_runner_job_with_protocols(
+        &self,
+        runner_id: &str,
+        project_id: Option<&str>,
+        lease_ms: u64,
+        concurrency_limit: Option<usize>,
+        execution_protocol: Option<
+            &crate::runner_job_execution_context::RunnerJobExecutionProtocol,
+        >,
+        workspace_claim_protocol: Option<&crate::workspace_claim::WorkspaceClaimProtocol>,
+        workspace_owner_lease_protocol: Option<
+            &crate::workspace_claim::WorkspaceOwnerLeaseProtocol,
+        >,
+    ) -> Result<Option<RemoteRunnerJobClaim>> {
         if runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
                 "runner_id",
@@ -950,6 +1037,20 @@ impl JobStore {
                     }
                     None => None,
                 };
+                if request.requires_workspace_claim_protocol() {
+                    workspace_claim_protocol
+                        .ok_or_else(|| crate::runner_job_execution_context::rejected(
+                            "worker did not advertise the required workspace-claim protocol",
+                        ))?
+                        .verify()?;
+                }
+                if request.requires_workspace_owner_lease_protocol() {
+                    workspace_owner_lease_protocol
+                        .ok_or_else(|| crate::runner_job_execution_context::rejected(
+                            "worker did not advertise the required workspace-owner-lease protocol",
+                        ))?
+                        .verify()?;
+                }
                 if let Some(context) = execution_context.as_ref() {
                     inner
                         .jobs
@@ -986,11 +1087,19 @@ impl JobStore {
             .as_ref()
             .map(|_| execution_protocol.cloned())
             .flatten();
+        let workspace_claim_protocol = request
+            .requires_workspace_claim_protocol()
+            .then(crate::workspace_claim::WorkspaceClaimProtocol::current);
+        let workspace_owner_lease_protocol = request
+            .requires_workspace_owner_lease_protocol()
+            .then(crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current);
         Ok(Some(RemoteRunnerJobClaim {
             job,
             request,
             execution_context,
             execution_protocol,
+            workspace_claim_protocol,
+            workspace_owner_lease_protocol,
         }))
     }
 
@@ -1124,6 +1233,55 @@ impl JobStore {
             Ok(())
         })?;
         self.get(job_id)
+    }
+
+    /// Commit a broker claim renewal and the owner epoch returned by the
+    /// authority store together. Callers renew the authority first; this
+    /// replacement prevents a stale worker token from being accepted later.
+    pub(crate) fn renew_remote_runner_claim_with_workspace_owner_lease(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        claim_id: &str,
+        lease_ms: u64,
+        expected_owner_lease: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+        renewed_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+    ) -> Result<Job> {
+        let now = timestamp_ms();
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            if stored.job.claimed_by_runner_id.as_deref() != Some(runner_id)
+                || stored.job.claim_id.as_deref() != Some(claim_id)
+                || stored.job.status != JobStatus::Running
+                || stored
+                    .job
+                    .claim_expires_at_ms
+                    .is_none_or(|expires| expires <= now)
+            {
+                return Err(crate::runner_job_execution_context::rejected(
+                    "durable runner claim is no longer live",
+                ));
+            }
+            let remote = stored
+                .remote_runner
+                .as_mut()
+                .expect("checked remote runner");
+            if remote.request.workspace_owner_lease.as_ref() != expected_owner_lease {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "heartbeat owner lease does not match the durable job",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            remote.request.workspace_owner_lease = renewed_owner_lease;
+            stored.job.updated_at_ms = now;
+            stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms.max(1)));
+            Ok(stored.job.clone())
+        })
     }
 
     /// Atomically revalidate and consume a claim immediately before provider
@@ -1359,7 +1517,7 @@ impl JobStore {
         Ok(reconciled)
     }
 
-    fn ensure_remote_runner_claim(
+    pub(crate) fn ensure_remote_runner_claim(
         &self,
         job_id: Uuid,
         runner_id: &str,

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -44,6 +44,8 @@ pub(crate) struct AdmissionReservation {
     pub(crate) token: String,
     pub(crate) expires_at_ms: u64,
     pub(crate) created: bool,
+    /// Exact direct-daemon authority registered before this reservation commit.
+    pub(crate) workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -56,6 +58,8 @@ pub struct JobStore {
     terminal_write_failures: Arc<AtomicU64>,
     #[cfg(test)]
     durable_write_failures: Arc<AtomicU64>,
+    #[cfg(test)]
+    durable_write_skips: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Clone)]
@@ -162,6 +166,12 @@ pub(crate) struct LocalRunnerJob {
     pub(crate) command: Vec<String>,
     pub(crate) cwd: Option<String>,
     pub(crate) lifecycle: Option<super::remote_runner::RunnerJobLifecycleMetadata>,
+    /// Reconciliation claims remain reverse-broker-only authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    /// Exact direct-daemon authority required to execute this queued job.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -338,11 +348,17 @@ impl JobStore {
         };
         #[cfg(test)]
         if self
-            .durable_write_failures
+            .durable_write_skips
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
                 remaining.checked_sub(1)
             })
-            .is_ok()
+            .is_err()
+            && self
+                .durable_write_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
         {
             return Err(Error::internal_io(
                 "injected durable store write failure",
@@ -548,6 +564,8 @@ impl JobStore {
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]
             durable_write_failures: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            durable_write_skips: Arc::new(AtomicU64::new(0)),
         };
 
         store.durable_transaction(|inner| {
@@ -707,6 +725,8 @@ impl JobStore {
             terminal_write_failures: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]
             durable_write_failures: Arc::new(AtomicU64::new(0)),
+            #[cfg(test)]
+            durable_write_skips: Arc::new(AtomicU64::new(0)),
         };
         store.durable_transaction(|_| Ok(()))?;
         Ok(store)
@@ -808,6 +828,8 @@ impl JobStore {
         metadata: Value,
         idempotency_key: &str,
         now: u64,
+        workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+        workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     ) -> Result<AdmissionReservation> {
         self.durable_transaction(|inner| {
             if let Some(stored) = inner
@@ -826,6 +848,32 @@ impl JobStore {
                         None,
                     ));
                 }
+                if stored
+                    .local_runner
+                    .as_ref()
+                    .and_then(|runner| runner.workspace_claim_binding.as_ref())
+                    != workspace_claim_binding.as_ref()
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "workspace_claim_binding",
+                        "admission idempotency key belongs to a differently bound reservation",
+                        Some(idempotency_key.to_string()),
+                        None,
+                    ));
+                }
+                if stored
+                    .local_runner
+                    .as_ref()
+                    .and_then(|runner| runner.workspace_owner_lease.as_ref())
+                    != workspace_owner_lease.as_ref()
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "workspace_owner_lease",
+                        "admission idempotency key belongs to a differently leased reservation",
+                        Some(idempotency_key.to_string()),
+                        None,
+                    ));
+                }
                 let lease = stored.admission_lease.as_mut().ok_or_else(|| {
                     Error::internal_unexpected("active admission reservation is missing its lease")
                 })?;
@@ -837,10 +885,21 @@ impl JobStore {
                     token: lease.token.clone(),
                     expires_at_ms: lease.expires_at_ms,
                     created: false,
+                    workspace_owner_lease: stored
+                        .local_runner
+                        .as_ref()
+                        .and_then(|runner| runner.workspace_owner_lease.clone()),
                 };
                 return Ok(reservation);
             }
-            self.create_admission_inner(inner, metadata, Some(idempotency_key.to_string()), now)
+            self.create_admission_inner(
+                inner,
+                metadata,
+                Some(idempotency_key.to_string()),
+                now,
+                workspace_claim_binding,
+                workspace_owner_lease,
+            )
         })
     }
 
@@ -848,8 +907,19 @@ impl JobStore {
         &self,
         metadata: Value,
         now: u64,
+        workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+        workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     ) -> Result<AdmissionReservation> {
-        self.durable_transaction(|inner| self.create_admission_inner(inner, metadata, None, now))
+        self.durable_transaction(|inner| {
+            self.create_admission_inner(
+                inner,
+                metadata,
+                None,
+                now,
+                workspace_claim_binding,
+                workspace_owner_lease,
+            )
+        })
     }
 
     /// Legacy, tokenless admission used only by pre-lease protocol clients
@@ -875,6 +945,8 @@ impl JobStore {
         metadata: Value,
         idempotency_key: Option<String>,
         now: u64,
+        workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+        workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     ) -> Result<AdmissionReservation> {
         let (job, created) = self.create_or_reuse_active_local_runner_job_inner(
             inner,
@@ -882,7 +954,14 @@ impl JobStore {
             None,
             Some(metadata),
             None,
-            None,
+            Some(LocalRunnerJob {
+                runner_id: "admission".to_string(),
+                command: Vec::new(),
+                cwd: None,
+                lifecycle: None,
+                workspace_claim_binding,
+                workspace_owner_lease: workspace_owner_lease.clone(),
+            }),
             idempotency_key.clone(),
         )?;
         let stored = inner.jobs.get_mut(&job.id).expect("admission exists");
@@ -906,6 +985,7 @@ impl JobStore {
                 token,
                 expires_at_ms,
                 created: false,
+                workspace_owner_lease,
             };
             return Ok(reservation);
         }
@@ -920,6 +1000,7 @@ impl JobStore {
             token: lease.token,
             expires_at_ms: lease.expires_at_ms,
             created,
+            workspace_owner_lease,
         })
     }
 
@@ -946,8 +1027,161 @@ impl JobStore {
                 token,
                 expires_at_ms,
                 created: false,
+                workspace_owner_lease: stored
+                    .local_runner
+                    .as_ref()
+                    .and_then(|runner| runner.workspace_owner_lease.clone()),
             };
             Ok(reservation)
+        })
+    }
+
+    /// Commit an admission renewal and its exact direct workspace authority in
+    /// one durable-store transaction. The daemon renews the owner lease first;
+    /// callers must retain the returned lease as the only valid cleanup token.
+    pub(crate) fn renew_admission_with_workspace_owner_lease_at(
+        &self,
+        job_id: Uuid,
+        token: &str,
+        expected_owner_lease: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+        renewed_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+        now: u64,
+    ) -> Result<AdmissionReservation> {
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let current_owner_lease = stored.local_runner.as_ref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not an admission reservation",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if current_owner_lease.workspace_owner_lease.as_ref() != expected_owner_lease {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "admission renewal lease does not match the durable reservation",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let (reservation_token, expires_at_ms) = {
+                let lease = Self::admission_lease_for_live_job(stored, token, now)?;
+                lease.expires_at_ms = now.saturating_add(ADMISSION_RESERVATION_LEASE_MS);
+                lease.renewals = lease.renewals.saturating_add(1);
+                (lease.token.clone(), lease.expires_at_ms)
+            };
+            stored.job.updated_at_ms = now;
+            stored
+                .local_runner
+                .as_mut()
+                .expect("admission local runner was checked")
+                .workspace_owner_lease = renewed_owner_lease.clone();
+            Ok(AdmissionReservation {
+                job: stored.job.clone(),
+                token: reservation_token,
+                expires_at_ms,
+                created: false,
+                workspace_owner_lease: renewed_owner_lease,
+            })
+        })
+    }
+
+    /// Check the exact live admission capability and owner lease before an
+    /// authority renewal. The replacement transaction below repeats this check
+    /// as its CAS predicate because another request may win in the meantime.
+    pub(crate) fn authorize_admission_renewal_with_workspace_owner_lease_at(
+        &self,
+        job_id: Uuid,
+        token: &str,
+        expected_owner_lease: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+        now: u64,
+    ) -> Result<()> {
+        let mut inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get_mut(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        let current_owner_lease = stored.local_runner.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job_id",
+                "job is not an admission reservation",
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+        if current_owner_lease.workspace_owner_lease.as_ref() != expected_owner_lease {
+            return Err(Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                "admission renewal lease does not match the durable reservation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        Self::admission_lease_for_live_job(stored, token, now)?;
+        Ok(())
+    }
+
+    /// Fail closed when authority renewal succeeded but its replacement lease
+    /// could not be durably recorded. The expected lease keeps a concurrent
+    /// successful renewal from being overwritten or terminalized.
+    pub(crate) fn fail_admission_renewal_after_owner_replacement_failure(
+        &self,
+        job_id: Uuid,
+        token: &str,
+        expected_owner_lease: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+        error: &Error,
+        now: u64,
+    ) -> Result<()> {
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            let current_owner_lease = stored.local_runner.as_ref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job_id",
+                    "job is not an admission reservation",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if current_owner_lease.workspace_owner_lease.as_ref() != expected_owner_lease {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "admission renewal lease no longer matches the durable reservation",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            Self::admission_lease_for_live_job(stored, token, now)?;
+            stored
+                .local_runner
+                .as_mut()
+                .expect("admission local runner was checked")
+                .workspace_owner_lease = None;
+            Self::append_event_already_locked(
+                self,
+                inner,
+                job_id,
+                JobEventKind::Error,
+                Some("workspace owner lease renewal could not be persisted".to_string()),
+                Some(serde_json::json!({
+                    "schema": "homeboy/workspace-owner-lease-renewal-failure/v1",
+                    "error_code": error.code.as_str(),
+                    "error": error.to_string(),
+                })),
+            )?;
+            let stored = inner.jobs.get_mut(&job_id).expect("admission job exists");
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason =
+                Some("workspace owner lease renewal could not be persisted".to_string());
+            Ok(())
         })
     }
 
@@ -991,6 +1225,52 @@ impl JobStore {
             .get(&job_id)
             .ok_or_else(|| job_not_found(job_id))?;
         Ok(stored.admission_lease.is_some())
+    }
+
+    pub(crate) fn admission_workspace_claim_binding(
+        &self,
+        job_id: Uuid,
+    ) -> Result<Option<crate::workspace_claim::WorkspaceClaimBinding>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        if stored.job.operation != "runner.admission" {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "job is not an admission reservation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        Ok(stored
+            .local_runner
+            .as_ref()
+            .and_then(|runner| runner.workspace_claim_binding.clone()))
+    }
+
+    pub(crate) fn admission_workspace_owner_lease(
+        &self,
+        job_id: Uuid,
+    ) -> Result<Option<crate::workspace_claim::WorkspaceOwnerLease>> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&job_id)
+            .ok_or_else(|| job_not_found(job_id))?;
+        if stored.job.operation != "runner.admission" {
+            return Err(Error::validation_invalid_argument(
+                "job_id",
+                "job is not an admission reservation",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+        Ok(stored
+            .local_runner
+            .as_ref()
+            .and_then(|runner| runner.workspace_owner_lease.clone()))
     }
 
     pub(crate) fn reconcile_expired_admissions_at(&self, now: u64) -> Result<Vec<Uuid>> {
@@ -1063,6 +1343,7 @@ impl JobStore {
         admission_idempotency_key: Option<String>,
     ) -> Result<(Job, bool)> {
         let now = timestamp_ms();
+        let operation = operation.into();
         let runner_job_projection = metadata
             .as_ref()
             .and_then(|metadata| metadata.get("runner_job_projection"))
@@ -1075,7 +1356,7 @@ impl JobStore {
             .filter(|run_id| !run_id.trim().is_empty());
         let job = Job {
             id: Uuid::new_v4(),
-            operation: operation.into(),
+            operation: operation.clone(),
             status: JobStatus::Queued,
             created_at_ms: now,
             updated_at_ms: now,
@@ -1128,7 +1409,9 @@ impl JobStore {
                 return Ok((existing, false));
             }
         }
-        let consumes_admission = local_runner.is_some();
+        // Admissions carry LocalRunnerJob solely to persist direct workspace
+        // authority. Only a real runner execution consumes an admission.
+        let consumes_admission = local_runner.is_some() && operation != "runner.admission";
         inner.jobs.insert(
             job.id,
             StoredJob {
@@ -1294,6 +1577,11 @@ impl JobStore {
     #[cfg(test)]
     pub(crate) fn fail_next_durable_writes(&self, count: u64) {
         self.durable_write_failures.store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn skip_next_durable_writes(&self, count: u64) {
+        self.durable_write_skips.store(count, Ordering::SeqCst);
     }
 
     pub(crate) fn controller_job_state(&self, job_id: Uuid) -> Result<ControllerJobState> {
@@ -1975,14 +2263,50 @@ impl JobStore {
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
-        let (job, created) = self.create_or_reuse_active_local_runner_job(
+        self.try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
             source_snapshot,
             metadata,
             path_materialization_plan,
-            Some(local_runner.clone()),
+            local_runner,
             admission_idempotency_key,
-        );
+            capacity,
+            run,
+        )
+        .expect("local runner queue admission must persist")
+    }
+
+    /// Fallible variant used by the daemon request boundary so a failed durable
+    /// queue commit can roll back a just-registered workspace owner.
+    pub(crate) fn try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner<
+        T,
+        F,
+    >(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        metadata: Option<Value>,
+        path_materialization_plan: Option<PathMaterializationPlan>,
+        local_runner: LocalRunnerJob,
+        admission_idempotency_key: Option<String>,
+        capacity: usize,
+        run: F,
+    ) -> Result<JobRunner>
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
+        let (job, created) = self.durable_transaction(|inner| {
+            self.create_or_reuse_active_local_runner_job_inner(
+                inner,
+                operation,
+                source_snapshot,
+                metadata,
+                path_materialization_plan,
+                Some(local_runner.clone()),
+                admission_idempotency_key,
+            )
+        })?;
         let job_id = job.id;
         // An idempotent resubmission reused an already-enqueued job that already
         // has its own worker. Do not spawn a second worker for it — return a
@@ -1990,7 +2314,7 @@ impl JobStore {
         // `JobRunner` contract is preserved.
         if !created {
             let handle = thread::spawn(|| {});
-            return JobRunner { job_id, handle };
+            return Ok(JobRunner { job_id, handle });
         }
         let handle_store = self.clone();
         let worker_store = self.clone();
@@ -2046,7 +2370,7 @@ impl JobStore {
                 }
             }
         });
-        JobRunner { job_id, handle }
+        Ok(JobRunner { job_id, handle })
     }
 
     fn run_background_with_start_policy<T, F>(
@@ -2102,7 +2426,7 @@ impl JobStore {
         message: impl Into<String>,
     ) -> Result<Job> {
         let message = message.into();
-        self.durable_transaction(|inner| {
+        let terminal_owner_lease = self.durable_transaction(|inner| {
             let stored = inner
                 .jobs
                 .get_mut(&job_id)
@@ -2111,7 +2435,11 @@ impl JobStore {
             // It is a no-op so callers receive the authoritative terminal job without
             // adding a duplicate cancellation event.
             if stored.job.status == JobStatus::Cancelled && next_status == JobStatus::Cancelled {
-                return Ok(stored.job.clone());
+                let owner_lease = stored
+                    .local_runner
+                    .as_ref()
+                    .and_then(|runner| runner.workspace_owner_lease.clone());
+                return Ok((stored.job.clone(), owner_lease));
             }
             if next_status == JobStatus::Succeeded
                 && stored
@@ -2150,11 +2478,122 @@ impl JobStore {
                 Some(message),
                 Some(serde_json::json!({ "status": next_status })),
             )?;
-            inner
+            let job = inner
                 .jobs
                 .get(&job_id)
                 .map(|stored| stored.job.clone())
-                .ok_or_else(|| job_not_found(job_id))
+                .ok_or_else(|| job_not_found(job_id))?;
+            let owner_lease = next_status
+                .is_terminal()
+                .then(|| {
+                    inner.jobs.get(&job_id).and_then(|stored| {
+                        stored
+                            .local_runner
+                            .as_ref()
+                            .and_then(|runner| runner.workspace_owner_lease.clone())
+                    })
+                })
+                .flatten();
+            Ok((job, owner_lease))
+        })?;
+        // The terminal job is already durable. Cleanup is intentionally best
+        // effort so an authority-store I/O failure cannot hide its outcome.
+        if let Some(lease) = terminal_owner_lease.1 {
+            if let Ok(root) = crate::paths::homeboy_data() {
+                if let Err(error) = crate::workspace_claim::WorkspaceClaimStore::new(
+                    root.join("daemon-workspace-claims"),
+                )
+                .release_owner(&lease, timestamp_ms())
+                {
+                    let _ = self.record_workspace_owner_cleanup_failure(job_id, &error);
+                }
+            }
+        }
+        Ok(terminal_owner_lease.0)
+    }
+
+    /// Exact direct-owner leases attached to terminal records. Keeping them
+    /// durable makes restart cleanup idempotent and auditable.
+    pub(crate) fn terminal_workspace_owner_leases(
+        &self,
+    ) -> Vec<(Uuid, crate::workspace_claim::WorkspaceOwnerLease)> {
+        let inner = self.inner.lock().expect("job store mutex poisoned");
+        inner
+            .jobs
+            .values()
+            .filter(|stored| stored.job.status.is_terminal())
+            .filter_map(|stored| {
+                stored
+                    .local_runner
+                    .as_ref()
+                    .and_then(|runner| runner.workspace_owner_lease.clone())
+                    .map(|lease| (stored.job.id, lease))
+            })
+            .collect()
+    }
+
+    /// A release failure is evidence on the terminal job, never a replacement
+    /// for that job's already-durable outcome.
+    pub(crate) fn record_workspace_owner_cleanup_failure(
+        &self,
+        job_id: Uuid,
+        error: &Error,
+    ) -> Result<()> {
+        self.append_terminal_evidence(
+            job_id,
+            JobEventKind::Progress,
+            Some("workspace owner lease cleanup failed".to_string()),
+            Some(serde_json::json!({
+                "schema": "homeboy/workspace-owner-lease-cleanup/v1",
+                "outcome_preserved": true,
+                "error": error.to_string(),
+                "error_code": error.code.as_str(),
+            })),
+        )
+        .map(|_| ())
+    }
+
+    /// Replace a direct job's exact owner token in the same durable record that
+    /// terminal cleanup reads. Authority renewal without this write is unsafe:
+    /// a restart would otherwise retain only a stale epoch.
+    pub(crate) fn replace_local_runner_workspace_owner_lease(
+        &self,
+        job_id: Uuid,
+        expected: &crate::workspace_claim::WorkspaceOwnerLease,
+        renewed: crate::workspace_claim::WorkspaceOwnerLease,
+    ) -> Result<()> {
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            if stored.job.status.is_terminal() {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "cannot renew workspace authority for a terminal job",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let local = stored.local_runner.as_mut().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "job has no direct workspace owner lease",
+                    Some(job_id.to_string()),
+                    None,
+                )
+            })?;
+            if local.workspace_owner_lease.as_ref() != Some(expected) {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "renewed workspace authority no longer matches the durable job lease",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            local.workspace_owner_lease = Some(renewed);
+            stored.job.updated_at_ms = timestamp_ms();
+            Ok(())
         })
     }
 
@@ -2556,6 +2995,45 @@ impl JobStore {
 }
 
 impl JobStore {
+    /// Append durable evidence after a terminal outcome without changing that
+    /// outcome. This is intentionally narrower than `append_event`: terminal
+    /// jobs otherwise reject mutable progress and stream events.
+    fn append_terminal_evidence(
+        &self,
+        job_id: Uuid,
+        kind: JobEventKind,
+        message: Option<String>,
+        data: Option<Value>,
+    ) -> Result<JobEvent> {
+        self.durable_transaction(|inner| {
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            if !stored.job.status.is_terminal() {
+                return Err(Error::validation_invalid_argument(
+                    "status",
+                    "terminal evidence requires a terminal job",
+                    Some(job_id.to_string()),
+                    None,
+                ));
+            }
+            let event = JobEvent {
+                sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
+                job_id,
+                kind,
+                timestamp_ms: timestamp_ms(),
+                message,
+                data,
+            };
+            stored.events.push(event.clone());
+            apply_event_retention(&mut stored.events, self.event_retention_limit());
+            stored.job.event_count = stored.events.len();
+            stored.job.updated_at_ms = event.timestamp_ms;
+            Ok(event)
+        })
+    }
+
     pub(super) fn append_event_already_locked(
         &self,
         inner: &mut JobStoreInner,

--- a/crates/homeboy-core/src/api_jobs/tests/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/mod.rs
@@ -61,6 +61,8 @@ pub(super) fn remote_runner_request(
         require_paths: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: Some(json!({ "submitted_by": "controller" })),
     }
 }

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -98,7 +98,12 @@ fn admission_leases_create_renew_expire_and_release_capacity_with_an_injected_cl
     let store = JobStore::open_without_reconciliation(&path).expect("open store");
     let now = 10_000;
     let reservation = store
-        .create_admission_at(json!({ "admission": { "state": "reserved" } }), now)
+        .create_admission_at(
+            json!({ "admission": { "state": "reserved" } }),
+            now,
+            None,
+            None,
+        )
         .expect("create admission");
     assert!(reservation.created);
     assert_eq!(store.active_runner_jobs().len(), 1);
@@ -140,7 +145,12 @@ fn status_excludes_an_expired_admission_before_daemon_restart_reconciles_it() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open_without_reconciliation(&path).expect("open store");
     store
-        .create_admission_at(json!({ "admission": { "state": "reserved" } }), 0)
+        .create_admission_at(
+            json!({ "admission": { "state": "reserved" } }),
+            0,
+            None,
+            None,
+        )
         .expect("create already-expired admission");
 
     assert_eq!(
@@ -155,10 +165,10 @@ fn admission_lease_rejects_wrong_tokens_and_terminal_idempotency_replays() {
     let store = JobStore::default();
     let now = 10_000;
     let reservation = store
-        .create_or_renew_admission_at(json!({}), "attempt-1", now)
+        .create_or_renew_admission_at(json!({}), "attempt-1", now, None, None)
         .expect("create keyed admission");
     let replay = store
-        .create_or_renew_admission_at(json!({}), "attempt-1", now + 1)
+        .create_or_renew_admission_at(json!({}), "attempt-1", now + 1, None, None)
         .expect("renew live idempotency replay");
     assert_eq!(replay.job.id, reservation.job.id);
     assert!(!replay.created);
@@ -177,7 +187,7 @@ fn admission_lease_rejects_wrong_tokens_and_terminal_idempotency_replays() {
         JobStatus::Cancelled
     );
     assert!(store
-        .create_or_renew_admission_at(json!({}), "attempt-1", now + 4)
+        .create_or_renew_admission_at(json!({}), "attempt-1", now + 4, None, None)
         .is_err());
 }
 
@@ -186,7 +196,7 @@ fn admission_lease_races_have_one_terminal_outcome() {
     let store = JobStore::default();
     let now = 10_000;
     let reservation = store
-        .create_admission_at(json!({}), now)
+        .create_admission_at(json!({}), now, None, None)
         .expect("create admission");
     let store_for_renew = store.clone();
     let token = reservation.token.clone();
@@ -327,6 +337,8 @@ fn runner_capacity_is_claimed_before_reserving_an_agent_task_child() {
             active_child_count: None,
             active_cell_count: None,
         }),
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
     };
     let first = store.create_test_local_runner_job(Some(local_runner()));
     let second = store.create_test_local_runner_job(Some(local_runner()));
@@ -390,6 +402,8 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
         command: vec!["homeboy".to_string(), "agent-task".to_string()],
         cwd: Some("/runner/worktree".to_string()),
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
     };
     let starts = Arc::new(AtomicUsize::new(0));
     let (first_started_tx, first_started_rx) = mpsc::channel();
@@ -478,6 +492,8 @@ fn capacity_queued_agent_task_persists_typed_failure_before_child_identity() {
             command: vec!["homeboy".to_string(), "agent-task".to_string()],
             cwd: Some("/runner/worktree".to_string()),
             lifecycle: None,
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
         },
         None,
         1,
@@ -699,6 +715,8 @@ fn local_runner_jobs_retain_durable_identity_in_active_projection() {
                     active_child_count: None,
                     active_cell_count: None,
                 }),
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
             }),
             move |_job| {
                 let _ = wait.recv();
@@ -740,6 +758,8 @@ fn active_runner_job_for_durable_run_id_finds_the_enqueued_job_for_idempotent_re
                     active_child_count: None,
                     active_cell_count: None,
                 }),
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
             }),
             move |_job| {
                 let _ = wait.recv();
@@ -789,6 +809,8 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
             active_child_count: None,
             active_cell_count: None,
         }),
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
     };
 
     let first = store

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -442,6 +442,56 @@ fn remote_runner_claim_rejects_workers_without_the_context_protocol() {
 }
 
 #[test]
+fn workspace_bound_reverse_jobs_reject_old_or_missing_worker_capability() {
+    let store = JobStore::default();
+    let workspace =
+        crate::workspace_claim::WorkspaceIdentity::new("test", "reverse-worker").expect("identity");
+    let claim = crate::workspace_claim::WorkspaceClaim {
+        schema: crate::workspace_claim::WORKSPACE_CLAIM_SCHEMA.to_string(),
+        protocol: crate::workspace_claim::WorkspaceClaimProtocol::current(),
+        workspace: workspace.clone(),
+        lifecycle_revision: 4,
+        token: "broker-token".to_string(),
+        expires_at_ms: crate::api_jobs::timestamp_ms() + 30_000,
+    };
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.workspace_claim_binding = Some(crate::workspace_claim::WorkspaceClaimBinding {
+        workspace,
+        lifecycle_revision: 4,
+        claim: Some(claim),
+    });
+    let job = store.submit_remote_runner_job(request).expect("job queues");
+
+    assert!(store
+        .claim_remote_runner_job_with_protocols("homeboy-lab", None, 30_000, None, None, None, None)
+        .is_err());
+    assert_eq!(
+        store.get(job.id).expect("queued job").status,
+        JobStatus::Queued
+    );
+
+    let old = crate::workspace_claim::WorkspaceClaimProtocol {
+        capability: crate::workspace_claim::WORKSPACE_CLAIM_CAPABILITY.to_string(),
+        version: 0,
+    };
+    assert!(store
+        .claim_remote_runner_job_with_protocols(
+            "homeboy-lab",
+            None,
+            30_000,
+            None,
+            Some(&crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()),
+            Some(&old),
+            None,
+        )
+        .is_err());
+    assert_eq!(
+        store.get(job.id).expect("queued job").status,
+        JobStatus::Queued
+    );
+}
+
+#[test]
 fn remote_runner_legacy_claims_remain_available_only_for_context_free_jobs() {
     let store = JobStore::default();
     let job = store
@@ -1004,6 +1054,18 @@ fn dead_daemon_recovery_preserves_remote_work_and_uses_broker_claim_reconciliati
         store.get(queued.id).expect("running job").status,
         JobStatus::Running
     );
+    store
+        .consume_remote_runner_execution(
+            queued.id,
+            "homeboy-lab",
+            &claim_id,
+            claim
+                .execution_context
+                .as_ref()
+                .expect("authenticated claim context")
+                .id(),
+        )
+        .expect("worker consumes the accepted execution receipt");
 
     let completed = store
         .finish_remote_runner_job(

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -790,6 +790,10 @@ struct ExecRequest {
     /// extraction.
     #[serde(default)]
     idempotency_key: Option<String>,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_request: Option<WorkspaceOwnerRegisterRequest>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1122,6 +1126,8 @@ where
     // Expire only reservations that never recorded a child identity.
     job_store.reconcile_expired_local_child_reservations()?;
     job_store.reconcile_expired_admissions()?;
+    reconcile_pending_workspace_owner_releases();
+    reconcile_terminal_workspace_owner_leases(&job_store);
     recover_controller_jobs(&job_store);
     let _ = daemon_runtime_snapshot();
     let loopback_bind = local_addr.ip().is_loopback();
@@ -1242,6 +1248,8 @@ fn spawn_local_child_reservation_reconciler(
     std::thread::spawn(move || loop {
         let _ = job_store.reconcile_expired_local_child_reservations();
         let _ = job_store.reconcile_expired_admissions();
+        reconcile_pending_workspace_owner_releases();
+        reconcile_terminal_workspace_owner_leases(&job_store);
         if shutdown
             .recv_timeout(std::time::Duration::from_secs(
                 LOCAL_CHILD_RESERVATION_RECONCILE_INTERVAL_SECS,
@@ -1473,6 +1481,16 @@ where
             }),
             artifact: None,
         },
+        ("GET", "/capabilities") => daemon_endpoint_response(
+            "daemon.capabilities",
+            json!({
+                "schema": "homeboy/daemon-capabilities/v1",
+                "capabilities": [
+                    crate::workspace_claim::WorkspaceClaimProtocol::current(),
+                    crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+                ],
+            }),
+        ),
         ("GET", "/config/paths") => match config_paths_body() {
             Ok(body) => HttpResponse {
                 status_code: 200,
@@ -1488,6 +1506,38 @@ where
         },
         ("POST", "/exec") => match enqueue_exec_job(body, job_store) {
             Ok(body) => daemon_endpoint_response("jobs.exec", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-claims/acquire") => match acquire_workspace_claim(body) {
+            Ok(body) => daemon_endpoint_response("workspace_claim.acquire", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-claims/validate") => match validate_workspace_claim(body) {
+            Ok(body) => daemon_endpoint_response("workspace_claim.validate", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-claims/release") => match release_workspace_claim(body) {
+            Ok(body) => daemon_endpoint_response("workspace_claim.release", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-claims/authority") => match workspace_claim_authority_status(body) {
+            Ok(body) => daemon_endpoint_response("workspace_claim.authority", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-owners/register") => match register_workspace_owner(body) {
+            Ok(body) => daemon_endpoint_response("workspace_owner.register", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-owners/validate") => match validate_workspace_owner(body) {
+            Ok(body) => daemon_endpoint_response("workspace_owner.validate", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-owners/renew") => match renew_workspace_owner(body) {
+            Ok(body) => daemon_endpoint_response("workspace_owner.renew", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/workspace-owners/release") => match release_workspace_owner(body) {
+            Ok(body) => daemon_endpoint_response("workspace_owner.release", body),
             Err(err) => error_response(400, err),
         },
         ("POST", "/controller/jobs") => match enqueue_controller_job(body, job_store) {
@@ -1572,6 +1622,14 @@ where
         }
         ("GET", "/exec")
         | ("GET", "/admissions")
+        | ("GET", "/workspace-claims/acquire")
+        | ("GET", "/workspace-claims/validate")
+        | ("GET", "/workspace-claims/release")
+        | ("GET", "/workspace-claims/authority")
+        | ("GET", "/workspace-owners/register")
+        | ("GET", "/workspace-owners/validate")
+        | ("GET", "/workspace-owners/renew")
+        | ("GET", "/workspace-owners/release")
         | ("GET", "/jobs/reconcile-terminal")
         | ("GET", "/controller/jobs") => HttpResponse {
             status_code: 405,
@@ -1585,13 +1643,24 @@ where
         ("POST", "/runner/sessions")
         | ("POST", "/runner/jobs")
         | ("POST", "/runner/jobs/reconcile")
-        | ("POST", "/runner/jobs/claim") => {
+        | ("POST", "/runner/jobs/claim")
+        | ("POST", "/runner/workspace-claims/acquire")
+        | ("POST", "/runner/workspace-claims/validate")
+        | ("POST", "/runner/workspace-claims/release")
+        | ("POST", "/runner/workspace-claims/authority")
+        | ("POST", "/runner/workspace-owners/register")
+        | ("POST", "/runner/workspace-owners/validate")
+        | ("POST", "/runner/workspace-owners/renew")
+        | ("POST", "/runner/workspace-owners/release") => {
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         ("GET", "/runner/sessions")
         | ("GET", "/runner/jobs")
         | ("GET", "/runner/jobs/reconcile")
         | ("GET", "/runner/jobs/claim") => method_not_allowed(),
+        ("GET", "/runner/workspace-claims/capabilities") => {
+            remote_runner::route(method, path, body, job_store, &broker_auth)
+        }
         ("GET", path) if path.starts_with("/runner/jobs/") => {
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
@@ -1644,6 +1713,28 @@ fn reserve_admission(
     job_store: &JobStore,
 ) -> Result<serde_json::Value> {
     let body = body.unwrap_or_else(|| json!({}));
+    let workspace_claim_binding = workspace_claim_binding_from_body(&Some(body.clone()))?;
+    let workspace_owner_request = body
+        .get("workspace_owner_request")
+        .cloned()
+        .map(|value| serde_json::from_value::<WorkspaceOwnerRegisterRequest>(value))
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "workspace_owner_request",
+                format!("malformed direct workspace owner request: {error}"),
+                None,
+                None,
+            )
+        })?;
+    if workspace_owner_request.is_some() && workspace_claim_binding.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "workspace_claim_binding",
+            "direct admission uses an owner lease, not a reconciliation claim",
+            None,
+            None,
+        ));
+    }
     let runner_id = body
         .get("runner_id")
         .and_then(serde_json::Value::as_str)
@@ -1695,6 +1786,8 @@ fn reserve_admission(
             "daemon_lease_id": daemon_lease.lease_id.clone(),
             "idempotency_key": idempotency_key,
         },
+        "workspace_claim_binding": body.get("workspace_claim_binding").cloned().unwrap_or(serde_json::Value::Null),
+        "workspace_owner_lease": serde_json::Value::Null,
     });
     // Lease protocol is opt-in so an older controller can finish an admission
     // after a daemon upgrade. New controllers also tolerate old daemons that
@@ -1724,14 +1817,44 @@ fn reserve_admission(
             "idempotent_resubmission": !created,
         }));
     }
+    // Register before committing the admission so reconciliation cannot win the
+    // inter-store window. A failed commit is rolled back below.
+    let mut pending_owner_lease = PendingWorkspaceOwnerLease::new(
+        workspace_owner_request
+            .as_ref()
+            .map(|request| {
+                daemon_workspace_claim_store()?.register_owner(
+                    request.workspace.clone(),
+                    request.owner_id.clone(),
+                    request.ttl_ms,
+                    workspace_claim_now_ms(),
+                )
+            })
+            .transpose()?,
+    );
     let reservation = match idempotency_key {
         Some(idempotency_key) => job_store.create_or_renew_admission_at(
             metadata,
             idempotency_key,
             crate::api_jobs::timestamp_ms(),
-        )?,
-        None => job_store.create_admission_at(metadata, crate::api_jobs::timestamp_ms())?,
+            workspace_claim_binding,
+            pending_owner_lease.lease().cloned(),
+        ),
+        None => job_store.create_admission_at(
+            metadata,
+            crate::api_jobs::timestamp_ms(),
+            workspace_claim_binding,
+            pending_owner_lease.lease().cloned(),
+        ),
     };
+    let reservation = match reservation {
+        Ok(reservation) => reservation,
+        Err(mut error) => {
+            pending_owner_lease.rollback_error(&mut error);
+            return Err(error);
+        }
+    };
+    let workspace_owner_lease = pending_owner_lease.disarm();
     Ok(json!({
         "job": reservation.job,
         "daemon_lease_id": daemon_lease.lease_id,
@@ -1744,6 +1867,7 @@ fn reserve_admission(
             "expires_at_ms": reservation.expires_at_ms,
             "renewable": true,
         },
+        "workspace_owner_lease": workspace_owner_lease,
     }))
 }
 
@@ -1759,6 +1883,326 @@ fn validate_admission_lease(expected_lease_id: &str, actual_lease_id: &str) -> R
         Some(expected_lease_id.to_string()),
         None,
     ))
+}
+
+fn daemon_workspace_claim_store() -> Result<crate::workspace_claim::WorkspaceClaimStore> {
+    Ok(crate::workspace_claim::WorkspaceClaimStore::new(
+        crate::paths::homeboy_data()?.join("daemon-workspace-claims"),
+    ))
+}
+
+fn workspace_claim_now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// Owns a direct workspace lease until a durable job or admission has recorded
+/// the exact token and epoch. Drop closes panic and early-return windows.
+struct PendingWorkspaceOwnerLease {
+    lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+}
+
+impl PendingWorkspaceOwnerLease {
+    fn new(lease: Option<crate::workspace_claim::WorkspaceOwnerLease>) -> Self {
+        Self { lease }
+    }
+
+    fn lease(&self) -> Option<&crate::workspace_claim::WorkspaceOwnerLease> {
+        self.lease.as_ref()
+    }
+
+    fn disarm(mut self) -> Option<crate::workspace_claim::WorkspaceOwnerLease> {
+        self.lease.take()
+    }
+
+    fn rollback_error(&mut self, error: &mut Error) {
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        let cleanup = daemon_workspace_claim_store().and_then(|store| {
+            let release = store.release_owner(&lease, workspace_claim_now_ms());
+            let recovery = release
+                .as_ref()
+                .err()
+                .map(|release_error| store.record_owner_release_failure(&lease, release_error))
+                .transpose()?;
+            Ok((release, recovery))
+        });
+        let (released, cleanup_error, recovery) = match cleanup {
+            Ok((Ok(()), _)) => (true, None, None),
+            Ok((Err(release_error), recovery)) => {
+                (false, Some(release_error.to_string()), recovery)
+            }
+            Err(recovery_error) => (false, Some(recovery_error.to_string()), None),
+        };
+        error.details["workspace_owner_lease_cleanup"] = json!({
+            "schema": "homeboy/workspace-owner-lease-cleanup/v1",
+            "attempted": true,
+            "released": released,
+            "error": cleanup_error,
+            "recovery": recovery,
+        });
+    }
+}
+
+impl Drop for PendingWorkspaceOwnerLease {
+    fn drop(&mut self) {
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        let _ = daemon_workspace_claim_store()
+            .and_then(|store| store.release_owner(&lease, workspace_claim_now_ms()));
+    }
+}
+
+/// Restart reconciliation releases only terminal direct records. Queued and
+/// running records retain their exact lease for renewal by their live owner.
+fn reconcile_terminal_workspace_owner_leases(job_store: &JobStore) {
+    let Ok(store) = daemon_workspace_claim_store() else {
+        return;
+    };
+    for (job_id, lease) in job_store.terminal_workspace_owner_leases() {
+        if let Err(error) = store.release_owner(&lease, workspace_claim_now_ms()) {
+            let _ = job_store.record_workspace_owner_cleanup_failure(job_id, &error);
+        }
+    }
+}
+
+/// Failed pre-commit rollback has no job record to attach to. Its durable claim
+/// store evidence is therefore reconciled independently at daemon startup.
+fn reconcile_pending_workspace_owner_releases() {
+    let Ok(store) = daemon_workspace_claim_store() else {
+        return;
+    };
+    let Ok(recoveries) = store.pending_owner_release_recoveries() else {
+        return;
+    };
+    for recovery in recoveries {
+        let _ = store.release_owner(&recovery.lease, workspace_claim_now_ms());
+    }
+}
+
+const DIRECT_WORKSPACE_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Keeps direct `/exec` ownership below the five-minute authority TTL. The
+/// replacement is committed to the job before the child can continue; a failed
+/// replacement cancels execution and leaves durable recovery evidence.
+struct DirectWorkspaceOwnerRenewer {
+    stop: mpsc::Sender<()>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DirectWorkspaceOwnerRenewer {
+    fn start(
+        job_id: Uuid,
+        lease: crate::workspace_claim::WorkspaceOwnerLease,
+        job_store: JobStore,
+        cancellation_requested: Arc<AtomicBool>,
+    ) -> Self {
+        let (stop, shutdown) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let mut lease = lease;
+            while shutdown
+                .recv_timeout(DIRECT_WORKSPACE_OWNER_RENEW_INTERVAL)
+                .is_err()
+            {
+                let mut recovery_lease = lease.clone();
+                let outcome = (|| {
+                    let store = daemon_workspace_claim_store()?;
+                    let renewed = store.renew_owner(
+                        &lease,
+                        crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+                        workspace_claim_now_ms(),
+                    )?;
+                    recovery_lease = renewed.clone();
+                    job_store.replace_local_runner_workspace_owner_lease(
+                        job_id,
+                        &lease,
+                        renewed.clone(),
+                    )?;
+                    Ok(renewed)
+                })();
+                match outcome {
+                    Ok(renewed) => lease = renewed,
+                    Err(error) => {
+                        cancellation_requested.store(true, Ordering::SeqCst);
+                        // If the authority advanced but the job write failed,
+                        // retain the exact new token for startup reconciliation.
+                        if let Ok(store) = daemon_workspace_claim_store() {
+                            let _ = store.record_owner_release_failure(&recovery_lease, &error);
+                        }
+                        let _ = job_store.fail_with_data(
+                            job_id,
+                            "workspace owner lease renewal failed",
+                            Some(json!({
+                                "schema": "homeboy/workspace-owner-lease-renewal-failure/v1",
+                                "error_code": error.code.as_str(),
+                                "error": error.to_string(),
+                                "lease": recovery_lease,
+                                "recovery": "daemon startup retries the exact durable owner lease",
+                            })),
+                        );
+                        return;
+                    }
+                }
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for DirectWorkspaceOwnerRenewer {
+    fn drop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn workspace_claim_request<T: serde::de::DeserializeOwned>(
+    body: Option<serde_json::Value>,
+    field: &str,
+) -> Result<T> {
+    serde_json::from_value(body.unwrap_or_else(|| json!({}))).map_err(|error| {
+        Error::validation_invalid_argument(
+            field,
+            format!("malformed workspace claim request: {error}"),
+            None,
+            None,
+        )
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct WorkspaceClaimAcquireRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+    ttl_ms: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct WorkspaceClaimRequest {
+    claim: crate::workspace_claim::WorkspaceClaim,
+}
+
+#[derive(serde::Deserialize)]
+struct WorkspaceAuthorityStatusRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+struct WorkspaceOwnerRegisterRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+    owner_id: String,
+    #[serde(default = "default_workspace_owner_ttl_ms")]
+    ttl_ms: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct WorkspaceOwnerLeaseRequest {
+    lease: crate::workspace_claim::WorkspaceOwnerLease,
+    #[serde(default = "default_workspace_owner_ttl_ms")]
+    ttl_ms: u64,
+}
+
+fn default_workspace_owner_ttl_ms() -> u64 {
+    crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS
+}
+
+fn register_workspace_owner(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceOwnerRegisterRequest =
+        workspace_claim_request(body, "workspace_owner_lease")?;
+    let lease = daemon_workspace_claim_store()?.register_owner(
+        request.workspace,
+        request.owner_id,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "lease": lease }))
+}
+fn validate_workspace_owner(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceOwnerLeaseRequest =
+        workspace_claim_request(body, "workspace_owner_lease")?;
+    Ok(
+        json!({ "valid": daemon_workspace_claim_store()?.validate_owner(&request.lease, workspace_claim_now_ms())? }),
+    )
+}
+fn renew_workspace_owner(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceOwnerLeaseRequest =
+        workspace_claim_request(body, "workspace_owner_lease")?;
+    let lease = daemon_workspace_claim_store()?.renew_owner(
+        &request.lease,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "lease": lease }))
+}
+fn release_workspace_owner(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceOwnerLeaseRequest =
+        workspace_claim_request(body, "workspace_owner_lease")?;
+    daemon_workspace_claim_store()?.release_owner(&request.lease, workspace_claim_now_ms())?;
+    Ok(json!({ "released": true }))
+}
+
+fn acquire_workspace_claim(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceClaimAcquireRequest = workspace_claim_request(body, "workspace_claim")?;
+    let claim = daemon_workspace_claim_store()?.acquire(
+        request.workspace,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "claim": claim }))
+}
+
+fn validate_workspace_claim(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceClaimRequest = workspace_claim_request(body, "workspace_claim")?;
+    let valid =
+        daemon_workspace_claim_store()?.validate(&request.claim, workspace_claim_now_ms())?;
+    Ok(json!({ "valid": valid }))
+}
+
+fn release_workspace_claim(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceClaimRequest = workspace_claim_request(body, "workspace_claim")?;
+    daemon_workspace_claim_store()?.release(&request.claim, workspace_claim_now_ms())?;
+    Ok(json!({ "released": true }))
+}
+
+fn workspace_claim_authority_status(body: Option<serde_json::Value>) -> Result<serde_json::Value> {
+    let request: WorkspaceAuthorityStatusRequest = workspace_claim_request(body, "workspace")?;
+    Ok(
+        json!({ "status": daemon_workspace_claim_store()?.authority_status(
+        &request.workspace,
+        workspace_claim_now_ms(),
+    )? }),
+    )
+}
+
+fn authorize_workspace_claim_binding(
+    binding: Option<&crate::workspace_claim::WorkspaceClaimBinding>,
+) -> Result<()> {
+    if let Some(binding) = binding {
+        daemon_workspace_claim_store()?.authorize_binding(binding, workspace_claim_now_ms())?;
+    }
+    Ok(())
+}
+
+fn workspace_claim_binding_from_body(
+    body: &Option<serde_json::Value>,
+) -> Result<Option<crate::workspace_claim::WorkspaceClaimBinding>> {
+    body.as_ref()
+        .and_then(|body| body.get("workspace_claim_binding"))
+        .map(|value| serde_json::from_value(value.clone()))
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "workspace_claim_binding",
+                format!("malformed workspace claim binding: {error}"),
+                None,
+                None,
+            )
+        })
 }
 
 fn admission_job_id(path: &str, suffix: &str) -> Result<uuid::Uuid> {
@@ -1799,6 +2243,37 @@ fn release_admission(
     job_store: &JobStore,
 ) -> Result<serde_json::Value> {
     let job_id = admission_job_id(path, "/release")?;
+    let workspace_owner_lease = body
+        .as_ref()
+        .and_then(|body| body.get("workspace_owner_lease"))
+        .cloned()
+        .map(serde_json::from_value::<crate::workspace_claim::WorkspaceOwnerLease>)
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                format!("malformed direct workspace owner lease: {error}"),
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+    authorize_exact_admission_workspace_owner_lease(
+        job_store,
+        job_id,
+        workspace_owner_lease.as_ref(),
+    )?;
+    if let Some(lease) = workspace_owner_lease.as_ref() {
+        if !daemon_workspace_claim_store()?.validate_owner(lease, workspace_claim_now_ms())? {
+            return Err(Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                "direct workspace owner lease is no longer live",
+                Some(job_id.to_string()),
+                None,
+            ));
+        }
+    }
+    let binding = workspace_claim_binding_from_body(&body)?;
+    authorize_exact_admission_workspace_claim_binding(job_store, job_id, binding.as_ref())?;
     let job = match body
         .and_then(|body| {
             body.get("admission_token")
@@ -1831,6 +2306,13 @@ fn release_admission(
             job_store.cancel(job_id, "admission reservation released")?
         }
     };
+    if let Some(lease) = workspace_owner_lease.as_ref() {
+        if let Err(error) =
+            daemon_workspace_claim_store()?.release_owner(lease, workspace_claim_now_ms())
+        {
+            let _ = job_store.record_workspace_owner_cleanup_failure(job_id, &error);
+        }
+    }
     Ok(json!({ "job": job }))
 }
 
@@ -1840,13 +2322,146 @@ fn renew_admission(
     job_store: &JobStore,
 ) -> Result<serde_json::Value> {
     let job_id = admission_job_id(path, "/renew")?;
+    let workspace_owner_lease = body
+        .as_ref()
+        .and_then(|body| body.get("workspace_owner_lease"))
+        .cloned()
+        .map(serde_json::from_value::<crate::workspace_claim::WorkspaceOwnerLease>)
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                format!("malformed direct workspace owner lease: {error}"),
+                Some(job_id.to_string()),
+                None,
+            )
+        })?;
+    authorize_exact_admission_workspace_owner_lease(
+        job_store,
+        job_id,
+        workspace_owner_lease.as_ref(),
+    )?;
+    let binding = workspace_claim_binding_from_body(&body)?;
+    authorize_exact_admission_workspace_claim_binding(job_store, job_id, binding.as_ref())?;
     let token = admission_token(body)?;
-    let reservation =
-        job_store.renew_admission_at(job_id, &token, crate::api_jobs::timestamp_ms())?;
+    let now = crate::api_jobs::timestamp_ms();
+    // Authentication and the exact durable reservation must be valid before
+    // touching authority. The replacement write remains a CAS for races after
+    // this preflight.
+    job_store.authorize_admission_renewal_with_workspace_owner_lease_at(
+        job_id,
+        &token,
+        workspace_owner_lease.as_ref(),
+        now,
+    )?;
+    let renewed_workspace_owner_lease = workspace_owner_lease
+        .as_ref()
+        .map(|lease| {
+            daemon_workspace_claim_store()?.renew_owner(
+                lease,
+                crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+                workspace_claim_now_ms(),
+            )
+        })
+        .transpose()?;
+    let reservation = job_store.renew_admission_with_workspace_owner_lease_at(
+        job_id,
+        &token,
+        workspace_owner_lease.as_ref(),
+        renewed_workspace_owner_lease.clone(),
+        now,
+    );
+    let reservation = match reservation {
+        Ok(reservation) => reservation,
+        Err(mut error) => {
+            if let Some(renewed) = renewed_workspace_owner_lease.as_ref() {
+                let cleanup = daemon_workspace_claim_store().and_then(|store| {
+                    let release = store.release_owner(renewed, workspace_claim_now_ms());
+                    let recovery = release
+                        .as_ref()
+                        .err()
+                        .map(|release_error| {
+                            store.record_owner_release_failure(renewed, release_error)
+                        })
+                        .transpose()?;
+                    Ok((release, recovery))
+                });
+                let terminal = job_store.fail_admission_renewal_after_owner_replacement_failure(
+                    job_id,
+                    &token,
+                    workspace_owner_lease.as_ref(),
+                    &error,
+                    now,
+                );
+                let terminal_recovery = terminal
+                    .as_ref()
+                    .err()
+                    .map(|terminal_error| {
+                        daemon_workspace_claim_store()?
+                            .record_owner_release_failure(renewed, terminal_error)
+                    })
+                    .transpose();
+                error.details["workspace_owner_lease_renewal_recovery"] = json!({
+                    "schema": "homeboy/workspace-owner-lease-renewal-recovery/v1",
+                    "replacement_lease": renewed,
+                    "cleanup": cleanup.as_ref().map(|(release, recovery)| json!({
+                        "released": release.is_ok(),
+                        "error": release.as_ref().err().map(ToString::to_string),
+                        "recovery": recovery,
+                    })).unwrap_or_else(|cleanup_error| json!({
+                        "released": false,
+                        "error": cleanup_error.to_string(),
+                    })),
+                    "terminalized": terminal.is_ok(),
+                    "terminal_error": terminal.err().map(|terminal_error| terminal_error.to_string()),
+                    "terminal_recovery": terminal_recovery.as_ref().map(|recovery| json!(recovery)).unwrap_or_else(|recovery_error| json!({ "error": recovery_error.to_string() })),
+                });
+            }
+            return Err(error);
+        }
+    };
     Ok(json!({
         "job": reservation.job,
         "lease": { "expires_at_ms": reservation.expires_at_ms, "renewable": true },
+        "workspace_owner_lease": renewed_workspace_owner_lease,
     }))
+}
+
+/// A reservation's initial authorization is durable authority. Renew and release
+/// must present exactly that binding, rather than merely any live claim for the
+/// same workspace. This prevents a newer or different owner from taking over a
+/// reserved admission through its token path.
+fn authorize_exact_admission_workspace_claim_binding(
+    job_store: &JobStore,
+    job_id: uuid::Uuid,
+    presented: Option<&crate::workspace_claim::WorkspaceClaimBinding>,
+) -> Result<()> {
+    let persisted = job_store.admission_workspace_claim_binding(job_id)?;
+    if persisted != presented.cloned() {
+        return Err(Error::validation_invalid_argument(
+            "workspace_claim_binding",
+            "admission renew or release binding does not match the durable reservation",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    authorize_workspace_claim_binding(presented)
+}
+
+fn authorize_exact_admission_workspace_owner_lease(
+    job_store: &JobStore,
+    job_id: uuid::Uuid,
+    presented: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+) -> Result<()> {
+    if job_store.admission_workspace_owner_lease(job_id)?.as_ref() != presented {
+        return Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "admission renew or release lease does not match the durable reservation",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn lifecycle_stop_request(body: Option<serde_json::Value>) -> Result<LifecycleStopRequest> {
@@ -1989,6 +2604,17 @@ fn enqueue_exec_job(
                 None,
             )
         })?;
+    // Reconciliation bindings are not direct execution authority. Existing
+    // clients may still send one only for ordinary compatibility; workspace
+    // work must carry an owner registration request negotiated through v2.
+    if request.workspace_owner_request.is_some() && request.workspace_claim_binding.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "workspace_claim_binding",
+            "direct workspace execution uses an owner lease, not a reconciliation claim",
+            None,
+            None,
+        ));
+    }
     let mut base_plan = request
         .lab_runner_workload
         .as_ref()
@@ -2072,6 +2698,7 @@ fn enqueue_exec_job(
         "path_materialization_plan": path_materialization_plan,
         "extension_env_providers": plan.extension_env_provenance,
         "lifecycle": lifecycle.clone(),
+        "workspace_owner_request": request.workspace_owner_request.clone(),
     });
 
     // Idempotent resubmission: a daemon `/exec` is not idempotent at the
@@ -2123,11 +2750,32 @@ fn enqueue_exec_job(
     } else {
         None
     };
+    let mut pending_owner_lease = PendingWorkspaceOwnerLease::new(
+        request
+            .workspace_owner_request
+            .as_ref()
+            .map(|owner| {
+                daemon_workspace_claim_store()?.register_owner(
+                    owner.workspace.clone(),
+                    owner.owner_id.clone(),
+                    owner.ttl_ms,
+                    workspace_claim_now_ms(),
+                )
+            })
+            .transpose()?,
+    );
+    if let Some(lease) = pending_owner_lease.lease() {
+        run_ref_metadata["workspace_owner_lease"] = serde_json::to_value(lease)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    }
+    let workspace_owner_lease = pending_owner_lease.lease().cloned();
     let local_runner = LocalRunnerJob {
         runner_id: plan.runner_id.clone(),
         command: plan.command.clone(),
         cwd: Some(plan.cwd.clone()),
         lifecycle: lifecycle.clone(),
+        workspace_claim_binding: request.workspace_claim_binding.clone(),
+        workspace_owner_lease: workspace_owner_lease.clone(),
     };
     let execution_controller_run_id = lifecycle
         .as_ref()
@@ -2137,8 +2785,9 @@ fn enqueue_exec_job(
     // admitting them outside this queue can wedge the shared transport.
     let capacity = plan.concurrency_limit.unwrap_or(usize::MAX).max(1);
     let stall_watchdog_store = job_store.clone();
-    let runner = job_store
-        .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
+    let workspace_owner_renewal_store = (*job_store).clone();
+    let runner = match job_store
+        .try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
             operation,
             source_snapshot.clone(),
             Some(run_ref_metadata),
@@ -2150,6 +2799,16 @@ fn enqueue_exec_job(
             capacity,
             move |job| {
                 let mut plan = plan;
+                if let Some(lease) = workspace_owner_lease.as_ref() {
+                    if !daemon_workspace_claim_store()?.validate_owner(lease, workspace_claim_now_ms())? {
+                        return Err(Error::validation_invalid_argument(
+                            "workspace_owner_lease",
+                            "direct workspace owner lease is no longer live before process spawn",
+                            Some(job.job_id().to_string()),
+                            None,
+                        ));
+                    }
+                }
                 job.progress(json!({ "phase": "local_child_reservation_lookup_started" }))?;
                 let reservation_id = match job.local_child_reservation_id() {
                     Ok(reservation_id) => reservation_id,
@@ -2189,6 +2848,14 @@ fn enqueue_exec_job(
                     .insert("HOMEBOY_RUNNER_CHILD_RESERVATION".to_string(), reservation_id);
                 let liveness = Arc::new(Mutex::new(ExecLiveness::new(Instant::now())));
                 let cancellation_requested = Arc::new(AtomicBool::new(false));
+                let _workspace_owner_renewer = workspace_owner_lease.clone().map(|lease| {
+                    DirectWorkspaceOwnerRenewer::start(
+                        job.job_id(),
+                        lease,
+                        workspace_owner_renewal_store.clone(),
+                        Arc::clone(&cancellation_requested),
+                    )
+                });
                 let stall_evidence = Arc::new(Mutex::new(None));
                 let progress_job = job.clone();
                 let progress_liveness = Arc::clone(&liveness);
@@ -2389,7 +3056,14 @@ fn enqueue_exec_job(
 
                 Ok(result)
             },
-        );
+        ) {
+        Ok(runner) => runner,
+        Err(mut error) => {
+            pending_owner_lease.rollback_error(&mut error);
+            return Err(error);
+        }
+    };
+    let _workspace_owner_lease = pending_owner_lease.disarm();
     let job = job_store.get(runner.job_id)?;
 
     Ok(json!({
@@ -3172,6 +3846,44 @@ mod tests {
     use std::process::Command;
     use std::sync::Arc;
 
+    fn direct_owner_workspace() -> crate::workspace_claim::WorkspaceIdentity {
+        crate::workspace_claim::WorkspaceIdentity::new("test-workspace", "owner-transfer")
+            .expect("workspace identity")
+    }
+
+    fn register_direct_owner(owner_id: &str) -> crate::workspace_claim::WorkspaceOwnerLease {
+        daemon_workspace_claim_store()
+            .expect("owner store")
+            .register_owner(
+                direct_owner_workspace(),
+                owner_id,
+                crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+                workspace_claim_now_ms(),
+            )
+            .expect("register owner")
+    }
+
+    fn assert_owner_live(lease: &crate::workspace_claim::WorkspaceOwnerLease, expected: bool) {
+        assert_eq!(
+            daemon_workspace_claim_store()
+                .expect("owner store")
+                .validate_owner(lease, workspace_claim_now_ms())
+                .expect("validate owner"),
+            expected
+        );
+    }
+
+    fn direct_local_runner(lease: crate::workspace_claim::WorkspaceOwnerLease) -> LocalRunnerJob {
+        LocalRunnerJob {
+            runner_id: "test-runner".to_string(),
+            command: vec!["test".to_string()],
+            cwd: None,
+            lifecycle: None,
+            workspace_claim_binding: None,
+            workspace_owner_lease: Some(lease),
+        }
+    }
+
     pub(super) struct EnqueueTestDriver;
 
     /// Register the enqueue test driver for daemon `/exec` tests. The daemon
@@ -3227,6 +3939,524 @@ mod tests {
     }
 
     #[test]
+    fn admission_commit_failure_releases_owner() {
+        with_isolated_home(|_| {
+            let lease = register_direct_owner("admission-failure");
+            let mut pending = PendingWorkspaceOwnerLease::new(Some(lease.clone()));
+            let mut error = Error::internal_io("injected admission commit failure", None);
+            pending.rollback_error(&mut error);
+            assert_owner_live(&lease, false);
+            assert_eq!(
+                error.details["workspace_owner_lease_cleanup"]["released"],
+                true
+            );
+        });
+    }
+
+    #[test]
+    fn queue_commit_failure_releases_owner() {
+        with_isolated_home(|_| {
+            let lease = register_direct_owner("queue-failure");
+            let pending = PendingWorkspaceOwnerLease::new(Some(lease.clone()));
+            // Drop is the panic/early-return fallback around queue persistence.
+            drop(pending);
+            assert_owner_live(&lease, false);
+        });
+    }
+
+    #[test]
+    fn renewed_admission_persists_epoch_and_releases() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-renew-owner";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "renew-owner"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let token = reserved["admission_token"].as_str().expect("token");
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+            let renewed = renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": lease })),
+                &store,
+            )
+            .expect("renew admission");
+            let renewed_lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(renewed["workspace_owner_lease"].clone())
+                    .expect("renewed lease");
+            assert!(renewed_lease.lifecycle_revision > lease.lifecycle_revision);
+            assert_owner_live(&renewed_lease, true);
+            let renewed_again = renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": renewed_lease })),
+                &store,
+            )
+            .expect("renew admission with replacement epoch");
+            let renewed_again_lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(renewed_again["workspace_owner_lease"].clone())
+                    .expect("twice-renewed lease");
+            assert!(renewed_again_lease.lifecycle_revision > renewed_lease.lifecycle_revision);
+            assert_owner_live(&renewed_again_lease, true);
+            release_admission(
+                &format!("/admissions/{job_id}/release"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": renewed_again_lease })),
+                &store,
+            )
+            .expect("release renewed admission");
+            assert_owner_live(&renewed_again_lease, false);
+        });
+    }
+
+    #[test]
+    fn invalid_admission_renewal_token_does_not_advance_authority_epoch() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-renew-invalid-token";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "invalid-token"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+
+            let error = renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": "not-the-token", "workspace_owner_lease": lease })),
+                &store,
+            )
+            .expect_err("invalid token must be rejected before authority renewal");
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert_owner_live(&lease, true);
+            let renewed = daemon_workspace_claim_store()
+                .expect("owner store")
+                .renew_owner(
+                    &lease,
+                    crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+                    workspace_claim_now_ms(),
+                )
+                .expect("the original epoch remains authoritative");
+            assert!(renewed.lifecycle_revision > lease.lifecycle_revision);
+        });
+    }
+
+    #[test]
+    fn concurrent_admission_renewals_have_one_winner_and_no_stranded_owner() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-concurrent-renew";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "concurrent-renew"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id").to_string();
+            let token = reserved["admission_token"]
+                .as_str()
+                .expect("token")
+                .to_string();
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+            let barrier = Arc::new(std::sync::Barrier::new(2));
+            let handles = (0..2)
+                .map(|_| {
+                    let store = store.clone();
+                    let job_id = job_id.clone();
+                    let token = token.clone();
+                    let lease = lease.clone();
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        renew_admission(
+                            &format!("/admissions/{job_id}/renew"),
+                            Some(
+                                json!({ "admission_token": token, "workspace_owner_lease": lease }),
+                            ),
+                            &store,
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            let results = handles
+                .into_iter()
+                .map(|handle| handle.join().expect("renewal thread"))
+                .collect::<Vec<_>>();
+            assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+            let winner = results
+                .into_iter()
+                .find_map(Result::ok)
+                .expect("one renewal winner");
+            let renewed: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(winner["workspace_owner_lease"].clone())
+                    .expect("winner lease");
+            assert_owner_live(&renewed, true);
+            release_admission(
+                &format!("/admissions/{job_id}/release"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": renewed.clone() })),
+                &store,
+            )
+            .expect("release exact winner lease");
+            assert_owner_live(&renewed, false);
+        });
+    }
+
+    #[test]
+    fn failed_admission_renewal_releases_replacement_and_terminalizes_reservation() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-renew-durable-failure";
+            write_test_lease(lease_id);
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "durable-failure"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let token = reserved["admission_token"].as_str().expect("token");
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+            store.fail_next_durable_writes(1);
+
+            let error = renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": lease })),
+                &store,
+            )
+            .expect_err("replacement persistence fails");
+            assert_eq!(
+                error.details["workspace_owner_lease_renewal_recovery"]["terminalized"], true,
+                "{:#?}",
+                error.details
+            );
+            assert_eq!(
+                store
+                    .get(uuid::Uuid::parse_str(job_id).expect("job UUID"))
+                    .expect("reservation")
+                    .status,
+                JobStatus::Failed
+            );
+            assert_owner_live(&lease, false);
+        });
+    }
+
+    #[test]
+    fn failed_admission_renewal_cleanup_evidence_is_consumed_on_restart() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-renew-cleanup-failure";
+            write_test_lease(lease_id);
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "cleanup-failure"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let token = reserved["admission_token"].as_str().expect("token");
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+            daemon_workspace_claim_store()
+                .expect("owner store")
+                .fail_next_owner_releases(&lease.workspace, 1)
+                .expect("inject cleanup failure");
+            store.fail_next_durable_writes(1);
+
+            renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": lease })),
+                &store,
+            )
+            .expect_err("replacement persistence fails");
+            let owner_store = daemon_workspace_claim_store().expect("owner store");
+            assert_eq!(
+                owner_store
+                    .pending_owner_release_recoveries()
+                    .expect("recovery evidence")
+                    .len(),
+                1
+            );
+            reconcile_pending_workspace_owner_releases();
+            assert!(owner_store
+                .pending_owner_release_recoveries()
+                .expect("cleared recovery evidence")
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn failed_admission_renewal_terminal_persistence_records_recovery_evidence() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-renew-terminal-persistence-failure";
+            write_test_lease(lease_id);
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": {
+                        "workspace": direct_owner_workspace(), "owner_id": "terminal-persistence-failure"
+                    },
+                })),
+                &store,
+            )
+            .expect("reserve admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let token = reserved["admission_token"].as_str().expect("token");
+            let lease: crate::workspace_claim::WorkspaceOwnerLease =
+                serde_json::from_value(reserved["workspace_owner_lease"].clone()).expect("lease");
+            store.fail_next_durable_writes(2);
+
+            let error = renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_owner_lease": lease })),
+                &store,
+            )
+            .expect_err("replacement and terminal persistence fail");
+            assert_eq!(
+                error.details["workspace_owner_lease_renewal_recovery"]["terminalized"],
+                false
+            );
+            let owner_store = daemon_workspace_claim_store().expect("owner store");
+            assert_eq!(
+                owner_store
+                    .pending_owner_release_recoveries()
+                    .expect("terminal persistence evidence")
+                    .len(),
+                1,
+                "{:#?}",
+                error.details
+            );
+            reconcile_pending_workspace_owner_releases();
+            assert!(owner_store
+                .pending_owner_release_recoveries()
+                .expect("consumed evidence")
+                .is_empty());
+        });
+    }
+
+    #[test]
+    fn top_level_router_handles_reverse_owner_lifecycle() {
+        with_isolated_home(|_| {
+            let store = JobStore::default();
+            let registered = route_with_job_store_and_body(
+                "POST",
+                "/runner/workspace-owners/register",
+                Some(json!({
+                    "workspace": direct_owner_workspace(),
+                    "owner_id": "reverse-router-owner",
+                    "ttl_ms": 1_000,
+                })),
+                &store,
+            );
+            assert_eq!(registered.status_code, 200, "{:#?}", registered.body);
+            let lease = registered.body["body"]["workspace_owner_lease"].clone();
+            let renewed = route_with_job_store_and_body(
+                "POST",
+                "/runner/workspace-owners/renew",
+                Some(json!({ "workspace_owner_lease": lease, "ttl_ms": 1_000 })),
+                &store,
+            );
+            assert_eq!(renewed.status_code, 200, "{:#?}", renewed.body);
+            let replacement = renewed.body["body"]["workspace_owner_lease"].clone();
+            let released = route_with_job_store_and_body(
+                "POST",
+                "/runner/workspace-owners/release",
+                Some(json!({ "workspace_owner_lease": replacement })),
+                &store,
+            );
+            assert_eq!(released.status_code, 200, "{:#?}", released.body);
+            assert_eq!(released.body["body"]["released"], true);
+        });
+    }
+
+    #[test]
+    fn queued_cancel_and_spawn_failure_release_owner() {
+        with_isolated_home(|_| {
+            let store = JobStore::default();
+            for (owner, reason) in [
+                ("queued-cancel", "cancel"),
+                ("spawn-failure", "spawn failure"),
+            ] {
+                let lease = register_direct_owner(owner);
+                let job =
+                    store.create_test_local_runner_job(Some(direct_local_runner(lease.clone())));
+                if reason == "cancel" {
+                    store.cancel(job.id, reason).expect("cancel queued job");
+                } else {
+                    store.fail(job.id, reason).expect("record spawn failure");
+                }
+                assert!(store
+                    .get(job.id)
+                    .expect("terminal job")
+                    .status
+                    .is_terminal());
+                assert_owner_live(&lease, false);
+            }
+        });
+    }
+
+    #[test]
+    fn terminal_job_releases_owner() {
+        with_isolated_home(|_| {
+            let store = JobStore::default();
+            let lease = register_direct_owner("terminal");
+            let job = store.create_test_local_runner_job(Some(direct_local_runner(lease.clone())));
+            store.start(job.id).expect("start job");
+            store.complete(job.id, None).expect("complete job");
+            assert_eq!(store.get(job.id).expect("job").status, JobStatus::Succeeded);
+            assert_owner_live(&lease, false);
+        });
+    }
+
+    #[test]
+    fn restart_releases_orphaned_owner_and_preserves_live_owner() {
+        with_isolated_home(|_| {
+            let store = JobStore::default();
+            let orphan = register_direct_owner("restart-orphan");
+            let orphan_job =
+                store.create_test_local_runner_job(Some(direct_local_runner(orphan.clone())));
+            store
+                .fail(orphan_job.id, "terminal before restart")
+                .expect("terminalize orphan");
+            let live = register_direct_owner("restart-live");
+            store.create_test_local_runner_job(Some(direct_local_runner(live.clone())));
+            reconcile_terminal_workspace_owner_leases(&store);
+            assert_owner_live(&orphan, false);
+            assert_owner_live(&live, true);
+        });
+    }
+
+    #[test]
+    fn cleanup_failure_preserves_terminal_outcome_and_records_typed_evidence() {
+        with_isolated_home(|_| {
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            let lease = register_direct_owner("terminal-cleanup-failure");
+            daemon_workspace_claim_store()
+                .expect("owner store")
+                .fail_next_owner_releases(&lease.workspace, 1)
+                .expect("inject exact owner release failure");
+            let job = store.create_test_local_runner_job(Some(direct_local_runner(lease)));
+            store
+                .fail(job.id, "terminal outcome")
+                .expect("terminalize job");
+            assert_eq!(
+                store.get(job.id).expect("terminal job").status,
+                JobStatus::Failed
+            );
+            assert!(store.events(job.id).expect("evidence").iter().any(|event| {
+                event.data.as_ref().is_some_and(|data| {
+                    data["schema"] == "homeboy/workspace-owner-lease-cleanup/v1"
+                        && data["outcome_preserved"] == true
+                })
+            }));
+        });
+    }
+
+    #[test]
+    fn admissions_commit_failure_releases_new_owner_before_persisting() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-admission-commit-failure";
+            write_test_lease(lease_id);
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            store.fail_next_durable_writes(1);
+            let workspace = direct_owner_workspace();
+            let error = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "admission_lease_protocol": 1,
+                    "workspace_owner_request": { "workspace": workspace, "owner_id": "admission-commit" },
+                })),
+                &store,
+            )
+            .expect_err("durable admission commit fails");
+            assert_eq!(error.code.as_str(), "internal.io_error");
+            assert!(store.list().is_empty());
+            daemon_workspace_claim_store()
+                .expect("owner store")
+                .acquire(direct_owner_workspace(), 1, workspace_claim_now_ms())
+                .expect("rollback leaves no live owner");
+        });
+    }
+
+    #[test]
+    fn exec_queue_commit_failure_releases_new_owner_before_persisting() {
+        with_isolated_home(|_| {
+            register_enqueue_test_driver();
+            let store = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store");
+            store.fail_next_durable_writes(1);
+            let workspace = direct_owner_workspace();
+            let error = enqueue_exec_job(
+                Some(json!({
+                    "runner_id": "lab", "cwd": "/tmp", "command": ["homeboy", "test"],
+                    "workspace_owner_request": { "workspace": workspace, "owner_id": "queue-commit" },
+                })),
+                &store,
+            )
+            .expect_err("durable queue commit fails");
+            assert_eq!(error.code.as_str(), "internal.io_error");
+            assert!(store.list().is_empty());
+            daemon_workspace_claim_store()
+                .expect("owner store")
+                .acquire(direct_owner_workspace(), 1, workspace_claim_now_ms())
+                .expect("rollback leaves no live owner");
+        });
+    }
+
+    #[test]
     fn admission_reservation_dedupes_a_detached_run_and_releases_it() {
         with_isolated_home(|_| {
             let lease_id = "lease-deduped-admission";
@@ -3268,6 +4498,55 @@ mod tests {
                 0,
                 "a failed or timed-out handoff leaves no active admission job"
             );
+        });
+    }
+
+    #[test]
+    fn admission_renew_and_release_require_the_exact_durable_binding() {
+        with_isolated_home(|_| {
+            let lease_id = "lease-bound-admission";
+            write_test_lease(lease_id);
+            let store = JobStore::default();
+            let workspace = crate::workspace_claim::WorkspaceIdentity::new("test", "run-1")
+                .expect("workspace identity");
+            let claim = crate::workspace_claim::WorkspaceClaim {
+                schema: crate::workspace_claim::WORKSPACE_CLAIM_SCHEMA.to_string(),
+                protocol: crate::workspace_claim::WorkspaceClaimProtocol::current(),
+                workspace: workspace.clone(),
+                lifecycle_revision: 7,
+                token: "claim-token-a".to_string(),
+                expires_at_ms: u64::MAX,
+            };
+            let binding = crate::workspace_claim::WorkspaceClaimBinding {
+                workspace,
+                lifecycle_revision: 7,
+                claim: Some(claim),
+            };
+            let reserved = reserve_admission(
+                Some(json!({
+                    "runner_id": "lab", "expected_daemon_lease_id": lease_id,
+                    "idempotency_key": "bound-run", "admission_lease_protocol": 1,
+                    "workspace_claim_binding": binding,
+                })),
+                &store,
+            )
+            .expect("reserve bound admission");
+            let job_id = reserved["job"]["id"].as_str().expect("job id");
+            let token = reserved["admission_token"].as_str().expect("token");
+            let mut substituted = binding.clone();
+            substituted.claim.as_mut().expect("claim").token = "claim-token-b".to_string();
+            assert!(renew_admission(
+                &format!("/admissions/{job_id}/renew"),
+                Some(json!({ "admission_token": token, "workspace_claim_binding": substituted })),
+                &store,
+            )
+            .is_err());
+            assert!(release_admission(
+                &format!("/admissions/{job_id}/release"),
+                Some(json!({ "admission_token": token, "workspace_claim_binding": binding })),
+                &store,
+            )
+            .is_ok());
         });
     }
 

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -65,6 +65,10 @@ struct ClaimRequest {
     concurrency_limit: Option<usize>,
     #[serde(default)]
     execution_protocol: Option<crate::runner_job_execution_context::RunnerJobExecutionProtocol>,
+    #[serde(default)]
+    workspace_claim_protocol: Option<crate::workspace_claim::WorkspaceClaimProtocol>,
+    #[serde(default)]
+    workspace_owner_lease_protocol: Option<crate::workspace_claim::WorkspaceOwnerLeaseProtocol>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -76,6 +80,10 @@ struct EventRequest {
     message: Option<String>,
     #[serde(default)]
     data: Option<Value>,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -83,6 +91,10 @@ struct FinishRequest {
     runner_id: String,
     claim_id: String,
     result: RemoteRunnerJobResult,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -91,6 +103,10 @@ struct HeartbeatRequest {
     claim_id: String,
     #[serde(default)]
     lease_ms: Option<u64>,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -98,6 +114,17 @@ struct ConsumeRequest {
     runner_id: String,
     claim_id: String,
     context_id: String,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct OwnerValidationRequest {
+    runner_id: String,
+    claim_id: String,
+    workspace_owner_lease: crate::workspace_claim::WorkspaceOwnerLease,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -126,6 +153,46 @@ pub(in crate::daemon) fn route(
     auth: &BrokerAuthContext,
 ) -> HttpResponse {
     match (method, path) {
+        ("GET", "/runner/workspace-claims/capabilities") => {
+            match workspace_claim_capabilities(auth) {
+                Ok(body) => daemon_endpoint_response("runner.workspace_claims.capabilities", body),
+                Err(err) => auth_or_bad_request(err),
+            }
+        }
+        ("POST", "/runner/workspace-claims/acquire") => match acquire_workspace_claim(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_claims.acquire", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-claims/validate") => match validate_workspace_claim(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_claims.validate", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-claims/release") => match release_workspace_claim(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_claims.release", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-claims/authority") => {
+            match workspace_claim_authority_status(body, auth) {
+                Ok(body) => daemon_endpoint_response("runner.workspace_claims.authority", body),
+                Err(err) => auth_or_bad_request(err),
+            }
+        }
+        ("POST", "/runner/workspace-owners/register") => match register_workspace_owner(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_owners.register", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-owners/validate") => match validate_workspace_owner(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_owners.validate", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-owners/renew") => match renew_workspace_owner(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_owners.renew", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/workspace-owners/release") => match release_workspace_owner(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.workspace_owners.release", body),
+            Err(err) => auth_or_bad_request(err),
+        },
         ("POST", "/runner/sessions") => match register_session(body, auth) {
             Ok(body) => daemon_endpoint_response("runner.sessions.register", body),
             Err(err) => auth_or_bad_request(err),
@@ -424,6 +491,9 @@ fn reconcile(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext
         now_ms,
         grant.as_ref().map(|grant| grant.runner_id.as_str()),
     )?;
+    for job in &reconciled {
+        release_terminal_workspace_owner(job_store, job.id);
+    }
     Ok(json!({
         "command": "api.runner.jobs.reconcile",
         "reconciled": reconciled,
@@ -492,6 +562,8 @@ fn register_session(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Val
 fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
     let mut request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
     auth.authorize(BrokerScope::Submit, Some(request.runner_id.as_str()))?;
+    authorize_workspace_claim_binding(request.workspace_claim_binding.as_ref())?;
+    authorize_workspace_owner_lease(request.workspace_owner_lease.as_ref())?;
     request.normalize();
     let public_request = request.public_metadata();
     let job = job_store.submit_remote_runner_job(request)?;
@@ -544,12 +616,14 @@ fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) ->
     let concurrency_limit = request
         .concurrency_limit
         .or_else(|| super::runner_workspace_root::runner_concurrency_limit(&request.runner_id));
-    let claim = job_store.claim_remote_runner_job_with_execution_protocol(
+    let claim = job_store.claim_remote_runner_job_with_protocols(
         &request.runner_id,
         request.project_id.as_deref(),
         request.lease_ms.unwrap_or(30_000),
         concurrency_limit,
         request.execution_protocol.as_ref(),
+        request.workspace_claim_protocol.as_ref(),
+        request.workspace_owner_lease_protocol.as_ref(),
     )?;
     Ok(json!({
         "command": "api.runner.jobs.claim",
@@ -571,7 +645,7 @@ fn update(
                 "unknown remote runner job path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, /runner/jobs/<job-id>/consume, or /runner/jobs/<job-id>/cancel.".to_string(),
+                    "Use /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, /runner/jobs/<job-id>/validate-owner, /runner/jobs/<job-id>/consume, or /runner/jobs/<job-id>/cancel.".to_string(),
                 ]),
             ),
         );
@@ -592,6 +666,10 @@ fn update(
         },
         "consume" => match consume(job_id, body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.jobs.consume", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        "validate-owner" => match validate_owner(job_id, body, job_store, auth) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.owner.validate", body),
             Err(err) => auth_or_bad_request(err),
         },
         "cancel" => match cancel(job_id, job_store, auth) {
@@ -649,6 +727,16 @@ fn append_event(
     let request: EventRequest = parse_body(body, "remote runner event request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
+    authorize_exact_workspace_claim_binding(
+        job_store,
+        job_id,
+        request.workspace_claim_binding.as_ref(),
+    )?;
+    authorize_exact_workspace_owner_lease(
+        job_store,
+        job_id,
+        request.workspace_owner_lease.as_ref(),
+    )?;
     let event = job_store.append_remote_runner_event(
         job_id,
         &request.runner_id,
@@ -672,12 +760,23 @@ fn finish(
     let request: FinishRequest = parse_body(body, "remote runner finish request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
+    authorize_exact_workspace_claim_binding(
+        job_store,
+        job_id,
+        request.workspace_claim_binding.as_ref(),
+    )?;
+    authorize_exact_workspace_owner_lease(
+        job_store,
+        job_id,
+        request.workspace_owner_lease.as_ref(),
+    )?;
     let job = job_store.finish_remote_runner_job(
         job_id,
         &request.runner_id,
         &request.claim_id,
         request.result,
     )?;
+    release_terminal_workspace_owner(job_store, job_id);
     Ok(json!({
         "command": "api.runner.jobs.finish",
         "job": job,
@@ -693,15 +792,46 @@ fn heartbeat(
     let request: HeartbeatRequest = parse_body(body, "remote runner heartbeat request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
-    let job = job_store.renew_remote_runner_claim(
+    authorize_exact_workspace_claim_binding(
+        job_store,
+        job_id,
+        request.workspace_claim_binding.as_ref(),
+    )?;
+    authorize_exact_workspace_owner_lease(
+        job_store,
+        job_id,
+        request.workspace_owner_lease.as_ref(),
+    )?;
+    let lease_ms = request.lease_ms.unwrap_or(30_000);
+    let renewed_owner_lease = request
+        .workspace_owner_lease
+        .as_ref()
+        .map(|lease| {
+            workspace_claim_store()?.renew_owner(lease, lease_ms, workspace_claim_now_ms())
+        })
+        .transpose()?;
+    let job = match job_store.renew_remote_runner_claim_with_workspace_owner_lease(
         job_id,
         &request.runner_id,
         &request.claim_id,
-        request.lease_ms.unwrap_or(30_000),
-    )?;
+        lease_ms,
+        request.workspace_owner_lease.as_ref(),
+        renewed_owner_lease.clone(),
+    ) {
+        Ok(job) => job,
+        Err(error) => {
+            // The authority has advanced but the queue did not. Preserve typed
+            // recovery work rather than accepting either epoch ambiguously.
+            if let Some(lease) = renewed_owner_lease.as_ref() {
+                let _ = workspace_claim_store()?.record_owner_release_failure(lease, &error);
+            }
+            return Err(error);
+        }
+    };
     Ok(json!({
         "command": "api.runner.jobs.heartbeat",
         "job": job,
+        "workspace_owner_lease": renewed_owner_lease,
     }))
 }
 
@@ -714,6 +844,16 @@ fn consume(
     let request: ConsumeRequest = parse_body(body, "remote runner execution consume request")?;
     auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
     touch_reverse_session(&request.runner_id)?;
+    authorize_exact_workspace_claim_binding(
+        job_store,
+        job_id,
+        request.workspace_claim_binding.as_ref(),
+    )?;
+    authorize_exact_workspace_owner_lease(
+        job_store,
+        job_id,
+        request.workspace_owner_lease.as_ref(),
+    )?;
     let job = job_store.consume_remote_runner_execution(
         job_id,
         &request.runner_id,
@@ -727,9 +867,30 @@ fn consume(
     }))
 }
 
+/// This is deliberately separate from consume: the worker uses it immediately
+/// before input materialization, while the receipt remains one-time at provider
+/// invocation.
+fn validate_owner(
+    job_id: Uuid,
+    body: Option<Value>,
+    job_store: &JobStore,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    let request: OwnerValidationRequest =
+        parse_body(body, "remote runner owner validation request")?;
+    auth.authorize(BrokerScope::Work, Some(request.runner_id.as_str()))?;
+    touch_reverse_session(&request.runner_id)?;
+    authorize_exact_workspace_owner_lease(job_store, job_id, Some(&request.workspace_owner_lease))?;
+    job_store.ensure_remote_runner_claim(job_id, &request.runner_id, &request.claim_id)?;
+    let valid = workspace_claim_store()?
+        .validate_owner(&request.workspace_owner_lease, workspace_claim_now_ms())?;
+    Ok(json!({ "valid": valid }))
+}
+
 fn cancel(job_id: Uuid, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
     authorize_job_submit(job_id, job_store, auth)?;
     let job = job_store.cancel_remote_runner_job(job_id, "cancel requested via broker API")?;
+    release_terminal_workspace_owner(job_store, job_id);
     let events = job_store.events(job_id)?;
     Ok(json!({
         "command": "api.runner.jobs.cancel",
@@ -757,6 +918,21 @@ fn authorize_job_submit(
     Ok(())
 }
 
+fn release_terminal_workspace_owner(job_store: &JobStore, job_id: Uuid) {
+    let Ok(Some(lease)) = job_store.remote_runner_workspace_owner_lease(job_id) else {
+        return;
+    };
+    if let Err(error) = workspace_claim_store().and_then(|store| {
+        if let Err(release_error) = store.release_owner(&lease, workspace_claim_now_ms()) {
+            store.record_owner_release_failure(&lease, &release_error)?;
+            return Err(release_error);
+        }
+        Ok(())
+    }) {
+        let _ = job_store.record_workspace_owner_cleanup_failure(job_id, &error);
+    }
+}
+
 /// Map a handler error to an HTTP response. Broker auth rejections become
 /// `401 Unauthorized` (so unauthenticated callers see a distinct status), all
 /// other errors keep the existing `400 Bad Request` contract.
@@ -772,6 +948,202 @@ fn parse_body<T: for<'de> Deserialize<'de>>(body: Option<Value>, label: &str) ->
     serde_json::from_value(body.unwrap_or_else(|| json!({}))).map_err(|err| {
         Error::validation_invalid_argument("body", format!("invalid {label}: {err}"), None, None)
     })
+}
+
+fn workspace_claim_store() -> Result<crate::workspace_claim::WorkspaceClaimStore> {
+    Ok(crate::workspace_claim::WorkspaceClaimStore::new(
+        paths::homeboy_data()?.join("reverse-broker-workspace-claims"),
+    ))
+}
+
+fn workspace_claim_now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+#[derive(Deserialize)]
+struct WorkspaceClaimAcquireRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+    ttl_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceClaimRequest {
+    claim: crate::workspace_claim::WorkspaceClaim,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceAuthorityStatusRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceOwnerRegisterRequest {
+    workspace: crate::workspace_claim::WorkspaceIdentity,
+    owner_id: String,
+    ttl_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceOwnerRequest {
+    workspace_owner_lease: crate::workspace_claim::WorkspaceOwnerLease,
+    #[serde(default = "default_workspace_owner_ttl_ms")]
+    ttl_ms: u64,
+}
+
+fn default_workspace_owner_ttl_ms() -> u64 {
+    crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS
+}
+
+fn workspace_claim_capabilities(auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    Ok(json!({ "capabilities": [
+        crate::workspace_claim::WorkspaceClaimProtocol::current(),
+        crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+    ] }))
+}
+
+fn register_workspace_owner(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceOwnerRegisterRequest =
+        parse_body(body, "reverse broker workspace owner register request")?;
+    let lease = workspace_claim_store()?.register_owner(
+        request.workspace,
+        request.owner_id,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "workspace_owner_lease": lease }))
+}
+
+fn validate_workspace_owner(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceOwnerRequest =
+        parse_body(body, "reverse broker workspace owner validate request")?;
+    Ok(
+        json!({ "valid": workspace_claim_store()?.validate_owner(&request.workspace_owner_lease, workspace_claim_now_ms())? }),
+    )
+}
+
+fn renew_workspace_owner(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceOwnerRequest =
+        parse_body(body, "reverse broker workspace owner renew request")?;
+    let lease = workspace_claim_store()?.renew_owner(
+        &request.workspace_owner_lease,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "workspace_owner_lease": lease }))
+}
+
+fn release_workspace_owner(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceOwnerRequest =
+        parse_body(body, "reverse broker workspace owner release request")?;
+    workspace_claim_store()?
+        .release_owner(&request.workspace_owner_lease, workspace_claim_now_ms())?;
+    Ok(json!({ "released": true }))
+}
+
+fn acquire_workspace_claim(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceClaimAcquireRequest =
+        parse_body(body, "reverse broker workspace claim acquire request")?;
+    let claim = workspace_claim_store()?.acquire(
+        request.workspace,
+        request.ttl_ms,
+        workspace_claim_now_ms(),
+    )?;
+    Ok(json!({ "claim": claim }))
+}
+
+fn validate_workspace_claim(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceClaimRequest =
+        parse_body(body, "reverse broker workspace claim validate request")?;
+    Ok(
+        json!({ "valid": workspace_claim_store()?.validate(&request.claim, workspace_claim_now_ms())? }),
+    )
+}
+
+fn release_workspace_claim(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceClaimRequest =
+        parse_body(body, "reverse broker workspace claim release request")?;
+    workspace_claim_store()?.release(&request.claim, workspace_claim_now_ms())?;
+    Ok(json!({ "released": true }))
+}
+
+fn workspace_claim_authority_status(
+    body: Option<Value>,
+    auth: &BrokerAuthContext,
+) -> Result<Value> {
+    auth.authorize(BrokerScope::Submit, None)?;
+    let request: WorkspaceAuthorityStatusRequest =
+        parse_body(body, "reverse broker workspace claim authority request")?;
+    Ok(json!({ "status": workspace_claim_store()?.authority_status(
+        &request.workspace,
+        workspace_claim_now_ms(),
+    )? }))
+}
+
+fn authorize_workspace_claim_binding(
+    binding: Option<&crate::workspace_claim::WorkspaceClaimBinding>,
+) -> Result<()> {
+    if let Some(binding) = binding {
+        workspace_claim_store()?.authorize_binding(binding, workspace_claim_now_ms())?;
+    }
+    Ok(())
+}
+
+fn authorize_exact_workspace_claim_binding(
+    job_store: &JobStore,
+    job_id: Uuid,
+    presented: Option<&crate::workspace_claim::WorkspaceClaimBinding>,
+) -> Result<()> {
+    let persisted = job_store.remote_runner_workspace_claim_binding(job_id)?;
+    if persisted.as_ref() != presented {
+        return Err(Error::validation_invalid_argument(
+            "workspace_claim_binding",
+            "reverse runner workspace claim binding does not match the durable job",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    authorize_workspace_claim_binding(presented)
+}
+
+fn authorize_workspace_owner_lease(
+    lease: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+) -> Result<()> {
+    if let Some(lease) = lease {
+        if !workspace_claim_store()?.validate_owner(lease, workspace_claim_now_ms())? {
+            return Err(Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                "reverse runner workspace owner lease is stale or no longer live",
+                Some(lease.owner_id.clone()),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn authorize_exact_workspace_owner_lease(
+    job_store: &JobStore,
+    job_id: Uuid,
+    presented: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+) -> Result<()> {
+    let persisted = job_store.remote_runner_workspace_owner_lease(job_id)?;
+    if persisted.as_ref() != presented {
+        return Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "reverse runner workspace owner lease does not match the durable job",
+            Some(job_id.to_string()),
+            None,
+        ));
+    }
+    authorize_workspace_owner_lease(presented)
 }
 
 fn touch_reverse_session(runner_id: &str) -> Result<()> {
@@ -1017,6 +1389,41 @@ mod auth_tests {
             "homeboy/remote-runner-observation-run-detail/v1"
         );
         assert_eq!(response.body["body"]["run"]["run"]["id"], "run-1");
+    }
+
+    #[test]
+    fn workspace_claim_authority_requires_submit_auth_and_reports_live_owner() {
+        let _home = HomeGuard::new();
+        let token = pair("runner-a", BrokerScope::Submit);
+        let workspace = crate::workspace_claim::WorkspaceIdentity::new("test", "reverse-authority")
+            .expect("workspace identity");
+        let denied = route(
+            "POST",
+            "/runner/workspace-claims/authority",
+            Some(json!({ "workspace": workspace })),
+            &JobStore::default(),
+            &enforcing_auth(None),
+        );
+        assert_eq!(denied.status_code, 401);
+        let owner = route(
+            "POST",
+            "/runner/workspace-owners/register",
+            Some(json!({ "workspace": workspace, "owner_id": "reverse-owner", "ttl_ms": 30_000 })),
+            &JobStore::default(),
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(owner.status_code, 200, "owner: {}", owner.body);
+        let status = route(
+            "POST",
+            "/runner/workspace-claims/authority",
+            Some(json!({ "workspace": workspace })),
+            &JobStore::default(),
+            &enforcing_auth(Some(&token)),
+        );
+        assert_eq!(status.status_code, 200, "status: {}", status.body);
+        assert_eq!(status.body["body"]["status"]["clear"], false);
+        assert_eq!(status.body["body"]["status"]["live_owner_count"], 1);
+        assert!(!status.body.to_string().contains("reverse-owner"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -207,6 +207,7 @@ pub(crate) mod transient_workspace_policy;
 pub mod test_support;
 pub mod update_check_cache;
 pub mod validation_progress;
+pub mod workspace_claim;
 pub mod workspace_snapshot;
 pub mod worktree;
 pub mod worktree_providers;

--- a/crates/homeboy-core/src/workspace_claim.rs
+++ b/crates/homeboy-core/src/workspace_claim.rs
@@ -1,0 +1,982 @@
+//! Durable, transport-neutral workspace authority.
+//!
+//! A workspace has either renewable owners or one short reconciliation fence.
+//! The durable revision and opaque tokens, rather than clocks, establish authority.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::{Error, Result};
+
+pub const WORKSPACE_CLAIM_CAPABILITY: &str = "workspace-claim";
+pub const WORKSPACE_OWNER_LEASE_CAPABILITY: &str = "workspace-owner-lease";
+pub const WORKSPACE_CLAIM_PROTOCOL_VERSION: u32 = 2;
+pub const WORKSPACE_IDENTITY_SCHEMA: &str = "homeboy/workspace-identity/v1";
+pub const WORKSPACE_CLAIM_SCHEMA: &str = "homeboy/workspace-claim/v2";
+pub const WORKSPACE_OWNER_LEASE_SCHEMA: &str = "homeboy/workspace-owner-lease/v2";
+pub const WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA: &str =
+    "homeboy/workspace-owner-release-recovery/v1";
+const WORKSPACE_AUTHORITY_SCHEMA: &str = "homeboy/workspace-authority/v2";
+pub const MAX_WORKSPACE_CLAIM_TTL_MS: u64 = 300_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaimProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+impl WorkspaceClaimProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: WORKSPACE_CLAIM_CAPABILITY.into(),
+            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
+        }
+    }
+    pub fn verify(&self) -> Result<()> {
+        (self.capability == WORKSPACE_CLAIM_CAPABILITY
+            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_claim_protocol",
+                    "workspace authority does not advertise the required claim protocol",
+                )
+            })
+    }
+}
+
+/// Versioned negotiation record for direct-daemon owner leases. Reconciliation
+/// claims deliberately use a different capability so the two authorities
+/// cannot be substituted for one another.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerLeaseProtocol {
+    pub capability: String,
+    pub version: u32,
+}
+impl WorkspaceOwnerLeaseProtocol {
+    pub fn current() -> Self {
+        Self {
+            capability: WORKSPACE_OWNER_LEASE_CAPABILITY.into(),
+            version: WORKSPACE_CLAIM_PROTOCOL_VERSION,
+        }
+    }
+    pub fn verify(&self) -> Result<()> {
+        (self.capability == WORKSPACE_OWNER_LEASE_CAPABILITY
+            && self.version == WORKSPACE_CLAIM_PROTOCOL_VERSION)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_owner_lease_protocol",
+                    "workspace authority does not advertise the required owner lease protocol",
+                )
+            })
+    }
+}
+
+/// A portable logical locator. Host paths are deliberately excluded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WorkspaceIdentity {
+    pub schema: String,
+    pub kind: String,
+    pub locator: String,
+}
+impl WorkspaceIdentity {
+    pub fn new(kind: impl Into<String>, locator: impl Into<String>) -> Result<Self> {
+        let identity = Self {
+            schema: WORKSPACE_IDENTITY_SCHEMA.into(),
+            kind: kind.into(),
+            locator: locator.into(),
+        };
+        identity.verify()?;
+        Ok(identity)
+    }
+    pub fn verify(&self) -> Result<()> {
+        (self.schema == WORKSPACE_IDENTITY_SCHEMA
+            && !self.kind.trim().is_empty()
+            && !self.locator.trim().is_empty()
+            && !self.kind.contains('\n')
+            && !self.locator.contains('\n'))
+        .then_some(())
+        .ok_or_else(|| {
+            invalid(
+                "workspace_identity",
+                "workspace identity is malformed or unsupported",
+            )
+        })
+    }
+}
+
+/// An exclusive short reconciliation fence. `lifecycle_revision` is an
+/// authority-issued monotonically increasing epoch; callers never supply it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaim {
+    pub schema: String,
+    pub protocol: WorkspaceClaimProtocol,
+    pub workspace: WorkspaceIdentity,
+    pub lifecycle_revision: u64,
+    pub token: String,
+    pub expires_at_ms: u64,
+}
+
+/// A renewable active-task authority. Several distinct owner identities may be live.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerLease {
+    pub schema: String,
+    pub protocol: WorkspaceOwnerLeaseProtocol,
+    pub workspace: WorkspaceIdentity,
+    pub owner_id: String,
+    pub lifecycle_revision: u64,
+    pub token: String,
+    pub expires_at_ms: u64,
+}
+
+/// Token-free owner identity returned by authority inventory. The stable digest
+/// lets callers distinguish live owners without disclosing owner identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RedactedWorkspaceOwnerIdentity {
+    pub kind: String,
+    pub redacted_id: String,
+    pub lifecycle_revision: u64,
+}
+
+/// Read-only authority inventory for one exact workspace identity. This is safe
+/// for transport responses: it deliberately contains neither claim nor lease
+/// tokens (or expiry timestamps that could be used as authority receipts).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceAuthorityStatus {
+    pub schema: String,
+    pub protocol: WorkspaceClaimProtocol,
+    pub workspace: WorkspaceIdentity,
+    pub lifecycle_revision: u64,
+    pub live_reconciliation_claim: bool,
+    pub live_owner_count: usize,
+    pub live_owners: Vec<RedactedWorkspaceOwnerIdentity>,
+    pub clear: bool,
+}
+
+pub const WORKSPACE_AUTHORITY_STATUS_SCHEMA: &str = "homeboy/workspace-authority-status/v2";
+
+impl WorkspaceAuthorityStatus {
+    pub fn verify(&self, workspace: &WorkspaceIdentity) -> Result<()> {
+        self.protocol.verify()?;
+        self.workspace.verify()?;
+        (self.schema == WORKSPACE_AUTHORITY_STATUS_SCHEMA
+            && &self.workspace == workspace
+            && self.live_owner_count == self.live_owners.len()
+            && self.clear == (!self.live_reconciliation_claim && self.live_owners.is_empty())
+            && self.live_owners.iter().all(|owner| {
+                owner.kind == "workspace-owner-sha256/v1"
+                    && owner.lifecycle_revision > 0
+                    && owner.redacted_id.len() == 64
+                    && owner
+                        .redacted_id
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit())
+            }))
+        .then_some(())
+        .ok_or_else(|| {
+            invalid(
+                "workspace_authority_status",
+                "workspace authority status is malformed",
+            )
+        })
+    }
+}
+
+/// Durable evidence that a direct-owner rollback could not release its exact
+/// lease. Daemon startup retries these records before accepting new work.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerReleaseRecovery {
+    pub schema: String,
+    pub lease: WorkspaceOwnerLease,
+    pub error_code: String,
+    pub error_message: String,
+}
+
+/// Optional transport binding for a reconciliation operation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceClaimBinding {
+    pub workspace: WorkspaceIdentity,
+    pub lifecycle_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim: Option<WorkspaceClaim>,
+}
+impl WorkspaceClaimBinding {
+    pub fn verify(&self) -> Result<()> {
+        self.workspace.verify()?;
+        if let Some(claim) = &self.claim {
+            claim.verify_shape(0)?;
+            if claim.workspace != self.workspace
+                || claim.lifecycle_revision != self.lifecycle_revision
+            {
+                return Err(invalid(
+                    "workspace_claim_binding",
+                    "workspace identity and authority epoch do not agree",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+impl WorkspaceClaim {
+    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
+        self.protocol.verify()?;
+        self.workspace.verify()?;
+        (self.schema == WORKSPACE_CLAIM_SCHEMA
+            && !self.token.trim().is_empty()
+            && self.lifecycle_revision > 0
+            && self.expires_at_ms > now_ms)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_claim",
+                    "workspace reconciliation claim is malformed or expired",
+                )
+            })
+    }
+}
+impl WorkspaceOwnerLease {
+    pub fn verify_shape(&self, now_ms: u64) -> Result<()> {
+        self.protocol.verify()?;
+        self.workspace.verify()?;
+        (self.schema == WORKSPACE_OWNER_LEASE_SCHEMA
+            && !self.owner_id.trim().is_empty()
+            && !self.token.trim().is_empty()
+            && self.lifecycle_revision > 0
+            && self.expires_at_ms > now_ms)
+            .then_some(())
+            .ok_or_else(|| {
+                invalid(
+                    "workspace_owner_lease",
+                    "workspace owner lease is malformed or expired",
+                )
+            })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkspaceAuthority {
+    schema: String,
+    workspace: WorkspaceIdentity,
+    lifecycle_revision: u64,
+    owners: Vec<WorkspaceOwnerLease>,
+    reconciliation: Option<WorkspaceClaim>,
+    #[serde(default)]
+    owner_release_recoveries: Vec<WorkspaceOwnerReleaseRecovery>,
+}
+impl WorkspaceAuthority {
+    fn empty(workspace: WorkspaceIdentity) -> Self {
+        Self {
+            schema: WORKSPACE_AUTHORITY_SCHEMA.into(),
+            workspace,
+            lifecycle_revision: 0,
+            owners: Vec::new(),
+            reconciliation: None,
+            owner_release_recoveries: Vec::new(),
+        }
+    }
+    fn verify(&self) -> Result<()> {
+        if self.schema != WORKSPACE_AUTHORITY_SCHEMA {
+            return Err(invalid(
+                "workspace_authority",
+                "workspace authority state has an unsupported schema",
+            ));
+        }
+        self.workspace.verify()?;
+        for owner in &self.owners {
+            owner.verify_shape(0)?;
+            if owner.workspace != self.workspace {
+                return Err(invalid(
+                    "workspace_authority",
+                    "owner workspace does not match authority workspace",
+                ));
+            }
+        }
+        if let Some(claim) = &self.reconciliation {
+            claim.verify_shape(0)?;
+            if claim.workspace != self.workspace {
+                return Err(invalid(
+                    "workspace_authority",
+                    "claim workspace does not match authority workspace",
+                ));
+            }
+        }
+        for recovery in &self.owner_release_recoveries {
+            if recovery.schema != WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA
+                || recovery.lease.workspace != self.workspace
+            {
+                return Err(invalid(
+                    "workspace_owner_release_recovery",
+                    "owner release recovery evidence is malformed or belongs to another workspace",
+                ));
+            }
+            recovery.lease.verify_shape(0)?;
+        }
+        Ok(())
+    }
+    fn prune(&mut self, now_ms: u64) -> bool {
+        let before = self.owners.len();
+        self.owners.retain(|owner| owner.expires_at_ms > now_ms);
+        if self
+            .reconciliation
+            .as_ref()
+            .is_some_and(|claim| claim.expires_at_ms <= now_ms)
+        {
+            self.reconciliation = None;
+            return true;
+        }
+        before != self.owners.len()
+    }
+}
+
+/// One durable state file and lock per normalized portable workspace identity.
+pub struct WorkspaceClaimStore {
+    root: PathBuf,
+}
+impl WorkspaceClaimStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Atomically registers an active owner unless reconciliation is fenced.
+    pub fn register_owner(
+        &self,
+        workspace: WorkspaceIdentity,
+        owner_id: impl Into<String>,
+        ttl_ms: u64,
+        now_ms: u64,
+    ) -> Result<WorkspaceOwnerLease> {
+        workspace.verify()?;
+        let owner_id = owner_id.into();
+        valid_ttl(ttl_ms)?;
+        if owner_id.trim().is_empty() {
+            return Err(invalid(
+                "workspace_owner_id",
+                "workspace owner identity must not be empty",
+            ));
+        }
+        self.with_lock(&workspace, || {
+            let mut state = self.read_or_empty(&workspace)?;
+            let mut changed = state.prune(now_ms);
+            if state.reconciliation.is_some() {
+                if changed {
+                    self.commit(&mut state)?;
+                }
+                return Err(invalid(
+                    "workspace_reconciliation_fence",
+                    "workspace is fenced by a live reconciliation claim",
+                ));
+            }
+            if let Some(owner) = state
+                .owners
+                .iter()
+                .find(|owner| owner.owner_id == owner_id)
+                .cloned()
+            {
+                if changed {
+                    self.commit(&mut state)?;
+                }
+                return Ok(owner);
+            }
+            let lease = WorkspaceOwnerLease {
+                schema: WORKSPACE_OWNER_LEASE_SCHEMA.into(),
+                protocol: WorkspaceOwnerLeaseProtocol::current(),
+                workspace: workspace.clone(),
+                owner_id,
+                lifecycle_revision: state.lifecycle_revision + 1,
+                token: uuid::Uuid::new_v4().to_string(),
+                expires_at_ms: now_ms.saturating_add(ttl_ms),
+            };
+            state.owners.push(lease.clone());
+            changed = true;
+            if changed {
+                self.commit(&mut state)?;
+            }
+            let mut issued = lease;
+            issued.lifecycle_revision = state.lifecycle_revision;
+            Ok(issued)
+        })
+    }
+
+    pub fn renew_owner(
+        &self,
+        lease: &WorkspaceOwnerLease,
+        ttl_ms: u64,
+        now_ms: u64,
+    ) -> Result<WorkspaceOwnerLease> {
+        lease.verify_shape(0)?;
+        valid_ttl(ttl_ms)?;
+        self.with_lock(&lease.workspace, || {
+            let mut state = self.read_or_empty(&lease.workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            if state.reconciliation.is_some() {
+                return Err(invalid(
+                    "workspace_reconciliation_fence",
+                    "a live reconciliation fence cannot renew an owner",
+                ));
+            }
+            let owner = state
+                .owners
+                .iter_mut()
+                .find(|owner| owner.owner_id == lease.owner_id)
+                .ok_or_else(|| invalid("workspace_owner_lease", "owner lease is no longer live"))?;
+            if owner.token != lease.token || owner.lifecycle_revision != lease.lifecycle_revision {
+                return Err(invalid(
+                    "workspace_owner_lease",
+                    "owner lease token or epoch does not match durable authority",
+                ));
+            }
+            owner.expires_at_ms = now_ms.saturating_add(ttl_ms);
+            owner.lifecycle_revision = state.lifecycle_revision + 1;
+            self.commit(&mut state)?;
+            Ok(state
+                .owners
+                .iter()
+                .find(|owner| owner.owner_id == lease.owner_id)
+                .unwrap()
+                .clone())
+        })
+    }
+
+    /// Check the exact live owner token and epoch without extending its lease.
+    pub fn validate_owner(&self, lease: &WorkspaceOwnerLease, now_ms: u64) -> Result<bool> {
+        lease.verify_shape(now_ms)?;
+        self.with_lock(&lease.workspace, || {
+            let mut state = self.read_or_empty(&lease.workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            Ok(state.reconciliation.is_none() && state.owners.iter().any(|owner| owner == lease))
+        })
+    }
+
+    pub fn release_owner(&self, lease: &WorkspaceOwnerLease, now_ms: u64) -> Result<()> {
+        lease.workspace.verify()?;
+        self.with_lock(&lease.workspace, || {
+            #[cfg(any(test, feature = "test-support"))]
+            self.inject_owner_release_failure(&lease.workspace)?;
+            let mut state = self.read_or_empty(&lease.workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            match state
+                .owners
+                .iter()
+                .position(|owner| owner.owner_id == lease.owner_id)
+            {
+                None => {
+                    // Recovery can replay after a prior release succeeded but
+                    // its caller could not durably record the terminal state.
+                    // The absent owner proves the exact cleanup is complete.
+                    let recoveries = state.owner_release_recoveries.len();
+                    state
+                        .owner_release_recoveries
+                        .retain(|recovery| recovery.lease != *lease);
+                    if state.owner_release_recoveries.len() != recoveries {
+                        self.commit(&mut state)?;
+                    }
+                    Ok(())
+                }
+                Some(index)
+                    if state.owners[index].token == lease.token
+                        && state.owners[index].lifecycle_revision == lease.lifecycle_revision =>
+                {
+                    state.owners.remove(index);
+                    state
+                        .owner_release_recoveries
+                        .retain(|recovery| recovery.lease != *lease);
+                    self.commit(&mut state)
+                }
+                Some(_) => Err(invalid(
+                    "workspace_owner_lease",
+                    "owner lease token or epoch does not match durable authority",
+                )),
+            }
+        })
+    }
+
+    /// Persist the exact lease and release failure so a later daemon startup can
+    /// retry rollback even though no job or admission was committed.
+    pub fn record_owner_release_failure(
+        &self,
+        lease: &WorkspaceOwnerLease,
+        error: &Error,
+    ) -> Result<WorkspaceOwnerReleaseRecovery> {
+        lease.verify_shape(0)?;
+        self.with_lock(&lease.workspace, || {
+            let mut state = self.read_or_empty(&lease.workspace)?;
+            let recovery = WorkspaceOwnerReleaseRecovery {
+                schema: WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA.into(),
+                lease: lease.clone(),
+                error_code: error.code.as_str().to_string(),
+                error_message: error.to_string(),
+            };
+            state
+                .owner_release_recoveries
+                .retain(|existing| existing.lease != *lease);
+            state.owner_release_recoveries.push(recovery.clone());
+            self.commit(&mut state)?;
+            Ok(recovery)
+        })
+    }
+
+    /// Return durable rollback work that was left pending by a failed admission
+    /// or queue commit. A successful `release_owner` removes the matching record.
+    pub fn pending_owner_release_recoveries(&self) -> Result<Vec<WorkspaceOwnerReleaseRecovery>> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut recoveries = Vec::new();
+        for entry in fs::read_dir(&self.root).map_err(io_error)? {
+            let path = entry.map_err(io_error)?.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let state: WorkspaceAuthority =
+                serde_json::from_slice(&fs::read(&path).map_err(io_error)?).map_err(|error| {
+                    Error::internal_json(error.to_string(), Some(path.display().to_string()))
+                })?;
+            state.verify()?;
+            recoveries.extend(state.owner_release_recoveries);
+        }
+        Ok(recoveries)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn fail_next_owner_releases(
+        &self,
+        workspace: &WorkspaceIdentity,
+        count: u64,
+    ) -> Result<()> {
+        workspace.verify()?;
+        fs::create_dir_all(&self.root).map_err(io_error)?;
+        fs::write(
+            self.owner_release_failure_path(workspace),
+            count.to_string(),
+        )
+        .map_err(io_error)
+    }
+
+    /// Acquire reconciliation only after atomically pruning expired owners and
+    /// proving no active owner remains.
+    pub fn acquire(
+        &self,
+        workspace: WorkspaceIdentity,
+        ttl_ms: u64,
+        now_ms: u64,
+    ) -> Result<WorkspaceClaim> {
+        workspace.verify()?;
+        valid_ttl(ttl_ms)?;
+        self.with_lock(&workspace, || {
+            let mut state = self.read_or_empty(&workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            if !state.owners.is_empty() {
+                return Err(live_owners(&state.owners));
+            }
+            if state.reconciliation.is_some() {
+                return Err(invalid(
+                    "workspace_claim",
+                    "workspace already has a live reconciliation claim",
+                ));
+            }
+            let claim = WorkspaceClaim {
+                schema: WORKSPACE_CLAIM_SCHEMA.into(),
+                protocol: WorkspaceClaimProtocol::current(),
+                workspace: workspace.clone(),
+                lifecycle_revision: state.lifecycle_revision + 1,
+                token: uuid::Uuid::new_v4().to_string(),
+                expires_at_ms: now_ms.saturating_add(ttl_ms),
+            };
+            state.reconciliation = Some(claim);
+            self.commit(&mut state)?;
+            Ok(state.reconciliation.unwrap())
+        })
+    }
+
+    pub fn validate(&self, claim: &WorkspaceClaim, now_ms: u64) -> Result<bool> {
+        claim.verify_shape(now_ms)?;
+        self.with_lock(&claim.workspace, || {
+            Ok(self
+                .read_or_empty(&claim.workspace)?
+                .reconciliation
+                .as_ref()
+                == Some(claim))
+        })
+    }
+    /// Return whether this authority still has a live reconciliation claim or
+    /// owner lease. Recovery uses this token-free inventory only after the
+    /// maximum claim lifetime has elapsed.
+    pub fn has_live_authority(&self, workspace: &WorkspaceIdentity, now_ms: u64) -> Result<bool> {
+        workspace.verify()?;
+        self.with_lock(workspace, || {
+            let mut state = self.read_or_empty(workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            Ok(state.reconciliation.is_some() || !state.owners.is_empty())
+        })
+    }
+    /// Return a token-free, exact-identity inventory after pruning expiry while
+    /// holding the workspace lock. Pruning is the only mutation this probe may do.
+    pub fn authority_status(
+        &self,
+        workspace: &WorkspaceIdentity,
+        now_ms: u64,
+    ) -> Result<WorkspaceAuthorityStatus> {
+        workspace.verify()?;
+        self.with_lock(workspace, || {
+            let mut state = self.read_or_empty(workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            let live_owners = state
+                .owners
+                .iter()
+                .map(|owner| RedactedWorkspaceOwnerIdentity {
+                    kind: "workspace-owner-sha256/v1".into(),
+                    redacted_id: sha256_hex(&owner.owner_id),
+                    lifecycle_revision: owner.lifecycle_revision,
+                })
+                .collect::<Vec<_>>();
+            Ok(WorkspaceAuthorityStatus {
+                schema: WORKSPACE_AUTHORITY_STATUS_SCHEMA.into(),
+                protocol: WorkspaceClaimProtocol::current(),
+                workspace: workspace.clone(),
+                lifecycle_revision: state.lifecycle_revision,
+                live_reconciliation_claim: state.reconciliation.is_some(),
+                live_owner_count: live_owners.len(),
+                clear: state.reconciliation.is_none() && live_owners.is_empty(),
+                live_owners,
+            })
+        })
+    }
+    /// Exact reconciliation release is idempotent; a different live token fails.
+    pub fn release(&self, claim: &WorkspaceClaim, now_ms: u64) -> Result<()> {
+        claim.workspace.verify()?;
+        self.with_lock(&claim.workspace, || {
+            let mut state = self.read_or_empty(&claim.workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            match &state.reconciliation {
+                None => Ok(()),
+                Some(current) if current == claim => {
+                    state.reconciliation = None;
+                    self.commit(&mut state)
+                }
+                Some(_) => Err(invalid(
+                    "workspace_claim",
+                    "reconciliation claim token or epoch does not match durable authority",
+                )),
+            }
+        })
+    }
+    /// Atomically authorizes only the exact live reconciliation operation.
+    pub fn authorize_binding(&self, binding: &WorkspaceClaimBinding, now_ms: u64) -> Result<()> {
+        binding.verify()?;
+        self.with_lock(&binding.workspace, || {
+            let state = self.read_or_empty(&binding.workspace)?;
+            match state.reconciliation {
+                None => Ok(()),
+                Some(claim) if claim.expires_at_ms <= now_ms => Ok(()),
+                Some(claim) if binding.claim.as_ref() == Some(&claim) => Ok(()),
+                Some(_) => Err(invalid(
+                    "workspace_claim",
+                    "workspace is fenced by a live reconciliation claim",
+                )),
+            }
+        })
+    }
+
+    fn with_lock<T>(
+        &self,
+        workspace: &WorkspaceIdentity,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        fs::create_dir_all(&self.root).map_err(io_error)?;
+        sync_dir(&self.root)?;
+        let lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(self.lock_path(workspace))
+            .map_err(io_error)?;
+        lock.lock_exclusive().map_err(io_error)?;
+        let result = operation();
+        let _ = FileExt::unlock(&lock);
+        result
+    }
+    #[cfg(any(test, feature = "test-support"))]
+    fn inject_owner_release_failure(&self, workspace: &WorkspaceIdentity) -> Result<()> {
+        // This runs under the target workspace lock, so one test's injected
+        // release failure cannot be consumed by another workspace.
+        let path = self.owner_release_failure_path(workspace);
+        let remaining = match fs::read_to_string(&path) {
+            Ok(value) => value.trim().parse::<u64>().unwrap_or_default(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(io_error(error)),
+        };
+        if remaining == 0 {
+            return Ok(());
+        }
+        if remaining == 1 {
+            fs::remove_file(path).map_err(io_error)?;
+        } else {
+            fs::write(path, (remaining - 1).to_string()).map_err(io_error)?;
+        }
+        Err(Error::internal_io(
+            "injected workspace owner release failure",
+            None,
+        ))
+    }
+    fn read_or_empty(&self, workspace: &WorkspaceIdentity) -> Result<WorkspaceAuthority> {
+        let path = self.state_path(workspace);
+        if !path.exists() {
+            return Ok(WorkspaceAuthority::empty(workspace.clone()));
+        }
+        let state: WorkspaceAuthority = serde_json::from_slice(&fs::read(&path).map_err(io_error)?)
+            .map_err(|error| {
+                Error::internal_json(error.to_string(), Some(path.display().to_string()))
+            })?;
+        state.verify()?;
+        if state.workspace != *workspace {
+            return Err(invalid(
+                "workspace_authority",
+                "authority state does not match requested workspace",
+            ));
+        }
+        Ok(state)
+    }
+    fn commit(&self, state: &mut WorkspaceAuthority) -> Result<()> {
+        state.lifecycle_revision = state
+            .lifecycle_revision
+            .checked_add(1)
+            .ok_or_else(|| invalid("workspace_authority", "authority epoch overflow"))?;
+        self.write_state(state)
+    }
+    fn write_state(&self, state: &WorkspaceAuthority) -> Result<()> {
+        let path = self.state_path(&state.workspace);
+        let bytes = serde_json::to_vec(state)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        let temporary = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+        let mut file = File::create(&temporary).map_err(io_error)?;
+        file.write_all(&bytes).map_err(io_error)?;
+        file.sync_all().map_err(io_error)?;
+        fs::rename(&temporary, &path).map_err(io_error)?;
+        sync_dir(&self.root)
+    }
+    fn state_path(&self, workspace: &WorkspaceIdentity) -> PathBuf {
+        self.root.join(format!("{}.json", workspace_key(workspace)))
+    }
+    fn lock_path(&self, workspace: &WorkspaceIdentity) -> PathBuf {
+        self.root.join(format!("{}.lock", workspace_key(workspace)))
+    }
+    #[cfg(any(test, feature = "test-support"))]
+    fn owner_release_failure_path(&self, workspace: &WorkspaceIdentity) -> PathBuf {
+        self.root.join(format!(
+            "{}.owner-release-failures.test",
+            workspace_key(workspace)
+        ))
+    }
+}
+
+fn valid_ttl(ttl_ms: u64) -> Result<()> {
+    (ttl_ms > 0 && ttl_ms <= MAX_WORKSPACE_CLAIM_TTL_MS)
+        .then_some(())
+        .ok_or_else(|| {
+            invalid(
+                "workspace_claim_ttl_ms",
+                "workspace authority TTL must be positive and bounded",
+            )
+        })
+}
+fn live_owners(owners: &[WorkspaceOwnerLease]) -> Error {
+    Error::validation_invalid_argument(
+        "workspace_live_owners",
+        "workspace has live owner leases",
+        None,
+        Some(
+            owners
+                .iter()
+                .map(|owner| format!("{}@{}", owner.owner_id, owner.lifecycle_revision))
+                .collect(),
+        ),
+    )
+}
+fn sync_dir(path: &Path) -> Result<()> {
+    File::open(path)
+        .and_then(|dir| dir.sync_all())
+        .map_err(io_error)
+}
+fn workspace_key(workspace: &WorkspaceIdentity) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(workspace.schema.as_bytes());
+    hasher.update([0]);
+    hasher.update(workspace.kind.as_bytes());
+    hasher.update([0]);
+    hasher.update(workspace.locator.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+fn invalid(field: &str, message: &str) -> Error {
+    Error::validation_invalid_argument(field, message, None, None)
+}
+fn io_error(error: std::io::Error) -> Error {
+    Error::internal_io(error.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn identity() -> WorkspaceIdentity {
+        WorkspaceIdentity::new("managed-workspace", "repo@task").unwrap()
+    }
+    fn store() -> (tempfile::TempDir, WorkspaceClaimStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = WorkspaceClaimStore::new(dir.path());
+        (dir, store)
+    }
+
+    #[test]
+    fn owners_block_reconciliation_and_can_coexist() {
+        let (_dir, store) = store();
+        let one = store
+            .register_owner(identity(), "local:one", 100, 10)
+            .unwrap();
+        let two = store
+            .register_owner(identity(), "reverse:two", 100, 10)
+            .unwrap();
+        assert_ne!(one.token, two.token);
+        assert!(store
+            .acquire(identity(), 10, 11)
+            .unwrap_err()
+            .message
+            .contains("live owner leases"));
+    }
+    #[test]
+    fn claim_blocks_owner_registration_and_release_is_idempotent() {
+        let (_dir, store) = store();
+        let claim = store.acquire(identity(), 100, 10).unwrap();
+        assert!(store.register_owner(identity(), "owner", 10, 11).is_err());
+        store.release(&claim, 11).unwrap();
+        store.release(&claim, 11).unwrap();
+        assert!(store.register_owner(identity(), "owner", 10, 11).is_ok());
+    }
+    #[test]
+    fn renewal_keeps_owner_live_beyond_five_minutes() {
+        let (_dir, store) = store();
+        let mut owner = store
+            .register_owner(identity(), "owner", MAX_WORKSPACE_CLAIM_TTL_MS, 0)
+            .unwrap();
+        for now in [299_999, 599_998, 899_997] {
+            owner = store
+                .renew_owner(&owner, MAX_WORKSPACE_CLAIM_TTL_MS, now)
+                .unwrap();
+        }
+        assert!(store.acquire(identity(), 10, 900_000).is_err());
+    }
+    #[test]
+    fn expired_owners_are_pruned_before_reconciliation() {
+        let (_dir, store) = store();
+        store.register_owner(identity(), "owner", 10, 0).unwrap();
+        assert!(store.acquire(identity(), 10, 11).is_ok());
+    }
+    #[test]
+    fn owner_validation_requires_the_exact_token_and_epoch() {
+        let (_dir, store) = store();
+        let lease = store.register_owner(identity(), "owner", 100, 0).unwrap();
+        assert!(store.validate_owner(&lease, 1).unwrap());
+        let mut substituted = lease.clone();
+        substituted.token = "other".into();
+        assert!(!store.validate_owner(&substituted, 1).unwrap());
+    }
+    #[test]
+    fn epochs_are_monotonic_across_expiry_reacquire_and_restart() {
+        let (dir, store) = store();
+        let first = store.acquire(identity(), 10, 0).unwrap();
+        let second = store.acquire(identity(), 10, 11).unwrap();
+        let restarted = WorkspaceClaimStore::new(dir.path());
+        restarted.release(&second, 12).unwrap();
+        let third = restarted.acquire(identity(), 10, 13).unwrap();
+        assert!(
+            first.lifecycle_revision < second.lifecycle_revision
+                && second.lifecycle_revision < third.lifecycle_revision
+        );
+    }
+    #[test]
+    fn stale_epoch_and_token_substitution_are_rejected() {
+        let (_dir, store) = store();
+        let stale = store.acquire(identity(), 100, 0).unwrap();
+        store.release(&stale, 1).unwrap();
+        let claim = store.acquire(identity(), 100, 2).unwrap();
+        assert!(!store.validate(&stale, 1).unwrap());
+        assert!(store.release(&stale, 1).is_err());
+        let mut forged = claim.clone();
+        forged.token = "other".into();
+        assert!(!store.validate(&forged, 1).unwrap());
+    }
+    #[test]
+    fn registration_and_reconciliation_race_have_one_winner() {
+        use std::sync::{Arc, Barrier};
+        let (_dir, store) = store();
+        let store = Arc::new(store);
+        let barrier = Arc::new(Barrier::new(2));
+        let owner_store = store.clone();
+        let owner_barrier = barrier.clone();
+        let owner = std::thread::spawn(move || {
+            owner_barrier.wait();
+            owner_store
+                .register_owner(identity(), "owner", 100, 1)
+                .is_ok()
+        });
+        barrier.wait();
+        let claim = store.acquire(identity(), 100, 1).is_ok();
+        assert_ne!(owner.join().unwrap(), claim);
+    }
+    #[test]
+    fn durable_write_leaves_restartable_state() {
+        let (dir, store) = store();
+        let claim = store.acquire(identity(), 100, 1).unwrap();
+        drop(store);
+        let restarted = WorkspaceClaimStore::new(dir.path());
+        assert!(restarted.validate(&claim, 2).unwrap());
+    }
+    #[test]
+    fn authority_status_is_token_free_and_prunes_expiry_under_lock() {
+        let (_dir, store) = store();
+        let owner = store.register_owner(identity(), "owner", 10, 0).unwrap();
+        let status = store.authority_status(&identity(), 1).unwrap();
+        assert!(!status.clear);
+        assert_eq!(status.live_owner_count, 1);
+        assert_ne!(status.live_owners[0].redacted_id, owner.owner_id);
+        assert!(!serde_json::to_string(&status)
+            .unwrap()
+            .contains(&owner.token));
+        let expired = store.authority_status(&identity(), 11).unwrap();
+        assert!(expired.clear);
+        assert_eq!(expired.live_owner_count, 0);
+    }
+    #[test]
+    fn authority_status_reports_a_live_reconciliation_claim() {
+        let (_dir, store) = store();
+        let claim = store.acquire(identity(), 10, 0).unwrap();
+        let status = store.authority_status(&identity(), 1).unwrap();
+        assert!(status.live_reconciliation_claim);
+        assert!(!status.clear);
+        assert!(!serde_json::to_string(&status)
+            .unwrap()
+            .contains(&claim.token));
+    }
+}

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -17,14 +17,16 @@ static TASK_WORKTREE_REGISTRY_GATE: OnceLock<RwLock<()>> = OnceLock::new();
 const MALFORMED_RECORD_REPAIR_LIMIT: usize = 20;
 
 pub use types::{
-    AdoptedWorkspaceRecord, BranchCleanupIntent, BranchCleanupStatus, CleanupPolicy,
-    TaskWorktreeRecord, TaskWorktreeState, WorkspaceRefRecord, WorktreeAdoptOptions,
-    WorktreeAdoptOutput, WorktreeBranchCleanupReport, WorktreeCleanupCandidate,
-    WorktreeCleanupCounts, WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupSkipped,
-    WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput, WorktreeQueueCreateOptions,
-    WorktreeQueueCreateOutput, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
-    WorktreeQueueLockHolder, WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport,
-    WorktreeStatusOutput,
+    authority_set_fingerprint, task_worktree_workspace_identity, AdoptedWorkspaceRecord,
+    BranchCleanupIntent, BranchCleanupStatus, CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState,
+    TerminalWorkspaceAuthorityObservation, TerminalWorkspaceAuthorityProof, WorkspaceRefRecord,
+    WorktreeAdoptOptions, WorktreeAdoptOutput, WorktreeBranchCleanupReport,
+    WorktreeCleanupCandidate, WorktreeCleanupCounts, WorktreeCleanupOptions, WorktreeCleanupOutput,
+    WorktreeCleanupSkipped, WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput,
+    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeQueueCreateRow,
+    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
 pub fn create(options: WorktreeCreateOptions) -> Result<WorktreeCreateOutput> {
@@ -37,6 +39,42 @@ pub fn adopt(options: WorktreeAdoptOptions) -> Result<WorktreeAdoptOutput> {
 
 pub fn list() -> Result<WorktreeListOutput> {
     with_task_worktree_registry_read_lock(list_unlocked)
+}
+
+/// Cache exact terminal authority evidence before a reconciliation claim is
+/// acquired. The receipt binds the manifest revision that was observed.
+pub fn persist_terminal_workspace_authority(
+    id: &str,
+    expected_revision: u64,
+    proof: TerminalWorkspaceAuthorityProof,
+) -> Result<()> {
+    with_task_worktree_registry_write_lock(|| {
+        let store = metadata_dir()?;
+        let mut record = read_record(&store, id)?;
+        if record.lifecycle_revision != expected_revision
+            || !proof.exact_for(&record, record.run_id.as_deref())
+        {
+            return Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "terminal workspace authority proof does not exactly bind the current manifest",
+                Some(id.to_string()),
+                None,
+            ));
+        }
+        match &record.terminal_workspace_authority {
+            Some(existing) if existing != &proof => Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "terminal workspace authority proof conflicts with immutable manifest evidence",
+                Some(id.to_string()),
+                None,
+            )),
+            Some(_) => Ok(()),
+            None => {
+                record.terminal_workspace_authority = Some(proof);
+                write_record(&store, &record)
+            }
+        }
+    })
 }
 
 pub(crate) fn list_unlocked() -> Result<WorktreeListOutput> {
@@ -390,12 +428,15 @@ pub(crate) fn record_active_for_test(id: &str, worktree_path: &Path) {
         worktree_path: worktree_path.to_string_lossy().to_string(),
         branch: format!("task/{id}"),
         base_ref: "main".to_string(),
+        workspace_identity: None,
         task_url: None,
         run_id: None,
         cleanup_policy: CleanupPolicy::RemoveWhenSafe,
         branch_cleanup_intent: BranchCleanupIntent::default(),
         created_at: "2026-01-01T00:00:00Z".to_string(),
         state: TaskWorktreeState::Active,
+        lifecycle_revision: 0,
+        terminal_workspace_authority: None,
     };
     let store = metadata_dir().expect("task worktree store");
     write_record(&store, &record).expect("write task worktree record");

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -217,6 +217,7 @@ pub(super) fn create_with_store(
         worktree_path: worktree_path.to_string_lossy().to_string(),
         branch: options.branch,
         base_ref,
+        workspace_identity: None,
         task_url: options.task_url,
         run_id: options.run_id.clone(),
         cleanup_policy: options
@@ -225,7 +226,11 @@ pub(super) fn create_with_store(
         branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
         created_at: chrono::Utc::now().to_rfc3339(),
         state: TaskWorktreeState::Active,
+        lifecycle_revision: 0,
+        terminal_workspace_authority: None,
     };
+    let mut record = record;
+    record.workspace_identity = Some(record.effective_workspace_identity()?);
     write_record(store_dir, &record)?;
     Ok(WorktreeCreateOutput { record })
 }
@@ -664,6 +669,7 @@ pub(super) fn record_path(store_dir: &Path, id: &str) -> PathBuf {
 }
 
 pub(super) fn write_record(store_dir: &Path, record: &TaskWorktreeRecord) -> Result<()> {
+    record.effective_workspace_identity()?;
     with_task_worktree_registry_write_lock(|| {
         let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
         fs::create_dir_all(store_dir).map_err(|err| {

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -65,13 +65,58 @@ fn fixture_record(source: &Path, worktree: &Path) -> TaskWorktreeRecord {
         worktree_path: worktree.to_string_lossy().to_string(),
         branch: "task".to_string(),
         base_ref: "HEAD".to_string(),
+        workspace_identity: None,
         task_url: Some("https://example.com/task".to_string()),
         run_id: None,
         cleanup_policy: CleanupPolicy::RemoveWhenSafe,
         branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
         created_at: "2026-01-01T00:00:00Z".to_string(),
         state: TaskWorktreeState::Active,
+        lifecycle_revision: 0,
+        terminal_workspace_authority: None,
     }
+}
+
+#[test]
+fn task_worktree_identity_is_path_independent_and_rejects_conflicts() {
+    let source = tempfile::tempdir().expect("source");
+    let first = fixture_record(source.path(), &source.path().join("one"));
+    let second = fixture_record(source.path(), &source.path().join("two"));
+    let identity = first
+        .effective_workspace_identity()
+        .expect("derive legacy identity");
+
+    assert_eq!(
+        identity,
+        second
+            .effective_workspace_identity()
+            .expect("same identity")
+    );
+    assert_eq!(identity.kind, "task-worktree");
+    assert_eq!(identity.locator, "fixture/fixture@task");
+
+    let claim_store = tempfile::tempdir().expect("claim store");
+    let claims = crate::workspace_claim::WorkspaceClaimStore::new(claim_store.path());
+    let owner = claims
+        .register_owner(identity.clone(), "agent-task-run", 1_000, 1)
+        .expect("register task-worktree owner");
+    assert_eq!(owner.workspace, identity);
+    assert!(claims
+        .acquire(
+            second
+                .effective_workspace_identity()
+                .expect("record identity"),
+            1_000,
+            2
+        )
+        .is_err());
+
+    let mut conflicting = first;
+    conflicting.workspace_identity = Some(
+        crate::workspace_claim::WorkspaceIdentity::new("task-worktree", "other/record")
+            .expect("identity"),
+    );
+    assert!(conflicting.effective_workspace_identity().is_err());
 }
 
 fn git_repo() -> tempfile::TempDir {

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -1,5 +1,18 @@
 use serde::{Deserialize, Serialize};
 
+use crate::error::Result;
+use crate::workspace_claim::WorkspaceIdentity;
+
+/// Canonical, portable identity for a managed task worktree. The registry
+/// handle and registered component identify the physical allocation; paths and
+/// logical agent-task IDs intentionally do not participate.
+pub fn task_worktree_workspace_identity(
+    component_id: &str,
+    handle: &str,
+) -> Result<WorkspaceIdentity> {
+    WorkspaceIdentity::new("task-worktree", format!("{component_id}/{handle}"))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskWorktreeState {
@@ -56,6 +69,10 @@ pub struct TaskWorktreeRecord {
     pub worktree_path: String,
     pub branch: String,
     pub base_ref: String,
+    /// Stored for new manifests. Older records deterministically derive the
+    /// same value from their stable registry identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_identity: Option<WorkspaceIdentity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +82,158 @@ pub struct TaskWorktreeRecord {
     pub branch_cleanup_intent: BranchCleanupIntent,
     pub created_at: String,
     pub state: TaskWorktreeState,
+    #[serde(default)]
+    pub lifecycle_revision: u64,
+    /// Immutable terminal evidence is retained on the manifest so reconciliation
+    /// remains possible after the controller compacts its run record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_workspace_authority: Option<TerminalWorkspaceAuthorityProof>,
+}
+
+pub const TERMINAL_WORKSPACE_AUTHORITY_SCHEMA: &str = "homeboy/terminal-workspace-authority/v1";
+pub const TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY: &str = "terminal-workspace-authority";
+
+/// Versioned, portable evidence that every authority which could own a task
+/// workspace observed a terminal outcome. This is evidence, not a time fence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalWorkspaceAuthorityProof {
+    pub schema: String,
+    pub capability: String,
+    pub capability_version: u32,
+    pub workspace: WorkspaceIdentity,
+    pub task_worktree_id: String,
+    pub manifest_revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub controller_state: String,
+    pub controller_version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_runner_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_runner_job_id: Option<String>,
+    pub authority_set: Vec<String>,
+    pub authority_set_fingerprint: String,
+    pub observations: Vec<TerminalWorkspaceAuthorityObservation>,
+    pub issued_evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalWorkspaceAuthorityObservation {
+    pub authority: String,
+    pub capability: String,
+    pub capability_version: u32,
+    pub status: String,
+    pub evidence: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_job_id: Option<String>,
+}
+
+impl TerminalWorkspaceAuthorityProof {
+    pub fn exact_for(&self, record: &TaskWorktreeRecord, expected_run_id: Option<&str>) -> bool {
+        let Ok(workspace) = record.effective_workspace_identity() else {
+            return false;
+        };
+        let mut authorities = self.authority_set.clone();
+        authorities.sort();
+        authorities.dedup();
+        let controller_terminal = matches!(
+            self.controller_state.as_str(),
+            "Succeeded"
+                | "CandidateRecoverable"
+                | "PartialRecoverable"
+                | "PartialFailure"
+                | "Failed"
+                | "Cancelled"
+        );
+        let accepted_binding_matches =
+            self.accepted_runner_id.is_some() == self.accepted_runner_job_id.is_some();
+        let observation_bindings_match = self.observations.iter().all(|observation| {
+            observation.run_id.as_deref() == expected_run_id
+                && (observation.authority == "controller"
+                    || observation.runner_job_id == self.accepted_runner_job_id)
+        });
+        let controller_observation_matches = self.observations.iter().any(|observation| {
+            observation.authority == "controller"
+                && observation.status == "terminal"
+                && observation.runner_job_id.is_none()
+        });
+        let accepted_observation_matches =
+            match (&self.accepted_runner_id, &self.accepted_runner_job_id) {
+                (Some(runner_id), Some(job_id)) => self.observations.iter().any(|observation| {
+                    observation.authority == *runner_id
+                        && observation.runner_job_id.as_deref() == Some(job_id)
+                }),
+                (None, None) => true,
+                _ => false,
+            };
+        self.schema == TERMINAL_WORKSPACE_AUTHORITY_SCHEMA
+            && self.capability == TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY
+            && self.capability_version == 1
+            && self.workspace == workspace
+            && self.task_worktree_id == record.id
+            && self.manifest_revision == record.lifecycle_revision
+            && self.run_id.as_deref() == expected_run_id
+            && self
+                .issued_evidence
+                .iter()
+                .any(|evidence| match expected_run_id {
+                    Some(run_id) => evidence == &format!("controller-run:{run_id}"),
+                    None => evidence == "controller-no-run-id",
+                })
+            && controller_terminal
+            && accepted_binding_matches
+            && authorities == self.authority_set
+            && authorities
+                .first()
+                .is_some_and(|authority| authority == "controller")
+            && self.authority_set_fingerprint == authority_set_fingerprint(&authorities)
+            && self.observations.len() == authorities.len()
+            && self.observations.iter().all(|observation| {
+                observation.capability == TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY
+                    && observation.capability_version == 1
+                    && !observation.authority.trim().is_empty()
+                    && matches!(observation.status.as_str(), "terminal" | "absent_terminal")
+            })
+            && self
+                .observations
+                .iter()
+                .map(|observation| &observation.authority)
+                .collect::<std::collections::BTreeSet<_>>()
+                == authorities.iter().collect()
+            && observation_bindings_match
+            && controller_observation_matches
+            && accepted_observation_matches
+    }
+}
+
+pub fn authority_set_fingerprint(authorities: &[String]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for authority in authorities {
+        hasher.update(authority.as_bytes());
+        hasher.update([0]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+impl TaskWorktreeRecord {
+    pub fn effective_workspace_identity(&self) -> Result<WorkspaceIdentity> {
+        let derived = task_worktree_workspace_identity(&self.component_id, &self.id)?;
+        if let Some(identity) = &self.workspace_identity {
+            identity.verify()?;
+            if identity != &derived {
+                return Err(crate::error::Error::validation_invalid_argument(
+                    "workspace_identity",
+                    "task worktree manifest identity conflicts with its stable handle and component",
+                    Some(self.id.clone()),
+                    None,
+                ));
+            }
+        }
+        Ok(derived)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -7,12 +7,120 @@
 
 use homeboy_agents::agent_task_lifecycle::{RunnerContinuationProvider, RunnerJobReconciliation};
 use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
-use homeboy_core::error::Result;
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use homeboy_core::error::{Error, Result};
+use homeboy_core::workspace_claim::{
+    WorkspaceAuthorityStatus, WorkspaceClaim, WorkspaceClaimProtocol, WorkspaceIdentity,
+    WORKSPACE_CLAIM_CAPABILITY,
+};
 
 /// The runner layer's `RunnerContinuationProvider`. Registered with core at startup.
 pub struct RunnerContinuation;
 
 impl RunnerContinuationProvider for RunnerContinuation {
+    fn supports_workspace_claims(&self) -> bool {
+        true
+    }
+
+    fn supports_terminal_workspace_authority(&self) -> bool {
+        true
+    }
+
+    fn workspace_claim_runner_ids(&self) -> Result<Vec<String>> {
+        Ok(super::list()?
+            .into_iter()
+            .filter(|runner| runner.id != "local")
+            .map(|runner| runner.id)
+            .collect())
+    }
+
+    fn acquire_workspace_claim(
+        &self,
+        runner_id: &str,
+        workspace: WorkspaceIdentity,
+        lifecycle_revision: u64,
+    ) -> Result<WorkspaceClaim> {
+        let body = workspace_claim_post(
+            runner_id,
+            "/workspace-claims/acquire",
+            json!({
+                "workspace": workspace,
+                "lifecycle_revision": lifecycle_revision,
+                "ttl_ms": homeboy_core::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+            }),
+        )?;
+        let claim: WorkspaceClaim = serde_json::from_value(
+            body.get("claim").cloned().unwrap_or(Value::Null),
+        )
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("malformed acquire response: {error}"))
+        })?;
+        claim.protocol.verify()?;
+        if claim.workspace != workspace {
+            return Err(workspace_claim_error(
+                runner_id,
+                "daemon returned a claim for a different workspace",
+            ));
+        }
+        Ok(claim)
+    }
+
+    fn validate_workspace_claim(&self, runner_id: &str, claim: &WorkspaceClaim) -> Result<bool> {
+        let body = workspace_claim_post(
+            runner_id,
+            "/workspace-claims/validate",
+            json!({ "claim": claim }),
+        )?;
+        body.get("valid").and_then(Value::as_bool).ok_or_else(|| {
+            workspace_claim_error(
+                runner_id,
+                "malformed validate response missing boolean valid",
+            )
+        })
+    }
+
+    fn release_workspace_claim(&self, runner_id: &str, claim: &WorkspaceClaim) -> Result<()> {
+        let body = workspace_claim_post(
+            runner_id,
+            "/workspace-claims/release",
+            json!({ "claim": claim }),
+        )?;
+        if body.get("released").and_then(Value::as_bool) != Some(true) {
+            return Err(workspace_claim_error(
+                runner_id,
+                "malformed release response missing released acknowledgement",
+            ));
+        }
+        Ok(())
+    }
+
+    fn workspace_claim_authority_is_clear(
+        &self,
+        runner_id: &str,
+        workspace: &WorkspaceIdentity,
+    ) -> Result<bool> {
+        // This uses the same deterministic transport selection as acquisition:
+        // direct sessions inspect the daemon and reverse sessions inspect the
+        // broker, which are the respective stores that can own this workspace.
+        let body = workspace_claim_post(
+            runner_id,
+            "/workspace-claims/authority",
+            json!({ "workspace": workspace }),
+        )?;
+        let status: WorkspaceAuthorityStatus = serde_json::from_value(
+            body.get("status").cloned().unwrap_or(Value::Null),
+        )
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("malformed authority response: {error}"))
+        })?;
+        status.verify(workspace)?;
+        Ok(status.clear)
+    }
     fn runner_job_log_snapshot(
         &self,
         runner_id: &str,
@@ -115,6 +223,201 @@ impl RunnerContinuationProvider for RunnerContinuation {
     ) -> Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
         super::connection::lookup_reverse_broker_submission(runner_id, submission_key)
     }
+}
+
+#[derive(Deserialize)]
+struct DaemonEnvelope {
+    success: bool,
+    data: Option<Value>,
+}
+
+fn workspace_claim_post(runner_id: &str, path: &str, payload: Value) -> Result<Value> {
+    let report = super::connection::status(runner_id)?;
+    let session = report
+        .session
+        .filter(|_| report.connected)
+        .ok_or_else(|| workspace_claim_error(runner_id, "direct daemon is not connected"))?;
+    if session.mode == super::RunnerTunnelMode::Reverse {
+        let broker_url = session.broker_url.ok_or_else(|| {
+            workspace_claim_error(runner_id, "reverse runner session has no broker endpoint")
+        })?;
+        return reverse_workspace_claim_post(runner_id, &broker_url, path, payload);
+    }
+    if session.mode != super::RunnerTunnelMode::DirectSsh {
+        return Err(workspace_claim_error(
+            runner_id,
+            "workspace claims require a direct daemon transport",
+        ));
+    }
+    let local_url = session.local_url.ok_or_else(|| {
+        workspace_claim_error(runner_id, "direct daemon session has no local endpoint")
+    })?;
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("build daemon client: {error}"))
+        })?;
+    let capabilities = daemon_get_json(&client, &local_url, "/capabilities", runner_id)?;
+    let protocols: Vec<WorkspaceClaimProtocol> = serde_json::from_value(
+        capabilities
+            .get("capabilities")
+            .cloned()
+            .unwrap_or(Value::Null),
+    )
+    .map_err(|error| {
+        workspace_claim_error(runner_id, format!("malformed daemon capabilities: {error}"))
+    })?;
+    if !protocols.iter().any(|protocol| {
+        protocol.capability == WORKSPACE_CLAIM_CAPABILITY && protocol.verify().is_ok()
+    }) {
+        return Err(workspace_claim_error(
+            runner_id,
+            "daemon does not advertise workspace claim capability v1",
+        ));
+    }
+    daemon_post_json(&client, &local_url, path, payload, runner_id)
+}
+
+fn reverse_workspace_claim_post(
+    runner_id: &str,
+    broker_url: &str,
+    daemon_path: &str,
+    payload: Value,
+) -> Result<Value> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("build broker client: {error}"))
+        })?;
+    let token = homeboy_core::broker_auth::broker_submit_token_for_runner(runner_id)?;
+    let capabilities = client
+        .get(format!(
+            "{}/runner/workspace-claims/capabilities",
+            broker_url.trim_end_matches('/')
+        ))
+        .bearer_auth(token.as_deref().unwrap_or_default())
+        .send()
+        .map_err(|error| {
+            workspace_claim_error(
+                runner_id,
+                format!("broker capability request failed: {error}"),
+            )
+        })?;
+    let capabilities = daemon_response(
+        capabilities.status().as_u16(),
+        capabilities.text(),
+        "/runner/workspace-claims/capabilities",
+        runner_id,
+    )?;
+    let protocols: Vec<WorkspaceClaimProtocol> = serde_json::from_value(
+        capabilities
+            .get("capabilities")
+            .cloned()
+            .unwrap_or(Value::Null),
+    )
+    .map_err(|error| {
+        workspace_claim_error(runner_id, format!("malformed broker capabilities: {error}"))
+    })?;
+    if !protocols.iter().any(|protocol| {
+        protocol.capability == WORKSPACE_CLAIM_CAPABILITY && protocol.verify().is_ok()
+    }) {
+        return Err(workspace_claim_error(
+            runner_id,
+            "reverse broker does not advertise workspace claim capability v1",
+        ));
+    }
+    let operation = daemon_path.trim_start_matches("/workspace-claims/");
+    let response = client
+        .post(format!(
+            "{}/runner/workspace-claims/{operation}",
+            broker_url.trim_end_matches('/')
+        ))
+        .bearer_auth(token.as_deref().unwrap_or_default())
+        .json(&payload)
+        .send()
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("broker claim request failed: {error}"))
+        })?;
+    daemon_response(
+        response.status().as_u16(),
+        response.text(),
+        "/runner/workspace-claims",
+        runner_id,
+    )
+}
+
+fn daemon_get_json(client: &Client, url: &str, path: &str, runner_id: &str) -> Result<Value> {
+    let response = client
+        .get(format!("{}{}", url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|error| {
+            workspace_claim_error(
+                runner_id,
+                format!("daemon capability request failed: {error}"),
+            )
+        })?;
+    daemon_response(response.status().as_u16(), response.text(), path, runner_id)
+}
+
+fn daemon_post_json(
+    client: &Client,
+    url: &str,
+    path: &str,
+    payload: Value,
+    runner_id: &str,
+) -> Result<Value> {
+    let response = client
+        .post(format!("{}{}", url.trim_end_matches('/'), path))
+        .json(&payload)
+        .send()
+        .map_err(|error| {
+            workspace_claim_error(runner_id, format!("daemon claim request failed: {error}"))
+        })?;
+    daemon_response(response.status().as_u16(), response.text(), path, runner_id)
+}
+
+fn daemon_response(
+    status: u16,
+    body: reqwest::Result<String>,
+    path: &str,
+    runner_id: &str,
+) -> Result<Value> {
+    let body = body.map_err(|error| {
+        workspace_claim_error(runner_id, format!("read daemon {path} response: {error}"))
+    })?;
+    let envelope: DaemonEnvelope = serde_json::from_str(&body).map_err(|error| {
+        workspace_claim_error(
+            runner_id,
+            format!("malformed daemon {path} response: {error}"),
+        )
+    })?;
+    if status != 200 || !envelope.success {
+        return Err(workspace_claim_error(
+            runner_id,
+            format!("daemon {path} refused workspace claim request"),
+        ));
+    }
+    let data = envelope.data.ok_or_else(|| {
+        workspace_claim_error(runner_id, format!("daemon {path} response has no data"))
+    })?;
+    data.get("body").cloned().ok_or_else(|| {
+        workspace_claim_error(
+            runner_id,
+            format!("daemon {path} response has no canonical body"),
+        )
+    })
+}
+
+fn workspace_claim_error(runner_id: &str, message: impl Into<String>) -> Error {
+    Error::validation_invalid_argument(
+        "workspace_claim",
+        message,
+        Some(runner_id.to_string()),
+        None,
+    )
 }
 
 fn job_not_found(error: &homeboy_core::error::Error, job_id: &str) -> bool {

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -4,7 +4,10 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
-use homeboy_core::api_jobs::{Job, JobStatus, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata};
+use homeboy_core::api_jobs::{
+    Job, JobStatus, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup,
+    RunnerJobLifecycleMetadata,
+};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::redaction::redact_argv;
@@ -80,6 +83,45 @@ pub(super) fn exec_via_reverse_broker(
             env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
         }
     }
+    // Reverse jobs hold a renewable owner lease while queued/running. A
+    // reconciliation claim is a separate exclusive fence and is never used as
+    // ordinary execution ownership.
+    let workspace_owner_lease = run_id
+        .as_deref()
+        .map(homeboy_agents::agent_task_lifecycle::workspace_owner_registration_if_present)
+        .transpose()?
+        .flatten()
+        .map(|(workspace, owner_id)| {
+            let token = homeboy_core::broker_auth::broker_submit_token_for_runner(&runner.id)?;
+            let data = broker_http::post_json(
+                &client,
+                broker_url,
+                "/runner/workspace-owners/register",
+                serde_json::json!({
+                    "workspace": workspace,
+                    "owner_id": owner_id,
+                    "ttl_ms": homeboy_core::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+                }),
+                "register reverse broker workspace owner",
+                token.as_deref(),
+            )?;
+            let lease: homeboy_core::workspace_claim::WorkspaceOwnerLease = serde_json::from_value(
+                data.get("workspace_owner_lease")
+                    .cloned()
+                    .unwrap_or_default(),
+            )
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    format!("malformed reverse broker owner lease: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+            lease.verify_shape(chrono::Utc::now().timestamp_millis().max(0) as u64)?;
+            Ok::<_, Error>(lease)
+        })
+        .transpose()?;
     let mut request = RemoteRunnerJobRequest {
         runner_id: runner.id.clone(),
         project_id,
@@ -109,6 +151,8 @@ pub(super) fn exec_via_reverse_broker(
             durable_run_id: run_id.clone(),
             ..Default::default()
         }),
+        workspace_claim_binding: None,
+        workspace_owner_lease: workspace_owner_lease.clone(),
         require_paths: require_paths.clone(),
         extension_env_providers,
     };
@@ -142,7 +186,82 @@ pub(super) fn exec_via_reverse_broker(
         })?,
         "submit reverse runner job",
         broker_token.as_deref(),
-    )?;
+    );
+    let data = match data {
+        Ok(data) => data,
+        Err(error) => {
+            let submission_key = request.submission_key().map(str::to_string);
+            let accepted =
+                submission_key.as_deref().map(|submission_key| {
+                    broker_http::post_json(
+                    &client,
+                    broker_url,
+                    "/runner/jobs/submissions/lookup",
+                    serde_json::json!({ "runner_id": runner.id, "submission_key": submission_key }),
+                    "look up ambiguous reverse broker submission",
+                    broker_token.as_deref(),
+                )
+                .and_then(|data| {
+                    serde_json::from_value::<RemoteRunnerSubmissionLookup>(
+                        data.get("result").cloned().unwrap_or_default(),
+                    )
+                    .map_err(|parse_error| Error::internal_json(
+                        parse_error.to_string(),
+                        Some("parse reverse broker submission lookup".to_string()),
+                    ))
+                })
+                });
+            if let Some(Ok(RemoteRunnerSubmissionLookup::Accepted { job })) = accepted.as_ref() {
+                // The broker accepted this exact immutable request. Keep its
+                // original owner lease and continue through normal binding.
+                serde_json::json!({ "job": job })
+            } else {
+                let non_acceptance = matches!(
+                    accepted.as_ref(),
+                    Some(Ok(RemoteRunnerSubmissionLookup::Absent
+                        | RemoteRunnerSubmissionLookup::Expired { .. }))
+                );
+                if !non_acceptance {
+                    return Err(Error::new(
+                        error.code,
+                        error.message,
+                        serde_json::json!({
+                            "workspace_owner_lease_recovery": {
+                                "schema": homeboy_core::workspace_claim::WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA,
+                                "lease": workspace_owner_lease,
+                                "submission_key": submission_key,
+                                "lookup": accepted.as_ref().and_then(|result| result.as_ref().err()).map(ToString::to_string),
+                            }
+                        }),
+                    ));
+                }
+                if let Some(lease) = workspace_owner_lease.as_ref() {
+                    let cleanup = broker_http::post_json(
+                        &client,
+                        broker_url,
+                        "/runner/workspace-owners/release",
+                        serde_json::json!({ "workspace_owner_lease": lease }),
+                        "rollback reverse broker workspace owner",
+                        broker_token.as_deref(),
+                    );
+                    if let Err(cleanup_error) = cleanup {
+                        return Err(Error::new(
+                            error.code,
+                            error.message,
+                            serde_json::json!({
+                                "workspace_owner_lease_cleanup": {
+                                    "schema": homeboy_core::workspace_claim::WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA,
+                                    "lease": lease,
+                                    "error": cleanup_error.message,
+                                }
+                            }),
+                        ));
+                    }
+                }
+                return Err(error);
+            }
+        }
+    };
     let job_value = data
         .get("job")
         .ok_or_else(|| Error::internal_unexpected("reverse broker submit returned no job"))?;

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -94,6 +94,18 @@ pub(super) fn exec_via_daemon(
             env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
         }
     }
+    let workspace_owner_request = if run_id_owns_generic_exec {
+        None
+    } else {
+        run_id
+            .as_deref()
+            .map(homeboy_agents::agent_task_lifecycle::workspace_owner_registration_if_present)
+            .transpose()?
+            .flatten()
+    };
+    if workspace_owner_request.is_some() {
+        require_daemon_workspace_owner_lease_v2(&client, local_url)?;
+    }
     let payload = json!({
         "runner_id": runner.id,
         "runner": runner,
@@ -115,6 +127,11 @@ pub(super) fn exec_via_daemon(
         // reconstruct it from nested lifecycle/metadata, so a resubmission after
         // a transport drop is a safe no-op. Uses the durable run id when present.
         "idempotency_key": run_id,
+        "workspace_owner_request": workspace_owner_request.as_ref().map(|(workspace, owner_id)| json!({
+            "workspace": workspace,
+            "owner_id": owner_id,
+            "ttl_ms": homeboy_core::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+        })),
     });
     let response = submit_daemon_exec_with_session_recovery(
         local_url,
@@ -441,12 +458,52 @@ pub(super) fn exec_via_daemon(
     ))
 }
 
+/// Workspace-bound direct work must establish that the daemon understands the
+/// v2 lease contract before any mutating endpoint is called.
+fn require_daemon_workspace_owner_lease_v2(client: &Client, local_url: &str) -> Result<()> {
+    let data = daemon_get(client, local_url, "/capabilities").map_err(|error| {
+        Error::validation_invalid_argument(
+            "daemon_capabilities",
+            format!(
+                "direct daemon is unavailable for workspace owner lease v2 preflight: {}",
+                error.message
+            ),
+            Some(local_url.to_string()),
+            None,
+        )
+    })?;
+    let body = canonical_daemon_body(&data, "daemon capabilities response")?;
+    let supported = body
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .is_some_and(|capabilities| {
+            capabilities.iter().any(|capability| {
+                capability.get("capability").and_then(Value::as_str)
+                    == Some(homeboy_core::workspace_claim::WORKSPACE_OWNER_LEASE_CAPABILITY)
+                    && capability.get("version").and_then(Value::as_u64)
+                        == Some(
+                            homeboy_core::workspace_claim::WORKSPACE_CLAIM_PROTOCOL_VERSION as u64,
+                        )
+            })
+        });
+    supported.then_some(()).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "daemon_capabilities",
+            "direct daemon does not advertise workspace owner lease v2",
+            Some(local_url.to_string()),
+            None,
+        )
+    })
+}
+
 /// Selects whether an admission may interoperate with legacy daemon responses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DaemonAdmissionPolicy {
     LegacyCompatible,
     DurableLeaseRequired,
 }
+
+type WorkspaceOwnerRegistration = (homeboy_core::workspace_claim::WorkspaceIdentity, String);
 
 const ADMISSION_RECOVERY_WINDOW: Duration = Duration::from_secs(10);
 const ADMISSION_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(250);
@@ -555,6 +612,7 @@ pub(crate) struct DaemonAdmissionReservation {
     local_url: String,
     job_id: String,
     token: Option<String>,
+    workspace_owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
     renewer_stop: Option<Sender<()>>,
     renewer: Option<std::thread::JoinHandle<()>>,
     authority: DaemonAdmissionReservationAuthority,
@@ -589,11 +647,10 @@ impl Drop for DaemonAdmissionReservation {
             &client,
             &self.local_url,
             &format!("/admissions/{}/release", self.job_id),
-            &self
-                .token
-                .as_ref()
-                .map(|token| json!({ "admission_token": token }))
-                .unwrap_or_else(|| json!({})),
+            &json!({
+                "admission_token": self.token.as_deref(),
+                "workspace_owner_lease": self.workspace_owner_lease.lock().expect("admission owner lease lock").as_ref(),
+            }),
             DaemonPostOptions::default(),
         );
     }
@@ -606,6 +663,7 @@ pub(crate) fn reserve_daemon_admission(
     expected_daemon_lease_id: &str,
     idempotency_key: Option<&str>,
     policy: DaemonAdmissionPolicy,
+    workspace_owner_registration: Option<WorkspaceOwnerRegistration>,
 ) -> Result<DaemonAdmissionReservation> {
     let client = Client::builder()
         .no_proxy()
@@ -614,6 +672,9 @@ pub(crate) fn reserve_daemon_admission(
         .map_err(|err| {
             Error::internal_unexpected(format!("build daemon admission client: {err}"))
         })?;
+    if workspace_owner_registration.is_some() {
+        require_daemon_workspace_owner_lease_v2(&client, local_url)?;
+    }
     let response = daemon_post_json_text(
         &client,
         local_url,
@@ -624,6 +685,11 @@ pub(crate) fn reserve_daemon_admission(
             "expected_daemon_lease_id": expected_daemon_lease_id,
             "idempotency_key": idempotency_key,
             "admission_lease_protocol": 1,
+            "workspace_owner_request": workspace_owner_registration.as_ref().map(|(workspace, owner_id)| json!({
+                "workspace": workspace,
+                "owner_id": owner_id,
+                "ttl_ms": homeboy_core::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+            })),
         }),
         DaemonPostOptions::default(),
     )?;
@@ -669,6 +735,27 @@ pub(crate) fn reserve_daemon_admission(
             Some("parse daemon admission job".to_string()),
         )
     })?;
+    let workspace_owner_lease = body
+        .get("workspace_owner_lease")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|err| {
+            Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                format!("malformed direct daemon owner lease: {err}"),
+                None,
+                None,
+            )
+        })?;
+    if workspace_owner_registration.is_some() && workspace_owner_lease.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "direct daemon admission did not return its durable owner lease",
+            Some(runner_id.to_string()),
+            None,
+        ));
+    }
     let token = body
         .get("admission_token")
         .and_then(Value::as_str)
@@ -706,6 +793,7 @@ pub(crate) fn reserve_daemon_admission(
                 local_url.to_string(),
                 job.id.to_string(),
                 token.to_string(),
+                Arc::new(Mutex::new(workspace_owner_lease.clone())),
                 renewal_health.clone(),
             );
             (Some(stop), Some(renewer))
@@ -718,6 +806,7 @@ pub(crate) fn reserve_daemon_admission(
         local_url: local_url.to_string(),
         job_id: job.id.to_string(),
         token,
+        workspace_owner_lease: Arc::new(Mutex::new(workspace_owner_lease)),
         renewer_stop,
         renewer,
         authority: DaemonAdmissionReservationAuthority {
@@ -740,6 +829,7 @@ pub(crate) fn reserve_daemon_admission_with_recovery(
     expected_daemon_lease_id: &str,
     idempotency_key: Option<&str>,
     policy: DaemonAdmissionPolicy,
+    workspace_owner_registration: Option<WorkspaceOwnerRegistration>,
 ) -> Result<DaemonAdmissionReservation> {
     reserve_daemon_admission_with_recovery_with(
         runner_id,
@@ -753,6 +843,7 @@ pub(crate) fn reserve_daemon_admission_with_recovery(
                 expected_daemon_lease_id,
                 idempotency_key,
                 policy,
+                workspace_owner_registration.clone(),
             )
         },
         || std::thread::sleep(ADMISSION_RECOVERY_RETRY_INTERVAL),
@@ -905,6 +996,7 @@ fn spawn_admission_renewer(
     local_url: String,
     job_id: String,
     token: String,
+    workspace_owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
     health: Arc<Mutex<AdmissionRenewalHealth>>,
 ) -> (Sender<()>, std::thread::JoinHandle<()>) {
     let (stop, shutdown) = mpsc::channel();
@@ -925,10 +1017,13 @@ fn spawn_admission_renewer(
                 &client,
                 &local_url,
                 &format!("/admissions/{job_id}/renew"),
-                &json!({ "admission_token": token }),
+                &json!({
+                    "admission_token": token,
+                    "workspace_owner_lease": workspace_owner_lease.lock().expect("admission owner lease lock").as_ref(),
+                }),
                 DaemonPostOptions::default(),
             );
-            let expires_at_ms = response
+            let body = response
                 .ok()
                 .and_then(|response| serde_json::from_str::<DaemonEnvelope>(&response.body).ok())
                 .and_then(|envelope| envelope.data)
@@ -936,10 +1031,33 @@ fn spawn_admission_renewer(
                     canonical_daemon_body(&data, "daemon admission renewal response")
                         .ok()
                         .cloned()
-                })
+                });
+            let expires_at_ms = body
+                .as_ref()
                 .and_then(|body| body.pointer("/lease/expires_at_ms").and_then(Value::as_u64));
-            match expires_at_ms {
-                Some(expires_at_ms) if expires_at_ms > 0 => {
+            let renewed_owner = body.as_ref().and_then(|body| {
+                serde_json::from_value(body["workspace_owner_lease"].clone()).ok()
+            });
+            match (expires_at_ms, renewed_owner) {
+                (Some(expires_at_ms), owner) if expires_at_ms > 0 => {
+                    if workspace_owner_lease
+                        .lock()
+                        .expect("admission owner lease lock")
+                        .is_some()
+                        && owner.is_none()
+                    {
+                        health
+                            .lock()
+                            .expect("admission renewal health lock")
+                            .failure =
+                            Some("daemon did not return renewed workspace owner lease".to_string());
+                        return;
+                    }
+                    if let Some(owner) = owner {
+                        *workspace_owner_lease
+                            .lock()
+                            .expect("admission owner lease lock") = Some(owner);
+                    }
                     health
                         .lock()
                         .expect("admission renewal health lock")

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1050,6 +1050,7 @@ fn probe_reconnected_admission_readiness(runner_id: &str, identity_commit: &str)
                 expected_lease_id,
                 None,
                 DaemonAdmissionPolicy::LegacyCompatible,
+                None,
             )
             .map(|reservation| {
                 // Drop releases the reservation immediately; readiness is the

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2098,6 +2098,11 @@ pub(crate) fn run_lab_offload_inner(
                     expected_daemon_lease_id,
                     agent_task_run_id.as_deref(),
                     DaemonAdmissionPolicy::DurableLeaseRequired,
+                    agent_task_run_id
+                        .as_deref()
+                        .map(homeboy_agents::agent_task_lifecycle::workspace_owner_registration_if_present)
+                        .transpose()?
+                        .flatten(),
                 )
             })
             .transpose()

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3092,6 +3092,9 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
                     lease_id,
                     Some(&request.recipe.run_id),
                     crate::execution::DaemonAdmissionPolicy::DurableLeaseRequired,
+                    homeboy_agents::agent_task_lifecycle::workspace_owner_registration_if_present(
+                        &request.recipe.run_id,
+                    )?,
                 )?;
                 let authority = admission.authority();
                 authority.prove_server_owned_expiry_or_cancellation_authority()?;

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -1,4 +1,7 @@
-use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::sync::{
+    mpsc::{self, RecvTimeoutError, Sender},
+    Arc, Mutex,
+};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -25,6 +28,8 @@ pub(super) fn claim_job(
             "lease_ms": options.lease_ms.max(1),
             "concurrency_limit": options.concurrency_limit,
             "execution_protocol": homeboy_core::runner_job_execution_context::RunnerJobExecutionProtocol::current(),
+            "workspace_claim_protocol": homeboy_core::workspace_claim::WorkspaceClaimProtocol::current(),
+            "workspace_owner_lease_protocol": homeboy_core::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
         }),
         "claim reverse runner job",
         options.broker_token.as_deref(),
@@ -48,6 +53,8 @@ pub(super) fn append_progress_data(
     runner_id: &str,
     job: &Job,
     data: serde_json::Value,
+    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
 ) -> Result<()> {
     let claim_id = remote_runner_claim_id(job)?;
     broker_http::post_json(
@@ -59,6 +66,8 @@ pub(super) fn append_progress_data(
             "claim_id": claim_id,
             "kind": "progress",
             "data": data,
+            "workspace_claim_binding": workspace_claim_binding,
+            "workspace_owner_lease": workspace_owner_lease,
         }),
         "append reverse runner progress event",
         token,
@@ -73,6 +82,8 @@ pub(super) fn finish_job(
     runner_id: &str,
     job: &Job,
     result: RemoteRunnerJobResult,
+    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
 ) -> Result<Job> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
@@ -83,16 +94,19 @@ pub(super) fn finish_job(
             "runner_id": runner_id,
             "claim_id": claim_id,
             "result": result,
+            "workspace_claim_binding": workspace_claim_binding,
+            "workspace_owner_lease": workspace_owner_lease,
         }),
         "finish reverse runner job",
         token,
     )?;
-    serde_json::from_value(data["job"].clone()).map_err(|err| {
+    let job = serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse finished reverse runner job".to_string()),
         )
-    })
+    })?;
+    Ok(job)
 }
 
 pub(super) fn consume_execution(
@@ -102,6 +116,8 @@ pub(super) fn consume_execution(
     runner_id: &str,
     job: &Job,
     context_id: &str,
+    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
 ) -> Result<Job> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
@@ -112,16 +128,53 @@ pub(super) fn consume_execution(
             "runner_id": runner_id,
             "claim_id": claim_id,
             "context_id": context_id,
+            "workspace_claim_binding": workspace_claim_binding,
+            "workspace_owner_lease": workspace_owner_lease,
         }),
         "consume reverse runner execution receipt",
         token,
     )?;
-    serde_json::from_value(data["job"].clone()).map_err(|err| {
+    let job = serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse consumed reverse runner job".to_string()),
         )
-    })
+    })?;
+    Ok(job)
+}
+
+/// Check the exact durable owner lease without consuming the execution receipt.
+/// Input materialization is intentionally gated on this call, not on consume.
+pub(super) fn validate_workspace_owner(
+    client: &Client,
+    broker_url: &str,
+    token: Option<&str>,
+    runner_id: &str,
+    job: &Job,
+    workspace_owner_lease: &homeboy_core::workspace_claim::WorkspaceOwnerLease,
+) -> Result<()> {
+    let claim_id = remote_runner_claim_id(job)?;
+    let data = broker_http::post_json(
+        client,
+        broker_url,
+        &format!("/runner/jobs/{}/validate-owner", job.id),
+        json!({
+            "runner_id": runner_id,
+            "claim_id": claim_id,
+            "workspace_owner_lease": workspace_owner_lease,
+        }),
+        "validate reverse runner workspace owner lease",
+        token,
+    )?;
+    if data["valid"].as_bool() != Some(true) {
+        return Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "reverse runner workspace owner lease is no longer live",
+            Some(job.id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn renew_claim(
@@ -131,7 +184,12 @@ fn renew_claim(
     runner_id: &str,
     job: &Job,
     lease_ms: u64,
-) -> Result<Job> {
+    workspace_claim_binding: Option<&homeboy_core::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<&homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+) -> Result<(
+    Job,
+    Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
+)> {
     let claim_id = remote_runner_claim_id(job)?;
     let data = broker_http::post_json(
         client,
@@ -141,22 +199,28 @@ fn renew_claim(
             "runner_id": runner_id,
             "claim_id": claim_id,
             "lease_ms": lease_ms.max(1),
+            "workspace_claim_binding": workspace_claim_binding,
+            "workspace_owner_lease": workspace_owner_lease,
         }),
         "renew reverse runner claim",
         token,
     )?;
-    serde_json::from_value(data["job"].clone()).map_err(|err| {
+    let job = serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse reverse runner heartbeat job".to_string()),
         )
-    })
+    })?;
+    let owner = serde_json::from_value(data["workspace_owner_lease"].clone()).ok();
+    Ok((job, owner))
 }
 
 pub(super) fn start_claim_heartbeat(
     client: &Client,
     options: &ReverseRunnerWorkerOptions,
     job: &Job,
+    workspace_claim_binding: Option<homeboy_core::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>,
 ) -> Result<ClaimHeartbeat> {
     remote_runner_claim_id(job)?;
     let (stop, stopped) = mpsc::channel();
@@ -167,41 +231,66 @@ pub(super) fn start_claim_heartbeat(
     let job = job.clone();
     let lease_ms = options.lease_ms.max(1);
     let interval = Duration::from_millis((lease_ms / 2).max(1));
+    let current_owner = Arc::new(Mutex::new(workspace_owner_lease));
+    let heartbeat_owner = current_owner.clone();
     let handle = thread::spawn(move || loop {
         match stopped.recv_timeout(interval) {
             Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
             Err(RecvTimeoutError::Timeout) => {}
         }
-        if let Err(err) = renew_claim(
+        let presented_owner = heartbeat_owner.lock().expect("owner lease lock").clone();
+        match renew_claim(
             &client,
             &broker_url,
             broker_token.as_deref(),
             &runner_id,
             &job,
             lease_ms,
+            workspace_claim_binding.as_ref(),
+            presented_owner.as_ref(),
         ) {
-            eprintln!(
-                "{}",
-                json!({
-                    "command": "runner.work",
-                    "event": "claim_heartbeat_failed",
-                    "runner_id": runner_id,
-                    "broker_url": broker_url,
-                    "job_id": job.id,
-                    "error": err.to_string(),
-                })
-            );
+            Ok((_job, renewed_owner)) => {
+                *heartbeat_owner.lock().expect("owner lease lock") = renewed_owner
+            }
+            Err(err) => {
+                eprintln!(
+                    "{}",
+                    json!({
+                        "command": "runner.work",
+                        "event": "claim_heartbeat_failed",
+                        "runner_id": runner_id,
+                        "broker_url": broker_url,
+                        "job_id": job.id,
+                        "error": err.to_string(),
+                    })
+                );
+            }
         }
     });
     Ok(ClaimHeartbeat {
         stop: Some(stop),
         handle: Some(handle),
+        owner_lease: current_owner,
     })
 }
 
 pub(super) struct ClaimHeartbeat {
     stop: Option<Sender<()>>,
     handle: Option<JoinHandle<()>>,
+    owner_lease: Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>>,
+}
+
+impl ClaimHeartbeat {
+    pub(super) fn owner_lease_handle(
+        &self,
+    ) -> Arc<Mutex<Option<homeboy_core::workspace_claim::WorkspaceOwnerLease>>> {
+        self.owner_lease.clone()
+    }
+    pub(super) fn workspace_owner_lease(
+        &self,
+    ) -> Option<homeboy_core::workspace_claim::WorkspaceOwnerLease> {
+        self.owner_lease.lock().expect("owner lease lock").clone()
+    }
 }
 
 impl Drop for ClaimHeartbeat {

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -17,7 +17,7 @@ use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
 use super::super::execution::{exec_worker_local_until_cancelled_with_progress, RunnerExecOptions};
 use super::broker::{
     append_progress_data, cancelled_job_snapshot, claim_job, consume_execution, finish_job,
-    start_claim_heartbeat,
+    start_claim_heartbeat, validate_workspace_owner,
 };
 use super::result::{
     cancelled_output, claimed_output, log_worker_event, remote_runner_result_from_exec_output,
@@ -266,6 +266,34 @@ fn run_once_output(
             )
         })?
         .verify()?;
+    if claim.request.requires_workspace_claim_protocol() {
+        claim
+            .workspace_claim_protocol
+            .as_ref()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace_claim_protocol",
+                    "reverse runner claim predates workspace-claim protocol negotiation",
+                    Some(claim.job.id.to_string()),
+                    None,
+                )
+            })?
+            .verify()?;
+    }
+    if claim.request.requires_workspace_owner_lease_protocol() {
+        claim
+            .workspace_owner_lease_protocol
+            .as_ref()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace_owner_lease_protocol",
+                    "reverse runner claim predates workspace owner lease protocol negotiation",
+                    Some(claim.job.id.to_string()),
+                    None,
+                )
+            })?
+            .verify()?;
+    }
     let execution_context = execution_context.verify_claim(&claim.job, &claim.request)?;
 
     // Commit runner-owned evidence before materializing any broker input. The
@@ -297,8 +325,17 @@ fn run_once_output(
             "phase": "runner_job_execution_context_verified",
             "runner_job_execution_context": execution_context.evidence_record()?,
         }),
+        claim.request.workspace_claim_binding.as_ref(),
+        claim.request.workspace_owner_lease.as_ref(),
     )?;
-    let _heartbeat = start_claim_heartbeat(&client, &options, &claim.job)?;
+    let heartbeat = start_claim_heartbeat(
+        &client,
+        &options,
+        &claim.job,
+        claim.request.workspace_claim_binding.clone(),
+        claim.request.workspace_owner_lease.clone(),
+    )?;
+    let current_owner_lease = heartbeat.owner_lease_handle();
     // Remote capability-parity preflight: validate that this runner can satisfy
     // the claimed job's top-level command (and any required paths) before
     // starting execution, so a missing tool fails before remote dispatch instead
@@ -306,6 +343,23 @@ fn run_once_output(
     // before handing the claimed job directly to the local runtime.
     let capability_preflight = reverse_worker_capability_preflight(&claim.request);
     let mut execution_envelope = claim.request.execution_envelope();
+    // Authorize the exact durable owner lease immediately before any workspace,
+    // private-file, or source materialization. This intentionally does not consume
+    // the receipt; consume remains at the provider-invocation boundary below.
+    if let Some(lease) = current_owner_lease
+        .lock()
+        .expect("owner lease lock")
+        .as_ref()
+    {
+        validate_workspace_owner(
+            &client,
+            &options.broker_url,
+            options.broker_token.as_deref(),
+            &options.runner_id,
+            &claim.job,
+            lease,
+        )?;
+    }
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
@@ -320,6 +374,11 @@ fn run_once_output(
             &options.runner_id,
             &claim.job,
             result,
+            claim.request.workspace_claim_binding.as_ref(),
+            current_owner_lease
+                .lock()
+                .expect("owner lease lock")
+                .as_ref(),
         )
     };
     let mut cancel_seen = false;
@@ -328,6 +387,8 @@ fn run_once_output(
     let progress_client = client.clone();
     let progress_options = options.clone();
     let progress_job = claim.job.clone();
+    let progress_workspace_claim_binding = claim.request.workspace_claim_binding.clone();
+    let progress_owner_lease = current_owner_lease.clone();
     let progress_sink = Arc::new(move |data| {
         append_progress_data(
             &progress_client,
@@ -336,6 +397,11 @@ fn run_once_output(
             &progress_options.runner_id,
             &progress_job,
             data,
+            progress_workspace_claim_binding.as_ref(),
+            progress_owner_lease
+                .lock()
+                .expect("owner lease lock")
+                .as_ref(),
         )
     });
     let exec_result = exec_worker_local_until_cancelled_with_progress(
@@ -356,6 +422,11 @@ fn run_once_output(
                 &options.runner_id,
                 &claim.job,
                 recovered.id(),
+                claim.request.workspace_claim_binding.as_ref(),
+                current_owner_lease
+                    .lock()
+                    .expect("owner lease lock")
+                    .as_ref(),
             )?;
             // Consumption atomically verifies the live claim and commits the
             // one-time receipt. Its returned job has a newer timestamp, so it

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -69,6 +69,8 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -363,6 +365,8 @@ fn reverse_worker_verifies_private_at_file_then_cleans_it_up() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit private file job");
@@ -415,6 +419,8 @@ fn reverse_worker_rejects_tampered_private_at_file() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit tampered file job");
@@ -466,6 +472,8 @@ fn private_at_file_snapshot_survives_source_replacement_before_exec() {
         extension_env_providers: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: None,
     };
     let mut envelope = request.execution_envelope();
@@ -616,6 +624,8 @@ fn private_at_file_request(path: &std::path::Path) -> RemoteRunnerJobRequest {
         extension_env_providers: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: None,
     }
 }
@@ -979,6 +989,8 @@ fn reverse_worker_reports_execution_failure_to_broker() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -1024,6 +1036,8 @@ fn reverse_worker_loop_reports_failed_job_status() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -1100,6 +1114,8 @@ fn reverse_worker_skips_execution_when_claim_is_cancelled_before_start() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -1166,6 +1182,8 @@ fn reverse_worker_skips_finish_when_cancelled_after_execution() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -1241,6 +1259,8 @@ fn reverse_worker_interrupts_running_job_when_broker_cancel_is_observed() {
                 extension_env_providers: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: None,
             })
             .expect("submit job");
@@ -1313,6 +1333,8 @@ fn run_id_echo_request() -> RemoteRunnerJobRequest {
         extension_env_providers: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: None,
     }
 }
@@ -1387,6 +1409,8 @@ fn provider_request(
         extension_env_providers: Vec::new(),
         lab_runner_workload: None,
         lifecycle: None,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
         metadata: Some(serde_json::json!({
             "controller_run_id": controller_run_id,
             "controller_attempt_id": attempt_id,

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -117,6 +117,37 @@ The envelope accepts only these fields and never controls job lifecycle. Lines
 that are malformed, use another schema, or include terminal-state fields stay
 ordinary bounded stdout and cannot change the runner job status.
 
+## Workspace authority
+
+Workspace mutation uses two distinct, durable authorities. A queued or running
+job holds a `workspace-owner-lease`; the daemon renews it before its five-minute
+maximum TTL and durably replaces the exact token and epoch on the job record.
+Terminal cleanup releases that latest exact lease. A renewal that cannot be
+persisted cancels or fails the job with typed recovery evidence, which daemon
+startup retries before accepting conflicting work.
+
+Reconciliation uses short exclusive `workspace-claim` fences only after no
+owner lease remains live. Composite reconciliation acquires local and remote
+components independently. Each authority validates its own opaque token and
+store-issued epoch; a composite generation identifies the composition but is
+not an authority epoch. Reverse brokers expose the same owner operations at
+`/runner/workspace-owners/register`, `validate`, `renew`, and `release`.
+
+Managed task worktrees use the portable `task-worktree` workspace identity with
+the registry component and handle as its locator. The task-worktree manifest
+persists that identity when created; legacy manifests derive it from those same
+stable fields. Paths, inodes, runner hosts, and agent plan/task IDs are not part
+of this identity. Controllers copy the exact manifest identity into the
+agent-task plan and durable run record before local, direct, or reverse owner
+registration, so every authority blocks reconciliation on the same workspace.
+An active legacy run that has no durable owner lease fails closed for ownership
+mutations; terminal reconciliation is the authority for historical recovery.
+
+Reverse submission transport failures are ambiguous until the broker's
+submission-key lookup reports `accepted`, `absent`, or `expired`. Controllers
+retain the original owner lease for accepted or unresolved submissions and
+release it only after authoritative non-acceptance.
+
 ## Failure context
 
 Runner exec results expose a generic `failure_context` object when the executed

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -3328,6 +3328,155 @@ fn routes_exec_body_to_daemon_job() {
 }
 
 #[test]
+fn workspace_claim_authority_route_reports_clear_and_live_owner_without_tokens() {
+    let _home = HomeGuard::new();
+    let store = JobStore::default();
+    let workspace = crate::workspace_claim::WorkspaceIdentity::new("test-workspace", "authority")
+        .expect("workspace identity");
+    let clear = route_with_body(
+        "POST",
+        "/workspace-claims/authority",
+        Some(serde_json::json!({ "workspace": workspace })),
+        &store,
+    );
+    assert_eq!(clear.status_code, 200);
+    assert_eq!(clear.body["body"]["status"]["clear"], true);
+
+    let owner = route_with_body(
+        "POST",
+        "/workspace-owners/register",
+        Some(serde_json::json!({ "workspace": workspace, "owner_id": "visible-only-in-store" })),
+        &store,
+    );
+    assert_eq!(owner.status_code, 200);
+    let live = route_with_body(
+        "POST",
+        "/workspace-claims/authority",
+        Some(serde_json::json!({ "workspace": workspace })),
+        &store,
+    );
+    assert_eq!(live.status_code, 200);
+    assert_eq!(live.body["body"]["status"]["clear"], false);
+    assert_eq!(live.body["body"]["status"]["live_owner_count"], 1);
+    assert!(!live.body.to_string().contains("visible-only-in-store"));
+    assert!(!live.body.to_string().contains(
+        owner.body["body"]["lease"]["token"]
+            .as_str()
+            .expect("token")
+    ));
+}
+
+#[test]
+fn exec_commit_failure_keeps_primary_error_and_restart_recovers_failed_owner_rollback() {
+    super::tests::register_enqueue_test_driver();
+    let _home = create_lab_local_runner();
+    let store = JobStore::open_without_reconciliation(
+        crate::paths::daemon_jobs_file().expect("daemon jobs path"),
+    )
+    .expect("durable job store");
+    let workspace = crate::workspace_claim::WorkspaceIdentity::new(
+        "test-workspace",
+        "endpoint-commit-rollback",
+    )
+    .expect("workspace identity");
+    let claims_root = crate::paths::homeboy_data()
+        .expect("homeboy data")
+        .join("daemon-workspace-claims");
+    let claims = crate::workspace_claim::WorkspaceClaimStore::new(&claims_root);
+    claims
+        .fail_next_owner_releases(&workspace, 1)
+        .expect("inject owner release failure");
+    // The endpoint's pre-dispatch reconciler writes first; fail the following
+    // durable queue commit, after owner registration.
+    store.skip_next_durable_writes(1);
+    store.fail_next_durable_writes(1);
+
+    // Exercise the daemon's actual `/exec` endpoint path after it has registered
+    // the direct owner, rather than testing the rollback helper in isolation.
+    let response = route_with_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "lab-local",
+            "cwd": std::env::current_dir().expect("cwd"),
+            "command": ["sh", "-c", "printf should-not-run"],
+            "workspace_owner_request": {
+                "workspace": workspace,
+                "owner_id": "endpoint-commit-rollback"
+            }
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 400, "response: {}", response.body);
+    assert_eq!(response.body["error"], "internal.io_error");
+    assert_eq!(
+        response.body["details"]["error"],
+        "injected durable store write failure"
+    );
+    assert!(
+        store.list().is_empty(),
+        "failed commit created no active job"
+    );
+    let recovery = &response.body["details"]["workspace_owner_lease_cleanup"]["recovery"];
+    assert_eq!(
+        recovery["schema"], "homeboy/workspace-owner-release-recovery/v1",
+        "response: {}",
+        response.body
+    );
+    assert_eq!(
+        recovery["lease"]["workspace"],
+        serde_json::to_value(&workspace).expect("serialize workspace")
+    );
+    let token = recovery["lease"]["token"].as_str().expect("owner token");
+    assert!(!token.is_empty());
+    let lease: crate::workspace_claim::WorkspaceOwnerLease =
+        serde_json::from_value(recovery["lease"].clone()).expect("recovery owner lease");
+    assert!(claims
+        .validate_owner(&lease, crate::api_jobs::timestamp_ms())
+        .expect("validate pending owner"));
+    assert_eq!(
+        crate::workspace_claim::WorkspaceClaimStore::new(&claims_root)
+            .pending_owner_release_recoveries()
+            .expect("durable recovery evidence"),
+        vec![serde_json::from_value(recovery.clone()).expect("typed recovery evidence")]
+    );
+
+    // A fresh daemon consumes the durable recovery record before servicing its
+    // first request. The one-shot release injection has now cleared.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("listener address");
+    let server = std::thread::spawn(move || serve_listener_for_requests(listener, 1));
+    let health: Value = reqwest::blocking::get(format!("http://{addr}/health"))
+        .expect("restart health response")
+        .json()
+        .expect("restart health JSON");
+    assert_eq!(health["success"], true);
+    server
+        .join()
+        .expect("join restart daemon")
+        .expect("restart daemon");
+
+    assert!(
+        !crate::workspace_claim::WorkspaceClaimStore::new(&claims_root)
+            .validate_owner(&lease, crate::api_jobs::timestamp_ms())
+            .expect("validate released owner")
+    );
+    assert!(
+        crate::workspace_claim::WorkspaceClaimStore::new(&claims_root)
+            .pending_owner_release_recoveries()
+            .expect("recovery records")
+            .is_empty()
+    );
+    assert!(JobStore::open_without_reconciliation(
+        crate::paths::daemon_jobs_file().expect("daemon jobs path")
+    )
+    .expect("reopen durable jobs")
+    .list()
+    .is_empty());
+}
+
+#[test]
 fn routes_exec_preserves_path_materialization_plan_on_job_metadata() {
     super::tests::register_enqueue_test_driver();
     let _home = create_lab_local_runner();

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -357,6 +357,8 @@ fn queued_local_runner_job(store: &JobStore, durable_run_id: Option<&str>) -> cr
             active_child_count: None,
             active_cell_count: None,
         }),
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
     }))
 }
 
@@ -590,6 +592,8 @@ fn runs_list_includes_active_runner_jobs() {
                 require_paths: Vec::new(),
                 lab_runner_workload: None,
                 lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
                 metadata: Some(serde_json::json!({
                     "source": "lab",
                     "kind": "agent-task-cook",


### PR DESCRIPTION
## Summary

- add portable workspace identities, renewable owner leases, and exclusive reconciliation claims
- atomically fence local, direct-daemon, and reverse-runner admissions
- add versioned mixed-runner capability negotiation with fail-closed reconciliation behavior
- preserve exact lease evidence through heartbeat, attachment, terminal, cancellation, and restart paths
- add durable write-ahead cleanup recovery and token-free authority-clear probes
- compose controller and configured-runner authority without holding registry locks over network calls

Closes #11347.

## Verification

- core workspace-claim, daemon, API-job, and route suites
- `cargo test -p homeboy-agents workspace_claims --lib`
- `cargo test -p homeboy-agents agent_task_lifecycle --lib`
- `cargo test -p homeboy-lab-runner worker --lib`
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-lab-runner`
- `cargo fmt --check`
- `git diff --check`

## AI Assistance

- **Model:** OpenAI `openai/gpt-5.6-sol`
- **Tool:** OpenCode
- **Used for:** protocol design, implementation, distributed race analysis, independent safety reviews, and verification

Chris Huber remains responsible for every line of the change.