### PR TITLE
fix(runner): diagnose persisted session readiness drift

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -2877,7 +2877,8 @@ fn stale_daemon_warning(
             daemon_matches_configured,
             controller_identity.git_dirty == Some(true),
         )
-        .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths),
+        .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths)
+        .with_persisted_session_version(&runner.id, session.homeboy_version.clone()),
     ))
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -652,6 +652,30 @@ fn identical_rendered_runtime_identities_are_current_without_refresh() {
 }
 
 #[test]
+fn persisted_session_version_drift_rejects_admission_with_bounded_recovery() {
+    let identity = "homeboy 0.328.0+1e63f1ae0369";
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "0.328.0".to_string(),
+        Some(identity.to_string()),
+        Some(identity.to_string()),
+    )
+    .with_persisted_session_version("homeboy-lab", "0.327.9".to_string());
+
+    assert_eq!(
+        warning.mismatch_predicate,
+        "session_homeboy_version != job_command_binary_version"
+    );
+    assert_eq!(warning.session_homeboy_version, "0.327.9");
+    assert_eq!(warning.active_daemon_control_plane_version, "0.328.0");
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
+    );
+}
+
+#[test]
 fn same_version_different_controller_build_is_incompatible_and_truthful() {
     let warning = RunnerStaleDaemonWarning::new(
         "homeboy-lab",
@@ -694,6 +718,71 @@ fn same_version_different_controller_build_is_incompatible_and_truthful() {
         ["homeboy runner refresh-homeboy homeboy-lab --ref controller --reconnect --allow-downgrade"]
     );
     assert!(!warning.refresh_command.contains("--ref configured"));
+    let diagnostics = serde_json::to_value(&warning).expect("serialize controller build skew");
+    assert_eq!(
+        diagnostics["mismatch_predicate"],
+        "controller_build_commit != job_command_binary_build_commit"
+    );
+    assert_eq!(
+        diagnostics["recovery_commands"][0],
+        "homeboy runner refresh-homeboy homeboy-lab --ref controller --reconnect --allow-downgrade"
+    );
+}
+
+#[test]
+fn controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions() {
+    let identity = "homeboy 0.328.0+1e63f1ae0369";
+    let dirty = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "0.328.0".to_string(),
+        Some(identity.to_string()),
+        Some(identity.to_string()),
+    )
+    .with_controller_compatibility(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "homeboy 0.328.0+dirty-controller-dirty".to_string(),
+        true,
+        true,
+        true,
+    );
+    let version_skew = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "0.328.0".to_string(),
+        Some(identity.to_string()),
+        Some(identity.to_string()),
+    )
+    .with_controller_compatibility(
+        "homeboy-lab",
+        "0.327.9".to_string(),
+        "homeboy 0.327.9+controller".to_string(),
+        false,
+        true,
+        false,
+    );
+
+    let dirty_diagnostics = serde_json::to_value(&dirty).expect("serialize dirty controller");
+    assert_eq!(
+        dirty_diagnostics["mismatch_predicate"],
+        "controller_git_dirty == true"
+    );
+    assert_eq!(
+        dirty_diagnostics["recovery_commands"][0],
+        "homeboy upgrade --force"
+    );
+
+    let version_diagnostics =
+        serde_json::to_value(&version_skew).expect("serialize controller version skew");
+    assert_eq!(
+        version_diagnostics["mismatch_predicate"],
+        "controller_version != job_command_binary_version"
+    );
+    assert!(version_diagnostics["recovery_commands"]
+        .as_array()
+        .expect("serialized recovery command list")
+        .is_empty());
 }
 
 #[test]
