### PR TITLE
Fix exact-ref component config resolution

### DIFF
--- a/crates/homeboy-core/src/project/component/mod.rs
+++ b/crates/homeboy-core/src/project/component/mod.rs
@@ -15,6 +15,7 @@ pub use report::{
     BatchComponentAttachmentInput, BatchComponentAttachmentWorktreePolicy, ProjectComponentsOutput,
 };
 pub use resolution::{
-    resolve_project_component, resolve_project_component_with_standalone_snapshot,
-    resolve_project_components, StandaloneComponentConfigSnapshot,
+    bind_materialized_component_to_project, resolve_project_component,
+    resolve_project_component_with_standalone_snapshot, resolve_project_components,
+    StandaloneComponentConfigSnapshot,
 };

--- a/crates/homeboy-core/src/project/component/resolution.rs
+++ b/crates/homeboy-core/src/project/component/resolution.rs
@@ -18,62 +18,53 @@ pub fn resolve_project_component_with_standalone_snapshot(
     component_id: &str,
     standalone_snapshot: Option<&StandaloneComponentConfigSnapshot>,
 ) -> Result<crate::component::Component> {
-    let (
-        mut component,
-        attachment_local_path,
+    let (component, attachment_local_path, attachment_remote_path, attachment_deployment_provider) =
+        if let Some(attachment) = project
+            .components
+            .iter()
+            .find(|component| component.id == component_id)
+        {
+            super::super::validate_component_local_path(project, component_id)?;
+            crate::component::resolution::validate_duplicate_portable_component_ids(
+                component_id,
+                Path::new(&attachment.local_path),
+                None,
+            )?;
+            (
+                discover_from_portable(Path::new(&attachment.local_path)).ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "components.local_path",
+                        format!(
+                            "Project component '{}' points to '{}' but no homeboy.json was found",
+                            component_id, attachment.local_path
+                        ),
+                        Some(project.id.clone()),
+                        None,
+                    )
+                })?,
+                attachment.local_path.clone(),
+                attachment.remote_path.clone(),
+                attachment.deployment_provider.clone(),
+            )
+        } else {
+            return Err(Error::validation_invalid_argument(
+                "components",
+                format!(
+                    "Project '{}' has no attached component '{}'",
+                    project.id, component_id
+                ),
+                Some(project.id.clone()),
+                None,
+            ));
+        };
+
+    let mut resolved = bind_materialized_component_to_project(
+        component,
+        project,
+        standalone_snapshot,
         attachment_remote_path,
         attachment_deployment_provider,
-    ) = if let Some(attachment) = project
-        .components
-        .iter()
-        .find(|component| component.id == component_id)
-    {
-        super::super::validate_component_local_path(project, component_id)?;
-        crate::component::resolution::validate_duplicate_portable_component_ids(
-            component_id,
-            Path::new(&attachment.local_path),
-            None,
-        )?;
-        (
-            discover_from_portable(Path::new(&attachment.local_path)).ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "components.local_path",
-                    format!(
-                        "Project component '{}' points to '{}' but no homeboy.json was found",
-                        component_id, attachment.local_path
-                    ),
-                    Some(project.id.clone()),
-                    None,
-                )
-            })?,
-            attachment.local_path.clone(),
-            attachment.remote_path.clone(),
-            attachment.deployment_provider.clone(),
-        )
-    } else {
-        return Err(Error::validation_invalid_argument(
-            "components",
-            format!(
-                "Project '{}' has no attached component '{}'",
-                project.id, component_id
-            ),
-            Some(project.id.clone()),
-            None,
-        ));
-    };
-
-    if let Some(remote_path) = attachment_remote_path {
-        if !remote_path.trim().is_empty() {
-            component.remote_path = remote_path;
-        }
-    }
-    if attachment_deployment_provider.is_some() {
-        component.deployment_provider = attachment_deployment_provider;
-    }
-
-    apply_standalone_component_fallbacks(&mut component, standalone_snapshot);
-
-    let mut resolved = apply_component_overrides(&component, project);
+    );
     // Normalize the attachment `local_path` to an absolute path before it becomes
     // the resolved component's machine-local checkout. Deploy resolves components
     // directly through this function, while `release` reaches the same attachment
