### PR TITLE
Report stack status without a checkout

### DIFF
--- a/crates/homeboy-stack/src/stack/mod.rs
+++ b/crates/homeboy-stack/src/stack/mod.rs
@@ -45,7 +45,7 @@ pub use push::{push, PushOutput, PushStatus};
 pub use spec::{
     exists, expand_path, list, list_ids, load, parse_git_ref, save, GitRef, StackPrEntry, StackSpec,
 };
-pub use status::{status, LocalState, StatusOutput, StatusPr};
+pub use status::{status, LocalEvidenceUnavailable, LocalState, StatusOutput, StatusPr};
 pub use sync::{
     diff, sync, DiffOutput, DroppedPr, ReplayedPr, SyncOutput, SyncPreview, UncertainPr,
 };

--- a/crates/homeboy-stack/src/stack/status.rs
+++ b/crates/homeboy-stack/src/stack/status.rs
@@ -1,8 +1,8 @@
 //! `homeboy stack status` — read-only report on a stack's PR list and
 //! local target state.
 //!
-//! Performs ONE `git fetch <base.remote>` so ahead-counts are fresh; no
-//! other mutations.
+//! Performs read-only local git probes only. It never clones, fetches, or
+//! mutates a checkout.
 //!
 //! For each declared PR:
 //!   - `gh pr view <repo> <number> --json state,mergedAt,reviewDecision,title,url,headRefOid`
@@ -14,12 +14,13 @@
 //! to a per-PR error note; the rest of the report still renders.
 
 use serde::Serialize;
+use std::path::Path;
 
 use homeboy_core::error::Result;
 
 use super::git::run_git;
 use super::pr_meta::fetch_pr_meta;
