### PR TITLE
Report orphaned stack provenance

### DIFF
--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -100,6 +100,12 @@ pub struct StackSourceMetadata {
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub source_dirty: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_content_hash: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -204,6 +210,9 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             discovery_path: prepared.discovery_path.to_string_lossy().to_string(),
             linked: prepared.linked,
             source_revision: prepared.source_revision.clone(),
+            source_ref: prepared.source_ref.clone(),
+            source_dirty: prepared.source_dirty,
+            source_content_hash: Some(prepared.source_content_hash.clone()),
         };
         write_stack_source_metadata(&stack.id, &metadata)?;
 

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -84,10 +84,10 @@ pub use runner::{
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
     list_sources, remove_source, update_all_sources, update_source, update_source_for_rig,
-    InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack, RigSourceGroup,
-    RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
-    RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,
-    SkippedRigSourceStack, SkippedRigSourceUpdate,
+    InvalidRigSourceMetadata, OrphanedRigSourceStack, RemovedRigSourceRig, RemovedRigSourceStack,
+    RigSourceGroup, RigSourceListResult, RigSourceRecoveryAction, RigSourceRemoveResult,
+    RigSourceRig, RigSourceStack, RigSourceUpdateResult, RigSourceUpdatedRig,
+    RigSourceUpdatedStack, SkippedRigSourceRig, SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
 pub use spec::{
     normalize_dependency_materialization_steps, validate_dependency_materialization_steps,

--- a/crates/homeboy-rig/src/source.rs
+++ b/crates/homeboy-rig/src/source.rs
@@ -3,7 +3,7 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::paths;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -14,14 +14,15 @@ use super::install::{
 
 mod types;
 pub use types::{
-    FailedRigSourceUpdate, InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack,
-    RigSourceGroup, RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
-    RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,
-    SkippedRigSourceStack, SkippedRigSourceUpdate,
+    FailedRigSourceUpdate, InvalidRigSourceMetadata, OrphanedRigSourceStack, RemovedRigSourceRig,
+    RemovedRigSourceStack, RigSourceGroup, RigSourceListResult, RigSourceRecoveryAction,
+    RigSourceRemoveResult, RigSourceRig, RigSourceStack, RigSourceUpdateResult,
+    RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig, SkippedRigSourceStack,
+    SkippedRigSourceUpdate,
 };
 
 pub fn list_sources() -> Result<RigSourceListResult> {
-    read_source_entries().map(group_source_entries)
+    read_source_entries().and_then(group_source_entries)
 }
 
 pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
@@ -276,6 +277,17 @@ pub fn update_source(selector: Option<&str>) -> Result<RigSourceUpdateResult> {
 }
 
 fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
+    if source.discovery_path.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            "Installed rig source has no validated discovery path; refusing to refresh",
+            Some(source.source),
+            Some(vec![
+                "Reinstall the package from its authoritative source to record provenance."
+                    .to_string(),
+            ]),
+        ));
+    }
     let source_root = PathBuf::from(&source.source_root);
     if !source_root.exists() {
         return Err(Error::validation_invalid_argument(
@@ -359,6 +371,8 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
     }
 
     let current_stacks = discover_stacks(Path::new(&source.discovery_path))?;
+    let source_content_hash =
+        super::install::package_content_hash(Path::new(&source.package_path))?;
     for stack in current_stacks {
         let existing = source.stacks.iter().find(|entry| entry.id == stack.id);
         let config_path = paths::stack_config(&stack.id)?;
@@ -385,6 +399,9 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
             discovery_path: source.discovery_path.clone(),
             linked: false,
             source_revision: source_revision.clone(),
+            source_ref: source_ref.clone(),
+            source_dirty,
+            source_content_hash: Some(source_content_hash.clone()),
         };
         write_stack_source_metadata(&stack.id, &metadata)?;
 
@@ -430,6 +447,12 @@ struct SourceEntries {
     valid: Vec<RigSourceEntry>,
     valid_stacks: Vec<StackSourceEntry>,
     invalid: Vec<InvalidRigSourceMetadata>,
+}
+
+#[derive(Debug)]
+struct InstalledStack {
+    id: String,
+    path: PathBuf,
 }
 
 #[derive(Debug)]
@@ -498,7 +521,12 @@ fn invalid_source_metadata(
     }
 }
 
-fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
+fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
+    let managed_stack_ids = entries
+        .valid_stacks
+        .iter()
+        .map(|entry| entry.id.clone())
+        .collect::<HashSet<_>>();
     let mut groups: BTreeMap<String, RigSourceGroup> = BTreeMap::new();
     for entry in entries.valid {
         let key = format!("{}\0{}", entry.metadata.source, entry.metadata.package_path);
@@ -541,28 +569,13 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
         source.stacks.sort_by(|a, b| a.id.cmp(&b.id));
     }
 
-    RigSourceListResult {
-        sources,
-        invalid: entries.invalid,
-    }
-}
+    let orphaned_stacks = installed_stacks_without_source_metadata(&managed_stack_ids)?;
 