@@ -106,6 +97,27 @@ pub fn resolve_project_component_with_standalone_snapshot(
     crate::component::resolve_remote_path(&mut resolved);
 
     Ok(resolved)
+}
+
+/// Apply the project-owned layers to component configuration discovered from a
+/// materialized source tree. Exact-ref and isolated tag checkouts use this so
+/// their source-owned fields come from the selected commit while attachment and
+/// fleet/project policy keeps its normal precedence.
+pub fn bind_materialized_component_to_project(
+    mut component: crate::component::Component,
+    project: &Project,
+    standalone_snapshot: Option<&StandaloneComponentConfigSnapshot>,
+    attachment_remote_path: Option<String>,
+    attachment_deployment_provider: Option<crate::component::DeploymentProviderAttachment>,
+) -> crate::component::Component {
+    if let Some(remote_path) = attachment_remote_path.filter(|path| !path.trim().is_empty()) {
+        component.remote_path = remote_path;
+    }
+    if attachment_deployment_provider.is_some() {
+        component.deployment_provider = attachment_deployment_provider;
+    }
+    apply_standalone_component_fallbacks(&mut component, standalone_snapshot);
+    apply_component_overrides(&component, project)
 }
 
 fn apply_standalone_component_fallbacks(
@@ -216,8 +228,10 @@ pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::compon
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::component::Component;
     use crate::project::{ProjectComponentAttachment, ProjectComponentOverrides};
     use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
     use tempfile::TempDir;
 
     fn repo_with_portable_remote_path(remote_path: &str) -> TempDir {
@@ -356,6 +370,79 @@ mod tests {
                 Some("custom-extract {{artifact}}")
             );
         });
