### PR TITLE
fix(cook): authenticate legacy applied promotions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3483,12 +3483,20 @@ fn tracked_promotion_continuation(
     let Some(promotion) = persisted_promotion_for_attempt(&options.initial_run_id)? else {
         return Ok(None);
     };
+    let has_post_apply_checkpoint = ["/post_apply", "/resumed_post_apply_promotion"]
+        .into_iter()
+        .any(|pointer| promotion.provenance.pointer(pointer) == Some(&Value::Bool(true)));
+    let authenticated_legacy_review =
+        if promotion.status == AgentTaskPromotionStatus::Applied && !has_post_apply_checkpoint {
+            let record = agent_task_lifecycle::status(&options.initial_run_id)?;
+            terminal_review_form_continuation_is_eligible(&options.initial_plan, &record)?
+        } else {
+            false
+        };
     if !matches!(
         promotion.status,
         AgentTaskPromotionStatus::VerificationPending | AgentTaskPromotionStatus::Applied
-    ) || !["/post_apply", "/resumed_post_apply_promotion"]
-        .into_iter()
-        .any(|pointer| promotion.provenance.pointer(pointer) == Some(&Value::Bool(true)))
+    ) || (!has_post_apply_checkpoint && !authenticated_legacy_review)
     {
         return Ok(None);
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6446,6 +6446,10 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         )
         .unwrap();
         source_promotion["status"] = serde_json::json!("applied");
+        source_promotion["provenance"]
+            .as_object_mut()
+            .unwrap()
+            .remove("post_apply");
         agent_task_lifecycle::record_promotion(&source_options.initial_run_id, source_promotion)
             .unwrap();
 


### PR DESCRIPTION
## Summary

- recognize pre-marker `Applied` promotion records only when the existing terminal review-form predicate authenticates an exact copied source lineage
- continue enforcing configured-provider baseline verification plus canonical path, branch, and candidate fingerprint equality
- exercise a markerless legacy promotion through the full-boundary continuation regression while retaining zero-dispatch rejection for drift, cancellation, and malformed evidence

Closes #11398.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `cargo test -p homeboy-agents review_form --lib`

Production reproduction: Cook `agent-task-b69190cd-81f2-40c5-9f92-0cf80400a888`, created by Homeboy `0.328.0+1e63f1ae0369`, whose applied promotion predates the `/post_apply` marker. Candidate fingerprint remains `f9ab9dd085790549a411333b96b8372864e89cbc971ad407274463f728989f52`.

## AI Assistance

OpenCode with OpenAI gpt-5.6-sol was used to inspect the durable production record, identify the legacy marker mismatch, and implement and verify the bounded compatibility rule. Chris Huber remains responsible for every line.