### PR TITLE
Fix remaining deterministic Cook lifecycle regressions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1492,7 +1492,12 @@ fn run_promotion_gates(
     worktree_path: &Path,
     expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
 ) -> Result<PromotionGateRun> {
-    homeboy_core::repository_integrity::verify_tracked_symlink_portability(worktree_path, "HEAD")?;
+    if worktree_path.is_dir() {
+        homeboy_core::repository_integrity::verify_tracked_symlink_portability(
+            worktree_path,
+            "HEAD",
+        )?;
+    }
     if options.dry_run
         || (options.gates.verify.is_empty() && options.gates.private_verify.is_empty())
     {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -437,6 +437,22 @@ fn promote_exports_committed_changes_when_executor_reports_no_patch_artifact() {
     std::fs::write(repo.join("lib.rs"), "old\n").expect("write base file");
     git(&repo, &["add", "lib.rs"]);
     git(&repo, &["commit", "-m", "base"]);
+    let remote = temp.path().join("origin.git");
+    assert!(Command::new("git")
+        .args(["init", "--bare", remote.to_str().expect("remote path")])
+        .status()
+        .expect("create remote")
+        .success());
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    git(&repo, &["push", "-u", "origin", "main"]);
     let base = git_head(&repo, "HEAD");
     std::fs::write(repo.join("lib.rs"), "new\n").expect("write committed change");
     git(&repo, &["commit", "-am", "agent: committed change"]);
@@ -745,7 +761,13 @@ fn explicit_candidate_rejects_non_ancestor_base_and_dirty_source_before_apply() 
         &mut provider,
     )
     .expect_err("non-ancestor base");
-    assert!(error.message.contains("ancestor"), "{}", error.message);
+    assert!(
+        error
+            .message
+            .contains("recorded task base is unrelated to the adopted candidate parent"),
+        "{}",
+        error.message
+    );
     assert!(provider.apply_calls.is_empty());
 
     std::fs::write(repo.join("dirty.txt"), "dirty\n").expect("dirty source");

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -874,6 +874,22 @@ fn promote_exports_all_agent_commits_after_the_recorded_task_base() {
     std::fs::write(repo.join("first.txt"), "base\n").expect("base");
     git(&repo, &["add", "."]);
     git(&repo, &["commit", "-m", "base"]);
+    let remote = temp.path().join("origin.git");
+    assert!(Command::new("git")
+        .args(["init", "--bare", remote.to_str().expect("remote path")])
+        .status()
+        .expect("create remote")
+        .success());
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("remote path"),
+        ],
+    );
+    git(&repo, &["push", "-u", "origin", "main"]);
     let base = git_head(&repo, "HEAD");
     git(&repo, &["checkout", "-b", "agent/work"]);
     std::fs::write(repo.join("first.txt"), "one\n").expect("first");

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -41,7 +41,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
-fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_failed() {
+fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending() {
     homeboy_core::test_support::with_isolated_home(|_| {
         for (run_id, contents) in [
             ("recovered-missing-finalized", None),
@@ -82,14 +82,14 @@ fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_failed() {
                 None,
                 Some(&identity),
             )
-            .expect("bridge preserves aggregate while surfacing failed projection");
+            .expect("bridge preserves aggregate while surfacing recoverable projection");
 
             let record = crate::agent_task_lifecycle::status(run_id).expect("lifecycle status");
-            assert_eq!(record.metadata["artifact_projection"]["status"], "failed");
-            assert!(record.metadata["artifact_projection"]["error"]
-                .as_str()
-                .expect("actionable error")
-                .contains("controller-finalized bytes"));
+            assert_eq!(record.metadata["artifact_projection"]["status"], "pending");
+            assert_eq!(
+                record.metadata["artifact_projection"]["recovery_action"]["kind"],
+                "fetch_and_reconcile"
+            );
             let artifacts = homeboy_core::observation::ObservationStore::open_initialized()
                 .expect("store")
                 .list_artifacts(run_id)
@@ -415,7 +415,7 @@ fn promote_reports_no_changes_for_empty_patch_metadata() {
         })
         .expect("empty patch reports no changes");
 
-        assert_eq!(report.status, AgentTaskPromotionStatus::NoChanges);
+        assert_eq!(report.status, AgentTaskPromotionStatus::VerifiedNoChanges);
         assert!(report.changed_files.is_empty());
         match prior_promotion_command {
             Some(command) => std::env::set_var("HOMEBOY_AGENT_TASK_PROMOTION_COMMAND", command),
@@ -631,9 +631,7 @@ fn promote_applies_patch_with_fake_workspace_provider() {
         provider.apply_calls[0].to_workspace,
         "repo@controlled-worktree"
     );
-    assert!(provider.apply_calls[0]
-        .patch_path
-        .ends_with("changes.patch"));
+    assert_eq!(provider.applied_patch_contents, vec![VALID_PATCH]);
     assert_eq!(provider.apply_calls[0].changed_files, vec!["src/lib.rs"]);
     assert_eq!(
         provider.verify_calls,
@@ -727,6 +725,7 @@ fn promote_materializes_worktree_dependencies_before_verify_gate() {
     // verify gate executes. This uses a runtime-agnostic component `deps`
     // script (no composer/npm binary required) to prove the install ran.
     homeboy_core::test_support::with_isolated_home(|_| {
+        homeboy_extension::component_script::register_component_script_runner();
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -537,49 +537,51 @@ fn promote_dry_run_validates_provider_request_without_applying() {
 
 #[test]
 fn promote_verification_failure_keeps_the_applied_target_recoverable() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let worktree_path = temp.path().join("fresh-managed-target");
-    std::fs::create_dir(&worktree_path).expect("create target");
-    git(&worktree_path, &["init"]);
-    let (source_path, source) = write_patch_source(&temp);
-    let mut provider = FakePromotionWorkspaceProvider {
-        workspace_path: Some(worktree_path.clone()),
-        verify_exit_code: 1,
-        ..Default::default()
-    };
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let worktree_path = temp.path().join("fresh-managed-target");
+        std::fs::create_dir(&worktree_path).expect("create target");
+        git(&worktree_path, &["init"]);
+        let (source_path, source) = write_patch_source(&temp);
+        let mut provider = FakePromotionWorkspaceProvider {
+            workspace_path: Some(worktree_path.clone()),
+            verify_exit_code: 1,
+            ..Default::default()
+        };
 
-    let report = promote_with_provider(
-        AgentTaskPromotionOptions {
-            source,
-            source_run_id: Some("runner-only-run".to_string()),
-            source_path: Some(source_path),
-            source_worktree_path: None,
-            base_ref: None,
-            task_base_sha: None,
-            candidate_ref: None,
-            to_worktree: "homeboy@fix-7964".to_string(),
-            task_id: None,
-            artifact_id: None,
-            dry_run: false,
-            gates: VerifyGateOptions {
-                verify: vec!["false".to_string()],
-                private_verify: Vec::new(),
-                private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
-                ..Default::default()
+        let report = promote_with_provider(
+            AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some("runner-only-run".to_string()),
+                source_path: Some(source_path),
+                source_worktree_path: None,
+                base_ref: None,
+                task_base_sha: None,
+                candidate_ref: None,
+                to_worktree: "homeboy@fix-7964".to_string(),
+                task_id: None,
+                artifact_id: None,
+                dry_run: false,
+                gates: VerifyGateOptions {
+                    verify: vec!["false".to_string()],
+                    private_verify: Vec::new(),
+                    private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+                    ..Default::default()
+                },
+                provider_command: None,
+                provider_invocation: None,
             },
-            provider_command: None,
-            provider_invocation: None,
-        },
-        &mut provider,
-    )
-    .expect("verification failure is a recoverable promotion report");
+            &mut provider,
+        )
+        .expect("verification failure is a recoverable promotion report");
 
-    assert_eq!(report.status, AgentTaskPromotionStatus::GateFailed);
-    assert!(report.status.patch_promoted());
-    assert_eq!(report.target.path.as_deref(), worktree_path.to_str());
-    assert_eq!(provider.apply_calls.len(), 1);
-    assert_eq!(provider.verify_calls.len(), 1);
-    assert_eq!(report.operator_notification.status, "blocked");
+        assert_eq!(report.status, AgentTaskPromotionStatus::GateFailed);
+        assert!(report.status.patch_promoted());
+        assert_eq!(report.target.path.as_deref(), worktree_path.to_str());
+        assert_eq!(provider.apply_calls.len(), 1);
+        assert_eq!(provider.verify_calls.len(), 1);
+        assert_eq!(report.operator_notification.status, "blocked");
+    });
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2720,6 +2720,12 @@ fn cook_failure_context(
             ]
         })
         .unwrap_or_default();
+    if recovery_legal {
+        legal_actions.push(super::AgentTaskCookRecoveryAction {
+            action: "resume".to_string(),
+            command: format!("homeboy agent-task cook-continue {chronological_latest_run_id}"),
+        });
+    }
     if blocking_claim.is_some() {
         legal_actions.insert(
             2,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2101,7 +2101,7 @@ fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
         let retry_run_id = retry.record.run_id.clone();
         let completed = crate::agent_task_service::execution::run_submitted(
             retry_run_id.clone(),
-            ReviewFormOnlyExecutor,
+            ImmediateSuccessExecutor,
         )
         .expect("corrected environment retry succeeds");
 
@@ -3157,20 +3157,11 @@ fn cook_persists_materialization_failure_without_provider_execution() {
         let result =
             run_cook(options, UnusedExecutor).expect("cook records materialization failure");
 
-        assert_eq!(result.value.status, "pre_execution_failure");
-        assert_eq!(result.value.attempts.len(), 1);
-        assert_eq!(
-            result.value.terminal_phase.as_deref(),
-            Some("materialize_initial_candidate_baseline")
-        );
-        assert_eq!(
-            result.value.terminal_failure_classification.as_deref(),
-            Some("invalid_input")
-        );
-        let record = agent_task_lifecycle::status(cook_id).expect("cook alias resolves failure");
-        assert_eq!(record.run_id, run_id);
-        assert!(record.provider_handles.is_empty());
-        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(result.value.status, "durable_failure");
+        assert!(result.value.attempts.is_empty());
+        assert!(result.value.failure_context.is_some());
+        assert!(super::super::recipe_exists(cook_id).expect("durable recipe lookup"));
+        assert!(!agent_task_lifecycle::run_record_exists(run_id).expect("run record lookup"));
     });
 }
 
@@ -5091,8 +5082,8 @@ fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empt
         assert_eq!(record.run_id, second_run_id);
         assert_eq!(
             super::super::resolve_cook_continuation_run_id(cook_id)
-                .expect("continuation follows selection"),
-            second_run_id
+                .expect("continuation follows the latest feedback attempt"),
+            third_run_id
         );
         let recipe = super::super::load_recipe(cook_id).expect("load recipe");
         assert_eq!(
@@ -5110,8 +5101,8 @@ fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empt
         .expect("remove legacy-missing Cook index fixture");
         assert_eq!(
             super::super::resolve_cook_continuation_run_id(cook_id)
-                .expect("recipe attempts preserve substantive selection without an index"),
-            second_run_id
+                .expect("recipe attempts preserve chronological continuation without an index"),
+            third_run_id
         );
     });
 }
@@ -7274,8 +7265,9 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         let mut preflight_backend = CaptureBackend::default();
         let preflight =
             recover_cook_pr_with_backend(cook_id, Vec::new(), true, &mut preflight_backend)
-                .unwrap();
-        assert_eq!(preflight["status"], "validated");
+                .expect_err("recovery without an executed model fails closed");
+        assert_eq!(preflight.details["field"], "provider_model");
+        assert!(preflight.message.contains("no concrete executed model"));
         assert!(!preflight_backend.committed);
         assert!(!preflight_backend.pushed);
         assert!(!preflight_backend.created);
@@ -7290,7 +7282,7 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         );
 
         let mut publish_backend = CaptureBackend::default();
-        let report = recover_cook_pr_with_backend(
+        let publish = recover_cook_pr_with_backend(
             run_id,
             vec![crate::agent_task_review_dossier::AgentTaskReviewOverride {
                 target: crate::agent_task_review_dossier::AgentTaskReviewOverrideTarget::Summary,
@@ -7300,24 +7292,11 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
             false,
             &mut publish_backend,
         )
-        .unwrap();
-        assert_eq!(report["status"], "review_ready");
-        assert_eq!(report["run_id"], run_id);
-        assert_eq!(report["changed_files"], serde_json::json!(["src/lib.rs"]));
-        assert!(publish_backend.committed && publish_backend.pushed && publish_backend.created);
-        assert!(publish_backend
-            .body
-            .contains("Recovered from durable Cook evidence."));
-        let record = agent_task_lifecycle::status(run_id).unwrap();
-        assert_eq!(record.metadata["latest_promotion"]["status"], "applied");
-        assert_eq!(
-            record.metadata["latest_promotion"]["operator_notification"]["status"],
-            "completed"
-        );
-        assert!(
-            record.metadata["latest_promotion"]["operator_notification"]["resumable_blocker"]
-                .is_null()
-        );
+        .expect_err("publication without an executed model fails closed");
+        assert_eq!(publish.details["field"], "provider_model");
+        assert!(!publish_backend.committed);
+        assert!(!publish_backend.pushed);
+        assert!(!publish_backend.created);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -696,8 +696,8 @@ fn service_materializes_component_worktree_before_provider_dispatch() {
             "provider must run in an isolated attempt worktree, not the managed worktree"
         );
         assert!(
-            observed_root.contains("homeboy-agent-task-attempts"),
-            "attempt worktree should live under the agent-task attempts scratch root, got {observed_root}"
+            observed_root.contains("controller-scratch/attempts"),
+            "attempt worktree should live under the registered controller scratch root, got {observed_root}"
         );
         assert!(observed.workspace.attempt.is_some());
         assert_eq!(observed.workspace.slug.as_deref(), Some("fixture"));
@@ -917,10 +917,7 @@ fn reconcile_dry_run_reports_but_does_not_cancel_stale_runs() {
         agent_task_lifecycle::rewrite_record_for_test("run-reconcile-dry", |record| {
             agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
-            record.metadata = serde_json::json!({
-                "runner_id": "homeboy-lab",
-                "runner_job_id": "job-dry",
-            });
+            record.metadata = serde_json::json!({ "runner_pid": u32::MAX });
         })
         .expect("stale record stored");
 
@@ -944,10 +941,7 @@ fn reconcile_cancels_stale_running_record_without_manual_edit() {
         agent_task_lifecycle::rewrite_record_for_test("run-reconcile-live", |record| {
             agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
             record.tasks[0].state = AgentTaskState::Running;
-            record.metadata = serde_json::json!({
-                "runner_id": "homeboy-lab",
-                "runner_job_id": "job-live",
-            });
+            record.metadata = serde_json::json!({ "runner_pid": u32::MAX });
         })
         .expect("stale record stored");
 
@@ -1390,6 +1384,18 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
             },
         )
         .expect("controller handoff persisted before runner acceptance");
+        let submission_request: homeboy_core::api_jobs::RemoteRunnerJobRequest =
+            serde_json::from_value(serde_json::json!({
+                "runner_id": "homeboy-lab",
+                "command": command,
+                "metadata": { "submission_key": "controller-handoff-unaccepted" }
+            }))
+            .expect("fixture runner submission request");
+        agent_task_lifecycle::record_lab_offload_submission_request(
+            "controller-handoff-unaccepted",
+            &submission_request,
+        )
+        .expect("persist complete pending handoff request");
         agent_task_lifecycle::rewrite_record_for_test("controller-handoff-unaccepted", |record| {
             record
                 .lab_handoff
@@ -1411,15 +1417,67 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
             "homeboy agent-task status controller-handoff-unaccepted"
         );
 
-        let reconciliation = reconcile_stale_active_runs(false).expect("reconciled");
-        assert_eq!(reconciliation.reconciled, 1);
-        assert_eq!(reconciliation.runs[0].action, "reconciled");
-        let terminal =
-            lifecycle_status("controller-handoff-unaccepted").expect("terminal controller record");
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            AbsentSubmissionProvider,
+        ));
+        let terminal = lifecycle_status("controller-handoff-unaccepted")
+            .expect("terminal controller record after confirmed absence");
         assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
         assert_eq!(terminal.metadata["provider_executions_consumed"], 0);
         assert_eq!(terminal.metadata["retryable"], true);
     });
+}
+
+struct AbsentSubmissionProvider;
+
+impl agent_task_lifecycle::RunnerContinuationProvider for AbsentSubmissionProvider {
+    fn runner_job_log_snapshot(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> homeboy_core::Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+        Err(homeboy_core::Error::internal_unexpected(
+            "unused in fixture",
+        ))
+    }
+
+    fn is_runner_connected(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn runner_exists(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn run_continuation_exec(
+        &self,
+        _runner_id: &str,
+        _cwd: &str,
+        _command: &[String],
+        _run_id: &str,
+    ) -> homeboy_core::Result<i32> {
+        Err(homeboy_core::Error::internal_unexpected(
+            "unused in fixture",
+        ))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        _request: homeboy_core::api_jobs::RemoteRunnerJobRequest,
+    ) -> homeboy_core::Result<homeboy_core::api_jobs::Job> {
+        Err(homeboy_core::Error::internal_unexpected(
+            "unused in fixture",
+        ))
+    }
+
+    fn lookup_reverse_broker_submission(
+        &self,
+        _runner_id: &str,
+        _submission_key: &str,
+    ) -> homeboy_core::Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
+        Ok(homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Absent)
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- align promotion fixtures with strict origin, dependency hydration, projection recovery, and verified no-change contracts
- expose legal Cook resume guidance and fail recovery closed without concrete executed-model lineage
- make stale-run and controller-handoff fixtures prove authoritative runner absence
- skip repository integrity probing when a provider intentionally exposes no local workspace directory

Closes #11383.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p homeboy-agents --all-targets`
- all 80 `agent_task_promotion::tests::part_{a,b,c,d}` tests
- directly affected Cook, service-worktree, stale reconciliation, and controller-handoff regression tests

Full serialized workspace runtime remains separately tracked by #11399.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode analyzed deterministic failures, updated implementation and fixtures, and ran focused verification. Chris Huber reviewed and remains responsible for every line.