### PR TITLE
feat(status): report controller binary staleness

### DIFF
--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -14,6 +14,7 @@ use homeboy::core::context;
 use homeboy::core::scope::{self, Scope};
 use homeboy_deploy::ReleaseStateStatus;
 use homeboy_release::release::version;
+use homeboy_upgrade::controller_staleness::{self, ControllerStaleness};
 use std::collections::HashMap;
 
 use super::CmdResult;
@@ -42,24 +43,33 @@ pub fn run(args: StatusArgs) -> CmdResult<StatusResult> {
         .then(|| homeboy::core::runtime_promotion::acquire("status refresh", "status"))
         .transpose()?;
 
+    // Every component freshness signal below takes this binary as its reference
+    // point, so resolve the reference's own freshness first and say so. Read
+    // once from the daily update-check cache — no network, no per-path
+    // re-resolution (#11483).
+    let controller = controller_staleness::current();
+    log_controller_staleness(&controller);
+
     // Explicit scope selection. `--path` and `--project` keep their historical
     // routes (checkout inspection and the project dashboard); the remaining
     // selectors resolve through the shared scope resolver into the same
     // component summary the default view builds.
     match args.scope.selection() {
-        Some(Scope::Path { .. }) => return run_path_status(&args),
-        Some(Scope::Project(ref project_id)) => return run_project_dashboard(project_id, &args),
+        Some(Scope::Path { .. }) => return run_path_status(&args, controller),
+        Some(Scope::Project(ref project_id)) => {
+            return run_project_dashboard(project_id, &args, controller)
+        }
         Some(selected) => {
             let timer = StatusTimer::new(args.timings);
             let components = scope::resolve_scope_component_records(&selected)?;
-            return summarize_components(components, &args, timer);
+            return summarize_components(components, &args, timer, controller);
         }
         None => {}
     }
 
     // Project dashboard mode: `homeboy status <project-id>`
     if let Some(ref project_id) = args.target {
-        return run_project_dashboard(project_id, &args);
+        return run_project_dashboard(project_id, &args, controller);
     }
 
     if !args.full && !args.all {
@@ -119,13 +129,26 @@ pub fn run(args: StatusArgs) -> CmdResult<StatusResult> {
             .collect()
     };
 
-    summarize_components(components, &args, timer)
+    summarize_components(components, &args, timer, controller)
+}
+
+/// Emit the controller-staleness warning to the status channel.
+///
+/// Reporting only, never fatal: a stale controller still runs the command it
+/// was asked to run. `ControllerStaleness` yields a line only when staleness is
+/// *established*, so an offline host or a disabled update check stays silent
+/// rather than warning on a verdict it does not have.
+fn log_controller_staleness(controller: &ControllerStaleness) {
+    if let Some(line) = controller.warning_line() {
+        homeboy::log_status!("status", "{}", line);
+    }
 }
 
 fn summarize_components(
     components: Vec<component::Component>,
     args: &StatusArgs,
     mut timer: StatusTimer,
+    controller: ControllerStaleness,
 ) -> CmdResult<StatusResult> {
     let total = components.len();
 
@@ -241,13 +264,14 @@ fn summarize_components(
             unreleased_merges_note,
             timings: timer.into_timings(),
             clean,
+            controller,
         }),
         0,
     ))
 }
 
 /// Path override mode: inspect one checkout without requiring registry membership.
-fn run_path_status(args: &StatusArgs) -> CmdResult<StatusResult> {
+fn run_path_status(args: &StatusArgs, controller: ControllerStaleness) -> CmdResult<StatusResult> {
     let path = args.scope.path.as_deref();
     let mut timer = StatusTimer::new(args.timings);
     timer.begin("resolve_path_component");
@@ -260,14 +284,18 @@ fn run_path_status(args: &StatusArgs) -> CmdResult<StatusResult> {
         return Ok((StatusResult::Full(report), 0));
     }
 
-    summarize_components(vec![component], args, timer)
+    summarize_components(vec![component], args, timer, controller)
 }
 
 /// Project dashboard: show version drift across all components in a project.
 ///
 /// Combines local version, remote (deployed) version, release state, upstream
 /// drift, and unreleased commit count into a single view per component.
-fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<StatusResult> {
+fn run_project_dashboard(
+    project_id: &str,
+    args: &StatusArgs,
+    controller: ControllerStaleness,
+) -> CmdResult<StatusResult> {
     let mut timer = StatusTimer::new(args.timings);
 
     timer.begin("resolve_project_components");
@@ -477,6 +505,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
             components: rows,
             summary,
             timings: timer.into_timings(),
+            controller,
         }),
         0,
     ))
@@ -602,7 +631,61 @@ mod tests {
             unreleased_merges_note: None,
             timings: Vec::new(),
             clean: 0,
+            controller: controller_staleness::current(),
         }