+    }
+
+    #[test]
+    fn materialized_source_binding_reapplies_all_explicit_project_overrides() {
+        let source = Component {
+            id: "fixture".to_string(),
+            remote_path: "source/path".to_string(),
+            build_artifact: Some("source.zip".to_string()),
+            extract_command: Some("source-extract".to_string()),
+            hooks: HashMap::from([("post:deploy".to_string(), vec!["source-hook".to_string()])]),
+            scopes: Some(crate::component::ScopeConfig::default()),
+            artifact_inputs: vec![crate::component::ArtifactInput {
+                component: "source".to_string(),
+                artifact: "source.zip".to_string(),
+                target: "vendor".to_string(),
+                sha256: None,
+            }],
+            cli_path: Some("source-cli".to_string()),
+            ..Component::default()
+        };
+        let project = Project {
+            id: "site".to_string(),
+            component_overrides: HashMap::from([(
+                "fixture".to_string(),
+                ProjectComponentOverrides {
+                    build_artifact: Some("project.zip".to_string()),
+                    extract_command: Some("project-extract".to_string()),
+                    hooks: HashMap::from([(
+                        "post:deploy".to_string(),
+                        vec!["project-hook".to_string()],
+                    )]),
+                    scopes: Some(crate::component::ScopeConfig {
+                        deploy: Some(crate::component::CommandScopeConfig {
+                            exclude: vec!["project-only".to_string()],
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    artifact_inputs: vec![crate::component::ArtifactInput {
+                        component: "project".to_string(),
+                        artifact: "project.zip".to_string(),
+                        target: "vendor".to_string(),
+                        sha256: None,
+                    }],
+                    cli_path: Some("project-cli".to_string()),
+                    ..ProjectComponentOverrides::default()
+                },
+            )]),
+            ..Project::default()
+        };
+
+        let bound = bind_materialized_component_to_project(
+            source,
+            &project,
+            None,
+            Some("project/path".to_string()),
+            None,
+        );
+
+        assert_eq!(bound.remote_path, "project/path");
+        assert_eq!(bound.build_artifact.as_deref(), Some("project.zip"));
+        assert_eq!(bound.extract_command.as_deref(), Some("project-extract"));
+        assert_eq!(bound.hooks["post:deploy"], ["project-hook"]);
+        assert_eq!(
+            bound
+                .scopes
+                .as_ref()
+                .and_then(|scopes| scopes.deploy.as_ref())
+                .map(|scope| scope.exclude.as_slice()),
+            Some(["project-only".to_string()].as_slice())
+        );
+        assert_eq!(bound.artifact_inputs[0].component, "project");
+        assert_eq!(bound.cli_path.as_deref(), Some("project-cli"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -22,14 +22,15 @@ mod types;
 
 pub use component::{
     apply_component_overrides, attach_component_path, attach_component_path_report,
-    attach_component_paths_report, attach_discovered_component_path, clear_component_attachments,
-    clear_components, has_component, list_components, project_component_ids,
-    rebase_monorepo_component_paths, remove_components, remove_components_report,
-    resolve_project_component, resolve_project_component_with_standalone_snapshot,
-    resolve_project_components, set_component_attachments, set_components,
-    BatchComponentAttachmentFailurePolicy, BatchComponentAttachmentInput,
-    BatchComponentAttachmentWorktreePolicy, MonorepoComponentPathChange,
-    MonorepoComponentPathStatus, ProjectComponentsOutput, StandaloneComponentConfigSnapshot,
+    attach_component_paths_report, attach_discovered_component_path,
+    bind_materialized_component_to_project, clear_component_attachments, clear_components,
+    has_component, list_components, project_component_ids, rebase_monorepo_component_paths,
+    remove_components, remove_components_report, resolve_project_component,
+    resolve_project_component_with_standalone_snapshot, resolve_project_components,
+    set_component_attachments, set_components, BatchComponentAttachmentFailurePolicy,
+    BatchComponentAttachmentInput, BatchComponentAttachmentWorktreePolicy,
+    MonorepoComponentPathChange, MonorepoComponentPathStatus, ProjectComponentsOutput,
+    StandaloneComponentConfigSnapshot,
 };
 pub use effective_remote_path::{
     component_remote_path, project_with_detected_path_roots, resolve_effective_remote_path,

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -169,6 +169,7 @@ pub(super) fn deploy_components(
                                 component,
                                 requested_ref,
                                 config.resolved_ref_for(&component.id),
+                                Some(&project),
                             )
                         })
                 })
@@ -337,6 +338,7 @@ pub(super) fn deploy_components(
                     &entry.component,
                     &requested_ref,
                     resolved_sha.as_deref(),
+                    Some(&project),
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -2251,7 +2253,7 @@ mod tests {
                 "fixture-packager".to_string(),
                 homeboy_core::component::ScopedExtensionConfig::default(),
             )]));
-            let checkout = ExactRefCheckout::materialize(&component, "requested", None)
+            let checkout = ExactRefCheckout::materialize(&component, "requested", None, None)
                 .expect("materialize requested ref");
             checkout.verify().expect("verify requested ref");
 
@@ -2287,6 +2289,158 @@ mod tests {
                 requested_sha
             );
         });
