### PR TITLE
fix(agent-task): enumerate available backends when no default is configured

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -456,6 +456,42 @@ fn config_default_backend() -> Option<String> {
         .filter(|backend| !backend.trim().is_empty())
 }
 
+/// The validation error raised when `agent-task cook` was given no `--backend`
+/// and no policy layer supplies a default.
+///
+/// The error enumerates the backends the discovered provider catalog declares
+/// so the operator gets a usable value from the failing command itself (#11478).
+/// Enumeration is *declaration*, not readiness — a listed backend can still fail
+/// its runner/config preflight at dispatch — so the message points at
+/// `agent-task providers --validate-readiness` rather than promising usability.
+fn missing_default_backend_error(available_backends: &[String]) -> Error {
+    const PROBLEM: &str =
+        "agent-task cook requires --backend because no default backend policy is configured";
+
+    let mut tried = vec![
+        "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
+    ];
+
+    let problem = if available_backends.is_empty() {
+        tried.push(
+            "No agent-task executor providers were discovered here; run `homeboy agent-task providers` to diagnose runtime discovery."
+                .to_string(),
+        );
+        PROBLEM.to_string()
+    } else {
+        tried.push(
+            "Listed backends are declared, not verified: run `homeboy agent-task providers --backend <backend> --validate-readiness` to confirm one is usable."
+                .to_string(),
+        );
+        format!(
+            "{PROBLEM}; available backends: {}",
+            available_backends.join(", ")
+        )
+    };
+
+    Error::validation_invalid_argument("backend", problem, None, Some(tried))
+}
+
 /// Resolution core that also takes the Homeboy-config default resolver so tests
 /// can drive deterministic source classification (#5685).
 fn resolve_dispatch_request_with_default_and_config(
@@ -471,15 +507,13 @@ fn resolve_dispatch_request_with_default_and_config(
             Some(backend) => (backend, BackendSelectionSource::Cli),
             None => {
                 let resolved = default_backend(command.repo.as_deref())?.ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "backend",
-                    "agent-task cook requires --backend because no default backend policy is configured",
-                    None,
-                    Some(vec![
-                        "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
-                    ]),
-                )
-            })?;
+                    // The provider catalog already knows every dispatchable
+                    // backend at this point, so discover it rather than making
+                    // the operator run `agent-task providers` and parse JSON to
+                    // answer a question this command can answer (#11478).
+                    // Discovery only happens on the failure path.
+                    missing_default_backend_error(&AgentTaskProviderCatalog::discover().backends())
+                })?;
                 // The policy resolver prefers component/extension defaults over the
                 // Homeboy config default; if the resolved value matches the config
                 // default we attribute it to config, otherwise to higher-priority
@@ -573,6 +607,77 @@ mod tests {
             backend: backend.map(str::to_string),
             ..AgentTaskDispatchCommand::default()
         }
+    }
+
+    #[test]
+    fn missing_default_backend_error_enumerates_available_backends() {
+        let error = missing_default_backend_error(&[
+            "claude-code".to_string(),
+            "codex".to_string(),
+            "opencode".to_string(),
+        ]);
+
+        assert!(
+            error
+                .message
+                .contains("requires --backend because no default backend policy is configured"),
+            "{}",
+            error.message
+        );
+        assert!(
+            error
+                .message
+                .contains("available backends: claude-code, codex, opencode"),
+            "the failing command must name the values it will accept: {}",
+            error.message
+        );
+        // The configuration fix stays first; readiness is a caveat, not a promise.
+        assert_eq!(
+            error.details["tried"][0].as_str(),
+            Some("Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.")
+        );
+        assert!(error.details["tried"][1]
+            .as_str()
+            .expect("readiness caveat")
+            .contains("--validate-readiness"));
+    }
+
+    #[test]
+    fn missing_default_backend_error_without_providers_points_at_discovery() {
+        let error = missing_default_backend_error(&[]);
+
+        assert!(
+            !error.message.contains("available backends"),
+            "an empty catalog must not advertise an empty list: {}",
+            error.message
+        );
+        assert!(error.details["tried"][1]
+            .as_str()
+            .expect("discovery hint")
+            .contains("homeboy agent-task providers"));
+    }
+
+    #[test]
+    fn missing_default_backend_is_raised_when_no_policy_resolves_a_backend() {
+        // Isolated home so catalog discovery on the failure path cannot read the
+        // developer's real runtimes.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let error = resolve_dispatch_request_with_default_and_config(
+                command_with_backend(None),
+                |_| Ok(None),
+                || None,
+            )
+            .expect_err("no backend and no default policy");
+
+            assert_eq!(
+                error.code,
+                homeboy_core::ErrorCode::ValidationInvalidArgument
+            );
+            assert_eq!(error.details["field"].as_str(), Some("backend"));
+            assert!(error
+                .message
+                .contains("requires --backend because no default backend policy is configured"));
+        });
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -65,6 +65,29 @@ impl AgentTaskProviderCatalog {
         &self.diagnostics
     }
 
