### PR TITLE
Reap remote SSH descendants

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -417,7 +417,8 @@ impl SshClient {
             Ok(stdin) => stdin,
             Err(error) => return ssh_process_error(error),
         };
-        let args = self.build_ssh_args(Some(&effective), false);
+        let remote_command = wrap_timed_remote_command(&effective);
+        let args = self.build_ssh_args(Some(&remote_command), false);
         let mut cmd = Command::new("ssh");
         cmd.args(&args)
             .stdin(Stdio::piped())
@@ -514,7 +515,8 @@ impl SshClient {
         stdin: Option<&[u8]>,
         timeout: Duration,
     ) -> CommandOutput {
-        let args = self.build_ssh_args(Some(command), false);
+        let remote_command = wrap_timed_remote_command(command);
+        let args = self.build_ssh_args(Some(&remote_command), false);
         let mut cmd = Command::new("ssh");
         cmd.args(&args)
             .stdout(Stdio::piped())
@@ -1068,6 +1070,16 @@ mod bounded_probe_output_tests {
 
 const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 const PROCESS_REAP_DEADLINE: Duration = Duration::from_millis(250);
+
+/// Run a timed SSH command in a remote session that Homeboy explicitly owns.
+/// The remote shell, rather than the controller's local `ssh` process group,
+/// owns cleanup of descendants that inherit the SSH output pipes.
+pub(super) fn wrap_timed_remote_command(command: &str) -> String {
+    format!(
+        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy timed SSH execution requires remote setsid process authority.' >&2; exit 127; }}; setsid sh -c {} & __homeboy_remote_pid=$!; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
+        shell::quote_arg(command)
+    )
+}
 
 fn terminate_process_group_with_deadline(
     child: &mut std::process::Child,

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -17,7 +17,7 @@ use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_source_timeout,
     execute_command_with_stdin_timeout, execute_command_with_writer_factory,
     run_command_with_stdin_source, wrap_command_with_secret_env_read_loop,
-    SECRET_ENV_STDIN_SENTINEL,
+    wrap_timed_remote_command, SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandOutput, SshClient};
 
@@ -144,6 +144,67 @@ fn small_secret_stdin_payload_completes_successfully() {
 
     assert!(output.success, "{}", output.stderr);
     assert_eq!(output.stdout, "done");
+}
+
+#[test]
+fn timed_ssh_envelope_owns_remote_descendant_cleanup() {
+    let envelope = wrap_timed_remote_command("sleep 30 & printf terminal-result");
+
+    assert!(envelope.contains("setsid sh -c"));
+    assert!(envelope.contains("kill -TERM -\"$__homeboy_remote_pid\""));
+    assert!(envelope.contains("kill -KILL -\"$__homeboy_remote_pid\""));
+    assert!(envelope.contains("exit \"$__homeboy_remote_status\""));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn timed_piped_ssh_envelope_preserves_stdin_and_output_while_reaping_descendants() {
+    let descendant_pid_path = std::env::temp_dir().join(format!(
+        "homeboy-disconnect-descendant-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&descendant_pid_path);
+    let mut command = Command::new("sh");
+    command
+        .args([
+            "-c",
+            &wrap_timed_remote_command(&format!(
+                "input=$(cat); sleep 30 & descendant=$!; printf '%s' \"$descendant\" > {}; printf '{{\"success\":true,\"data\":{{\"input\":\"%s\",\"action\":\"stop\",\"stopped\":true}}}}\\n' \"$input\"",
+                crate::engine::shell::quote_path(&descendant_pid_path.to_string_lossy())
+            )),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+
+    let started = Instant::now();
+    let input = tempfile::NamedTempFile::new().expect("piped stdin fixture");
+    std::fs::write(input.path(), "piped-input").expect("write piped stdin fixture");
+    let output = execute_command_with_stdin_source_timeout(
+        command,
+        StdinSource::Piped(std::fs::File::open(input.path()).expect("open piped stdin fixture")),
+        Duration::from_secs(2),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(
+        output.stdout,
+        "{\"success\":true,\"data\":{\"input\":\"piped-input\",\"action\":\"stop\",\"stopped\":true}}\n"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "remote descendant cleanup must not retain the foreground command"
+    );
+    let descendant_pid = std::fs::read_to_string(&descendant_pid_path)
+        .expect("disconnect shim records its pipe-holding descendant")
+        .parse()
+        .expect("descendant PID");
+    assert!(
+        !crate::process::pid_is_running(descendant_pid),
+        "runner disconnect left its attributed pipe-holding descendant running"
+    );
+    let _ = std::fs::remove_file(descendant_pid_path);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- wrap timed SSH commands in an owned remote process group
- cover piped-stdin timeout paths
- preserve successful terminal output without controller-platform false failures

## Tests
- timed SSH envelope descendant cleanup
- piped stdin deadline cleanup

Closes #11414

AI assistance: gpt-5.6-sol via OpenCode implemented, reviewed, rebased, and tested this change under human direction.