### PR TITLE
fix(cook): authenticate dirty review continuation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1739,7 +1739,10 @@ fn review_form_attempt_is_ready_for_cook_continuation(
         && promotion.changed_files == source.changed_files
         && promotion.verified_base == source.verified_base
         && promotion.deterministic_gates == source.deterministic_gates
-        && promotion.command_evidence == source.command_evidence)
+        && promotion.command_evidence == source.command_evidence
+        && promotion.provenance.get("candidate") == source.provenance.get("candidate")
+        && promotion.provenance.get("gate_feedback_baseline")
+            == source.provenance.get("gate_feedback_baseline"))
 }
 
 fn retryable_review_form_terminal_failure(
@@ -1765,7 +1768,7 @@ pub fn terminal_review_form_continuation_is_eligible(
     plan: &AgentTaskPlan,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<bool> {
-    if !record.state.is_terminal()
+    if record.state != agent_task_lifecycle::AgentTaskRunState::Failed
         || !review_form_attempt_is_ready_for_cook_continuation(plan, record)?
     {
         return Ok(false);
@@ -2071,8 +2074,11 @@ where
                     .and_then(Value::as_str)
                     == Some("verification_pending")
         });
+    let authenticated_historical_review_continuation =
+        allow_historical_terminal && authenticated_historical_review_form_workspace(&options)?;
     if !moving_base_continuation
         && !verification_pending_continuation
+        && !authenticated_historical_review_continuation
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -3404,6 +3410,55 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
         ));
     }
     Ok(())
+}
+
+/// The normal configured-provider preflight rejects every dirty destination. A
+/// terminal review-form retry can retain its candidate only after its copied
+/// promotion lineage and the resolved destination prove an exact match.
+fn authenticated_historical_review_form_workspace(
+    options: &AgentTaskCookServiceOptions,
+) -> Result<bool> {
+    if !agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
+        return Ok(false);
+    }
+    let record = agent_task_lifecycle::status(&options.initial_run_id)?;
+    if !terminal_review_form_continuation_is_eligible(&options.initial_plan, &record)
+        .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+    let Some(promotion) = persisted_promotion_for_attempt(&options.initial_run_id).unwrap_or(None)
+    else {
+        return Ok(false);
+    };
+    if promotion.status != AgentTaskPromotionStatus::Applied {
+        return Ok(false);
+    }
+    let Some(continuation) = tracked_promotion_continuation(options).unwrap_or(None) else {
+        return Ok(false);
+    };
+    let resolution =
+        match homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            &options.to_worktree,
+            &homeboy_core::defaults::load_config(),
+            Some(&continuation.baseline),
+        ) {
+            Ok(resolution) => resolution,
+            Err(_) => return Ok(false),
+        };
+    if resolution.worktree.handle != options.to_worktree
+        || homeboy_core::worktree_providers::validate_task_worktree_root(
+            std::path::Path::new(&resolution.worktree.path),
+            &options.to_worktree,
+        )
+        .is_err()
+    {
+        return Ok(false);
+    }
+    let Ok(target) = std::fs::canonicalize(&resolution.worktree.path) else {
+        return Ok(false);
+    };
+    Ok(authenticate_tracked_promotion_continuation(&target, &continuation).is_ok())
 }
 
 struct TrackedPromotionContinuation {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -176,6 +176,49 @@ fn seed_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
     .unwrap();
 }
 
