### PR TITLE
fix: register audit compiler-warning provider at CLI startup

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -160,10 +160,11 @@ pub fn register_startup_providers_before_reconcile() {
     homeboy_extension::build::register_component_build_runner();
     homeboy_extension::lifecycle::register_component_install_runner();
     // Register extension-backed audit providers so code_audit can load
-    // grammars and run fallback fingerprint scripts without depending on the
-    // extension registry or script runner.
+    // grammars, run fallback fingerprint scripts, and collect compiler
+    // warnings without depending on the extension registry or script runner.
     homeboy_extension::audit_fingerprint_script_provider::register();
     homeboy_extension::audit_grammar_source_provider::register();
+    homeboy_extension::audit_compiler_warning_provider::register();
     // Register the audit recorded-artifact provider so the artifact-portability
     // detector can read past runs' artifacts from the observation store without
     // code_audit depending on observation — the last seam before audit becomes

--- a/crates/homeboy-cli/tests/provider_registry_completeness.rs
+++ b/crates/homeboy-cli/tests/provider_registry_completeness.rs
@@ -39,24 +39,12 @@ struct OptionalRegistry {
 /// how a registry graduates to "must be wired", and wiring one of these up later
 /// shrinks the unregistered set without breaking the test. Adding an entry is
 /// the deliberate, reviewable act of accepting an inert subsystem.
-const OPTIONAL_REGISTRIES: &[OptionalRegistry] = &[
-    OptionalRegistry {
-        id: "homeboy_agents::agent_task_lifecycle::acceptance_verifier::register_acceptance_verifier",
-        reason: "Conditional by design. `register_acceptance_verifier_from_config` returns \
+const OPTIONAL_REGISTRIES: &[OptionalRegistry] = &[OptionalRegistry {
+    id: "homeboy_agents::agent_task_lifecycle::acceptance_verifier::register_acceptance_verifier",
+    reason: "Conditional by design. `register_acceptance_verifier_from_config` returns \
                  Ok(()) without registering when `agent_task.acceptance_verifier` is unset, \
                  which is the default. Tests inject their own verifier through the registry.",
-    },
-    OptionalRegistry {
-        id: "homeboy_code_audit::compiler_warning_provider::register_compiler_warning_provider",
-        reason: "NOT WIRED (found while closing #11133). \
-                 `homeboy_extension::audit_compiler_warning_provider::register` exists and its \
-                 doc comment claims it is \"called once at binary startup by the CLI\", but no \
-                 caller exists anywhere in the workspace, so audit's compiler-warning provider \
-                 is inert in production and silently returns the no-op. Recorded here rather \
-                 than fixed because wiring it changes audit behavior, which is out of scope for \
-                 the detection fix. Removing this entry is the fix.",
-    },
-];
+}];
 
 /// A registry that must exist in the inventory for this test to mean anything.
 /// The inventory is collected at link time; a collection that silently yielded


### PR DESCRIPTION
Closes #11168

## Problem

`homeboy_extension::audit_compiler_warning_provider::register()` exists, and its doc comment claims it is "Called once at binary startup by the CLI" — but **no caller existed anywhere in the workspace**. The boxed provider registry slot stayed empty and dispatched to its no-op, so audit's compiler-warning provider has been silently inert in production for its entire life.

The gap was already known and recorded: `OPTIONAL_REGISTRIES` in `provider_registry_completeness.rs` carried an entry whose reason ended with **"Removing this entry is the fix."** It was deferred when #11133 was closed because wiring it changes audit behavior, which was out of scope for that detection fix.

## Change

Two edits, nothing else:

1. `crates/homeboy-cli/src/cli_runtime.rs` — call `homeboy_extension::audit_compiler_warning_provider::register()` in `register_startup_providers_before_reconcile()`, immediately after its two sibling extension-backed audit providers. Order in that function is load-bearing, so the registration is placed adjacent to its existing group and nothing else moved. The group comment now also accounts for compiler warnings.
2. `crates/homeboy-cli/tests/provider_registry_completeness.rs` — remove the `compiler_warning_provider` allowlist entry. The completeness assertion is a subset check, so removing the entry is exactly how a registry graduates to "must be wired". `SENTINEL_REGISTRY`, `MINIMUM_DECLARED_REGISTRIES`, and the assertion logic are untouched. `cargo fmt` collapsed the now-single-element array.

## Reviewer note — expect an audit behavior change

**This wires up a provider that was previously doing nothing.** `code_audit` may now emit compiler-warning findings that were silently dropped before. That is the point of the fix, but it means audit output can legitimately change on this PR.

The issue's second half — "deal with whatever findings it starts producing" — is deliberately **not** in scope here. No detector, baseline, or ratchet file was touched. If new findings surface, they should be triaged on their merits rather than folded into this wiring change.

## Verification

`cargo fmt --check` passes. Full build and test are left to CI per this repo's build policy — the change is a single call to an existing `pub fn register()` (`crates/homeboy-extension/src/audit_compiler_warning_provider.rs:97`, exported at `lib.rs:4`) from a crate that already depends on `homeboy-extension` and already calls two of its siblings.

🤖 Authored by chubes-bot