### PR TITLE
test: add durable Cook compatibility fixture

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -33,10 +33,81 @@ use homeboy_core::run_lifecycle_record::{
     ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
     RunLifecycleRecord,
 };
+use serde::Deserialize;
 use sha2::Digest;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Condvar};
+
+const DURABLE_COOK_FIXTURE_SCHEMA: &str = "homeboy/durable-cook-fixture/v1";
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixture {
+    schema: String,
+    producer: DurableCookFixtureProducer,
+    cook: DurableCookFixtureCook,
+    source_record: DurableCookFixtureSourceRecord,
+    continuation_record: DurableCookFixtureContinuationRecord,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureProducer {
+    runtime: String,
+    run_record_schema: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureCook {
+    id: String,
+    source_attempt: u32,
+    continuation_attempt: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureSourceRecord {
+    schema: String,
+    state: String,
+    latest_promotion: DurableCookFixturePromotion,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixturePromotion {
+    status: String,
+    post_apply: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureContinuationRecord {
+    schema: String,
+    state: String,
+    latest_promotion: DurableCookFixtureContinuationPromotion,
+    aggregate: DurableCookFixtureAggregate,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureContinuationPromotion {
+    follow_up_kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableCookFixtureAggregate {
+    status: String,
+    outcome_status: String,
+}
+
+fn durable_cook_0_328_fixture() -> DurableCookFixture {
+    let fixture: DurableCookFixture = serde_json::from_str(include_str!(
+        "fixtures/durable_cook_0.328_review_form_timeout.json"
+    ))
+    .expect("0.328 durable Cook fixture is valid JSON");
+    assert_eq!(fixture.schema, DURABLE_COOK_FIXTURE_SCHEMA);
+    assert_eq!(fixture.producer.runtime, "0.328.1");
+    assert_eq!(
+        fixture.producer.run_record_schema,
+        "homeboy/agent-task-run/v1"
+    );
+    fixture
+}
 
 /// Seed a terminal aggregate whose last outcome carries a valid AI-authored
 /// review form under `outputs["review_form"]`, so cook finalization (which now
@@ -130,6 +201,29 @@ fn terminal_review_form_continuation_rejects_generic_failed_and_cancelled_runs()
                     .unwrap()
             );
         }
+    });
+}
+
+#[test]
+fn durable_cook_inspection_reports_an_unsupported_run_schema() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = batch_cook_options(
+            "unsupported-durable-cook-schema",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        let run_id = "unsupported-durable-cook-schema-attempt-1";
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).unwrap();
+        agent_task_lifecycle::inject_raw_record_metadata_for_corruption_test(run_id, |metadata| {
+            metadata["agent_task_run"]["schema"] = serde_json::json!("homeboy/agent-task-run/v999");
+        })
+        .unwrap();
+
+        let error = agent_task_lifecycle::status(run_id)
+            .expect_err("unsupported durable record schema must be diagnosable");
+        assert!(error
+            .message
+            .contains("unsupported durable agent-task run schema"));
+        assert!(error.message.contains("homeboy/agent-task-run/v999"));
     });
 }
 
@@ -6282,6 +6376,7 @@ fn fresh_cook_has_no_tracked_promotion_before_lifecycle_materialization() {
 #[test]
 fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let fixture = durable_cook_0_328_fixture();
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         let target = temp.path().join("candidate");
@@ -6321,7 +6416,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
 
         let mut options = tracked_promotion_continuation_options(
-            "cook-tracked-promotion",
+            &fixture.cook.id,
             "run-tracked-promotion",
             &target,
         );
@@ -6421,7 +6516,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
         let mut historical = options.clone();
         historical.initial_plan = batch_cook_options(
-            "cook-historical-review-form",
+            &fixture.cook.id,
             Arc::new(AcceptedDetachedAttemptDispatcher),
         )
         .initial_plan;
@@ -6461,7 +6556,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         .unwrap();
         copied_promotion["source"]["run_id"] = serde_json::json!(historical.initial_run_id);
         copied_promotion["provenance"]["cook_follow_up"] = serde_json::json!({
-            "kind": "review_form_only",
+            "kind": fixture.continuation_record.latest_promotion.follow_up_kind,
             "source_run_id": source_options.initial_run_id,
         });
         agent_task_lifecycle::submit_plan(
@@ -6479,6 +6574,42 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             record.state = agent_task_lifecycle::AgentTaskRunState::PartialFailure;
         })
         .unwrap();
