### PR TITLE
fix(runner): fence admission across unresolved generations

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -44,7 +44,11 @@ pub(super) fn status(
         // Count the draining generations before optionally dropping the expanded
         // ledger, so the summary's count is accurate whether or not the caller
         // asked for the full list.
-        let admission_summary = Some(report.admission_summary(generation_inventory.len()));
+        let admission_summary =
+            Some(report.admission_summary_with_generations(
+                &generation_inventory,
+                generation_inventory.len(),
+            ));
         // By default the expanded per-generation ledger is omitted — the summary
         // already carries the count, and on a long-lived runner the full
         // inventory runs to thousands of lines that make old ownership look like
@@ -185,7 +189,10 @@ pub(super) fn reconcile(id: &str) -> CmdResult<RunnerOutput> {
             command: "runner.reconcile".to_string(),
             id: Some(id.to_string()),
             extra: RunnerExtra {
-                admission_summary: Some(report.admission_summary(generation_inventory.len())),
+                admission_summary: Some(report.admission_summary_with_generations(
+                    &generation_inventory,
+                    generation_inventory.len(),
+                )),
                 connection: Some(RunnerConnectionOutput::Status(report.clone())),
                 generation_inventory,
                 operator_hints: runner_status_operator_hints(&report),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -789,7 +789,7 @@ fn connect_with_orphan_adoption_and_live_lease(
                     live_lease_expectation,
                     Some(&replacement_operation_id),
                     admission_fence,
-                    true,
+                    false,
                 )
                 .map_err(Error::internal_unexpected)
             },

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -410,8 +410,6 @@ fn connect_with_orphan_adoption_and_live_lease(
     let mut previous_session =
         super::generation_store::admission_session(runner_id, previous_session.as_ref())?
             .or(previous_session);
-    let admission_fence =
-        super::generation_store::admission_fence(runner_id, previous_session.as_ref())?;
     let mut pending_replacement = super::generation_store::pending_replacement(runner_id)?;
     let mut replacement_operation_id = None;
     if let Some(pending) = pending_replacement.as_ref() {
@@ -496,7 +494,13 @@ fn connect_with_orphan_adoption_and_live_lease(
             } else {
                 command
             };
-            let output = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
+            let output = fenced_remote_mutation(
+                runner_id,
+                previous_session.as_ref(),
+                &client,
+                &command,
+                REMOTE_LEASELESS_RECOVERY_TIMEOUT,
+            );
             if !output.success {
                 return Ok(failed_connect(
                     runner_id,
@@ -615,7 +619,13 @@ fn connect_with_orphan_adoption_and_live_lease(
                 "state-loss",
                 &command,
             )?;
-            let recovery = client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
+            let recovery = fenced_remote_mutation(
+                runner_id,
+                previous_session.as_ref(),
+                &client,
+                &command,
+                REMOTE_LEASELESS_RECOVERY_TIMEOUT,
+            );
             if !recovery.success {
                 return Ok(failed_connect(
                     runner_id,
@@ -685,7 +695,13 @@ fn connect_with_orphan_adoption_and_live_lease(
                         child_resource: None,
                     };
                 }
-                client.execute_with_timeout(&command, REMOTE_LEASELESS_RECOVERY_TIMEOUT)
+                fenced_remote_mutation(
+                    runner_id,
+                    previous_session.as_ref(),
+                    &client,
+                    &command,
+                    REMOTE_LEASELESS_RECOVERY_TIMEOUT,
+                )
             },
         );
         let (contract, recovery) = match recovery {
@@ -758,19 +774,27 @@ fn connect_with_orphan_adoption_and_live_lease(
         // Normal reconnects must inspect the live daemon first: a reachable,
         // compatible generation reattaches, while an idle stale generation
         // follows ReplaceIdleStale instead of bypassing its fenced lifecycle.
-        None => ensure_remote_daemon(
-            &client,
-            homeboy,
+        None => super::generation_store::with_admission_fence(
             runner_id,
             previous_session.as_ref(),
-            &configured_build_identity,
-            orphan_lease_id,
-            confirmed_no_pid_job_ids,
-            live_lease_expectation,
-            Some(&replacement_operation_id),
-            admission_fence.as_ref(),
+            |admission_fence| {
+                ensure_remote_daemon(
+                    &client,
+                    homeboy,
+                    runner_id,
+                    previous_session.as_ref(),
+                    &configured_build_identity,
+                    orphan_lease_id,
+                    confirmed_no_pid_job_ids,
+                    live_lease_expectation,
+                    Some(&replacement_operation_id),
+                    admission_fence,
+                    true,
+                )
+                .map_err(Error::internal_unexpected)
+            },
         )
-        .map(|daemon| daemon),
+        .map_err(|error| error.message),
     };
     let Ok(daemon) = daemon else {
         let (mut report, exit_code) = failed_connect_after_recovery(
@@ -1276,6 +1300,39 @@ fn remote_state_loss_recovery_command(
     )
 }
 
+fn fenced_remote_mutation(
+    runner_id: &str,
+    previous_session: Option<&RunnerSession>,
+    client: &SshClient,
+    command: &str,
+    timeout: Duration,
+) -> homeboy_core::server::CommandOutput {
+    match super::generation_store::with_admission_fence(runner_id, previous_session, |fence| {
+        if let Some(fence) = fence {
+            return Err(Error::validation_invalid_argument(
+                    "reconnect",
+                    format!(
+                        "runner `{runner_id}` generation `{}` has {} unresolved active job(s); refusing daemon recovery before terminal job evidence is available",
+                        fence.generation, fence.active_job_count,
+                    ),
+                    Some(runner_id.to_string()),
+                    None,
+                ));
+        }
+        Ok(client.execute_with_timeout(command, timeout))
+    }) {
+        Ok(output) => output,
+        Err(error) => homeboy_core::server::CommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: error.message,
+            exit_code: 1,
+            timed_out: false,
+            child_resource: None,
+        },
+    }
+}
+
 pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerConnectReport, i32)> {
     if options.runner_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -1469,7 +1526,17 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     {
         freshness.active_jobs = active_jobs;
     }
-    let active_job_count = direct_daemon_active_jobs.unwrap_or(active_jobs.len());
+    let selected_active_job_count = direct_daemon_active_jobs.unwrap_or(active_jobs.len());
+    // A connected admission daemon is not the only generation that can own
+    // mutable work. Keep the full status headline consistent with the
+    // admission summary by retaining unresolved draining ownership too.
+    let unresolved_generation_jobs =
+        super::generation_store::status_projection(runner_id, session.as_ref())?
+            .into_iter()
+            .filter(|generation| !generation.admission_owner)
+            .map(|generation| generation.active_job_count)
+            .sum::<usize>();
+    let active_job_count = selected_active_job_count + unresolved_generation_jobs;
     let active_job_error = match (active_job_error, direct_daemon_active_jobs) {
         (Some(error), _) => Some(error),
         (None, Some(authoritative_count)) if authoritative_count != active_jobs.len() => {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -497,6 +497,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             let output = fenced_remote_mutation(
                 runner_id,
                 previous_session.as_ref(),
+                "replay_replacement_operation",
                 &client,
                 &command,
                 REMOTE_LEASELESS_RECOVERY_TIMEOUT,
@@ -622,6 +623,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             let recovery = fenced_remote_mutation(
                 runner_id,
                 previous_session.as_ref(),
+                "recover_missing_lease_state",
                 &client,
                 &command,
                 REMOTE_LEASELESS_RECOVERY_TIMEOUT,
@@ -698,6 +700,7 @@ fn connect_with_orphan_adoption_and_live_lease(
                 fenced_remote_mutation(
                     runner_id,
                     previous_session.as_ref(),
+                    "reconcile_leaseless_orphans",
                     &client,
                     &command,
                     REMOTE_LEASELESS_RECOVERY_TIMEOUT,
@@ -777,6 +780,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         None => super::generation_store::with_admission_fence(
             runner_id,
             previous_session.as_ref(),
+            "ensure_remote_daemon",
             |admission_fence| {
                 ensure_remote_daemon(
                     &client,
@@ -1303,13 +1307,18 @@ fn remote_state_loss_recovery_command(
 fn fenced_remote_mutation(
     runner_id: &str,
     previous_session: Option<&RunnerSession>,
+    operation_name: &str,
     client: &SshClient,
     command: &str,
     timeout: Duration,
 ) -> homeboy_core::server::CommandOutput {
-    match super::generation_store::with_admission_fence(runner_id, previous_session, |fence| {
-        if let Some(fence) = fence {
-            return Err(Error::validation_invalid_argument(
+    match super::generation_store::with_admission_fence(
+        runner_id,
+        previous_session,
+        operation_name,
+        |fence| {
+            if let Some(fence) = fence {
+                return Err(Error::validation_invalid_argument(
                     "reconnect",
                     format!(
                         "runner `{runner_id}` generation `{}` has {} unresolved active job(s); refusing daemon recovery before terminal job evidence is available",
@@ -1318,9 +1327,10 @@ fn fenced_remote_mutation(
                     Some(runner_id.to_string()),
                     None,
                 ));
-        }
-        Ok(client.execute_with_timeout(command, timeout))
-    }) {
+            }
+            Ok(client.execute_with_timeout(command, timeout))
+        },
+    ) {
         Ok(output) => output,
         Err(error) => homeboy_core::server::CommandOutput {
             success: false,

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -410,6 +410,8 @@ fn connect_with_orphan_adoption_and_live_lease(
     let mut previous_session =
         super::generation_store::admission_session(runner_id, previous_session.as_ref())?
             .or(previous_session);
+    let admission_fence =
+        super::generation_store::admission_fence(runner_id, previous_session.as_ref())?;
     let mut pending_replacement = super::generation_store::pending_replacement(runner_id)?;
     let mut replacement_operation_id = None;
     if let Some(pending) = pending_replacement.as_ref() {
@@ -766,6 +768,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             confirmed_no_pid_job_ids,
             live_lease_expectation,
             Some(&replacement_operation_id),
+            admission_fence.as_ref(),
         )
         .map(|daemon| daemon),
     };

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -613,6 +613,7 @@ pub(super) fn ensure_remote_daemon(
     live_lease_expectation: Option<(&str, u32)>,
     replacement_operation_id: Option<&str>,
     admission_fence: Option<&crate::generation_store::AdmissionFence>,
+    registry_lock_held: bool,
 ) -> std::result::Result<RemoteDaemon, String> {
     let mut status = remote_daemon_status(client, homeboy)?;
     probe_remote_daemon_endpoint(client, &mut status);
@@ -655,7 +656,12 @@ pub(super) fn ensure_remote_daemon(
         }
         RemoteDaemonConnectAction::Start => {
             negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
-            journal_ensure_running_replay(runner_id, homeboy, replacement_operation_id)?;
+            journal_ensure_running_replay(
+                runner_id,
+                homeboy,
+                replacement_operation_id,
+                registry_lock_held,
+            )?;
             return remote_daemon_ensure_running(client, homeboy, replacement_operation_id);
         }
         RemoteDaemonConnectAction::ReplaceIdleStale
@@ -665,7 +671,12 @@ pub(super) fn ensure_remote_daemon(
             negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
             // Persist B's idempotent receipt key before removing A. A retry then
             // replays this command before inspecting or replacing any lease.
-            journal_ensure_running_replay(runner_id, homeboy, replacement_operation_id)?;
+            journal_ensure_running_replay(
+                runner_id,
+                homeboy,
+                replacement_operation_id,
+                registry_lock_held,
+            )?;
             let daemon = status.daemon.as_ref().expect("replacement requires daemon");
             let lease_id = daemon
                 .lease_id
@@ -705,16 +716,26 @@ fn journal_ensure_running_replay(
     runner_id: &str,
     homeboy: &str,
     replacement_operation_id: Option<&str>,
+    registry_lock_held: bool,
 ) -> std::result::Result<(), String> {
     if replacement_operation_id.is_none() {
         return Ok(());
     }
-    crate::generation_store::record_replacement_operation_replay(
-        runner_id,
-        "ensure-running",
-        &remote_daemon_ensure_running_command(homeboy, replacement_operation_id),
-    )
-    .map_err(|error| error.to_string())
+    let command = remote_daemon_ensure_running_command(homeboy, replacement_operation_id);
+    let write = if registry_lock_held {
+        crate::generation_store::record_replacement_operation_replay_locked(
+            runner_id,
+            "ensure-running",
+            &command,
+        )
+    } else {
+        crate::generation_store::record_replacement_operation_replay(
+            runner_id,
+            "ensure-running",
+            &command,
+        )
+    };
+    write.map_err(|error| error.to_string())
 }
 
 pub(super) fn negotiate_ensure_running_operation_id(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -612,6 +612,7 @@ pub(super) fn ensure_remote_daemon(
     confirmed_no_pid_job_ids: &[uuid::Uuid],
     live_lease_expectation: Option<(&str, u32)>,
     replacement_operation_id: Option<&str>,
+    admission_fence: Option<&crate::generation_store::AdmissionFence>,
 ) -> std::result::Result<RemoteDaemon, String> {
     let mut status = remote_daemon_status(client, homeboy)?;
     probe_remote_daemon_endpoint(client, &mut status);
@@ -636,13 +637,15 @@ pub(super) fn ensure_remote_daemon(
     // carries an executable repair plan, and a plan naming a command that does
     // not exist is worse than no plan at all (#10302).
     let inspected_freshness = remote_daemon_recovery_freshness_from_status(runner_id, &status);
-    match remote_daemon_connect_action_for_runner(
+    let action = remote_daemon_connect_action_for_runner(
         previous_session,
         &status,
         configured_identity,
         runner_id,
         live_lease_expectation,
-    )? {
+    )?;
+    let action = fence_generation_admission(action, admission_fence, runner_id)?;
+    match action {
         RemoteDaemonConnectAction::Reattach => {
             let mut daemon = status.daemon.ok_or_else(|| {
                 "remote daemon reattach selected without a daemon lease".to_string()
@@ -679,6 +682,23 @@ pub(super) fn ensure_remote_daemon(
             );
         }
     }
+}
+
+pub(super) fn fence_generation_admission(
+    action: RemoteDaemonConnectAction,
+    fence: Option<&crate::generation_store::AdmissionFence>,
+    runner_id: &str,
+) -> std::result::Result<RemoteDaemonConnectAction, String> {
+    let Some(fence) = fence else {
+        return Ok(action);
+    };
+    if action == RemoteDaemonConnectAction::Reattach {
+        return Ok(action);
+    }
+    Err(format!(
+        "runner `{runner_id}` generation `{}` has {} unresolved active job(s); refusing to create or replace an admission daemon. Reattach the live generation when available, or run `homeboy runner reconcile {runner_id}` after terminal job evidence is available",
+        fence.generation, fence.active_job_count,
+    ))
 }
 
 fn journal_ensure_running_replay(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -618,6 +618,12 @@ pub(super) fn ensure_remote_daemon(
     let mut status = remote_daemon_status(client, homeboy)?;
     probe_remote_daemon_endpoint(client, &mut status);
     if let Some(lease_id) = orphan_lease_id {
+        if let Some(fence) = admission_fence {
+            return Err(format!(
+                "runner `{runner_id}` generation `{}` has {} unresolved active job(s); refusing orphan adoption before terminal job evidence is available",
+                fence.generation, fence.active_job_count,
+            ));
+        }
         if status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
             && status
                 .daemon

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -46,6 +46,78 @@ fn reads_remote_active_job_count_from_daemon_freshness() {
     assert_eq!(remote_daemon_active_jobs(&status), 2);
 }
 
+/// A lost controller tunnel must not turn durable active work into permission
+/// to start another daemon generation.
+#[cfg(unix)]
+#[test]
+fn connect_fences_two_active_jobs_before_starting_a_new_daemon_generation() {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        let ensure_running = home.path().join("ensure-running");
+        std::fs::write(
+            &daemon,
+            format!(
+                r#"#!/bin/sh
+case "$1 $2" in
+  "self identity")
+    printf '%s\n' '{{"success":true,"data":{{"version":"0.284.0","display":"homeboy 0.284.0+test"}}}}'
+    ;;
+  "daemon status")
+    printf '%s\n' '{{"success":true,"data":{{"running":false,"fresh":false,"reachable":false,"freshness":{{"active_jobs":0}}}}}}'
+    ;;
+  "daemon ensure-running")
+    : > "{}"
+    ;;
+esac
+"#,
+                ensure_running.display()
+            ),
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        server::create(
+            &serde_json::json!({ "id": "homeboy-lab", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        crate::create(
+            &serde_json::json!({
+                "id": "homeboy-lab",
+                "kind": "ssh",
+                "homeboy_path": daemon,
+            })
+            .to_string(),
+            false,
+        )
+        .expect("create runner");
+        let active = direct_ssh_session("lease-active");
+        crate::generation_store::record_job("homeboy-lab", &active, "job-a")
+            .expect("record first active job");
+        crate::generation_store::record_job("homeboy-lab", &active, "job-b")
+            .expect("record second active job");
+
+        let (report, exit_code) = connect("homeboy-lab").expect("connect result");
+
+        assert_eq!(exit_code, 20);
+        assert!(!report.connected);
+        assert!(report
+            .failure_message
+            .as_deref()
+            .is_some_and(|message| message.contains("2 unresolved active job(s)")));
+        assert!(
+            !ensure_running.exists(),
+            "active generation fence must prevent daemon ensure-running"
+        );
+        let generations = crate::generation_store::status_projection("homeboy-lab", Some(&active))
+            .expect("generation projection");
+        assert_eq!(generations.len(), 1);
+        assert_eq!(generations[0].active_job_count, 2);
+    });
+}
+
 #[test]
 fn reattaches_active_daemon_without_changing_lease_or_pid() {
     let session = direct_ssh_session("lease-active");
@@ -1785,6 +1857,7 @@ fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_ow
                 &[],
                 None,
                 None,
+                None,
             )
             .expect("replacement succeeds");
             assert_eq!(daemon.lease_id.as_deref(), Some("lease-new"));
@@ -1815,6 +1888,7 @@ fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
                 &[],
                 None,
                 None,
+                None,
             )
             .expect_err("concurrent stale daemon is refused");
             assert!(error.contains("ownership changed"));
@@ -1837,6 +1911,7 @@ fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
                 configured_identity,
                 None,
                 &[],
+                None,
                 None,
                 None,
             )

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1858,6 +1858,7 @@ fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_ow
                 None,
                 None,
                 None,
+                false,
             )
             .expect("replacement succeeds");
             assert_eq!(daemon.lease_id.as_deref(), Some("lease-new"));
@@ -1889,6 +1890,7 @@ fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
                 None,
                 None,
                 None,
+                false,
             )
             .expect_err("concurrent stale daemon is refused");
             assert!(error.contains("ownership changed"));
@@ -1914,6 +1916,7 @@ fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
                 None,
                 None,
                 None,
+                false,
             )
             .expect_err("stale replacement identity is refused");
             assert!(error.contains("does not match configured runner binary"));

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -30,6 +30,33 @@ fn first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists() {
 }
 
 #[test]
+fn unresolved_generation_fence_allows_reattach_but_rejects_new_admission() {
+    let fence = crate::generation_store::AdmissionFence {
+        generation: "lease-active".to_string(),
+        active_job_count: 2,
+    };
+
+    assert_eq!(
+        remote_daemon::fence_generation_admission(
+            RemoteDaemonConnectAction::Reattach,
+            Some(&fence),
+            "homeboy-lab",
+        )
+        .expect("live generation remains reconnectable"),
+        RemoteDaemonConnectAction::Reattach
+    );
+    let error = remote_daemon::fence_generation_admission(
+        RemoteDaemonConnectAction::Start,
+        Some(&fence),
+        "homeboy-lab",
+    )
+    .expect_err("two unresolved jobs block a new generation");
+    assert!(error.contains("generation `lease-active`"));
+    assert!(error.contains("2 unresolved active job(s)"));
+    assert!(error.contains("homeboy runner reconcile homeboy-lab"));
+}
+
+#[test]
 fn missing_daemon_state_with_active_jobs_refuses_ensure_running() {
     let status = RemoteDaemonStatus {
         daemon: None,

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -3,9 +3,14 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use chrono::Utc;
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
+use homeboy_core::process::{
+    process_identity_state_with_start_identity, process_start_identity, ProcessIdentityState,
+    ProcessStartIdentity,
+};
 use homeboy_core::server::SshClient;
 
 use crate::rolling_generation::RollingResultOwnerRetirement;
@@ -50,9 +55,15 @@ fn admission_reservation_path(runner_id: &str) -> Result<PathBuf> {
         .join("admission-mutation-reservation.json"))
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct AdmissionReservation {
     operation_id: String,
+    owner_pid: u32,
+    owner_start_identity: ProcessStartIdentity,
+    created_at: String,
+    operation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generation: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -408,14 +419,29 @@ pub(crate) fn admission_session(
 pub(crate) fn with_admission_fence<T>(
     runner_id: &str,
     legacy: Option<&RunnerSession>,
+    operation_name: &str,
     operation: impl FnOnce(Option<&AdmissionFence>) -> Result<T>,
 ) -> Result<T> {
     let (reservation, fence) = with_registry_lock(runner_id, || {
+        if let Some(reservation) = active_admission_reservation_locked(runner_id)? {
+            return Err(admission_reservation_error(runner_id, &reservation));
+        }
+        let generations = read_locked(runner_id, legacy)?;
         let reservation = AdmissionReservation {
             operation_id: uuid::Uuid::new_v4().to_string(),
+            owner_pid: std::process::id(),
+            owner_start_identity: process_start_identity(std::process::id())
+                .map_err(Error::internal_unexpected)?
+                .ok_or_else(|| {
+                    Error::internal_unexpected(
+                        "current process exited while reserving daemon mutation",
+                    )
+                })?,
+            created_at: Utc::now().to_rfc3339(),
+            operation: operation_name.to_string(),
+            generation: legacy.map(legacy_generation),
         };
         write_durable_json(&admission_reservation_path(runner_id)?, &reservation)?;
-        let generations = read_locked(runner_id, legacy)?;
         let fence = generations.as_ref().and_then(|generations| {
             generations
                 .generations
@@ -429,23 +455,91 @@ pub(crate) fn with_admission_fence<T>(
         Ok((reservation, fence))
     })?;
     let result = operation(fence.as_ref());
+    let clear = clear_owned_admission_reservation(runner_id, &reservation);
+    match (result, clear) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) | (Err(error), Err(_)) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+    }
+}
+
+/// Read a reservation while holding the registry lock. A process that has
+/// exited or whose PID was reused cannot still own a remote mutation, so its
+/// durable reservation is reclaimed before a new owner proceeds.
+fn active_admission_reservation_locked(runner_id: &str) -> Result<Option<AdmissionReservation>> {
+    let path = admission_reservation_path(runner_id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let reservation: AdmissionReservation =
+        serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    match process_identity_state_with_start_identity(
+        reservation.owner_pid,
+        None,
+        Some(&reservation.owner_start_identity),
+    ) {
+        ProcessIdentityState::Dead | ProcessIdentityState::IdentityMismatch => {
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", path.display())),
+                )
+            })?;
+            Ok(None)
+        }
+        ProcessIdentityState::Live | ProcessIdentityState::Unverifiable => Ok(Some(reservation)),
+    }
+}
+
+fn clear_owned_admission_reservation(
+    runner_id: &str,
+    reservation: &AdmissionReservation,
+) -> Result<()> {
     with_registry_lock(runner_id, || {
         let path = admission_reservation_path(runner_id)?;
-        if path.exists()
-            && serde_json::from_slice::<AdmissionReservation>(&std::fs::read(&path).map_err(
-                |error| {
-                    Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
-                },
-            )?)
-            .ok()
-            .is_some_and(|current| current.operation_id == reservation.operation_id)
+        if !path.exists() {
+            return Ok(());
+        }
+        let current: AdmissionReservation =
+            serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+            })?)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        if current.operation_id == reservation.operation_id
+            && current.owner_pid == reservation.owner_pid
+            && current.owner_start_identity == reservation.owner_start_identity
         {
-            std::fs::remove_file(path)
-                .map_err(|error| Error::internal_io(error.to_string(), None))?;
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("remove {}", path.display())),
+                )
+            })?;
         }
         Ok(())
-    })?;
-    result
+    })
+}
+
+fn admission_reservation_error(runner_id: &str, reservation: &AdmissionReservation) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "runner_mutation_reservation",
+        format!(
+            "runner `{runner_id}` daemon mutation `{}` for generation `{}` is still owned by PID {}; retry admission after it completes or run `homeboy runner reconcile {runner_id}` to recover a dead owner",
+            reservation.operation,
+            reservation.generation.as_deref().unwrap_or("unknown"),
+            reservation.owner_pid,
+        ),
+        Some(runner_id.to_string()),
+        Some(vec![format!("homeboy runner reconcile {runner_id}")]),
+    )
+    .with_retryable(true);
+    error.details["reservation_operation"] = serde_json::json!(reservation.operation);
+    error.details["reservation_generation"] = serde_json::json!(reservation.generation);
+    error.details["reservation_created_at"] = serde_json::json!(reservation.created_at);
+    error
 }
 
 /// A recovery-created daemon is durable before a controller can authenticate
@@ -1236,13 +1330,8 @@ fn reconcile_with(
 
 pub(crate) fn record_job(runner_id: &str, session: &RunnerSession, job_id: &str) -> Result<()> {
     with_registry_lock(runner_id, || {
-        if admission_reservation_path(runner_id)?.exists() {
-            return Err(Error::validation_invalid_argument(
-                "runner",
-                "runner daemon mutation reservation is active; retry job admission after reconnect completes",
-                Some(runner_id.to_string()),
-                None,
-            ));
+        if let Some(reservation) = active_admission_reservation_locked(runner_id)? {
+            return Err(admission_reservation_error(runner_id, &reservation));
         }
         let mut generations = read_locked(runner_id, Some(session))?.unwrap_or_else(|| {
             RollingGenerations::new(legacy_generation(session), session.clone())
@@ -1571,6 +1660,127 @@ mod tests {
             last_seen_at: None,
             leaseless_recovery_evidence: None,
         }
+    }
+
+    fn reservation(
+        operation: &str,
+        pid: u32,
+        identity: ProcessStartIdentity,
+    ) -> AdmissionReservation {
+        AdmissionReservation {
+            operation_id: uuid::Uuid::new_v4().to_string(),
+            owner_pid: pid,
+            owner_start_identity: identity,
+            created_at: "2026-08-03T00:00:00Z".to_string(),
+            operation: operation.to_string(),
+            generation: Some("lease-a".to_string()),
+        }
+    }
+
+    #[test]
+    fn live_reservation_blocks_admission_with_retryable_reconcile_action() {
+        test_support::with_isolated_home(|_| {
+            let current_identity = process_start_identity(std::process::id())
+                .expect("inspect test process")
+                .expect("test process is live");
+            write_durable_json(
+                &admission_reservation_path("runner-a").expect("reservation path"),
+                &reservation("ensure_remote_daemon", std::process::id(), current_identity),
+            )
+            .expect("write live reservation");
+
+            let error = record_job("runner-a", &session("lease-a", "daemon-a", None), "job-a")
+                .expect_err("live mutation blocks admission");
+
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert_eq!(error.retryable, Some(true));
+            assert_eq!(error.details["field"], "runner_mutation_reservation");
+            assert_eq!(
+                error.details["reservation_operation"],
+                "ensure_remote_daemon"
+            );
+            assert_eq!(
+                error.details["tried"],
+                serde_json::json!(["homeboy runner reconcile runner-a"])
+            );
+        });
+    }
+
+    #[test]
+    fn failed_mutation_clears_its_owned_reservation_before_returning() {
+        test_support::with_isolated_home(|_| {
+            let error = with_admission_fence("runner-a", None, "ensure_remote_daemon", |_| {
+                Err::<(), _>(Error::internal_unexpected("remote mutation failed"))
+            })
+            .expect_err("operation failure is returned");
+            assert_eq!(error.message, "remote mutation failed");
+            assert!(
+                !admission_reservation_path("runner-a")
+                    .expect("reservation path")
+                    .exists(),
+                "an error path must not strand its reservation"
+            );
+            record_job("runner-a", &session("lease-a", "daemon-a", None), "job-a")
+                .expect("admission proceeds after failed mutation cleanup");
+        });
+    }
+
+    #[test]
+    fn concurrent_admission_observes_mutation_reservation_without_waiting_for_remote_work() {
+        test_support::with_isolated_home(|_| {
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let holder_barrier = std::sync::Arc::clone(&barrier);
+            let holder = std::thread::spawn(move || {
+                with_admission_fence("runner-a", None, "ensure_remote_daemon", |_| {
+                    holder_barrier.wait();
+                    holder_barrier.wait();
+                    Ok(())
+                })
+            });
+
+            barrier.wait();
+            let error = record_job("runner-a", &session("lease-a", "daemon-a", None), "job-a")
+                .expect_err("admission races a durable mutation reservation");
+            assert_eq!(error.retryable, Some(true));
+            assert_eq!(
+                error.details["reservation_operation"],
+                "ensure_remote_daemon"
+            );
+            barrier.wait();
+            holder
+                .join()
+                .expect("mutation owner thread")
+                .expect("mutation succeeds");
+            record_job("runner-a", &session("lease-a", "daemon-a", None), "job-a")
+                .expect("admission succeeds after reservation release");
+        });
+    }
+
+    #[test]
+    fn dead_reservation_is_reclaimed_before_admission() {
+        test_support::with_isolated_home(|_| {
+            let mut owner = std::process::Command::new("sh")
+                .args(["-c", "sleep 60"])
+                .spawn()
+                .expect("start reservation owner");
+            let identity = process_start_identity(owner.id())
+                .expect("inspect child")
+                .expect("child is live");
+            owner.kill().expect("stop reservation owner");
+            owner.wait().expect("reap reservation owner");
+            write_durable_json(
+                &admission_reservation_path("runner-a").expect("reservation path"),
+                &reservation("recover_missing_lease_state", owner.id(), identity),
+            )
+            .expect("write dead reservation");
+
+            record_job("runner-a", &session("lease-a", "daemon-a", None), "job-a")
+                .expect("dead owner reservation is reclaimed");
+
+            assert!(!admission_reservation_path("runner-a")
+                .expect("reservation path")
+                .exists());
+        });
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -44,6 +44,17 @@ fn replacement_operation_path(runner_id: &str) -> Result<PathBuf> {
         .join("replacement-operation.json"))
 }
 
+fn admission_reservation_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(paths::runner_sessions_dir()?
+        .join(runner_id)
+        .join("admission-mutation-reservation.json"))
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AdmissionReservation {
+    operation_id: String,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 struct ReplacementOperation {
     runner_id: String,
@@ -391,16 +402,19 @@ pub(crate) fn admission_session(
     }))
 }
 
-/// Serialize a daemon-creating or replacement mutation with job admission.
-/// The callback runs while the registry lock is held, so a concurrent
-/// `record_job` cannot make a previously idle generation active after the
-/// final fence observation and before the remote mutation begins.
+/// Reserve daemon mutation under the registry lock, then release it for remote
+/// I/O. Job admission observes the durable reservation and fails closed until
+/// the mutation completes or its reservation is cleared.
 pub(crate) fn with_admission_fence<T>(
     runner_id: &str,
     legacy: Option<&RunnerSession>,
     operation: impl FnOnce(Option<&AdmissionFence>) -> Result<T>,
 ) -> Result<T> {
-    with_registry_lock(runner_id, || {
+    let (reservation, fence) = with_registry_lock(runner_id, || {
+        let reservation = AdmissionReservation {
+            operation_id: uuid::Uuid::new_v4().to_string(),
+        };
+        write_durable_json(&admission_reservation_path(runner_id)?, &reservation)?;
         let generations = read_locked(runner_id, legacy)?;
         let fence = generations.as_ref().and_then(|generations| {
             generations
@@ -412,8 +426,26 @@ pub(crate) fn with_admission_fence<T>(
                     active_job_count: entry.active_jobs,
                 })
         });
-        operation(fence.as_ref())
-    })
+        Ok((reservation, fence))
+    })?;
+    let result = operation(fence.as_ref());
+    with_registry_lock(runner_id, || {
+        let path = admission_reservation_path(runner_id)?;
+        if path.exists()
+            && serde_json::from_slice::<AdmissionReservation>(&std::fs::read(&path).map_err(
+                |error| {
+                    Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+                },
+            )?)
+            .ok()
+            .is_some_and(|current| current.operation_id == reservation.operation_id)
+        {
+            std::fs::remove_file(path)
+                .map_err(|error| Error::internal_io(error.to_string(), None))?;
+        }
+        Ok(())
+    })?;
+    result
 }
 
 /// A recovery-created daemon is durable before a controller can authenticate
@@ -1204,6 +1236,14 @@ fn reconcile_with(
 
 pub(crate) fn record_job(runner_id: &str, session: &RunnerSession, job_id: &str) -> Result<()> {
     with_registry_lock(runner_id, || {
+        if admission_reservation_path(runner_id)?.exists() {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "runner daemon mutation reservation is active; retry job admission after reconnect completes",
+                Some(runner_id.to_string()),
+                None,
+            ));
+        }
         let mut generations = read_locked(runner_id, Some(session))?.unwrap_or_else(|| {
             RollingGenerations::new(legacy_generation(session), session.clone())
         });

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -11,6 +11,12 @@ use homeboy_core::server::SshClient;
 use crate::rolling_generation::RollingResultOwnerRetirement;
 use crate::{RollingGenerations, RunnerDaemonGenerationStatus, RunnerSession};
 
+#[derive(Debug, Clone)]
+pub(crate) struct AdmissionFence {
+    pub generation: String,
+    pub active_job_count: usize,
+}
+
 /// The durable generation registry is scoped to one runner. Keep this wrapper
 /// at the state-store boundary so rolling ownership remains reusable in memory.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -382,6 +388,25 @@ pub(crate) fn admission_session(
             .generations
             .get(&generations.admission_owner)
             .map(|generation| generation.endpoint.clone())
+    }))
+}
+
+/// A nonzero persisted count remains an admission fence until that generation
+/// authoritatively reports terminal work. A reconnect may restore a tunnel to
+/// a live daemon, but cannot create or replace an admission generation past it.
+pub(crate) fn admission_fence(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+) -> Result<Option<AdmissionFence>> {
+    Ok(read(runner_id, legacy)?.and_then(|generations| {
+        generations
+            .generations
+            .iter()
+            .find(|(_, entry)| entry.active_jobs > 0)
+            .map(|(generation, entry)| AdmissionFence {
+                generation: generation.clone(),
+                active_job_count: entry.active_jobs,
+            })
     }))
 }
 

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -391,23 +391,29 @@ pub(crate) fn admission_session(
     }))
 }
 
-/// A nonzero persisted count remains an admission fence until that generation
-/// authoritatively reports terminal work. A reconnect may restore a tunnel to
-/// a live daemon, but cannot create or replace an admission generation past it.
-pub(crate) fn admission_fence(
+/// Serialize a daemon-creating or replacement mutation with job admission.
+/// The callback runs while the registry lock is held, so a concurrent
+/// `record_job` cannot make a previously idle generation active after the
+/// final fence observation and before the remote mutation begins.
+pub(crate) fn with_admission_fence<T>(
     runner_id: &str,
     legacy: Option<&RunnerSession>,
-) -> Result<Option<AdmissionFence>> {
-    Ok(read(runner_id, legacy)?.and_then(|generations| {
-        generations
-            .generations
-            .iter()
-            .find(|(_, entry)| entry.active_jobs > 0)
-            .map(|(generation, entry)| AdmissionFence {
-                generation: generation.clone(),
-                active_job_count: entry.active_jobs,
-            })
-    }))
+    operation: impl FnOnce(Option<&AdmissionFence>) -> Result<T>,
+) -> Result<T> {
+    with_registry_lock(runner_id, || {
+        let generations = read_locked(runner_id, legacy)?;
+        let fence = generations.as_ref().and_then(|generations| {
+            generations
+                .generations
+                .iter()
+                .find(|(_, entry)| entry.active_jobs > 0)
+                .map(|(generation, entry)| AdmissionFence {
+                    generation: generation.clone(),
+                    active_job_count: entry.active_jobs,
+                })
+        });
+        operation(fence.as_ref())
+    })
 }
 
 /// A recovery-created daemon is durable before a controller can authenticate
@@ -503,6 +509,24 @@ pub(crate) fn record_replacement_operation_replay(
         operation.kind = Some(kind.to_string());
         write_durable_json(&path, &operation)
     })
+}
+
+/// Update an operation journal while the caller holds this runner's registry
+/// lock through [`with_admission_fence`].
+pub(crate) fn record_replacement_operation_replay_locked(
+    runner_id: &str,
+    kind: &str,
+    command: &str,
+) -> Result<()> {
+    let path = replacement_operation_path(runner_id)?;
+    let mut operation: ReplacementOperation =
+        serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+        })?)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    operation.replay_command = Some(command.to_string());
+    operation.kind = Some(kind.to_string());
+    write_durable_json(&path, &operation)
 }
 
 pub(crate) fn record_pending_replacement(runner_id: &str, session: &RunnerSession) -> Result<()> {

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -631,9 +631,9 @@ impl RunnerGenerationLedgerSummary {
 /// (#9478/#9522): `runner status` embedded every draining daemon generation
 /// with full owner counts, and non-authoritative per-generation
 /// `active_job_count` values made stale ownership look like current load. This
-/// summary is derived only from the authoritative selected-daemon state plus a
-/// bounded count of draining generations, so it stays small and fast no matter
-/// how much history accumulates. The full generation list remains available
+/// summary is derived from selected-daemon state plus unresolved draining
+/// ownership, so it stays small and fast without hiding work that can still
+/// mutate shared runner resources. The full generation list remains available
 /// behind an explicit detail view.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunnerAdmissionSummary {
@@ -654,8 +654,10 @@ pub struct RunnerAdmissionSummary {
     /// The exact build identity of the selected daemon, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daemon_build_identity: Option<String>,
-    /// Number of historical draining generations, summarized rather than
-    /// expanded. Never presented as active load.
+    /// The unresolved non-admission generation that currently fences new work.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_generation: Option<String>,
+    /// Number of draining generations, summarized rather than expanded.
     pub draining_generation_count: usize,
     /// Whether it is safe to rotate the runner now — true only when no
     /// authoritative current job is active on the selected daemon.
@@ -677,17 +679,38 @@ impl RunnerStatusReport {
     /// `draining_generation_count` is supplied by the caller from the same
     /// generation inventory used for the detail view, so the summary and detail
     /// derive from one source. Only the authoritative selected-daemon
-    /// `active_job_count` drives `active_job_count`/`safe_to_rotate` — historical
-    /// per-generation counts (non-authoritative) never contribute.
+    /// `active_job_count` and `safe_to_rotate` include unresolved generation
+    /// ownership when the caller supplies the ledger projection.
     pub fn admission_summary(&self, draining_generation_count: usize) -> RunnerAdmissionSummary {
+        self.admission_summary_with_generations(&[], draining_generation_count)
+    }
+
+    /// Include unresolved draining generations in the headline safety state.
+    /// Their persisted counts are conservative ownership claims, not merely
+    /// historical load, so changing admission owner cannot erase them.
+    pub fn admission_summary_with_generations(
+        &self,
+        generations: &[RunnerDaemonGenerationStatus],
+        draining_generation_count: usize,
+    ) -> RunnerAdmissionSummary {
         let connected = self.is_connected();
         let daemon_fresh = self.stale_daemon.is_none();
-        let active_job_count = self.active_job_count;
+        let blocking_generation = generations
+            .iter()
+            .find(|generation| !generation.admission_owner && generation.active_job_count > 0)
+            .map(|generation| generation.generation.clone());
+        let unresolved_generation_jobs = generations
+            .iter()
+            .filter(|generation| !generation.admission_owner)
+            .map(|generation| generation.active_job_count)
+            .sum::<usize>();
+        let active_job_count = self.active_job_count + unresolved_generation_jobs;
         // A persisted session proves neither current daemon liveness nor its
         // active-job count. Admission and rotation remain fail-closed until a
         // current job view is available.
         let active_jobs_available = self.active_job_state == RunnerActiveJobState::Available;
-        let accepting_jobs = connected && daemon_fresh && active_jobs_available;
+        let accepting_jobs =
+            connected && daemon_fresh && active_jobs_available && blocking_generation.is_none();
         let safe_to_rotate = active_jobs_available && active_job_count == 0;
         let daemon_build_identity = self
             .session
@@ -700,6 +723,8 @@ impl RunnerStatusReport {
             Some("homeboy runner refresh-homeboy --reconnect".to_string())
         } else if !active_jobs_available {
             Some("homeboy runner status --full".to_string())
+        } else if blocking_generation.is_some() {
+            Some(format!("homeboy runner reconcile {}", self.runner_id))
         } else if active_job_count > 0 {
             None
         } else {
@@ -714,6 +739,7 @@ impl RunnerStatusReport {
             active_job_count,
             stale_job_count: self.stale_runner_job_count,
             daemon_build_identity,
+            blocking_generation,
             draining_generation_count,
             safe_to_rotate,
             next_action,
@@ -1019,6 +1045,55 @@ mod status_serialization_tests {
             "draining history is not current load"
         );
         assert!(summary.safe_to_rotate);
+    }
+
+    #[test]
+    fn admission_summary_keeps_unresolved_draining_generation_work_visible() {
+        let mut report = base_report();
+        report.active_job_state = RunnerActiveJobState::Available;
+        let generations = vec![
+            RunnerDaemonGenerationStatus {
+                generation: "lease-active".to_string(),
+                admission_owner: false,
+                drain_state: crate::RollingDrainState::Draining,
+                active_job_count: 2,
+                observed_active_job_count: Some(2),
+                active_job_count_authoritative: true,
+                job_owner_count: 2,
+                run_owner_count: 0,
+                artifact_owner_count: 0,
+                homeboy_build_identity: None,
+                remote_daemon_lease_id: Some("lease-active".to_string()),
+                remote_daemon_address: None,
+                local_url: None,
+            },
+            RunnerDaemonGenerationStatus {
+                generation: "lease-new".to_string(),
+                admission_owner: true,
+                drain_state: crate::RollingDrainState::Admitting,
+                active_job_count: 0,
+                observed_active_job_count: Some(0),
+                active_job_count_authoritative: true,
+                job_owner_count: 0,
+                run_owner_count: 0,
+                artifact_owner_count: 0,
+                homeboy_build_identity: None,
+                remote_daemon_lease_id: Some("lease-new".to_string()),
+                remote_daemon_address: None,
+                local_url: None,
+            },
+        ];
+
+        let summary = report.admission_summary_with_generations(&generations, 1);
+
+        assert_eq!(summary.active_job_count, 2);
+        assert_eq!(summary.blocking_generation.as_deref(), Some("lease-active"));
+        assert!(!summary.accepting_jobs);
+        assert!(!summary.safe_to_rotate);
+        assert_eq!(
+            summary.next_action.as_deref(),
+            Some("homeboy runner reconcile homeboy-lab")
+        );
     }
 }
 

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -894,7 +894,6 @@ mod status_serialization_tests {
     fn admission_summary_fresh_idle_accepts_and_is_safe_to_rotate() {
         let mut report = base_report();
         report.active_job_state = RunnerActiveJobState::Available;
-        report.active_job_count = 2;
         let summary = report.admission_summary(0);
         assert!(summary.connected);
         assert!(summary.daemon_fresh);

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -699,12 +699,10 @@ impl RunnerStatusReport {
             .iter()
             .find(|generation| !generation.admission_owner && generation.active_job_count > 0)
             .map(|generation| generation.generation.clone());
-        let unresolved_generation_jobs = generations
-            .iter()
-            .filter(|generation| !generation.admission_owner)
-            .map(|generation| generation.active_job_count)
-            .sum::<usize>();
-        let active_job_count = self.active_job_count + unresolved_generation_jobs;
+        // `connection::status` already includes unresolved draining ownership
+        // in this headline field. Reusing it avoids counting the same ledger
+        // entries once here and once in the connection projection.
+        let active_job_count = self.active_job_count;
         // A persisted session proves neither current daemon liveness nor its
         // active-job count. Admission and rotation remain fail-closed until a
         // current job view is available.
@@ -896,6 +894,7 @@ mod status_serialization_tests {
     fn admission_summary_fresh_idle_accepts_and_is_safe_to_rotate() {
         let mut report = base_report();
         report.active_job_state = RunnerActiveJobState::Available;
+        report.active_job_count = 2;
         let summary = report.admission_summary(0);
         assert!(summary.connected);
         assert!(summary.daemon_fresh);
@@ -1051,6 +1050,7 @@ mod status_serialization_tests {
     fn admission_summary_keeps_unresolved_draining_generation_work_visible() {
         let mut report = base_report();
         report.active_job_state = RunnerActiveJobState::Available;
+        report.active_job_count = 2;
         let generations = vec![
             RunnerDaemonGenerationStatus {
                 generation: "lease-active".to_string(),


### PR DESCRIPTION
## Summary

- add crash-safe daemon mutation reservations
- prevent reconnect and orphan adoption from bypassing unresolved generation ownership
- aggregate generation safety into truthful status and admission decisions
- cover racing mutation, recovery, and active-generation fencing behavior

Closes #11378.

## Verification

- `cargo test -p homeboy-lab-runner connection::tests::recovery`
- `cargo test -p homeboy-lab-runner generation_store::tests`
- combined five-fix integration verification passed

## AI assistance

OpenAI gpt-5.6-sol and gpt-5.6-terra via OpenCode were used to trace generation admission behavior, implement durable fencing and regression coverage, review the branch, and run verification. Chris Huber reviewed and remains responsible for every line.