+fn seed_timeout_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
+    use crate::agent_task::{AgentTaskOutcome, AgentTaskOutcomeStatus};
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    };
+
+    let task = plan.tasks.first().expect("review form plan has one task");
+    agent_task_lifecycle::record_run_aggregate(
+        run_id,
+        plan,
+        &AgentTaskAggregate {
+            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Failed,
+            totals: AgentTaskAggregateTotals {
+                failed: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: task.task_id.clone(),
+                status: AgentTaskOutcomeStatus::Timeout,
+                summary: Some("review form provider timed out".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: serde_json::json!({ "model": task.executor.model() }),
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        },
+    )
+    .unwrap();
+}
+
 fn seed_missing_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
     use crate::agent_task::{AgentTaskOutcome, AgentTaskOutcomeStatus};
     use crate::agent_task_scheduler::{
@@ -1426,6 +1469,22 @@ impl AgentTaskExecutorAdapter for ReviewFormOnlyExecutor {
             follow_up: None,
             metadata: serde_json::json!({ "model": request.executor.model() }),
         }
+    }
+}
+
+#[derive(Clone)]
+struct RecordingReviewFormExecutor {
+    executions: Arc<AtomicUsize>,
+}
+
+impl AgentTaskExecutorAdapter for RecordingReviewFormExecutor {
+    fn execute(
+        &self,
+        request: crate::agent_task::AgentTaskRequest,
+        context: crate::agent_task_scheduler::AgentTaskExecutionContext,
+    ) -> crate::agent_task::AgentTaskOutcome {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        ReviewFormOnlyExecutor.execute(request, context)
     }
 }
 
