### PR TITLE
fix(lab): retain workspaces while remote state is uncertain

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -717,17 +717,17 @@ pub(crate) fn exec_lab_context(
                         .build(),
                 );
                 if let Some(job_id) = in_flight_job_id.as_deref() {
+                    if let Some(workspace) = context.materialized_workspace.as_mut() {
+                        workspace.retain_for_reconciliation(
+                            job_id,
+                            context
+                                .runner_status
+                                .session
+                                .as_ref()
+                                .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+                        );
+                    }
                     if let Some(run_id) = context.agent_task_run_id.as_deref() {
-                        if let Some(workspace) = context.materialized_workspace.as_mut() {
-                            workspace.retain_for_reconciliation(
-                                job_id,
-                                context
-                                    .runner_status
-                                    .session
-                                    .as_ref()
-                                    .and_then(|session| session.remote_daemon_lease_id.as_deref()),
-                            );
-                        }
                         return in_flight_daemon_disconnect_outcome(
                             context.plan,
                             runner_id,
@@ -790,17 +790,17 @@ pub(crate) fn exec_lab_context(
                 };
             }
             if let Some(job_id) = in_flight_job_id.as_deref() {
+                if let Some(workspace) = context.materialized_workspace.as_mut() {
+                    workspace.retain_for_reconciliation(
+                        job_id,
+                        context
+                            .runner_status
+                            .session
+                            .as_ref()
+                            .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+                    );
+                }
                 if let Some(run_id) = context.agent_task_run_id.as_deref() {
-                    if let Some(workspace) = context.materialized_workspace.as_mut() {
-                        workspace.retain_for_reconciliation(
-                            job_id,
-                            context
-                                .runner_status
-                                .session
-                                .as_ref()
-                                .and_then(|session| session.remote_daemon_lease_id.as_deref()),
-                        );
-                    }
                     return in_flight_daemon_disconnect_outcome(
                         context.plan,
                         runner_id,

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -672,14 +672,15 @@ pub(crate) fn exec_lab_context(
         Ok(output) => output,
         Err(err) => {
             if let Some(run_id) = context.agent_task_run_id.as_deref() {
-                if let Some(job_id) = accepted_runner_job_id(runner_id, run_id) {
+                if let Some(job) = accepted_runner_job_id(runner_id, run_id) {
                     if let Some(workspace) = context.materialized_workspace.as_mut() {
-                        workspace.preserve();
+                        workspace
+                            .retain_for_reconciliation(&job.id, job.daemon_generation.as_deref());
                     }
                     return in_flight_daemon_disconnect_outcome(
                         context.plan,
                         runner_id,
-                        &job_id,
+                        &job.id,
                         run_id,
                         &remote_cwd,
                         &context.remote_command,
@@ -718,7 +719,14 @@ pub(crate) fn exec_lab_context(
                 if let Some(job_id) = in_flight_job_id.as_deref() {
                     if let Some(run_id) = context.agent_task_run_id.as_deref() {
                         if let Some(workspace) = context.materialized_workspace.as_mut() {
-                            workspace.preserve();
+                            workspace.retain_for_reconciliation(
+                                job_id,
+                                context
+                                    .runner_status
+                                    .session
+                                    .as_ref()
+                                    .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+                            );
                         }
                         return in_flight_daemon_disconnect_outcome(
                             context.plan,
@@ -784,7 +792,14 @@ pub(crate) fn exec_lab_context(
             if let Some(job_id) = in_flight_job_id.as_deref() {
                 if let Some(run_id) = context.agent_task_run_id.as_deref() {
                     if let Some(workspace) = context.materialized_workspace.as_mut() {
-                        workspace.preserve();
+                        workspace.retain_for_reconciliation(
+                            job_id,
+                            context
+                                .runner_status
+                                .session
+                                .as_ref()
+                                .and_then(|session| session.remote_daemon_lease_id.as_deref()),
+                        );
                     }
                     return in_flight_daemon_disconnect_outcome(
                         context.plan,
@@ -1044,7 +1059,13 @@ pub(crate) fn exec_lab_context(
 /// `/exec` is not an idempotent operation. When its response is lost, query the
 /// daemon's durable active-job projection by the preassigned run ID rather than
 /// submitting the workload again.
-fn accepted_runner_job_id(runner_id: &str, run_id: &str) -> Option<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AcceptedRunnerJob {
+    pub(crate) id: String,
+    pub(crate) daemon_generation: Option<String>,
+}
+
+fn accepted_runner_job_id(runner_id: &str, run_id: &str) -> Option<AcceptedRunnerJob> {
     accepted_runner_job_id_with(runner_id, run_id, || crate::status(runner_id))
 }
 
@@ -1052,7 +1073,7 @@ pub(crate) fn accepted_runner_job_id_with<F>(
     runner_id: &str,
     run_id: &str,
     status: F,
-) -> Option<String>
+) -> Option<AcceptedRunnerJob>
 where
     F: FnOnce() -> Result<crate::RunnerStatusReport>,
 {
@@ -1060,6 +1081,10 @@ where
     if status.runner_id != runner_id {
         return None;
     }
+    let daemon_generation = status
+        .session
+        .as_ref()
+        .and_then(|session| session.remote_daemon_lease_id.clone());
     let mut matching = status
         .active_runner_jobs
         .into_iter()
@@ -1067,7 +1092,10 @@ where
         .map(|job| job.job_id)
         .collect::<Vec<_>>();
     matching.sort();
-    (matching.len() == 1).then(|| matching.remove(0))
+    (matching.len() == 1).then(|| AcceptedRunnerJob {
+        id: matching.remove(0),
+        daemon_generation,
+    })
 }
 
 fn promotion_handoff_intent(args: &[String], stdout: &str) -> Result<Option<PromotionPatchIntent>> {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/exec_errors.rs
@@ -64,6 +64,11 @@ fn lost_exec_response_reconciles_the_single_accepted_durable_job() {
         )
         .expect("record controller proxy before daemon acceptance");
         let mut status = reverse_status("homeboy-lab");
+        status
+            .session
+            .as_mut()
+            .expect("reverse session")
+            .remote_daemon_lease_id = Some("generation-8525".to_string());
         status.active_runner_jobs.push(crate::RunnerJob {
             runner_id: "homeboy-lab".to_string(),
             job_id: "job-8525".to_string(),
@@ -88,12 +93,14 @@ fn lost_exec_response_reconciles_the_single_accepted_durable_job() {
         });
 
         let response_error = Error::internal_unexpected("/exec response connection reset");
-        let job_id = accepted_runner_job_id_with("homeboy-lab", run_id, || Ok(status))
+        let job = accepted_runner_job_id_with("homeboy-lab", run_id, || Ok(status))
             .expect("reconcile exactly one accepted daemon job");
+        assert_eq!(job.id, "job-8525");
+        assert_eq!(job.daemon_generation.as_deref(), Some("generation-8525"));
         let outcome = in_flight_daemon_disconnect_outcome(
             base_lab_plan(Some(&portable_lab_command("agent-task cook"))),
             "homeboy-lab",
-            &job_id,
+            &job.id,
             run_id,
             "/runner/workspace",
             &[

--- a/crates/homeboy-lab-runner/src/workspace/materialized.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materialized.rs
@@ -19,7 +19,7 @@
 use homeboy_core::resource_lifecycle_index::ResourceLifecycleResourceStatus;
 
 use super::sync::{reap_run_workspace, record_workspace_terminal_evidence};
-use super::types::RunnerWorkspaceTerminalEvidence;
+use super::types::{RunnerWorkspaceReconciliation, RunnerWorkspaceTerminalEvidence};
 
 /// Teardown policy for a run-owned materialized workspace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +92,7 @@ pub(crate) struct MaterializedWorkspace {
     policy: WorkspaceCleanupPolicy,
     outcome: WorkspaceTerminalOutcome,
     authoritative_terminal_outcome: bool,
+    reconciliation: Option<RunnerWorkspaceReconciliation>,
     relinquished: bool,
 }
 
@@ -107,11 +108,11 @@ impl MaterializedWorkspace {
             remote_path,
             artifact_dir,
             policy,
-            // Until the daemon publishes a terminal result and the controller
-            // completes its result handoff, the remote job may still own this
-            // checkout. Retain that uncertainty through a bounded lifecycle.
-            outcome: WorkspaceTerminalOutcome::UncertainHandoff,
-            authoritative_terminal_outcome: false,
+            // Workspace creation and setup errors happen before daemon
+            // admission, so they retain the existing immediate cleanup policy.
+            outcome: WorkspaceTerminalOutcome::Failure,
+            authoritative_terminal_outcome: true,
+            reconciliation: None,
             relinquished: false,
         }
     }
@@ -129,6 +130,35 @@ impl MaterializedWorkspace {
     pub(crate) fn preserve(&mut self) {
         self.relinquished = true;
         self.outcome = WorkspaceTerminalOutcome::UncertainHandoff;
+    }
+
+    /// Retain a workspace after an accepted daemon job becomes unobservable.
+    /// The exact owner makes reconnect/reconciliation actionable while the
+    /// standard TTL lifecycle bounds retention if recovery never completes.
+    pub(crate) fn retain_for_reconciliation(
+        &mut self,
+        job_id: &str,
+        daemon_generation: Option<&str>,
+    ) {
+        self.outcome = WorkspaceTerminalOutcome::UncertainHandoff;
+        self.authoritative_terminal_outcome = false;
+        self.reconciliation = Some(RunnerWorkspaceReconciliation {
+            job_id: job_id.to_string(),
+            daemon_generation: daemon_generation.map(ToString::to_string),
+            reconnect_command: format!(
+                "homeboy runner status {} --full",
+                homeboy_core::engine::shell::quote_arg(&self.runner_id),
+            ),
+            reconcile_command: format!(
+                "homeboy runner job reconcile {}",
+                homeboy_core::engine::shell::quote_arg(&self.runner_id),
+            ),
+            job_logs_command: format!(
+                "homeboy runner job logs {} {} --follow",
+                homeboy_core::engine::shell::quote_arg(&self.runner_id),
+                homeboy_core::engine::shell::quote_arg(job_id),
+            ),
+        });
     }
 
     fn should_reap(&self) -> bool {
@@ -178,6 +208,7 @@ impl MaterializedWorkspace {
             reconciliation_needed: !self.authoritative_terminal_outcome && !self.relinquished,
             reconciliation_ttl: (!self.authoritative_terminal_outcome && !self.relinquished)
                 .then(runner_workspace_ttl),
+            reconciliation: self.reconciliation.clone(),
         };
         if let Err(error) = record_workspace_terminal_evidence(
             &self.runner_id,

--- a/crates/homeboy-lab-runner/src/workspace/materialized.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materialized.rs
@@ -9,7 +9,8 @@
 //! [`MaterializedWorkspace`] is the run-owned handle that closes that gap: it
 //! carries a [`WorkspaceCleanupPolicy`] and reaps the remote workspace (and its
 //! artifact sibling) on drop. The default policy
-//! [`WorkspaceCleanupPolicy::DeleteAlways`] reaps every known terminal outcome.
+//! [`WorkspaceCleanupPolicy::DeleteAlways`] reaps every authoritatively observed
+//! terminal outcome.
 //! The explicit `PreserveOnFailure` debugging policy retains failed workspaces
 //! through the registered TTL lifecycle. Reap is best-effort: a teardown error
 //! is logged, never propagated, and the controller-side `runner workspace prune`
@@ -90,6 +91,7 @@ pub(crate) struct MaterializedWorkspace {
     artifact_dir: Option<String>,
     policy: WorkspaceCleanupPolicy,
     outcome: WorkspaceTerminalOutcome,
+    authoritative_terminal_outcome: bool,
     relinquished: bool,
 }
 
@@ -105,7 +107,11 @@ impl MaterializedWorkspace {
             remote_path,
             artifact_dir,
             policy,
-            outcome: WorkspaceTerminalOutcome::Failure,
+            // Until the daemon publishes a terminal result and the controller
+            // completes its result handoff, the remote job may still own this
+            // checkout. Retain that uncertainty through a bounded lifecycle.
+            outcome: WorkspaceTerminalOutcome::UncertainHandoff,
+            authoritative_terminal_outcome: false,
             relinquished: false,
         }
     }
@@ -114,6 +120,7 @@ impl MaterializedWorkspace {
     /// from failure before this run-owned handle is dropped.
     pub(crate) fn set_terminal_outcome(&mut self, outcome: WorkspaceTerminalOutcome) {
         self.outcome = outcome;
+        self.authoritative_terminal_outcome = true;
     }
 
     /// Relinquish run-scoped ownership without reaping — e.g. the remote run
@@ -127,7 +134,7 @@ impl MaterializedWorkspace {
     fn should_reap(&self) -> bool {
         // Preserve evidence if we are unwinding from a panic, and honor an
         // explicit relinquish handing the workspace to a live remote job.
-        if self.relinquished || std::thread::panicking() {
+        if self.relinquished || !self.authoritative_terminal_outcome || std::thread::panicking() {
             return false;
         }
         match self.policy {
@@ -164,10 +171,13 @@ impl MaterializedWorkspace {
             } else {
                 "runner.workspace".to_string()
             },
-            cleanup_trigger: (!retained && !self.relinquished)
-                .then(|| "terminal_job_owner".to_string()),
+            cleanup_trigger: (!retained && self.authoritative_terminal_outcome)
+                .then(|| "authoritative_terminal_result_and_handoff".to_string()),
             retained_location: retained.then(|| self.remote_path.clone()),
             reclaim_command: (retained && !self.relinquished).then(|| self.reclaim_command()),
+            reconciliation_needed: !self.authoritative_terminal_outcome && !self.relinquished,
+            reconciliation_ttl: (!self.authoritative_terminal_outcome && !self.relinquished)
+                .then(runner_workspace_ttl),
         };
         if let Err(error) = record_workspace_terminal_evidence(
             &self.runner_id,
@@ -182,6 +192,14 @@ impl MaterializedWorkspace {
             );
         }
     }
+}
+
+fn runner_workspace_ttl() -> String {
+    homeboy_core::defaults::load_config()
+        .lab
+        .runner_workspace_ttl
+        .filter(|ttl| !ttl.trim().is_empty())
+        .unwrap_or_else(|| "P7D".to_string())
 }
 
 impl Drop for MaterializedWorkspace {

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2007,13 +2007,18 @@ pub(crate) fn record_workspace_terminal_evidence(
         })?;
     if let Some(lifecycle) = metadata.resource_lifecycle.as_mut() {
         lifecycle.status = lifecycle_status;
-        // A detached or uncertain daemon handoff still has a live job owner.
-        // Prevent every automatic reclaimer from treating this workspace as a
-        // terminal TTL artifact until that owner publishes a terminal result.
+        // A detached daemon handoff still has a known live job owner. Prevent
+        // every automatic reclaimer from treating it as a terminal artifact.
         if relinquished {
             lifecycle.cleanup_policy = ResourceCleanupPolicy::Preserve;
             lifecycle.ttl = None;
             lifecycle.cleanup_command = None;
+        } else if evidence.reconciliation_needed {
+            // The controller cannot establish whether the daemon job completed.
+            // Keep its workspace recoverable while bounding retention through
+            // the normal runner-prune lifecycle.
+            lifecycle.cleanup_policy = ResourceCleanupPolicy::DeleteAfterTtl;
+            lifecycle.ttl = evidence.reconciliation_ttl.clone();
         }
     }
     metadata.terminal_evidence = Some(evidence);

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -2021,6 +2021,9 @@ pub(crate) fn record_workspace_terminal_evidence(
             lifecycle.ttl = evidence.reconciliation_ttl.clone();
         }
     }
+    if let Some(reconciliation) = evidence.reconciliation.as_ref() {
+        metadata.job_id = Some(reconciliation.job_id.clone());
+    }
     metadata.terminal_evidence = Some(evidence);
     write_workspace_metadata(&runner, metadata)
 }

--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -457,6 +457,66 @@ fn runner_job_authority_requires_exact_transport_state_and_consistent_snapshot()
 }
 
 #[test]
+fn non_agent_task_polling_loss_retains_job_owned_workspace_until_terminal_reconciliation() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source_parent = tempfile::tempdir().expect("source parent");
+        let source = source_parent.path().join("review-source");
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        fs::create_dir_all(&source).expect("source dir");
+        fs::write(source.join("file.txt"), "review\n").expect("source file");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-local-review-poll-loss","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let (synced, _) = sync_workspace(
+            "lab-local-review-poll-loss",
+            sync_options(source.display().to_string()),
+        )
+        .expect("sync review workspace");
+
+        // A review has no agent-task run id, but a live accepted daemon job
+        // still owns its workspace after the controller loses polling.
+        {
+            let mut workspace = MaterializedWorkspace::new(
+                "lab-local-review-poll-loss".to_string(),
+                synced.remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::DeleteAlways,
+            );
+            workspace.retain_for_reconciliation("review-job-11380", Some("generation-review"));
+        }
+
+        let metadata =
+            fs::read_to_string(Path::new(&synced.remote_path).join(WORKSPACE_METADATA_FILE))
+                .expect("retained workspace metadata");
+        let metadata: serde_json::Value = serde_json::from_str(&metadata).expect("metadata json");
+        assert_eq!(metadata["job_id"], "review-job-11380");
+        assert_eq!(
+            metadata["terminal_evidence"]["reconciliation"]["daemon_generation"],
+            "generation-review"
+        );
+
+        let active = vec!["review-job-11380".to_string()];
+        let polling_loss =
+            runner_job_liveness_with("review-job-11380", Ok(JobStatus::Running), Some(&active));
+        assert_eq!(polling_loss.state, "live");
+        assert!(Path::new(&synced.remote_path).exists());
+
+        let terminal =
+            runner_job_liveness_with("review-job-11380", Ok(JobStatus::Succeeded), Some(&[]));
+        assert_eq!(terminal.state, "inactive");
+        assert!(
+            revalidated_candidate_is_deletable(&terminal),
+            "terminal reconciliation authorizes the retained workspace for cleanup"
+        );
+    });
+}
+
+#[test]
 fn prune_revalidates_job_authority_before_deletion() {
     let scanned = runner_job_liveness_with("job-1", Ok(JobStatus::Succeeded), Some(&[]));
     let revalidated = runner_job_liveness_with(

--- a/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
@@ -125,15 +125,16 @@ fn controller_tunnel_loss_during_live_workload_retains_workspace_for_reconciliat
         let live_workload = Path::new(&remote_path).join("live-workload");
         fs::write(&live_workload, "still running\n").expect("live workload input");
 
-        // Simulate losing the controller tunnel after dispatch but before an
-        // authoritative daemon terminal result or artifact handoff arrives.
+        // Simulate losing the controller tunnel while an accepted daemon job is
+        // live, before its terminal result or artifact handoff arrives.
         {
-            let _handle = MaterializedWorkspace::new(
+            let mut handle = MaterializedWorkspace::new(
                 "lab-local-tunnel-loss".to_string(),
                 remote_path.clone(),
                 None,
                 WorkspaceCleanupPolicy::DeleteAlways,
             );
+            handle.retain_for_reconciliation("job-11380", Some("generation-11380"));
         }
 
         assert!(
@@ -148,12 +149,49 @@ fn controller_tunnel_loss_during_live_workload_retains_workspace_for_reconciliat
             "uncertain_handoff"
         );
         assert_eq!(metadata["terminal_evidence"]["reconciliation_needed"], true);
+        assert_eq!(metadata["job_id"], "job-11380");
+        assert_eq!(
+            metadata["terminal_evidence"]["reconciliation"]["daemon_generation"],
+            "generation-11380"
+        );
+        assert_eq!(
+            metadata["terminal_evidence"]["reconciliation"]["reconnect_command"],
+            "homeboy runner status lab-local-tunnel-loss --full"
+        );
+        assert_eq!(
+            metadata["terminal_evidence"]["reconciliation"]["reconcile_command"],
+            "homeboy runner job reconcile lab-local-tunnel-loss"
+        );
         assert_eq!(
             metadata["resource_lifecycle"]["cleanup_policy"],
             "delete_after_ttl"
         );
         assert!(metadata["resource_lifecycle"]["ttl"].is_string());
         assert!(metadata["terminal_evidence"]["cleanup_trigger"].is_null());
+    });
+}
+
+#[test]
+fn pre_dispatch_failure_reaps_workspace_under_delete_on_terminal_policy() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-pre-dispatch", runner_root.path());
+
+        // Setup, runtime materialization, hydration, and preflight fail before
+        // daemon admission, so they must not enter reconciliation retention.
+        {
+            let _handle = MaterializedWorkspace::new(
+                "lab-local-pre-dispatch".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::DeleteAlways,
+            );
+        }
+
+        assert!(
+            !Path::new(&remote_path).exists(),
+            "a proven pre-dispatch failure must use immediate policy cleanup"
+        );
     });
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/reap.rs
@@ -118,6 +118,46 @@ fn materialized_workspace_reaps_on_success_under_default_policy() {
 }
 
 #[test]
+fn controller_tunnel_loss_during_live_workload_retains_workspace_for_reconciliation() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = tempfile::tempdir().expect("runner root tempdir");
+        let remote_path = sync_local_workspace("lab-local-tunnel-loss", runner_root.path());
+        let live_workload = Path::new(&remote_path).join("live-workload");
+        fs::write(&live_workload, "still running\n").expect("live workload input");
+
+        // Simulate losing the controller tunnel after dispatch but before an
+        // authoritative daemon terminal result or artifact handoff arrives.
+        {
+            let _handle = MaterializedWorkspace::new(
+                "lab-local-tunnel-loss".to_string(),
+                remote_path.clone(),
+                None,
+                WorkspaceCleanupPolicy::DeleteAlways,
+            );
+        }
+
+        assert!(
+            live_workload.exists(),
+            "an unobserved daemon job must retain its live workspace"
+        );
+        let metadata = fs::read_to_string(Path::new(&remote_path).join(WORKSPACE_METADATA_FILE))
+            .expect("reconciliation metadata");
+        let metadata: serde_json::Value = serde_json::from_str(&metadata).expect("metadata json");
+        assert_eq!(
+            metadata["terminal_evidence"]["final_outcome"],
+            "uncertain_handoff"
+        );
+        assert_eq!(metadata["terminal_evidence"]["reconciliation_needed"], true);
+        assert_eq!(
+            metadata["resource_lifecycle"]["cleanup_policy"],
+            "delete_after_ttl"
+        );
+        assert!(metadata["resource_lifecycle"]["ttl"].is_string());
+        assert!(metadata["terminal_evidence"]["cleanup_trigger"].is_null());
+    });
+}
+
+#[test]
 fn materialized_workspace_preserves_on_failure_under_explicit_debug_policy() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner_root = tempfile::tempdir().expect("runner root tempdir");

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -604,6 +604,12 @@ pub(crate) struct RunnerWorkspaceTerminalEvidence {
     pub retained_location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reclaim_command: Option<String>,
+    /// The controller could not observe an authoritative terminal daemon result.
+    /// This workspace remains recoverable until its bounded lifecycle expires.
+    #[serde(default)]
+    pub reconciliation_needed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconciliation_ttl: Option<String>,
 }
 
 // RunnerWorkspaceCurrentSummary now lives in the shared runner-contract crate

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -610,6 +610,19 @@ pub(crate) struct RunnerWorkspaceTerminalEvidence {
     pub reconciliation_needed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconciliation_ttl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconciliation: Option<RunnerWorkspaceReconciliation>,
+}
+
+/// Exact remote ownership retained when the controller loses an accepted job.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RunnerWorkspaceReconciliation {
+    pub job_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon_generation: Option<String>,
+    pub reconnect_command: String,
+    pub reconcile_command: String,
+    pub job_logs_command: String,
 }
 
 // RunnerWorkspaceCurrentSummary now lives in the shared runner-contract crate


### PR DESCRIPTION
## Summary

- retain accepted job workspaces when controller polling disconnects
- represent uncertain cleanup as reconciliation-needed state
- preserve owning job and generation metadata for later reconciliation
- cover both agent-task and non-agent workspace retention paths

Closes #11380.

## Verification

- `cargo test -p homeboy-lab-runner workspace::tests::reap`
- `cargo test -p homeboy-lab-runner workspace::tests::prune`
- combined five-fix integration verification passed

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to trace uncertain remote cleanup, implement lifecycle retention and regression coverage, review the branch, and run verification. Chris Huber reviewed and remains responsible for every line.