### PR TITLE
Settle the pre-provider recipe correction contract

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3262,10 +3262,28 @@ fn cook_transport_preparation_failure_does_not_exhaust_cook_retries() {
         options.initial_run_id = "cook-runner-exhaustion-attempt-1".to_string();
         options.max_attempts = 2;
 
-        let error = run_cook(options, UnusedExecutor)
-            .expect_err("transport preparation remains outside cook retries");
+        // A cook that already owns a durable recipe reports its failure through
+        // the normal result contract rather than an opaque `Err`. That is what
+        // `durable_cook_error_report` exists for: the caller needs the cook id
+        // and its legal recovery actions, and a bare error carries neither.
+        // The invariant this test is named for — transport preparation not
+        // consuming provider budget — is asserted below and is unaffected.
+        let reported = run_cook(options, UnusedExecutor)
+            .expect("durable transport failure is reported, not raised");
 
-        assert!(error.message.contains("fixture runner is unavailable"));
+        assert_eq!(reported.value.status, "durable_failure");
+        let diagnostic = reported
+            .value
+            .failure_context
+            .as_ref()
+            .and_then(|context| context.diagnostic.as_ref())
+            .expect("durable failure carries its diagnostic");
+        assert!(
+            diagnostic
+                .to_string()
+                .contains("fixture runner is unavailable"),
+            "transport failure must stay legible: {diagnostic}"
+        );
         let record = agent_task_lifecycle::status("cook-runner-exhaustion")
             .expect("transport failure remains inspectable");
         assert_eq!(
@@ -3741,7 +3759,7 @@ fn cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_compl
 }
 
 #[test]
-fn orphaned_recipe_materializes_once_and_rejects_changed_inputs() {
+fn orphaned_recipe_materializes_once_and_accepts_pre_provider_corrections() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-orphan-recovery";
         let run_id = "cook-orphan-recovery-attempt-1";
@@ -3769,14 +3787,26 @@ fn orphaned_recipe_materializes_once_and_rejects_changed_inputs() {
         let replayed = run_cook(options.clone(), UnusedExecutor).expect("idempotent replay");
         assert_eq!(replayed.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
-        assert_eq!(agent_task_lifecycle::status(run_id).unwrap(), record);
+        // Compare the fields replay must not disturb rather than the whole
+        // record: a replay re-observes runner handoff state, which moves a
+        // heartbeat timestamp inside `metadata`. Not dispatching again is the
+        // property that matters, and it is asserted above.
+        let after_replay = agent_task_lifecycle::status(run_id).expect("record after replay");
+        assert_eq!(after_replay.run_id, record.run_id);
+        assert_eq!(after_replay.state, record.state);
+        assert_eq!(after_replay.runner_job_id(), record.runner_job_id());
+        assert_eq!(after_replay.submitted_at, record.submitted_at);
 
+        // `title` is frozen only at the finalization boundary, and this cook has
+        // reached provider dispatch. Correcting it before a PR exists is exactly
+        // the pre-provider correction the freeze model permits, so it is accepted
+        // and must not re-dispatch the provider.
         let mut changed = options;
-        changed.title = "changed immutable finalization title".to_string();
-        let error = run_cook(changed, UnusedExecutor).expect_err("changed recipe rejected");
-        assert!(error
-            .message
-            .contains("durable cook recipe already exists with different execution inputs"));
+        changed.title = "changed pre-finalization title".to_string();
+        let corrected =
+            run_cook(changed, UnusedExecutor).expect("pre-provider correction accepted");
+        assert_eq!(corrected.value.status, "in_flight");
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     });
 }
 


### PR DESCRIPTION
Refs #11383. You asked me to make the call, so this PR is the decision plus the code.

## The situation

`6d0495a7e` (`fix(cook): allow pre-provider recipe corrections`, 2026-07-24) changed two Cook contracts and left the tests encoding the old ones. Main has been red on them for ten days.

Established by automated bisect over the 259-commit window between a passing tree 10 days ago (`2ba66bd74`) and a failing tree 9 days ago (`d57893d13`):

```
6d0495a7ef09e2bec91cdaa8beaade42e0596914 is the first bad commit
    fix(cook): allow pre-provider recipe corrections
```

**Both behavior changes are correct. The tests are what needed to move.** Here is the reasoning, since that was the open question.

## Decision 1 — a durable failure is reported, not raised

Once a Cook owns a durable recipe, `durable_cook_error_report` converts a post-materialization error into the normal result contract instead of propagating `Err`. `6d0495a7e` makes a recipe exist in more situations, so more failures take that path.

**Keeping the conversion.** A bare `Err` carries no cook id and no legal recovery actions — exactly what an orchestrator needs in order to do anything but give up. The report carries both. Reverting to an opaque error to satisfy a test would make the failure *less* actionable.

Nothing is lost. The diagnostic survives verbatim:

```
failure_context.diagnostic =
  "Invalid argument 'runner': fixture runner is unavailable"
```

And the invariant the test is actually named for is untouched:

```rust
assert_eq!(record.metadata["provider_executions_consumed"], 0);
```

The `expect_err` was incidental to that. It now asserts through the report.

## Decision 2 — `title` is frozen at finalization, not at dispatch

Under `RecipeFreezeBoundary`'s derived ordering (`Provider < Candidate < Promotion < Gate < Finalization`), the guard `mismatch_freeze_boundary(field) <= reached` means a `title` correction on a Cook that has only reached provider dispatch is **deliberately permitted**.

**Keeping that too.** No PR exists yet at provider dispatch, so nothing immutable has been published — correcting the title before finalization is precisely the "pre-provider correction" the commit set out to allow. Freezing it earlier would forbid a safe, useful fix.

The test asserted the removed rejection message, so it now asserts acceptance plus the property worth protecting: **the provider is not re-dispatched**. Renamed, because `..._rejects_changed_inputs` no longer describes what it verifies.

## Also: stop comparing whole run records across a replay

That test asserted full `AgentTaskRunRecord` equality after an idempotent replay. Diffing the two records field by field, the *only* difference was a heartbeat timestamp inside `metadata`, moved by re-observing runner handoff state:

```
"updated_at": "...:27.701576787"   vs   "...:27.487901946"
```

Everything else identical, and `dispatches == 1` still held — so no duplicate provider work. It now compares the fields a replay must not disturb (`run_id`, `state`, `runner_job_id`, `submitted_at`); not re-dispatching is already asserted directly.

## Verification

- `cook_transport_preparation_failure_does_not_exhaust_cook_retries` — **ok**
- `orphaned_recipe_materializes_once_and_accepts_pre_provider_corrections` — **ok**

Both single-threaded, so not a parallelism artifact. Against the full 35-name failing set on main, this branch alone takes it from 0 to 2 passing; with #11382 the combined recovery is 13 of 35.

## What is left

22 tests. Several are the same durable-failure conversion surfacing through other paths (the Family A `aggregate.json` group in #11383), and now that the contract question is settled they can follow this pattern — but each needs its own verification rather than a blanket edit, since some may be masking real defects behind a stale assertion the way this one masked an IO error.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: bisected to the causing commit, probed the runtime values behind each failure, decided both contract questions, and updated the tests. Chris Huber remains responsible for every line.