### PR TITLE
feat(agent-task): serve local Cook detach by re-executing in a new session

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -59,7 +59,9 @@ pub enum AgentTaskCommand {
     /// Cook report. This is the default when neither flag is passed.
     ///
     /// `--detach-after-handoff` returns once the run is durably accepted. Its
-    /// result describes a submission, not an outcome.
+    /// result describes a submission, not an outcome. It is honored on every
+    /// placement: with `--placement local` the Cook is re-executed in its own
+    /// session, so it survives a client that is interrupted or times out.
     ///
     /// Do not infer the wait policy from client interactivity. An orchestration
     /// client that needs one predictable contract should pass the flag rather than

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -52,10 +52,22 @@ pub fn route_after_parse_with_provenance(
     // recursively route back through a runner-side controller daemon.
     let managed_runner_placement =
         crate::commands::utils::resource_policy::is_managed_runner_placement_context();
-    if lab_routing::is_lab_offload_subprocess()
+    let runner_side = lab_routing::is_lab_offload_subprocess()
         || managed_runner_placement
-        || runner_resident_execution(cli)
+        || runner_resident_execution(cli);
+
+    // A locally-placed Cook asking to detach is served by re-executing it in
+    // its own session, so the durable run id means what Cook's help says it
+    // means on every placement (#11476). This is evaluated before the
+    // runner-side bail-out because the request needs a verdict — detach here,
+    // or an explicit rejection there — in both contexts.
+    if let Some(exit_code) =
+        local_detach::intercept_local_detached_cook(cli, normalized_args, runner_side)?
     {
+        return Ok(Some(exit_code));
+    }
+
+    if runner_side {
         return Ok(None);
     }
 
@@ -839,9 +851,14 @@ fn run_split_placement_fanout(
 /// controller-transport variable let a contradictory cook through to real
 /// worktree and provider work instead of a fast rejection (#10917).
 ///
-/// This is the only place these two rejections live. `run_split_placement_cook`
-/// deliberately does not repeat them: duplicated validation drifts, and which
+/// This is the only place this rejection lives. `run_split_placement_cook`
+/// deliberately does not repeat it: duplicated validation drifts, and which
 /// message an operator sees should never depend on the path taken to reach it.
+///
+/// `--placement local --detach-after-handoff` used to be rejected here too. It
+/// is not a contradiction — it is a request this controller can now serve by
+/// re-executing the Cook in its own session, so its verdict belongs to
+/// [`local_detach::intercept_local_detached_cook`] (#11476).
 fn reject_contradictory_cook_arguments(cli: &Cli) -> homeboy::core::Result<()> {
     let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
         command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
@@ -857,21 +874,6 @@ fn reject_contradictory_cook_arguments(cli: &Cli) -> homeboy::core::Result<()> {
             None,
             Some(vec![
                 "Use `homeboy agent-task run-plan --plan <materialized-plan> --record-run-id <run-id> --queue-only` only when a controller owns the corresponding continuation.".to_string(),
-            ]),
-        ));
-    }
-
-    // `--runner` implies Lab placement and is mutually exclusive with an
-    // explicit `--placement` at argument parsing, so `--placement local` here
-    // always means a fully local cook with no pinned runner, and no runner
-    // daemon can own the attempt to detach from.
-    if cli.placement == homeboy::cli_surface::Placement::Local && cli.detach_after_handoff {
-        return Err(Error::validation_invalid_argument(
-            "detach-after-handoff",
-            "agent-task cook cannot detach after handoff with --placement local because no runner daemon owns the provider attempt",
-            None,
-            Some(vec![
-                "Use --placement lab or --runner <runner-id> to detach after a runner daemon accepts the provider attempt.".to_string(),
             ]),
         ));
     }
@@ -3022,6 +3024,7 @@ fn agent_task_fanout_cook_batch_dispatch_id(
     })
 }
 