+    }
+
+    fn stale_controller() -> ControllerStaleness {
+        controller_staleness::assess(
+            &homeboy::core::build_identity::BuildIdentity {
+                version: "0.327.0".to_string(),
+                git_commit: Some("ed33954781a9".to_string()),
+                git_dirty: None,
+                display: "homeboy 0.327.0+ed33954781a9".to_string(),
+            },
+            Some("0.329.1"),
+            Some(1_000),
+            1_100,
+        )
+    }
+
+    /// The controller's own freshness is part of the status contract, not an
+    /// optional extra: every other freshness signal in this report is measured
+    /// against this binary (#11483).
+    #[test]
+    fn status_output_always_carries_controller_freshness() {
+        let output = StatusOutput {
+            controller: stale_controller(),
+            ..empty_status_output()
+        };
+        let json = serde_json::to_value(&output).expect("serialize status output");
+
+        assert_eq!(json["controller"]["status"], "behind_minor");
+        assert_eq!(json["controller"]["stale"], true);
+        assert_eq!(json["controller"]["escalated"], true);
+        assert_eq!(json["controller"]["minor_releases_behind"], 2);
+        assert_eq!(json["controller"]["latest_version"], "0.329.1");
+        assert_eq!(json["controller"]["remediation"], "homeboy upgrade");
+    }
+
+    /// A current or unestablished controller must still emit the field, so a
+    /// reader can distinguish "checked, current" from "never checked" instead
+    /// of reading silence as health.
+    #[test]
+    fn status_output_emits_controller_freshness_when_not_stale() {
+        let json = serde_json::to_value(empty_status_output()).expect("serialize status output");
+
+        let controller = json.get("controller").expect("controller field is present");
+        assert!(controller.get("status").and_then(|v| v.as_str()).is_some());
+        assert!(controller.get("detail").and_then(|v| v.as_str()).is_some());
+    }
+
+    /// Reporting only: the staleness warning is emitted, never turned into a
+    /// non-zero exit or an error.
+    #[test]
+    fn controller_staleness_logging_is_advisory_only() {
+        log_controller_staleness(&stale_controller());
+        log_controller_staleness(&empty_status_output().controller);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -1,6 +1,7 @@
 //! Data types for the `status` command: CLI args, serialized output shapes,
 //! dashboard rows/summaries, and the phase timer.
 
+use homeboy_upgrade::controller_staleness::ControllerStaleness;
 use serde::Serialize;
 use std::time::Instant;
 
@@ -171,6 +172,15 @@ pub struct StatusOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub timings: Vec<StatusTiming>,
     pub clean: usize,
+    /// Freshness of the `homeboy` binary that produced this report, relative to
+    /// the latest published release.
+    ///
+    /// Emitted unconditionally (not only when stale) so a reader can tell
+    /// `current` from `unknown` — a controller whose freshness was never
+    /// established is exactly the state that let a two-release-old binary
+    /// triage its own issue tracker unnoticed (#11483). Costs one cached file
+    /// read; see [`homeboy_upgrade::controller_staleness`].
+    pub controller: ControllerStaleness,
 }
 
 #[derive(Debug, Serialize)]
