### PR TITLE
Preserve inherited gate failure truth

### DIFF
--- a/crates/contracts/homeboy-gate-contract/src/gate.rs
+++ b/crates/contracts/homeboy-gate-contract/src/gate.rs
@@ -49,6 +49,10 @@ pub enum HomeboyGateKind {
 pub enum HomeboyGateStatus {
     Passed,
     Failed,
+    /// The candidate failed, but the same failure was reproduced against its
+    /// immutable baseline. This remains red unless a caller explicitly accepts
+    /// the proven non-regression for its own policy boundary.
+    AcceptedInheritedFailure,
     Skipped,
     Blocked,
 }

--- a/crates/contracts/homeboy-gate-contract/src/proof.rs
+++ b/crates/contracts/homeboy-gate-contract/src/proof.rs
@@ -337,6 +337,7 @@ pub fn gate_status_label(status: HomeboyGateStatus) -> &'static str {
     match status {
         HomeboyGateStatus::Passed => "passed",
         HomeboyGateStatus::Failed => "failed",
+        HomeboyGateStatus::AcceptedInheritedFailure => "accepted_inherited_failure",
         HomeboyGateStatus::Skipped => "skipped",
         HomeboyGateStatus::Blocked => "blocked",
     }

--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -75,6 +75,9 @@ pub struct AgentTaskCookLoopReport {
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskCookLoopStatus {
     GreenCompleted,
+    /// The candidate and immutable baseline failed identically. The candidate
+    /// is not a regression, but required verification is still red.
+    BaselineRed,
     IntentionalNoChange,
     NoChanges,
     NoOpGateFailed,
@@ -202,7 +205,12 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         .promotion_report
         .deterministic_gates
         .iter()
-        .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
+        .filter(|gate| {
+            matches!(
+                gate.status,
+                AgentTaskGateStatus::Failed | AgentTaskGateStatus::AcceptedInheritedFailure
+            )
+        })
         .map(|gate| gate_failure(gate, options.source_run_id.as_deref()))
         .collect();
     let failed_gate_results: Vec<HomeboyGateResult> = options
@@ -213,6 +221,18 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         .filter(|gate| gate.status == HomeboyGateStatus::Failed)
         .collect();
     let retry_budget_remaining = options.max_attempts.saturating_sub(options.attempt);
+    let baseline_red = options
+        .promotion_report
+        .deterministic_gates
+        .iter()
+        .any(|gate| {
+            gate.status == AgentTaskGateStatus::AcceptedInheritedFailure
+                && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
+                    comparison.result
+                        == crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed
+                        && comparison.matches_candidate_failure
+                })
+        });
     let intentional_no_change = (options.promotion_report.status
         == AgentTaskPromotionStatus::VerifiedNoChanges)
         .then(|| {
@@ -229,6 +249,7 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     apply_failure_progression_to_quality(&mut quality, &failure_progression);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
         && !failed_gates.is_empty()
+        && !baseline_red
         && retry_budget_remaining > 0;
     // Deterministic gates take precedence: a red gate must be fixed before the
     // review form is even worth requesting. Only once the change itself is green
@@ -265,6 +286,8 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         AgentTaskCookLoopStatus::IntentionalNoChange
     } else if quality.classification == AgentTaskCookLoopQualityClassification::NoChanges {
         AgentTaskCookLoopStatus::NoChanges
+    } else if baseline_red {
+        AgentTaskCookLoopStatus::BaselineRed
     } else if !failed_gates.is_empty() {
         AgentTaskCookLoopStatus::RetriesExhausted
     } else if matches!(&review_form_gap, Some(Some(_))) {
@@ -289,7 +312,7 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         failed_gate_results,
         follow_up_request,
         intentional_no_change,
-        metadata: report_metadata(options.metadata, &failure_progression),
+        metadata: report_metadata(options.metadata, &failure_progression, baseline_red),
     }
 }
 
@@ -705,9 +728,20 @@ fn follow_up_instructions(
     )
 }
 