+    }
+
+    #[test]
+    fn exact_ref_preparation_preserves_duplicate_source_version_target_artifact_paths() {
+        let repo = TempDir::new().expect("repo");
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+        run_git(repo.path(), &["config", "user.name", "Test"]);
+        std::fs::create_dir_all(repo.path().join("source")).expect("source directory");
+        std::fs::write(
+            repo.path().join("source/plugin.txt"),
+            "PluginVersion: 1.2.3\nPluginRelease: 1.2.3\n",
+        )
+        .expect("plugin source");
+        std::fs::write(
+            repo.path().join("source/release-set.txt"),
+            "SetVersion: 1.2.3\nSetRelease: 1.2.3\nSetManifest: 1.2.3\n",
+        )
+        .expect("release-set source");
+        let version_targets = |artifact_paths: bool| {
+            serde_json::json!([
+                {"file": "source/plugin.txt", "pattern": "PluginVersion: ([0-9.]+)", "artifact_path": artifact_paths.then_some("wp-build.php")},
+                {"file": "source/plugin.txt", "pattern": "PluginRelease: ([0-9.]+)", "artifact_path": artifact_paths.then_some("wp-build.php")},
+                {"file": "source/release-set.txt", "pattern": "SetVersion: ([0-9.]+)", "artifact_path": artifact_paths.then_some("shared/release-set.json")},
+                {"file": "source/release-set.txt", "pattern": "SetRelease: ([0-9.]+)", "artifact_path": artifact_paths.then_some("shared/release-set.json")},
+                {"file": "source/release-set.txt", "pattern": "SetManifest: ([0-9.]+)", "artifact_path": artifact_paths.then_some("shared/release-set.json")},
+            ])
+        };
+        let write_config = |artifact_paths| {
+            std::fs::write(
+                repo.path().join("homeboy.json"),
+                serde_json::json!({
+                    "id": "fixture",
+                    "build_artifact": "build/fixture.zip",
+                    "extract_command": if artifact_paths { "source-extract {{artifact}}" } else { "stale-extract {{artifact}}" },
+                    "scripts": {"build": ["mkdir -p build/stage/shared && cp source/plugin.txt build/stage/wp-build.php && cp source/release-set.txt build/stage/shared/release-set.json && (cd build/stage && zip -qr ../fixture.zip .)"]},
+                    "version_targets": version_targets(artifact_paths),
+                })
+                .to_string(),
+            )
+            .expect("portable config");
+        };
+        write_config(false);
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-q", "-m", "configured"]);
+        let configured = git_stdout(repo.path(), &["rev-parse", "HEAD"]);
+        write_config(true);
+        run_git(repo.path(), &["commit", "-am", "requested", "-q"]);
+        run_git(repo.path(), &["branch", "requested"]);
+        run_git(repo.path(), &["checkout", "-q", &configured]);
+
+        let project = Project {
+            id: "site".to_string(),
+            components: vec![ProjectComponentAttachment {
+                id: "fixture".to_string(),
+                local_path: repo.path().display().to_string(),
+                remote_path: Some("plugins/fixture".to_string()),
+                ..ProjectComponentAttachment::default()
+            }],
+            component_overrides: HashMap::from([(
+                "fixture".to_string(),
+                homeboy_core::component::ComponentOverrideConfig {
+                    build_artifact: Some("build/fixture.zip".to_string()),
+                    extract_command: Some("project-extract {{artifact}}".to_string()),
+                    hooks: HashMap::from([(
+                        "post:deploy".to_string(),
+                        vec!["project-hook".to_string()],
+                    )]),
+                    scopes: Some(homeboy_core::component::ScopeConfig {
+                        deploy: Some(homeboy_core::component::CommandScopeConfig {
+                            exclude: vec!["project-only".to_string()],
+                            ..homeboy_core::component::CommandScopeConfig::default()
+                        }),
+                        ..homeboy_core::component::ScopeConfig::default()
+                    }),
+                    cli_path: Some("project-cli".to_string()),
+                    ..homeboy_core::component::ComponentOverrideConfig::default()
+                },
+            )]),
+            ..Project::default()
+        };
+        let component = homeboy_core::project::resolve_project_component(&project, "fixture")
+            .expect("resolve inline project attachment");
+        assert!(component
+            .version_targets
+            .as_ref()
+            .expect("configured targets")
+            .iter()
+            .all(|target| target.artifact_path.is_none()));
+
+        let checkout = ExactRefCheckout::materialize(&component, "requested", None, Some(&project))
+            .expect("materialize requested ref");
+        assert_eq!(checkout.component.remote_path, "plugins/fixture");
+        assert_eq!(
+            checkout.component.extract_command.as_deref(),
+            Some("project-extract {{artifact}}")
+        );
+        assert_eq!(
+            checkout.component.build_artifact.as_deref(),
+            Some("build/fixture.zip")
+        );
+        assert_eq!(
+            checkout.component.hooks.get("post:deploy"),
+            Some(&vec!["project-hook".to_string()])
+        );
+        assert_eq!(checkout.component.cli_path.as_deref(), Some("project-cli"));
+        assert_eq!(
+            checkout
+                .component
+                .scopes
+                .as_ref()
+                .and_then(|scopes| scopes.deploy.as_ref())
+                .map(|scope| scope.exclude.as_slice()),
+            Some(["project-only".to_string()].as_slice())
+        );
+        assert_eq!(
+            checkout
+                .component
+                .scripts
+                .as_ref()
+                .map(|scripts| scripts.build.len()),
+            Some(1)
+        );
+        let mut config = base_deploy_config();
+        config.requested_ref = Some("requested".to_string());
+        config.force = true;
+        let local_versions = HashMap::from([("fixture".to_string(), "1.2.3".to_string())]);
+        let prepared = prepare_component_deployments(
+            &[checkout.component.clone()],
+            &config,
+            &project,
+            "/srv/site",
+            &local_versions,
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .expect("every mapped version target must pass exact-ref ZIP preflight");
+
+        let targets = prepared[0]
+            .component
+            .version_targets
+            .as_deref()
+            .expect("version targets");
+        assert_eq!(targets.len(), 5);
+        assert_eq!(targets[0].artifact_path.as_deref(), Some("wp-build.php"));
+        assert_eq!(targets[1].artifact_path.as_deref(), Some("wp-build.php"));
+        for target in &targets[2..] {
+            assert_eq!(
+                target.artifact_path.as_deref(),
+                Some("shared/release-set.json")
+            );
+        }
     }
 
     #[test]
@@ -2362,7 +2516,7 @@ mod tests {
             }),
             ..Component::default()
         };
