### PR TITLE
feat(agent-task): attach managed services

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
@@ -17,6 +17,88 @@ use serde_json::Value;
 
 use crate::agent_task_outcome::{AgentTaskFailureClassification, AgentTaskOutcomeStatus};
 
+fn default_managed_service_version() -> u32 {
+    AgentTaskManagedService::VERSION
+}
+
+fn default_managed_service_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+/// A generic process owned by an agent-task plan. Values in `env` are durable
+/// configuration; `secret_env` names inherited environment variables without
+/// serializing their values into a plan or run record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskManagedService {
+    #[serde(default = "default_managed_service_version")]
+    pub version: u32,
+    pub id: String,
+    pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
+    #[serde(default = "default_managed_service_host")]
+    pub host: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<AgentTaskManagedServiceReadiness>,
+    /// An externally provisioned reviewer URL. Homeboy treats this as a
+    /// reference and never assumes a particular tunnel or preview provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+}
+
+impl AgentTaskManagedService {
+    pub const VERSION: u32 = 1;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskManagedServiceReadiness {
+    #[serde(default)]
+    pub kind: AgentTaskManagedServiceReadinessKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskManagedServiceReadinessKind {
+    #[default]
+    Tcp,
+    Http,
+}
+
+#[cfg(test)]
+mod managed_service_contract_tests {
+    use super::*;
+
+    #[test]
+    fn managed_service_is_a_portable_lab_handoff_contract() {
+        let service: AgentTaskManagedService = serde_json::from_value(serde_json::json!({
+            "id": "neutral-http", "command": ["fixture", "--serve"],
+            "port": 8080, "readiness": { "kind": "http", "path": "/ready" },
+            "secret_env": ["FIXTURE_TOKEN"], "public_url": "https://preview.example.test/run"
+        }))
+        .expect("service contract");
+        assert_eq!(service.version, AgentTaskManagedService::VERSION);
+        assert_eq!(service.host, "127.0.0.1");
+        assert_eq!(
+            service.readiness.as_ref().unwrap().kind,
+            AgentTaskManagedServiceReadinessKind::Http
+        );
+        assert!(serde_json::to_value(&service)
+            .expect("serialize")
+            .get("secret_env")
+            .is_some());
+    }
+}
+
 fn default_max_concurrency() -> usize {
     1
 }

--- a/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent_task_outcome::{AgentTaskFailureClassification, AgentTaskOutcomeStatus};
+use crate::secret_env_plan::SecretEnvPlan;
 
 fn default_managed_service_version() -> u32 {
     AgentTaskManagedService::VERSION
@@ -38,22 +39,48 @@ pub struct AgentTaskManagedService {
     pub cwd: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub env: HashMap<String, String>,
+    /// Names copied from the selected execution host. An empty list gives a
+    /// service no ambient environment; plans must make every dependency clear.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_allowlist: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_env: Vec<String>,
+    /// Portable, redacted secret handoff for a Lab or another selected target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_env_plan: Option<SecretEnvPlan>,
     #[serde(default = "default_managed_service_host")]
     pub host: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
+    /// Environment variable receiving the leased port. `None` means the
+    /// command has an externally fixed endpoint and no port lease is required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port_env: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub readiness: Option<AgentTaskManagedServiceReadiness>,
     /// An externally provisioned reviewer URL. Homeboy treats this as a
     /// reference and never assumes a particular tunnel or preview provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
+    #[serde(default)]
+    pub lifecycle: AgentTaskManagedServiceLifecycle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
 }
 
 impl AgentTaskManagedService {
     pub const VERSION: u32 = 1;
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskManagedServiceLifecycle {
+    /// The service is owned by the complete plan, including postprocess steps.
+    #[default]
+    Plan,
+    /// The service is owned by the selected execution target and must be
+    /// reconciled there after an interrupted controller handoff.
+    Target,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -2,6 +2,21 @@ use super::*;
 
 pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    // Service ownership is independent of the scheduler process. Reconcile the
+    // durable ledger before terminalizing so an interrupted controller cannot
+    // leave a runner-local preview alive after its run is cancelled.
+    let service_cleanup = crate::agent_task_scheduler::managed_services::reconcile_run_services(
+        &record.run_id,
+        reason.unwrap_or("cancelled"),
+    )
+    .map_err(Error::internal_unexpected)?;
+    if !service_cleanup.is_empty() {
+        record.ensure_metadata_object().insert(
+            "managed_service_cleanup".to_string(),
+            serde_json::to_value(&service_cleanup).unwrap_or(serde_json::Value::Null),
+        );
+        store::write_record(&record)?;
+    }
     if record
         .candidate_adoption
         .as_ref()

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -780,11 +780,16 @@ mod managed_service_plan_tests {
             command: vec!["server".to_string()],
             cwd: None,
             env: HashMap::new(),
+            env_allowlist: Vec::new(),
             secret_env: vec!["TOKEN".to_string()],
+            secret_env_plan: None,
             host: "127.0.0.1".to_string(),
             port: Some(3000),
+            port_env: None,
             readiness: None,
             public_url: Some("https://preview.example.test".to_string()),
+            lifecycle: AgentTaskManagedServiceLifecycle::Plan,
+            target: None,
         });
         plan.rebuild_homeboy_plan();
         let round_trip = AgentTaskPlan::from_homeboy_plan(plan.homeboy_plan.clone());
@@ -800,11 +805,16 @@ mod managed_service_plan_tests {
             command: vec!["server".to_string()],
             cwd: None,
             env: HashMap::new(),
+            env_allowlist: Vec::new(),
             secret_env: Vec::new(),
+            secret_env_plan: None,
             host: "127.0.0.1".to_string(),
             port: Some(3000),
+            port_env: None,
             readiness: None,
             public_url: None,
+            lifecycle: AgentTaskManagedServiceLifecycle::Plan,
+            target: None,
         });
         plan.postprocess_steps
             .push(AgentTaskArtifactPostprocessStep {

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -28,6 +28,7 @@ mod plan {
         pub output_dependencies: HashMap<String, AgentTaskOutputDependencies>,
         pub artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
         pub postprocess_steps: Vec<AgentTaskArtifactPostprocessStep>,
+        pub services: Vec<AgentTaskManagedService>,
         pub options: AgentTaskScheduleOptions,
         pub metadata: Value,
         pub workspace_identity: Option<WorkspaceIdentity>,
@@ -47,6 +48,7 @@ mod plan {
                 output_dependencies: HashMap::new(),
                 artifact_outputs: HashMap::new(),
                 postprocess_steps: Vec::new(),
+                services: Vec::new(),
                 options: AgentTaskScheduleOptions::default(),
                 metadata: Value::Null,
                 workspace_identity: None,
@@ -135,6 +137,11 @@ mod plan {
                 .get("metadata")
                 .cloned()
                 .unwrap_or(Value::Null);
+            let services = homeboy_plan
+                .inputs
+                .get("managed_services")
+                .and_then(|value| serde_json::from_value(value.clone()).ok())
+                .unwrap_or_default();
 
             Self {
                 schema,
@@ -145,6 +152,7 @@ mod plan {
                 output_dependencies,
                 artifact_outputs,
                 postprocess_steps,
+                services,
                 options,
                 metadata,
                 workspace_identity: None,
@@ -193,6 +201,12 @@ mod plan {
                 plan.inputs.insert(
                     "component_contracts".to_string(),
                     serde_json::to_value(&self.component_contracts).unwrap_or(Value::Null),
+                );
+            }
+            if !self.services.is_empty() {
+                plan.inputs.insert(
+                    "managed_services".to_string(),
+                    serde_json::to_value(&self.services).unwrap_or(Value::Null),
                 );
             }
             plan.policy.insert(
@@ -309,6 +323,7 @@ mod plan {
         artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         postprocess_steps: Vec<AgentTaskArtifactPostprocessStep>,
+        services: Vec<AgentTaskManagedService>,
         #[serde(default)]
         options: AgentTaskScheduleOptions,
         #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -341,6 +356,7 @@ mod plan {
                 output_dependencies: self.output_dependencies,
                 artifact_outputs: self.artifact_outputs,
                 postprocess_steps: self.postprocess_steps,
+                services: self.services,
                 options: self.options,
                 metadata: self.metadata,
                 workspace_identity: self.workspace_identity,
@@ -364,6 +380,7 @@ mod plan {
                 output_dependencies: plan.output_dependencies.clone(),
                 artifact_outputs: plan.artifact_outputs.clone(),
                 postprocess_steps: plan.postprocess_steps.clone(),
+                services: plan.services.clone(),
                 options: plan.options.clone(),
                 metadata: plan.metadata.clone(),
                 workspace_identity: plan.workspace_identity.clone(),
@@ -742,3 +759,69 @@ pub use cancellation::*;
 pub use defaults::*;
 pub use homeboy_core::agent_task_config::*;
 pub use plan::*;
+
+#[cfg(test)]
+mod managed_service_plan_tests {
+    use super::*;
+
+    #[test]
+    fn task_only_plans_remain_byte_compatible_and_services_round_trip_through_homeboy_plan() {
+        let task_only = AgentTaskPlan::new("task-only", Vec::new());
+        assert!(serde_json::to_value(&task_only)
+            .unwrap()
+            .get("services")
+            .is_none());
+
+        let mut plan = AgentTaskPlan::new("services", Vec::new());
+        plan.services.push(AgentTaskManagedService {
+            version: AgentTaskManagedService::VERSION,
+            id: "preview".to_string(),
+            command: vec!["server".to_string()],
+            cwd: None,
+            env: HashMap::new(),
+            secret_env: vec!["TOKEN".to_string()],
+            host: "127.0.0.1".to_string(),
+            port: Some(3000),
+            readiness: None,
+            public_url: Some("https://preview.example.test".to_string()),
+        });
+        plan.rebuild_homeboy_plan();
+        let round_trip = AgentTaskPlan::from_homeboy_plan(plan.homeboy_plan.clone());
+        assert_eq!(round_trip.services, plan.services);
+    }
+
+    #[test]
+    fn managed_services_and_postprocess_steps_round_trip_together() {
+        let mut plan = AgentTaskPlan::new("composed", Vec::new());
+        plan.services.push(AgentTaskManagedService {
+            version: AgentTaskManagedService::VERSION,
+            id: "preview".to_string(),
+            command: vec!["server".to_string()],
+            cwd: None,
+            env: HashMap::new(),
+            secret_env: Vec::new(),
+            host: "127.0.0.1".to_string(),
+            port: Some(3000),
+            readiness: None,
+            public_url: None,
+        });
+        plan.postprocess_steps.push(AgentTaskArtifactPostprocessStep {
+            id: "postprocess".to_string(),
+            depends_on: Vec::new(),
+            required: true,
+            plan: homeboy_core::artifacts::ArtifactPostprocessPlan {
+                schema: "homeboy/artifact-postprocess/v1".to_string(),
+                plan_id: "postprocess".to_string(),
+                artifact_roots: Vec::new(),
+                actions: Vec::new(),
+                reviewer_refs: Vec::new(),
+                metadata: Value::Null,
+            },
+        });
+
+        plan.rebuild_homeboy_plan();
+        let round_trip = AgentTaskPlan::from_homeboy_plan(plan.homeboy_plan.clone());
+        assert_eq!(round_trip.services, plan.services);
+        assert_eq!(round_trip.postprocess_steps, plan.postprocess_steps);
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -323,6 +323,7 @@ mod plan {
         artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         postprocess_steps: Vec<AgentTaskArtifactPostprocessStep>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         services: Vec<AgentTaskManagedService>,
         #[serde(default)]
         options: AgentTaskScheduleOptions,
@@ -805,19 +806,20 @@ mod managed_service_plan_tests {
             readiness: None,
             public_url: None,
         });
-        plan.postprocess_steps.push(AgentTaskArtifactPostprocessStep {
-            id: "postprocess".to_string(),
-            depends_on: Vec::new(),
-            required: true,
-            plan: homeboy_core::artifacts::ArtifactPostprocessPlan {
-                schema: "homeboy/artifact-postprocess/v1".to_string(),
-                plan_id: "postprocess".to_string(),
-                artifact_roots: Vec::new(),
-                actions: Vec::new(),
-                reviewer_refs: Vec::new(),
-                metadata: Value::Null,
-            },
-        });
+        plan.postprocess_steps
+            .push(AgentTaskArtifactPostprocessStep {
+                id: "postprocess".to_string(),
+                depends_on: Vec::new(),
+                required: true,
+                plan: homeboy_core::artifacts::ArtifactPostprocessPlan {
+                    schema: "homeboy/artifact-postprocess/v1".to_string(),
+                    plan_id: "postprocess".to_string(),
+                    artifact_roots: Vec::new(),
+                    actions: Vec::new(),
+                    reviewer_refs: Vec::new(),
+                    metadata: Value::Null,
+                },
+            });
 
         plan.rebuild_homeboy_plan();
         let round_trip = AgentTaskPlan::from_homeboy_plan(plan.homeboy_plan.clone());

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -98,6 +98,44 @@ where
             .unwrap_or_else(|| format!("ephemeral-{}", uuid::Uuid::new_v4()));
         let max_concurrency = plan.options.max_concurrency.max(1);
         let total_tasks = plan.tasks.len();
+        let services = match super::managed_services::ManagedServices::start(
+            &plan.services,
+            &scratch_run_id,
+        ) {
+            Ok(services) => Some(services),
+            Err(error) => {
+                let outcomes = plan
+                    .tasks
+                    .iter()
+                    .map(|request| AgentTaskOutcome {
+                        task_id: request.task_id.clone(),
+                        status: AgentTaskOutcomeStatus::Failed,
+                        summary: Some(error.clone()),
+                        failure_classification: Some(
+                            AgentTaskFailureClassification::ExecutionFailed,
+                        ),
+                        diagnostics: vec![AgentTaskDiagnostic {
+                            class: "managed_service_startup".to_string(),
+                            message: error.clone(),
+                            data: serde_json::Value::Null,
+                        }],
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>();
+                return AgentTaskAggregate {
+                    schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                    plan_id: plan.plan_id,
+                    status: AgentTaskScheduleSupport::aggregate_status(&outcomes),
+                    totals: AgentTaskScheduleSupport::totals(total_tasks, &outcomes),
+                    outcomes,
+                    events: Vec::new(),
+                    artifact_lineage: Vec::new(),
+                    child_runs: Vec::new(),
+                    artifact_bindings: Vec::new(),
+                    queue: Default::default(),
+                };
+            }
+        };
         let max_queue_depth = plan.options.max_queue_depth.or(plan.options.max_tasks);
         let retry_budget_total = plan.options.retry.max_retries_total;
         let output_dependencies = plan.output_dependencies.clone();
@@ -367,6 +405,9 @@ where
                 };
                 let scheduled = queued.remove(next_index).expect("queued task");
                 let mut request = scheduled.request;
+                if let Some(services) = services.as_ref() {
+                    services.bind_into(&mut request.inputs, &mut request.metadata);
+                }
                 if let Err(outcome) = AgentTaskScheduleSupport::render_output_dependencies(
                     &mut request,
                     &completed_by_task,
@@ -1095,6 +1136,22 @@ where
             }
         }
 
+        let services = services
+            .map(|services| {
+                services.cleanup(if cancellation.is_cancelled() {
+                    "cancelled"
+                } else {
+                    "terminal"
+                })
+            })
+            .unwrap_or_default();
+        for outcome in &mut outcomes {
+            if !outcome.metadata.is_object() {
+                outcome.metadata = serde_json::json!({});
+            }
+            outcome.metadata["managed_services"] =
+                serde_json::to_value(&services).unwrap_or(serde_json::Value::Null);
+        }
         AgentTaskAggregate {
             schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
             plan_id: plan.plan_id,

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -1,0 +1,302 @@
+//! Plan-owned, runner-local process services for agent-task execution.
+//!
+//! This deliberately owns only process allocation/readiness and lifecycle
+//! evidence. Public URLs are opaque references supplied by a preview/tunnel
+//! provider, keeping this contract independent of any product integration.
+
+use std::fs::OpenOptions;
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use homeboy_core::agent_task_config::AgentTaskManagedServiceReadiness;
+use serde_json::{json, Value};
+
+use super::{AgentTaskManagedService, AgentTaskManagedServiceReadinessKind};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(super) struct AgentTaskManagedServiceRecord {
+    pub id: String,
+    pub state: String,
+    pub local_url: Option<String>,
+    pub public_url: Option<String>,
+    pub log_path: Option<String>,
+    pub pid: Option<u32>,
+    pub cleanup: Option<String>,
+    pub provenance: Value,
+}
+
+pub(super) struct ManagedServices {
+    services: Vec<RunningService>,
+}
+
+struct RunningService {
+    spec: AgentTaskManagedService,
+    child: Child,
+    containment: homeboy_core::process::ProcessContainment,
+    record: AgentTaskManagedServiceRecord,
+}
+
+impl ManagedServices {
+    pub(super) fn start(specs: &[AgentTaskManagedService], run_id: &str) -> Result<Self, String> {
+        let mut services = Self {
+            services: Vec::new(),
+        };
+        for spec in specs {
+            if spec.version != AgentTaskManagedService::VERSION {
+                return Err(format!(
+                    "managed service '{}' has unsupported version {}; supported version is {}",
+                    spec.id,
+                    spec.version,
+                    AgentTaskManagedService::VERSION
+                ));
+            }
+            if spec.id.trim().is_empty() || spec.command.is_empty() {
+                return Err("managed service requires a non-empty id and command argv".to_string());
+            }
+            if services
+                .services
+                .iter()
+                .any(|service| service.spec.id == spec.id)
+            {
+                return Err(format!(
+                    "managed service id '{}' is declared more than once",
+                    spec.id
+                ));
+            }
+            if let Err(error) = services.start_one(spec.clone(), run_id) {
+                services.cleanup("startup_failure");
+                return Err(error);
+            }
+        }
+        Ok(services)
+    }
+
+    fn start_one(&mut self, spec: AgentTaskManagedService, run_id: &str) -> Result<(), String> {
+        let log_dir = homeboy_core::paths::homeboy_data()
+            .map_err(|error| error.message)?
+            .join("agent-task-runs")
+            .join(run_id)
+            .join("services");
+        std::fs::create_dir_all(&log_dir).map_err(|error| error.to_string())?;
+        let log_path = log_dir.join(format!("{}.log", spec.id));
+        let log = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .map_err(|error| format!("open managed service log: {error}"))?;
+        let stderr = log
+            .try_clone()
+            .map_err(|error| format!("clone managed service log: {error}"))?;
+        let mut command = Command::new(&spec.command[0]);
+        command
+            .args(&spec.command[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(stderr));
+        if let Some(cwd) = &spec.cwd {
+            command.current_dir(cwd);
+        }
+        command.envs(&spec.env);
+        for name in &spec.secret_env {
+            let value = std::env::var(name).map_err(|_| {
+                format!(
+                    "managed service '{}' requires secret environment variable '{name}'",
+                    spec.id
+                )
+            })?;
+            command.env(name, value);
+        }
+        let mut containment = homeboy_core::process::ProcessContainment::prepare(&mut command)
+            .map_err(|error| error.message)?;
+        let child = command
+            .spawn()
+            .map_err(|error| format!("start managed service '{}': {error}", spec.id))?;
+        containment.attach(&child).map_err(|error| error.message)?;
+        let local_url = spec.port.map(|port| format!("http://{}:{port}", spec.host));
+        let mut record = AgentTaskManagedServiceRecord {
+            id: spec.id.clone(),
+            state: "starting".to_string(),
+            local_url: local_url.clone(),
+            public_url: spec.public_url.clone(),
+            log_path: Some(log_path.display().to_string()),
+            pid: Some(child.id()),
+            cleanup: None,
+            provenance: json!({"schema":"homeboy/agent-task-managed-service/v1", "argv": spec.command, "cwd": spec.cwd, "host": spec.host, "port": spec.port, "secret_env": spec.secret_env}),
+        };
+        if let Err(error) = wait_ready(&spec, local_url.as_deref()) {
+            let _ = containment.terminate_on_failure_bounded(Duration::from_secs(2), false);
+            record.state = "failed".to_string();
+            record.cleanup = Some("terminated_after_readiness_failure".to_string());
+            return Err(format!("managed service '{}': {error}", spec.id));
+        }
+        record.state = "ready".to_string();
+        self.services.push(RunningService {
+            spec,
+            child,
+            containment,
+            record,
+        });
+        Ok(())
+    }
+
+    pub(super) fn bind_into(&self, inputs: &mut Value, metadata: &mut Value) {
+        let values = self.records().into_iter().map(|record| (record.id.clone(), json!({
+            "local_url": record.local_url, "public_url": record.public_url,
+            "browser_origin": record.public_url.clone().or(record.local_url.clone()),
+            "lease_ref": format!("managed-service:{}", record.id), "readiness_evidence": record.provenance,
+        }))).collect::<serde_json::Map<_, _>>();
+        if !inputs.is_object() {
+            *inputs = json!({});
+        }
+        inputs["services"] = Value::Object(values.clone());
+        if !metadata.is_object() {
+            *metadata = json!({});
+        }
+        metadata["managed_services"] = Value::Object(values);
+    }
+
+    pub(super) fn records(&self) -> Vec<AgentTaskManagedServiceRecord> {
+        self.services
+            .iter()
+            .map(|service| service.record.clone())
+            .collect()
+    }
+
+    pub(super) fn cleanup(mut self, reason: &str) -> Vec<AgentTaskManagedServiceRecord> {
+        for service in &mut self.services {
+            let exited = service.child.try_wait().ok().flatten().is_some();
+            let cleanup = if exited {
+                Ok(())
+            } else {
+                service
+                    .containment
+                    .terminate_on_failure_bounded(Duration::from_secs(2), false)
+            };
+            let _ = service.child.wait();
+            service.record.state = "stopped".to_string();
+            service.record.cleanup = Some(match cleanup {
+                Ok(()) => format!("cleaned_up:{reason}"),
+                Err(error) => format!("cleanup_failed:{reason}:{}", error.message),
+            });
+        }
+        self.records()
+    }
+}
+
+fn wait_ready(spec: &AgentTaskManagedService, local_url: Option<&str>) -> Result<(), String> {
+    let Some(port) = spec.port else {
+        return Ok(());
+    };
+    let readiness = spec.readiness.as_ref();
+    let timeout = readiness
+        .and_then(|probe| probe.timeout_ms)
+        .unwrap_or(10_000);
+    let deadline = Instant::now() + Duration::from_millis(timeout);
+    loop {
+        let ready = match readiness
+            .map(|probe| probe.kind)
+            .unwrap_or(AgentTaskManagedServiceReadinessKind::Tcp)
+        {
+            AgentTaskManagedServiceReadinessKind::Tcp => {
+                TcpStream::connect((spec.host.as_str(), port)).is_ok()
+            }
+            AgentTaskManagedServiceReadinessKind::Http => local_url
+                .and_then(|url| {
+                    readiness
+                        .and_then(|probe| probe.path.as_deref())
+                        .map(|path| format!("{url}{path}"))
+                })
+                .map(|url| {
+                    reqwest::blocking::get(url)
+                        .map(|response| response.status().is_success())
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false),
+        };
+        if ready {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("readiness probe timed out after {timeout}ms"));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use homeboy_core::test_support::with_isolated_home;
+
+    fn free_port() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        listener.local_addr().expect("local address").port()
+    }
+
+    fn fixture(port: u16) -> AgentTaskManagedService {
+        AgentTaskManagedService {
+            version: AgentTaskManagedService::VERSION,
+            id: "fixture".to_string(),
+            command: vec![
+                "python3".to_string(), "-u".to_string(), "-c".to_string(),
+                "import http.server, os; http.server.HTTPServer(('127.0.0.1', int(os.environ['PORT'])), http.server.SimpleHTTPRequestHandler).serve_forever()".to_string(),
+            ],
+            cwd: None,
+            env: HashMap::from([("PORT".to_string(), port.to_string())]),
+            secret_env: Vec::new(),
+            host: "127.0.0.1".to_string(),
+            port: Some(port),
+            readiness: Some(AgentTaskManagedServiceReadiness {
+                kind: AgentTaskManagedServiceReadinessKind::Http,
+                path: Some("/".to_string()), timeout_ms: Some(5_000),
+            }),
+            public_url: Some("https://preview.example.test/fixture".to_string()),
+        }
+    }
+
+    #[test]
+    fn neutral_http_fixture_binds_provenance_and_is_cleaned_up() {
+        with_isolated_home(|_| {
+            let services = ManagedServices::start(&[fixture(free_port())], "fixture-run")
+                .expect("start fixture");
+            let mut inputs = Value::Null;
+            let mut metadata = Value::Null;
+            services.bind_into(&mut inputs, &mut metadata);
+            assert!(inputs["services"]["fixture"]["local_url"]
+                .as_str()
+                .unwrap()
+                .starts_with("http://127.0.0.1:"));
+            assert_eq!(
+                inputs["services"]["fixture"]["public_url"],
+                "https://preview.example.test/fixture"
+            );
+            assert_eq!(
+                metadata["managed_services"]["fixture"]["browser_origin"],
+                "https://preview.example.test/fixture"
+            );
+            let records = services.cleanup("success");
+            assert_eq!(records[0].state, "stopped");
+            assert_eq!(records[0].cleanup.as_deref(), Some("cleaned_up:success"));
+            assert!(std::path::Path::new(records[0].log_path.as_deref().unwrap()).exists());
+        });
+    }
+
+    #[test]
+    fn readiness_failure_reaps_any_service_started_earlier() {
+        with_isolated_home(|_| {
+            let mut failing = fixture(free_port());
+            failing.id = "never-ready".to_string();
+            failing.command = vec!["sh".to_string(), "-c".to_string(), "exit 1".to_string()];
+            failing.readiness.as_mut().unwrap().timeout_ms = Some(50);
+            let error =
+                match ManagedServices::start(&[fixture(free_port()), failing], "failure-run") {
+                    Ok(_) => panic!("readiness should fail"),
+                    Err(error) => error,
+                };
+            assert!(error.contains("never-ready"));
+        });
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -4,18 +4,24 @@
 //! evidence. Public URLs are opaque references supplied by a preview/tunnel
 //! provider, keeping this contract independent of any product integration.
 
-use std::fs::OpenOptions;
-use std::net::TcpStream;
+use std::fs::{File, OpenOptions};
+use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use homeboy_core::agent_task_config::AgentTaskManagedServiceReadiness;
+use homeboy_core::process::{
+    process_identity_state_with_start_identity, process_start_identity, terminate_process_tree,
+    ProcessIdentityState, ProcessStartIdentity,
+};
 use serde_json::{json, Value};
 
-use super::{AgentTaskManagedService, AgentTaskManagedServiceReadinessKind};
+use super::{
+    AgentTaskManagedService, AgentTaskManagedServiceLifecycle, AgentTaskManagedServiceReadinessKind,
+};
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub(super) struct AgentTaskManagedServiceRecord {
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AgentTaskManagedServiceRecord {
     pub id: String,
     pub state: String,
     pub local_url: Option<String>,
@@ -24,6 +30,10 @@ pub(super) struct AgentTaskManagedServiceRecord {
     pub pid: Option<u32>,
     pub cleanup: Option<String>,
     pub provenance: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_identity: Option<ProcessStartIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port_lease: Option<String>,
 }
 
 pub(super) struct ManagedServices {
@@ -35,6 +45,18 @@ struct RunningService {
     child: Child,
     containment: homeboy_core::process::ProcessContainment,
     record: AgentTaskManagedServiceRecord,
+    port_lease: Option<PortLease>,
+}
+
+struct PortLease {
+    path: std::path::PathBuf,
+    _file: File,
+}
+
+impl Drop for PortLease {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 impl ManagedServices {
@@ -88,6 +110,9 @@ impl ManagedServices {
         let stderr = log
             .try_clone()
             .map_err(|error| format!("clone managed service log: {error}"))?;
+        let mut spec = spec;
+        let (port, port_lease) = lease_port(&spec)?;
+        spec.port = port;
         let mut command = Command::new(&spec.command[0]);
         command
             .args(&spec.command[1..])
@@ -97,15 +122,26 @@ impl ManagedServices {
         if let Some(cwd) = &spec.cwd {
             command.current_dir(cwd);
         }
+        // A service never receives the controller's ambient environment by
+        // accident. The plan declares public inheritance and secret handoff.
+        command.env_clear();
+        for name in &spec.env_allowlist {
+            if let Ok(value) = std::env::var(name) {
+                command.env(name, value);
+            }
+        }
         command.envs(&spec.env);
-        for name in &spec.secret_env {
-            let value = std::env::var(name).map_err(|_| {
-                format!(
-                    "managed service '{}' requires secret environment variable '{name}'",
-                    spec.id
-                )
-            })?;
-            command.env(name, value);
+        if let Some(plan) = &spec.secret_env_plan {
+            let values = crate::agent_task_secrets::resolve_secret_env_plan(plan)
+                .map_err(|error| format!("managed service '{}': {}", spec.id, error.message))?;
+            command.envs(values);
+        } else {
+            let values = crate::agent_task_secrets::resolve_secret_env(&spec.secret_env)
+                .map_err(|error| format!("managed service '{}': {}", spec.id, error.message))?;
+            command.envs(values);
+        }
+        if let Some(port) = spec.port {
+            command.env(spec.port_env.as_deref().unwrap_or("PORT"), port.to_string());
         }
         let mut containment = homeboy_core::process::ProcessContainment::prepare(&mut command)
             .map_err(|error| error.message)?;
@@ -122,8 +158,14 @@ impl ManagedServices {
             log_path: Some(log_path.display().to_string()),
             pid: Some(child.id()),
             cleanup: None,
-            provenance: json!({"schema":"homeboy/agent-task-managed-service/v1", "argv": spec.command, "cwd": spec.cwd, "host": spec.host, "port": spec.port, "secret_env": spec.secret_env}),
+            provenance: json!({"schema":"homeboy/agent-task-managed-service/v2", "run_id": run_id, "argv": spec.command, "cwd": spec.cwd, "host": spec.host, "port": spec.port, "target": spec.target, "lifecycle": spec.lifecycle, "env_allowlist": spec.env_allowlist, "secret_env": spec.secret_env, "secret_env_plan": spec.secret_env_plan.as_ref().map(|plan| plan.redacted())}),
+            process_identity: process_start_identity(child.id())
+                .map_err(|error| format!("inspect managed service process identity: {error}"))?,
+            port_lease: port_lease
+                .as_ref()
+                .map(|lease| lease.path.display().to_string()),
         };
+        persist_record(run_id, &record)?;
         if let Err(error) = wait_ready(&spec, local_url.as_deref()) {
             let _ = containment.terminate_on_failure_bounded(Duration::from_secs(2), false);
             record.state = "failed".to_string();
@@ -131,11 +173,13 @@ impl ManagedServices {
             return Err(format!("managed service '{}': {error}", spec.id));
         }
         record.state = "ready".to_string();
+        persist_record(run_id, &record)?;
         self.services.push(RunningService {
             spec,
             child,
             containment,
             record,
+            port_lease,
         });
         Ok(())
     }
@@ -184,9 +228,123 @@ impl ManagedServices {
                 Ok(()) => format!("cleaned_up:{reason}"),
                 Err(error) => format!("cleanup_failed:{reason}:{}", error.message),
             });
+            if let Some(run_id) = service
+                .record
+                .provenance
+                .get("run_id")
+                .and_then(Value::as_str)
+            {
+                let _ = persist_record(run_id, &service.record);
+            }
         }
         self.records()
     }
+}
+
+fn lease_port(spec: &AgentTaskManagedService) -> Result<(Option<u16>, Option<PortLease>), String> {
+    let Some(requested) = spec.port else {
+        return Ok((None, None));
+    };
+    let port = if requested == 0 {
+        TcpListener::bind((spec.host.as_str(), 0))
+            .map_err(|error| format!("allocate managed service port: {error}"))?
+            .local_addr()
+            .map_err(|error| format!("read managed service port: {error}"))?
+            .port()
+    } else {
+        requested
+    };
+    let lease_dir = homeboy_core::paths::homeboy_data()
+        .map_err(|error| error.message)?
+        .join("agent-task-service-ports");
+    std::fs::create_dir_all(&lease_dir)
+        .map_err(|error| format!("create managed service lease directory: {error}"))?;
+    let host = spec
+        .host
+        .replace(|character: char| !character.is_ascii_alphanumeric(), "_");
+    let path = lease_dir.join(format!("{host}-{port}.lease"));
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|_| {
+            format!(
+                "managed service '{}' port allocation collision on {}:{port}",
+                spec.id, spec.host
+            )
+        })?;
+    Ok((Some(port), Some(PortLease { path, _file: file })))
+}
+
+fn persist_record(run_id: &str, record: &AgentTaskManagedServiceRecord) -> Result<(), String> {
+    let path = homeboy_core::paths::homeboy_data()
+        .map_err(|error| error.message)?
+        .join("agent-task-runs")
+        .join(run_id)
+        .join("services")
+        .join(format!("{}.json", record.id));
+    let bytes = serde_json::to_vec_pretty(record).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension("json.tmp");
+    std::fs::write(&temporary, bytes)
+        .map_err(|error| format!("persist managed service ownership: {error}"))?;
+    std::fs::rename(temporary, path)
+        .map_err(|error| format!("commit managed service ownership: {error}"))
+}
+
+/// Reap service leaders left by an interrupted controller. The persisted kernel
+/// process-start identity prevents a recycled PID from ever being signalled.
+pub(crate) fn reconcile_run_services(
+    run_id: &str,
+    reason: &str,
+) -> Result<Vec<AgentTaskManagedServiceRecord>, String> {
+    let directory = homeboy_core::paths::homeboy_data()
+        .map_err(|error| error.message)?
+        .join("agent-task-runs")
+        .join(run_id)
+        .join("services");
+    let entries = match std::fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(format!("read managed service ledger: {error}")),
+    };
+    let mut records = Vec::new();
+    for entry in entries.flatten() {
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(entry.path()) else {
+            continue;
+        };
+        let Ok(mut record) = serde_json::from_slice::<AgentTaskManagedServiceRecord>(&bytes) else {
+            continue;
+        };
+        if matches!(record.state.as_str(), "stopped" | "failed") {
+            records.push(record);
+            continue;
+        }
+        let outcome = match (record.pid, record.process_identity.as_ref()) {
+            (Some(pid), identity) => {
+                match process_identity_state_with_start_identity(pid, None, identity) {
+                    ProcessIdentityState::Live => terminate_process_tree(pid)
+                        .map(|_| "reaped".to_string())
+                        .unwrap_or_else(|error| format!("cleanup_failed:{error}")),
+                    ProcessIdentityState::Dead => "already_exited".to_string(),
+                    ProcessIdentityState::IdentityMismatch => {
+                        "ownership_mismatch_not_signalled".to_string()
+                    }
+                    ProcessIdentityState::Unverifiable => {
+                        "ownership_unverifiable_not_signalled".to_string()
+                    }
+                }
+            }
+            _ => "no_process_identity".to_string(),
+        };
+        record.state = "stopped".to_string();
+        record.cleanup = Some(format!("{outcome}:{reason}"));
+        persist_record(run_id, &record)?;
+        records.push(record);
+    }
+    Ok(records)
 }
 
 fn wait_ready(spec: &AgentTaskManagedService, local_url: Option<&str>) -> Result<(), String> {
@@ -251,14 +409,19 @@ mod tests {
             ],
             cwd: None,
             env: HashMap::from([("PORT".to_string(), port.to_string())]),
+            env_allowlist: vec!["PATH".to_string()],
             secret_env: Vec::new(),
+            secret_env_plan: None,
             host: "127.0.0.1".to_string(),
             port: Some(port),
+            port_env: Some("PORT".to_string()),
             readiness: Some(AgentTaskManagedServiceReadiness {
                 kind: AgentTaskManagedServiceReadinessKind::Http,
                 path: Some("/".to_string()), timeout_ms: Some(5_000),
             }),
             public_url: Some("https://preview.example.test/fixture".to_string()),
+            lifecycle: AgentTaskManagedServiceLifecycle::Plan,
+            target: None,
         }
     }
 
@@ -302,6 +465,23 @@ mod tests {
                     Err(error) => error,
                 };
             assert!(error.contains("never-ready"));
+        });
+    }
+
+    #[test]
+    fn rejects_a_second_live_lease_for_the_same_port() {
+        with_isolated_home(|_| {
+            let port = free_port();
+            let first =
+                ManagedServices::start(&[fixture(port)], "lease-first").expect("first lease");
+            let mut second = fixture(port);
+            second.id = "second".to_string();
+            let error = match ManagedServices::start(&[second], "lease-second") {
+                Ok(_) => panic!("port lease collision"),
+                Err(error) => error,
+            };
+            assert!(error.contains("port allocation collision"));
+            first.cleanup("test");
         });
     }
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -167,7 +167,12 @@ impl ManagedServices {
         for service in &mut self.services {
             let exited = service.child.try_wait().ok().flatten().is_some();
             let cleanup = if exited {
-                Ok(())
+                // A daemonized child can outlive its direct service leader.
+                // ProcessContainment owns the platform-specific scope marker
+                // needed to reap those descendants after a normal leader exit.
+                service
+                    .containment
+                    .cleanup_after_leader_exit_bounded(Duration::from_secs(2))
             } else {
                 service
                     .containment

--- a/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
@@ -7,6 +7,7 @@ mod attempt_workspace;
 mod candidate_adoption;
 mod engine;
 mod harvest;
+mod managed_services;
 mod outcome;
 mod outcome_artifacts;
 mod outcome_status;
@@ -31,11 +32,12 @@ pub use crate::agent_task_schedule::{
     AgentTaskArtifactRunBinding, AgentTaskBackpressureStatus, AgentTaskCancellationToken,
     AgentTaskCandidateAdoption, AgentTaskCandidateAdoptionDecision,
     AgentTaskCandidateCompletionPolicy, AgentTaskChildRun, AgentTaskExecutionBudget,
-    AgentTaskExecutionContext, AgentTaskOutputBinding, AgentTaskOutputDependencies, AgentTaskPlan,
-    AgentTaskProgressEvent, AgentTaskProviderRotationAttempt, AgentTaskProviderRotationEntry,
-    AgentTaskProviderRotationPolicy, AgentTaskQueueStatus, AgentTaskResourceBudget,
-    AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState,
-    AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
+    AgentTaskExecutionContext, AgentTaskManagedService, AgentTaskManagedServiceReadiness,
+    AgentTaskManagedServiceReadinessKind, AgentTaskOutputBinding, AgentTaskOutputDependencies,
+    AgentTaskPlan, AgentTaskProgressEvent, AgentTaskProviderRotationAttempt,
+    AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy, AgentTaskQueueStatus,
+    AgentTaskResourceBudget, AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy,
+    AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
 };
 use crate::agent_task_timeout::timeout_with_grace;
 use crate::agent_task_timeout_artifacts::{

--- a/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
@@ -7,7 +7,7 @@ mod attempt_workspace;
 mod candidate_adoption;
 mod engine;
 mod harvest;
-mod managed_services;
+pub(crate) mod managed_services;
 mod outcome;
 mod outcome_artifacts;
 mod outcome_status;
@@ -32,12 +32,13 @@ pub use crate::agent_task_schedule::{
     AgentTaskArtifactRunBinding, AgentTaskBackpressureStatus, AgentTaskCancellationToken,
     AgentTaskCandidateAdoption, AgentTaskCandidateAdoptionDecision,
     AgentTaskCandidateCompletionPolicy, AgentTaskChildRun, AgentTaskExecutionBudget,
-    AgentTaskExecutionContext, AgentTaskManagedService, AgentTaskManagedServiceReadiness,
-    AgentTaskManagedServiceReadinessKind, AgentTaskOutputBinding, AgentTaskOutputDependencies,
-    AgentTaskPlan, AgentTaskProgressEvent, AgentTaskProviderRotationAttempt,
-    AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy, AgentTaskQueueStatus,
-    AgentTaskResourceBudget, AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy,
-    AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
+    AgentTaskExecutionContext, AgentTaskManagedService, AgentTaskManagedServiceLifecycle,
+    AgentTaskManagedServiceReadiness, AgentTaskManagedServiceReadinessKind, AgentTaskOutputBinding,
+    AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskProgressEvent,
+    AgentTaskProviderRotationAttempt, AgentTaskProviderRotationEntry,
+    AgentTaskProviderRotationPolicy, AgentTaskQueueStatus, AgentTaskResourceBudget,
+    AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState,
+    AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
 };
 use crate::agent_task_timeout::timeout_with_grace;
 use crate::agent_task_timeout_artifacts::{


### PR DESCRIPTION
## Summary
- add versioned, Lab-portable managed-service declarations to agent-task plans
- start argv services with cwd/env/secret requirements, readiness probes, containment, logs, typed endpoint bindings, and terminal cleanup
- preserve task-only plans and cover portable contract serialization plus a neutral HTTP lifecycle fixture
- preserve plan-native artifact postprocess steps and managed services together through the generic Homeboy-plan projection

Closes #11495

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-lab-contract --lib` (60 passed)
- `cargo test -p homeboy-agents --lib --no-run`
- focused managed-service readiness, lifecycle, task-only compatibility, and postprocess coexistence tests
- `cargo clippy -p homeboy-agents -- -D warnings` remains blocked by existing warnings in `homeboy-paths` and `homeboy-lab-runner-contract`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagent; used to implement and verify agent-task managed service lifecycles. Chris Huber remains responsible for every line.