+mod local_detach;
 mod rig_source;
 use rig_source::*;
 fn is_runs_list_runner_option(args: &[String]) -> bool {

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -1,0 +1,682 @@
+//! Local-placement Cook detachment.
+//!
+//! Cook advertises a durable run id "persisted before materialization" as the
+//! handle that makes a cook observable and recoverable independently of the
+//! caller. On Lab placement a runner daemon owns the provider attempt, so that
+//! promise holds. On local placement it did not: the cook ran in the calling
+//! client's process group, so a client that hit its command timeout took the
+//! cook down with it — `local_provider_ownership.state: "owner_dead"`, the run
+//! cancelled, the durable record good only for reading a tombstone (#11476).
+//!
+//! The remedy is the one the operator was reaching for by hand with `setsid
+//! nohup ... &`: the launcher re-executes the same Cook in its own session and
+//! returns a bounded handoff. Nothing about the cook's own lifecycle changes —
+//! it is the same controller-owned cook, executing the same argv, writing the
+//! same durable records. Only its parentage does.
+//!
+//! This composes with, rather than contradicts, provider process-group
+//! containment (#11477): containment makes a cook's children die *with* the
+//! cook; detachment makes the cook survive *its launcher*. The detached cook is
+//! the containment owner, so a cancelled or killed cook still reaps its
+//! provider tree.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
+use homeboy::cli_surface::{Cli, Commands};
+use homeboy::core::Error;
+use serde_json::{json, Value};
+
+const HANDOFF_SCHEMA: &str = "homeboy/agent-task-cook-local-detach-handoff/v1";
+
+/// Bound on how long the launcher waits for the detached cook to publish its
+/// durable identity before reporting the handoff as still pending. The wait
+/// exists so a returned run id is addressable, not so the launcher becomes a
+/// second `--wait`.
+const DEFAULT_HANDOFF_TIMEOUT_MS: u64 = 30_000;
+const HANDOFF_POLL: Duration = Duration::from_millis(100);
+
+/// Test and operator override for the bounded handoff wait.
+const HANDOFF_TIMEOUT_ENV: &str = "HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS";
+
+/// Whether this invocation is a locally-placed Cook asking to be detached.
+fn is_local_detached_cook(cli: &Cli) -> bool {
+    cli.detach_after_handoff
+        && cli.placement == homeboy::cli_surface::Placement::Local
+        && matches!(
+            cli.command,
+            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
+            })
+        )
+}
+
+/// Serve `--placement local --detach-after-handoff` by re-executing this exact
+/// Cook in its own session and returning a bounded handoff.
+///
+/// `runner_side` is true when this process is a Lab offload subprocess, a
+/// managed-runner placement, or a runner-resident execution. There the request
+/// is genuinely unserveable: the process is already the runner's owned
+/// execution of one attempt and has no controller lifecycle to hand off, so
+/// detaching would orphan work the runner believes it owns.
+pub(super) fn intercept_local_detached_cook(
+    cli: &Cli,
+    normalized_args: &[String],
+    runner_side: bool,
+) -> homeboy::core::Result<Option<i32>> {
+    if !is_local_detached_cook(cli) {
+        return Ok(None);
+    }
+    if runner_side {
+        return Err(runner_side_detach_error());
+    }
+
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+    }) = &cli.command
+    else {
+        return Ok(None);
+    };
+
+    let requested_cook_id = cook.dispatch.run_id.clone();
+    let cook_id = requested_cook_id
+        .clone()
+        .unwrap_or_else(|| format!("cook-detached-{}", uuid::Uuid::new_v4()));
+    let mut child_args =
+        detached_cook_child_args(normalized_args, &cook_id, requested_cook_id.is_some());
+    let session_root = detached_session_root(&cook_id)?;
+    // A detached child cannot answer a `--prompt -`: its stdin is closed and the
+    // bytes live only in the launcher's pipe. Capture them here so the exact
+    // prompt survives the handoff instead of the cook stalling on an empty read.
+    materialize_stdin_prompt(&mut child_args, &session_root)?;
+    let log_path = session_root.join("cook.log");
+
+    let mut child = spawn_detached_cook(&child_args, &log_path)?;
+    let pid = child.id();
+    let handoff = await_durable_handoff(&cook_id, &mut child, handoff_timeout());
+
+    if let Some(run_id) = handoff.run_id.as_deref() {
+        crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), run_id);
+    }
+    let envelope = handoff_envelope(&cook_id, pid, &log_path, &handoff);
+    let stdout = serde_json::to_string_pretty(&envelope).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize detached local cook handoff".to_string()),
+        )
+    })?;
+    println!("{stdout}");
+    Ok(Some(0))
+}
+
+/// The one context where local detachment stays a rejection.
+fn runner_side_detach_error() -> Error {
+    Error::validation_invalid_argument(
+        "detach-after-handoff",
+        "agent-task cook cannot detach after handoff with --placement local inside a runner-owned execution because the runner already owns this attempt",
+        None,
+        Some(vec![
+            "Detach from the controller that dispatches the attempt, not from the runner process executing it.".to_string(),
+        ]),
+    )
+}
+
+/// The argv the detached cook executes.
+///
+/// It is the caller's own argv with two edits: the detach request is consumed
+/// by the launcher, and the cook id is pinned so the launcher can name the run
+/// it just handed off. Everything else is preserved byte for byte — a detached
+/// cook that silently differs from the requested one is worse than no detach.
+fn detached_cook_child_args(
+    normalized_args: &[String],
+    cook_id: &str,
+    has_explicit_cook_id: bool,
+) -> Vec<String> {
+    let mut args: Vec<String> = normalized_args
+        .iter()
+        .skip(1)
+        .filter(|arg| {
+            arg.as_str() != "--detach-after-handoff" && !arg.starts_with("--detach-after-handoff=")
+        })
+        .cloned()
+        .collect();
+    if !has_explicit_cook_id {
+        args.push("--run-id".to_string());
+        args.push(cook_id.to_string());
+    }
+    args
+}
+
+/// Replace a `--prompt -` stdin request with a file the detached cook can read.
+///
+/// Returns the materialized path when a rewrite happened.
+fn materialize_stdin_prompt(
+    args: &mut [String],
+    session_root: &Path,
+) -> homeboy::core::Result<Option<PathBuf>> {
+    materialize_prompt_from(args, session_root, &mut std::io::stdin().lock())
+}
+
+/// The reader is a parameter so the capture can be exercised without a test
+/// reaching for the harness's own stdin, which may never reach EOF.
+fn materialize_prompt_from(
+    args: &mut [String],
+    session_root: &Path,
+    source: &mut impl Read,
+) -> homeboy::core::Result<Option<PathBuf>> {
+    let Some(index) = stdin_prompt_index(args) else {
+        return Ok(None);
+    };
+    let mut prompt = Vec::new();
+    source.read_to_end(&mut prompt).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read stdin prompt for a detached local cook".to_string()),
+        )
+    })?;
+    let path = session_root.join("prompt.txt");
+    std::fs::write(&path, &prompt)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    args[index] = if args[index] == "-" {
+        format!("@{}", path.display())
+    } else {
+        format!("--prompt=@{}", path.display())
+    };
+    Ok(Some(path))
+}
+
+/// Index of the argv element holding a stdin prompt request, if any.
+///
+/// Both spellings clap accepts are covered: a separated `--prompt -` names the
+/// following element, an attached `--prompt=-` names itself.
+fn stdin_prompt_index(args: &[String]) -> Option<usize> {
+    args.iter().enumerate().find_map(|(index, arg)| {
+        if arg == "--prompt" && args.get(index + 1).is_some_and(|value| value == "-") {
+            Some(index + 1)
+        } else if arg == "--prompt=-" {
+            Some(index)
+        } else {
+            None
+        }
+    })
+}
+
+/// Per-cook scratch directory for the launcher's captured stdio and prompt.
+fn detached_session_root(cook_id: &str) -> homeboy::core::Result<PathBuf> {
+    let root = homeboy::core::paths::homeboy_data()?
+        .join("agent-task-detached")
+        .join(homeboy::core::paths::sanitize_path_segment(cook_id));
+    std::fs::create_dir_all(&root)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
+    Ok(root)
+}
+
+fn spawn_detached_cook(
+    args: &[String],
+    log_path: &Path,
+) -> homeboy::core::Result<std::process::Child> {
+    let exe = std::env::current_exe().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve current executable for a detached local cook".to_string()),
+        )
+    })?;
+    let log = std::fs::File::create(log_path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
+    })?;
+    let log_err = log.try_clone().map_err(|error| {
+        Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
+    })?;
+
+    let mut command = Command::new(exe);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err));
+    homeboy::core::process::detach_from_caller_session(&mut command);
+    command.spawn().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("spawn detached local cook".to_string()),
+        )
+    })
+}
+
+/// What the launcher could prove about the cook before returning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DetachedCookHandoff {
+    state: DetachedHandoffState,
+    run_id: Option<String>,
+    waited_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetachedHandoffState {
+    /// The detached cook published its durable cook index; the returned ids are
+    /// addressable now.
+    Accepted,
+    /// The process is alive but has not reached durable submission yet. The
+    /// cook id is still the correct handle — it is pinned on the child's argv.
+    Pending,
+    /// The detached process exited before publishing durable identity. The log
+    /// is the only evidence, and this is reported rather than dressed up as a
+    /// successful handoff.
+    ExitedBeforeHandoff,
+}
+
+impl DetachedHandoffState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Pending => "pending",
+            Self::ExitedBeforeHandoff => "exited_before_handoff",
+        }
+    }
+}
+
+fn handoff_timeout() -> Duration {
+    let millis = std::env::var(HANDOFF_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_HANDOFF_TIMEOUT_MS);
+    Duration::from_millis(millis)
+}
+
+/// Poll durable state until the detached cook is addressable, it dies, or the
+/// bound elapses. A launcher that returned before the record existed would hand
+/// back an id that `agent-task status` cannot yet resolve.
+///
+/// Liveness is read from the child handle rather than from the pid. The
+/// detached cook is still this process's direct child until this process exits,
+/// so an early exit leaves a zombie that a pid probe reports as running on
+/// platforms without a `/proc` state check — which would turn a cook that died
+/// on startup into an indefinite "pending" handoff.
+fn await_durable_handoff(
+    cook_id: &str,
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> DetachedCookHandoff {
+    let started = Instant::now();
+    loop {
+        if agent_task_lifecycle::cook_index_exists(cook_id).unwrap_or(false) {
+            let run_id = agent_task_lifecycle::cook_index(cook_id)
+                .ok()
+                .map(|index| index.latest_run_id);
+            return DetachedCookHandoff {
+                state: DetachedHandoffState::Accepted,
+                run_id,
+                waited_ms: started.elapsed().as_millis() as u64,
+            };
+        }
+        if matches!(child.try_wait(), Ok(Some(_)) | Err(_)) {
+            return DetachedCookHandoff {
+                state: DetachedHandoffState::ExitedBeforeHandoff,
+                run_id: None,
+                waited_ms: started.elapsed().as_millis() as u64,
+            };
+        }
+        if started.elapsed() >= timeout {
+            return DetachedCookHandoff {
+                state: DetachedHandoffState::Pending,
+                run_id: None,
+                waited_ms: started.elapsed().as_millis() as u64,
+            };
+        }
+        std::thread::sleep(HANDOFF_POLL);
+    }
+}
+
+/// The launcher's only output: a bounded, machine-readable handoff naming the
+/// durable handle and the evidence needed to follow or stop the cook.
+fn handoff_envelope(
+    cook_id: &str,
+    pid: u32,
+    log_path: &Path,
+    handoff: &DetachedCookHandoff,
+) -> Value {
+    json!({
+        "schema": HANDOFF_SCHEMA,
+        "placement": "local",
+        "detached": true,
+        "cook_id": cook_id,
+        "run_id": handoff.run_id,
+        "pid": pid,
+        "launcher_log": log_path.display().to_string(),
+        "handoff": {
+            "state": handoff.state.as_str(),
+            "waited_ms": handoff.waited_ms,
+        },
+        "status_command": format!("homeboy agent-task status {cook_id}"),
+        "logs_command": format!("homeboy agent-task logs {cook_id}"),
+        "cancel_command": format!("homeboy agent-task cancel {cook_id}"),
+        // The detached cook, not this launcher, owns any `--output-file`: it
+        // writes the final Cook report there when the run completes.
+        "output_file_owner": "detached_cook",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn cook_cli(extra: &[&str]) -> (Cli, Vec<String>) {
+        let mut argv = vec!["homeboy"];
+        argv.extend_from_slice(extra);
+        argv.extend_from_slice(&[
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "true",
+        ]);
+        let cli = Cli::try_parse_from(argv.clone()).expect("parse cook invocation");
+        (cli, args(&argv))
+    }
+
+    /// The rejection this replaces was unconditional. Preserving it inside a
+    /// runner-owned execution is the whole reason `runner_side` exists.
+    #[test]
+    fn a_runner_owned_execution_still_refuses_to_detach() {
+        let (cli, normalized) = cook_cli(&["--placement", "local", "--detach-after-handoff"]);
+
+        let error = intercept_local_detached_cook(&cli, &normalized, true)
+            .expect_err("a runner-owned execution cannot detach");
+
+        assert!(
+            error
+                .message
+                .contains("cannot detach after handoff with --placement local"),
+            "{}",
+            error.message
+        );
+        assert!(
+            error.message.contains("runner-owned execution"),
+            "{}",
+            error.message
+        );
+    }
+
+    /// Nothing but a locally-placed, detach-requesting Cook may be intercepted:
+    /// every other invocation has to fall through to normal routing untouched.
+    /// These cases must not spawn anything.
+    #[test]
+    fn only_a_locally_placed_detaching_cook_is_intercepted() {
+        for extra in [
+            vec!["--placement", "local"],
+            vec!["--placement", "local", "--wait"],
+            vec!["--detach-after-handoff"],
+            vec!["--placement", "lab-or-local", "--detach-after-handoff"],
+            vec![],
+        ] {
+            let (cli, normalized) = cook_cli(&extra);
+
+            assert!(!is_local_detached_cook(&cli), "{extra:?}");
+            assert_eq!(
+                intercept_local_detached_cook(&cli, &normalized, false).expect("no interception"),
+                None,
+                "{extra:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_cook_command_is_never_intercepted() {
+        let cli = Cli::try_parse_from(["homeboy", "--placement", "local", "status"])
+            .expect("parse status invocation");
+
+        assert!(!is_local_detached_cook(&cli));
+    }
+
+    #[test]
+    fn child_args_drop_the_detach_request_and_pin_a_generated_cook_id() {
+        let normalized = args(&[
+            "homeboy",
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "fix it",
+        ]);
+
+        let child = detached_cook_child_args(&normalized, "cook-generated", false);
+
+        assert_eq!(
+            child,
+            args(&[
+                "--placement",
+                "local",
+                "agent-task",
+                "cook",
+                "--prompt",
+                "fix it",
+                "--run-id",
+                "cook-generated",
+            ])
+        );
+    }
+
+    #[test]
+    fn child_args_preserve_an_explicit_cook_id_without_duplicating_it() {
+        let normalized = args(&[
+            "homeboy",
+            "--detach-after-handoff",
+            "--placement",
+            "local",
+            "agent-task",
+            "cook",
+            "--run-id",
+            "cook-explicit",
+            "--prompt",
+            "fix it",
+        ]);
+
+        let child = detached_cook_child_args(&normalized, "cook-explicit", true);
+
+        assert_eq!(
+            child.iter().filter(|arg| *arg == "--run-id").count(),
+            1,
+            "{child:?}"
+        );
+        assert!(
+            !child.iter().any(|arg| arg == "--detach-after-handoff"),
+            "{child:?}"
+        );
+        assert_eq!(child.last().map(String::as_str), Some("fix it"));
+    }
+
+    /// The re-executed cook must be the requested cook. Anything the launcher
+    /// silently drops is work the operator asked for and did not get.
+    #[test]
+    fn child_args_preserve_every_other_flag_verbatim() {
+        let normalized = args(&[
+            "homeboy",
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "--allow-dirty-lab-workspace",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "true",
+            "--max-attempts",
+            "5",
+            "--no-finalize",
+        ]);
+
+        let child = detached_cook_child_args(&normalized, "cook-generated", false);
+
+        for expected in [
+            "--allow-dirty-lab-workspace",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "--max-attempts",
+            "5",
+            "--no-finalize",
+        ] {
+            assert!(child.iter().any(|arg| arg == expected), "{child:?}");
+        }
+    }
+
+    /// A detached child's stdin is closed, and the piped bytes live only in the
+    /// launcher's pipe. Losing them would strand the cook on an empty prompt.
+    #[test]
+    fn stdin_prompt_is_captured_verbatim_for_the_detached_cook() {
+        let session = tempfile::tempdir().expect("session root");
+        let mut child = args(&["agent-task", "cook", "--prompt", "-"]);
+        let piped = "fix `$THING`\n\nwith a trailing newline\n";
+
+        let path = materialize_prompt_from(
+            &mut child,
+            session.path(),
+            &mut std::io::Cursor::new(piped.as_bytes()),
+        )
+        .expect("materialize stdin prompt")
+        .expect("a stdin prompt was present");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("prompt file"), piped);
+        assert_eq!(child.last(), Some(&format!("@{}", path.display())));
+    }
+
+    #[test]
+    fn a_prompt_that_is_not_stdin_is_left_alone() {
+        let session = tempfile::tempdir().expect("session root");
+        let mut child = args(&["agent-task", "cook", "--prompt", "@task.md"]);
+
+        let rewritten = materialize_prompt_from(
+            &mut child,
+            session.path(),
+            &mut std::io::Cursor::new(b"unused".as_slice()),
+        )
+        .expect("inspect prompt");
+
+        assert_eq!(rewritten, None);
+        assert_eq!(child.last().map(String::as_str), Some("@task.md"));
+    }
+
+    /// A literal `-` that is the value of some other option is not a prompt.
+    #[test]
+    fn only_the_prompt_option_claims_a_stdin_marker() {
+        assert_eq!(
+            stdin_prompt_index(&args(&["--base", "-", "--prompt", "@task.md"])),
+            None
+        );
+        assert_eq!(
+            stdin_prompt_index(&args(&["--prompt", "-", "--no-finalize"])),
+            Some(1)
+        );
+        assert_eq!(
+            stdin_prompt_index(&args(&["--prompt=-", "--no-finalize"])),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn an_attached_stdin_prompt_keeps_its_option_when_rewritten() {
+        let session = tempfile::tempdir().expect("session root");
+        let mut child = args(&["agent-task", "cook", "--prompt=-", "--no-finalize"]);
+
+        let path = materialize_prompt_from(
+            &mut child,
+            session.path(),
+            &mut std::io::Cursor::new(b"piped".as_slice()),
+        )
+        .expect("materialize stdin prompt")
+        .expect("a stdin prompt was present");
+
+        assert_eq!(child[2], format!("--prompt=@{}", path.display()));
+    }
+
+    #[test]
+    fn an_accepted_handoff_reports_the_addressable_ids_and_follow_up_commands() {
+        let handoff = DetachedCookHandoff {
+            state: DetachedHandoffState::Accepted,
+            run_id: Some("cook-11476-attempt-1-ab12cd34".to_string()),
+            waited_ms: 240,
+        };
+
+        let envelope = handoff_envelope(
+            "cook-11476",
+            4242,
+            Path::new("/data/agent-task-detached/cook-11476/cook.log"),
+            &handoff,
+        );
+
+        assert_eq!(envelope["schema"], HANDOFF_SCHEMA);
+        assert_eq!(envelope["placement"], "local");
+        assert_eq!(envelope["detached"], true);
+        assert_eq!(envelope["cook_id"], "cook-11476");
+        assert_eq!(envelope["run_id"], "cook-11476-attempt-1-ab12cd34");
+        assert_eq!(envelope["pid"], 4242);
+        assert_eq!(envelope["handoff"]["state"], "accepted");
+        assert_eq!(
+            envelope["status_command"],
+            "homeboy agent-task status cook-11476"
+        );
+        assert_eq!(
+            envelope["cancel_command"],
+            "homeboy agent-task cancel cook-11476"
+        );
+    }
+
+    /// A launcher that dressed an unproven handoff as an accepted one would
+    /// reproduce the exact dishonesty this change exists to remove.
+    #[test]
+    fn an_unproven_handoff_is_reported_as_such() {
+        for (state, expected) in [
+            (DetachedHandoffState::Pending, "pending"),
+            (
+                DetachedHandoffState::ExitedBeforeHandoff,
+                "exited_before_handoff",
+            ),
+        ] {
+            let handoff = DetachedCookHandoff {
+                state,
+                run_id: None,
+                waited_ms: 30_000,
+            };
+
+            let envelope =
+                handoff_envelope("cook-11476", 4242, Path::new("/tmp/cook.log"), &handoff);
+
+            assert_eq!(envelope["handoff"]["state"], expected);
+            assert_eq!(envelope["run_id"], Value::Null);
+            assert_eq!(envelope["launcher_log"], "/tmp/cook.log");
+        }
+    }
+
+    #[test]
+    fn a_dead_detached_process_is_never_reported_as_an_accepted_handoff() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut child = Command::new("sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+                .expect("spawn a child that exits immediately");
+
+            let handoff = await_durable_handoff(
+                "cook-never-submitted",
+                &mut child,
+                std::time::Duration::from_millis(5_000),
+            );
+
+            assert_eq!(handoff.state, DetachedHandoffState::ExitedBeforeHandoff);
+            assert_eq!(handoff.run_id, None);
+        });
+    }
+}

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -2339,24 +2339,9 @@ fn spawn_and_wait_for_lease_attempt(
 
 /// Keep the daemon and its workload children alive when a transient launcher
 /// connection, such as direct SSH, disconnects.
-#[cfg(unix)]
 fn detach_from_launcher_session(command: &mut Command) {
-    use std::os::unix::process::CommandExt;
-
-    // SAFETY: `pre_exec` runs in the child immediately before exec. `setsid`
-    // only changes that child process's session and reports failure via errno.
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
+    crate::process::detach_from_caller_session(command);
 }
-
-#[cfg(not(unix))]
-fn detach_from_launcher_session(_command: &mut Command) {}
 
 /// Resolve the daemon base URL, falling back to the running daemon's address.
 fn resolve_daemon_url(daemon_url: Option<String>) -> Result<String> {

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -140,6 +140,45 @@ impl ProcessStep {
     }
 }
 
+/// Detach a child from the caller's session and process group before it execs.
+///
+/// A process that shares its launcher's process group dies with it: the shell,
+/// agent harness, or SSH session that terminates the launcher signals the whole
+/// group. Work that a caller was told is durable and independently observable
+/// must not inherit that fate, so the child leads its own session.
+///
+/// `setsid` fails with `EPERM` when the child is already a process-group
+/// leader — which is exactly what [`ProcessContainment::prepare`] arranges via
+/// `process_group(0)`. That is not a failure of intent: the child is already
+/// outside the caller's group, which is the property this exists to guarantee.
+/// Treating it as success is what lets containment and detachment compose on
+/// the same command instead of fighting over who calls `setpgid` first.
+#[cfg(unix)]
+pub fn detach_from_caller_session(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: `pre_exec` runs in the forked child immediately before exec.
+    // `setsid` only changes that child process's session and reports failure
+    // through errno; it allocates nothing and touches no shared state.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::EPERM) {
+                    // Already a process-group leader, so already detached from
+                    // the caller's group. Nothing left to guarantee.
+                    return Ok(());
+                }
+                return Err(error);
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+pub fn detach_from_caller_session(_command: &mut Command) {}
+
 pub fn pid_is_running(pid: u32) -> bool {
     if pid > i32::MAX as u32 {
         return false;
@@ -1366,6 +1405,74 @@ mod process_tree_tests {
 
         let _ = reaper.join();
         assert!(!pid_is_running(pid));
+    }
+
+    fn process_group_of(pid: u32) -> libc::pid_t {
+        // SAFETY: `getpgid` reads kernel state for a pid and reports failure
+        // through its return value; it mutates nothing in this process.
+        unsafe { libc::getpgid(pid as libc::pid_t) }
+    }
+
+    /// The behaviour a detached launch has to escape: a plain child shares its
+    /// launcher's process group, so whatever signals the group — a shell, an
+    /// agent harness enforcing a command timeout, a closing SSH session — takes
+    /// the child with it.
+    #[test]
+    fn a_plain_child_shares_the_caller_process_group() {
+        let child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn attached child");
+        let pid = child.id();
+        let child_group = process_group_of(pid);
+        let caller_group = process_group_of(std::process::id());
+        let reaper = reap_in_background(child);
+
+        let _ = terminate_process_tree(pid);
+        let _ = reaper.join();
+
+        assert_eq!(child_group, caller_group);
+    }
+
+    #[test]
+    fn a_detached_child_leads_its_own_session() {
+        let mut command = Command::new("sleep");
+        command.arg("30");
+        detach_from_caller_session(&mut command);
+        let child = command.spawn().expect("spawn detached child");
+        let pid = child.id();
+        let child_group = process_group_of(pid);
+        let caller_group = process_group_of(std::process::id());
+        let reaper = reap_in_background(child);
+
+        let _ = terminate_process_tree(pid);
+        let _ = reaper.join();
+
+        assert_ne!(child_group, caller_group);
+        assert_eq!(child_group, pid as libc::pid_t);
+    }
+
+    /// Containment (children die with their owner) and detachment (the owner
+    /// survives its launcher) are complementary, and a single command can carry
+    /// both. `setsid` refuses for a process that `process_group(0)` already made
+    /// a group leader, so the tolerated `EPERM` is what keeps the pair from
+    /// turning into a spawn failure.
+    #[test]
+    fn detachment_composes_with_process_group_containment() {
+        let mut command = Command::new("sleep");
+        command.arg("30");
+        let _containment = ProcessContainment::prepare(&mut command).expect("prepare containment");
+        detach_from_caller_session(&mut command);
+        let child = command.spawn().expect("spawn contained detached child");
+        let pid = child.id();
+        let child_group = process_group_of(pid);
+        let caller_group = process_group_of(std::process::id());
+        let reaper = reap_in_background(child);
+
+        let _ = terminate_process_tree(pid);
+        let _ = reaper.join();
+
+        assert_ne!(child_group, caller_group);
     }
 
     #[test]

--- a/docs/reference/cli/commands/agent-task.md
+++ b/docs/reference/cli/commands/agent-task.md
@@ -95,7 +95,7 @@ WAIT POLICY: Cook always persists a durable run id before materialization, so a 
 
 `--wait` observes until the lifecycle is terminal and returns the terminal Cook report. This is the default when neither flag is passed.
 
-`--detach-after-handoff` returns once the run is durably accepted. Its result describes a submission, not an outcome.
+`--detach-after-handoff` returns once the run is durably accepted. Its result describes a submission, not an outcome. It is honored on every placement: with `--placement local` the Cook is re-executed in its own session, so it survives a client that is interrupted or times out.
 
 Do not infer the wait policy from client interactivity. An orchestration client that needs one predictable contract should pass the flag rather than rely on the default, and read the terminal outcome from `agent-task status <run-id>` in either case.
 

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -4,8 +4,9 @@ use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary
 
 /// Run the fixture binary through the shared hermetic harness.
 ///
-/// Every case in this file asserts that a contradictory invocation is rejected
-/// during argument validation, *before* any worktree or provider resolution.
+/// Every case in this file asserts what an invocation settles *before* any
+/// worktree or provider resolution: a contradictory combination is rejected,
+/// and a locally-detached Cook is handed off (#11476).
 ///
 /// `HermeticTestContext::command` owns the complete isolation contract — HOME,
 /// XDG config and data roots, artifact root, runtime and temp dirs — and strips
@@ -78,6 +79,11 @@ fn contradictory_cook_arguments_survive_controller_transport_context() {
         bounded_output(command)
     };
 
+    // Local detach is served on a controller (#11476), but not here: this
+    // process IS the runner's owned execution of one attempt. It has no
+    // controller lifecycle to hand off, so detaching would orphan work the
+    // runner believes it owns. The rejection must still land before any
+    // worktree or provider resolution.
     let detach = cook(&[
         "--placement",
         "local",
@@ -94,7 +100,9 @@ fn contradictory_cook_arguments_survive_controller_transport_context() {
     assert!(!detach.status.success());
     let detach_stdout = String::from_utf8_lossy(&detach.stdout);
     assert!(
-        detach_stdout.contains("cannot detach after handoff with --placement local"),
+        detach_stdout.contains(
+            "cannot detach after handoff with --placement local inside a runner-owned execution"
+        ),
         "{detach_stdout}"
     );
     assert!(
@@ -154,26 +162,76 @@ fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
     assert!(!stderr.contains("worktree provider"));
 }
 
+/// `--placement local --detach-after-handoff` is served, not rejected (#11476).
+///
+/// The launcher hands the Cook to a process in its own session and returns a
+/// bounded handoff naming the durable handle. It performs no worktree or
+/// provider resolution itself — that belongs to the detached cook — so this
+/// still asserts the fast, work-free return the old rejection guaranteed.
 #[test]
-fn cook_rejects_local_detach_before_worktree_resolution() {
-    let output = homeboy(&[
-        "--placement",
-        "local",
-        "--detach-after-handoff",
-        "agent-task",
-        "cook",
-        "--prompt",
-        "implement the fix",
-        "--to-worktree",
-        "missing@worktree",
-        "--verify",
-        "true",
-    ]);
+fn cook_detaches_local_placement_instead_of_rejecting_it() {
+    let context = HermeticTestContext::new();
+    let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    command
+        // Bound the launcher's wait so an unresolvable destination reports an
+        // honest handoff state promptly instead of holding the default budget.
+        .env("HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS", "5000")
+        .args([
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+        ]);
+    let output = bounded_output(command);
 
-    assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("cannot detach after handoff with --placement local"));
-    assert!(!stdout.contains("worktree provider"));
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        !stdout.contains("cannot detach after handoff with --placement local"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("worktree provider"), "{stdout}");
+
+    // The envelope is the last thing the launcher writes, so parse from the
+    // first object brace rather than assuming stdout holds nothing else.
+    let envelope_start = stdout
+        .find('{')
+        .unwrap_or_else(|| panic!("handoff envelope is present\n{stdout}"));
+    let envelope: serde_json::Value = serde_json::from_str(stdout[envelope_start..].trim())
+        .unwrap_or_else(|error| panic!("handoff envelope is JSON: {error}\n{stdout}"));
+    assert_eq!(
+        envelope["schema"], "homeboy/agent-task-cook-local-detach-handoff/v1",
+        "{stdout}"
+    );
+    assert_eq!(envelope["placement"], "local", "{stdout}");
+    assert_eq!(envelope["detached"], true, "{stdout}");
+    let cook_id = envelope["cook_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("handoff names a cook id\n{stdout}"));
+    assert!(!cook_id.is_empty(), "{stdout}");
+    assert_eq!(
+        envelope["status_command"],
+        format!("homeboy agent-task status {cook_id}"),
+        "{stdout}"
+    );
+    let pid = envelope["pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("handoff names the detached pid\n{stdout}"));
+    assert!(pid > 0, "{stdout}");
+
+    // Never leave a detached process behind a test. An unresolvable destination
+    // normally kills it well before this, so this is belt-and-braces cleanup.
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #11476 for the single-Cook local path. Partial by design — see "What this does not do".

## The problem

`--placement local --detach-after-handoff` was rejected outright, so on a controller with no connected Lab runner the only option was `--wait`. When the launching client hit its command timeout, the cook died with it — `local_provider_ownership.state: "owner_dead"`, `queue_visibility: "cancelled"`, `liveness: "terminal"` — *after* Cook had already printed:

> cook: durable run id `agent-task-…` — persisted before materialization.

Cook's help presents that id as what makes a cook observable and recoverable independently of the caller. On local placement it was only ever good for reading a tombstone. The documented workaround (`--placement lab`) does not exist on a controller with no runner, so there was no configuration in which a Cook could survive its launcher.

## What changed

**Option 2 from the issue**, implemented at the launcher rather than at the provider child.

`crates/homeboy-cli/src/commands/infra/route/local_detach.rs` (new) intercepts a locally-placed, detach-requesting Cook and re-executes the caller's own argv through `setsid`: its own session, `stdin` closed, stdio to a per-cook log under `<data>/agent-task-detached/<cook-id>/cook.log`. It then returns a bounded handoff envelope (`homeboy/agent-task-cook-local-detach-handoff/v1`) naming the cook id, the detached pid, the log path, and the status/logs/cancel commands.

Details worth calling out:

- **The handle is the cook id, not the attempt run id.** `cook_attempt_run_id` appends a random suffix, so the launcher cannot predict it. It pins `--run-id <cook-id>` on the child argv instead (respecting an explicit one), waits for the durable cook index to appear, and then reports the resolved `run_id` too.
- **The wait is bounded and honest.** Default 30s, overridable with `HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS`. It resolves early on either durable submission or child death, and reports `accepted` / `pending` / `exited_before_handoff` rather than dressing an unproven handoff as an accepted one. Liveness is read from the `Child` handle, not a pid probe, so an early exit is not misread as "still running" via the zombie.
- **The rejection survives where it was ever true.** Inside a runner-owned execution (Lab offload subprocess, managed-runner placement, runner-resident), the runner already owns the attempt and there is no controller lifecycle to hand off. That path now returns a message naming the actual reason instead of the old (incorrect) "no runner daemon owns the provider attempt".
- **A piped `--prompt -` is captured to a file and rewritten** before handoff, since the detached child's stdin is closed. Both `--prompt -` and `--prompt=-` spellings.
- **The re-executed argv is otherwise byte-identical**, minus the consumed `--detach-after-handoff`. `--output-file` stays with the detached cook, which writes the final report there on completion; the launcher only prints the envelope to stdout.

`homeboy_core::process::detach_from_caller_session` is the shared `setsid` primitive, replacing the private copy in `daemon/control.rs`.

## Interaction with #11477 (please read — a sibling agent is touching `command_runner.rs`)

These are complementary and there is **no file overlap**: #11477 works in `agent_task_provider/command_runner.rs` and `agent_task_gate_executor.rs`; this PR does not touch either.

- #11477 makes provider children **die with the cook** (`ControllerChildGuard` / process-group containment).
- This PR makes the cook **survive its launcher**.

Composed: client dies → the detached cook keeps running (own session) → its provider children keep running because their containment owner is alive → cancelling or killing the cook still reaps the whole provider tree. The durable run genuinely owns the work in both directions.

The one way they could have fought is mechanical, and it is handled here: `ProcessContainment::prepare` calls `process_group(0)`, which makes the child a process-group leader, and `setsid` returns `EPERM` for a group leader. `detach_from_caller_session` treats `EPERM` as success — the child is already outside the caller's group, which is the only property detachment needs — so both can be applied to the same `Command` without a spawn failure. `detachment_composes_with_process_group_containment` pins exactly that.

## Tests

- `crates/homeboy-core/src/process.rs`: `a_plain_child_shares_the_caller_process_group` (the bug), `a_detached_child_leads_its_own_session` (the fix), `detachment_composes_with_process_group_containment` (the #11477 interaction). Real processes, real `getpgid`.
- `local_detach.rs` unit tests: argv rewriting (drop detach, pin/preserve cook id, preserve everything else verbatim), stdin-prompt capture for both spellings, envelope shape for accepted vs unproven handoffs, the runner-side rejection, and the negative set that must not be intercepted.
- `tests/cook_lab_handoff_test.rs`: `cook_rejects_local_detach_before_worktree_resolution` is **rewritten**, not removed, into `cook_detaches_local_placement_instead_of_rejecting_it` — it now asserts the handoff envelope and still asserts the launcher does no worktree/provider resolution. The runner-side case in `contradictory_cook_arguments_survive_controller_transport_context` is tightened to the new message. No test was deleted or `#[ignore]`d.

## What this does not do

- **Fanout** (#10906) is untouched. `agent-task fanout cook-batch --run-plan` has its own coordinator and its own detach semantics.
- **Option 1 (hand the attempt to the local daemon)** is not implemented. This is deliberate: option 2 makes the durable run id honest on *every* placement, whereas daemon ownership would only fix the local case and would need a new admission path for controller-owned Cook lifecycles. If the daemon should own local Cooks, that is a separate design change on top of this one.
- **`agent-task status --wait` as a re-attach mode** (the second half of the issue's option 2) is not implemented. Detach and status are both usable now; making `--wait` purely an observation mode that can be re-attached is a follow-up.
- The launcher pays `preflight_hot_command` and the controller-runtime seal, and the detached child pays the preflight again. Harmless duplication, not optimized here.

## Compilation

**I could not compile locally.** This VPS runs several agents in parallel and a cargo build OOMs the machine, so per repo policy I ran `cargo fmt` only and pushed for CI to gate. The changes are reasoned from source: `Cli`/`Commands` pattern shapes and `cook.dispatch.run_id` follow existing `route.rs` call sites, `cook_index_exists`/`cook_index` are `pub` in `agent_task_lifecycle`, and `paths::homeboy_data`/`sanitize_path_segment`, `tempfile`, `libc`, and `serde_json` are all already available to the crates that use them here. The likeliest CI findings are import or trait-bound nits in the new test module, not design.

## Reviewer note

`reject_contradictory_cook_arguments` kept its "only place this rejection lives" contract; the local-detach verdict moved out of it because it is no longer a contradiction. The interception is evaluated before the runner-side bail-out on purpose — the request needs a verdict in both contexts, and letting it fall through to normal routing would silently ignore a flag the operator passed.
