### PR TITLE
docs: remove codebox literals from core source comments

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1299,7 +1299,7 @@ fn cook_batch_inner(
     apply_provider_profile(&mut args);
     // Resolve the effective backend (explicit --backend or the configured
     // default) and validate it up front (#7717). Otherwise an omitted
-    // --backend silently rode a config default like `codebox` all the way to
+    // --backend silently rode a configured default all the way to
     // provider execution, where each child cook failed late with a
     // provider-shaped `no extension agent-task provider found for backend`
     // error instead of an early, actionable configuration failure. Making the

--- a/crates/homeboy-rig/src/lint.rs
+++ b/crates/homeboy-rig/src/lint.rs
@@ -715,10 +715,10 @@ struct ScanFrame {
 /// Report keys declared more than once inside the same JSON object.
 ///
 /// `serde_json` accepts duplicate object keys and silently keeps the last one,
-/// so a rig spec can lose an entire declaration with no signal at all. In
-/// chubes4/homeboy-rigs, `woocommerce-wp-codebox-target.base.json` declares
-/// `"lifecycle"` twice and the first block's `intent: "external"` is dropped,
-/// changing that rig's cleanup contract invisibly.
+/// so a rig spec can lose an entire declaration with no signal at all. Observed
+/// in a published rig package: a base spec declares `"lifecycle"` twice and the
+/// first block's `intent: "external"` is dropped, changing that rig's cleanup
+/// contract invisibly.
 ///
 /// This is a raw token pass rather than a `serde` visitor because the visitor
 /// API cannot report where in the source each declaration sits, and "the key
@@ -1146,9 +1146,9 @@ const IMPORT_KEYWORDS: &[&str] = &["from", "import", "require"];
 ///
 /// A workload is only ever loaded by its runner, so a wrong relative depth is
 /// invisible to every other check in this lint: the JSON is valid, the path in
-/// the rig spec exists, and the profile reference resolves. In
-/// chubes4/homeboy-rigs, four Gutenberg `.trace.mjs` workloads import
-/// `'../shared/wp-codebox/recipe.mjs'` where the correct depth is
+/// the rig spec exists, and the profile reference resolves. Observed in a
+/// published rig package: four `.trace.mjs` workloads import
+/// `'../shared/<package>/recipe.mjs'` where the correct depth is
 /// `'../../../shared/...'`, and CI lints that package green.
 ///
 /// Scope is intentionally narrow. Only static relative specifiers (`./`, `../`)

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -442,7 +442,7 @@ impl RigRequirementsSpec {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunnerToolRequirementSpec {
-    /// Logical tool id, e.g. `wp-codebox`.
+    /// Logical tool id, as declared by the extension that requires the tool.
     pub tool: String,
 
     /// Binary/command name used when no configured env path is present.

--- a/crates/homeboy-rig/src/spec/pipeline.rs
+++ b/crates/homeboy-rig/src/spec/pipeline.rs
@@ -298,9 +298,8 @@ pub enum PipelineStep {
     /// Apply (or verify) an idempotent local-only patch to a file in a
     /// component checkout. Use case: upstream-source patches that can't be
     /// committed to the consumer branch because rebases would carry them
-    /// to every fresh checkout. Examples: TSRMLS_CC fallback macros on
-    /// upstream Playground C sources, build-time tweaks that aren't
-    /// upstream yet.
+    /// to every fresh checkout. Examples: compatibility shims against an
+    /// upstream source tree, build-time tweaks that aren't upstream yet.
     ///
     /// Idempotency is marker-based: if `marker` is already present in
     /// the file, the step is a no-op. If the optional `after` anchor is


### PR DESCRIPTION
> Homeboy is not allowed to know about codebox.

Checked, and in behavioral terms it does not. All 62 `codebox` occurrences under
`crates/**/*.rs` are test fixtures, argv examples, or refactor-rename test
strings — every one sits after a `#[cfg(test)]` or in a `tests.rs`.

But the boundary is enforced by `core-agnostic-source`, which scans **comments
too** — the same class as #5249. `homeboy review audit` reports 8
`core_boundary_leak` findings for `codebox`, `wp-codebox`, and `playground`:

| file | term |
|---|---|
| `homeboy-cli/src/commands/agent_task/fanout.rs:1302` | `codebox` cited as an example config default |
| `homeboy-rig/src/spec.rs:445` | tool id documented as `wp-codebox` |
| `homeboy-rig/src/lint.rs:719` | cites the rig filename `woocommerce-wp-codebox-target.base.json` |
| `homeboy-rig/src/lint.rs:1151` | cites the import path `'../shared/wp-codebox/recipe.mjs'` |
| `homeboy-rig/src/spec/pipeline.rs:302` | "upstream Playground C sources" |

Reworded to keep the reasoning and drop the ecosystem literal. The two `lint.rs`
doc comments earn their length by citing real observed breakage, so those keep
the concrete failure and lose only the package name — a duplicate `"lifecycle"`
key silently dropping `intent: "external"` is the point, not which rig it
happened in.

**Comments only. No behavioral change.**

## Verification

`homeboy review audit` before and after, full tree:

```
codebox        before=4  after=0
wp-codebox     before=3  after=0
playground     before=1  after=0

total core_boundary_leak: 666 -> 657
terms that INCREASED: none
```

No local `cargo build`/`test` per the VPS build policy; this is a comments-only
change and CI owns the gates.

## Worth knowing

`review audit` is a blocking PR gate but differential, so the remaining **657**
leaks do not block merges — and a *new* codebox literal in a touched file would
be caught. The boundary is enforced going forward without adding a gate here.

The rest of that 657 is a different conversation, dominated by build-tool terms
rather than ecosystem coupling: `cargo` 116, `rust` 97, `php` 94, `node` 74,
`homebrew` 33, `node_modules` 19, `composer` 17, `wordpress` 15. Not in scope
for this PR.