-use super::spec::{resolve_existing_component_path, StackPrEntry, StackSpec};
+use super::spec::{expand_path, resolve_existing_component_path, StackPrEntry, StackSpec};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct StatusOutput {
@@ -35,9 +36,20 @@ pub struct StatusOutput {
     /// `None` when the local target branch doesn't exist yet.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_behind: Option<usize>,
+    /// Why local branch evidence is unavailable. Omitted when the configured
+    /// checkout exists and can be inspected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_evidence_unavailable: Option<LocalEvidenceUnavailable>,
     pub prs: Vec<StatusPr>,
     pub merged_count: usize,
     pub success: bool,
+}
+
+/// Structured evidence for a status report whose configured checkout cannot be inspected.
+#[derive(Debug, Clone, Serialize)]
+pub struct LocalEvidenceUnavailable {
+    pub reason: String,
+    pub recovery_commands: Vec<String>,
 }
 
 /// Per-PR row in the status report.
@@ -93,31 +105,46 @@ fn is_false(b: &bool) -> bool {
 
 /// Run `homeboy stack status <id>`.
 pub fn status(spec: &StackSpec) -> Result<StatusOutput> {
-    let path = resolve_existing_component_path(spec)?;
-
-    // Single fetch of the base, so ahead-counts are honest. Failure here is
-    // non-fatal — we want status to work offline.
-    let _ = run_git(&path, &["fetch", &spec.base.remote, &spec.base.branch]);
+    let component_path = expand_path(&spec.component_path);
+    let path = resolve_existing_component_path(spec)
+        .ok()
+        .filter(|path| is_git_checkout(path));
+    let local_evidence_reason = if path.is_some() {
+        None
+    } else if Path::new(&component_path).exists() {
+        Some(format!(
+            "Component path '{}' is not a Git checkout",
+            component_path
+        ))
+    } else {
+        Some(format!(
+            "Component path '{}' does not exist",
+            component_path
+        ))
+    };
 
     let base_ref = format!("{}/{}", spec.base.remote, spec.base.branch);
     let target_branch = &spec.target.branch;
 
-    let target_exists = git_ref_exists(&path, target_branch);
+    let target_exists = path
+        .as_deref()
+        .is_some_and(|path| git_ref_exists(path, target_branch));
 
-    let (target_ahead, target_behind) = if target_exists {
-        (
-            count_revs(&path, &base_ref, target_branch),
-            count_revs(&path, target_branch, &base_ref),
-        )
-    } else {
-        (None, None)
-    };
+    let (target_ahead, target_behind) =
+        if let Some(path) = path.as_deref().filter(|_| target_exists) {
+            (
+                count_revs(path, &base_ref, target_branch),
+                count_revs(path, target_branch, &base_ref),
+            )
+        } else {
+            (None, None)
+        };
 
     let mut prs: Vec<StatusPr> = Vec::with_capacity(spec.prs.len());
     let mut merged_count = 0usize;
 
     for pr in &spec.prs {
-        let row = build_status_row(&path, target_branch, &base_ref, target_exists, pr);
+        let row = build_status_row(path.as_deref(), target_branch, &base_ref, target_exists, pr);
         if row.upstream_state.as_deref() == Some("MERGED") {
             merged_count += 1;
         }
@@ -126,19 +153,33 @@ pub fn status(spec: &StackSpec) -> Result<StatusOutput> {
 
     Ok(StatusOutput {
         stack_id: spec.id.clone(),
-        component_path: path,
+        component_path: component_path.clone(),
         base: spec.base.display(),
         target: spec.target.display(),
         target_ahead,
         target_behind,
+        local_evidence_unavailable: local_evidence_reason.map(|reason| LocalEvidenceUnavailable {
+            reason,
+            recovery_commands: vec![
+                format!("git clone <repository-url> {}", component_path),
+                format!("homeboy stack status {}", spec.id),
+            ],
+        }),
         prs,
         merged_count,
         success: true,
     })
 }
 
+fn is_git_checkout(path: &str) -> bool {
+    let Ok(output) = run_git(path, &["rev-parse", "--is-inside-work-tree"]) else {
+        return false;
+    };
+    output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+}
+
 fn build_status_row(
-    path: &str,
+    path: Option<&str>,
     target_branch: &str,
     base_ref: &str,
     target_exists: bool,
@@ -149,7 +190,11 @@ fn build_status_row(
             let local_state = if !target_exists {
                 LocalState::Unknown
             } else {
-                match commit_reachable(path, &meta.head_sha, target_branch) {
+                match commit_reachable(
+                    path.expect("target exists requires a checkout"),
+                    &meta.head_sha,
+                    target_branch,
+                ) {
                     Some(true) => LocalState::Applied,
                     Some(false) => {
                         // Squash-merge fallback: head SHA isn't reachable
@@ -159,7 +204,13 @@ fn build_status_row(
                         // deliberately uses the BASE ref (not target) — the
                         // question is "did upstream absorb this content?",
                         // not "is it on target?".
-                        if patch_in_base(path, &meta.head_sha, base_ref).unwrap_or(false) {
+                        if patch_in_base(
+                            path.expect("target exists requires a checkout"),
+                            &meta.head_sha,
+                            base_ref,
+                        )
+                        .unwrap_or(false)
+                        {
                             LocalState::Applied
                         } else {
                             LocalState::Missing

--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -102,7 +102,9 @@ available planning path before mutating a stack branch.
 homeboy stack status <stack-id>
 ```
 
-Read-only report combining upstream PR state from GitHub with local target-branch state. Use it to spot merged PRs, missing local picks, and review status without mutating the checkout.
+Read-only report combining upstream PR state from GitHub with local target-branch state. It does not clone, fetch, or mutate a checkout.
+
+When `component_path` is absent, status still reports each PR's GitHub metadata. Local branch, ahead, and behind evidence is omitted and `local_evidence_unavailable` explains the missing path with recovery commands. Per-PR `local_state` is `unknown` in that case. Use it to spot merged PRs and review status before materializing a checkout.
 
 ### `sync`
 

--- a/tests/core/stack/status_test.rs
+++ b/tests/core/stack/status_test.rs
@@ -1,16 +1,137 @@
 //! Tests for `core::stack::status` — read-only stack status.
 //!
-//! The full `status()` entry point hits `gh` for upstream PR metadata, so
-//! tests here focus on the deterministic git-side helpers that build the
-//! report's local-state columns: ahead/behind counts, ref existence, and
-//! commit reachability. End-to-end reporting is verified out-of-band via
-//! the live-verify fixture spec described in the PR body.
+//! Includes focused end-to-end status coverage with a fake `gh`, plus the
+//! deterministic git-side helpers that build local-state columns.
 
-use crate::stack::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
+use crate::stack::status::{
+    commit_reachable, count_revs, git_ref_exists, patch_in_base, status, LocalState,
+};
+use crate::stack::{GitRef, StackPrEntry, StackSpec};
+use homeboy_core::test_support::home_env_guard;
 use std::fs;
 
 mod support;
 use support::{commit_file, git, init_repo};
+
+fn stack_spec(id: &str, component_path: String) -> StackSpec {
+    StackSpec {
+        id: id.to_string(),
+        description: String::new(),
+        component: "homeboy".to_string(),
+        component_path,
+        base: GitRef {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        },
+        target: GitRef {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        },
+        prs: vec![StackPrEntry {
+            repo: "Extra-Chill/homeboy".to_string(),
+            number: 11410,
+            note: None,
+        }],
+    }
+}
+
+fn with_fake_gh(stdout: &str, exit_code: u8, run: impl FnOnce()) {
+    let _guard = home_env_guard();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let gh = dir.path().join("gh");
+    fs::write(
+        &gh,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' '{}'\nexit {}\n",
+            stdout, exit_code
+        ),
+    )
+    .expect("write fake gh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&gh, fs::Permissions::from_mode(0o755))
+            .expect("make fake gh executable");
+    }
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{}", dir.path().display(), old_path));
+    run();
+    std::env::set_var("PATH", old_path);
+}
+
+const PR_JSON: &str = r#"{"headRefOid":"deadbeef","state":"OPEN","title":"Checkout-free status","url":"https://github.com/Extra-Chill/homeboy/pull/11410","reviewDecision":"APPROVED","mergedAt":null}"#;
+
+#[test]
+fn status_reports_upstream_and_local_evidence_for_present_checkout() {
+    let (_dir, path) = init_repo();
+    with_fake_gh(PR_JSON, 0, || {
+        let report = status(&stack_spec("present", path.clone())).expect("status report");
+        assert!(report.local_evidence_unavailable.is_none());
+        assert_eq!(report.prs[0].upstream_state.as_deref(), Some("OPEN"));
+        assert_eq!(report.prs[0].local_state, LocalState::Unknown);
+    });
+}
+
+#[test]
+fn status_reports_github_metadata_when_checkout_is_missing() {
+    let path = "/definitely/missing/homeboy-stack-status".to_string();
+    with_fake_gh(PR_JSON, 0, || {
+        let report = status(&stack_spec("missing", path.clone())).expect("status report");
+        assert_eq!(report.prs[0].upstream_state.as_deref(), Some("OPEN"));
+        assert_eq!(report.prs[0].local_state, LocalState::Unknown);
+        assert_eq!(report.target_ahead, None);
+        let evidence = report
+            .local_evidence_unavailable
+            .expect("missing checkout evidence");
+        assert_eq!(
+            evidence.reason,
+            format!("Component path '{}' does not exist", path)
+        );
+        assert_eq!(
+            evidence.recovery_commands[0],
+            format!("git clone <repository-url> {}", path)
+        );
+    });
+}
+
+#[test]
+fn status_reports_local_evidence_unavailable_for_non_git_directory() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let path = dir.path().to_string_lossy().to_string();
+    fs::write(dir.path().join("not-a-repository.txt"), "local files").expect("write fixture");
+
+    with_fake_gh(PR_JSON, 0, || {
+        let report = status(&stack_spec("non-git", path.clone())).expect("status report");
+        assert_eq!(report.prs[0].upstream_state.as_deref(), Some("OPEN"));
+        assert_eq!(report.prs[0].local_state, LocalState::Unknown);
+        assert_eq!(report.target_ahead, None);
+        assert_eq!(report.target_behind, None);
+        assert_eq!(
+            report
+                .local_evidence_unavailable
+                .expect("non-Git checkout evidence")
+                .reason,
+            format!("Component path '{}' is not a Git checkout", path)
+        );
+    });
+}
+
+#[test]
+fn status_reports_both_unavailable_evidence_when_github_lookup_fails() {
+    let path = "/definitely/missing/homeboy-stack-status".to_string();
+    with_fake_gh("GitHub unavailable", 1, || {
+        let report = status(&stack_spec("missing", path)).expect("status report");
+        assert!(report.prs[0].upstream_state.is_none());
+        assert_eq!(report.prs[0].local_state, LocalState::Unknown);
+        assert!(report.prs[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("gh pr view Extra-Chill/homeboy#11410 failed"));
+        assert!(report.local_evidence_unavailable.is_some());
+    });
+}
 
 // ---------------------------------------------------------------------------
 // git_ref_exists


### PR DESCRIPTION
## Summary
- report upstream stack metadata when no local checkout exists
- distinguish missing and non-Git local evidence
- keep status read-only and schema-compatible

## Tests
- `cargo test -p homeboy-stack --lib`

Closes #11410

AI assistance: gpt-5.6-sol via OpenCode implemented, reviewed, rebased, and tested this change under human direction.