@@ -799,6 +888,39 @@ fn runtime_path_drift_is_stale_and_names_the_changed_generation() {
     assert!(warning.message.contains("HOMEBOY_EXTENSION_PATH"));
     assert!(warning.message.contains("sha256:old"));
     assert!(warning.message.contains("sha256:new"));
+    assert_eq!(
+        warning.mismatch_predicate,
+        "runtime_paths.loaded != runtime_paths.configured"
+    );
+}
+
+#[test]
+fn runtime_path_diagnostics_redact_sensitive_values_without_hiding_path_drift() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "0.328.0".to_string(),
+        Some("homeboy 0.328.0+1e63f1ae0369".to_string()),
+        Some("homeboy 0.328.0+1e63f1ae0369".to_string()),
+    )
+    .with_runtime_paths(
+        "homeboy-lab",
+        Vec::new(),
+        vec![RunnerChangedRuntimePath {
+            env: "HOMEBOY_EXTENSION_PATH".to_string(),
+            loaded_path: Some("/srv/extensions?token=old-secret".to_string()),
+            configured_path: Some("/srv/extensions?token=new-secret".to_string()),
+        }],
+    );
+
+    let serialized = serde_json::to_string(&warning).expect("serialize path diagnostics");
+    assert!(!serialized.contains("old-secret"));
+    assert!(!serialized.contains("new-secret"));
+    assert!(serialized.contains("/srv/extensions?token=[REDACTED]"));
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
+    );
 }
 
 #[test]
