### PR TITLE
test(cook): align two cook fixtures with the workspace and lineage contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3364,8 +3364,11 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("temp source root");
+        // Cook refuses provider execution against a primary checkout, so the
+        // candidate workspace has to be a linked worktree of a primary.
+        let primary = temp.path().join("primary");
         let source = temp.path().join("source");
-        std::fs::create_dir(&source).expect("create source repository");
+        std::fs::create_dir(&primary).expect("create primary repository");
         for args in [
             vec!["init"],
             vec!["config", "user.email", "agent@example.test"],
@@ -3373,20 +3376,32 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
         ] {
             assert!(Command::new("git")
                 .args(args)
-                .current_dir(&source)
+                .current_dir(&primary)
                 .status()
                 .expect("run git")
                 .success());
         }
-        std::fs::write(source.join("lib.rs"), "base\n").expect("write base");
+        std::fs::write(primary.join("lib.rs"), "base\n").expect("write base");
         for args in [vec!["add", "lib.rs"], vec!["commit", "-m", "base"]] {
             assert!(Command::new("git")
                 .args(args)
-                .current_dir(&source)
+                .current_dir(&primary)
                 .status()
                 .expect("run git")
                 .success());
         }
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "--detach",
+                source.to_str().expect("UTF-8 source path"),
+                "HEAD",
+            ])
+            .current_dir(&primary)
+            .status()
+            .expect("run git")
+            .success());
         std::fs::write(source.join("lib.rs"), "candidate\n").expect("dirty candidate");
 
         let entered = temp.path().join("baseline-entered");
@@ -3428,7 +3443,18 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
         );
         options.initial_run_id = "cook-slow-baseline-attempt-1".to_string();
         options.provider_command = Some("fixture-provider".to_string());
-        options.source_worktree_path = Some(source);
+        options.source_worktree_path = Some(source.clone());
+        // Cook validates the destination before it stages a baseline, so the
+        // fixture has to declare a real workspace rather than a bare handle.
+        options.to_worktree = source.display().to_string();
+        options.initial_plan.tasks[0].workspace.root = Some(source.display().to_string());
+        options.initial_plan.tasks[0].workspace.kind = Some("homeboy-worktree".to_string());
+        options.initial_plan.tasks[0].workspace.materialization = serde_json::json!({
+            "kind": "homeboy-worktree",
+            "id": "source@cook-slow-baseline",
+            "root": source,
+            "branch": "fix/cook-slow-baseline",
+        });
         let resume_options = options.clone();
         let controller = std::thread::spawn(move || run_cook(options, UnusedExecutor));
         let entered_staging = (0..500).any(|_| {
@@ -8437,6 +8463,9 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         options.gates.verify = vec!["true".to_string()];
         options.no_finalize = false;
         options.head = Some("fix/8058".to_string());
+        // Finalization authenticates the disclosure lineage against a concrete
+        // executed model, and the seeded aggregate takes its model from the plan.
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
         super::super::persist_initial_recipe(&options).unwrap();
         let run_id = options.initial_run_id.clone();
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&run_id)).unwrap();


### PR DESCRIPTION
Clears the remaining two of the three `homeboy-agents` cook tests red on `main`.
(#11439 fixed the third — a real product bug in `candidate_tree`.)

`agent_task_service::cook::tests`: **121 passed, 0 failed.**

## `cook_claims_its_durable_attempt_before_slow_baseline_materialization`

This one hid itself well. The test installs a `git` wrapper on `PATH` that
blocks on `git status`, then asserts baseline materialization blocked. It never
did — and instrumenting showed why:

`run_cook_with_boundaries_observed_inner` was **entered** but never reached
`validate_cook_candidate_group`, `materialize_initial_cook_attempt`, the gate
preflight, or the attempt loop — with no `return` anywhere in that span, and
without the caller seeing an error, because
`run_cook_with_boundaries_reported` converts an inner `Err` into
`durable_cook_error_report(..)` → `Ok`. So `.expect("accepted detached attempt")`
passed while the cook had already failed.

Logging that conversion gave the real errors, in order:

```
Invalid argument 'to_worktree': worktree handle `fixture@cook-slow-baseline`
is not a Homeboy task worktree and was not returned by a configured worktree
provider (no worktree providers are configured)
```

then, after declaring the workspace:

```
Invalid argument 'to_worktree': task worktree /…/source is a primary or
non-linked checkout; refusing provider execution
```

The fixture set only `source_worktree_path`, left `to_worktree` as a bare
handle, and built the candidate as a plain `git init` primary. Cook validates
the destination *before* it stages a baseline, so it never got that far.

Fixed by matching the sibling fixture in
`cook_alias_continuation_starts_from_failed_gate_feedback_attempt` /
`admission-retry`: declare `to_worktree`, `workspace.root`, `workspace.kind`,
and `workspace.materialization`, and create the candidate with
`git worktree add --detach` off a primary.

## `fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_attempt`

`exit_code` 1 vs 0, from:

```
Invalid argument 'provider_model': Cook lineage attempt has no concrete executed model
```

This test finalizes (`no_finalize = false`), and finalization authenticates the
disclosure lineage through `required_execution_model`.
`seed_review_form_aggregate` takes its outcome model from
`task.executor.model()`, and `batch_cook_options` leaves `executor.model` as
`None`. Non-finalizing tests using the same helper never hit the requirement,
which is why only this one broke.

Set `executor.model` like the other finalizing fixtures do.

## Both are fixture drift, not product bugs

The workspace validation and the lineage model requirement are both deliberate
contracts. These fixtures predate them.

## Wider state, for the record

`cargo test -p homeboy-agents --lib` is **1296 passed / 17 failed**. The
remaining 17 are outside these three and pre-existing — I verified two of the
scarier-sounding ones
(`timed_out_attempt_rotates_after_recovering_a_malformed_scratch_index`,
`rotation_adopts_only_the_explicit_portable_candidate`, both of which touch
scratch-index handling and so could plausibly have been collateral from #11439)
fail identically at `ea98b7e9b~1`, before that fix landed.