+
+        let source = persisted_promotion_for_attempt(&source_options.initial_run_id)
+            .unwrap()
+            .expect("fixture source promotion is inspectable");
+        let continuation = persisted_promotion_for_attempt(&historical.initial_run_id)
+            .unwrap()
+            .expect("fixture continuation promotion is inspectable");
+        assert_eq!(
+            serde_json::to_value(source.status).unwrap(),
+            fixture.source_record.latest_promotion.status
+        );
+        assert_eq!(fixture.source_record.schema, "homeboy/agent-task-run/v1");
+        assert_eq!(fixture.source_record.state, "succeeded");
+        assert!(!fixture.source_record.latest_promotion.post_apply);
+        assert_eq!(source.provenance.pointer("/post_apply"), None);
+        assert_eq!(
+            continuation.provenance["cook_follow_up"]["kind"],
+            fixture.continuation_record.latest_promotion.follow_up_kind
+        );
+        assert_eq!(fixture.cook.source_attempt, 1);
+        assert_eq!(fixture.cook.continuation_attempt, 2);
+        let aggregate = agent_task_lifecycle::read_aggregate(&historical.initial_run_id)
+            .expect("fixture continuation aggregate is inspectable");
+        assert_eq!(
+            serde_json::to_value(aggregate.status).unwrap(),
+            fixture.continuation_record.aggregate.status
+        );
+        assert_eq!(
+            serde_json::to_value(aggregate.outcomes[0].status).unwrap(),
+            fixture.continuation_record.aggregate.outcome_status
+        );
+        assert_eq!(
+            fixture.continuation_record.schema,
+            "homeboy/agent-task-run/v1"
+        );
+        assert_eq!(fixture.continuation_record.state, "partial_failure");
 
         assert!(
             authenticated_historical_review_form_workspace(&historical).unwrap(),

--- a/crates/homeboy-agents/src/agent_task_service/fixtures/durable_cook_0.328_review_form_timeout.json
+++ b/crates/homeboy-agents/src/agent_task_service/fixtures/durable_cook_0.328_review_form_timeout.json
@@ -1,0 +1,31 @@
+{
+  "schema": "homeboy/durable-cook-fixture/v1",
+  "producer": {
+    "runtime": "0.328.1",
+    "run_record_schema": "homeboy/agent-task-run/v1"
+  },
+  "cook": {
+    "id": "cook-11398-production-reproduction",
+    "source_attempt": 1,
+    "continuation_attempt": 2
+  },
+  "source_record": {
+    "schema": "homeboy/agent-task-run/v1",
+    "state": "succeeded",
+    "latest_promotion": {
+      "status": "applied",
+      "post_apply": false
+    }
+  },
+  "continuation_record": {
+    "schema": "homeboy/agent-task-run/v1",
+    "state": "partial_failure",
+    "latest_promotion": {
+      "follow_up_kind": "review_form_only"
+    },
+    "aggregate": {
+      "status": "failed",
+      "outcome_status": "timeout"
+    }
+  }
+}

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -568,6 +568,18 @@ pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
                 Some(format!("parse agent-task run {}", run.id)),
             )
         })?;
+    if record.schema != super::records::schemas::RUN {
+        return Err(Error::validation_invalid_argument(
+            "agent_task_run.schema",
+            format!(
+                "unsupported durable agent-task run schema `{}`; this Homeboy build supports `{}`",
+                record.schema,
+                super::records::schemas::RUN
+            ),
+            Some(run.id.clone()),
+            None,
+        ));
+    }
     record.hydrate_legacy_lab_handoff();
     if let Some(problem) = record.lab_handoff_validation_error() {
         return Err(Error::internal_json(


### PR DESCRIPTION
## Summary
- add a compact, sanitized Homeboy 0.328.1 durable Cook source/continuation fixture derived from #11398
- drive the exact promoted-candidate review-form continuation through the fixture while preserving drift, malformed evidence, and cancellation rejection coverage
- reject unsupported durable agent-task run schemas with an explicit diagnostic

## Verification
- `cargo test -p homeboy-agents --lib cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate`
- `cargo test -p homeboy-agents --lib durable_cook_inspection_reports_an_unsupported_run_schema`
- `cargo fmt --check`
- `git diff --check`

Closes #11435

AI assistance: OpenCode with OpenAI gpt-5.6-terra implemented the fixture, tests, and schema diagnostic. Chris Huber remains responsible for every line.