### PR TITLE
fix(cook): trace continuation admission decisions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -344,6 +344,7 @@ mod tests {
             phase: "controller".to_string(),
             reason_code: "validation_invalid_argument".to_string(),
             diagnostic: None,
+            continuation_admission: None,
             blocking_claim: None,
             provider_budget_consumed: true,
             provider_executions_consumed: 1,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -768,6 +768,10 @@ pub struct AgentTaskCookFailureContext {
     pub reason_code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostic: Option<Value>,
+    /// Bounded, durable admission predicates for a denied historical
+    /// continuation. It intentionally contains no provider output or evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation_admission: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blocking_claim: Option<Value>,
     pub provider_budget_consumed: bool,
@@ -778,6 +782,49 @@ pub struct AgentTaskCookFailureContext {
     pub legal_actions: Vec<AgentTaskCookRecoveryAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<AgentTaskCookRecoveryAction>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ContinuationAdmissionTrace {
+    schema: &'static str,
+    predicates: Vec<ContinuationAdmissionPredicate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_authoritative_denial: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct ContinuationAdmissionPredicate {
+    name: &'static str,
+    outcome: &'static str,
+}
+
+impl ContinuationAdmissionTrace {
+    fn new() -> Self {
+        Self {
+            schema: "homeboy/cook-continuation-admission/v1",
+            predicates: Vec::new(),
+            first_authoritative_denial: None,
+        }
+    }
+
+    fn pass(&mut self, name: &'static str) {
+        self.predicates.push(ContinuationAdmissionPredicate {
+            name,
+            outcome: "pass",
+        });
+    }
+
+    fn deny(&mut self, name: &'static str, outcome: &'static str) {
+        self.predicates
+            .push(ContinuationAdmissionPredicate { name, outcome });
+        if self.first_authoritative_denial.is_none() {
+            self.first_authoritative_denial = Some(name);
+        }
+    }
+
+    fn value(&self) -> Value {
+        serde_json::to_value(self).expect("continuation admission trace serializes")
+    }
 }
 
 /// An exact command that is legal for the durable Cook state.
@@ -2077,8 +2124,11 @@ where
                     .and_then(Value::as_str)
                     == Some("verification_pending")
         });
-    let authenticated_historical_review_continuation =
-        allow_historical_terminal && authenticated_historical_review_form_workspace(&options)?;
+    let authenticated_historical_review_continuation = if allow_historical_terminal {
+        authenticated_historical_review_form_workspace(&options)?
+    } else {
+        false
+    };
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
@@ -3421,25 +3471,52 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
 fn authenticated_historical_review_form_workspace(
     options: &AgentTaskCookServiceOptions,
 ) -> Result<bool> {
+    let mut trace = ContinuationAdmissionTrace::new();
     if !agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
+        trace.deny("run_record", "unavailable");
         return Ok(false);
     }
+    trace.pass("run_record");
     let record = agent_task_lifecycle::status(&options.initial_run_id)?;
-    if !terminal_review_form_continuation_is_eligible(&options.initial_plan, &record)
-        .unwrap_or(false)
-    {
-        return Ok(false);
+    match terminal_review_form_continuation_is_eligible(&options.initial_plan, &record) {
+        Ok(true) => trace.pass("terminal_review_form_eligibility"),
+        Ok(false) => {
+            trace.deny("terminal_review_form_eligibility", "fail");
+            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            return Ok(false);
+        }
+        Err(_) => {
+            trace.deny("terminal_review_form_eligibility", "unavailable");
+            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            return Ok(false);
+        }
     }
     let Some(promotion) = persisted_promotion_for_attempt(&options.initial_run_id).unwrap_or(None)
     else {
+        trace.deny("applied_promotion", "unavailable");
+        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
         return Ok(false);
     };
     if promotion.status != AgentTaskPromotionStatus::Applied {
+        trace.deny("applied_promotion", "fail");
+        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
         return Ok(false);
     }
-    let Some(continuation) = tracked_promotion_continuation(options).unwrap_or(None) else {
-        return Ok(false);
+    trace.pass("applied_promotion");
+    let continuation = match tracked_promotion_continuation(options) {
+        Ok(Some(continuation)) => continuation,
+        Ok(None) => {
+            trace.deny("continuation_evidence", "unavailable");
+            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            return Ok(false);
+        }
+        Err(_) => {
+            trace.deny("continuation_evidence", "fail");
+            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            return Ok(false);
+        }
     };
+    trace.pass("continuation_evidence");
     let resolution =
         match homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
             &options.to_worktree,
@@ -3447,8 +3524,21 @@ fn authenticated_historical_review_form_workspace(
             Some(&continuation.baseline),
         ) {
             Ok(resolution) => resolution,
-            Err(_) => return Ok(false),
+            Err(error) => {
+                let predicate = if error.details.pointer("/workspace/classification")
+                    == Some(&Value::String("workspace.resolved_but_dirty".to_string()))
+                {
+                    "provider_baseline_verification"
+                } else {
+                    "provider_resolution"
+                };
+                trace.deny(predicate, "fail");
+                record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+                return Ok(false);
+            }
         };
+    trace.pass("provider_resolution");
+    trace.pass("provider_baseline_verification");
     if resolution.worktree.handle != options.to_worktree
         || homeboy_core::worktree_providers::validate_task_worktree_root(
             std::path::Path::new(&resolution.worktree.path),
@@ -3456,12 +3546,35 @@ fn authenticated_historical_review_form_workspace(
         )
         .is_err()
     {
+        trace.deny("worktree_root", "fail");
+        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
         return Ok(false);
     }
+    trace.pass("worktree_root");
     let Ok(target) = std::fs::canonicalize(&resolution.worktree.path) else {
+        trace.deny("candidate_fingerprint", "unavailable");
+        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
         return Ok(false);
     };
-    Ok(authenticate_tracked_promotion_continuation(&target, &continuation).is_ok())
+    if authenticate_tracked_promotion_continuation(&target, &continuation).is_err() {
+        trace.deny("candidate_fingerprint", "fail");
+        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        return Ok(false);
+    }
+    trace.pass("candidate_fingerprint");
+    record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+    Ok(true)
+}
+
+fn record_continuation_admission_trace(
+    run_id: &str,
+    trace: &ContinuationAdmissionTrace,
+) -> Result<()> {
+    agent_task_lifecycle::record_metadata_value(
+        run_id,
+        "cook_continuation_admission",
+        trace.value(),
+    )
 }
 
 struct TrackedPromotionContinuation {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2691,6 +2691,10 @@ fn cook_failure_context(
         .as_ref()
         .filter(|claim| claim.state == agent_task_lifecycle::ClaimState::Failed)
         .and_then(|claim| claim.result.clone());
+    let continuation_admission = record
+        .as_ref()
+        .and_then(|record| record.metadata.get("cook_continuation_admission"))
+        .cloned();
     let (phase, reason_code) = if blocking_claim.is_some() {
         ("promotion".to_string(), "operation_in_progress".to_string())
     } else if let Some(diagnostic) = diagnostic.as_ref() {
@@ -2809,6 +2813,7 @@ fn cook_failure_context(
         phase,
         reason_code,
         diagnostic,
+        continuation_admission,
         blocking_claim,
         provider_budget_consumed: provider_executions_consumed > 0,
         provider_executions_consumed,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6507,6 +6507,15 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             error.details["workspace"]["classification"],
             "workspace.resolved_but_dirty"
         );
+        let trace = agent_task_lifecycle::status(&historical.initial_run_id)
+            .unwrap()
+            .metadata["cook_continuation_admission"]
+            .clone();
+        assert_eq!(
+            trace["first_authoritative_denial"],
+            "provider_baseline_verification"
+        );
+        assert_eq!(trace["predicates"][4]["outcome"], "fail");
         assert_eq!(executions.load(Ordering::SeqCst), 0);
 
         std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
@@ -6530,6 +6539,15 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             error.details["workspace"]["classification"],
             "workspace.resolved_but_dirty"
         );
+        let trace = agent_task_lifecycle::status(&historical.initial_run_id)
+            .unwrap()
+            .metadata["cook_continuation_admission"]
+            .clone();
+        assert_eq!(
+            trace["first_authoritative_denial"],
+            "terminal_review_form_eligibility"
+        );
+        assert_eq!(trace["predicates"][1]["outcome"], "fail");
         assert_eq!(executions.load(Ordering::SeqCst), 0);
 
         agent_task_lifecycle::rewrite_record_for_test(&historical.initial_run_id, |record| {
@@ -6559,6 +6577,15 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             error.details["workspace"]["classification"],
             "workspace.resolved_but_dirty"
         );
+        let trace = agent_task_lifecycle::status(&historical.initial_run_id)
+            .unwrap()
+            .metadata["cook_continuation_admission"]
+            .clone();
+        assert_eq!(
+            trace["first_authoritative_denial"],
+            "terminal_review_form_eligibility"
+        );
+        assert_eq!(trace["predicates"][1]["outcome"], "fail");
         assert_eq!(executions.load(Ordering::SeqCst), 0);
         agent_task_lifecycle::record_promotion(&historical.initial_run_id, copied_promotion)
             .unwrap();
@@ -6579,6 +6606,14 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             result.value.failure_context
         );
         assert_ne!(result.value.status, "durable_failure");
+        let trace = agent_task_lifecycle::status(&historical.initial_run_id)
+            .unwrap()
+            .metadata["cook_continuation_admission"]
+            .clone();
+        assert_eq!(trace["schema"], "homeboy/cook-continuation-admission/v1");
+        assert_eq!(trace["first_authoritative_denial"], serde_json::Value::Null);
+        assert_eq!(trace["predicates"].as_array().unwrap().len(), 8);
+        assert!(trace.to_string().len() < 2048, "trace remains bounded");
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -963,6 +963,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         "missing_artifacts": missing_artifacts.clone(),
         "hydrated_evidence": hydrated_evidence,
         "hydrated_evidence_total": total_hydrated_evidence,
+        "continuation_admission": record.metadata.get("cook_continuation_admission"),
         "next_commands": next_commands,
     });
     if let Some(selection) = target.selection {


### PR DESCRIPTION
## Summary
- persist a bounded `homeboy/cook-continuation-admission/v1` trace for historical continuation admission
- expose predicate outcomes and the first authoritative denial through `agent-task diagnose` and Cook failure context
- cover exact legacy continuation, drift, malformed lineage, cancellation, and bounded serialization

Closes #11432.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `git diff --check`

AI assistance: OpenCode with OpenAI gpt-5.6-terra was used to implement and verify this diagnostics change. Chris Huber remains responsible for every line.