-fn report_metadata(metadata: Value, progression: &AgentTaskCookLoopFailureProgression) -> Value {
+fn report_metadata(
+    metadata: Value,
+    progression: &AgentTaskCookLoopFailureProgression,
+    baseline_red: bool,
+) -> Value {
     let mut metadata = metadata.as_object().cloned().unwrap_or_default();
     metadata.insert("failure_progression".to_string(), json!(progression));
+    if baseline_red {
+        metadata.insert("baseline_red".to_string(), Value::Bool(true));
+        metadata.insert(
+            "failure_origin".to_string(),
+            Value::String("inherited_infrastructure".to_string()),
+        );
+    }
     Value::Object(metadata)
 }
 
@@ -1074,39 +1108,93 @@ mod tests {
     }
 
     #[test]
-    fn accepted_inherited_failure_completes_without_hiding_a_regression() {
+    fn baseline_comparison_keeps_required_gate_truthful() {
         let mut inherited = failed_gate();
         inherited.status = AgentTaskGateStatus::AcceptedInheritedFailure;
-        let accepted = evaluate_cook_loop(AgentTaskCookLoopOptions {
+        inherited.baseline_comparison =
+            Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
+                base_ref: "base".to_string(),
+                exit_code: 1,
+                failure_fingerprint: "rustup unavailable".to_string(),
+                matches_candidate_failure: true,
+                result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+            });
+        let baseline_red = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request: source_request(),
-            promotion_report: promotion_report(AgentTaskPromotionStatus::Applied, vec![inherited]),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![inherited],
+            ),
             attempt: 1,
-            max_attempts: 1,
+            max_attempts: 3,
             source_run_id: Some("run-inherited".to_string()),
             current_diff: String::new(),
             require_review_form: false,
             review_form: None,
             metadata: Value::Null,
         });
-        assert_eq!(accepted.status, AgentTaskCookLoopStatus::GreenCompleted);
-        assert!(accepted.failed_gates.is_empty());
+        assert_eq!(baseline_red.status, AgentTaskCookLoopStatus::BaselineRed);
+        assert_eq!(baseline_red.failed_gates.len(), 1);
+        assert!(baseline_red.follow_up_request.is_none());
+        assert_eq!(
+            baseline_red.metadata["failure_origin"],
+            "inherited_infrastructure"
+        );
 
-        let regression = evaluate_cook_loop(AgentTaskCookLoopOptions {
+        let candidate_only_failure = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request: source_request(),
             promotion_report: promotion_report(
                 AgentTaskPromotionStatus::GateFailed,
                 vec![failed_gate()],
             ),
             attempt: 1,
-            max_attempts: 1,
+            max_attempts: 3,
             source_run_id: Some("run-regression".to_string()),
             current_diff: String::new(),
             require_review_form: false,
             review_form: None,
             metadata: Value::Null,
         });
-        assert_eq!(regression.status, AgentTaskCookLoopStatus::RetriesExhausted);
-        assert_eq!(regression.failed_gates.len(), 1);
+        assert_eq!(
+            candidate_only_failure.status,
+            AgentTaskCookLoopStatus::RetryRequested
+        );
+
+        // A red baseline does not taint a candidate that passed its required gate.
+        let baseline_only_failure = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-baseline-only".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+        assert_eq!(
+            baseline_only_failure.status,
+            AgentTaskCookLoopStatus::GreenCompleted
+        );
+
+        let true_pass = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-true-pass".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+        assert_eq!(true_pass.status, AgentTaskCookLoopStatus::GreenCompleted);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -111,7 +111,10 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
         }
         options.evidence.lifecycle = Some(lifecycle);
     }
-    validate_green_gates(&options.normalized_gate_results)?;
+    validate_finalization_gates(
+        &options.normalized_gate_results,
+        options.accept_inherited_failures,
+    )?;
     options.review_dossier.apply_overrides()?;
     let current_branch = backend.current_branch(&options.path)?;
     let head = options
@@ -596,7 +599,10 @@ fn is_review_form_only_follow_up(promotion: &AgentTaskPromotionReport, run_id: &
             .is_some_and(|source_run_id| !source_run_id.is_empty() && source_run_id != run_id)
 }
 
