### PR TITLE
feat(agent-task): layer capability requirements

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -274,9 +274,19 @@ pub struct PreparedLabRunnerCapability {
 
 impl From<PreparedLabRunnerCapability> for RunnerCapabilityPreflight {
     fn from(plan: PreparedLabRunnerCapability) -> Self {
+        let mut required_tools = plan.required_tools;
+        // Capability labels are runner-owned admission requirements. Preserve
+        // them as probeable tool IDs at the execution boundary so reservation
+        // revalidates the same decision that placement made.
+        for capability in plan.required_capabilities {
+            let tool = RunnerRequiredTool::new(capability);
+            if !required_tools.contains(&tool) {
+                required_tools.push(tool);
+            }
+        }
         Self {
             command: plan.command.to_string(),
-            required_tools: plan.required_tools,
+            required_tools,
             required_commands: Vec::new(),
             required_tool_capabilities: Vec::new(),
             required_toolchain_probes: Vec::new(),

--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -274,19 +274,9 @@ pub struct PreparedLabRunnerCapability {
 
 impl From<PreparedLabRunnerCapability> for RunnerCapabilityPreflight {
     fn from(plan: PreparedLabRunnerCapability) -> Self {
-        let mut required_tools = plan.required_tools;
-        // Capability labels are runner-owned admission requirements. Preserve
-        // them as probeable tool IDs at the execution boundary so reservation
-        // revalidates the same decision that placement made.
-        for capability in plan.required_capabilities {
-            let tool = RunnerRequiredTool::new(capability);
-            if !required_tools.contains(&tool) {
-                required_tools.push(tool);
-            }
-        }
         Self {
             command: plan.command.to_string(),
-            required_tools,
+            required_tools: plan.required_tools,
             required_commands: Vec::new(),
             required_tool_capabilities: Vec::new(),
             required_toolchain_probes: Vec::new(),

--- a/crates/homeboy-agents/src/agent_task.rs
+++ b/crates/homeboy-agents/src/agent_task.rs
@@ -32,6 +32,7 @@ pub use artifacts::{
     AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskDiagnostic, AgentTaskEvidenceRef,
     AgentTaskFollowUp, AgentTaskTypedArtifact,
 };
+pub(crate) use capabilities::ready_attached_tools_from_metadata;
 pub use capabilities::{
     AgentTaskAttachedToolCapability, AgentTaskCapabilityEvidence, AgentTaskCapabilityRequirements,
     AgentTaskToolCapabilityContribution, AGENT_TASK_CAPABILITY_EVIDENCE_SCHEMA,

--- a/crates/homeboy-agents/src/agent_task.rs
+++ b/crates/homeboy-agents/src/agent_task.rs
@@ -10,8 +10,8 @@ pub use super::agent_task_fanout::{
 
 mod artifacts;
 pub mod bench_matrix_provider;
-mod command_policy;
 mod capabilities;
+mod command_policy;
 mod executor;
 mod matrix;
 mod outcome;
@@ -32,15 +32,15 @@ pub use artifacts::{
     AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskDiagnostic, AgentTaskEvidenceRef,
     AgentTaskFollowUp, AgentTaskTypedArtifact,
 };
-pub use command_policy::{
-    AgentCommandDecision, AgentCommandDenial, AgentCommandPolicy, AgentCommandPolicyMode,
-    AgentCommandRule, AGENT_COMMAND_POLICY_SCHEMA, COMMAND_DENIAL_REMEDIATION,
-    DEFAULT_COMMAND_DENIAL_REASON,
-};
 pub use capabilities::{
     AgentTaskAttachedToolCapability, AgentTaskCapabilityEvidence, AgentTaskCapabilityRequirements,
     AgentTaskToolCapabilityContribution, AGENT_TASK_CAPABILITY_EVIDENCE_SCHEMA,
     AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA,
+};
+pub use command_policy::{
+    AgentCommandDecision, AgentCommandDenial, AgentCommandPolicy, AgentCommandPolicyMode,
+    AgentCommandRule, AGENT_COMMAND_POLICY_SCHEMA, COMMAND_DENIAL_REMEDIATION,
+    DEFAULT_COMMAND_DENIAL_REASON,
 };
 pub use executor::{
     AgentTaskAttemptWorkspace, AgentTaskCandidateAdoption, AgentTaskExecutor,

--- a/crates/homeboy-agents/src/agent_task.rs
+++ b/crates/homeboy-agents/src/agent_task.rs
@@ -11,6 +11,7 @@ pub use super::agent_task_fanout::{
 mod artifacts;
 pub mod bench_matrix_provider;
 mod command_policy;
+mod capabilities;
 mod executor;
 mod matrix;
 mod outcome;
@@ -35,6 +36,11 @@ pub use command_policy::{
     AgentCommandDecision, AgentCommandDenial, AgentCommandPolicy, AgentCommandPolicyMode,
     AgentCommandRule, AGENT_COMMAND_POLICY_SCHEMA, COMMAND_DENIAL_REMEDIATION,
     DEFAULT_COMMAND_DENIAL_REASON,
+};
+pub use capabilities::{
+    AgentTaskAttachedToolCapability, AgentTaskCapabilityEvidence, AgentTaskCapabilityRequirements,
+    AgentTaskToolCapabilityContribution, AGENT_TASK_CAPABILITY_EVIDENCE_SCHEMA,
+    AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA,
 };
 pub use executor::{
     AgentTaskAttemptWorkspace, AgentTaskCandidateAdoption, AgentTaskExecutor,

--- a/crates/homeboy-agents/src/agent_task/capabilities.rs
+++ b/crates/homeboy-agents/src/agent_task/capabilities.rs
@@ -127,6 +127,35 @@ impl AgentTaskCapabilityRequirements {
     }
 }
 
+/// Readiness is produced by the runtime-tool owner. This intentionally accepts
+/// a compact, provider-neutral metadata projection until #11511's typed runtime
+/// tool contract is available to this crate.
+pub fn ready_attached_tools_from_metadata(metadata: &Value) -> BTreeSet<String> {
+    let Some(readiness) = metadata.get("attached_tool_readiness") else {
+        return BTreeSet::new();
+    };
+    match readiness {
+        Value::Object(entries) => entries
+            .iter()
+            .filter_map(|(id, value)| {
+                (value == "ready" || value.get("state").and_then(Value::as_str) == Some("ready"))
+                    .then(|| id.trim().to_string())
+            })
+            .filter(|id| !id.is_empty())
+            .collect(),
+        Value::Array(entries) => entries
+            .iter()
+            .filter_map(|value| {
+                let id = value.get("id").and_then(Value::as_str)?.trim();
+                (value.get("state").and_then(Value::as_str) == Some("ready"))
+                    .then(|| id.to_string())
+            })
+            .filter(|id| !id.is_empty())
+            .collect(),
+        _ => BTreeSet::new(),
+    }
+}
+
 pub fn requirements_from_metadata(
     metadata: &Value,
     legacy_provider: &[String],
@@ -201,5 +230,16 @@ mod tests {
         );
         assert_eq!(ready.tool_contributed[0].readiness, "ready");
         assert!(ready.resolved.contains(&"browser_control".to_string()));
+    }
+
+    #[test]
+    fn persisted_runtime_tool_readiness_contributes_only_ready_tools() {
+        let ready = ready_attached_tools_from_metadata(&json!({
+            "attached_tool_readiness": {
+                "browser": { "state": "ready" },
+                "missing": { "state": "failed" }
+            }
+        }));
+        assert_eq!(ready, ["browser".to_string()].into_iter().collect());
     }
 }

--- a/crates/homeboy-agents/src/agent_task/capabilities.rs
+++ b/crates/homeboy-agents/src/agent_task/capabilities.rs
@@ -1,0 +1,205 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+pub const AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA: &str =
+    "homeboy/agent-task-capability-requirements/v1";
+pub const AGENT_TASK_CAPABILITY_EVIDENCE_SCHEMA: &str = "homeboy/agent-task-capability-evidence/v1";
+
+/// Capability declarations are deliberately split by the actor that can satisfy
+/// them. Provider capabilities cannot be satisfied by a runner or an attached
+/// tool, and runner capabilities cannot be satisfied by a provider.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCapabilityRequirements {
+    #[serde(default = "capability_requirements_schema")]
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runner: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attached_tools: Vec<AgentTaskAttachedToolCapability>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskAttachedToolCapability {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contributes: Vec<String>,
+}
+
+/// Durable evidence is append-only: declarations are requested inputs, while
+/// advertised and contributed values are observations made by their owners.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCapabilityEvidence {
+    #[serde(default = "capability_evidence_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub requested: AgentTaskCapabilityRequirements,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_advertised: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runner_advertised: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_contributed: Vec<AgentTaskToolCapabilityContribution>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolved: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskToolCapabilityContribution {
+    pub tool_id: String,
+    pub capabilities: Vec<String>,
+    pub readiness: String,
+}
+
+impl AgentTaskCapabilityRequirements {
+    pub fn normalized(mut self) -> Self {
+        normalize(&mut self.provider);
+        normalize(&mut self.runner);
+        for tool in &mut self.attached_tools {
+            tool.id = tool.id.trim().to_string();
+            normalize(&mut tool.contributes);
+        }
+        self.attached_tools
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        self.attached_tools
+            .dedup_by(|left, right| left.id == right.id);
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        for (layer, capabilities) in [("provider", &self.provider), ("runner", &self.runner)] {
+            if capabilities
+                .iter()
+                .any(|capability| capability.trim().is_empty())
+            {
+                return Err(format!(
+                    "{layer} capability requirements contain an empty capability"
+                ));
+            }
+        }
+        if self.attached_tools.iter().any(|tool| tool.id.is_empty()) {
+            return Err(
+                "attached tool capability requirements contain an empty tool id".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    pub fn evidence(
+        &self,
+        provider_advertised: impl IntoIterator<Item = String>,
+        runner_advertised: impl IntoIterator<Item = String>,
+        ready_tools: &BTreeSet<String>,
+    ) -> AgentTaskCapabilityEvidence {
+        let requested = self.clone().normalized();
+        let mut provider_advertised = provider_advertised.into_iter().collect::<Vec<_>>();
+        let mut runner_advertised = runner_advertised.into_iter().collect::<Vec<_>>();
+        normalize(&mut provider_advertised);
+        normalize(&mut runner_advertised);
+        let tool_contributed = requested
+            .attached_tools
+            .iter()
+            .filter(|tool| ready_tools.contains(&tool.id))
+            .map(|tool| AgentTaskToolCapabilityContribution {
+                tool_id: tool.id.clone(),
+                capabilities: tool.contributes.clone(),
+                readiness: "ready".to_string(),
+            })
+            .collect::<Vec<_>>();
+        let mut resolved = provider_advertised.clone();
+        resolved.extend(runner_advertised.clone());
+        resolved.extend(
+            tool_contributed
+                .iter()
+                .flat_map(|tool| tool.capabilities.clone()),
+        );
+        normalize(&mut resolved);
+        AgentTaskCapabilityEvidence {
+            schema: capability_evidence_schema(),
+            requested,
+            provider_advertised,
+            runner_advertised,
+            tool_contributed,
+            resolved,
+        }
+    }
+}
+
+pub fn requirements_from_metadata(
+    metadata: &Value,
+    legacy_provider: &[String],
+) -> Result<AgentTaskCapabilityRequirements, String> {
+    let Some(value) = metadata.get("capability_requirements") else {
+        // v1 had one executor-owned field. This is an explicit migration, not a
+        // cross-layer inference: old values remain provider requirements only.
+        return Ok(AgentTaskCapabilityRequirements {
+            schema: AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA.to_string(),
+            provider: legacy_provider.to_vec(),
+            ..Default::default()
+        }
+        .normalized());
+    };
+    let requirements: AgentTaskCapabilityRequirements = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid capability_requirements: {error}"))?;
+    if requirements.schema != AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA {
+        return Err(format!(
+            "unsupported capability requirements schema '{}'",
+            requirements.schema
+        ));
+    }
+    let requirements = requirements.normalized();
+    requirements.validate()?;
+    Ok(requirements)
+}
+
+fn normalize(values: &mut Vec<String>) {
+    values.retain_mut(|value| {
+        *value = value.trim().to_string();
+        !value.is_empty()
+    });
+    values.sort();
+    values.dedup();
+}
+
+fn capability_requirements_schema() -> String {
+    AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA.to_string()
+}
+
+fn capability_evidence_schema() -> String {
+    AGENT_TASK_CAPABILITY_EVIDENCE_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn migrates_v1_executor_requirements_only_to_the_provider_layer() {
+        let requirements = requirements_from_metadata(&Value::Null, &["structured_outcome".into()])
+            .expect("v1 migration");
+        assert_eq!(requirements.provider, ["structured_outcome"]);
+        assert!(requirements.runner.is_empty());
+    }
+
+    #[test]
+    fn only_ready_attached_tools_contribute_capabilities() {
+        let requirements: AgentTaskCapabilityRequirements = serde_json::from_value(json!({
+            "schema": AGENT_TASK_CAPABILITY_REQUIREMENTS_SCHEMA,
+            "runner": ["browser"],
+            "attached_tools": [{ "id": "browser-mcp", "contributes": ["browser_control"] }]
+        }))
+        .expect("requirements");
+        let not_ready = requirements.evidence(Vec::new(), vec!["browser".into()], &BTreeSet::new());
+        assert!(!not_ready.resolved.contains(&"browser_control".to_string()));
+        let ready = requirements.evidence(
+            Vec::new(),
+            vec!["browser".into()],
+            &["browser-mcp".to_string()].into_iter().collect(),
+        );
+        assert_eq!(ready.tool_contributed[0].readiness, "ready");
+        assert!(ready.resolved.contains(&"browser_control".to_string()));
+    }
+}

--- a/crates/homeboy-agents/src/agent_task/request.rs
+++ b/crates/homeboy-agents/src/agent_task/request.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 use super::schema::request_schema;
 use super::{
-    AgentTaskArtifactDeclaration, AgentTaskEvidenceRef, AgentTaskExecutor, AgentTaskLimits,
-    AgentTaskOutcome, AgentTaskPolicy, AgentTaskSourceRef, AgentTaskWorkspace,
+    AgentTaskArtifactDeclaration, AgentTaskCapabilityEvidence, AgentTaskCapabilityRequirements,
+    AgentTaskEvidenceRef, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskPolicy,
+    AgentTaskSourceRef, AgentTaskWorkspace,
 };
 
 /// Provider capability payload used by extension discovery and durable run metadata.
@@ -200,6 +201,20 @@ impl std::ops::Deref for AgentTaskExecutorRequest {
 }
 
 impl AgentTaskRequest {
+    pub fn capability_requirements(&self) -> Result<AgentTaskCapabilityRequirements, String> {
+        super::capabilities::requirements_from_metadata(
+            &self.metadata,
+            &self.executor.required_capabilities,
+        )
+    }
+
+    pub fn record_capability_evidence(&mut self, evidence: AgentTaskCapabilityEvidence) {
+        if !self.metadata.is_object() {
+            self.metadata = Value::Object(Default::default());
+        }
+        self.metadata["capability_evidence"] =
+            serde_json::to_value(evidence).unwrap_or(Value::Null);
+    }
     pub fn canonical_artifact_declarations(&self) -> Vec<AgentTaskArtifactDeclaration> {
         let mut declarations = Vec::new();
         for declaration in &self.artifact_declarations {

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -1,7 +1,6 @@
 use super::command_runner::{failure_outcome, run_materialized_provider_command};
 use super::fixtures::run_fixture_provider;
 use super::*;
-use std::borrow::Cow;
 
 impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
     fn execute(
@@ -37,20 +36,72 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             return run_repo_local_gate_task(&request);
         }
 
+        let requirements = match request.capability_requirements() {
+            Ok(requirements) => requirements,
+            Err(message) => {
+                return failure_outcome(
+                    &request,
+                    AgentTaskOutcomeStatus::Failed,
+                    AgentTaskFailureClassification::CapabilityMissing,
+                    "agent_task.capability_requirements_invalid",
+                    message,
+                    json!({ "layer": "declaration" }),
+                )
+            }
+        };
         let provider = match resolved_provider_from_request(&request) {
-            Ok(Some(provider)) => Cow::Owned(provider),
+            Ok(Some(provider)) => provider,
             Ok(None) => match resolve_provider_for_backend(
-                self.providers(),
+                &self
+                    .providers()
+                    .iter()
+                    .filter(|provider| {
+                        requirements
+                            .provider
+                            .iter()
+                            .all(|capability| provider.capabilities.contains(capability))
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>(),
                 &request.executor.backend,
                 request.executor.selector.as_deref(),
             ) {
-                ProviderResolution::Resolved(provider) => Cow::Borrowed(provider),
+                ProviderResolution::Resolved(provider) => provider.clone(),
                 resolution => {
+                    if self
+                        .providers()
+                        .iter()
+                        .any(|provider| provider.backend == request.executor.backend)
+                        && requirements.provider.iter().any(|capability| {
+                            !self.providers().iter().any(|provider| {
+                                provider.backend == request.executor.backend
+                                    && provider.capabilities.contains(capability)
+                            })
+                        })
+                    {
+                        return failure_outcome(
+                            &request,
+                            AgentTaskOutcomeStatus::Failed,
+                            AgentTaskFailureClassification::CapabilityMissing,
+                            "agent_task.provider_capability_unavailable",
+                            format!(
+                                "no provider for backend '{}' advertises required capabilities: {}",
+                                request.executor.backend,
+                                requirements.provider.join(", ")
+                            ),
+                            json!({
+                                "layer": "provider",
+                                "required_capabilities": requirements.provider,
+                                "candidates": self.providers().iter().filter(|provider| provider.backend == request.executor.backend).map(|provider| json!({ "id": provider.id, "advertised_capabilities": provider.capabilities })).collect::<Vec<_>>(),
+                                "remediation": "Select a provider that advertises every required provider capability or change the provider requirement."
+                            }),
+                        );
+                    }
                     return provider_resolution_failure_outcome(
                         &request,
                         resolution,
                         self.diagnostics(),
-                    )
+                    );
                 }
             },
             Err(message) => {
@@ -65,19 +116,6 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             }
         };
 
-        let requirements = match request.capability_requirements() {
-            Ok(requirements) => requirements,
-            Err(message) => {
-                return failure_outcome(
-                    &request,
-                    AgentTaskOutcomeStatus::Failed,
-                    AgentTaskFailureClassification::CapabilityMissing,
-                    "agent_task.capability_requirements_invalid",
-                    message,
-                    json!({ "layer": "declaration" }),
-                )
-            }
-        };
         let missing_capabilities: Vec<String> = requirements
             .provider
             .iter()
@@ -104,14 +142,15 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             );
         }
 
-        // A provider only records what it owns. Runner admission appends runner
-        // observations and attached-tool contributions after its readiness pass.
+        // Readiness is owned by the attached runtime tool. A declaration alone
+        // cannot contribute capabilities; only its persisted ready observation can.
+        let ready_tools = crate::agent_task::ready_attached_tools_from_metadata(&request.metadata);
         request
             .request
             .record_capability_evidence(requirements.evidence(
                 provider.capabilities.clone(),
                 Vec::new(),
-                &std::collections::BTreeSet::new(),
+                &ready_tools,
             ));
 
         run_materialized_provider_command(&request, &provider, context.run_id.as_deref())

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -9,7 +9,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         request: AgentTaskRequest,
         context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
-        let request = match materialize_executor_request(request, &context) {
+        let mut request = match materialize_executor_request(request, &context) {
             Ok(request) => request,
             Err((request, path, error)) => {
                 return failure_outcome(
@@ -65,9 +65,21 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             }
         };
 
-        let missing_capabilities: Vec<String> = request
-            .executor
-            .required_capabilities
+        let requirements = match request.capability_requirements() {
+            Ok(requirements) => requirements,
+            Err(message) => {
+                return failure_outcome(
+                    &request,
+                    AgentTaskOutcomeStatus::Failed,
+                    AgentTaskFailureClassification::CapabilityMissing,
+                    "agent_task.capability_requirements_invalid",
+                    message,
+                    json!({ "layer": "declaration" }),
+                )
+            }
+        };
+        let missing_capabilities: Vec<String> = requirements
+            .provider
             .iter()
             .filter(|capability| !provider.capabilities.contains(capability))
             .cloned()
@@ -83,9 +95,24 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
                     provider.id,
                     missing_capabilities.join(", ")
                 ),
-                json!({ "provider": provider.id, "missing_capabilities": missing_capabilities }),
+                json!({
+                    "layer": "provider",
+                    "provider": provider.id,
+                    "missing_capabilities": missing_capabilities,
+                    "advertised_capabilities": provider.capabilities,
+                }),
             );
         }
+
+        // A provider only records what it owns. Runner admission appends runner
+        // observations and attached-tool contributions after its readiness pass.
+        request
+            .request
+            .record_capability_evidence(requirements.evidence(
+                provider.capabilities.clone(),
+                Vec::new(),
+                &std::collections::BTreeSet::new(),
+            ));
 
         run_materialized_provider_command(&request, &provider, context.run_id.as_deref())
     }

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -559,8 +559,12 @@ fn evaluate_lab_runner_capabilities(
         .cloned()
         .collect::<Vec<_>>();
     for capability in &plan.required_capabilities {
-        if !capabilities.components.contains(capability.as_str()) {
-            push_unique(&mut missing_tools, RunnerRequiredTool::new(capability));
+        let tool = RunnerRequiredTool::new(capability.trim());
+        if !capability.trim().is_empty()
+            && !capabilities.has_capability(capability)
+            && !missing_tools.contains(&tool)
+        {
+            missing_tools.push(tool);
         }
     }
 
@@ -598,6 +602,14 @@ fn evaluate_lab_runner_capabilities(
         missing_tools,
         reason,
         remediation,
+    }
+}
+
+impl RunnerCapabilitySnapshot {
+    fn has_capability(&self, capability: &str) -> bool {
+        self.tools.iter().any(|tool| tool.id() == capability)
+            || self.components.contains(capability)
+            || self.tool_capabilities.contains(capability)
     }
 }
 
@@ -1004,6 +1016,31 @@ mod tests {
         assert!(remediation
             .iter()
             .any(|item| item.contains("omit --runner")));
+    }
+
+    #[test]
+    fn lab_runner_gate_refuses_a_runner_missing_a_declared_capability() {
+        let plan = PreparedLabRunnerCapability {
+            command: "agent-task",
+            required_tools: vec![RunnerRequiredTool::git()],
+            required_capabilities: vec!["browser".to_string()],
+        };
+        let decision = evaluate_lab_runner_capabilities(
+            "lab",
+            &plan,
+            &RunnerCapabilitySnapshot {
+                tools: [RunnerRequiredTool::git()].into_iter().collect(),
+                commands: BTreeSet::new(),
+                tool_capabilities: BTreeSet::new(),
+                failed_toolchain_probes: HashMap::new(),
+                components: BTreeSet::new(),
+            },
+            LabRunnerGateMode::Explicit,
+        );
+        let LabRunnerGateDecision::Missing { missing_tools, .. } = decision else {
+            panic!("runner without declared capability must be refused");
+        };
+        assert_eq!(missing_tools, vec![RunnerRequiredTool::new("browser")]);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1530,11 +1530,32 @@ pub(crate) fn run_lab_offload_inner(
     )?;
     // Public preflight constructs the same typed routed command before entering
     // this compiler, so no admission requirement can diverge at this boundary.
-    let admission_plan = crate::lab_selection::compile_lab_admission_plan(
+    let mut admission_plan = crate::lab_selection::compile_lab_admission_plan(
         &contract,
         &source_path,
         &command_prefix.required_tools,
     )?;
+    // Durable plan declarations are controller-owned inputs to the same
+    // admission plan, never a replacement routed command or a wrapper-only
+    // preflight. The converted preflight is rechecked before reservation.
+    if let Some(durable_plan) = request.durable_agent_task_plan {
+        for task in &durable_plan.tasks {
+            let requirements = task.capability_requirements().map_err(|message| {
+                Error::validation_invalid_argument(
+                    "capability_requirements",
+                    message,
+                    Some(task.task_id.clone()),
+                    Some(vec!["Use homeboy/agent-task-capability-requirements/v1 with explicit provider, runner, and attached-tool declarations.".to_string()]),
+                )
+            })?;
+            admission_plan
+                .capability
+                .required_capabilities
+                .extend(requirements.runner);
+        }
+    }
+    admission_plan.capability.required_capabilities.sort();
+    admission_plan.capability.required_capabilities.dedup();
     let execution_toolchain = admission_plan.toolchain;
     let capability_plan = Some(admission_plan.capability);
     if let Some(capability_plan) = &capability_plan {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1535,27 +1535,10 @@ pub(crate) fn run_lab_offload_inner(
         &source_path,
         &command_prefix.required_tools,
     )?;
-    // Durable plan declarations are controller-owned inputs to the same
-    // admission plan, never a replacement routed command or a wrapper-only
-    // preflight. The converted preflight is rechecked before reservation.
-    if let Some(durable_plan) = request.durable_agent_task_plan {
-        for task in &durable_plan.tasks {
-            let requirements = task.capability_requirements().map_err(|message| {
-                Error::validation_invalid_argument(
-                    "capability_requirements",
-                    message,
-                    Some(task.task_id.clone()),
-                    Some(vec!["Use homeboy/agent-task-capability-requirements/v1 with explicit provider, runner, and attached-tool declarations.".to_string()]),
-                )
-            })?;
-            admission_plan
-                .capability
-                .required_capabilities
-                .extend(requirements.runner);
-        }
-    }
-    admission_plan.capability.required_capabilities.sort();
-    admission_plan.capability.required_capabilities.dedup();
+    crate::lab_selection::project_durable_agent_task_capabilities(
+        &mut admission_plan,
+        request.durable_agent_task_plan,
+    )?;
     let execution_toolchain = admission_plan.toolchain;
     let capability_plan = Some(admission_plan.capability);
     if let Some(capability_plan) = &capability_plan {

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -73,6 +73,10 @@ pub enum PlacementReadinessInvocation {
     AgentTaskCook {
         provider: String,
         source_path: String,
+        /// Optional serialized durable plan. v2 callers omit this; v3 callers
+        /// let mutation-free preflight compile the same runner requirements as execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        durable_plan: Option<serde_json::Value>,
     },
     CapabilityAudit {
         source_path: String,
@@ -125,13 +129,43 @@ pub fn compile_lab_admission_plan(
     })
 }
 
+/// Add controller-owned durable task requirements to an already routed plan.
+/// This is shared by public preflight and execution, so a ready snapshot cannot
+/// omit a runner capability that execution will later reject.
+pub fn project_durable_agent_task_capabilities(
+    plan: &mut LabAdmissionPlan,
+    durable_plan: Option<&homeboy_agents::agent_task_scheduler::AgentTaskPlan>,
+) -> Result<()> {
+    let Some(durable_plan) = durable_plan else {
+        return Ok(());
+    };
+    for task in &durable_plan.tasks {
+        let requirements = task.capability_requirements().map_err(|message| {
+            Error::validation_invalid_argument(
+                "capability_requirements",
+                message,
+                Some(task.task_id.clone()),
+                Some(vec!["Use homeboy/agent-task-capability-requirements/v1 with explicit provider, runner, and attached-tool declarations.".to_string()]),
+            )
+        })?;
+        plan.capability
+            .required_capabilities
+            .extend(requirements.runner);
+    }
+    plan.capability.required_capabilities.sort();
+    plan.capability.required_capabilities.dedup();
+    Ok(())
+}
+
 fn compile_placement_readiness_plan(
     request: &PlacementReadinessRequest,
 ) -> Result<LabAdmissionPlan> {
-    if request.schema != "homeboy/placement-readiness/v2" {
+    if request.schema != "homeboy/placement-readiness/v2"
+        && request.schema != "homeboy/placement-readiness/v3"
+    {
         return Err(Error::validation_invalid_argument(
             "schema",
-            "placement readiness accepts homeboy/placement-readiness/v2 requests",
+            "placement readiness accepts homeboy/placement-readiness/v2 or v3 requests",
             Some(request.schema.clone()),
             None,
         ));
@@ -143,10 +177,12 @@ fn compile_placement_readiness_plan(
         source_path_inputs,
         required_capabilities,
         extensions,
+        durable_plan,
     ) = match &request.invocation {
         PlacementReadinessInvocation::AgentTaskCook {
             provider,
             source_path,
+            durable_plan,
         } => (
             "agent-task".to_string(),
             "agent-task cook",
@@ -154,6 +190,7 @@ fn compile_placement_readiness_plan(
             vec![source_path.clone()],
             vec!["extension_parity".to_string()],
             vec![provider.clone()],
+            durable_plan.as_ref(),
         ),
         PlacementReadinessInvocation::CapabilityAudit {
             source_path,
@@ -165,6 +202,7 @@ fn compile_placement_readiness_plan(
             vec![source_path.clone()],
             vec![capability_id.clone()],
             Vec::new(),
+            None,
         ),
     };
     if source_path_inputs.iter().any(|path| path.trim().is_empty())
@@ -197,6 +235,18 @@ fn compile_placement_readiness_plan(
         std::path::Path::new(source_path),
         &[super::RunnerRequiredTool::homeboy()],
     )?;
+    let durable_plan = durable_plan
+        .map(|value| serde_json::from_value(value.clone()))
+        .transpose()
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "durable_plan",
+                format!("invalid durable agent-task plan: {error}"),
+                None,
+                None,
+            )
+        })?;
+    project_durable_agent_task_capabilities(&mut plan, durable_plan.as_ref())?;
     // Public preflight is mutation-free: it never invokes extension programs.
     // Execution reuses the same compiled probes through the bounded runner
     // diagnostic transport immediately before dispatch.
@@ -416,6 +466,7 @@ fn admission_identity(
         PlacementReadinessInvocation::AgentTaskCook {
             provider,
             source_path,
+            ..
         } => (
             "agent-task".to_string(),
             "agent-task cook".to_string(),
@@ -1757,6 +1808,55 @@ mod placement_readiness_tests {
     }
 
     #[test]
+    fn v3_durable_plan_projects_the_same_runner_requirements_as_execution() {
+        let durable_plan: homeboy_agents::agent_task_scheduler::AgentTaskPlan =
+            serde_json::from_value(serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "capability-plan",
+                "tasks": [{
+                    "schema": "homeboy/agent-task-request/v1",
+                    "task_id": "task",
+                    "executor": { "backend": "fixture" },
+                    "instructions": "test",
+                    "metadata": {
+                        "capability_requirements": {
+                            "schema": "homeboy/agent-task-capability-requirements/v1",
+                            "runner": ["browser"]
+                        }
+                    }
+                }]
+            }))
+            .expect("durable plan");
+        let routed = homeboy_core::lab_routing::lab_offload_command_from_contract(
+            homeboy_core::lab_contract::LabCommandContract::portable(
+                "audit capability",
+                None,
+                false,
+                &[],
+            )
+            .with_extra_required_capabilities(vec!["extension_parity".to_string()]),
+            Vec::new(),
+        );
+        let mut preflight = compile_lab_admission_plan(
+            &routed,
+            std::path::Path::new("/workspace/source"),
+            &[super::super::RunnerRequiredTool::homeboy()],
+        )
+        .expect("preflight plan");
+        let mut execution = preflight.clone();
+        project_durable_agent_task_capabilities(&mut preflight, Some(&durable_plan))
+            .expect("project preflight requirements");
+        project_durable_agent_task_capabilities(&mut execution, Some(&durable_plan))
+            .expect("project execution requirements");
+
+        assert_eq!(preflight.capability, execution.capability);
+        assert!(preflight
+            .capability
+            .required_capabilities
+            .contains(&"browser".to_string()));
+    }
+
+    #[test]
     fn public_json_cannot_supply_probe_commands_or_capabilities() {
         let request = request();
         let encoded = serde_json::to_value(&request).expect("encode compiled request");
@@ -1780,6 +1880,7 @@ mod placement_readiness_tests {
         request.invocation = PlacementReadinessInvocation::AgentTaskCook {
             provider: " ".to_string(),
             source_path: " ".to_string(),
+            durable_plan: None,
         };
         assert!(compile_placement_readiness_plan(&request).is_err());
     }


### PR DESCRIPTION
Closes #11494\n\nIntroduces versioned, ownership-layered agent-task capability declarations and durable evidence. Legacy executor requirements migrate explicitly to provider requirements; Lab selection and execution preflight enforce runner requirements from durable plans.\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagent; used to implement and verify layered agent-task capabilities. Chris Huber remains responsible for every line.