@@ -244,6 +254,9 @@ pub struct ProjectDashboardOutput {
     pub summary: ProjectDashboardSummary,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub timings: Vec<StatusTiming>,
+    /// Freshness of the `homeboy` binary that produced this dashboard. See
+    /// [`StatusOutput::controller`].
+    pub controller: ControllerStaleness,
 }
 
 pub(super) struct StatusTimer {

--- a/crates/homeboy-upgrade/src/controller_staleness.rs
+++ b/crates/homeboy-upgrade/src/controller_staleness.rs
@@ -1,0 +1,563 @@
+//! Controller binary staleness — is the `homeboy` binary executing this command
+//! behind the latest published release?
+//!
+//! Runner-side freshness already has surfaces: `runtime_overlay_freshness`
+//! compares a synced build against its source, and the controller↔runner version
+//! check (`require_exact_homeboy_version`) compares a runner daemon against the
+//! controller. Both take the *controller* as the reference point and none of
+//! them ask whether that reference is itself current. A controller two minor
+//! releases behind dispatches work whose behavior it may not model correctly —
+//! the same class of bug, one level up (#11483).
+//!
+//! # Cost
+//!
+//! This module performs **no network I/O**. It reads the latest published
+//! version out of the daily update-check cache that
+//! [`crate::upgrade::update_check::run_startup_check`] already maintains, so the
+//! whole surface costs one small file read per command and at most one network
+//! call per day — the call the startup check was already making.
+//!
+//! Every failure mode degrades to [`ControllerCurrency::Unknown`]: no cache, an
+//! unparseable version, an operator-disabled update check, or an offline host
+//! all report "not established" rather than guessing "current" or failing a
+//! command.
+//!
+//! # What this deliberately does not compute
+//!
+//! The issue asks for a commit delta ("215 commits behind"). That requires a
+//! source checkout with an up-to-date `origin/main`, which a packaged install
+//! does not have and which would cost a `git fetch`. The release delta is
+//! derivable from facts already on hand, so that is what is reported; the
+//! embedded build commit is carried alongside it so an operator with a checkout
+//! can compute the commit delta themselves.
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::upgrade::update_check;
+use homeboy_core::build_identity::{self, BuildIdentity};
+use homeboy_core::update_check_cache;
+
+/// Minor-release distance at or beyond which staleness is escalated from a note
+/// to a warning.
+///
+/// One minor release behind is ordinary drift on a project that releases
+/// continuously. *More than* one minor release behind is the threshold the
+/// issue names: at that distance the controller is dispatching work against
+/// behavior it may not model correctly.
+pub const ESCALATION_MINOR_RELEASES_BEHIND: u64 = 2;
+
+/// The command that resolves controller staleness. Reported as remediation so
+/// the operator never has to look it up.
+pub const REMEDIATION_COMMAND: &str = "homeboy upgrade";
+
+/// Where the running controller binary sits relative to the latest published
+/// release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControllerCurrency {
+    /// Running exactly the latest published release.
+    Current,
+    /// Running something newer than the latest published release — normal for a
+    /// source build on an unreleased branch. Not staleness.
+    Ahead,
+    /// Behind by patch releases only, within the same minor line.
+    BehindPatch,
+    /// Behind by one or more minor releases.
+    BehindMinor,
+    /// Behind by one or more major releases.
+    BehindMajor,
+    /// Not established: no cached release to compare against, an unparseable
+    /// version, or the update check is disabled. Never treated as current.
+    Unknown,
+}
+
+impl ControllerCurrency {
+    /// True only when the controller is provably behind the latest published
+    /// release. [`ControllerCurrency::Unknown`] is deliberately not behind — an
+    /// unestablished verdict must not manufacture a warning.
+    pub fn is_behind(self) -> bool {
+        matches!(
+            self,
+            Self::BehindPatch | Self::BehindMinor | Self::BehindMajor
+        )
+    }
+}
+
+/// Freshness of the controller binary running this command, plus everything an
+/// operator needs to act on it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControllerStaleness {
+    pub status: ControllerCurrency,
+    /// `true` only when the controller is provably behind a published release.
+    pub stale: bool,
+    /// `true` when the drift is past [`ESCALATION_MINOR_RELEASES_BEHIND`] (or
+    /// any major release), i.e. worth a warning rather than a note.
+    pub escalated: bool,
+    /// Version of the binary executing this command.
+    pub running_version: String,
+    /// Full build identity including the embedded git commit, e.g.
+    /// `homeboy 0.327.0+ed33954781a9`.
+    pub build_identity: String,
+    /// Embedded git commit of the running build, when the build recorded one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
+    /// Latest published release, as of the cached check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
+    /// Minor releases between the running build and the latest published
+    /// release. `Some(0)` means same minor line; `None` when the comparison
+    /// could not be made or the majors differ (where a minor delta is
+    /// meaningless).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minor_releases_behind: Option<u64>,
+    /// Unix timestamp of the cached check the comparison used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked_at: Option<u64>,
+    /// Age of that cached check in seconds, so a reader can tell a fresh verdict
+    /// from one made against a week-old release list on an offline host.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_age_secs: Option<u64>,
+    /// One-line human summary.
+    pub detail: String,
+    /// Command that resolves the drift, present only when there is drift.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+}
+
+impl ControllerStaleness {
+    /// The single warning line for a stale controller, or `None` when the
+    /// controller is current, ahead, or unestablished.
+    pub fn warning_line(&self) -> Option<String> {
+        self.stale.then(|| self.detail.clone())
+    }
+}
+
+/// Staleness of the controller running this command, from the daily
+/// update-check cache. No network I/O; never fails.
+pub fn current() -> ControllerStaleness {
+    let identity = build_identity::current();
+    if update_check::is_disabled() {
+        return unknown(
+            &identity,
+            None,
+            None,
+            0,
+            "controller freshness not established: the update check is disabled \
+             (HOMEBOY_NO_UPDATE_CHECK or `homeboy config set /update_check false`)",
+        );
+    }
+
+    let cached = update_check::cached_latest_release();
+    assess(
+        &identity,
+        cached.as_ref().map(|entry| entry.latest_version.as_str()),
+        cached.as_ref().map(|entry| entry.checked_at),
+        update_check_cache::now_unix(),
+    )
+}
+
+/// Pure staleness comparison. Separated from cache and clock access so the
+/// classification, the escalation threshold, and the message are testable
+/// without touching the filesystem or the network.
+pub fn assess(
+    identity: &BuildIdentity,
+    latest: Option<&str>,
+    checked_at: Option<u64>,
+    now: u64,
+) -> ControllerStaleness {
+    let Some(latest_raw) = latest.map(normalize_version).filter(|v| !v.is_empty()) else {
+        return unknown(
+            identity,
+            None,
+            checked_at,
+            now,
+            "controller freshness not established: no cached release to compare against \
+             (the daily update check has not produced a result yet)",
+        );
+    };
+
+    let running_raw = normalize_version(&identity.version);
+    let parsed = Version::parse(&running_raw)
+        .ok()
+        .zip(Version::parse(&latest_raw).ok());
+
+    let Some((running, latest_version)) = parsed else {
+        return unknown(
+            identity,
+            Some(latest_raw),
+            checked_at,
+            now,
+            format!(
+                "controller freshness not established: could not compare `{}` against the latest published release",
+                identity.version
+            ),
+        );
+    };
+
+    let (status, minor_releases_behind) = classify(&running, &latest_version);
+    let stale = status.is_behind();
+    let escalated = matches!(status, ControllerCurrency::BehindMajor)
+        || minor_releases_behind.is_some_and(|behind| behind >= ESCALATION_MINOR_RELEASES_BEHIND);
+
+    let detail = detail_line(
+        identity,
+        status,
+        &latest_raw,
+        minor_releases_behind,
+        escalated,
+    );
+
+    ControllerStaleness {
+        status,
+        stale,
+        escalated,
+        running_version: identity.version.clone(),
+        build_identity: identity.display.clone(),
+        git_commit: identity.git_commit.clone(),
+        latest_version: Some(latest_raw),
+        minor_releases_behind,
+        checked_at,
+        cache_age_secs: checked_at.map(|at| age_secs(at, now)),
+        detail,
+        remediation: stale.then(|| REMEDIATION_COMMAND.to_string()),
+    }
+}
+
+/// Classify the running build against the latest published release, and count
+/// minor releases behind where that count is meaningful.
+///
+/// A minor delta across differing majors is not a distance an operator can act
+/// on, so it is reported as `None` rather than a misleading number; a major
+/// behind escalates on its own.
+fn classify(running: &Version, latest: &Version) -> (ControllerCurrency, Option<u64>) {
+    if latest.major > running.major {
+        return (ControllerCurrency::BehindMajor, None);
+    }
+    if latest.major < running.major {
+        return (ControllerCurrency::Ahead, None);
+    }
+    if latest.minor > running.minor {
+        return (
+            ControllerCurrency::BehindMinor,
+            Some(latest.minor - running.minor),
+        );
+    }
+    if latest.minor < running.minor {
+        return (ControllerCurrency::Ahead, None);
+    }
+    if latest.patch > running.patch {
+        return (ControllerCurrency::BehindPatch, Some(0));
+    }
+    if latest.patch < running.patch {
+        return (ControllerCurrency::Ahead, None);
+    }
+    (ControllerCurrency::Current, Some(0))
+}
+
+fn detail_line(
+    identity: &BuildIdentity,
+    status: ControllerCurrency,
+    latest: &str,
+    minor_releases_behind: Option<u64>,
+    escalated: bool,
+) -> String {
+    match status {
+        ControllerCurrency::Current => {
+            format!("{} is the latest published release", identity.display)
+        }
+        ControllerCurrency::Ahead => format!(
+            "{} is ahead of the latest published release v{latest} (unreleased build)",
+            identity.display
+        ),
+        ControllerCurrency::BehindPatch => format!(
+            "{} is behind the latest published release v{latest} (patch) — run `{REMEDIATION_COMMAND}`",
+            identity.display
+        ),
+        ControllerCurrency::BehindMinor => {
+            let releases = minor_releases_behind.unwrap_or(1);
+            let severity = if escalated { "STALE: " } else { "" };
+            format!(
+                "{severity}{} is {releases} minor release(s) behind v{latest} — run `{REMEDIATION_COMMAND}`",
+                identity.display
+            )
+        }
+        ControllerCurrency::BehindMajor => format!(
+            "STALE: {} is a major release behind v{latest} — run `{REMEDIATION_COMMAND}`",
+            identity.display
+        ),
+        ControllerCurrency::Unknown => format!(
+            "controller freshness not established for {}",
+            identity.display
+        ),
+    }
+}
+
+fn unknown(
+    identity: &BuildIdentity,
+    latest_version: Option<String>,
+    checked_at: Option<u64>,
+    now: u64,
+    detail: impl Into<String>,
+) -> ControllerStaleness {
+    ControllerStaleness {
+        status: ControllerCurrency::Unknown,
+        stale: false,
+        escalated: false,
+        running_version: identity.version.clone(),
+        build_identity: identity.display.clone(),
+        git_commit: identity.git_commit.clone(),
+        latest_version,
+        minor_releases_behind: None,
+        checked_at,
+        cache_age_secs: checked_at.map(|at| age_secs(at, now)),
+        detail: detail.into(),
+        remediation: None,
+    }
+}
+
+/// Saturating age so a clock that moved backwards reports `0` rather than
+/// wrapping into a nonsense age.
+fn age_secs(checked_at: u64, now: u64) -> u64 {
+    now.saturating_sub(checked_at)
+}
+
+fn normalize_version(version: &str) -> String {
+    version.trim().trim_start_matches('v').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(version: &str, commit: Option<&str>) -> BuildIdentity {
+        let display = match commit {
+            Some(commit) => format!("homeboy {version}+{commit}"),
+            None => format!("homeboy {version}"),
+        };
+        BuildIdentity {
+            version: version.to_string(),
+            git_commit: commit.map(str::to_string),
+            git_dirty: None,
+            display,
+        }
+    }
+
+    /// The exact scenario in #11483: 0.327.0 running against a published
+    /// v0.329.1 is two minor releases behind and must escalate.
+    #[test]
+    fn reported_issue_scenario_is_stale_and_escalated() {
+        let staleness = assess(
+            &identity("0.327.0", Some("ed33954781a9")),
+            Some("0.329.1"),
+            Some(1_000),
+            1_100,
+        );
+
+        assert_eq!(staleness.status, ControllerCurrency::BehindMinor);
+        assert!(staleness.stale);
+        assert!(staleness.escalated);
+        assert_eq!(staleness.minor_releases_behind, Some(2));
+        assert_eq!(staleness.latest_version.as_deref(), Some("0.329.1"));
+        assert_eq!(staleness.git_commit.as_deref(), Some("ed33954781a9"));
+        assert_eq!(staleness.remediation.as_deref(), Some("homeboy upgrade"));
+        assert_eq!(staleness.cache_age_secs, Some(100));
+
+        let warning = staleness.warning_line().expect("stale controller warns");
+        assert!(warning.contains("STALE"));
+        assert!(warning.contains("2 minor release(s) behind v0.329.1"));
+        // The embedded commit rides along so an operator with a checkout can
+        // compute the commit delta the release delta cannot express.
+        assert!(warning.contains("ed33954781a9"));
+        assert!(warning.contains("homeboy upgrade"));
+    }
+
+    #[test]
+    fn matching_version_is_current_and_silent() {
+        let staleness = assess(&identity("0.329.1", None), Some("0.329.1"), Some(10), 20);
+
+        assert_eq!(staleness.status, ControllerCurrency::Current);
+        assert!(!staleness.stale);
+        assert!(!staleness.escalated);
+        assert_eq!(staleness.minor_releases_behind, Some(0));
+        assert!(staleness.remediation.is_none());
+        assert!(staleness.warning_line().is_none());
+    }
+
+    /// A `v` prefix on the published tag is the shape GitHub returns; it must
+    /// not defeat the comparison.
+    #[test]
+    fn v_prefixed_release_tag_compares() {
+        let staleness = assess(&identity("0.329.1", None), Some("v0.329.1"), None, 0);
+
+        assert_eq!(staleness.status, ControllerCurrency::Current);
+        assert_eq!(staleness.latest_version.as_deref(), Some("0.329.1"));
+    }
+
+    #[test]
+    fn one_minor_behind_is_stale_but_not_escalated() {
+        let staleness = assess(&identity("0.328.0", None), Some("0.329.1"), None, 0);
+
+        assert_eq!(staleness.status, ControllerCurrency::BehindMinor);
+        assert!(staleness.stale);
+        assert!(!staleness.escalated);
+        assert_eq!(staleness.minor_releases_behind, Some(1));
+        let warning = staleness.warning_line().expect("stale controller warns");
+        assert!(!warning.contains("STALE"));
+        assert!(warning.contains("1 minor release(s) behind"));
+    }
+
+    #[test]
+    fn patch_behind_is_stale_but_not_escalated() {
+        let staleness = assess(&identity("0.329.0", None), Some("0.329.1"), None, 0);
+
+        assert_eq!(staleness.status, ControllerCurrency::BehindPatch);
+        assert!(staleness.stale);
+        assert!(!staleness.escalated);
+        assert_eq!(staleness.minor_releases_behind, Some(0));
+    }
+
+    #[test]
+    fn major_behind_escalates_without_a_minor_count() {
+        let staleness = assess(&identity("0.329.1", None), Some("1.0.0"), None, 0);
+
+        assert_eq!(staleness.status, ControllerCurrency::BehindMajor);
+        assert!(staleness.stale);
+        assert!(staleness.escalated);
+        // A minor delta across majors is not a distance an operator can act on.
+        assert!(staleness.minor_releases_behind.is_none());
+    }
+
+    /// A source build on an unreleased branch is ahead, not stale. Warning on it
+    /// would train operators to ignore this surface.
+    #[test]
+    fn newer_than_published_release_is_ahead_not_stale() {
+        let staleness = assess(
+            &identity("0.330.0", Some("abc123")),
+            Some("0.329.1"),
+            None,
+            0,
+        );
+
+        assert_eq!(staleness.status, ControllerCurrency::Ahead);
+        assert!(!staleness.stale);
+        assert!(!staleness.escalated);
+        assert!(staleness.warning_line().is_none());
+        assert!(staleness.detail.contains("ahead"));
+    }
+
+    /// Offline, first run, or a wiped cache: no published release to compare
+    /// against. Unknown, never "current", never a warning.
+    #[test]
+    fn missing_cached_release_is_unknown_not_current() {
+        let staleness = assess(&identity("0.327.0", None), None, None, 0);
+
+        assert_eq!(staleness.status, ControllerCurrency::Unknown);
+        assert!(!staleness.stale);
+        assert!(!staleness.escalated);
+        assert!(staleness.latest_version.is_none());
+        assert!(staleness.warning_line().is_none());
+        assert!(staleness.detail.contains("not established"));
+    }
+
+    #[test]
+    fn empty_cached_release_is_unknown() {
+        let staleness = assess(&identity("0.327.0", None), Some("   "), Some(5), 5);
+
+        assert_eq!(staleness.status, ControllerCurrency::Unknown);
+        assert!(staleness.latest_version.is_none());
+    }
+
+    #[test]
+    fn unparseable_version_is_unknown_not_current() {
+        let staleness = assess(
+            &identity("not-a-version", None),
+            Some("0.329.1"),
+            Some(7),
+            9,
+        );
+
+        assert_eq!(staleness.status, ControllerCurrency::Unknown);
+        assert!(!staleness.stale);
+        assert_eq!(staleness.latest_version.as_deref(), Some("0.329.1"));
+        assert_eq!(staleness.checked_at, Some(7));
+        assert_eq!(staleness.cache_age_secs, Some(2));
+    }
+
+    /// The cache age is how a reader tells a fresh verdict from one made
+    /// against a stale release list on an offline host.
+    #[test]
+    fn cache_age_is_reported_and_survives_backwards_clocks() {
+        let fresh = assess(&identity("0.329.1", None), Some("0.329.1"), Some(100), 400);
+        assert_eq!(fresh.cache_age_secs, Some(300));
+
+        let skewed = assess(&identity("0.329.1", None), Some("0.329.1"), Some(400), 100);
+        assert_eq!(skewed.cache_age_secs, Some(0));
+    }
+
+    #[test]
+    fn serialized_shape_is_stable() {
+        let staleness = assess(
+            &identity("0.327.0", Some("ed33954781a9")),
+            Some("0.329.1"),
+            Some(1_000),
+            1_100,
+        );
+        let json = serde_json::to_value(&staleness).expect("staleness serializes");
+
+        assert_eq!(json["status"], "behind_minor");
+        assert_eq!(json["stale"], true);
+        assert_eq!(json["escalated"], true);
+        assert_eq!(json["running_version"], "0.327.0");
+        assert_eq!(json["build_identity"], "homeboy 0.327.0+ed33954781a9");
+        assert_eq!(json["git_commit"], "ed33954781a9");
+        assert_eq!(json["latest_version"], "0.329.1");
+        assert_eq!(json["minor_releases_behind"], 2);
+        assert_eq!(json["remediation"], "homeboy upgrade");
+    }
+
+    /// A current controller emits no remediation and no optional drift fields,
+    /// so a JSON consumer can distinguish "current" from "unknown" by `status`
+    /// alone.
+    #[test]
+    fn current_controller_omits_remediation() {
+        let staleness = assess(&identity("0.329.1", None), Some("0.329.1"), None, 0);
+        let json = serde_json::to_value(&staleness).expect("staleness serializes");
+
+        assert_eq!(json["status"], "current");
+        assert!(json.get("remediation").is_none());
+        assert!(json.get("git_commit").is_none());
+    }
+
+    #[test]
+    fn currency_behind_predicate_excludes_unknown_and_ahead() {
+        assert!(ControllerCurrency::BehindPatch.is_behind());
+        assert!(ControllerCurrency::BehindMinor.is_behind());
+        assert!(ControllerCurrency::BehindMajor.is_behind());
+        assert!(!ControllerCurrency::Current.is_behind());
+        assert!(!ControllerCurrency::Ahead.is_behind());
+        assert!(!ControllerCurrency::Unknown.is_behind());
+    }
+
+    /// The escalation threshold is the issue's stated rule: *more than* one
+    /// minor version behind.
+    #[test]
+    fn escalation_threshold_is_more_than_one_minor() {
+        assert_eq!(ESCALATION_MINOR_RELEASES_BEHIND, 2);
+        assert!(!assess(&identity("0.329.0", None), Some("0.330.0"), None, 0).escalated);
+        assert!(assess(&identity("0.328.0", None), Some("0.330.0"), None, 0).escalated);
+    }
+
+    /// `current()` must never panic or perform network I/O, whatever the host
+    /// state. Its verdict depends on the ambient cache, so only its totality and
+    /// its self-consistency are asserted here.
+    #[test]
+    fn current_is_total_and_self_consistent() {
+        let staleness = current();
+
+        assert_eq!(staleness.running_version, build_identity::current().version);
+        assert_eq!(staleness.stale, staleness.status.is_behind());
+        assert_eq!(staleness.stale, staleness.remediation.is_some());
+        assert!(!staleness.detail.is_empty());
+    }
+}