-fn infer_discovery_path(rig_path: &str) -> String {
-    let path = Path::new(rig_path);
-    match path
-        .parent()
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str())
-    {
-        Some("rigs") => path
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap_or(path)
-            .to_string_lossy()
-            .to_string(),
-        _ => path.parent().unwrap_or(path).to_string_lossy().to_string(),
-    }
+    Ok(RigSourceListResult {
+        sources,
+        orphaned_stacks,
+        invalid: entries.invalid,
+    })
 }
 
 fn new_source_group(
@@ -572,9 +585,11 @@ fn new_source_group(
     discovery_path: String,
     linked: bool,
     source_revision: Option<String>,
+    source_content_hash: Option<String>,
 ) -> RigSourceGroup {
     let package_present = Path::new(package_path).exists();
     RigSourceGroup {
+        source_status: "managed",
         source: source.to_string(),
         source_root: source_root.to_string(),
         package_id: package_id_from_path(package_path),
@@ -583,6 +598,7 @@ fn new_source_group(
         discovery_path,
         linked,
         source_revision,
+        source_content_hash,
         stale_reason: stale_source_reason(linked, package_present),
         rigs: Vec::new(),
         stacks: Vec::new(),
@@ -598,13 +614,26 @@ fn new_rig_source_group(metadata: &RigSourceMetadata) -> RigSourceGroup {
         &metadata.source,
         source_root,
         &metadata.package_path,
-        metadata
-            .discovery_path
-            .clone()
-            .unwrap_or_else(|| infer_discovery_path(&metadata.rig_path)),
+        validated_rig_discovery_path(metadata).unwrap_or_default(),
         metadata.linked,
         metadata.source_revision.clone(),
+        metadata.source_content_hash.clone(),
     )
+}
+
+fn validated_rig_discovery_path(metadata: &RigSourceMetadata) -> Option<String> {
+    if let Some(path) = metadata
+        .discovery_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    {
+        return Some(path.to_string());
+    }
+
+    let package_path = Path::new(&metadata.package_path);
+    let rig_path = Path::new(&metadata.rig_path);
+    (package_path.is_absolute() && rig_path.is_absolute() && rig_path.starts_with(package_path))
+        .then(|| metadata.package_path.clone())
 }
 
 fn new_stack_source_group(metadata: &StackSourceMetadata) -> RigSourceGroup {
@@ -619,6 +648,7 @@ fn new_stack_source_group(metadata: &StackSourceMetadata) -> RigSourceGroup {
         metadata.discovery_path.clone(),
         metadata.linked,
         metadata.source_revision.clone(),
+        metadata.source_content_hash.clone(),
     )
 }
 
@@ -647,6 +677,7 @@ fn source_stack(
     config_owned: bool,
 ) -> RigSourceStack {
     let stack_present = Path::new(&entry.metadata.stack_path).is_file();
+    let (component_path, component_path_present) = stack_component_path(&entry.id);
     RigSourceStack {
         id: entry.id,
         stack_path: entry.metadata.stack_path,
@@ -654,8 +685,68 @@ fn source_stack(
         config_path: source_config_path(config_path),
         config_present,
         config_owned,
+        component_path,
+        component_path_present,
         stale_reason: stale_config_reason(stack_present, config_present),
     }
+}
+
+fn installed_stacks_without_source_metadata(
+    managed_stack_ids: &HashSet<String>,
+) -> Result<Vec<OrphanedRigSourceStack>> {
+    let dir = paths::stacks()?;
+    let entries = super::json_config::sorted_json_config_entries(
+        &dir,
+        "read stacks dir",
+        "read stack entry",
+        |error, context| Error::internal_io(error.to_string(), Some(context.into())),
+    )?;
+
+    Ok(entries
+        .into_iter()
+        .filter(|entry| !managed_stack_ids.contains(&entry.id))
+        .map(|entry| {
+            orphaned_stack(InstalledStack {
+                id: entry.id,
+                path: entry.path,
+            })
+        })
+        .collect())
+}
+
+fn orphaned_stack(stack: InstalledStack) -> OrphanedRigSourceStack {
+    let (component_path, component_path_present) = stack_component_path(&stack.id);
+    let content_identity = fs::read(&stack.path)
+        .map(|content| {
+            format!(
+                "sha256:{}",
+                homeboy_engine_primitives::content_hash::sha256_hex(&content)
+            )
+        })
+        .unwrap_or_else(|_| "unavailable".to_string());
+    OrphanedRigSourceStack {
+        id: stack.id,
+        config_path: stack.path.to_string_lossy().to_string(),
+        content_identity,
+        component_path,
+        component_path_present,
+        source_status: "legacy_missing_metadata",
+        recovery_actions: vec![RigSourceRecoveryAction {
+            kind: "adopt_package_source",
+            description: "Install the authoritative package source to record managed provenance.",
+            command: "homeboy rig install <authoritative-package-source> --all --reinstall",
+            required_parameters: vec!["authoritative-package-source"],
+        }],
+    }
+}
+
+fn stack_component_path(id: &str) -> (Option<String>, Option<bool>) {
+    let Ok(spec) = homeboy_stack::stack::load(id) else {
+        return (None, None);
+    };
+    let component_path = homeboy_stack::stack::expand_path(&spec.component_path);
+    let component_path_present = Path::new(&component_path).exists();
+    (Some(component_path), Some(component_path_present))
 }
 
 fn stale_source_reason(linked: bool, package_present: bool) -> Option<String> {

--- a/crates/homeboy-rig/src/source/types.rs
+++ b/crates/homeboy-rig/src/source/types.rs
@@ -3,11 +3,15 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceListResult {
     pub sources: Vec<RigSourceGroup>,
+    /// Installed stack specs with no source metadata. These are intentionally
+    /// separate from managed sources because their provenance is unknown.
+    pub orphaned_stacks: Vec<OrphanedRigSourceStack>,
     pub invalid: Vec<InvalidRigSourceMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceGroup {
+    pub source_status: &'static str,
     pub source: String,
     pub source_root: String,
     pub package_path: String,
@@ -17,6 +21,8 @@ pub struct RigSourceGroup {
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_content_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
     pub rigs: Vec<RigSourceRig>,
@@ -44,7 +50,32 @@ pub struct RigSourceStack {
     pub config_present: bool,
     pub config_owned: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path_present: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanedRigSourceStack {
+    pub id: String,
+    pub config_path: String,
+    pub content_identity: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path_present: Option<bool>,
+    pub source_status: &'static str,
+    pub recovery_actions: Vec<RigSourceRecoveryAction>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigSourceRecoveryAction {
+    pub kind: &'static str,
+    pub description: &'static str,
+    pub command: &'static str,
+    pub required_parameters: Vec<&'static str>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -257,7 +257,9 @@ homeboy rig sources refresh example-org-homeboy-rigs
 homeboy rig sources remove example-org-homeboy-rigs
 ```
 
-`sources list` groups installed rigs and stacks by package source, package path, revision, and ownership. `sources refresh` pulls recorded git-backed package paths, refreshes Homeboy-owned installed rig and stack specs, and reports source, before/after revisions, installed config path, and source spec path. `sources remove` removes Homeboy-owned config links and metadata for one source package; it also removes cloned git packages, while linked local package directories are left in place.
+`sources list` groups managed rigs and stacks by package source, package path, revision, content identity, and ownership. Managed groups carry `source_status: "managed"`; `package_present` and stack `component_path_present` are independent availability observations. The JSON report also includes `orphaned_stacks` for installed stack configs that have no source metadata. These rows are reported as `legacy_missing_metadata`, include a content identity and the `adopt_package_source` recovery action (`homeboy rig install <authoritative-package-source> --all --reinstall`), and never infer provenance from filenames or modify the spec during inspection.
+
+`sources refresh` pulls recorded git-backed package paths, refreshes Homeboy-owned installed rig and stack specs, and reports source, before/after revisions, installed config path, and source spec path. `sources remove` removes Homeboy-owned config links and metadata for one source package; it also removes cloned git packages, while linked local package directories are left in place.
 
 ## Stack Sync
 

--- a/docs/reference/cli/commands/rig.md
+++ b/docs/reference/cli/commands/rig.md
@@ -313,7 +313,7 @@ Inspect or remove installed rig sources
 homeboy rig sources list
 ```
 
-List installed rig source packages
+List managed rig source packages and standalone installed stacks. The JSON list report exposes managed package URL/path, revision, content identity, source spec paths, and ownership. `orphaned_stacks` reports legacy stack configs without source metadata, including independent component-path availability and non-mutating recovery actions.
 
 ## `homeboy rig sources remove`
 

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -54,6 +54,7 @@ fn test_list_sources() {
     assert_eq!(result.invalid.len(), 0);
     assert_eq!(result.sources.len(), 1);
     assert_eq!(result.sources[0].source, package.path().to_string_lossy());
+    assert_eq!(result.sources[0].source_status, "managed");
     assert!(result.sources[0].linked);
     assert_eq!(result.sources[0].rigs.len(), 2);
     assert_eq!(result.sources[0].rigs[0].id, "alpha");
@@ -122,6 +123,55 @@ fn list_sources_reports_stack_specs_from_package() {
     assert_eq!(result.sources[0].stacks[0].id, "alpha-combined");
     assert!(result.sources[0].stacks[0].config_present);
     assert!(result.sources[0].stacks[0].config_owned);
+    assert!(result.sources[0].source_content_hash.is_some());
+    assert!(result.orphaned_stacks.is_empty());
+}
+
+#[test]
+fn sources_list_reports_legacy_stack_without_inferring_or_mutating_provenance() {
+    let _home = HomeGuard::new();
+    let config = homeboy_core::paths::stack_config("legacy").expect("stack config");
+    fs::create_dir_all(config.parent().expect("stacks dir")).expect("stacks dir");
+    let content = minimal_stack("legacy", "legacy")
+        .replace("${env.DEV_ROOT}/legacy", "/definitely/missing/legacy");
+    fs::write(&config, &content).expect("legacy stack");
+
+    let result = list_sources().expect("sources");
+
+    assert!(result.sources.is_empty());
+    assert_eq!(result.orphaned_stacks.len(), 1);
+    let legacy = &result.orphaned_stacks[0];
+    assert_eq!(legacy.id, "legacy");
+    assert_eq!(legacy.source_status, "legacy_missing_metadata");
+    assert_eq!(
+        legacy.component_path.as_deref(),
+        Some("/definitely/missing/legacy")
+    );
+    assert_eq!(legacy.component_path_present, Some(false));
+    assert!(legacy.content_identity.starts_with("sha256:"));
+    assert_eq!(
+        legacy
+            .recovery_actions
+            .iter()
+            .map(|action| action.kind)
+            .collect::<Vec<_>>(),
+        vec!["adopt_package_source"]
+    );
+    assert_eq!(
+        legacy.recovery_actions[0].command,
+        "homeboy rig install <authoritative-package-source> --all --reinstall"
+    );
+    assert_eq!(
+        legacy.recovery_actions[0].required_parameters,
+        vec!["authoritative-package-source"]
+    );
+    assert_eq!(
+        fs::read_to_string(&config).expect("legacy stack unchanged"),
+        content
+    );
+    assert!(!homeboy_core::paths::stack_source_metadata("legacy")
+        .expect("metadata path")
+        .exists());
 }
 
 #[test]
@@ -321,12 +371,20 @@ fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
         "not json",
     )
     .expect("broken stack metadata");
+    fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
+    fs::write(
+        homeboy_core::paths::stack_config("broken-stack").expect("stack config"),
+        minimal_stack("broken-stack", "broken"),
+    )
+    .expect("installed stack");
 
     let result = list_sources().expect("sources");
 
     assert!(result.sources.is_empty());
     assert_eq!(result.invalid.len(), 1);
     assert_eq!(result.invalid[0].id, "broken-stack");
+    assert_eq!(result.orphaned_stacks.len(), 1);
+    assert_eq!(result.orphaned_stacks[0].id, "broken-stack");
     assert!(result.invalid[0]
         .metadata_path
         .ends_with("stack-sources/broken-stack.json"));
@@ -385,9 +443,14 @@ fn update_git_source_refreshes_owned_stack_specs() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::read_stack_source_metadata("alpha-combined")
-        .expect("stack metadata")
-        .source_revision;
+    let installed_metadata =
+        crate::read_stack_source_metadata("alpha-combined").expect("stack metadata");
+    let before = installed_metadata.source_revision;
+    fs::write(
+        Path::new(&installed_metadata.package_path).join("local-untracked"),
+        "preserve dirty provenance",
+    )
+    .expect("dirty installed package");
 
     fs::write(
         &source_stack,
@@ -406,6 +469,54 @@ fn update_git_source_refreshes_owned_stack_specs() {
         fs::read_to_string(homeboy_core::paths::stack_config("alpha-combined").unwrap())
             .expect("installed stack");
     assert!(installed.contains("updated stack"));
+    let metadata =
+        crate::read_stack_source_metadata("alpha-combined").expect("refreshed stack metadata");
+    assert_eq!(metadata.source_ref.as_deref(), Some("main"));
+    assert!(metadata.source_dirty);
+}
+
+#[test]
+fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let bare = create_bare_source(package.path());
+    let source = support::bare_source_path(&bare)
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    let mut metadata = crate::read_source_metadata("alpha").expect("metadata");
+    let installed_root = metadata.source_root.clone().expect("source root");
+    let installed_revision = homeboy_core::git::short_head_revision_at(Path::new(&installed_root));
+    metadata.discovery_path = None;
+    metadata.package_path = "relative-package-with-unknown-provenance".to_string();
+    fs::write(
+        homeboy_core::paths::rig_source_metadata("alpha").expect("metadata path"),
+        serde_json::to_vec_pretty(&metadata).expect("serialize metadata"),
+    )
+    .expect("write legacy metadata");
+
+    fs::write(
+        &source_rig,
+        minimal_rig("alpha").replace("alpha rig", "remote update"),
+    )
+    .expect("update remote package");
+    commit_package(package.path(), "remote update");
+    GitFixture::attach(package.path()).push_main(&source);
+
+    let error = update_source_for_rig("alpha").expect_err("invalid provenance must fail closed");
+
+    assert!(error.message.contains("no validated discovery path"));
+    assert_eq!(
+        homeboy_core::git::short_head_revision_at(Path::new(&installed_root)),
+        installed_revision
+    );
+    assert!(
+        !fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
+            .expect("installed rig")
+            .contains("remote update")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expose installed stacks with missing or corrupt source metadata
- fail closed when legacy discovery provenance cannot be validated
- preserve branch, dirty-state, and content identity on refresh

## Tests
- 22 focused rig source lifecycle tests

Closes #11413

AI assistance: gpt-5.6-sol via OpenCode implemented, reviewed, rebased, and tested this change under human direction.