### PR TITLE
Give the rotation baseline test a durable run record

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -269,6 +269,13 @@ mod provider_rotation_tests {
         plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
         enable_rotation(&mut plan);
 
+        // Scheduling against a run id needs that run to exist durably:
+        // `reserve_provider_execution` reads the record before it will let a
+        // provider execute, so without this every task fails admission with
+        // "agent-task run record not found" instead of rotating.
+        crate::agent_tasks::lifecycle::submit_plan(&plan, Some("run-8081")).expect("submit plan");
+        crate::agent_tasks::lifecycle::mark_running("run-8081").expect("mark running");
+
         let aggregate = scheduler.run(plan);
 
         assert_eq!(


### PR DESCRIPTION
Refs #11383. Same fixture gap as #11416, one more test.

## Fix

`rotation_preserves_uncommitted_candidate_and_dispatches_next_provider_from_clean_baseline` scheduled against `with_run_id("run-8081")` without creating that run. `reserve_provider_execution` reads the record before letting a provider execute, so every task failed admission with:

```
agent-task run record not found: run-8081
```

Adds the `submit_plan` + `mark_running` prelude the passing tests in this file already use. Verified: **14 passed** in `provider_rotation_tests`, up from 13.

## Two sibling tests I applied this to and backed out — worth reading

`rotation_adopts_only_the_explicit_portable_candidate` and `timed_out_attempt_rotates_after_recovering_a_malformed_scratch_index` have the *identical* `run record not found` failure (`run-adopt`, and the `run_id` variable). Adding the same prelude makes that error go away — and both then fail differently:

```
rotation_adopts_only_the_explicit_portable_candidate
  left: PartialRecoverable   right: Succeeded
  "provider execution stopped because its configured execution budget was exhausted"

timed_out_attempt_rotates_after_recovering_a_malformed_scratch_index
  left: Failed               right: Succeeded
```

That budget exhaustion is suspicious and may be a real defect rather than a fixture problem. `enable_rotation` sets a deliberately generous budget:

```rust
max_provider_executions: 10,
max_provider_rotations: 10,
```

Two executions should not exhaust ten. The reading worth checking is whether `reserve_provider_execution` and the rotation path each record an execution against the same budget — which would deplete it at twice the expected rate, and which would have been invisible for as long as the reservation was failing outright on the missing record.

I left those two alone rather than ship a change that trades one red for another, or paper over it by inflating a budget. Recorded here and on #11383 so the next person starts from the real question.

## AI Assistance

- Tool: OpenCode
- Model: Anthropic Claude
- Used for: traced the shared missing-run-record signature across the rotation family, fixed the one that goes green, and isolated the budget interaction the other two expose. Chris Huber remains responsible for every line.