### PR TITLE
fix(tests): complete Lab readiness fixture migration

### DIFF
--- a/crates/homeboy-cli/src/commands/trace/rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/rig_tests.rs
@@ -146,6 +146,7 @@ fn rig_component_path_and_trace_env_are_threaded() {
             remote_url: Some("https://github.com/example-org/studio".to_string()),
             triage_remote_url: None,
             stack: None,
+            lab_stack: None,
             branch: None,
             r#ref: None,
             default_ref: None,

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -860,7 +860,10 @@ mod tests {
             workspace_mode_policy: LabWorkspaceModePolicy::GitCheckoutRequired,
             capture_mutation_patch: true,
             mutation_flag: Some("--keep-overlay"),
-            extra_required_capabilities: LAB_TRACE_EXTRA_CAPABILITIES,
+            extra_required_capabilities: LAB_TRACE_EXTRA_CAPABILITIES
+                .iter()
+                .map(|capability| (*capability).to_string())
+                .collect(),
             secret_env_sources: crate::lab_contract::LAB_TRACE_SECRET_ENV_SOURCES,
             routing_policy: LabRoutingPolicy {
                 default_lab_offload: true,


### PR DESCRIPTION
## Summary

- migrate the trace Lab contract fixture to owned capability strings
- restore the explicit empty `lab_stack` field removed from the trace rig fixture
- restore merged-main workspace test compilation after #11473

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-core lab_offload_command_from_contract_preserves_routing_shape`
- `cargo test -p homeboy-cli rig_component_path_and_trace_env_are_threaded`
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- `cargo check --workspace --tests --locked`
- `git diff --check`

Closes #11512

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced and traced the merged-main failures to #11473, applied the minimal fixture migrations, and ran the verification above. Chris Huber reviewed and remains responsible for the change.