### PR TITLE
Fix merge-headed stack PR application

### DIFF
--- a/crates/homeboy-stack/src/stack/apply.rs
+++ b/crates/homeboy-stack/src/stack/apply.rs
@@ -13,7 +13,9 @@
 //!    - Resolve the PR's head SHA + head repo coordinates via `gh pr view`.
 //!    - Add a temporary remote for the PR's head repo (if it's not the
 //!      base repo and not already configured) and fetch the head SHA.
-//!    - `git cherry-pick <sha>`.
+//!    - For a merge head, fetch its GitHub `baseRefOid`, identify the unique
+//!      base-side parent, then `git cherry-pick -m <base-side-parent> <sha>`.
+//!      Non-merge heads use ordinary `git cherry-pick <sha>`.
 //!    - On `--allow-empty`-style "nothing to commit" outcome (the PR is
 //!      already in base), skip cleanly.
 //!    - On any other conflict, return [`Error::stack_apply_conflict`] with a
@@ -162,8 +164,17 @@ fn rebuild(
         let head_remote = ensure_head_remote(&path, pr, &head, &mut ensured_remotes)?;
         fetch_sha(&path, &head_remote, &head.sha)?;
 
-        // Cherry-pick.
-        match cherry_pick(&path, &head.sha)? {
+        // A shallow checkout may contain the fetched merge head without its
+        // GitHub-recorded base. Fetch that exact object before ancestry checks.
+        if is_merge_commit(&path, &head.sha)? {
+            let base_sha = required_merge_base_sha(pr, &head)?;
+            fetch_sha(&path, &spec.base.remote, base_sha)?;
+        }
+
+        // A merge head must be picked relative to its base-side parent so the
+        // resulting patch remains the PR's feature change rather than its
+        // base-branch merge.
+        match cherry_pick_pr_head(&path, pr, &head)? {
             CherryPickResult::Picked => {
                 picked += 1;
                 applied.push(AppliedPr {
@@ -456,7 +467,122 @@ pub(super) fn fetch_sha(path: &str, remote: &str, sha: &str) -> Result<()> {
 }
 
 pub(crate) fn cherry_pick(path: &str, sha: &str) -> Result<CherryPickResult> {
-    let output = run_git(path, &["cherry-pick", sha])?;
+    cherry_pick_with_mainline(path, sha, None)
+}
+
+fn cherry_pick_pr_head(path: &str, pr: &StackPrEntry, head: &PrHead) -> Result<CherryPickResult> {
+    let mainline = base_side_merge_parent(path, pr, head)?;
+    cherry_pick_with_mainline(path, &head.sha, mainline)
+}
+
+/// Return the one-based base-side parent number for a merge commit, if any.
+/// Non-merge heads retain ordinary cherry-pick behavior.
+fn base_side_merge_parent(path: &str, pr: &StackPrEntry, head: &PrHead) -> Result<Option<usize>> {
+    let parents = merge_parents(path, &head.sha)?;
+    if parents.len() < 2 {
+        return Ok(None);
+    }
+
+    let base_sha = required_merge_base_sha(pr, head)?;
+    let mut candidates = Vec::new();
+    for (index, parent) in parents.iter().enumerate() {
+        let output = run_git(path, &["merge-base", "--is-ancestor", parent, base_sha])?;
+        if output.status.success() {
+            candidates.push(index + 1);
+        } else if output.status.code() != Some(1) {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::git_command_failed(format!(
+                "git merge-base --is-ancestor {} {}: {}",
+                parent,
+                base_sha,
+                stderr.trim()
+            )));
+        }
+    }
+
+    match candidates.as_slice() {
+        [mainline] => Ok(Some(*mainline)),
+        _ => Err(merge_parent_error(
+            pr,
+            head,
+            "zero or multiple merge parents are equal to or ancestors of the authoritative PR base",
+            &candidates,
+        )),
+    }
+}
+
+fn is_merge_commit(path: &str, sha: &str) -> Result<bool> {
+    Ok(merge_parents(path, sha)?.len() >= 2)
+}
+
+fn merge_parents(path: &str, sha: &str) -> Result<Vec<String>> {
+    let output = run_git(path, &["rev-list", "--parents", "-n", "1", sha])?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git rev-list --parents -n 1 {}: {}",
+            sha,
+            stderr.trim()
+        )));
+    }
+    let revision_output = String::from_utf8_lossy(&output.stdout);
+    let mut revisions = revision_output.split_whitespace();
+    let _commit = revisions.next();
+    Ok(revisions.map(str::to_string).collect())
+}
+
+fn required_merge_base_sha<'a>(pr: &StackPrEntry, head: &'a PrHead) -> Result<&'a str> {
+    head.base_sha.as_deref().ok_or_else(|| {
+        merge_parent_error(
+            pr,
+            head,
+            "GitHub returned no baseRefOid for this merge head",
+            &[],
+        )
+    })
+}
+
+fn merge_parent_error(
+    pr: &StackPrEntry,
+    head: &PrHead,
+    reason: &str,
+    candidates: &[usize],
+) -> Error {
+    let candidate_text = if candidates.is_empty() {
+        "none".to_string()
+    } else {
+        candidates
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    Error::git_command_failed(format!(
+        "refusing to cherry-pick merge head {} for {}#{}: {} (baseRefOid: {}, candidate parents: {}). \
+         Rebase the PR onto its current base branch and retry; no cherry-pick was started.",
+        head.sha,
+        pr.repo,
+        pr.number,
+        reason,
+        head.base_sha.as_deref().unwrap_or("missing"),
+        candidate_text,
+    ))
+}
+
+fn cherry_pick_with_mainline(
+    path: &str,
+    sha: &str,
+    mainline: Option<usize>,
+) -> Result<CherryPickResult> {
+    let mainline_arg;
+    let args: Vec<&str> = match mainline {
+        Some(parent) => {
+            mainline_arg = parent.to_string();
+            vec!["cherry-pick", "-m", &mainline_arg, sha]
+        }
+        None => vec!["cherry-pick", sha],
+    };
+    let output = run_git(path, &args)?;
     if output.status.success() {
         return Ok(CherryPickResult::Picked);
     }

--- a/crates/homeboy-stack/src/stack/pr_meta.rs
+++ b/crates/homeboy-stack/src/stack/pr_meta.rs
@@ -10,6 +10,9 @@ use super::spec::StackPrEntry;
 #[derive(Debug, Clone)]
 pub(crate) struct PrHead {
     pub(crate) sha: String,
+    /// Authoritative base commit recorded by GitHub for this PR. Required to
+    /// identify the base-side parent when `sha` is a merge commit.
+    pub(crate) base_sha: Option<String>,
     /// `<owner>/<name>` of the head repo (may differ from the PR's base repo
     /// if the PR was opened from a fork).
     pub(crate) head_repo: String,
@@ -22,6 +25,7 @@ pub(crate) struct PrHead {
 #[derive(Debug, Clone)]
 pub(crate) struct StackPrMeta {
     pub(crate) head_sha: String,
+    pub(crate) base_sha: Option<String>,
     pub(crate) head_owner: Option<String>,
     pub(crate) head_name: Option<String>,
     pub(crate) state: String,
@@ -55,6 +59,7 @@ impl StackPrMeta {
         let head_repo = format!("{}/{}", head_owner, head_name);
         Ok(PrHead {
             sha: self.head_sha.clone(),
+            base_sha: self.base_sha.clone(),
             clone_url: format!("https://github.com/{}.git", head_repo),
             head_repo,
         })
@@ -79,7 +84,7 @@ pub(crate) fn fetch_pr_meta(pr: &StackPrEntry) -> Result<StackPrMeta> {
             "--repo",
             &pr.repo,
             "--json",
-            "headRefOid,headRepository,headRepositoryOwner,state,title,url,reviewDecision,mergedAt",
+            "headRefOid,baseRefOid,headRepository,headRepositoryOwner,state,title,url,reviewDecision,mergedAt",
         ])
         .output()
         .map_err(|e| {
@@ -113,6 +118,7 @@ pub(crate) fn parse_pr_meta(pr: &StackPrEntry, stdout: &str) -> Result<StackPrMe
 
     Ok(StackPrMeta {
         head_sha: string_field(&parsed, "headRefOid").unwrap_or_default(),
+        base_sha: non_empty_string_field(&parsed, "baseRefOid"),
         head_owner: nested_string_field(&parsed, "headRepositoryOwner", "login"),
         head_name: nested_string_field(&parsed, "headRepository", "name"),
         state: string_field(&parsed, "state").unwrap_or_default(),
@@ -160,6 +166,7 @@ mod tests {
     fn full_json() -> &'static str {
         r#"{
             "headRefOid": "abc123",
+            "baseRefOid": "base123",
             "headRepositoryOwner": { "login": "Extra-Chill" },
             "headRepository": { "name": "homeboy" },
             "state": "MERGED",
@@ -191,6 +198,7 @@ mod tests {
         std::env::set_var("PATH", old_path);
 
         assert_eq!(meta.head_sha, "abc123");
+        assert_eq!(meta.base_sha.as_deref(), Some("base123"));
         assert_eq!(meta.title.as_deref(), Some("Clean stack internals"));
     }
 
@@ -199,6 +207,7 @@ mod tests {
         let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
 
         assert_eq!(meta.head_sha, "abc123");
+        assert_eq!(meta.base_sha.as_deref(), Some("base123"));
         assert_eq!(meta.state, "MERGED");
         assert_eq!(meta.review_decision.as_deref(), Some("APPROVED"));
         assert_eq!(meta.merged_at.as_deref(), Some("2026-04-26T00:00:00Z"));
@@ -219,6 +228,7 @@ mod tests {
         let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
         let head = meta.require_head(&pr()).expect("required head");
         assert_eq!(head.sha, "abc123");
+        assert_eq!(head.base_sha.as_deref(), Some("base123"));
         assert_eq!(head.head_repo, "Extra-Chill/homeboy");
         assert_eq!(head.clone_url, "https://github.com/Extra-Chill/homeboy.git");
 

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -10,10 +10,11 @@
 //! fixture spec described in the PR body.
 
 use crate::stack::apply::{
-    checkout_force, cherry_pick, cherry_pick_in_progress, conflict_error, conflict_guidance,
-    ensure_no_cherry_pick_in_progress, rebase, url_matches, CherryPickResult, ConflictContext,
-    ConflictPolicy,
+    checkout_force, cherry_pick, cherry_pick_in_progress, cherry_pick_pr_head, conflict_error,
+    conflict_guidance, ensure_no_cherry_pick_in_progress, rebase, url_matches, CherryPickResult,
+    ConflictContext, ConflictPolicy,
 };
+use crate::stack::pr_meta::PrHead;
 use crate::stack::{save, GitRef, StackPrEntry, StackSpec};
 use homeboy_core::test_support::with_isolated_home;
 use std::fs;
@@ -49,6 +50,283 @@ fn cherry_pick_succeeds_picked() {
         .output()
         .unwrap();
     assert!(status.stdout.is_empty(), "working tree should be clean");
+}
+
+#[test]
+fn non_merge_pr_head_uses_ordinary_cherry_pick() {
+    let (dir, path) = init_repo();
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    let sha = commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    let pr = pr_entry();
+    let head = PrHead {
+        sha,
+        base_sha: None,
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let result = cherry_pick_pr_head(&path, &pr, &head).expect("non-merge PR head should apply");
+
+    assert!(matches!(result, CherryPickResult::Picked));
+    assert_eq!(
+        fs::read_to_string(dir.path().join("feature.txt")).unwrap(),
+        "feature change\n"
+    );
+}
+
+#[test]
+fn merge_pr_head_uses_base_side_parent_equal_to_github_base() {
+    let (dir, path) = init_repo();
+    let initial = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    let base_sha = commit_file(&dir, &path, "base.txt", "base change\n", "base commit");
+    git(&path, &["checkout", "-q", "feature"]);
+    git(
+        &path,
+        &[
+            "merge",
+            "-q",
+            "--no-ff",
+            "main",
+            "-m",
+            "merge base into feature",
+        ],
+    );
+    let merge_sha = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-B", "target", &initial]);
+    let pr = pr_entry();
+    let head = PrHead {
+        sha: merge_sha,
+        base_sha: Some(base_sha),
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let result = cherry_pick_pr_head(&path, &pr, &head).expect("merge PR head should apply");
+
+    assert!(matches!(result, CherryPickResult::Picked));
+    assert_eq!(
+        fs::read_to_string(dir.path().join("feature.txt")).unwrap(),
+        "feature change\n"
+    );
+    assert!(
+        !dir.path().join("base.txt").exists(),
+        "the base-side merge must not be included in the PR patch"
+    );
+}
+
+#[test]
+fn merge_pr_head_uses_base_side_parent_when_github_base_advanced_after_merge() {
+    let (dir, path) = init_repo();
+    let initial = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    let merged_base = commit_file(&dir, &path, "base.txt", "merged base\n", "base commit");
+    git(&path, &["checkout", "-q", "feature"]);
+    git(
+        &path,
+        &[
+            "merge",
+            "-q",
+            "--no-ff",
+            "main",
+            "-m",
+            "merge base into feature",
+        ],
+    );
+    let merge_sha = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "main"]);
+    let advanced_base = commit_file(
+        &dir,
+        &path,
+        "later.txt",
+        "later base\n",
+        "later base commit",
+    );
+    git(&path, &["checkout", "-q", "-B", "target", &initial]);
+    let pr = pr_entry();
+    let head = PrHead {
+        sha: merge_sha,
+        base_sha: Some(advanced_base.clone()),
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let result = cherry_pick_pr_head(&path, &pr, &head)
+        .expect("base parent remains valid after the GitHub base advances");
+
+    assert!(matches!(result, CherryPickResult::Picked));
+    assert!(
+        !dir.path().join("base.txt").exists(),
+        "the base-side merge must not be included in the PR patch"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("feature.txt")).unwrap(),
+        "feature change\n"
+    );
+    assert_ne!(merged_base, advanced_base);
+}
+
+#[test]
+fn merge_pr_head_with_no_base_side_parent_fails_before_starting_a_cherry_pick() {
+    let (dir, path) = init_repo();
+    let initial = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    commit_file(&dir, &path, "base.txt", "base change\n", "base commit");
+    git(&path, &["checkout", "-q", "feature"]);
+    git(
+        &path,
+        &[
+            "merge",
+            "-q",
+            "--no-ff",
+            "main",
+            "-m",
+            "merge base into feature",
+        ],
+    );
+    let merge_sha = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-B", "target", &initial]);
+    let pr = pr_entry();
+    let head = PrHead {
+        sha: merge_sha,
+        base_sha: Some(initial.clone()),
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let error =
+        cherry_pick_pr_head(&path, &pr, &head).expect_err("no base-side parent must fail closed");
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("candidate parents: none"), "{rendered}");
+    assert!(
+        rendered.contains("no cherry-pick was started"),
+        "{rendered}"
+    );
+    assert!(!cherry_pick_in_progress(&path));
+    assert_eq!(rev_parse(&path, "HEAD"), initial);
+    assert!(!dir.path().join("feature.txt").exists());
+}
+
+#[test]
+fn merge_pr_head_with_multiple_base_side_parents_fails_before_starting_a_cherry_pick() {
+    let (dir, path) = init_repo();
+    let initial = rev_parse(&path, "HEAD");
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    git(
+        &path,
+        &["merge", "-q", "--no-ff", "feature", "-m", "ambiguous merge"],
+    );
+    let merge_sha = rev_parse(&path, "HEAD");
+    let advanced_base = commit_file(
+        &dir,
+        &path,
+        "later.txt",
+        "later base\n",
+        "later base commit",
+    );
+    git(&path, &["checkout", "-q", "-B", "target", &initial]);
+    let pr = pr_entry();
+    let head = PrHead {
+        sha: merge_sha,
+        base_sha: Some(advanced_base),
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let error = cherry_pick_pr_head(&path, &pr, &head)
+        .expect_err("ambiguous base-side parents must fail closed");
+
+    let rendered = error.to_string();
+    assert!(rendered.contains("candidate parents: 1, 2"), "{rendered}");
+    assert!(
+        rendered.contains("no cherry-pick was started"),
+        "{rendered}"
+    );
+    assert!(!cherry_pick_in_progress(&path));
+    assert_eq!(rev_parse(&path, "HEAD"), initial);
+    assert!(!dir.path().join("feature.txt").exists());
+}
+
+#[test]
+fn merge_pr_head_without_github_base_fails_before_starting_a_cherry_pick() {
+    let (dir, path) = init_repo();
+    git(&path, &["checkout", "-q", "-b", "feature"]);
+    commit_file(
+        &dir,
+        &path,
+        "feature.txt",
+        "feature change\n",
+        "feature commit",
+    );
+    git(&path, &["checkout", "-q", "main"]);
+    commit_file(&dir, &path, "base.txt", "base change\n", "base commit");
+    git(&path, &["checkout", "-q", "feature"]);
+    git(
+        &path,
+        &[
+            "merge",
+            "-q",
+            "--no-ff",
+            "main",
+            "-m",
+            "merge base into feature",
+        ],
+    );
+    let pr = pr_entry();
+    let head = PrHead {
+        sha: rev_parse(&path, "HEAD"),
+        base_sha: None,
+        head_repo: "example-org/studio".to_string(),
+        clone_url: "https://github.com/example-org/studio.git".to_string(),
+    };
+
+    let error = cherry_pick_pr_head(&path, &pr, &head)
+        .expect_err("a merge head without baseRefOid must fail closed");
+
+    assert!(error
+        .to_string()
+        .contains("GitHub returned no baseRefOid for this merge head"));
+    assert!(!cherry_pick_in_progress(&path));
 }
 
 #[test]

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -22,6 +22,7 @@ use support::{commit_file, git, init_repo};
 fn meta(state: &str, head_sha: &str) -> PrMeta {
     PrMeta {
         head_sha: head_sha.to_string(),
+        base_sha: None,
         head_owner: Some("example-org".to_string()),
         head_name: Some("studio".to_string()),
         state: state.to_string(),


### PR DESCRIPTION
## Summary
- resolve merge-headed PR ancestry against the declared base
- fail closed on ambiguous parents
- cover advanced-base and sync behavior

## Tests
- `cargo test -p homeboy-stack --lib`

Closes #11394

AI assistance: gpt-5.6-sol via OpenCode implemented, reviewed, rebased, and tested this change under human direction.