### PR TITLE
fix(tests): migrate cook progress fixtures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6952,9 +6952,9 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
         let expected_run_id = run_id.clone();
         let observer_calls = Arc::new(AtomicUsize::new(0));
         let observed = Arc::clone(&observer_calls);
-        let observer = move |phase: &str, _: &str, _: &str| {
+        let observer = move |event: &CookProgressEvent<'_>| {
             observed.fetch_add(1, Ordering::SeqCst);
-            if phase == "promotion" {
+            if event.phase == "promotion" {
                 return Err(Error::internal_io(
                     "Broken pipe (os error 32)",
                     Some("write submitting client stdout".to_string()),

--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -796,7 +796,7 @@ mod tests {
         let lease =
             CookOutputLease::claim(path.to_str().expect("utf8 path")).expect("claim output");
         lease
-            .progress("in_flight", Some("cook-current"), Some("run-current"))
+            .progress("in_flight", Some("cook-current"), Some("run-current"), None)
             .expect("record current durable run");
         let in_flight: Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
@@ -839,7 +839,7 @@ mod tests {
         assert!(preparing.get("recovery").is_none());
 
         lease
-            .progress("in_flight", Some("cook-durable"), Some("run-durable"))
+            .progress("in_flight", Some("cook-durable"), Some("run-durable"), None)
             .unwrap();
         let durable: Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
@@ -868,7 +868,7 @@ mod tests {
         let path = dir.path().join("cook.json");
         let lease = CookOutputLease::claim(path.to_str().expect("utf8 path")).expect("claim");
         lease
-            .progress("in_flight", Some("cook-a"), Some("run-a"))
+            .progress("in_flight", Some("cook-a"), Some("run-a"), None)
             .unwrap();
         let before = std::fs::read(&path).expect("read active output");
 


### PR DESCRIPTION
## Summary

- migrate the stale broken-pipe observer fixture to `CookProgressEvent`
- pass the new optional activity argument in three output-runtime fixtures
- preserve existing promotion disconnect and durable output assertions

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finalization`
- `cargo test -p homeboy-cli commands::infra::output_runtime::tests` (17 passed)
- `cargo check --workspace --tests --locked`
- `git diff --check`

Closes #11498

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the stale post-#11492 test fixtures, applied the minimal API migrations, and ran the verification above. Chris Huber reviewed and remains responsible for the change.