### PR TITLE
feat(agent-task): carry provider activity on cook heartbeats and status

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1156,18 +1156,62 @@ pub fn record_cook_progress(
     attempt: u32,
     detail: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
+    record_cook_progress_with_activity(run_id, phase, attempt, detail, None)
+}
+
+/// Persist Cook phase together with a sample of what the provider is doing.
+///
+/// The activity sample is written into the same record as the phase so
+/// `agent-task status` answers "is this cook making progress?" from durable
+/// state, without the reader having to find the worktree and run `ps` and
+/// `git status` by hand (#11482). It is evidence, not authority: an absent
+/// sample leaves the previously recorded one in place rather than erasing it,
+/// because a single failed probe is not proof the provider stopped working.
+pub fn record_cook_progress_with_activity(
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+    activity: Option<Value>,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let record = store::mutate_record(&run_id, |record| {
         let now = now_timestamp();
-        record.ensure_metadata_object().insert(
-            "cook_progress".to_string(),
-            json!({
+        {
+            let metadata = record.ensure_metadata_object();
+            let previous = metadata.get("cook_progress").cloned();
+            let mut progress = json!({
                 "phase": phase,
                 "attempt": attempt,
                 "detail": detail,
                 "updated_at": now,
-            }),
-        );
+            });
+            match activity {
+                Some(activity) => {
+                    progress["activity"] = activity;
+                    progress["activity_observed_at"] = json!(now);
+                }
+                // A probe that could not read the worktree or the process table
+                // says nothing about the provider. Carry the last real sample
+                // forward with its own observation time so a reader can see both
+                // what was last seen and how stale it is.
+                None => {
+                    if let Some(previous) = previous.as_ref() {
+                        if let Some(retained) = previous
+                            .get("activity")
+                            .filter(|activity| !activity.is_null())
+                        {
+                            progress["activity"] = retained.clone();
+                            progress["activity_observed_at"] = previous
+                                .get("activity_observed_at")
+                                .cloned()
+                                .unwrap_or(Value::Null);
+                        }
+                    }
+                }
+            }
+            metadata.insert("cook_progress".to_string(), progress);
+        }
         if !record.state.is_terminal() && !record.is_runner_backed() {
             record.updated_at = Some(now_timestamp());
             update_lifecycle_heartbeat(record);

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -155,6 +155,49 @@ fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
 }
 
 #[test]
+fn cook_progress_carries_provider_activity_and_survives_a_failed_probe() {
+    with_isolated_home(|_| {
+        let run_id = "cook-progress-activity";
+        submit_plan(&test_plan(), Some(run_id)).expect("submit run");
+
+        // A sample makes it into the record an operator reads, dated.
+        let sampled = record_cook_progress_with_activity(
+            run_id,
+            "heartbeat",
+            1,
+            Some("provider execution is still running"),
+            Some(json!({
+                "files_changed": 0,
+                "command": "cargo test -q -p homeboy-agents",
+                "command_elapsed_seconds": 372
+            })),
+        )
+        .expect("record sampled progress");
+        assert_eq!(
+            sampled.metadata["cook_progress"]["activity"]["files_changed"],
+            0
+        );
+        let observed_at = sampled.metadata["cook_progress"]["activity_observed_at"].clone();
+        assert!(observed_at.is_string(), "a fresh sample is dated");
+
+        // A probe that could not read the worktree or the process table is not
+        // evidence the provider stopped. The last real sample is carried
+        // forward with its own observation time, so a reader can see both what
+        // was last seen and how stale it is.
+        let unsampled = record_cook_progress(run_id, "heartbeat", 1, Some("still running"))
+            .expect("record unsampled progress");
+        assert_eq!(
+            unsampled.metadata["cook_progress"]["activity"]["command"],
+            "cargo test -q -p homeboy-agents"
+        );
+        assert_eq!(
+            unsampled.metadata["cook_progress"]["activity_observed_at"], observed_at,
+            "a retained sample keeps the time it was actually observed"
+        );
+    });
+}
+
+#[test]
 fn provider_run_result_reads_declared_output_alias() {
     let role_aliases: AgentTaskProviderRoleAliases = serde_json::from_value(json!({
         "outputs": {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -23,6 +23,7 @@ use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::{Error, Result};
 
+use super::cook_activity::{CookActivityProbe, CookProviderActivity};
 use super::cook_baseline::{
     compare_gate_failures_to_verified_base, cook_attempt_harvest_context,
     materialize_follow_up_baseline, materialize_initial_candidate_baseline,
@@ -252,7 +253,36 @@ const FINALIZATION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_
 /// wins when available; this durable heartbeat covers quiet providers.
 const COOK_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 
-pub type CookProgressObserver<'a> = dyn Fn(&str, &str, &str) -> Result<()> + Send + Sync + 'a;
+/// One Cook progress event, as delivered to a foreground observer.
+///
+/// This used to be three bare `&str`s — `(phase, cook_id, run_id)` — which is
+/// why every heartbeat an operator saw was byte-identical and carried nothing
+/// about the run it described. `report_cook_progress` already received the
+/// attempt and a detail string and recorded them durably; both were thrown away
+/// at the observer boundary. Passing a struct means adding a fact is an
+/// additive change here rather than a signature change at every call site, so
+/// the boundary stops being the place state goes to die (#11482).
+#[derive(Clone, Copy, Debug)]
+pub struct CookProgressEvent<'a> {
+    pub phase: &'a str,
+    pub cook_id: &'a str,
+    pub run_id: &'a str,
+    /// Which provider attempt this event belongs to.
+    pub attempt: u32,
+    /// Controller-owned description of the phase.
+    pub detail: Option<&'a str>,
+    /// What the provider is doing right now, when it is observable.
+    pub activity: Option<&'a CookProviderActivity>,
+}
+
+impl CookProgressEvent<'_> {
+    /// Bounded one-line rendering of the provider's current activity.
+    pub fn activity_summary(&self) -> Option<String> {
+        self.activity.and_then(CookProviderActivity::summary_line)
+    }
+}
+
+pub type CookProgressObserver<'a> = dyn Fn(&CookProgressEvent<'_>) -> Result<()> + Send + Sync + 'a;
 
 fn report_cook_progress(
     observer: Option<&CookProgressObserver<'_>>,
@@ -262,9 +292,35 @@ fn report_cook_progress(
     attempt: u32,
     detail: Option<&str>,
 ) -> Result<()> {
-    agent_task_lifecycle::record_cook_progress(run_id, phase, attempt, detail)?;
+    report_cook_progress_with_activity(observer, cook_id, run_id, phase, attempt, detail, None)
+}
+
+fn report_cook_progress_with_activity(
+    observer: Option<&CookProgressObserver<'_>>,
+    cook_id: &str,
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+    activity: Option<&CookProviderActivity>,
+) -> Result<()> {
+    agent_task_lifecycle::record_cook_progress_with_activity(
+        run_id,
+        phase,
+        attempt,
+        detail,
+        activity.and_then(CookProviderActivity::to_record_value),
+    )?;
+    let event = CookProgressEvent {
+        phase,
+        cook_id,
+        run_id,
+        attempt,
+        detail,
+        activity,
+    };
     if let Some(observer) = observer {
-        if let Err(error) = observer(phase, cook_id, run_id) {
+        if let Err(error) = observer(&event) {
             // The observer is the submitting client's output channel. Once the
             // progress record exists, a broken client pipe is evidence about
             // observation, never authority to stop promotion or finalization.
@@ -2637,18 +2693,37 @@ where
                     let (heartbeat_stop, heartbeat_wait) = mpsc::channel();
                     let heartbeat_run_id = run_id.clone();
                     let heartbeat_cook_id = cook_id.clone();
+                    // Bind the probe to the workspace this dispatch actually
+                    // hands the provider, not to the cook's configured
+                    // destination: a follow-up attempt runs in a baseline
+                    // worktree, and measuring the wrong tree would report
+                    // "no files written" while the provider was editing.
+                    let heartbeat_activity = CookActivityProbe::new(
+                        dispatch_plan
+                            .tasks
+                            .first()
+                            .and_then(|task| task.workspace.root.as_deref())
+                            .map(PathBuf::from)
+                            .or_else(|| options.source_worktree_path.clone()),
+                    );
+                    // The provider runs as a descendant of this controller
+                    // process, so the controller pid is the root of the tree to
+                    // sample.
+                    let heartbeat_owner_pid = std::process::id();
                     std::thread::scope(|scope| {
                         scope.spawn(move || {
                             while let Err(mpsc::RecvTimeoutError::Timeout) =
                                 heartbeat_wait.recv_timeout(COOK_HEARTBEAT_INTERVAL)
                             {
-                                let _ = report_cook_progress(
+                                let activity = heartbeat_activity.sample(heartbeat_owner_pid);
+                                let _ = report_cook_progress_with_activity(
                                     durable_observer,
                                     &heartbeat_cook_id,
                                     &heartbeat_run_id,
                                     "heartbeat",
                                     attempt,
                                     Some("provider execution is still running"),
+                                    (!activity.is_empty()).then_some(&activity),
                                 );
                             }
                         });

--- a/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
@@ -1,0 +1,349 @@
+//! Live provider-activity sampling for a running Cook.
+//!
+//! A Cook's durable lifecycle record answers "what did this run do?". Until
+//! this module existed nothing answered "what is the provider doing *right
+//! now?*" — heartbeats were byte-identical and `agent-task status` described the
+//! run's budget, liveness and candidate scan, none of which distinguishes an
+//! agent that is editing from one that has spent six minutes compiling. The
+//! only way to tell them apart was `ps aux | grep` plus `git status` on a path
+//! the operator had to already know (#11482).
+//!
+//! Two independent signals answer it, and they are deliberately ordered:
+//!
+//! 1. **Edit count in the destination worktree.** "Zero files written after N
+//!    minutes" is the single most actionable thing an operator can learn about
+//!    a running cook, and unlike a process sample it is true regardless of what
+//!    the provider claims to be doing.
+//! 2. **The provider's current shell command and its age**, sampled from the
+//!    process tree.
+//!
+//! Both are diagnostics, so both fail soft: an unreadable worktree or an
+//! unavailable `ps` yields an absent field, never an error that can stop a
+//! cook. Sampling is bounded — one `git status`, one `ps`, one truncated
+//! command — because a diagnostic that scales with the work it observes is how
+//! observability becomes the outage.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use homeboy_core::process_activity::{self, DescendantActivity};
+
+/// A single sample of what a running Cook's provider is doing.
+///
+/// Every field is optional: this is evidence, and absent evidence is reported
+/// as absent rather than as a zero that reads like a measurement.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CookProviderActivity {
+    /// Destination worktree the provider is expected to write into.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_root: Option<String>,
+    /// Files with uncommitted changes in that worktree, untracked included.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_changed: Option<usize>,
+    /// Commits made in that worktree since the provider started working.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_written: Option<usize>,
+    /// The provider's current command line, truncated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_pid: Option<u32>,
+    /// How long that command has been running.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_elapsed_seconds: Option<u64>,
+    /// Seconds since provider execution began, i.e. elapsed time in the
+    /// current activity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_seconds: Option<u64>,
+}
+
+impl CookProviderActivity {
+    /// True when the sample carries nothing an operator could act on.
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// One bounded line describing the sample, for foreground progress output.
+    ///
+    /// Written so the two facts that decide "should I intervene?" — how much
+    /// has been written, and what has been running how long — read together:
+    /// "no files written yet, 6m12s in the build command it spawned, 6m40s
+    /// elapsed".
+    pub fn summary_line(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        match self.files_changed {
+            Some(0) => parts.push(match self.commits_written {
+                Some(commits) if commits > 0 => format!("{commits} commit(s), no pending edits"),
+                _ => "no files written yet".to_string(),
+            }),
+            Some(count) => {
+                let mut written = format!("{count} file(s) changed");
+                if let Some(commits) = self.commits_written.filter(|commits| *commits > 0) {
+                    written.push_str(&format!(", {commits} commit(s)"));
+                }
+                parts.push(written);
+            }
+            None => {}
+        }
+        if let Some(command) = self.command.as_deref() {
+            parts.push(match self.command_elapsed_seconds {
+                Some(seconds) => format!("{} in `{command}`", format_duration(seconds)),
+                None => format!("running `{command}`"),
+            });
+        }
+        if let Some(seconds) = self.elapsed_seconds {
+            parts.push(format!("{} elapsed", format_duration(seconds)));
+        }
+        (!parts.is_empty()).then(|| parts.join(", "))
+    }
+
+    /// Durable projection for the lifecycle record.
+    pub fn to_record_value(&self) -> Option<Value> {
+        (!self.is_empty()).then(|| serde_json::to_value(self).unwrap_or(Value::Null))
+    }
+}
+
+/// Render seconds the way an operator reads them off a stalled cook.
+pub fn format_duration(seconds: u64) -> String {
+    match seconds {
+        0..=59 => format!("{seconds}s"),
+        60..=3_599 => format!("{}m{:02}s", seconds / 60, seconds % 60),
+        _ => format!("{}h{:02}m", seconds / 3_600, (seconds % 3_600) / 60),
+    }
+}
+
+/// Samples provider activity for one provider execution.
+///
+/// The probe is constructed *before* the provider runs so "commits written"
+/// is measured against the tree the provider inherited, not against whatever
+/// base a reader guesses later. A follow-up attempt starts from a baseline
+/// worktree whose HEAD is not the cook's original base, so an inferred base
+/// would silently report a previous attempt's commits as this one's progress.
+pub struct CookActivityProbe {
+    worktree_root: Option<PathBuf>,
+    start_head: Option<String>,
+    started_at: Instant,
+}
+
+impl CookActivityProbe {
+    pub fn new(worktree_root: Option<PathBuf>) -> Self {
+        let start_head = worktree_root.as_deref().and_then(git_head_sha);
+        Self {
+            worktree_root,
+            start_head,
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Take one bounded sample. Never fails: an unreadable worktree or an
+    /// unavailable process table narrows the sample, it does not end the cook.
+    pub fn sample(&self, owner_pid: u32) -> CookProviderActivity {
+        let mut activity = CookProviderActivity {
+            elapsed_seconds: Some(self.started_at.elapsed().as_secs()),
+            ..Default::default()
+        };
+        if let Some(root) = self.worktree_root.as_deref() {
+            activity.worktree_root = Some(root.display().to_string());
+            activity.files_changed = worktree_files_changed(root);
+            activity.commits_written = self
+                .start_head
+                .as_deref()
+                .and_then(|base| commits_since(root, base));
+        }
+        if let Some(process) = process_activity::descendant_activity(owner_pid) {
+            let DescendantActivity {
+                pid,
+                elapsed_seconds,
+                command,
+                ..
+            } = process;
+            activity.command = Some(command);
+            activity.command_pid = Some(pid);
+            activity.command_elapsed_seconds = Some(elapsed_seconds);
+        }
+        activity
+    }
+}
+
+/// Count files the provider has written but not committed, untracked included.
+///
+/// Untracked files count because a provider that has created new files has
+/// unambiguously done work; excluding them would report a scaffolding cook as
+/// having produced nothing.
+pub fn worktree_files_changed(root: &Path) -> Option<usize> {
+    let porcelain = homeboy_core::git::output_allow_empty(
+        root,
+        &["status", "--porcelain", "--untracked-files=all"],
+    )?;
+    Some(count_porcelain_entries(&porcelain))
+}
+
+/// Count entries in `git status --porcelain` output.
+///
+/// Homeboy's own run state lives under `.homeboy/` inside a cook worktree and
+/// is written by the controller, not the provider. Counting it would report
+/// edits on a cook where the provider has written nothing at all — precisely
+/// the signal this exists to make trustworthy.
+pub fn count_porcelain_entries(porcelain: &str) -> usize {
+    porcelain
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter(|line| !is_homeboy_internal_entry(line))
+        .count()
+}
+
+fn is_homeboy_internal_entry(line: &str) -> bool {
+    // Porcelain v1 status lines are `XY <path>`; a rename is `XY <old> -> <new>`
+    // and the destination is what matters.
+    let path = line.get(3..).unwrap_or("").trim();
+    let path = path.rsplit(" -> ").next().unwrap_or(path).trim_matches('"');
+    path == ".homeboy" || path.starts_with(".homeboy/")
+}
+
+/// Count commits made in `root` since `base_sha`.
+fn commits_since(root: &Path, base_sha: &str) -> Option<usize> {
+    let range = format!("{base_sha}..HEAD");
+    homeboy_core::git::output_allow_empty(root, &["rev-list", "--count", range.as_str()])
+        .and_then(|count| count.trim().parse().ok())
+}
+
+fn git_head_sha(root: &Path) -> Option<String> {
+    homeboy_core::git::output_allow_empty(root, &["rev-parse", "HEAD"])
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_provider_written_files_but_not_homeboy_run_state() {
+        // Controller-written `.homeboy/` state must never read as provider
+        // progress: a cook where the agent wrote nothing has to report zero.
+        let porcelain = concat!(
+            " M crates/homeboy-agents/src/lib.rs\n",
+            "?? crates/homeboy-agents/src/new_module.rs\n",
+            "?? .homeboy/run/state.json\n",
+            " M .homeboy\n",
+            "R  docs/old.md -> docs/new.md\n",
+            "\n",
+        );
+
+        assert_eq!(count_porcelain_entries(porcelain), 3);
+    }
+
+    #[test]
+    fn a_clean_worktree_counts_zero_rather_than_reporting_nothing() {
+        // `Some(0)` and `None` mean different things to an operator: "the agent
+        // has written nothing" versus "we could not look".
+        assert_eq!(count_porcelain_entries(""), 0);
+    }
+
+    #[test]
+    fn zero_edits_is_the_headline_of_the_summary_line() {
+        let activity = CookProviderActivity {
+            files_changed: Some(0),
+            command: Some("cargo test -q -p homeboy-agents".to_string()),
+            command_elapsed_seconds: Some(372),
+            elapsed_seconds: Some(400),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(summary.starts_with("no files written yet"));
+        assert!(summary.contains("6m12s in `cargo test -q -p homeboy-agents`"));
+        assert!(summary.contains("6m40s elapsed"));
+    }
+
+    #[test]
+    fn committed_work_is_not_reported_as_no_progress() {
+        // A provider that committed leaves a clean tree. Reporting that as
+        // "no files written yet" would send the operator to kill a working cook.
+        let activity = CookProviderActivity {
+            files_changed: Some(0),
+            commits_written: Some(2),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(summary.contains("2 commit(s)"));
+        assert!(!summary.contains("no files written yet"));
+    }
+
+    #[test]
+    fn an_empty_sample_renders_nothing_rather_than_an_empty_line() {
+        let activity = CookProviderActivity::default();
+
+        assert!(activity.is_empty());
+        assert_eq!(activity.summary_line(), None);
+        assert_eq!(activity.to_record_value(), None);
+    }
+
+    #[test]
+    fn durations_read_the_way_an_operator_reads_them() {
+        assert_eq!(format_duration(0), "0s");
+        assert_eq!(format_duration(59), "59s");
+        assert_eq!(format_duration(60), "1m00s");
+        assert_eq!(format_duration(372), "6m12s");
+        assert_eq!(format_duration(3_600), "1h00m");
+        assert_eq!(format_duration(7_845), "2h10m");
+    }
+
+    #[test]
+    fn a_probe_without_a_worktree_still_reports_elapsed_time() {
+        let probe = CookActivityProbe::new(None);
+
+        let activity = probe.sample(std::process::id());
+
+        assert!(activity.elapsed_seconds.is_some());
+        assert_eq!(activity.worktree_root, None);
+        assert_eq!(activity.files_changed, None);
+    }
+
+    #[test]
+    fn worktree_edit_count_measures_a_real_repository_and_ignores_run_state() {
+        let temp = tempfile::tempdir().expect("probe fixture directory");
+        let root = temp.path();
+        let initialized = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(root)
+            .status()
+            .expect("git init runs");
+        assert!(initialized.success(), "git init succeeds");
+
+        // A cook that has produced nothing reports zero, not "unknown".
+        assert_eq!(worktree_files_changed(root), Some(0));
+
+        std::fs::write(root.join("edited.rs"), "fn main() {}\n").expect("write provider edit");
+        assert_eq!(worktree_files_changed(root), Some(1));
+
+        // Controller-owned run state is not provider progress.
+        std::fs::create_dir_all(root.join(".homeboy/run")).expect("create run state directory");
+        std::fs::write(root.join(".homeboy/run/state.json"), "{}\n").expect("write run state");
+        assert_eq!(worktree_files_changed(root), Some(1));
+    }
+
+    #[test]
+    fn activity_round_trips_through_its_durable_projection() {
+        let activity = CookProviderActivity {
+            worktree_root: Some("/tmp/wt".to_string()),
+            files_changed: Some(3),
+            commits_written: Some(1),
+            command: Some("cargo test".to_string()),
+            command_pid: Some(4242),
+            command_elapsed_seconds: Some(12),
+            elapsed_seconds: Some(30),
+        };
+
+        let value = activity.to_record_value().expect("non-empty activity");
+        let restored: CookProviderActivity =
+            serde_json::from_value(value).expect("durable projection round-trips");
+
+        assert_eq!(restored, activity);
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2939,21 +2939,21 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
 
         let observed = Arc::new(Mutex::new(Vec::new()));
         let observer_records = observed.clone();
-        let result =
-            run_cook_with_durable_observer(options, UnusedExecutor, &move |phase, cook, run| {
-                let status =
-                    agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
-                let logs =
-                    agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
-                assert_eq!(status.run_id, run);
-                assert!(!logs.events.is_empty());
-                observer_records
-                    .lock()
-                    .expect("observer records lock")
-                    .push((phase.to_string(), cook.to_string(), run.to_string()));
-                Ok(())
-            })
-            .expect("restart repairs the Cook alias");
+        let result = run_cook_with_durable_observer(options, UnusedExecutor, &move |event| {
+            let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
+            let status =
+                agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
+            let logs =
+                agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
+            assert_eq!(status.run_id, run);
+            assert!(!logs.events.is_empty());
+            observer_records
+                .lock()
+                .expect("observer records lock")
+                .push((phase.to_string(), cook.to_string(), run.to_string()));
+            Ok(())
+        })
+        .expect("restart repairs the Cook alias");
 
         assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
         assert_eq!(
@@ -3059,23 +3059,23 @@ fn cook_publishes_durable_identity_before_materialization_and_survives_interrupt
 
         let observed = Arc::new(Mutex::new(Vec::new()));
         let observer_records = observed.clone();
-        let result =
-            run_cook_with_durable_observer(options, UnusedExecutor, &move |phase, cook, run| {
-                observer_records
-                    .lock()
-                    .expect("observer records lock")
-                    .push((phase.to_string(), run.to_string()));
-                // Every identity-bearing event must be immediately actionable:
-                // the caller can look the run up the moment it is told about it.
-                assert_eq!(
-                    agent_task_lifecycle::status(cook)
-                        .expect("Cook alias resolves in observer")
-                        .run_id,
-                    run
-                );
-                Ok(())
-            })
-            .expect("interrupted materialization returns a durable report");
+        let result = run_cook_with_durable_observer(options, UnusedExecutor, &move |event| {
+            let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
+            observer_records
+                .lock()
+                .expect("observer records lock")
+                .push((phase.to_string(), run.to_string()));
+            // Every identity-bearing event must be immediately actionable:
+            // the caller can look the run up the moment it is told about it.
+            assert_eq!(
+                agent_task_lifecycle::status(cook)
+                    .expect("Cook alias resolves in observer")
+                    .run_id,
+                run
+            );
+            Ok(())
+        })
+        .expect("interrupted materialization returns a durable report");
 
         // 1. Identity is published before any materialization work.
         assert_eq!(
@@ -9452,4 +9452,49 @@ fn cook_report_invocation_run_ids_populated_for_policy_failure() {
         );
         assert_eq!(report.value.status, "policy_failure");
     });
+}
+
+#[test]
+fn a_progress_event_carries_provider_activity_to_the_observer() {
+    // The observer boundary used to drop everything but `(phase, cook_id,
+    // run_id)`, which is why every heartbeat an operator saw was identical.
+    // A heartbeat event now has to be able to say what the provider is doing
+    // (#11482).
+    let activity = CookProviderActivity {
+        files_changed: Some(0),
+        command: Some("cargo test -q -p homeboy-agents".to_string()),
+        command_elapsed_seconds: Some(372),
+        elapsed_seconds: Some(400),
+        ..Default::default()
+    };
+    let event = CookProgressEvent {
+        phase: "heartbeat",
+        cook_id: "cook-1",
+        run_id: "cook-1-attempt-1",
+        attempt: 1,
+        detail: Some("provider execution is still running"),
+        activity: Some(&activity),
+    };
+
+    let summary = event
+        .activity_summary()
+        .expect("event renders its activity");
+
+    assert!(summary.contains("no files written yet"));
+    assert!(summary.contains("cargo test -q -p homeboy-agents"));
+    assert_eq!(event.attempt, 1);
+}
+
+#[test]
+fn a_progress_event_without_a_sample_renders_no_activity() {
+    let event = CookProgressEvent {
+        phase: "provider_start",
+        cook_id: "cook-1",
+        run_id: "cook-1-attempt-1",
+        attempt: 1,
+        detail: None,
+        activity: None,
+    };
+
+    assert_eq!(event.activity_summary(), None);
 }

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -6,6 +6,7 @@
 //! `crate::agent_task_service::*` unchanged.
 
 mod cook;
+mod cook_activity;
 mod cook_adoption;
 mod cook_baseline;
 mod cook_budget;
@@ -19,6 +20,7 @@ mod reconcile;
 mod status_support;
 
 pub use cook::*;
+pub use cook_activity::{CookActivityProbe, CookProviderActivity};
 pub use cook_adoption::*;
 pub use cook_baseline::*;
 pub use cook_budget::*;

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -451,7 +451,7 @@ pub mod service {
         AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
         AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskPromotionJob,
         AgentTaskPromotionJobDriver, AgentTaskPromotionJobPhase, AgentTaskPromotionRequest,
-        AgentTaskRetryServiceResult, AgentTaskRunResult, AGENT_TASK_PROMOTION_JOB_TYPE,
-        AGENT_TASK_PROMOTION_JOB_VERSION,
+        AgentTaskRetryServiceResult, AgentTaskRunResult, CookActivityProbe, CookProgressEvent,
+        CookProviderActivity, AGENT_TASK_PROMOTION_JOB_TYPE, AGENT_TASK_PROMOTION_JOB_VERSION,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -57,15 +57,16 @@ pub fn run(args: AgentTaskArgs) -> CmdResult<Value> {
     let announced_identity = std::sync::atomic::AtomicBool::new(false);
     let no_progress = matches!(&args.command, AgentTaskCommand::Cook(cook) if cook.no_progress);
     let reporter = CookProgressReporter::new(no_progress);
-    let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
-        if let Some(run_id) = run_id {
-            if !announced_identity.swap(true, std::sync::atomic::Ordering::SeqCst) {
-                run::announce_durable_cook_identity(cook_id, run_id);
+    let progress =
+        |phase: &str, cook_id: Option<&str>, run_id: Option<&str>, activity: Option<&str>| {
+            if let Some(run_id) = run_id {
+                if !announced_identity.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    run::announce_durable_cook_identity(cook_id, run_id);
+                }
             }
-        }
-        reporter.report(phase, cook_id, run_id);
-        Ok(())
-    };
+            reporter.report(phase, cook_id, run_id, activity);
+            Ok(())
+        };
     run_with_cook_progress(args, Some(&progress))
 }
 
@@ -91,6 +92,9 @@ struct CookProgressState {
     emitted_lines: usize,
     heartbeat_count: usize,
     last_phase: Option<String>,
+    /// Last provider-activity sentence emitted, so an unchanged sample stays
+    /// silent while a genuinely new one gets a line.
+    last_activity: Option<String>,
 }
 
 /// Bounds foreground Cook progress independently from durable lifecycle events.
@@ -109,23 +113,34 @@ impl CookProgressReporter {
         }
     }
 
-    pub(crate) fn report(&self, phase: &str, cook_id: Option<&str>, run_id: Option<&str>) {
+    pub(crate) fn report(
+        &self,
+        phase: &str,
+        cook_id: Option<&str>,
+        run_id: Option<&str>,
+        activity: Option<&str>,
+    ) {
         if self.no_progress {
             return;
         }
         if crate::commands::utils::tty::is_stdout_tty() {
             crate::commands::utils::tty::status(&format!(
-                "cook: {phase}{}",
+                "cook: {phase}{}{}",
                 run_id
                     .map(|run_id| format!(" [{run_id}]"))
                     .or_else(|| cook_id.map(|cook_id| format!(" [{cook_id}]")))
+                    .unwrap_or_default(),
+                activity
+                    .map(|activity| format!(" — {activity}"))
                     .unwrap_or_default()
             ));
             return;
         }
 
         let mut state = self.state.lock().expect("cook progress state");
-        if let Some(message) = next_machine_progress_message(&mut state, phase, cook_id, run_id) {
+        if let Some(message) =
+            next_machine_progress_message(&mut state, phase, cook_id, run_id, activity)
+        {
             eprintln!("{message}");
         }
     }
@@ -136,6 +151,7 @@ fn next_machine_progress_message(
     phase: &str,
     cook_id: Option<&str>,
     run_id: Option<&str>,
+    activity: Option<&str>,
 ) -> Option<String> {
     if state.emitted_lines >= MAX_MACHINE_PROGRESS_LINES {
         return None;
@@ -146,12 +162,26 @@ fn next_machine_progress_message(
         .unwrap_or_default();
     if phase == "heartbeat" {
         state.heartbeat_count += 1;
-        if !matches!(state.heartbeat_count, 1 | 4 | 8) {
+        // Sampled liveness is emitted on a fixed schedule; a *changed* provider
+        // activity earns an extra line because it is new information, not
+        // repetition. Both stay under `MAX_MACHINE_PROGRESS_LINES`, so this
+        // cannot become the heartbeat flood that cap exists to prevent — but it
+        // does mean an operator watching a stalled cook sees the moment it
+        // started compiling instead of a wall of byte-identical lines (#11482).
+        let activity_changed = activity.is_some() && state.last_activity.as_deref() != activity;
+        if activity_changed {
+            state.last_activity = activity.map(str::to_string);
+        }
+        if !matches!(state.heartbeat_count, 1 | 4 | 8) && !activity_changed {
             return None;
         }
         state.emitted_lines += 1;
+        let detail = match activity {
+            Some(activity) => format!(" {activity}."),
+            None => String::new(),
+        };
         return Some(format!(
-            "Cook heartbeat{identity}: still running (liveness sample {}).",
+            "Cook heartbeat{identity}: still running (liveness sample {}).{detail}",
             state.heartbeat_count
         ));
     }
@@ -172,7 +202,9 @@ fn next_machine_progress_message(
 pub(crate) fn run_with_cook_progress(
     args: AgentTaskArgs,
     progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
+              + Send
+              + Sync),
     >,
 ) -> CmdResult<Value> {
     run_with_cook_progress_and_provenance(args, progress, None)
@@ -181,7 +213,9 @@ pub(crate) fn run_with_cook_progress(
 pub(crate) fn run_with_cook_progress_and_provenance(
     args: AgentTaskArgs,
     progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
+              + Send
+              + Sync),
     >,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value> {
@@ -290,7 +324,10 @@ pub(crate) fn run_with_cook_progress_and_provenance(
 
 #[cfg(test)]
 mod progress_tests {
-    use super::{cook_progress_message, next_machine_progress_message, CookProgressState};
+    use super::{
+        cook_progress_message, next_machine_progress_message, CookProgressState,
+        MAX_MACHINE_PROGRESS_LINES,
+    };
 
     #[test]
     fn non_tty_cook_progress_includes_durable_reconnect_commands() {
@@ -307,7 +344,7 @@ mod progress_tests {
         let mut messages = Vec::new();
         for _ in 0..100 {
             if let Some(message) =
-                next_machine_progress_message(&mut state, "heartbeat", None, Some("run-123"))
+                next_machine_progress_message(&mut state, "heartbeat", None, Some("run-123"), None)
             {
                 messages.push(message);
             }
@@ -317,6 +354,76 @@ mod progress_tests {
         assert!(messages
             .iter()
             .all(|message| message.contains("still running")));
+    }
+
+    #[test]
+    fn heartbeats_carry_the_provider_activity_that_diagnoses_a_stalled_cook() {
+        // The whole point of #11482: the heartbeat has to say what the agent is
+        // doing, not merely that something is running.
+        let mut state = CookProgressState::default();
+
+        let message = next_machine_progress_message(
+            &mut state,
+            "heartbeat",
+            None,
+            Some("run-123"),
+            Some("no files written yet, 6m12s in `cargo test -p homeboy-agents`"),
+        )
+        .expect("first heartbeat is emitted");
+
+        assert!(message.contains("no files written yet"));
+        assert!(message.contains("cargo test -p homeboy-agents"));
+    }
+
+    #[test]
+    fn an_unchanged_activity_sample_does_not_add_heartbeat_lines() {
+        // Repeating the same sentence is the flood the sampling cap exists to
+        // prevent (#10455, #11087); only new information earns a line.
+        let mut state = CookProgressState::default();
+        let mut messages = Vec::new();
+        for _ in 0..100 {
+            if let Some(message) = next_machine_progress_message(
+                &mut state,
+                "heartbeat",
+                None,
+                Some("run-123"),
+                Some("no files written yet"),
+            ) {
+                messages.push(message);
+            }
+        }
+
+        assert_eq!(
+            messages.len(),
+            3,
+            "a static sample keeps the sampled cadence"
+        );
+    }
+
+    #[test]
+    fn a_changed_activity_earns_a_line_but_stays_bounded() {
+        // An operator watching a cook must see the moment it stopped editing
+        // and started compiling — bounded by the same total line budget.
+        let mut state = CookProgressState::default();
+        let mut messages = Vec::new();
+        for sample in 0..100 {
+            let activity = format!("no files written yet, {sample}s in `cargo test`");
+            if let Some(message) = next_machine_progress_message(
+                &mut state,
+                "heartbeat",
+                None,
+                Some("run-123"),
+                Some(&activity),
+            ) {
+                messages.push(message);
+            }
+        }
+
+        assert_eq!(
+            messages.len(),
+            MAX_MACHINE_PROGRESS_LINES,
+            "changing activity is still capped by the machine progress budget"
+        );
     }
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -795,7 +795,9 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
     >,
     progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>) -> homeboy::core::Result<()> + Send + Sync),
+        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
+              + Send
+              + Sync),
     >,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value>
@@ -836,7 +838,7 @@ where
     let cook_id = requested_cook_id.clone().unwrap_or_else(|| run_id.clone());
     if !no_progress {
         if let Some(progress) = progress {
-            progress("preparing", None, None)?;
+            progress("preparing", None, None, None)?;
         }
     }
     let (run_id, mut initial_plan) = if let Some(attempt_plan) = args.attempt_plan.as_deref() {
@@ -907,12 +909,23 @@ where
         .first()
         .and_then(|task| task.executor.model())
         .map(str::to_string);
-    let durable_observer = |phase: &str, cook_id: &str, run_id: &str| {
-        if no_progress && phase != "durable_identity" {
+    let durable_observer = |event: &agent_task_service::CookProgressEvent<'_>| {
+        if no_progress && event.phase != "durable_identity" {
             return Ok(());
         }
+        // The observer renders the activity sample here rather than passing the
+        // struct on, so foreground clients (TTY, machine log, `--output` file)
+        // all describe a running provider with the same bounded sentence.
+        let activity = event.activity_summary();
         progress
-            .map(|progress| progress(phase, Some(cook_id), Some(run_id)))
+            .map(|progress| {
+                progress(
+                    event.phase,
+                    Some(event.cook_id),
+                    Some(event.run_id),
+                    activity.as_deref(),
+                )
+            })
             .unwrap_or(Ok(()))
     };
     let result = agent_task_service::run_cook_with_durable_observer(

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2983,6 +2983,7 @@ fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateStat
             "active_executions": active_provider_executions,
             "local_owner": local_provider_ownership,
         },
+        "provider_activity": provider_activity_summary(metadata),
         "stale_reason": metadata.get("stale_running_reason"),
         "runner_queue": metadata.get("runner_queue"),
         "next_action": if terminal && candidate_recoverable {
@@ -2995,6 +2996,44 @@ fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateStat
             "homeboy agent-task status <run-id> --full".to_string()
         },
     })
+}
+
+/// Project the durably recorded provider-activity sample into the status
+/// summary.
+///
+/// This is the answer to "what is the agent actually doing?" — the question
+/// `agent-task status` could not answer, which is why diagnosing a stalled cook
+/// meant `ps aux | grep` plus `git status` on a worktree path the operator had
+/// to already know (#11482). `files_changed` leads because "zero files written
+/// after N minutes" is the single most actionable fact about a running cook.
+///
+/// Absent when nothing was sampled: a fabricated zero would read as a
+/// measurement and send an operator to kill a healthy run.
+fn provider_activity_summary(metadata: &Value) -> Value {
+    let Some(activity) = metadata
+        .pointer("/cook_progress/activity")
+        .filter(|activity| !activity.is_null())
+    else {
+        return Value::Null;
+    };
+    let mut summary = activity.clone();
+    let Some(object) = summary.as_object_mut() else {
+        return Value::Null;
+    };
+    if let Some(observed_at) = metadata
+        .pointer("/cook_progress/activity_observed_at")
+        .filter(|observed_at| !observed_at.is_null())
+    {
+        object.insert("observed_at".to_string(), observed_at.clone());
+    }
+    if let Ok(activity) =
+        serde_json::from_value::<agent_task_service::CookProviderActivity>(activity.clone())
+    {
+        if let Some(line) = activity.summary_line() {
+            object.insert("summary".to_string(), json!(line));
+        }
+    }
+    summary
 }
 
 /// Project the durable `provider_executions` metadata into a compact list of the
@@ -3684,6 +3723,61 @@ mod tests {
             accepted_handoff["liveness"]["provider_boundary"]["runner_job_id"],
             "accepted-daemon-job"
         );
+    }
+
+    #[test]
+    fn compact_status_answers_what_the_provider_is_doing_right_now() {
+        // #11482: this is the question `agent-task status` could not answer, so
+        // diagnosing a stalled cook meant `ps aux | grep` and `git status` on a
+        // path the operator had to already know.
+        let summary = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-working",
+                "state": "running",
+                "tasks": [],
+                "metadata": {
+                    "cook_progress": {
+                        "phase": "heartbeat",
+                        "attempt": 1,
+                        "detail": "provider execution is still running",
+                        "activity": {
+                            "worktree_root": "/tmp/wt/11482",
+                            "files_changed": 0,
+                            "command": "cargo test -q -p homeboy-agents",
+                            "command_elapsed_seconds": 372,
+                            "elapsed_seconds": 400
+                        },
+                        "activity_observed_at": "2026-08-04T17:16:58Z"
+                    }
+                }
+            }),
+            "agent-task-working",
+        );
+
+        let activity = &summary["liveness"]["provider_activity"];
+        assert_eq!(activity["files_changed"], 0);
+        assert_eq!(activity["command"], "cargo test -q -p homeboy-agents");
+        assert_eq!(activity["observed_at"], "2026-08-04T17:16:58Z");
+        let rendered = activity["summary"].as_str().expect("rendered summary");
+        assert!(rendered.contains("no files written yet"));
+        assert!(rendered.contains("6m12s in `cargo test -q -p homeboy-agents`"));
+    }
+
+    #[test]
+    fn compact_status_reports_no_provider_activity_rather_than_a_fabricated_zero() {
+        // An unsampled cook must not read as "the agent has written nothing" —
+        // that is the signal an operator kills a run on.
+        let summary = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-unsampled",
+                "state": "running",
+                "tasks": [],
+                "metadata": { "cook_progress": { "phase": "provider_start", "attempt": 1 } }
+            }),
+            "agent-task-unsampled",
+        );
+
+        assert!(summary["liveness"]["provider_activity"].is_null());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -39,7 +39,7 @@ impl CookOutputLease {
             token,
             lock,
         };
-        lease.write_in_flight("preparing", None, None)?;
+        lease.write_in_flight("preparing", None, None, None)?;
         Ok(lease)
     }
 
@@ -48,8 +48,9 @@ impl CookOutputLease {
         phase: &str,
         cook_id: Option<&str>,
         run_id: Option<&str>,
+        activity: Option<&str>,
     ) -> homeboy::core::Result<()> {
-        self.write_in_flight(phase, cook_id, run_id)
+        self.write_in_flight(phase, cook_id, run_id, activity)
     }
 
     pub(crate) fn finish(
@@ -79,6 +80,7 @@ impl CookOutputLease {
         phase: &str,
         cook_id: Option<&str>,
         run_id: Option<&str>,
+        activity: Option<&str>,
     ) -> homeboy::core::Result<()> {
         let mut value = serde_json::json!({
             "schema": "homeboy/agent-task-cook-output/v1",
@@ -90,6 +92,12 @@ impl CookOutputLease {
             "updated_at": chrono::Utc::now().to_rfc3339(),
             "phase": phase,
         });
+        // An `--output` cook is watched by polling this file. Without the
+        // activity sentence the poller sees a phase that has not changed for
+        // minutes and has no way to tell work from a stall (#11482).
+        if let Some(activity) = activity {
+            value["provider_activity"] = serde_json::json!(activity);
+        }
         if let (Some(cook_id), Some(run_id)) = (cook_id, run_id) {
             let object = value.as_object_mut().expect("Cook output envelope object");
             object.insert("cook_id".to_string(), serde_json::json!(cook_id));

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1016,13 +1016,16 @@ fn run_split_placement_cook(
         job_overrides: lab_job_overrides(cli)?,
         progress_reporter: progress_reporter.clone(),
     });
-    let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
+    let progress = |phase: &str,
+                    cook_id: Option<&str>,
+                    run_id: Option<&str>,
+                    activity: Option<&str>| {
         if cook.no_progress && phase == "durable_identity" {
             if let Some(run_id) = run_id {
                 crate::commands::agent_task::run::announce_durable_cook_identity(cook_id, run_id);
             }
         } else {
-            progress_reporter.report(phase, cook_id, run_id);
+            progress_reporter.report(phase, cook_id, run_id, activity);
         }
         Ok(())
     };
@@ -1265,7 +1268,17 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
                 while let Err(mpsc::RecvTimeoutError::Timeout) =
                     heartbeat_wait.recv_timeout(Duration::from_secs(15))
                 {
-                    heartbeat_progress_reporter.report("heartbeat", None, Some(&heartbeat_run_id));
+                    // A Lab-offloaded attempt runs the provider on the runner,
+                    // so neither the local process tree nor a local worktree
+                    // describes it. Report liveness without activity rather
+                    // than sampling this host and reporting someone else's
+                    // work as the provider's (#11482).
+                    heartbeat_progress_reporter.report(
+                        "heartbeat",
+                        None,
+                        Some(&heartbeat_run_id),
+                        None,
+                    );
                 }
             });
             let outcome = lab_routing::dispatch_lab_offload(

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -46,8 +46,11 @@ pub fn run_command_output(
                                 .with_output_file_already_written();
                         }
                     };
-                    let progress = |phase: &str, cook_id: Option<&str>, run_id: Option<&str>| {
-                        lease.progress(phase, cook_id, run_id)
+                    let progress = |phase: &str,
+                                    cook_id: Option<&str>,
+                                    run_id: Option<&str>,
+                                    activity: Option<&str>| {
+                        lease.progress(phase, cook_id, run_id, activity)
                     };
                     let (result, exit_code) = map(
                         crate::commands::agent_task::run_with_cook_progress_and_provenance(

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -158,6 +158,7 @@ pub mod performance_hotspots;
 pub use homeboy_engine_primitives::phase_timing;
 pub use homeboy_gate_contract::plan;
 pub mod process;
+pub mod process_activity;
 // product_identity moved to the internal `homeboy-product-identity` crate.
 // Re-exported so `crate::product_identity::*` call sites keep working.
 pub use homeboy_product_identity as product_identity;

--- a/crates/homeboy-core/src/process_activity.rs
+++ b/crates/homeboy-core/src/process_activity.rs
@@ -1,0 +1,345 @@
+//! Read-only process-tree activity sampling.
+//!
+//! [`crate::process`] owns the *lifecycle* half of the process tree (signalling,
+//! scopes, termination). This module owns the *observability* half: answering
+//! "what is this process tree actually doing right now?" without changing it.
+//!
+//! The motivating case is diagnosing a stalled Cook. Before this existed the
+//! only way to learn that a provider agent was compiling instead of editing was
+//! `ps aux | grep` on the host (#11482). The same `ps -axo` walk that
+//! [`crate::process`] already uses for descendant discovery answers it, so the
+//! sampling is a plain read of the process table with no signals, no /proc
+//! assumptions, and no platform-specific parsing beyond `ps` itself.
+//!
+//! Everything here is bounded on purpose: one `ps` invocation, a truncated
+//! command string, and a single selected descendant. Diagnostics that scale
+//! with the size of the process tree are how observability turns into a flood.
+
+#[cfg(unix)]
+use std::process::Command;
+
+/// Maximum characters retained from a sampled command line.
+///
+/// Provider command lines embed the whole task prompt, so an untruncated
+/// sample would push kilobytes into every heartbeat and durable progress
+/// record. The retained prefix is where the actionable part lives — the program
+/// and its leading arguments — so truncate rather than drop.
+pub const MAX_ACTIVITY_COMMAND_CHARS: usize = 200;
+
+/// One row of the process table, as sampled from `ps`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessActivityRow {
+    pub pid: u32,
+    pub ppid: u32,
+    /// Wall-clock seconds since this process started.
+    pub elapsed_seconds: u64,
+    pub command: String,
+}
+
+/// The descendant selected as "what the tree is currently doing".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DescendantActivity {
+    pub pid: u32,
+    /// Hops from the observed owner. `1` is a direct child (for a Cook, the
+    /// provider process itself); `2` and deeper is work the provider spawned.
+    pub depth: usize,
+    pub elapsed_seconds: u64,
+    /// Command line, truncated to [`MAX_ACTIVITY_COMMAND_CHARS`].
+    pub command: String,
+    /// Total descendants observed under the owner, so a reader can tell a lone
+    /// process from a busy tree without being handed the whole tree.
+    pub descendant_count: usize,
+}
+
+/// Parse `ps -axo pid=,ppid=,etime=,args=` output into activity rows.
+///
+/// Kept separate from the `ps` invocation so selection behavior is testable on
+/// every platform, including ones where the probe itself returns nothing.
+pub fn parse_process_activity_rows(ps_output: &str) -> Vec<ProcessActivityRow> {
+    ps_output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse().ok()?;
+            let ppid = fields.next()?.parse().ok()?;
+            let etime = fields.next()?;
+            let elapsed_seconds = parse_ps_elapsed_seconds(etime)?;
+            // `args` is the remainder of the line, spaces included. Recover it
+            // from the original line rather than re-joining split fields so
+            // internal spacing survives.
+            let command = remainder_after_fields(line, 3).trim().to_string();
+            Some(ProcessActivityRow {
+                pid,
+                ppid,
+                elapsed_seconds,
+                command,
+            })
+        })
+        .collect()
+}
+
+/// Skip `count` whitespace-separated fields and return the rest of the line.
+fn remainder_after_fields(line: &str, count: usize) -> &str {
+    let mut rest = line.trim_start();
+    for _ in 0..count {
+        match rest.find(char::is_whitespace) {
+            Some(index) => rest = rest[index..].trim_start(),
+            None => return "",
+        }
+    }
+    rest
+}
+
+/// Parse a POSIX `ps` `etime` value (`[[dd-]hh:]mm:ss`) into seconds.
+pub fn parse_ps_elapsed_seconds(etime: &str) -> Option<u64> {
+    let etime = etime.trim();
+    if etime.is_empty() {
+        return None;
+    }
+    let (days, clock) = match etime.split_once('-') {
+        Some((days, clock)) => (days.parse::<u64>().ok()?, clock),
+        None => (0, etime),
+    };
+    let mut parts = clock.split(':').rev();
+    let seconds: u64 = parts.next()?.parse().ok()?;
+    let minutes: u64 = parts.next().map(str::parse).transpose().ok()?.unwrap_or(0);
+    let hours: u64 = parts.next().map(str::parse).transpose().ok()?.unwrap_or(0);
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(days * 86_400 + hours * 3_600 + minutes * 60 + seconds)
+}
+
+/// Truncate a command line to [`MAX_ACTIVITY_COMMAND_CHARS`] characters.
+///
+/// Truncation is on `char` boundaries so a multi-byte command line cannot panic
+/// the diagnostic that was supposed to explain what went wrong.
+pub fn truncate_command(command: &str) -> String {
+    let command = command.trim();
+    if command.chars().count() <= MAX_ACTIVITY_COMMAND_CHARS {
+        return command.to_string();
+    }
+    let mut truncated: String = command.chars().take(MAX_ACTIVITY_COMMAND_CHARS).collect();
+    truncated.push('…');
+    truncated
+}
+
+/// Select the descendant that best answers "what is this tree working on?".
+///
+/// Selection prefers the *longest-running spawned work* (depth >= 2) over the
+/// direct child itself, breaking ties toward the deeper process. That is what
+/// makes a six-minute build command — spawned by an agent that has also been up
+/// six minutes — win over both the agent and the three-second compiler process
+/// the build just launched. When the tree has no grandchildren the direct child
+/// is reported instead, so a quiet agent still shows up.
+///
+/// `ignore_pids` exists because the probe's own `ps` process is a direct child
+/// of the owner and would otherwise be a candidate.
+pub fn select_descendant_activity(
+    rows: &[ProcessActivityRow],
+    owner_pid: u32,
+    ignore_pids: &[u32],
+) -> Option<DescendantActivity> {
+    let descendants: Vec<(&ProcessActivityRow, usize)> = descendants_with_depth(rows, owner_pid)
+        .into_iter()
+        .filter(|(row, _)| !ignore_pids.contains(&row.pid))
+        .collect();
+    let descendant_count = descendants.len();
+    let candidate = descendants
+        .iter()
+        .filter(|(row, _)| !row.command.is_empty());
+    let spawned_work = candidate
+        .clone()
+        .filter(|(_, depth)| *depth >= 2)
+        .max_by_key(|(row, depth)| (row.elapsed_seconds, *depth, row.pid));
+    let selected =
+        spawned_work.or_else(|| candidate.max_by_key(|(row, depth)| (*depth, row.elapsed_seconds)));
+    let (row, depth) = selected?;
+    Some(DescendantActivity {
+        pid: row.pid,
+        depth: *depth,
+        elapsed_seconds: row.elapsed_seconds,
+        command: truncate_command(&row.command),
+        descendant_count,
+    })
+}
+
+/// Walk the owner's descendants, recording hop depth for each.
+fn descendants_with_depth(
+    rows: &[ProcessActivityRow],
+    owner_pid: u32,
+) -> Vec<(&ProcessActivityRow, usize)> {
+    let mut found: Vec<(&ProcessActivityRow, usize)> = Vec::new();
+    let mut frontier = vec![(owner_pid, 0usize)];
+    while let Some((parent, depth)) = frontier.pop() {
+        // A pid cycle cannot exist in a well-formed process table, but a
+        // torn `ps` snapshot can still produce one. Bound the walk by depth so
+        // a malformed sample cannot spin the heartbeat thread.
+        if depth >= 16 {
+            continue;
+        }
+        for row in rows {
+            if row.ppid != parent || row.pid == parent {
+                continue;
+            }
+            if found.iter().any(|(seen, _)| seen.pid == row.pid) {
+                continue;
+            }
+            found.push((row, depth + 1));
+            frontier.push((row.pid, depth + 1));
+        }
+    }
+    found
+}
+
+/// Sample the current activity of `owner_pid`'s process tree.
+///
+/// Returns `None` when the platform has no `ps`, the sample fails, or the tree
+/// has no observable descendants. Activity is a diagnostic: a failed sample
+/// must never be an error a caller has to handle.
+pub fn descendant_activity(owner_pid: u32) -> Option<DescendantActivity> {
+    #[cfg(unix)]
+    {
+        let output = Command::new("ps")
+            .args(["-axo", "pid=,ppid=,etime=,args="])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let rows = parse_process_activity_rows(&stdout);
+        // The probe's own `ps` is a direct child of the owner whenever the
+        // owner is this process; never report the observation as the activity.
+        select_descendant_activity(&rows, owner_pid, &[std::process::id()])
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = owner_pid;
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ps_etime_in_every_documented_shape() {
+        assert_eq!(parse_ps_elapsed_seconds("05"), Some(5));
+        assert_eq!(parse_ps_elapsed_seconds("06:12"), Some(372));
+        assert_eq!(parse_ps_elapsed_seconds("01:06:12"), Some(3_972));
+        assert_eq!(parse_ps_elapsed_seconds("2-01:06:12"), Some(176_772));
+        assert_eq!(parse_ps_elapsed_seconds("not-a-time"), None);
+        assert_eq!(parse_ps_elapsed_seconds(""), None);
+    }
+
+    #[test]
+    fn parses_command_lines_that_contain_spaces() {
+        let ps = "4242 100 06:12 timeout 1200 cargo test -q -p homeboy-agents\n";
+
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, 4242);
+        assert_eq!(rows[0].ppid, 100);
+        assert_eq!(rows[0].elapsed_seconds, 372);
+        assert_eq!(
+            rows[0].command,
+            "timeout 1200 cargo test -q -p homeboy-agents"
+        );
+    }
+
+    #[test]
+    fn ignores_rows_that_are_not_process_table_entries() {
+        let ps = "  PID  PPID     ELAPSED COMMAND\n4242 100 06:12 cargo test\n\n";
+
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, 4242);
+    }
+
+    #[test]
+    fn selects_the_longest_running_spawned_work_over_the_provider_and_its_newest_child() {
+        // The exact shape from #11482: a provider that has been up as long as
+        // the compile it launched, plus a freshly started compiler child. The
+        // actionable answer is `cargo test`, not `opencode` and not `rustc`.
+        let ps = concat!(
+            "100 1 06:20 opencode run --format json # Task: make Cook honor model rotation\n",
+            "200 100 06:12 timeout 1200 cargo test -q -j3 -p homeboy-agents\n",
+            "300 200 06:12 cargo test -q -j3 -p homeboy-agents\n",
+            "400 300 00:03 rustc --crate-name homeboy_agents\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let activity = select_descendant_activity(&rows, 100, &[]).expect("activity is observable");
+
+        assert_eq!(activity.pid, 300);
+        assert_eq!(activity.depth, 2);
+        assert_eq!(activity.elapsed_seconds, 372);
+        assert!(activity.command.starts_with("cargo test"));
+        assert_eq!(activity.descendant_count, 3);
+    }
+
+    #[test]
+    fn reports_the_provider_itself_when_it_has_spawned_nothing() {
+        // A provider that is thinking rather than shelling out still has to be
+        // visible — "no descendants" must not read as "no activity".
+        let ps = "100 1 02:00 opencode run --format json\n";
+        let rows = parse_process_activity_rows(ps);
+
+        let activity = select_descendant_activity(&rows, 1, &[]).expect("provider is observable");
+
+        assert_eq!(activity.pid, 100);
+        assert_eq!(activity.depth, 1);
+        assert_eq!(activity.command, "opencode run --format json");
+    }
+
+    #[test]
+    fn never_reports_the_observing_process_as_the_activity() {
+        let ps = concat!(
+            "100 1 06:20 opencode run\n",
+            "999 1 00:00 ps -axo pid=,ppid=,etime=,args=\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let activity =
+            select_descendant_activity(&rows, 1, &[999]).expect("provider is observable");
+
+        assert_eq!(activity.pid, 100);
+    }
+
+    #[test]
+    fn returns_nothing_when_the_tree_has_no_descendants() {
+        let rows = parse_process_activity_rows("100 1 06:20 opencode run\n");
+
+        assert_eq!(select_descendant_activity(&rows, 4242, &[]), None);
+    }
+
+    #[test]
+    fn truncates_command_lines_on_character_boundaries() {
+        let command = format!("cargo test {}", "é".repeat(400));
+
+        let truncated = truncate_command(&command);
+
+        assert_eq!(truncated.chars().count(), MAX_ACTIVITY_COMMAND_CHARS + 1);
+        assert!(truncated.ends_with('…'));
+        assert!(truncated.starts_with("cargo test"));
+    }
+
+    #[test]
+    fn a_torn_process_table_cannot_spin_the_walk() {
+        // A self-parenting row is impossible in a real table and trivial to
+        // produce in a torn snapshot; the walk must still terminate.
+        let ps = "100 100 01:00 wedged\n200 100 01:00 child\n";
+        let rows = parse_process_activity_rows(ps);
+
+        let activity = select_descendant_activity(&rows, 100, &[]).expect("child is observable");
+
+        assert_eq!(activity.pid, 200);
+    }
+}

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -341,6 +341,24 @@ homeboy agent-task status <run-id>
 homeboy agent-task evidence <run-id> --full
 ```
 
+#### Provider activity
+
+A locally executed Cook samples what the provider is actually doing and carries
+it on both the heartbeat line and `agent-task status`, under
+`liveness.provider_activity`:
+
+| Field | Meaning |
+|---|---|
+| `files_changed` | Uncommitted files in the destination worktree, untracked included. `0` after several minutes is the clearest sign a cook is not producing work. Homeboy's own `.homeboy/` run state is excluded, so this counts provider edits only. |
+| `commits_written` | Commits made in that worktree since the provider started. A provider that commits leaves a clean tree, so this is what distinguishes "finished" from "did nothing". |
+| `command` / `command_elapsed_seconds` | The longest-running command the provider has spawned, and its age — `cargo test -p homeboy-agents`, six minutes in. |
+| `elapsed_seconds` | Time since provider execution began. |
+| `observed_at` | When the sample was taken. A retained sample keeps its own observation time, so a stale reading is visible as stale. |
+
+Each field is absent when it could not be sampled; an unsampled cook reports no
+activity rather than a zero that would read as a measurement. Lab-offloaded
+attempts run the provider on the runner and therefore report no local activity.
+
 `--placement local` is safe only when local execution on this
 controller is intentional. For agent-task waves with concurrency greater than 1
 or multiple tasks, Homeboy prints `HOMEBOY_LOCAL_FANOUT_WARNING` before provider


### PR DESCRIPTION
Closes #11482.

## What changed

`agent-task status` and the Cook heartbeat now carry what the provider is actually doing, in the priority order the issue asked for.

**1. Edit count in the destination worktree** — the highest-value signal, so it leads. `crates/homeboy-agents/src/agent_task_service/cook_activity.rs` counts `git status --porcelain --untracked-files=all` entries in the worktree the dispatch actually hands the provider (a follow-up attempt runs in a baseline worktree, so measuring the configured destination would report "no files written" while the provider was editing). Homeboy's own `.homeboy/` run state is excluded — counting controller writes as provider progress would break exactly the signal this exists to make trustworthy. Commits are counted separately against the HEAD captured *before* the provider started, so a provider that committed and left a clean tree does not read as idle.

**2. The provider's current command and its age** — `crates/homeboy-core/src/process_activity.rs` samples `ps -axo pid=,ppid=,etime=,args=` and walks the controller's descendants. Selection prefers spawned work (depth ≥ 2) over the direct child, tie-breaking toward the deeper process: a six-minute build wins over both the agent above it and the three-second compiler below it. With no grandchildren the direct child is reported, so a quiet agent still shows up.

**3. Elapsed time in the current provider execution.**

### Observer boundary

`CookProgressObserver` was `dyn Fn(&str, &str, &str)` — which is why the `attempt` and `detail` that `report_cook_progress` already recorded durably were discarded at the boundary. It now takes a `CookProgressEvent { phase, cook_id, run_id, attempt, detail, activity }`. As the issue hints, this also gives the lifecycle fields #11076 wants a place to live: adding a fact is now additive here instead of a signature change at every call site. I did **not** populate the #11076 fields (gate, placement) — that is its own issue.

### Surfaces

- Heartbeat line: `Cook heartbeat [run-id]: still running (liveness sample 1). no files written yet, 6m12s in \`<cmd>\`, 6m40s elapsed.`
- `agent-task status <run-id>` → `liveness.provider_activity` (structured fields plus a rendered `summary` and `observed_at`).
- `--output` in-flight envelope → `provider_activity`, so a polling client sees work vs. stall.
- `docs/commands/agent-task.md` documents the fields.

### Bounding

The existing 1/4/8 sampling cap under `MAX_MACHINE_PROGRESS_LINES = 12` is unchanged. A *changed* activity sentence earns one extra line, because it is new information rather than repetition, and the 12-line total still caps it — `a_changed_activity_earns_a_line_but_stays_bounded` pins that. No flood (#10455, #11087). Per heartbeat the cost is one `git status`, one `ps`, and a command string truncated to 200 chars.

### Failing soft

Both probes are diagnostics, never authority. An unreadable worktree or unavailable process table narrows the sample instead of failing the cook. An unsampled cook reports **no** activity rather than a zero that would read as a measurement and send an operator to kill a healthy run. A heartbeat whose probe returned nothing carries the previous sample forward with its own `activity_observed_at`, so staleness is visible instead of erased.

Lab-offloaded attempts run the provider on the runner, so their heartbeat reports liveness without activity — sampling this host would attribute someone else's work to the provider.

## What I did not do

- No provider *transcript* / tool-call parsing. The sample is the OS process tree, so it is provider-agnostic; a structured "most recent tool call" would need per-runtime transcript plumbing.
- No watchdog or enforcement (#11081 is the enforcement counterpart; this is the observability half).
- No #11076 lifecycle fields, though the widened event is the place they go.
- Process sampling is Unix-only (`ps`); non-Unix returns `None` and the worktree edit count still works.

## Files changed

- `crates/homeboy-core/src/process_activity.rs` (new) + `lib.rs`
- `crates/homeboy-agents/src/agent_task_service/cook_activity.rs` (new) + `mod.rs`, `cook.rs`, `cook_tests.rs`, `agent_tasks.rs`
- `crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs` + `tests/submit_and_persist.rs`
- `crates/homeboy-cli/src/commands/agent_task.rs`, `agent_task/run.rs`, `agent_task/status.rs`, `infra/route.rs`, `infra/output_runtime.rs`, `json_output/mod.rs`
- `docs/commands/agent-task.md`

## Tests

19 new tests: `ps` parsing/selection (including the exact process shape from the issue, a torn process table, and never reporting the observing process), porcelain counting and `.homeboy/` exclusion, a real `git init` worktree measured end to end, summary rendering (zero-edits headline, committed-work-is-not-no-progress), durable activity retention across a failed probe, the widened event, the status projection, and the heartbeat output bound.

## Compilation uncertainty

**I could not compile or run tests locally** — this VPS runs nine parallel agents and a cargo build OOMs the box, so builds are prohibited here. `cargo fmt` is clean and the changes were reasoned from source. GitHub Actions is the gate. The likeliest place for a compile error is the borrow/match-ergonomics in `select_descendant_activity` (iterator of `&(&Row, usize)` with a cloned `Filter`), and the widened 4-argument CLI progress closure type — I swept every call site I could find (`run.rs`, `agent_task.rs`, `json_output`, `route.rs` ×2, `output_runtime`), but a missed one would surface as an arity mismatch.