@@ -6183,7 +6242,8 @@ fn record_tracked_promotion_continuation(
     checkpoint["target"] = serde_json::json!({
         "worktree": options.to_worktree,
         "path": target,
-        "branch": "cook-candidate"
+        "branch": "cook-candidate",
+        "head": fingerprint.head
     });
     checkpoint["patch_artifact"] = serde_json::json!({
         "id": "patch",
@@ -6195,6 +6255,7 @@ fn record_tracked_promotion_continuation(
     checkpoint["provenance"] = serde_json::json!({
         "post_apply": true,
         "candidate": candidate,
+        "worktree_path": target,
         "gate_feedback_baseline": {
             "schema": "homeboy/agent-task-gate-feedback-baseline/v1",
             "current_diff": patch
@@ -6323,6 +6384,15 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             .expect("tracked promotion continuation");
         assert_eq!(continuation.baseline["patch_artifact"]["id"], "patch");
 
+        let generic_preflight =
+            crate::agent_task_promotion::preflight_configured_workspace_provider(
+                &options.to_worktree,
+            )
+            .expect_err("generic provider preflight rejects every dirty destination");
+        assert_eq!(
+            generic_preflight.details["workspace"]["classification"],
+            "workspace.resolved_but_dirty"
+        );
         validate_cook_workspace(&options)
             .expect("exact dirty promoted provider destination resumes");
 
@@ -6344,6 +6414,167 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         assert!(error
             .message
             .contains("promoted candidate baseline could not be verified"));
+
+        // The historical admission branch is narrower than the workspace
+        // validator: it requires a terminal timed-out review-form retry whose
+        // copied applied promotion exactly matches its source promotion.
+        std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
+        let mut historical = options.clone();
+        historical.initial_plan = batch_cook_options(
+            "cook-historical-review-form",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        )
+        .initial_plan;
+        historical.initial_run_id = "run-historical-review-form".to_string();
+        historical.initial_plan.tasks[0].inputs = serde_json::json!({
+            "cook_loop": {
+                "review_form_required": true,
+                "execution_budget_authority": {
+                    "kind": "fresh_cook_review",
+                    "max_same_provider_retries": 1
+                }
+            }
+        });
+        historical.no_finalize = false;
+        let mut source_options = historical.clone();
+        source_options.initial_run_id = "run-tracked-promotion-source".to_string();
+        record_tracked_promotion_continuation(&source_options, &target);
+        let mut source_promotion = serde_json::to_value(
+            persisted_promotion_for_attempt(&source_options.initial_run_id)
+                .unwrap()
+                .expect("source promotion"),
+        )
+        .unwrap();
+        source_promotion["status"] = serde_json::json!("applied");
+        agent_task_lifecycle::record_promotion(&source_options.initial_run_id, source_promotion)
+            .unwrap();
+
+        let mut copied_promotion = serde_json::to_value(
+            persisted_promotion_for_attempt(&source_options.initial_run_id)
+                .unwrap()
+                .expect("applied source promotion"),
+        )
+        .unwrap();
+        copied_promotion["source"]["run_id"] = serde_json::json!(historical.initial_run_id);
+        copied_promotion["provenance"]["cook_follow_up"] = serde_json::json!({
+            "kind": "review_form_only",
+            "source_run_id": source_options.initial_run_id,
+        });
+        agent_task_lifecycle::submit_plan(
+            &historical.initial_plan,
+            Some(&historical.initial_run_id),
+        )
+        .unwrap();
+        agent_task_lifecycle::record_promotion(
+            &historical.initial_run_id,
+            copied_promotion.clone(),
+        )
+        .unwrap();
+        seed_timeout_review_form_aggregate(&historical.initial_run_id, &historical.initial_plan);
+        agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
+            record.state = agent_task_lifecycle::AgentTaskRunState::Failed;
+        })
+        .unwrap();
+
+        assert!(
+            authenticated_historical_review_form_workspace(&historical).unwrap(),
+            "the exact dirty candidate authorizes only this historical continuation"
+        );
+        historical.attempt_dispatcher = None;
+        let executions = Arc::new(AtomicUsize::new(0));
+        let executor = RecordingReviewFormExecutor {
+            executions: Arc::clone(&executions),
+        };
+
+        std::fs::write(target.join("tracked.txt"), "drifted\n").unwrap();
+        assert!(
+            !authenticated_historical_review_form_workspace(&historical).unwrap(),
+            "candidate drift falls through to normal preflight"
+        );
+        let error = run_cook_with_boundaries_observed_policy(
+            historical.clone(),
+            executor.clone(),
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+            true,
+        )
+        .expect_err("candidate drift is rejected before local dispatch");
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.resolved_but_dirty"
+        );
+        assert_eq!(executions.load(Ordering::SeqCst), 0);
+
+        std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
+        agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
+            record.state = agent_task_lifecycle::AgentTaskRunState::Cancelled;
+        })
+        .unwrap();
+        assert!(
+            !authenticated_historical_review_form_workspace(&historical).unwrap(),
+            "cancelled review-form attempts never authorize the bypass"
+        );
+        let error = run_cook_with_boundaries_observed_policy(
+            historical.clone(),
+            executor.clone(),
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+            true,
+        )
+        .expect_err("cancelled attempts are rejected before local dispatch");
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.resolved_but_dirty"
+        );
+        assert_eq!(executions.load(Ordering::SeqCst), 0);
+
+        agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
+            record.state = agent_task_lifecycle::AgentTaskRunState::Failed;
+        })
+        .unwrap();
+        agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
+            record.metadata["latest_promotion"]["provenance"]
+                .as_object_mut()
+                .unwrap()
+                .remove("candidate");
+        })
+        .unwrap();
+        assert!(
+            !authenticated_historical_review_form_workspace(&historical).unwrap(),
+            "missing legacy candidate evidence is an authorization denial"
+        );
+        let error = run_cook_with_boundaries_observed_policy(
+            historical.clone(),
+            executor.clone(),
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+            true,
+        )
+        .expect_err("malformed evidence is rejected before local dispatch");
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.resolved_but_dirty"
+        );
+        assert_eq!(executions.load(Ordering::SeqCst), 0);
+        agent_task_lifecycle::record_promotion(&historical.initial_run_id, copied_promotion)
+            .unwrap();
+
+        let result = run_cook_with_boundaries_observed_policy(
+            historical.clone(),
+            executor,
+            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            None,
+            true,
+        )
+        .expect("the exact promoted candidate reaches local review dispatch");
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "continuation status: {}; stop reason: {:?}",
+            result.value.status,
+            result.value.failure_context
+        );
+        assert_ne!(result.value.status, "durable_failure");
     });
 }
 


### PR DESCRIPTION
Closes #11398

## What changed
- authenticate historical review-form continuation against the exact copied applied promotion
- permit the configured workspace provider to resolve only that candidate-bound dirty destination
- reject cancellation, drift, and malformed legacy evidence before dispatch
- preserve candidate and gate-baseline provenance when comparing copied review-only promotions

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p homeboy-agents review_form --lib` (20 passed)
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`

## AI assistance
OpenCode with OpenAI `gpt-5.6-sol` was used to diagnose the continuation boundary, implement the repair, and add regression coverage. Chris Huber reviewed and remains responsible for the change.