+    /// The distinct backends this catalog declares, sorted and deduped.
+    ///
+    /// This is the answer to "what are the valid `--backend` values here?".
+    /// Without it that answer is only reachable by running `homeboy agent-task
+    /// providers` and parsing its JSON, which is what made the missing-default
+    /// backend error a papercut (#11478).
+    ///
+    /// Presence here means a provider *declares* the backend, not that the
+    /// backend is usable right now — runner/config readiness is a separate,
+    /// side-effecting probe (`validate_provider_runner_readiness_for_backend`).
+    /// Callers that enumerate these must not imply readiness.
+    pub fn backends(&self) -> Vec<String> {
+        let mut backends = self
+            .providers
+            .iter()
+            .map(|provider| provider.backend.trim().to_string())
+            .filter(|backend| !backend.is_empty())
+            .collect::<Vec<_>>();
+        backends.sort();
+        backends.dedup();
+        backends
+    }
+
     pub fn provider_requires_cwd_git_checkout(
         &self,
         backend: &str,
@@ -251,6 +274,43 @@ mod tests {
             providers: vec![disclosure_provider()],
             ..Default::default()
         }
+    }
+
+    fn provider_with_backend(id: &str, backend: &str) -> AgentTaskExecutorProvider {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "backend": backend,
+        }))
+        .expect("valid provider fixture")
+    }
+
+    #[test]
+    fn backends_are_sorted_deduped_and_skip_blanks() {
+        let catalog = AgentTaskProviderCatalog {
+            providers: vec![
+                provider_with_backend("b.opencode", "opencode"),
+                provider_with_backend("a.pi", "pi"),
+                // Two providers for one backend must not double-list it.
+                provider_with_backend("c.opencode", "opencode"),
+                provider_with_backend("d.claude", "claude-code"),
+                provider_with_backend("e.blank", "   "),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            catalog.backends(),
+            vec![
+                "claude-code".to_string(),
+                "opencode".to_string(),
+                "pi".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn backends_of_an_empty_catalog_is_empty() {
+        assert!(AgentTaskProviderCatalog::default().backends().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #11478.

## Problem

`agent-task cook` without `--backend` fails with:

```
Invalid argument 'backend': agent-task cook requires --backend because no default
backend policy is configured
  tried: Set agent_task.default_backend in component, extension, or Homeboy config
         policy, or pass --backend explicitly.
```

It never says which backends exist. The operator has to run `homeboy agent-task providers` and pipe a large JSON document through a parser to recover a usable value — a question the failing command already has the data to answer.

## What changed

- **`AgentTaskProviderCatalog::backends()`** (`crates/homeboy-agents/src/agent_task_provider/catalog.rs`) — the distinct backends the catalog declares, trimmed, sorted, deduped, blanks dropped. There was no existing accessor for this; `agent-task providers` renders whole provider records, not a backend list.
- **`missing_default_backend_error()`** (`crates/homeboy-agents/src/agent_task_dispatch_service.rs`) — extracted the inline error construction into a named, unit-testable builder that takes the backend list.

New message shape:

```
Invalid argument 'backend': agent-task cook requires --backend because no default
backend policy is configured; available backends: claude-code, codex, local-shell,
opencode, pi, wp-codebox
  tried: Set agent_task.default_backend in component, extension, or Homeboy config
         policy, or pass --backend explicitly.
         Listed backends are declared, not verified: run `homeboy agent-task
         providers --backend <backend> --validate-readiness` to confirm one is usable.
```

An empty catalog does not advertise an empty list — it points at `homeboy agent-task providers` to diagnose runtime discovery instead.

`AgentTaskProviderCatalog` was already imported at the call site and `discover()` is only invoked inside the `ok_or_else` closure, so the happy path pays nothing and no plumbing was added.

## Tests

- `backends_are_sorted_deduped_and_skip_blanks`, `backends_of_an_empty_catalog_is_empty` (catalog.rs)
- `missing_default_backend_error_enumerates_available_backends`, `missing_default_backend_error_without_providers_points_at_discovery`, `missing_default_backend_is_raised_when_no_policy_resolves_a_backend` (agent_task_dispatch_service.rs)

The end-to-end test runs under `with_isolated_home` so failure-path discovery cannot read the developer's real runtimes. No tests were deleted or `#[ignore]`d. The existing negative assertion in `commands/agent_task/tests/controller_run.rs:301` matches on the unchanged leading substring and still holds.

## What I did NOT do

- **No readiness state in the enumeration.** The issue's ideal output annotates how many backends are not usable right now. Determining that requires per-provider executable/env probes plus a configured readiness invocation (`validate_provider_runner_readiness_for_backend`) — side-effecting subprocess work on a validation error path. Instead the error is explicit that listed backends are declared, not verified, and names the command that checks. The companion "`available` does not mean usable" issue is the right place for that.
- **Did not touch the sibling message** at `crates/homeboy-cli/src/commands/agent_task/review.rs:989` (`providers --validate-readiness requires --backend ...`). Same class of papercut, out of scope for this issue.
- **No `[possible values: ...]` on `--backend`'s clap help.** The set is resolved at runtime from discovered providers; clap wants it at parse-definition time.

## Compilation

**I could not compile or run tests locally** — this VPS runs nine parallel agents and a cargo build OOMs it. Only `cargo fmt` was run (clean). Everything below is reasoned from source, not verified by a compiler:

- `AgentTaskExecutorProvider` deserialization from a `{id, backend}`-only JSON fixture: every other field is `#[serde(default)]`, only `id` and `backend` lack one, so the fixture should deserialize. This mirrors the existing `disclosure_provider()` fixture in the same test module.
- Implicit format-arg capture of a function-local `const` (`format!("{PROBLEM}; ...")`) — the same pattern exists at `crates/homeboy-refactor/src/auto/transaction.rs:248` and elsewhere.
- `homeboy_core::ErrorCode` / `homeboy_core::test_support::with_isolated_home` paths — both already used in this crate's tests, including the same module.

CI is the gate.