### PR TITLE
fix(cook): resume partial-failure reviews

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1768,8 +1768,11 @@ pub fn terminal_review_form_continuation_is_eligible(
     plan: &AgentTaskPlan,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<bool> {
-    if record.state != agent_task_lifecycle::AgentTaskRunState::Failed
-        || !review_form_attempt_is_ready_for_cook_continuation(plan, record)?
+    if !matches!(
+        record.state,
+        agent_task_lifecycle::AgentTaskRunState::Failed
+            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+    ) || !review_form_attempt_is_ready_for_cook_continuation(plan, record)?
     {
         return Ok(false);
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6472,7 +6472,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         .unwrap();
         seed_timeout_review_form_aggregate(&historical.initial_run_id, &historical.initial_plan);
         agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
-            record.state = agent_task_lifecycle::AgentTaskRunState::Failed;
+            record.state = agent_task_lifecycle::AgentTaskRunState::PartialFailure;
         })
         .unwrap();
 
@@ -6529,7 +6529,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         assert_eq!(executions.load(Ordering::SeqCst), 0);
 
         agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
-            record.state = agent_task_lifecycle::AgentTaskRunState::Failed;
+            record.state = agent_task_lifecycle::AgentTaskRunState::PartialFailure;
         })
         .unwrap();
         agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {


### PR DESCRIPTION
## Summary

- admit exact authenticated review-form continuations from `PartialFailure`, the durable state produced by provider timeouts
- retain the existing exact promotion/candidate authentication and cancellation rejection
- exercise the production timeout state in the full-boundary candidate, drift, malformed-evidence, and cancellation regression

Closes #11398.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `cargo test -p homeboy-agents review_form --lib`

Production reproduction: Cook `agent-task-b69190cd-81f2-40c5-9f92-0cf80400a888`, candidate fingerprint `f9ab9dd085790549a411333b96b8372864e89cbc971ad407274463f728989f52`.

## AI Assistance

OpenCode with OpenAI gpt-5.6-sol was used to inspect the durable production record, identify the `PartialFailure` lifecycle mismatch, and implement and verify the focused fix. Chris Huber remains responsible for every line.