### PR TITLE
test(lint): declare structured sidecars on the routed lint fixture

### DIFF
--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -70,6 +70,10 @@ fn routed_lint_component(home: &Path, source: &Path, script: &str) -> Component 
         r#"{
             "name":"Routed lint fixture",
             "version":"1.0.0",
+            "structured_sidecars":{
+                "lint.findings":true,
+                "lint.producers":true
+            },
             "lint":{
                 "extension_script":"lint.sh",
                 "changed_file_routes":[


### PR DESCRIPTION
Unblocks #11367.

## The failure

`lint::run::tests::workflow::successful_zero_finding_routes_initialize_and_clean_evidence`
panics with `primary run evidence remains caller-owned`.

**It fails on `main`, not because of #11367.** Verified directly against that
PR's base commit `35c29b7b2`:

```
running 10 tests
lint::run::tests::workflow::successful_zero_finding_routes_initialize_and_clean_evidence --- FAILED
test result: FAILED. 9 passed; 1 failed
```

#11367 is red only because it touches lint files, so the differential Test gate
selects a module that was already broken. Main's own Test job is red on a
different set (`homeboy-agents` cook tests), which is why this one has not been
surfacing there.

## Root cause

The test asserts the primary run's `lint-findings` sidecar exists after a
zero-finding run. That guarantee comes from #10765, which seeds an empty payload
before the runner executes.

The seeding is **declaration-gated** — `initialize_structured_sidecars` only
seeds sidecars the extension manifest declares:

```rust
for declaration in declared {
    if !homeboy_core::structured_sidecar::seeds_on_start(&declaration.name) { continue; }
    ...
}
```

`routed_lint_component`'s manifest declares no `structured_sidecars`, so nothing
was ever seeded and the asserted file could not exist. The fixture's lint script
is `#!/bin/sh\nexit 0\n`, which writes nothing either.

The gating is correct and deliberate — it is the same declaration that
`declares_lint_findings_sidecar` reads to make the missing-evidence contract
opt-in. Real extensions declare `lint.findings` and `lint.producers`.

**The fixture was the unrealistic part**, so that is what this changes.

## Effect

Declaring both sidecars makes the test exercise the contract its name claims.
It also moves the five other tests sharing this fixture onto the real evidence
path instead of the undeclared one, which is closer to production and costs
nothing — verified below.

```
cargo test -p homeboy-extension --lib lint::run::tests -- --test-threads=1
test result: ok. 38 passed; 0 failed; 0 ignored
```

Four added lines in a test fixture manifest. No source change.