-        let checkout = ExactRefCheckout::materialize(&component, "target", None)
+        let checkout = ExactRefCheckout::materialize(&component, "target", None, None)
             .expect("materialize target ref");
         checkout.verify().expect("verify target ref");
         if let Some(barrier) = barrier {

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -88,6 +88,7 @@ impl ExactRefCheckout {
         component: &Component,
         requested_ref: &str,
         accepted_sha: Option<&str>,
+        project: Option<&homeboy_core::project::Project>,
     ) -> Result<Self> {
         let source_root = source_root(component)?;
         let identity = match accepted_sha {
@@ -152,6 +153,48 @@ impl ExactRefCheckout {
                 &materialized_path,
             )
         });
+        if let Some(mut source_config) =
+            homeboy_core::component::try_discover_from_portable(&materialized_path)?
+        {
+            // Source-owned configuration must match the selected commit.
+            source_config.id = materialized.id.clone();
+            source_config.local_path = materialized.local_path.clone();
+            source_config.build_artifact =
+                source_config.build_artifact.as_deref().map(|artifact| {
+                    rebase_source_path(
+                        artifact,
+                        Path::new(&component.local_path),
+                        &materialized_path,
+                    )
+                });
+            materialized = match project {
+                Some(project) => {
+                    let attachment = project
+                        .components
+                        .iter()
+                        .find(|attachment| attachment.id == component.id)
+                        .ok_or_else(|| {
+                            Error::validation_invalid_argument(
+                                "components",
+                                format!(
+                                    "Project '{}' has no attached component '{}'",
+                                    project.id, component.id
+                                ),
+                                Some(project.id.clone()),
+                                None,
+                            )
+                        })?;
+                    homeboy_core::project::bind_materialized_component_to_project(
+                        source_config,
+                        project,
+                        None,
+                        attachment.remote_path.clone(),
+                        attachment.deployment_provider.clone(),
+                    )
+                }
+                None => source_config,
+            };
+        }
         Ok(Self {
             component: materialized,
             identity,
@@ -765,7 +808,7 @@ mod tests {
         assert_ne!(accepted_sha, checkout_head);
 
         let worktree_path = {
-            let checkout = ExactRefCheckout::materialize(&component, "accepted", None)
+            let checkout = ExactRefCheckout::materialize(&component, "accepted", None, None)
                 .expect("materialize accepted branch");
             assert_eq!(checkout.identity.resolved_sha, accepted_sha);
             assert_eq!(
@@ -837,7 +880,7 @@ mod tests {
         let named_head = git_output(&named_checkout, &["rev-parse", "HEAD"]);
         let named_index = git_output(&named_checkout, &["write-tree"]);
         let named_state = materialization_source_state(&named_checkout);
-        let checkout = ExactRefCheckout::materialize(&named_component, "accepted", None)
+        let checkout = ExactRefCheckout::materialize(&named_component, "accepted", None, None)
             .expect("fetch and materialize named remote ref");
         assert_eq!(checkout.identity.resolved_sha, fixture.target_sha);
         assert_eq!(checkout.identity.resolution_mode, "remote_named_ref");
@@ -897,7 +940,7 @@ mod tests {
         assert_ne!(accepted_sha, moved_sha);
 
         let materialized =
-            ExactRefCheckout::materialize(&component, "accepted", Some(&accepted_sha))
+            ExactRefCheckout::materialize(&component, "accepted", Some(&accepted_sha), None)
                 .expect("materialize preflighted commit");
         assert_eq!(materialized.identity.resolved_sha, accepted_sha);
         assert_eq!(
@@ -939,7 +982,7 @@ mod tests {
         git(repo.path(), &["add", "other.txt"]);
         commit(repo.path(), "other commit");
         let other_sha = git_output(repo.path(), &["rev-parse", "HEAD"]);
-        let checkout = ExactRefCheckout::materialize(&component, "accepted", None)
+        let checkout = ExactRefCheckout::materialize(&component, "accepted", None, None)
             .expect("materialize accepted branch");
         git(
             Path::new(&checkout.component.local_path),
@@ -967,7 +1010,7 @@ mod tests {
         let component = fixture_component(repo.path());
 
         let temporary_path = {
-            let checkout = ExactRefCheckout::materialize(&component, "HEAD", None)
+            let checkout = ExactRefCheckout::materialize(&component, "HEAD", None, None)
                 .expect("materialize exact ref");
             let temporary_path = PathBuf::from(&checkout.component.local_path);
             let error = checkout
@@ -1000,7 +1043,7 @@ mod tests {
         commit(repo.path(), "add failing provider");
         let component = fixture_component(repo.path());
         let checkout =
-            ExactRefCheckout::materialize(&component, "HEAD", None).expect("materialize");
+            ExactRefCheckout::materialize(&component, "HEAD", None, None).expect("materialize");
 
         assert!(checkout
             .hydrate_dependencies(true)
@@ -1019,7 +1062,7 @@ mod tests {
             ),
         }];
         let checkout =
-            ExactRefCheckout::materialize(&component, "HEAD", None).expect("materialize");
+            ExactRefCheckout::materialize(&component, "HEAD", None, None).expect("materialize");
 
         checkout
             .reconstruct_package_artifacts()
@@ -1044,7 +1087,7 @@ mod tests {
             reconstruct_command: None,
         }];
         let checkout =
-            ExactRefCheckout::materialize(&component, "HEAD", None).expect("materialize");
+            ExactRefCheckout::materialize(&component, "HEAD", None, None).expect("materialize");
 
         let error = checkout
             .reconstruct_package_artifacts()

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -432,7 +432,7 @@ fn prepare_payload(
         .config
         .requested_ref
         .as_deref()
-        .map(|reference| ExactRefCheckout::materialize(&component, reference, None))
+        .map(|reference| ExactRefCheckout::materialize(&component, reference, None, None))
         .transpose()?;
     if let Some(checkout) = checkout.as_ref() {
         checkout.verify()?;


### PR DESCRIPTION
## Summary

- load source-owned portable component configuration from detached exact-ref and isolated tag checkouts
- reapply attachment and fleet/project overrides through the existing precedence contract
- prove a stale attached checkout cannot replace selected-ref version targets, artifact paths, scripts, or packaging configuration
- preserve explicit project build, extraction, hook, scope, artifact-input, CLI, remote-path, and provider overrides

Fixes #11384.

## Verification

- `cargo test -p homeboy-deploy exact_ref_preparation_preserves_duplicate_source_version_target_artifact_paths`
- `cargo test -p homeboy-core materialized_source_binding_reapplies_all_explicit_project_overrides`
- `cargo check -p homeboy-core -p homeboy-deploy`
- `cargo fmt --all -- --check`
- `git diff --check`

The combined core/deploy suite encountered unrelated existing core test failures during an earlier bounded run; focused changed-path tests and compilation pass.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the mixed-config exact-ref path, implemented selected-ref configuration hydration, and added regression coverage. Chris Huber reviewed and remains responsible for every line.