### PR TITLE
fix(promotion): derive the candidate tree without Git's stat cache

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/fingerprint.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/fingerprint.rs
@@ -108,14 +108,31 @@ pub fn candidate_fingerprint(path: &str) -> Result<AgentTaskPromotionCandidate> 
     })
 }
 
+/// The candidate tree must be a pure function of the working tree, because it
+/// authenticates a candidate across time: a promotion records it, and
+/// moving-base recovery re-derives it to prove the destination still holds the
+/// exact promoted content.
+///
+/// Seeding the scratch index from `HEAD` rather than copying the live index is
+/// what makes that true. A copied index carries Git's stat cache, and `git add`
+/// skips any file whose stat still matches its cached entry — so a file that
+/// was modified without a stat change keeps its stale blob and the tree
+/// silently describes content that is not on disk. `read-tree` writes entries
+/// with no stat data, so every working-tree file is re-hashed.
 fn candidate_tree(path: &str) -> Result<String> {
-    let index = text(run_git(path, &["rev-parse", "--git-path", "index"])?);
-    let index = Path::new(path).join(index.trim());
     let temporary = tempfile::NamedTempFile::new()
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.to_string())))?;
-    std::fs::copy(&index, temporary.path()).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(index.display().to_string()))
-    })?;
+    let output = Command::new("git")
+        .args(["read-tree", "HEAD"])
+        .current_dir(path)
+        .env("GIT_INDEX_FILE", temporary.path())
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
     let output = Command::new("git")
         .args(["add", "-A"])
         .current_dir(path)


### PR DESCRIPTION
Fixes one of the three `homeboy-agents` cook tests failing on `main`.

## The bug

`candidate_fingerprint` authenticates a promoted candidate **across time**: the
promotion records it, and moving-base recovery re-derives it later to prove the
destination still holds the exact promoted content.

`candidate_tree` seeded its scratch index by copying the live `.git/index`,
which carries Git's **stat cache**. `git add` skips any file whose stat still
matches its cached entry, so a file modified without a stat change keeps its
stale blob and `write-tree` emits a tree describing content that is not on disk.

A fingerprint used for authentication cannot depend on Git's stat cache. It has
to be a pure function of the working tree.

## Evidence

`moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_divergence`
on `main`. Every fingerprint field matched except `tree`:

```
actual  tree=a6296f98…  head=f6eb2dd…  base=f6eb2dd…  sha256=76ba7930…
expect  tree=ce8b317e…  head=f6eb2dd…  base=f6eb2dd…  sha256=76ba7930…
```

Diffing the two trees in the destination:

```
git diff-tree -r --name-status ce8b317e a6296f98   →  M  src/lib.rs
git show ce8b317e:src/lib.rs   →  "new\n"     (expected — the candidate)
git show a6296f98:src/lib.rs   →  "old\n"     (actual — stale blob)
worktree src/lib.rs            →  "new\n"
git status --porcelain         →  " M src/lib.rs"
```

The working tree held the candidate. The freshly computed tree did not.

Recovery then refused its own candidate:

> moving-base recovery exhausted after 3 refreshed base observations: … moving-base recovery destination differs from the exact promoted candidate; refusing to rebase divergent content

so the finalizer was never invoked (`CALLS=0`) and the cook returned
`candidate_recoverable` instead of `review_ready`.

## The fix

Seed the scratch index with `git read-tree HEAD` instead of copying the live
index. `read-tree` writes entries with **no stat data**, so `git add -A` must
re-hash every working-tree file.

Seeding from `HEAD` rather than an empty index also keeps tracked-but-ignored
files in the tree, which an empty index would silently drop.

## Verification

- `moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_divergence` passes
- `agent_task_service::cook::tests`: **3 failures → 2** (119 passed)
- `agent_task_promotion`: unchanged at 93 passed / 2 failed — both
  (`part_b::configured_provider_timeout_is_bounded_and_retains_command_evidence`,
  `part_c::configured_provider_accepts_only_the_unpushed_immutable_candidate_destination`)
  reproduce identically on `main` with this change stashed, so they are
  pre-existing and untouched by it.

## Still red on main, not addressed here

- `cook_claims_its_durable_attempt_before_slow_baseline_materialization` —
  asserts baseline materialization blocks on a `git status` wrapper installed on
  `PATH`. It never fires. Instrumenting `run_cook_with_boundaries_observed_inner`
  showed the function is entered but returns before
  `validate_cook_candidate_group`, `materialize_initial_cook_attempt`, the gate
  preflight, and the attempt loop — all without erroring, since the caller's
  `.expect("accepted detached attempt")` succeeds. There is no `return` in that
  span, so the early exit is not obvious from reading it and wants a closer look.
- `fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_attempt`
  — `left: 1, right: 0` on a batch report; not yet investigated.