--- a/crates/homeboy-upgrade/src/lib.rs
+++ b/crates/homeboy-upgrade/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! Depends on homeboy-core; core does not depend on it.
 
+pub mod controller_staleness;
 pub mod self_status;
 pub mod upgrade;
 

--- a/crates/homeboy-upgrade/src/upgrade/update_check.rs
+++ b/crates/homeboy-upgrade/src/upgrade/update_check.rs
@@ -37,13 +37,51 @@ fn read_cache() -> Option<UpdateCheckCache> {
 /// check. Durable admission deliberately never performs network I/O: an
 /// unavailable cache is explicit offline evidence, not a reason to guess.
 pub fn latest_allowed_stable() -> Option<String> {
-    if is_disabled_by_env() || is_disabled_by_config() {
+    if is_disabled() {
         return None;
     }
     read_cache().and_then(|cache| {
         (is_cache_fresh(&cache) && cache.update_available && !cache.latest_version.is_empty())
             .then_some(cache.latest_version)
     })
+}
+
+/// The latest published release recorded by the daily update check, whatever
+/// the running binary's relation to it, plus when that check ran.
+///
+/// [`latest_allowed_stable`] deliberately answers a narrower question — "is
+/// there a newer stable release this controller is allowed to move to" — and
+/// therefore withholds the version when no update is available. Controller
+/// staleness reporting needs the recorded release unconditionally: reporting
+/// `current` requires knowing what the latest release *is*, not merely that it
+/// is not newer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedLatestRelease {
+    pub latest_version: String,
+    pub checked_at: u64,
+}
+
+/// Read the cached latest release. Pure cache read — never performs network
+/// I/O, so a caller on every command costs one small file read and the daily
+/// refresh stays the only network call.
+///
+/// A stale cache is returned rather than discarded: an offline host's day-old
+/// release list is still the best evidence available, and `checked_at` lets the
+/// caller say how old the verdict is instead of silently reporting nothing.
+pub fn cached_latest_release() -> Option<CachedLatestRelease> {
+    let cache = read_cache()?;
+    let latest_version = cache.latest_version.trim().to_string();
+    (!latest_version.is_empty()).then_some(CachedLatestRelease {
+        latest_version,
+        checked_at: cache.checked_at,
+    })
+}
+
+/// Whether the operator has turned the update check off, by environment or by
+/// config. Callers that report freshness must treat this as "not established"
+/// rather than "current".
+pub fn is_disabled() -> bool {
+    is_disabled_by_env() || is_disabled_by_config()
 }
 
 fn write_cache(cache: &UpdateCheckCache) {
@@ -65,17 +103,38 @@ pub(crate) fn is_disabled_by_config() -> bool {
     !homeboy_core::defaults::load_config().update_check
 }
 
-fn print_hint(latest: &str, current: &str) {
-    homeboy_core::log_status!(
-        "update",
-        "Homeboy {} is available (current: {}). Run `homeboy upgrade` to update.",
-        latest,
-        current
+/// One-line update hint.
+///
+/// The wording is derived from the shared controller-staleness assessment, so a
+/// controller more than one minor release behind reads as a warning instead of
+/// a neutral "an update is available" note (#11483). Because this runs at the
+/// start of every non-upgrade command, it is also how a long-running command
+/// such as `cook` carries the same verdict `homeboy status` reports.
+///
+/// When the assessment does not establish staleness — an unparseable version,
+/// or a "newer" release that semver does not agree is newer — the original
+/// neutral hint is emitted rather than nothing, so this can only add signal.
+fn print_hint(latest: &str, checked_at: Option<u64>) {
+    let staleness = crate::controller_staleness::assess(
+        &homeboy_core::build_identity::current(),
+        Some(latest),
+        checked_at,
+        update_check_cache::now_unix(),
     );
+
+    match staleness.warning_line() {
+        Some(line) => homeboy_core::log_status!("update", "{}", line),
+        None => homeboy_core::log_status!(
+            "update",
+            "Homeboy {} is available (current: {}). Run `homeboy upgrade` to update.",
+            latest,
+            upgrade::current_version()
+        ),
+    }
 }
 
 pub fn run_startup_check() {
-    if is_disabled_by_env() || is_disabled_by_config() {
+    if is_disabled() {
         return;
     }
 
@@ -84,7 +143,7 @@ pub fn run_startup_check() {
 
     if let Some(ref cache) = cached {
         if cache.update_available && cache.current_version == upgrade::current_version() {
-            print_hint(&cache.latest_version, upgrade::current_version());
+            print_hint(&cache.latest_version, Some(cache.checked_at));
             already_printed = true;
         }
 
@@ -98,16 +157,17 @@ pub fn run_startup_check() {
         Err(_) => return,
     };
 
+    let checked_at = update_check_cache::now_unix();
     write_cache(&UpdateCheckCache {
         latest_version: check.latest_version.clone().unwrap_or_default(),
         current_version: check.current_version.clone(),
         update_available: check.update_available,
-        checked_at: update_check_cache::now_unix(),
+        checked_at,
     });
 
     if !already_printed && check.update_available {
         if let Some(latest) = &check.latest_version {
-            print_hint(latest, &check.current_version);
+            print_hint(latest, Some(checked_at));
         }
     }
 }
@@ -116,20 +176,130 @@ pub fn run_startup_check() {
 mod tests {
     use super::*;
 
+    use homeboy_core::test_support::with_isolated_home;
+
+    /// Write a cache fixture the way the daily check would.
+    ///
+    /// `write_cache` swallows I/O errors by design (the update check must never
+    /// fail a command), so the fixture asserts the file landed — otherwise a
+    /// missing directory would present as a silently empty cache and every
+    /// assertion below would fail for the wrong reason.
+    fn seed_cache(latest_version: &str, update_available: bool, checked_at: u64) {
+        let path = update_check_cache::cache_path(CACHE_FILENAME).expect("cache path resolves");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create cache directory");
+        }
+
+        write_cache(&UpdateCheckCache {
+            latest_version: latest_version.to_string(),
+            current_version: upgrade::current_version().to_string(),
+            update_available,
+            checked_at,
+        });
+
+        assert!(path.is_file(), "cache fixture was written to {path:?}");
+    }
+
+    /// The staleness surface reads this cache on every command, so the read must
+    /// be a pure file read that round-trips what the daily check wrote.
+    #[test]
+    fn cached_latest_release_round_trips_the_daily_cache() {
+        with_isolated_home(|_home| {
+            let checked_at = update_check_cache::now_unix();
+            seed_cache("0.329.1", true, checked_at);
+
+            let cached = cached_latest_release().expect("cache is readable");
+            assert_eq!(cached.latest_version, "0.329.1");
+            assert_eq!(cached.checked_at, checked_at);
+        });
+    }
+
+    #[test]
+    fn cached_latest_release_is_absent_without_a_cache_file() {
+        with_isolated_home(|_home| {
+            assert!(cached_latest_release().is_none());
+        });
+    }
+
+    /// A cache written by a failed network check carries an empty version. That
+    /// is not a release to compare against, so it must read as absent rather
+    /// than as an empty "latest".
+    #[test]
+    fn cached_latest_release_rejects_an_empty_version() {
+        with_isolated_home(|_home| {
+            seed_cache("   ", false, update_check_cache::now_unix());
+
+            assert!(cached_latest_release().is_none());
+        });
+    }
+
+    /// A day-old cache on an offline host is still the best evidence available.
+    /// It is returned with its timestamp so the caller can report the age,
+    /// rather than discarded — which would report "unknown" on every command
+    /// once the host loses network.
+    #[test]
+    fn cached_latest_release_returns_a_stale_cache_with_its_timestamp() {
+        with_isolated_home(|_home| {
+            let old = update_check_cache::now_unix() - (CHECK_INTERVAL_SECS * 3);
+            seed_cache("0.329.1", true, old);
+
+            let cache = read_cache().expect("cache is readable");
+            assert!(!is_cache_fresh(&cache), "fixture must be past the interval");
+
+            let cached = cached_latest_release().expect("stale cache is still returned");
+            assert_eq!(cached.latest_version, "0.329.1");
+            assert_eq!(cached.checked_at, old);
+        });
+    }
+
+    /// The reason this accessor exists: `latest_allowed_stable` withholds the
+    /// version when no update is available, but reporting a controller as
+    /// *current* requires knowing which release it is current with.
+    #[test]
+    fn cached_latest_release_is_returned_when_no_update_is_available() {
+        with_isolated_home(|_home| {
+            // The hermetic home disables the update check; re-enable it so this
+            // exercises the enabled path. The guard restores the variable.
+            std::env::remove_var(ENV_VAR_DISABLE);
+            seed_cache("0.329.1", false, update_check_cache::now_unix());
+
+            assert!(latest_allowed_stable().is_none());
+            assert_eq!(
+                cached_latest_release().map(|cached| cached.latest_version),
+                Some("0.329.1".to_string())
+            );
+        });
+    }
+
+    #[test]
+    fn disabled_by_env_reports_disabled() {
+        with_isolated_home(|_home| {
+            std::env::remove_var(ENV_VAR_DISABLE);
+            assert!(!is_disabled());
+
+            std::env::set_var(ENV_VAR_DISABLE, "1");
+            assert!(is_disabled());
+        });
+    }
+
     #[test]
     fn test_env_var_disable() {
-        std::env::remove_var(ENV_VAR_DISABLE);
-        assert!(!is_disabled_by_env());
+        // Serialized against the other env-mutating tests in this module by the
+        // hermetic home guard, which also restores `HOMEBOY_NO_UPDATE_CHECK`.
+        with_isolated_home(|_home| {
+            std::env::remove_var(ENV_VAR_DISABLE);
+            assert!(!is_disabled_by_env());
 
-        std::env::set_var(ENV_VAR_DISABLE, "1");
-        assert!(is_disabled_by_env());
+            std::env::set_var(ENV_VAR_DISABLE, "1");
+            assert!(is_disabled_by_env());
 
-        std::env::set_var(ENV_VAR_DISABLE, "True");
-        assert!(is_disabled_by_env());
+            std::env::set_var(ENV_VAR_DISABLE, "True");
+            assert!(is_disabled_by_env());
 
-        std::env::set_var(ENV_VAR_DISABLE, "0");
-        assert!(!is_disabled_by_env());
+            std::env::set_var(ENV_VAR_DISABLE, "0");
+            assert!(!is_disabled_by_env());
 
-        std::env::remove_var(ENV_VAR_DISABLE);
+            std::env::remove_var(ENV_VAR_DISABLE);
+        });
     }
 }

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -65,6 +65,59 @@ and look at `outdated`. Together, `unreleased_merges` (tag-vs-merged),
 `ready_to_deploy` (local-vs-tag), and the project dashboard's `outdated`
 (installed-vs-tag) close the merged → released → deployed chain. See issue #4996.
 
+## `controller` — is the binary reporting this actually current?
+
+Every freshness signal above is measured *against the `homeboy` binary running
+the command*. Nothing was measuring that binary. A controller can sit two minor
+releases behind while it reports on everything else, and the report gives no
+hint (issue #11483).
+
+Both the summary and the project dashboard now carry a `controller` object:
+
+```json
+{
+  "controller": {
+    "status": "behind_minor",
+    "stale": true,
+    "escalated": true,
+    "running_version": "0.327.0",
+    "build_identity": "homeboy 0.327.0+ed33954781a9",
+    "git_commit": "ed33954781a9",
+    "latest_version": "0.329.1",
+    "minor_releases_behind": 2,
+    "checked_at": 1754320550,
+    "cache_age_secs": 900,
+    "detail": "STALE: homeboy 0.327.0+ed33954781a9 is 2 minor release(s) behind v0.329.1 — run `homeboy upgrade`",
+    "remediation": "homeboy upgrade"
+  }
+}
+```
+
+- `status` is one of `current`, `ahead`, `behind_patch`, `behind_minor`,
+  `behind_major`, `unknown`. It is emitted whether or not the controller is
+  stale, so a reader can tell *"checked, current"* from *"never checked"*
+  instead of reading silence as health.
+- `escalated` is `true` past **more than one minor release behind** (or any
+  major). At that distance the controller is dispatching work whose behavior it
+  may not model correctly — the controller-side analogue of the runner version
+  checks. When it is set, the `detail` line is prefixed `STALE:` and is also
+  written to stderr.
+- `unknown` covers an offline host, a first run, and an update check disabled
+  via `HOMEBOY_NO_UPDATE_CHECK` or `homeboy config set /update_check false`. An
+  unestablished verdict is never reported as `current` and never warns.
+
+**Cost.** No network call is made by `status`. The latest published release is
+read from the same daily cache the startup update check already maintains, so
+the whole surface is one small file read per command and at most one network
+call per day. A failure to check degrades to `unknown`; it never fails a
+command.
+
+**What is not reported.** The commit delta (`215 commits behind`) needs a source
+checkout with a fresh `origin/main`, which a packaged install does not have. The
+release delta is reported instead, with the running build's embedded git commit
+alongside it so anyone holding a checkout can compute the commit delta
+themselves.
+
 ## Common filters
 
 - `--full` — show the full workspace/context report


### PR DESCRIPTION
Closes #11483.

## The gap

Every freshness signal Homeboy emits — `upstream_drift`, `unreleased_merges`, the project dashboard's `outdated`, `runtime_overlay_freshness`, `require_exact_homeboy_version` — is measured *against the `homeboy` binary running the command*. Nothing was measuring that binary. A controller two minor releases behind can spend a session triaging its own issue tracker against `origin/main` and the report gives no hint.

## What changed

**New `homeboy_upgrade::controller_staleness`** (`crates/homeboy-upgrade/src/controller_staleness.rs`)

- `assess(&BuildIdentity, latest, checked_at, now)` — pure, no I/O. Classifies the running build against the latest published release as `current` / `ahead` / `behind_patch` / `behind_minor` / `behind_major` / `unknown`, with the minor-release delta, the running build's embedded git commit, the cache age, and the remediation command.
- `escalated` is set past **more than one minor release behind** (or any major) — the threshold #11483 names, and the controller-side analogue of the runner version checks.
- `current()` — the same assessment fed from the cache.

**Cache reuse, not a new mechanism** (`upgrade/update_check.rs`)

- New `cached_latest_release()` — a pure read of the `update_check.json` cache that `run_startup_check` already maintains daily. It exists because `latest_allowed_stable()` deliberately withholds the version when no update is available, and reporting a controller as *current* requires knowing which release it is current with.
- New `is_disabled()`, factored out of the two places that already had the expression.
- **No network I/O is added.** One small file read per command; the daily refresh remains the only network call. Every failure mode — offline host, missing cache, unparseable version, `HOMEBOY_NO_UPDATE_CHECK`, `update_check: false` — degrades to `unknown`, which is never reported as `current`, never warns, and never fails a command.

**`homeboy status`** (`commands/status/`)

- `StatusOutput` and `ProjectDashboardOutput` both carry a `controller` object, emitted **whether or not the controller is stale**, so a reader can distinguish "checked, current" from "never checked" instead of reading silence as health.
- When staleness is *established*, one line goes to the status channel. Advisory only — no exit-code or error-path change.
- The staleness is resolved once at the top of `run()` and threaded into whichever output path executes, so no path pays for it twice.

**Startup hint** — `print_hint` now derives its wording from the same assessment, so a controller well behind reads as a warning rather than a neutral "an update is available", and long-running commands like `cook` carry the same verdict. When the assessment does not establish staleness it falls back to the original message, so this can only add signal.

**Docs** — `docs/commands/status.md` gains a `controller` section covering the JSON shape, the escalation rule, the cost model, and what is deliberately not computed.

## What I did NOT do

- **No auto-upgrade.** Detect and report only.
- **No commit delta.** "215 commits behind" needs a source checkout with a fresh `origin/main`, which a packaged install does not have and which would cost a `git fetch` per command. The release delta is reported instead, with the running build's embedded git commit alongside it so anyone holding a checkout can compute the commit delta themselves. This is stated in the module header and in the docs rather than left as a silent omission.
- **No new surface on `homeboy self status`** — it already does a live probe and reports `version_relation`.
- **No tests deleted or ignored.** `test_env_var_disable` was wrapped in `with_isolated_home` so it is serialized against the other env-mutating tests in the module by the existing home guard.

## Tests

- 15 tests in `controller_staleness` covering the exact #11483 scenario (0.327.0+ed33954781a9 vs v0.329.1 → 2 minor behind, escalated), each classification branch, `v`-prefixed tags, the escalation threshold from both sides, ahead-not-stale, all four unknown paths, clock skew, and the serialized shape.
- 6 cache-behavior tests in `update_check` under `with_isolated_home`: round-trip, absent file, empty version, a stale cache still returned with its timestamp, and the `latest_allowed_stable` contrast that motivates the accessor.
- 3 tests in `status` pinning the `controller` field in the JSON contract for both the stale and the not-stale case, and that the logging is advisory.

## Compilation uncertainty

**I could not compile or run tests locally** — this VPS shares RAM with several other processes and a cargo build reliably OOMs it. I ran `cargo fmt` (clean, and it parses the whole module tree) and reasoned about types against the source. GitHub Actions is the gate.

Specific things I could not verify by compiler:

- The move of `controller` into the early-returning match arms in `status::run()`. All moving arms `return`, so flow-sensitive move checking should accept the later use — but this is the change most likely to produce an E0382 if I read it wrong.
- `homeboy::core::build_identity::BuildIdentity` resolving in the `homeboy-cli` test module (via `extern crate self as homeboy` + `pub use homeboy_core as core`).
- Whether `with_isolated_home`'s hermetic `.config/homeboy` is present before `write_cache` runs. `HermeticTestContext::new()` creates `daemon_dir()` beneath it, so it should be — and `seed_cache` creates the parent and asserts the file landed regardless, since `write_cache` swallows I/O errors by design.

I checked the new prose against the `core-agnostic-source` audit term list and removed the one ecosystem literal ("Homebrew") it would have flagged.