### PR TITLE
fix(agents): contain and reap provider process trees

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate_executor.rs
+++ b/crates/homeboy-agents/src/agent_task_gate_executor.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+
+use crate::agent_task_process_containment::AgentTaskProcessContainment;
 
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
@@ -206,12 +208,47 @@ fn run_execution(
         command.env(key, value);
     }
 
-    let output = command.output().map_err(|error| {
+    // A repo-local gate is arbitrary repo-owned tooling: it forks build and
+    // test processes that outlive it. Contain the tree so this controller's
+    // death — or an early return from this function — reaps them instead of
+    // leaving them running against a terminal run (#11477).
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut containment = AgentTaskProcessContainment::prepare(&mut command).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "contain repo-local gate {}",
+                execution.argv.join(" ")
+            )),
+        )
+    })?;
+    let mut child = command.spawn().map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some(format!("run repo-local gate {}", execution.argv.join(" "))),
         )
     })?;
+    if let Err(error) = containment.attach(&child) {
+        let _ = containment.terminate_live(&mut child);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "guard repo-local gate {}",
+                execution.argv.join(" ")
+            )),
+        ));
+    }
+    let output = child.wait_with_output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("run repo-local gate {}", execution.argv.join(" "))),
+        )
+    })?;
+    // The direct child is reaped; anything it left in the group is not.
+    let _ = containment.reap_after_exit();
     let exit_code = output.status.code().unwrap_or(1);
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/crates/homeboy-agents/src/agent_task_process_containment.rs
+++ b/crates/homeboy-agents/src/agent_task_process_containment.rs
@@ -1,0 +1,274 @@
+//! Process-tree containment for agent-task provider and gate command spawns.
+//!
+//! A provider agent is not a leaf process. It spawns its own tooling — build
+//! systems, test runners, linkers — and those grandchildren are what actually
+//! consume the host. Spawning a provider as a plain [`Command`] child leaves
+//! every one of those descendants unowned: `Child::kill` signals the direct
+//! child only, and a controller that dies (cancel, operator kill, OOM) reaps
+//! nothing at all. Extra-Chill/homeboy#11477 observed the full chain surviving
+//! a run Homeboy had already marked terminal: cook → provider → build driver →
+//! three compiler processes at 90-95% CPU, and later an orphaned linked test
+//! binary four minutes past termination. Every level had to be killed by hand,
+//! by pid.
+//!
+//! This module is the single place the agent-task execution paths obtain
+//! containment, so provider execution, provider readiness probes, and
+//! repo-local gate execution all terminalize the same way:
+//!
+//! * the child leads its own process group, so termination signals the whole
+//!   group instead of one pid;
+//! * a controller death guard (a `fork()`ed watcher holding the read end of a
+//!   pipe this process owns) SIGKILLs that group if this process exits for any
+//!   reason, including an untrappable SIGKILL;
+//! * every exit path — timeout, liveness kill, clean exit, early `return`, and
+//!   unwind — reaps whatever is left in the group.
+//!
+//! Reaping is deliberately unconditional rather than "only on failure". The
+//! orphaned test binary in #11477 outlived a provider that had already exited,
+//! so a clean provider exit is exactly the case that leaked.
+//!
+//! Known limitation, inherited from [`ControllerChildGuard`] and not addressed
+//! here: the death guard is `fork()`ed, so it inherits every open descriptor of
+//! this process — including the liveness write end of any *other* guard that is
+//! live at that moment. Two containments overlapping in one process therefore
+//! weaken each other's controller-death coverage, because the younger guard
+//! keeps the older guard's pipe from reaching EOF. Every explicit path in this
+//! module (timeout, liveness kill, clean exit, early return, unwind) is
+//! unaffected; only the "this process was SIGKILLed" fallback degrades.
+
+use std::process::{Child, Command};
+
+use homeboy_core::engine::command::{
+    terminate_process_tree_and_reap, terminate_remaining_process_group, ControllerChildGuard,
+};
+
+/// Owns the process group of one spawned agent-task child.
+///
+/// Construct with [`AgentTaskProcessContainment::prepare`] *before* spawning
+/// (the process-group isolation is installed on the [`Command`]) and call
+/// [`AgentTaskProcessContainment::attach`] immediately after spawning.
+pub(crate) struct AgentTaskProcessContainment {
+    /// Also held for its `Drop`, which closes the liveness pipe the forked
+    /// death guard watches — that closure is what makes controller death kill
+    /// the tree.
+    guard: ControllerChildGuard,
+    leader_pid: Option<u32>,
+    reaped: bool,
+}
+
+impl AgentTaskProcessContainment {
+    /// Install process-group isolation and the controller death guard on
+    /// `command`. Must be called before `command.spawn()`.
+    pub(crate) fn prepare(command: &mut Command) -> std::io::Result<Self> {
+        Ok(Self {
+            guard: ControllerChildGuard::prepare(command)?,
+            leader_pid: None,
+            reaped: false,
+        })
+    }
+
+    /// Start the death guard for `child`. Called after spawn so the guard
+    /// cannot inherit the standard library's private spawn error pipe.
+    pub(crate) fn attach(&mut self, child: &Child) -> std::io::Result<()> {
+        self.leader_pid = Some(child.id());
+        self.guard.attach(child)
+    }
+
+    /// The pid of the contained group leader, once attached.
+    pub(crate) fn leader_pid(&self) -> Option<u32> {
+        self.leader_pid
+    }
+
+    /// Terminate the contained tree while its leader is still running, then
+    /// reap the leader. Used by Homeboy-initiated kills (per-attempt timeout,
+    /// liveness watchdog, execution deadline).
+    ///
+    /// This replaces `Child::kill`, which signals only the direct child and
+    /// leaves its build/test descendants running.
+    pub(crate) fn terminate_live(&mut self, child: &mut Child) -> Result<(), String> {
+        // Recorded before the attempt so a failed termination is never retried
+        // against a pid the kernel may have recycled.
+        self.reaped = true;
+        terminate_process_tree_and_reap(child)
+            .map(|_| ())
+            .map_err(|error| {
+                format!(
+                    "could not terminate the contained provider process group{}: {error}",
+                    self.leader_suffix()
+                )
+            })
+    }
+
+    /// Reap whatever is still alive in the group after its leader exited on its
+    /// own. Idempotent, and a no-op once the tree has already been terminated.
+    ///
+    /// Call this before joining output-capture readers: a background descendant
+    /// still holding an inherited stdout/stderr pipe keeps those readers from
+    /// ever seeing EOF.
+    pub(crate) fn reap_after_exit(&mut self) -> Result<(), String> {
+        if self.reaped {
+            return Ok(());
+        }
+        self.reaped = true;
+        let Some(leader_pid) = self.leader_pid else {
+            return Ok(());
+        };
+        terminate_remaining_process_group(leader_pid).map_err(|error| {
+            format!(
+                "contained provider process group{} outlived its leader and did not exit: {error}",
+                self.leader_suffix()
+            )
+        })
+    }
+
+    fn leader_suffix(&self) -> String {
+        self.leader_pid
+            .map(|pid| format!(" (leader pid {pid})"))
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for AgentTaskProcessContainment {
+    fn drop(&mut self) {
+        // Early `return`s and unwinds are terminalization paths too. Without
+        // this, a caller that bails between spawn and its explicit cleanup
+        // leaks the whole subtree exactly the way #11477 described.
+        let _ = self.reap_after_exit();
+    }
+}
+
+/// Render an operator-facing recovery hint for a process group Homeboy could
+/// not confirm dead. Keyed on the recorded leader pid so nobody has to go
+/// hunting through `ps` output for orphaned build processes.
+pub(crate) fn contained_group_recovery_commands(leader_pid: Option<u32>) -> Vec<String> {
+    let Some(leader_pid) = leader_pid else {
+        return Vec::new();
+    };
+    vec![
+        format!("ps -eo pid=,pgid=,etime=,command= | awk '$2 == {leader_pid}'"),
+        format!("kill -TERM -{leader_pid}"),
+        format!("kill -KILL -{leader_pid}  # if it ignores SIGTERM"),
+    ]
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    /// Poll rather than sleep a fixed interval: `kill(2)` only queues the
+    /// signal, so a just-signalled pid can still read as running.
+    fn wait_until_gone(pid: u32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if !homeboy_core::process::pid_is_running(pid) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// Spawn a contained shell that leaves one background descendant behind and
+    /// exits immediately, returning `(child, descendant_pid)`.
+    fn spawn_leaking_child(script: &str) -> (AgentTaskProcessContainment, Child, u32) {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut containment =
+            AgentTaskProcessContainment::prepare(&mut command).expect("prepare containment");
+        let mut child = command.spawn().expect("spawn contained child");
+        containment.attach(&child).expect("attach death guard");
+
+        // Read one line rather than to EOF: the background descendant holds the
+        // inherited stdout pipe open, which is precisely the hang this
+        // containment exists to prevent.
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read descendant pid");
+        let descendant_pid: u32 = line.trim().parse().expect("descendant pid");
+
+        (containment, child, descendant_pid)
+    }
+
+    /// The #11477 regression: the provider exits cleanly and its build/test
+    /// descendant keeps running. A clean leader exit must still reap the group.
+    #[test]
+    fn reaping_after_leader_exit_kills_a_surviving_descendant() {
+        let (mut containment, mut child, descendant_pid) =
+            spawn_leaking_child("sleep 30 & echo $!; exit 0");
+
+        child.wait().expect("leader exits on its own");
+        assert!(
+            homeboy_core::process::pid_is_running(descendant_pid),
+            "descendant must outlive its leader for this to test anything"
+        );
+
+        containment
+            .reap_after_exit()
+            .expect("surviving group members are reaped");
+
+        assert!(
+            wait_until_gone(descendant_pid, Duration::from_secs(5)),
+            "descendant {descendant_pid} survived cleanup after its leader exited"
+        );
+    }
+
+    /// A Homeboy-initiated kill (timeout / liveness watchdog) must take the
+    /// whole tree, not just the direct child.
+    #[test]
+    fn terminating_a_live_leader_kills_its_descendants() {
+        let (mut containment, mut child, descendant_pid) =
+            spawn_leaking_child("sleep 30 & echo $!; sleep 30");
+        let leader_pid = child.id();
+
+        containment
+            .terminate_live(&mut child)
+            .expect("contained tree terminates");
+
+        assert!(
+            wait_until_gone(descendant_pid, Duration::from_secs(5)),
+            "descendant {descendant_pid} survived termination of leader {leader_pid}"
+        );
+        assert!(
+            wait_until_gone(leader_pid, Duration::from_secs(5)),
+            "leader {leader_pid} survived termination"
+        );
+    }
+
+    /// Dropping without an explicit cleanup call is an exit path too.
+    #[test]
+    fn dropping_containment_reaps_a_surviving_descendant() {
+        let (containment, mut child, descendant_pid) =
+            spawn_leaking_child("sleep 30 & echo $!; exit 0");
+        child.wait().expect("leader exits on its own");
+
+        drop(containment);
+
+        assert!(
+            wait_until_gone(descendant_pid, Duration::from_secs(5)),
+            "descendant {descendant_pid} survived containment drop"
+        );
+    }
+
+    #[test]
+    fn recovery_commands_are_keyed_on_the_recorded_leader_pid() {
+        let commands = contained_group_recovery_commands(Some(4242));
+
+        assert!(commands
+            .iter()
+            .any(|command| command.contains("$2 == 4242")));
+        assert!(commands
+            .iter()
+            .any(|command| command.contains("-TERM -4242")));
+        assert!(contained_group_recovery_commands(None).is_empty());
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -9,6 +9,9 @@ use super::runner_readiness::{
 use super::secrets::{provider_secret_env_plan_with_status, provider_secret_sources};
 use super::*;
 use crate::agent_task_executor_evidence::link_latest_executor_evidence;
+use crate::agent_task_process_containment::{
+    contained_group_recovery_commands, AgentTaskProcessContainment,
+};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -229,9 +232,70 @@ fn annotate_transient_retry(outcome: &mut AgentTaskOutcome, attempts: u32, exhau
     });
 }
 
+/// What Homeboy observed while tearing down the provider's contained process
+/// group. A failure here is not a provider defect, so it is surfaced as an
+/// additive diagnostic on whatever outcome the attempt produced rather than
+/// overwriting it (#11477).
+#[derive(Default)]
+pub(super) struct ProviderContainmentReport {
+    leader_pid: Option<u32>,
+    cleanup_errors: Vec<String>,
+}
+
+impl ProviderContainmentReport {
+    fn record(&mut self, containment: &AgentTaskProcessContainment, result: Result<(), String>) {
+        self.leader_pid = containment.leader_pid();
+        if let Err(error) = result {
+            self.cleanup_errors.push(error);
+        }
+    }
+
+    /// A terminal run that still owns live processes must say so. Nothing else
+    /// in the run record distinguishes "the provider tree is gone" from "three
+    /// compiler processes are still burning the host".
+    fn annotate(&self, outcome: &mut AgentTaskOutcome) {
+        if self.cleanup_errors.is_empty() {
+            return;
+        }
+        push_unique_diagnostic(
+            &mut outcome.diagnostics,
+            "agent_task.provider_process_group_survivors".to_string(),
+            format!(
+                "provider process group{} could not be confirmed terminated; it may still own live processes on this host",
+                self.leader_pid
+                    .map(|pid| format!(" (leader pid {pid})"))
+                    .unwrap_or_default()
+            ),
+            json!({
+                "leader_pid": self.leader_pid,
+                "cleanup_errors": self.cleanup_errors,
+                "recovery_commands": contained_group_recovery_commands(self.leader_pid),
+                "remediation_hints": [
+                    "A contained provider tree that outlives its run keeps consuming host RAM, CPU, and disk. Inspect and reap it with the recovery commands before starting another run."
+                ],
+            }),
+        );
+    }
+}
+
 pub(super) fn run_materialized_provider_command_once(
     request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
+) -> AgentTaskOutcome {
+    let mut containment_report = ProviderContainmentReport::default();
+    let mut outcome = run_materialized_provider_command_once_contained(
+        request,
+        provider,
+        &mut containment_report,
+    );
+    containment_report.annotate(&mut outcome);
+    outcome
+}
+
+fn run_materialized_provider_command_once_contained(
+    request: &AgentTaskExecutorRequest,
+    provider: &AgentTaskExecutorProvider,
+    containment_report: &mut ProviderContainmentReport,
 ) -> AgentTaskOutcome {
     let command = render_provider_command_display(provider);
     let deadline_remaining_ms = crate::agent_task_timeout::remaining_execution_deadline_ms(
@@ -405,12 +469,35 @@ pub(super) fn run_materialized_provider_command_once(
         command_builder.current_dir(cwd);
     }
 
-    let mut child = match command_builder
+    command_builder
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+
+    // A provider agent spawns its own build/test tooling. Contain the whole
+    // subtree before it exists so every terminalization path — Homeboy's
+    // timeout and liveness kills below, and the death of this controller
+    // process itself — reaps the descendants instead of only the direct child
+    // (#11477). Fail closed: an uncontainable provider is one whose orphans
+    // nothing can reap.
+    let mut containment = match AgentTaskProcessContainment::prepare(&mut command_builder) {
+        Ok(containment) => containment,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::Provider,
+                "agent_task.provider_containment_failed",
+                format!(
+                "Homeboy could not establish process-tree containment for provider '{}': {error}",
+                provider.id
+            ),
+                json!({ "provider": provider.id, "command": command, "phase": "prepare" }),
+            )
+        }
+    };
+
+    let mut child = match command_builder.spawn() {
         Ok(child) => child,
         Err(error) => {
             return failure_outcome(
@@ -423,6 +510,23 @@ pub(super) fn run_materialized_provider_command_once(
             )
         }
     };
+
+    if let Err(error) = containment.attach(&child) {
+        let attach_error = error.to_string();
+        let cleanup = containment.terminate_live(&mut child);
+        containment_report.record(&containment, cleanup);
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_containment_failed",
+            format!(
+                "Homeboy could not guard the process tree of provider '{}': {attach_error}",
+                provider.id
+            ),
+            json!({ "provider": provider.id, "command": command, "phase": "attach" }),
+        );
+    }
 
     let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     let stderr_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
@@ -483,10 +587,21 @@ pub(super) fn run_materialized_provider_command_once(
         }
     };
 
-    if killed_for_liveness || timed_out {
-        let _ = child.kill();
-        let _ = child.wait();
-    }
+    // `Child::kill` signals the direct child only; the build/test descendants
+    // it spawned keep running. Terminate the contained group instead, and reap
+    // it in the clean-exit case too — the orphan in #11477 outlived a provider
+    // that had already exited. This also has to happen before the capture
+    // readers are joined: a surviving descendant holding an inherited pipe
+    // means those readers never see EOF.
+    // `status.is_none()` without a Homeboy-initiated kill means the wait loop
+    // itself failed. The child is then still unreaped and still running, so it
+    // needs the live termination path rather than a leader-exited reap.
+    let containment_cleanup = if killed_for_liveness || timed_out || status.is_none() {
+        containment.terminate_live(&mut child)
+    } else {
+        containment.reap_after_exit()
+    };
+    containment_report.record(&containment, containment_cleanup);
 
     if let Some(handle) = stdout_reader {
         let _ = handle.join();
@@ -1540,9 +1655,20 @@ pub fn run_provider_readiness_invocation(
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
+    // A readiness invocation is still provider-owned code that can spawn
+    // tooling of its own; contain it so a timed-out probe cannot strand a
+    // subtree (#11477).
+    let mut containment = AgentTaskProcessContainment::prepare(&mut command)
+        .map_err(|error| format!("failed to contain provider readiness invocation: {error}"))?;
     let mut child = command
         .spawn()
         .map_err(|error| format!("failed to spawn provider readiness invocation: {error}"))?;
+    if let Err(error) = containment.attach(&child) {
+        let _ = containment.terminate_live(&mut child);
+        return Err(format!(
+            "failed to guard provider readiness invocation: {error}"
+        ));
+    }
     if let Some(mut stdin) = child.stdin.take() {
         stdin
             .write_all(&input)
@@ -1563,8 +1689,7 @@ pub fn run_provider_readiness_invocation(
                 std::thread::sleep(Duration::from_millis(10));
             }
             Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = containment.terminate_live(&mut child);
                 if let Some(reader) = stdout_reader {
                     let _ = reader.join();
                 }
@@ -1581,6 +1706,9 @@ pub fn run_provider_readiness_invocation(
             }
         }
     };
+    // Reap before joining: a descendant still holding the inherited stdout
+    // pipe would otherwise keep the capture reader from seeing EOF.
+    let _ = containment.reap_after_exit();
     if let Some(reader) = stdout_reader {
         let _ = reader.join();
     }
@@ -1750,6 +1878,19 @@ pub fn probe_provider_executor_resolves(
         command_builder.current_dir(cwd);
     }
 
+    // The probe loads the provider's full require graph, which can itself
+    // spawn helpers. Contain it so a timed-out probe leaves nothing behind
+    // (#11477).
+    let mut containment = match AgentTaskProcessContainment::prepare(&mut command_builder) {
+        Ok(containment) => containment,
+        Err(error) => {
+            return ProviderExecutorResolution::Unresolved {
+                command: command.clone(),
+                detail: format!("failed to contain executor probe: {error}"),
+            };
+        }
+    };
+
     let mut child = match command_builder.spawn() {
         Ok(child) => child,
         Err(error) => {
@@ -1760,14 +1901,21 @@ pub fn probe_provider_executor_resolves(
         }
     };
 
+    if let Err(error) = containment.attach(&child) {
+        let _ = containment.terminate_live(&mut child);
+        return ProviderExecutorResolution::Unresolved {
+            command: command.clone(),
+            detail: format!("failed to guard executor probe: {error}"),
+        };
+    }
+
     let started = Instant::now();
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,
             Ok(None) => {
                 if started.elapsed() >= EXECUTOR_RESOLUTION_PROBE_TIMEOUT {
-                    let _ = child.kill();
-                    let _ = child.wait();
+                    let _ = containment.terminate_live(&mut child);
                     return ProviderExecutorResolution::Unresolved {
                         command,
                         detail: "executor resolution probe timed out".to_string(),
@@ -1783,6 +1931,10 @@ pub fn probe_provider_executor_resolves(
             }
         }
     };
+
+    // Reap before draining stderr: a surviving descendant holding the
+    // inherited pipe would block `read_to_end` indefinitely.
+    let _ = containment.reap_after_exit();
 
     if status.success() {
         return ProviderExecutorResolution::Resolved;

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -43,6 +43,7 @@ pub mod agent_task_loop_controller;
 pub mod agent_task_loop_definition;
 pub mod agent_task_loop_runner_policy;
 mod agent_task_notify;
+mod agent_task_process_containment;
 #[allow(
     dead_code,
     unused_imports,

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -576,8 +576,12 @@ pub fn wait_with_bounded_output_supervised_with_progress(
 
 /// A command can exit before a background descendant closes inherited output
 /// pipes. Stop that remaining process group before joining capture readers.
+///
+/// Public so callers that run their own wait loop (the agent-task provider
+/// path supervises stdin delivery and liveness itself) can reap an isolated
+/// tree with the same semantics instead of reimplementing them.
 #[cfg(unix)]
-fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
+pub fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
     if !process_group_is_running(root_pid) {
         return Ok(());
     }
@@ -596,7 +600,7 @@ fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn terminate_remaining_process_group(_root_pid: u32) -> io::Result<()> {
+pub fn terminate_remaining_process_group(_root_pid: u32) -> io::Result<()> {
     Ok(())
 }
 


### PR DESCRIPTION
Closes #11477.

## The gap

The agent-task provider execution path spawned the provider as a plain `Command` child. That leaves every descendant unowned:

- `Child::kill` on the timeout/liveness path signals the direct child only — the build driver and compiler processes it spawned keep running.
- Nothing reaps the group when the provider exits cleanly, which is how the orphaned linked test binary in the report survived four minutes past termination.
- If the controller process itself dies (cancel, operator kill, OOM), nothing runs at all.

`crates/homeboy-core/src/server/client/ssh_client.rs` already had `configure_process_group_cleanup`; the provider path had no equivalent.

## What changed

**New `crates/homeboy-agents/src/agent_task_process_containment.rs`** — the single place agent-task execution paths obtain containment. It wraps the existing `ControllerChildGuard` primitive from `homeboy-engine-primitives`, so:

- the child leads its own process group (`setpgid(0,0)` via `pre_exec`), and termination signals the whole group;
- a `fork()`ed death guard holding the read end of a pipe this process owns SIGKILLs that group if this process exits for *any* reason, including an untrappable SIGKILL — this is the "cook died" case, which a `Drop` guard alone cannot cover;
- `terminate_live()` (Homeboy-initiated kill) and `reap_after_exit()` (leader exited on its own) are both idempotent, and `Drop` calls the reap so early returns and unwinds are covered too.

**Wired into four spawn sites:**

| site | before | after |
|---|---|---|
| `agent_task_provider/command_runner.rs` provider execution | `child.kill(); child.wait()` on timeout/liveness; nothing on clean exit | group termination on timeout/liveness/wait-loop-failure; group reap on clean exit |
| `command_runner.rs` `run_provider_readiness_invocation` | `child.kill()` on probe timeout | group termination; reap before joining the capture reader |
| `command_runner.rs` `probe_provider_executor_resolves` | `child.kill()` on probe timeout | group termination; reap before draining stderr |
| `agent_task_gate_executor.rs` repo-local gate | `command.output()`, no containment | contained spawn + `wait_with_output` + reap |

Reaping deliberately runs **before** the capture readers are joined: a surviving descendant holding an inherited stdout/stderr pipe means those readers never see EOF.

**Reporting.** When cleanup cannot confirm the group is dead, the attempt outcome now carries an additive `agent_task.provider_process_group_survivors` diagnostic with the leader pid, the cleanup errors, and copy-pasteable recovery commands. This is a smaller version of the issue's `agent-task status` ask — see below.

**`terminate_remaining_process_group` promoted to `pub`** in `homeboy-engine-primitives` (it was already the in-tree helper `wait_with_bounded_output_supervised_with_progress` uses for exactly this) so the provider path, which runs its own wait loop for stdin delivery and liveness, reaps with identical semantics instead of reimplementing them.

## Tests

Four new tests in `agent_task_process_containment`, all `#[cfg(all(test, unix))]` and cheap (`sh` + `sleep`, no builds):

- `reaping_after_leader_exit_kills_a_surviving_descendant` — the exact regression: leader exits cleanly, descendant keeps running, reap must kill it.
- `terminating_a_live_leader_kills_its_descendants` — a Homeboy-initiated kill takes the whole tree, not just the direct child.
- `dropping_containment_reaps_a_surviving_descendant` — drop is an exit path too.
- `recovery_commands_are_keyed_on_the_recorded_leader_pid`.

No tests deleted or `#[ignore]`d.

## What I did NOT do

- **The SSH path.** #11164 covers that separately, per scope.
- **`agent-task status` reporting live owned processes for a terminal run.** That needs the leader pid persisted on the durable record and a liveness probe in the status renderer — real plumbing across the lifecycle store. I took the cheaper 80%: the outcome diagnostic above surfaces survivors with recovery commands at the point cleanup fails. The status-surface half is still open.
- **A cleanup category** that can find and reap these after the fact (the third bullet of "Expected"). Nothing here registers with the cleanup subsystem.
- **`ControllerChildGuard`'s fd-inheritance limitation.** The death guard is `fork()`ed, so it inherits the liveness write end of any *other* guard live at that moment; two containments overlapping in one process weaken each other's controller-death coverage. Every explicit path (timeout, liveness, clean exit, early return, unwind) is unaffected — only the "this process was SIGKILLed" fallback degrades. Documented in the module header rather than fixed, because the fix lives in a shared primitive `homeboy-release` also depends on.
- **Gate execution in `agent_task_gate.rs`** already isolates its process tree when supervised; untouched.

## Compilation uncertainty

**I could not compile or run tests locally.** This VPS runs nine parallel agents on 15Gi shared with MariaDB, PHP-FPM, and two agent runtimes; a cargo build OOMs the machine. Only `cargo fmt` was run (clean — which does confirm every changed file parses). GitHub Actions is the gate.

Specific things I reasoned about from source but could not verify with the compiler:

- `Result<(), String>` in `command_runner.rs` assumes `Result` there is `std`'s two-parameter `Result`, not `homeboy_error::Result<T>` (one parameter). The pre-existing `run_provider_readiness_invocation(...) -> Result<(), String>` in the same file says it is.
- Borrow shape of `containment.terminate_live(&mut child)` followed by `containment_report.record(&containment, cleanup)` — the result is a value, so the mutable borrow should have ended.
- `child.wait_with_output()` consuming `child` in `agent_task_gate_executor.rs` after the attach-failure branch borrows it and returns.
- Behavioral change worth a reviewer's eye: the provider path now sends SIGTERM to the group after a clean provider exit. That is the intended fix, but it does mean a provider that deliberately backgrounds a helper past its own exit will now have that helper killed.

Ecosystem terms were kept out of the added comments and strings so `core-agnostic-source` does not pick up new `core_boundary_leak` findings.