### PR TITLE
Keep Cook promotion alive after observer disconnects

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1178,6 +1178,39 @@ pub fn record_cook_progress(
     record.ok_or_else(|| Error::internal_unexpected("Cook progress record was unchanged"))
 }
 
+/// Persist a failed foreground observer delivery without changing the Cook's
+/// controller-owned progress. Observers are notification sinks, so their
+/// transport lifetime cannot determine whether a durable operation continues.
+pub fn record_cook_observer_event(
+    run_id: &str,
+    phase: &str,
+    diagnostic: Value,
+) -> Result<AgentTaskRunRecord> {
+    const MAX_EVENTS: usize = 16;
+
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let events = metadata
+            .entry("cook_observer_events".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let events = events
+            .as_array_mut()
+            .expect("cook observer events are an array");
+        events.push(json!({
+            "kind": "delivery_failed",
+            "phase": phase,
+            "at": now_timestamp(),
+            "diagnostic": diagnostic,
+        }));
+        if events.len() > MAX_EVENTS {
+            events.drain(..events.len() - MAX_EVENTS);
+        }
+        true
+    })?;
+    record.ok_or_else(|| Error::internal_unexpected("Cook observer event record was unchanged"))
+}
+
 /// Bind the Cook's authoritative command result to its terminal progress
 /// record. Provider and gate state alone cannot establish whether publication
 /// completed, so readers use this positive completion fact rather than a list

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -264,7 +264,16 @@ fn report_cook_progress(
 ) -> Result<()> {
     agent_task_lifecycle::record_cook_progress(run_id, phase, attempt, detail)?;
     if let Some(observer) = observer {
-        observer(phase, cook_id, run_id)?;
+        if let Err(error) = observer(phase, cook_id, run_id) {
+            // The observer is the submitting client's output channel. Once the
+            // progress record exists, a broken client pipe is evidence about
+            // observation, never authority to stop promotion or finalization.
+            let _ = agent_task_lifecycle::record_cook_observer_event(
+                run_id,
+                phase,
+                bounded_error_diagnostic(&error),
+            );
+        }
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6639,7 +6639,7 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
 }
 
 #[test]
-fn normal_cook_finalizes_an_inherited_gate_failure_without_provider_retry() {
+fn closed_observer_pipe_does_not_stop_promotion_or_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("repository");
         let root = temp.path();
@@ -6713,10 +6713,22 @@ fn normal_cook_finalizes_an_inherited_gate_failure_without_provider_retry() {
         let finalization_count = Arc::clone(&finalized);
         let expected_base = base.clone();
         let expected_run_id = run_id.clone();
-        let result = run_cook_with_finalizer(
+        let observer_calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&observer_calls);
+        let observer = move |phase: &str, _: &str, _: &str| {
+            observed.fetch_add(1, Ordering::SeqCst);
+            if phase == "promotion" {
+                return Err(Error::internal_io(
+                    "Broken pipe (os error 32)",
+                    Some("write submitting client stdout".to_string()),
+                ));
+            }
+            Ok(())
+        };
+        let result = run_cook_with_boundaries_observed(
             options,
             UnusedExecutor,
-            move |_, received_run, promotion| {
+            DefaultCookSideEffects::new(move |_, received_run, promotion| {
                 finalization_count.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(received_run, expected_run_id);
                 assert_eq!(promotion.verified_base.as_ref().unwrap().sha, expected_base);
@@ -6729,13 +6741,28 @@ fn normal_cook_finalizes_an_inherited_gate_failure_without_provider_retry() {
                     crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed
                 );
                 Ok(serde_json::json!({"status": "review_ready"}))
-            },
+            }),
+            Some(&observer),
         )
         .unwrap();
         assert_eq!(result.value.status, "review_ready", "{:#?}", result.value);
         assert_eq!(finalized.load(Ordering::SeqCst), 1);
+        assert!(observer_calls.load(Ordering::SeqCst) >= 1);
         let record = agent_task_lifecycle::status(&run_id).unwrap();
         assert_eq!(record.metadata["provider_executions_consumed"], 1);
+        assert_eq!(
+            record.metadata["cook_observer_events"][0]["kind"],
+            "delivery_failed"
+        );
+        assert_eq!(
+            record.metadata["cook_observer_events"][0]["phase"],
+            "promotion"
+        );
+        assert_eq!(
+            record.metadata["cook_progress"]["terminal_success"],
+            serde_json::json!(true),
+            "the disconnected observer can reconnect to the terminal durable result"
+        );
         let persisted = persisted_promotion_for_attempt(&run_id).unwrap().unwrap();
         assert_eq!(persisted.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(persisted.deterministic_gates[0].exit_code, 1);


### PR DESCRIPTION
## Summary
- decouple durable Cook promotion/finalization from observer pipe writes
- record observer write failure without failing the operation
- cover closed-pipe promotion and finalization

## Verification
- `cargo test -p homeboy-agents closed_observer_pipe_does_not_stop_promotion_or_finalization --lib`
- `cargo fmt --check`
- `git diff --check`

Closes #11428.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode inspected the failure, implemented the fix, and ran focused verification. Chris Huber remains responsible for every line.