@@ -850,6 +972,15 @@ fn unverifiable_identity_warning_is_actionable_without_claiming_a_mismatch() {
     assert_eq!(
         warning.recovery_commands,
         ["homeboy runner refresh-homeboy homeboy-lab --reconnect"]
+    );
+    let diagnostics = serde_json::to_value(&warning).expect("serialize unverifiable identity");
+    assert_eq!(
+        diagnostics["mismatch_predicate"],
+        "immutable_build_identity(active_daemon_control_plane_build_identity) && immutable_build_identity(job_command_binary_build_identity) == false"
+    );
+    assert_eq!(
+        diagnostics["recovery_commands"][0],
+        "homeboy runner refresh-homeboy homeboy-lab --reconnect"
     );
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -248,6 +248,46 @@ fn explicit_connected_stale_runner_preserves_drift_diagnosis_and_recovery() {
 }
 
 #[test]
+fn persisted_session_drift_rejects_the_real_availability_and_preflight_path() {
+    let mut status = reverse_status("homeboy-lab");
+    status.stale_daemon = Some(
+        RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "0.328.0".to_string(),
+            "0.328.0".to_string(),
+            Some("homeboy 0.328.0+1e63f1ae0369".to_string()),
+            Some("homeboy 0.328.0+1e63f1ae0369".to_string()),
+        )
+        .with_persisted_session_version("homeboy-lab", "0.327.9".to_string()),
+    );
+    let availability = RunnerAvailability::from_status_parts(
+        status.runner_id.clone(),
+        status.connected,
+        status.stale_daemon.is_some(),
+        status.active_jobs.len(),
+        &status.active_job_state,
+        Some(1),
+    );
+
+    let error = lab_runner_availability_error(
+        "agent-task cook",
+        Some(&availability),
+        Some(&status),
+        vec![availability.clone()],
+    );
+
+    assert!(!availability.accepts_jobs);
+    assert_eq!(
+        error.details["runner_status"]["stale_daemon"]["mismatch_predicate"],
+        "session_homeboy_version != job_command_binary_version"
+    );
+    assert_eq!(
+        error.details["stale_daemon_recovery_command"],
+        "homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"
+    );
+}
+
+#[test]
 fn disconnected_runner_keeps_existing_availability_diagnosis() {
     let availability = RunnerAvailability::from_status_parts(
         "homeboy-lab",

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1399,6 +1399,32 @@ impl RunnerStaleDaemonWarning {
         self
     }
 
+    /// A persisted session record participates in readiness independently of
+    /// the live daemon endpoint. Report it separately so equal live identities
+    /// cannot hide a stale persisted generation.
+    pub fn with_persisted_session_version(
+        mut self,
+        runner_id: &str,
+        persisted_session_version: String,
+    ) -> Self {
+        if !same_homeboy_version(&persisted_session_version, &self.current_homeboy_version)
+            && self.mismatch_predicate == "daemon_configured_identity == equal"
+        {
+            self.mismatch_predicate = "session_homeboy_version != job_command_binary_version";
+            self.session_homeboy_version = persisted_session_version;
+            self.message = format!(
+                "persisted runner session version `{}` differs from configured job command binary version `{}`; run recovery_commands in order when runner active jobs are drained",
+                self.session_homeboy_version, self.current_homeboy_version,
+            );
+            self.set_recovery(recovery_action(
+                runner_id,
+                self.current_homeboy_build_identity.as_deref(),
+                &homeboy_product_identity::build_identity(),
+            ));
+        }
+        self
+    }
+
     pub fn with_runtime_paths(
         mut self,
         runner_id: &str,
@@ -1408,17 +1434,26 @@ impl RunnerStaleDaemonWarning {
         self.stale_runtime_paths = stale_runtime_paths;
         self.changed_runtime_paths = changed_runtime_paths;
         if !self.stale_runtime_paths.is_empty() || !self.changed_runtime_paths.is_empty() {
+            for path in &mut self.stale_runtime_paths {
+                path.path = redact_runtime_value(&path.path);
+                path.loaded_fingerprint = redact_runtime_value(&path.loaded_fingerprint);
+                path.current_fingerprint = redact_runtime_value(&path.current_fingerprint);
+            }
+            for path in &mut self.changed_runtime_paths {
+                path.loaded_path = path.loaded_path.as_deref().map(redact_runtime_value);
+                path.configured_path = path.configured_path.as_deref().map(redact_runtime_value);
+            }
             self.mismatch_predicate = "runtime_paths.loaded != runtime_paths.configured";
             let stale_paths = self.stale_runtime_paths.iter().map(|path| {
                 format!(
                     "{} at `{}` fingerprint `{}` -> `{}`",
-                    path.env, path.path, path.loaded_fingerprint, path.current_fingerprint
+                    path.env, path.path, path.loaded_fingerprint, path.current_fingerprint,
                 )
             });
             let changed_paths = self.changed_runtime_paths.iter().map(|path| {
                 format!(
                     "{} path `{:?}` -> `{:?}`",
-                    path.env, path.loaded_path, path.configured_path
+                    path.env, path.loaded_path, path.configured_path,
                 )
             });
             self.message = format!(
@@ -1438,6 +1473,10 @@ impl RunnerStaleDaemonWarning {
         }
         self
     }
+}
+
+fn redact_runtime_value(value: &str) -> String {
+    homeboy_core::redaction::RedactionPolicy::default().redact_env_value(value)
 }
 
 fn action_from_refresh_command(command: &str) -> Option<ExecutableAction> {


### PR DESCRIPTION
Fixes #11430.

Follow-up to prematurely merged #11442; references closed #9259.

## Problem
#11442 merged as bffd4624 before reviewed commit d52ae3eee landed. The merged diagnostic can still reject readiness because persisted `session.homeboy_version` differs from the configured command while the observed daemon/configured identities are equal. The warning then reports the equal identity predicate and provides no recovery.

## Fix
- Add `session_homeboy_version != job_command_binary_version` as the exact serialized predicate when persisted session metadata independently blocks readiness.
- Retain observed daemon/configured machine fields and generate the bounded immutable-ref `refresh-homeboy --reconnect` recovery.
- Preserve higher-priority controller, identity-verification, and runtime-path predicates.
- Redact sensitive query and inline-assignment material from serialized runtime-path diagnostics while retaining non-sensitive path context.

## Evidence
- Verified `e85d6d075` cherry-picks cleanly onto current origin/main and contains only this follow-up, with no duplicate #11442 changes.
- `cargo fmt --check` passed.
- `cargo test -p homeboy-lab-runner connection::tests::session --lib` passed.
- `cargo test -p homeboy-lab-runner lab::offload::tests::selection --lib` passed.
- `cargo check -p homeboy-lab-runner` passed.
- Tests construct persisted-session drift through RunnerAvailability and Lab preflight error serialization, and cover controller dirty/version/build skew, unverifiable identity, runtime-path drift, and runtime-path secret redaction.

## Compatibility
This is an additive diagnostic predicate and preserves fail-closed readiness. Existing mixed-version and capability policy remain unchanged. Runtime-path redaction removes recognized secret material only; non-sensitive path context and pinned recoveries remain actionable.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode isolated the omitted commit from #11442, rebased it as a clean one-commit follow-up on current main, ran focused verification, and prepared this PR. Chris Huber owns every line.