-fn validate_green_gates(gates: &[HomeboyGateResult]) -> Result<()> {
+fn validate_finalization_gates(
+    gates: &[HomeboyGateResult],
+    accept_inherited_failures: bool,
+) -> Result<()> {
     if gates.is_empty() {
         return Err(Error::validation_invalid_argument(
             "gate_results",
@@ -607,7 +613,11 @@ fn validate_green_gates(gates: &[HomeboyGateResult]) -> Result<()> {
     }
     let red: Vec<String> = gates
         .iter()
-        .filter(|gate| gate.status != HomeboyGateStatus::Passed)
+        .filter(|gate| {
+            gate.status != HomeboyGateStatus::Passed
+                && !(accept_inherited_failures
+                    && gate.status == HomeboyGateStatus::AcceptedInheritedFailure)
+        })
         .map(|gate| format!("{}={:?}", gate.name, gate.status))
         .collect();
     if !red.is_empty() {
@@ -876,6 +886,7 @@ fn report(
         changed_files,
         gate_results: options.gate_results.clone(),
         normalized_gate_results,
+        accept_inherited_failures: options.accept_inherited_failures,
         proof,
         publication_intent,
         publication_proof,

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2076,6 +2076,21 @@ fn validates_publication_intent_contract() {
     assert!(error.message.contains("target head ref"));
 }
 
+#[test]
+fn legacy_durable_finalization_report_defaults_inherited_failure_acceptance_to_false() {
+    let report =
+        finalize_pr_with_backend(options(), &mut MockBackend::default()).expect("finalized report");
+    let mut legacy = serde_json::to_value(report).expect("serialize report");
+    legacy
+        .as_object_mut()
+        .expect("report object")
+        .remove("accept_inherited_failures");
+
+    let restored: AgentTaskPrFinalizationReport =
+        serde_json::from_value(legacy).expect("legacy report remains readable");
+    assert!(!restored.accept_inherited_failures);
+}
+
 fn options() -> AgentTaskPrFinalizationOptions {
     let gate_results = vec![AgentTaskGateResult {
         name: "focused project check".to_string(),
@@ -2098,6 +2113,7 @@ fn options() -> AgentTaskPrFinalizationOptions {
         commit_message: "finalize cook loop PR plumbing".to_string(),
         gate_results,
         normalized_gate_results,
+        accept_inherited_failures: false,
         changed_files: Vec::new(),
         evidence: AgentTaskPrEvidence {
             source_refs: vec!["https://github.com/Extra-Chill/homeboy/issues/3678".to_string()],

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -31,6 +31,9 @@ pub struct AgentTaskPrFinalizationReport {
     pub gate_results: Vec<AgentTaskGateResult>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub normalized_gate_results: Vec<HomeboyGateResult>,
+    /// Explicit policy for a baseline-red gate that proved non-regression.
+    #[serde(default)]
+    pub accept_inherited_failures: bool,
     pub proof: HomeboyProof,
     pub publication_intent: AgentTaskPublicationIntent,
     pub publication_proof: AgentTaskPublicationProof,
@@ -249,6 +252,8 @@ pub struct AgentTaskPrFinalizationOptions {
     pub commit_message: String,
     pub gate_results: Vec<AgentTaskGateResult>,
     pub normalized_gate_results: Vec<HomeboyGateResult>,
+    /// Explicit policy for a baseline-red gate that proved non-regression.
+    pub accept_inherited_failures: bool,
     pub changed_files: Vec<String>,
     pub evidence: AgentTaskPrEvidence,
     pub ai_used_for: String,

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -2557,7 +2557,10 @@ mod tests {
         assert_eq!(step["status"], "failed");
         assert_eq!(step["outputs"]["accepted_inherited_failure"], true);
         assert_eq!(step["outputs"]["baseline_red"], true);
-        assert_eq!(step["outputs"]["gate_result"]["status"], "failed");
+        assert_eq!(
+            step["outputs"]["gate_result"]["status"],
+            "accepted_inherited_failure"
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -75,6 +75,11 @@ pub struct VerifyGateOptions {
     /// rerunning them after restart.
     #[serde(default)]
     pub rerun_completed_gates: bool,
+    /// Allow finalization after a required gate is proven red on both candidate
+    /// and immutable baseline. The gate remains explicitly baseline-red in all
+    /// reports; this only authorizes the finalization policy boundary.
+    #[serde(default)]
+    pub accept_inherited_failures: bool,
     /// Declarative, non-secret process environment policy for every gate.
     #[serde(default)]
     pub gate_environment: AgentTaskGateEnvironmentPolicy,
@@ -248,6 +253,7 @@ impl Default for VerifyGateOptions {
             gate_timeout_seconds: default_gate_timeout_seconds(),
             gate_heartbeat_interval_seconds: default_gate_heartbeat_interval_seconds(),
             rerun_completed_gates: false,
+            accept_inherited_failures: false,
             gate_environment: AgentTaskGateEnvironmentPolicy::default(),
             gate_toolchains: Vec::new(),
             gate_package_artifacts: Vec::new(),
@@ -654,16 +660,17 @@ pub struct AgentTaskGateSkipReason {
 }
 
 /// Canonical bridge from the binary agent-task gate status to the shared
-/// `HomeboyGateStatus`. Both the report constructor and the
-/// `HomeboyGateResult` conversion route through this single mapping so the
-/// pass/fail projection cannot drift between call sites.
+/// `HomeboyGateStatus`. A matching red baseline explains a failure; it never
+/// makes the candidate's required gate pass.
 impl From<AgentTaskGateStatus> for HomeboyGateStatus {
     fn from(status: AgentTaskGateStatus) -> Self {
         match status {
             AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
             AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
             AgentTaskGateStatus::Skipped => HomeboyGateStatus::Skipped,
-            AgentTaskGateStatus::AcceptedInheritedFailure => HomeboyGateStatus::Passed,
+            AgentTaskGateStatus::AcceptedInheritedFailure => {
+                HomeboyGateStatus::AcceptedInheritedFailure
+            }
         }
     }
 }
@@ -863,10 +870,10 @@ impl AgentTaskGateReport {
             id.clone(),
             "agent_task.gate",
             match status {
-                AgentTaskGateStatus::Succeeded | AgentTaskGateStatus::AcceptedInheritedFailure => {
-                    PlanStepStatus::Success
+                AgentTaskGateStatus::Succeeded => PlanStepStatus::Success,
+                AgentTaskGateStatus::Failed | AgentTaskGateStatus::AcceptedInheritedFailure => {
+                    PlanStepStatus::Failed
                 }
-                AgentTaskGateStatus::Failed => PlanStepStatus::Failed,
                 AgentTaskGateStatus::Skipped => PlanStepStatus::Skipped,
             },
         )
@@ -949,34 +956,79 @@ impl AgentTaskGateReport {
             self.id.clone(),
             self.id.clone(),
             HomeboyGateKind::Command,
-            HomeboyGateStatus::Passed,
+            HomeboyGateStatus::AcceptedInheritedFailure,
         )
         .summary(
-            "candidate failure matches the immutable baseline; no candidate regression detected",
+            "candidate failure matches the immutable baseline; required gate remains failed because the shared environment is red",
         )
         .visibility(self.visibility)
         .reveal_policy(self.reveal_policy)
         .retryable(false);
-        self.step = PlanStep::builder(self.id.clone(), "agent_task.gate", PlanStepStatus::Success)
+        self.step = PlanStep::builder(self.id.clone(), "agent_task.gate", PlanStepStatus::Failed)
             .inputs(PlanValues::new().json("command", &self.command))
             .output_value("exit_code", serde_json::json!(self.exit_code))
             .output_value("accepted_inherited_failure", serde_json::json!(true))
             .output_value("baseline_red", serde_json::json!(true))
+            .output_value(
+                "failure_origin",
+                serde_json::json!("inherited_infrastructure"),
+            )
             .gate_result(gate_result)
             .build();
     }
 }
 
-/// Normalize only transport-noise that cannot identify a command failure. The
-/// comparison remains fail-closed: a changed substantive line is a regression.
-pub(crate) fn failure_fingerprint(stdout: &str, stderr: &str) -> String {
-    [stdout, stderr]
+/// Produce a stable failure identity from the exit status, structured diagnostic
+/// identities, and a digest of normalized output records. Output is evidence,
+/// not the sole authority for accepting an inherited failure.
+pub(crate) fn failure_fingerprint(
+    exit_code: i32,
+    stdout: &str,
+    stderr: &str,
+    diagnostics: &[AgentTaskGateDiagnosticRecord],
+) -> String {
+    let mut output_records = [stdout, stderr]
         .into_iter()
         .flat_map(str::lines)
-        .map(str::trim)
+        .map(normalize_failure_record)
         .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    output_records.sort();
+    output_records.dedup();
+    let mut diagnostic_ids = diagnostics
+        .iter()
+        .map(|diagnostic| format!("{}:{}", diagnostic.producer.id, diagnostic.identity))
+        .collect::<Vec<_>>();
+    diagnostic_ids.sort();
+    diagnostic_ids.dedup();
+    let payload = json!({
+        "exit_code": exit_code,
+        "diagnostic_ids": diagnostic_ids,
+        "output_records": output_records,
+    });
+    format!(
+        "sha256:{:x}",
+        Sha256::digest(payload.to_string().as_bytes())
+    )
+}
+
+fn normalize_failure_record(line: &str) -> String {
+    line.trim()
+        .split_whitespace()
+        .map(|token| {
+            if token.contains('T')
+                && token.contains(':')
+                && token.chars().any(|c| c.is_ascii_digit())
+            {
+                "<timestamp>"
+            } else if token.starts_with("0x") && token[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+                "<address>"
+            } else {
+                token
+            }
+        })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join(" ")
 }
 
 #[cfg(test)]
@@ -989,13 +1041,38 @@ mod baseline_tests {
 
     #[test]
     fn matching_baseline_failure_is_distinct_from_a_new_failure() {
-        let baseline = failure_fingerprint("test alpha ... FAILED\n", "");
-        let matching_candidate = failure_fingerprint("test alpha ... FAILED\n", "");
+        let baseline = failure_fingerprint(1, "test alpha ... FAILED\n", "", &[]);
+        let matching_candidate = failure_fingerprint(1, "test alpha ... FAILED\n", "", &[]);
         let regressed_candidate =
-            failure_fingerprint("test alpha ... FAILED\ntest beta ... FAILED\n", "");
+            failure_fingerprint(1, "test alpha ... FAILED\ntest beta ... FAILED\n", "", &[]);
 
         assert_eq!(baseline, matching_candidate);
         assert_ne!(baseline, regressed_candidate);
+    }
+
+    #[test]
+    fn failure_fingerprint_distinguishes_exit_codes_and_ignores_volatile_reordered_output() {
+        let baseline = failure_fingerprint(
+            1,
+            "error E42 at 2026-08-04T12:00:00Z\nworker 0xabc failed\n",
+            "",
+            &[],
+        );
+        let reordered = failure_fingerprint(
+            1,
+            "worker 0xdef failed\nerror E42 at 2027-01-01T00:00:00Z\n",
+            "",
+            &[],
+        );
+        let divergent_exit = failure_fingerprint(
+            2,
+            "worker 0xdef failed\nerror E42 at 2027-01-01T00:00:00Z\n",
+            "",
+            &[],
+        );
+
+        assert_eq!(baseline, reordered);
+        assert_ne!(baseline, divergent_exit);
     }
 
     #[test]
@@ -2477,8 +2554,10 @@ mod tests {
 
         assert_eq!(report.status, AgentTaskGateStatus::AcceptedInheritedFailure);
         let step = serde_json::to_value(&report.step).expect("serialize step");
-        assert_eq!(step["status"], "success");
+        assert_eq!(step["status"], "failed");
         assert_eq!(step["outputs"]["accepted_inherited_failure"], true);
+        assert_eq!(step["outputs"]["baseline_red"], true);
+        assert_eq!(step["outputs"]["gate_result"]["status"], "failed");
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -2103,11 +2103,11 @@ fn promotion_notification_with_gate_summary(
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        let passed = gate_ids(&[
-            AgentTaskGateStatus::Succeeded,
+        let passed = gate_ids(&[AgentTaskGateStatus::Succeeded]);
+        let failed = gate_ids(&[
+            AgentTaskGateStatus::Failed,
             AgentTaskGateStatus::AcceptedInheritedFailure,
         ]);
-        let failed = gate_ids(&[AgentTaskGateStatus::Failed]);
         let skipped = gate_ids(&[AgentTaskGateStatus::Skipped]);
         notification.message.push_str(&format!(
             "; deterministic gates: passed=[{passed}], failed=[{failed}], skipped=[{skipped}]"

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -84,6 +84,25 @@ pub struct AgentTaskPromotionGateOutcome {
 }
 
 impl AgentTaskPromotionReport {
+    /// Whether the report can cross the finalization boundary. An accepted
+    /// inherited failure remains a baseline-red required gate in the report;
+    /// only the caller's explicit policy can accept its proven non-regression.
+    pub fn finalization_eligible(&self, accept_inherited_failures: bool) -> bool {
+        !self.deterministic_gates.is_empty()
+            && self.deterministic_gates.iter().all(|gate| match gate.status {
+                AgentTaskGateStatus::Succeeded => gate.exit_code == 0,
+                AgentTaskGateStatus::AcceptedInheritedFailure => {
+                    accept_inherited_failures
+                        && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
+                            comparison.matches_candidate_failure
+                                && comparison.result
+                                    == crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed
+                        })
+                }
+                AgentTaskGateStatus::Failed | AgentTaskGateStatus::Skipped => false,
+            })
+    }
+
     pub fn gate_outcome(&self) -> AgentTaskPromotionGateOutcome {
         let gate_results = self
             .deterministic_gates
@@ -91,8 +110,7 @@ impl AgentTaskPromotionReport {
             .cloned()
             .map(HomeboyGateResult::from)
             .collect::<Vec<_>>();
-        let all_gates_passed = !self.deterministic_gates.is_empty()
-            && self.deterministic_gates.iter().all(durable_gate_passed);
+        let all_gates_passed = self.finalization_eligible(false);
         let status = if self.status == AgentTaskPromotionStatus::GateFailed && all_gates_passed {
             AgentTaskPromotionStatus::Applied
         } else {
@@ -171,13 +189,9 @@ impl AgentTaskPromotionReport {
 fn durable_gate_passed(gate: &AgentTaskGateReport) -> bool {
     match gate.status {
         AgentTaskGateStatus::Succeeded => gate.exit_code == 0,
-        AgentTaskGateStatus::AcceptedInheritedFailure => {
-            gate.exit_code != 0
-                && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
-                    comparison.matches_candidate_failure && !comparison.base_ref.is_empty()
-                })
-        }
-        AgentTaskGateStatus::Failed | AgentTaskGateStatus::Skipped => false,
+        AgentTaskGateStatus::Failed
+        | AgentTaskGateStatus::Skipped
+        | AgentTaskGateStatus::AcceptedInheritedFailure => false,
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3206,6 +3206,50 @@ where
                     invocation_latest_run_id: Some(&run_id),
                 }));
             }
+            AgentTaskCookLoopStatus::BaselineRed => {
+                if options.gates.accept_inherited_failures && promotion.finalization_eligible(true)
+                {
+                    report_cook_progress(
+                        durable_observer,
+                        &cook_id,
+                        &run_id,
+                        "finalization",
+                        attempt,
+                        Some("accepted inherited baseline-red gate"),
+                    )?;
+                    let finalization = side_effects.finalize(&options, &run_id, &promotion)?;
+                    let final_status = finalization["status"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    return Ok(cook_report(CookReportInput {
+                        cook_id,
+                        status: &final_status,
+                        disposition: CookDisposition::Terminal,
+                        attempts,
+                        finalization: Some(finalization),
+                        stop_reason: Some(
+                            "finalized under explicit accepted inherited baseline-red gate policy"
+                                .to_string(),
+                        ),
+                        exit_code: if final_status == "review_ready" { 0 } else { 1 },
+                        invocation_latest_run_id: Some(&run_id),
+                    }));
+                }
+                return Ok(cook_report(CookReportInput {
+                    cook_id,
+                    status: "baseline_red",
+                    disposition: CookDisposition::Terminal,
+                    attempts,
+                    finalization: None,
+                    stop_reason: Some(
+                        "candidate and immutable baseline failed the same required gate; repair the inherited infrastructure or gate environment before rerunning Cook"
+                            .to_string(),
+                    ),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
+            }
             AgentTaskCookLoopStatus::NoChanges => {
                 return Ok(cook_report(CookReportInput {
                     cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -697,7 +697,33 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             }
         };
     }
-    if feedback.status != AgentTaskCookLoopStatus::GreenCompleted {
+    if feedback.status == AgentTaskCookLoopStatus::BaselineRed {
+        if options.gates.accept_inherited_failures && promotion.finalization_eligible(true) {
+            // Continue directly to finalization below; this adoption already has
+            // durable baseline proof and must not spend another provider attempt.
+        } else {
+            let reason = "candidate and immutable baseline failed the same required gate; repair the inherited infrastructure or gate environment before retrying adoption";
+            agent_task_lifecycle::finish_candidate_adoption(
+                &record.run_id,
+                Some(reason.to_string()),
+            )?;
+            return Ok(cook_report(CookReportInput {
+                cook_id: cook_id.to_string(),
+                status: "baseline_red",
+                disposition: CookDisposition::Terminal,
+                attempts: vec![attempt],
+                finalization: None,
+                stop_reason: Some(reason.to_string()),
+                exit_code: 1,
+                invocation_latest_run_id: Some(record.run_id.as_str()),
+            }));
+        }
+    }
+    if feedback.status != AgentTaskCookLoopStatus::GreenCompleted
+        && !(feedback.status == AgentTaskCookLoopStatus::BaselineRed
+            && options.gates.accept_inherited_failures
+            && promotion.finalization_eligible(true))
+    {
         agent_task_lifecycle::finish_candidate_adoption(
             &record.run_id,
             Some("adopted candidate did not pass the original deterministic gates".to_string()),

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -356,8 +356,14 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         base_ref: base_sha.to_string(),
                         exit_code: baseline.exit_code,
                         failure_fingerprint: failure_fingerprint(
+                            baseline.exit_code,
                             &baseline.stdout,
                             &baseline.stderr,
+                            baseline
+                                .failure_evidence
+                                .as_ref()
+                                .map(|evidence| evidence.diagnostics.as_slice())
+                                .unwrap_or_default(),
                         ),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::Inconclusive,
@@ -365,14 +371,36 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                     Ok(())
                 }
                 Ok(baseline) if baseline.status == AgentTaskGateStatus::Failed => {
-                    let matches = failure_fingerprint(&gate.stdout, &gate.stderr)
-                        == failure_fingerprint(&baseline.stdout, &baseline.stderr);
+                    let matches = failure_fingerprint(
+                        gate.exit_code,
+                        &gate.stdout,
+                        &gate.stderr,
+                        gate.failure_evidence
+                            .as_ref()
+                            .map(|evidence| evidence.diagnostics.as_slice())
+                            .unwrap_or_default(),
+                    ) == failure_fingerprint(
+                        baseline.exit_code,
+                        &baseline.stdout,
+                        &baseline.stderr,
+                        baseline
+                            .failure_evidence
+                            .as_ref()
+                            .map(|evidence| evidence.diagnostics.as_slice())
+                            .unwrap_or_default(),
+                    );
                     gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
                         base_ref: base_sha.to_string(),
                         exit_code: baseline.exit_code,
                         failure_fingerprint: failure_fingerprint(
+                            baseline.exit_code,
                             &baseline.stdout,
                             &baseline.stderr,
+                            baseline
+                                .failure_evidence
+                                .as_ref()
+                                .map(|evidence| evidence.diagnostics.as_slice())
+                                .unwrap_or_default(),
                         ),
                         matches_candidate_failure: matches,
                         result: if matches {
@@ -391,8 +419,14 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         base_ref: base_sha.to_string(),
                         exit_code: baseline.exit_code,
                         failure_fingerprint: failure_fingerprint(
+                            baseline.exit_code,
                             &baseline.stdout,
                             &baseline.stderr,
+                            baseline
+                                .failure_evidence
+                                .as_ref()
+                                .map(|evidence| evidence.diagnostics.as_slice())
+                                .unwrap_or_default(),
                         ),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::CandidateRegression,
@@ -790,7 +824,7 @@ mod tests {
             assert_eq!(
                 promotion.status,
                 if accepted {
-                    crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+                    crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
                 } else {
                     crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
                 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1272,10 +1272,10 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
 ) -> Result<Value> {
     let mut promotion = promotion.clone();
     promotion.normalize_gate_outcome();
-    if promotion.status != AgentTaskPromotionStatus::Applied {
+    if !promotion.finalization_eligible(options.gates.accept_inherited_failures) {
         return Err(Error::validation_invalid_argument(
             "promotion",
-            "agent-task cook finalization requires an applied promotion with green gates",
+            "agent-task cook finalization requires green gates or explicitly accepted inherited baseline failures",
             None,
             None,
         ));
@@ -1347,6 +1347,7 @@ pub(crate) fn cook_finalization_options(
         commit_message: options.commit_message.clone(),
         gate_results: Vec::new(),
         normalized_gate_results: promotion.gate_results.clone(),
+        accept_inherited_failures: options.gates.accept_inherited_failures,
         changed_files: promotion.changed_files.clone(),
         evidence: AgentTaskPrEvidence {
             source_refs,
@@ -1941,6 +1942,7 @@ fn manual_finalization_options(
         commit_message: "recovered manual finalization".to_string(),
         gate_results: report.gate_results,
         normalized_gate_results: report.normalized_gate_results,
+        accept_inherited_failures: report.accept_inherited_failures,
         changed_files: report.changed_files,
         evidence: report.evidence,
         ai_used_for: report.review_dossier.ai_assistance.used_for.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6795,13 +6795,13 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
 
     assert_eq!(
         accepted.status,
-        crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+        crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
     );
     assert_eq!(
         accepted.gate_results[0].status,
-        homeboy_core::gate::HomeboyGateStatus::Passed
+        homeboy_core::gate::HomeboyGateStatus::Failed
     );
-    assert!(accepted.has_visible_passed_gate_for_command(command));
+    assert!(!accepted.has_visible_passed_gate_for_command(command));
 
     let mut regression = accepted.clone();
     regression.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
@@ -6831,7 +6831,7 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
 }
 
 #[test]
-fn closed_observer_pipe_does_not_stop_promotion_or_finalization() {
+fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("repository");
         let root = temp.path();
@@ -6859,6 +6859,7 @@ fn closed_observer_pipe_does_not_stop_promotion_or_finalization() {
         options.to_worktree = root.display().to_string();
         options.source_worktree_path = Some(root.to_path_buf());
         options.max_attempts = 1;
+        options.gates.accept_inherited_failures = true;
         options.gates.verify = vec!["cat failure >&2; exit 1".to_string()];
         options.initial_plan.options.execution_budget =
             crate::agent_task_scheduler::AgentTaskExecutionBudget::new(1, 0, 0);
@@ -6938,6 +6939,11 @@ fn closed_observer_pipe_does_not_stop_promotion_or_finalization() {
         )
         .unwrap();
         assert_eq!(result.value.status, "review_ready", "{:#?}", result.value);
+        assert!(result
+            .value
+            .stop_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("accepted inherited baseline-red")));
         assert_eq!(finalized.load(Ordering::SeqCst), 1);
         assert!(observer_calls.load(Ordering::SeqCst) >= 1);
         let record = agent_task_lifecycle::status(&run_id).unwrap();
@@ -6956,11 +6962,15 @@ fn closed_observer_pipe_does_not_stop_promotion_or_finalization() {
             "the disconnected observer can reconnect to the terminal durable result"
         );
         let persisted = persisted_promotion_for_attempt(&run_id).unwrap().unwrap();
-        assert_eq!(persisted.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(persisted.status, AgentTaskPromotionStatus::GateFailed);
         assert_eq!(persisted.deterministic_gates[0].exit_code, 1);
         assert_eq!(
             persisted.deterministic_gates[0].status,
             crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+        );
+        assert_eq!(
+            persisted.gate_results[0].status,
+            homeboy_core::gate::HomeboyGateStatus::AcceptedInheritedFailure
         );
         assert_eq!(
             persisted.deterministic_gates[0]

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -59,6 +59,10 @@ pub struct VerifyGateArgs {
     /// attempt instead of reusing the recorded pass. Off by default.
     #[arg(long = "rerun-completed-gates")]
     pub rerun_completed_gates: bool,
+    /// Finalize only when an inherited required-gate failure was reproduced on
+    /// the immutable baseline. The gate remains reported as baseline-red.
+    #[arg(long = "accept-inherited-failures")]
+    pub accept_inherited_failures: bool,
     /// Environment for gate commands: `inherit` (default) extends the current
     /// environment; `replace` starts from an empty environment plus `--gate-env`.
     #[arg(
@@ -123,6 +127,7 @@ impl From<VerifyGateArgs> for VerifyGateOptions {
             gate_timeout_seconds: args.gate_timeout_seconds,
             gate_heartbeat_interval_seconds: args.gate_heartbeat_interval_seconds,
             rerun_completed_gates: args.rerun_completed_gates,
+            accept_inherited_failures: args.accept_inherited_failures,
             gate_environment: AgentTaskGateEnvironmentPolicy {
                 mode: match args.gate_environment_mode.as_str() {
                     "replace" => AgentTaskGateEnvironmentMode::Replace,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1916,6 +1916,7 @@ impl BatchCookSpec {
                     gate_timeout_seconds: self.gate_timeout_seconds,
                     gate_heartbeat_interval_seconds: self.gate_heartbeat_interval_seconds,
                     rerun_completed_gates: self.rerun_completed_gates,
+                    accept_inherited_failures: false,
                     gate_environment: self.gate_environment.clone(),
                     gate_toolchains: self.gate_toolchains.clone(),
                     gate_package_artifacts: self.gate_package_artifacts.clone(),

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -537,6 +537,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         commit_message,
         gate_results,
         normalized_gate_results,
+        accept_inherited_failures: false,
         changed_files: args.changed_files,
         evidence,
         ai_used_for: args.ai_used_for,

--- a/crates/homeboy-core/src/proof/validation.rs
+++ b/crates/homeboy-core/src/proof/validation.rs
@@ -129,7 +129,9 @@ fn validate_homeboy_proof(
     for (index, gate) in proof.gates.iter().enumerate() {
         if matches!(
             gate.status,
-            HomeboyGateStatus::Failed | HomeboyGateStatus::Blocked
+            HomeboyGateStatus::Failed
+                | HomeboyGateStatus::AcceptedInheritedFailure
+                | HomeboyGateStatus::Blocked
         ) {
             diagnostics.push(diagnostic(
                 "gate_not_complete",


### PR DESCRIPTION
## Summary
- retain inherited failures as explicit red gate evidence
- permit finalization only through explicit acceptance and immutable baseline proof
- preserve legacy durable report deserialization

## Tests
- `cargo test -p homeboy-agents inherited`
- legacy finalization compatibility test

Closes #11287

AI assistance: gpt-5.6-sol via OpenCode implemented, reviewed, rebased, and tested this change under human direction.