### PR TITLE
Give the scratch-retry scheduler test a durable run record

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -789,6 +789,9 @@ fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
         plan.options.retry.retryable_failure_classifications =
             vec![AgentTaskFailureClassification::ExecutionFailed];
 
+        crate::agent_tasks::lifecycle::submit_plan(&plan, Some("run-scratch-retry"))
+            .expect("submit plan");
+        crate::agent_tasks::lifecycle::mark_running("run-scratch-retry").expect("mark running");
         let aggregate =
             AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
                 provider,


### PR DESCRIPTION
Refs #11383.

## The failure

`provider_attempts_receive_distinct_allocated_runtime_tmpdirs` scheduled against `with_run_id("run-scratch-retry")` but never created that run. `reserve_provider_execution` reads the record before it will let a provider execute:

```rust
require_record_workspace_owner(&store::read_record(&run_id)?)?;
```

So every task failed admission:

```
could not allocate provider scratch root: could not durably record provider execution:
Invalid argument 'run_id': agent-task run record not found: run-scratch-retry
```

and the assertion saw `succeeded: 0` instead of `1`.

## Why the fixture, not the check

The reservation is a real safety property — it is what stops an interrupted controller from redispatching a provider (#9180). Loosening it to tolerate a missing record would trade a genuine guarantee for a green test.

The passing tests in this same file already do the right thing; `provider_empty_stdout_records_failed_run_with_executor_evidence` establishes the pattern:

```rust
crate::agent_tasks::lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
crate::agent_tasks::lifecycle::mark_running(run_id).expect("mark running");
let aggregate = scheduler.run(plan.clone());
```

This applies that prelude. Three lines.

## Verification

`cargo test -p homeboy-agents --lib -- --test-threads=1 provider_attempts_receive_distinct_allocated_runtime_tmpdirs` — **ok**

## One I attempted and backed out

`executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests` fails with the same root error, so I applied the same fix — and it failed differently:

```
submit plan: "controller admission request was cancelled"
```

That test does **not** run inside `with_isolated_home`. It builds a bare `tempfile::tempdir()` controller root, so calling the lifecycle API puts it against real controller admission. The right fix there is to make the test hermetic first, which is a larger change than this PR should carry, so I reverted it rather than ship something that happens to be green.

Worth noting for whoever takes it: a non-hermetic test in this file is its own latent problem, independent of #11383.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: traced the shared "run record not found" signature across the remaining failures, matched the working fixture pattern in the same file, and verified. Chris Huber remains responsible for every line.