### PR TITLE
fix(agents): stop exec'ing a temp script that is still open for writing

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/acceptance_verifier.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/acceptance_verifier.rs
@@ -688,12 +688,16 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn script(body: &str) -> NamedTempFile {
+    fn script(body: &str) -> tempfile::TempPath {
         use std::os::unix::fs::PermissionsExt;
-        let file = NamedTempFile::new().unwrap();
-        std::fs::write(file.path(), format!("#!/bin/sh\n{body}\n")).unwrap();
-        std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
-        file
+        // NamedTempFile holds its own write handle open for as long as it
+        // lives, and Linux refuses to exec a file that is open for writing
+        // (ETXTBSY). Convert to a TempPath so the script is closed before the
+        // verifier runs it while the file still outlives the test body.
+        let path = NamedTempFile::new().unwrap().into_temp_path();
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        path
     }
 
     #[cfg(unix)]
@@ -703,7 +707,7 @@ mod tests {
         let mut output = signed_output(&request);
         output = output.replacen("reviewer", "attacker", 1);
         let file = script(&format!("printf '%s' '{}'", output.replace('\'', "'\\''")));
-        let error = verifier(vec![file.path().display().to_string()], 2_000)
+        let error = verifier(vec![file.display().to_string()], 2_000)
             .verify_acceptance(&request)
             .unwrap_err();
         assert!(
@@ -720,7 +724,7 @@ mod tests {
         let output = signed_output(&request);
         let file = script(&format!("printf '%s' '{}'", output.replace('\'', "'\\''")));
 
-        let attestation = verifier(vec![file.path().display().to_string()], 2_000)
+        let attestation = verifier(vec![file.display().to_string()], 2_000)
             .verify_acceptance(&request)
             .expect("complete valid signed verifier output is accepted");
 
@@ -738,7 +742,7 @@ mod tests {
             output.replace('\'', "'\\''")
         ));
         let started = Instant::now();
-        let error = verifier(vec![file.path().display().to_string()], 2_000)
+        let error = verifier(vec![file.display().to_string()], 2_000)
             .verify_acceptance(&request)
             .unwrap_err();
         assert!(
@@ -789,7 +793,7 @@ mod tests {
     #[test]
     fn command_verifier_times_out_while_stdin_is_backpressured() {
         let file = script("sleep 5");
-        let error = verifier(vec![file.path().display().to_string()], 50)
+        let error = verifier(vec![file.display().to_string()], 50)
             .verify_acceptance(&request(&"x".repeat(512 * 1024)))
             .unwrap_err();
         assert!(error.message.contains("timed out"));
@@ -804,7 +808,7 @@ mod tests {
             "(sleep 1; printf escaped > '{marker_path}') & cat >&2; exit 1"
         ));
         let token = "literal-token-that-must-not-leak";
-        let error = verifier(vec![file.path().display().to_string()], 500)
+        let error = verifier(vec![file.display().to_string()], 500)
             .verify_acceptance(&request(token))
             .unwrap_err();
         assert!(!error.message.contains(token));

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -826,7 +826,11 @@ mod tests {
         git(source.path(), &["init", "-b", "main"]);
         fs::create_dir_all(source.path().join("src")).expect("source directory");
         fs::write(source.path().join("src/lib.rs"), "base").expect("source file");
-        git(source.path(), &["add", "src/lib.rs"]);
+        // Cleanup refuses to reclaim an artifact path holding untracked work
+        // that Git does not ignore, so the fixture has to ignore target/ the
+        // way a real Cargo checkout does.
+        fs::write(source.path().join(".gitignore"), "target/\n").expect("gitignore");
+        git(source.path(), &["add", "src/lib.rs", ".gitignore"]);
         git(
             source.path(),
             &[


### PR DESCRIPTION
Two more `homeboy-agents` failures, from the 16 that `cargo test -p homeboy-agents --lib` reports beyond the three cook tests.

## `acceptance_verifier` — a real bug, 4 tests

```
Invalid argument 'acceptance': acceptance verifier could not start: Text file busy (os error 26)
```

Reproduces with `--test-threads=1`, so it is not a parallelism flake.

The `script()` helper returns a `NamedTempFile`, which **keeps its own write
handle open for as long as the value lives**. Linux refuses to `exec` a file
that is open for writing — `ETXTBSY`. The test then hands that path to the
verifier, which can never start.

`std::fs::write(file.path(), ..)` writing through a second handle does not help;
it is `NamedTempFile`'s own handle, held for the whole test body, that blocks
the exec.

Converted to `TempPath`: the file still outlives the test and is still removed
on drop, but nothing holds it open for writing when the verifier execs it.

Fixes all four, including
`command_verifier_times_out_while_stdin_is_backpressured`, which was failing
with a plain `assertion failed` and turned out to be the same root cause.

`agent_task_lifecycle::acceptance_verifier`: **7 passed, 0 failed.**

## `terminal_cleanup_reclaims_build_output_before_preserving_changed_source` — fixture

`assertion failed: !attempt_root.join("target").exists()`.

Artifact cleanup deliberately refuses to reclaim an artifact path that holds
untracked work Git does not ignore:

```rust
if has_untracked_work_at(&safety.untracked_paths, &declaration.relative_path) {
    // "artifact path holds untracked work that Git does not ignore"
    continue;
}
```

That check is right — it is what stops an unscoped pass from deleting real work
(cf. #9481). The fixture wrote `target/debug/app` into a repo with **no
`.gitignore`**, so `target/` read as untracked work and was correctly retained.
Every real Cargo checkout ignores `target/`.

Traced by instrumenting `collect_worktree_candidates`: the declaration was
found (`declarations=Ok(1)`, kind `rust_target`) and skipped before the liveness
check, which ruled out the `#10810` active-target protection as the cause.

`agent_task_scheduler::attempt_workspace`: **5 passed, 0 failed.**

## Related

- #11439 — `candidate_tree` stale stat cache (merged)
- #11452 — the two cook fixtures

Still working through the rest.