### PR TITLE
fix: clear workspace test-target warnings blocking every open PR

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/observation/tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/tests.rs
@@ -16,7 +16,7 @@ use crate::commands::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
 use crate::commands::utils::resource_policy::{
-    self, resource_policy_context_from_evaluation, HotCommand, ResourcePolicyContext,
+    self, resource_policy_context_from_evaluation, HotCommand,
 };
 use crate::test_support::{serve_public_artifact_base_once, with_isolated_home};
 

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -228,14 +228,10 @@ fn explicit_local_promotion_defers_target_resolution_to_promotion() {
     assert_eq!(route_after_parse(&cli, &normalized, None).unwrap(), None);
 }
 use clap::Parser;
-use homeboy::command_contract::{lab_runner_supports_contract_label, LabCommandPortability};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
-
-use super::*;
 
 #[test]
 fn review_test_inlines_external_database_service_profile_before_lab_handoff() {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -4,12 +4,7 @@ use super::*;
 use clap::Parser;
 use homeboy::command_contract::{lab_runner_supports_contract_label, LabCommandPortability};
 use std::fs;
-use std::path::Path;
-use std::process::Command;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
-
-use super::*;
 
 #[test]
 fn rig_install_offload_translates_source_path_instead_of_forwarding_it() {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
@@ -4,15 +4,10 @@ mod dispatch;
 mod handoff;
 
 use super::*;
-use clap::Parser;
-use homeboy::command_contract::{lab_runner_supports_contract_label, LabCommandPortability};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use tempfile::tempdir;
-
-use super::*;
 
 pub(super) fn git_init(path: &Path) {
     let output = Command::new("git")

--- a/crates/homeboy-code-audit/Cargo.toml
+++ b/crates/homeboy-code-audit/Cargo.toml
@@ -8,6 +8,13 @@ publish = false
 # Exposes code_audit's shared test fixtures (test_helpers) so other crates'
 # tests (e.g. homeboy-core's refactor tests) can build audit findings/results.
 test-support = []
+# Opts in to the deliberately slow test tier (docs/internals/test-tiers.md):
+# full-pipeline audit regressions that walk real fixture trees and need an
+# installed fingerprinting extension. Off by default, so the default unit gate
+# stays bounded; run with `cargo test -p homeboy-code-audit --lib --features
+# slow-tests`. Declared here (as in homeboy-core) so the `#[cfg(feature =
+# "slow-tests")]` gates in this crate are a known check-cfg condition.
+slow-tests = []
 
 [dependencies]
 homeboy-audit-contract = { version = "0.1.0", path = "../contracts/homeboy-audit-contract" }

--- a/crates/homeboy-code-audit/src/audit_runtime_regression_test.rs
+++ b/crates/homeboy-code-audit/src/audit_runtime_regression_test.rs
@@ -185,6 +185,11 @@ fn finding_fingerprints(findings: &[Finding]) -> Vec<String> {
 /// audited through [`run_main_audit_workflow`] (the CI entry point).
 ///
 /// This list IS the regression guard. See module docs before editing.
+///
+/// Only `audit_runtime_regression_matches_snapshot` consumes it, and that test
+/// is slow-tier, so — like `run_fixture_audit` above — this is gated to the
+/// same tier to avoid a dead-code warning in the default build.
+#[cfg(feature = "slow-tests")]
 const EXPECTED_FINDINGS: &[&str] = &[
     "core_boundary_leak::src/boundary_leak.rs",
     "high_item_count::src/god_file.rs",

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -3168,7 +3168,7 @@ impl RecoveredTerminalJob {
 
 #[cfg(test)]
 #[derive(Clone)]
-pub(super) enum LinkedDurableRunResolution {
+pub(crate) enum LinkedDurableRunResolution {
     None,
     Terminal(RecoveredTerminalJob),
     Active(String),

--- a/crates/homeboy-core/src/api_jobs/tests/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/mod.rs
@@ -5,15 +5,10 @@ mod part_b;
 mod part_c;
 
 use std::collections::HashMap;
-use std::fs;
 
 use serde_json::json;
 
-use super::persistence::recovered_terminal_from_result;
-use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
 use super::*;
-use crate::secret_env_plan::SecretEnvPlan;
-use crate::source_snapshot::SourceSnapshot;
 use uuid::Uuid;
 
 pub(super) fn record_test_local_child(store: &JobStore, job_id: Uuid, pid: u32) {

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -1,17 +1,11 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
 use std::fs;
 
 use serde_json::json;
 
-use super::persistence::recovered_terminal_from_result;
-use super::store::{
-    LinkedDurableRunResolution, RecoveredTerminalJob, ADMISSION_RESERVATION_LEASE_MS,
-};
+use super::store::{LinkedDurableRunResolution, ADMISSION_RESERVATION_LEASE_MS};
 use super::*;
-use crate::secret_env_plan::SecretEnvPlan;
-use crate::source_snapshot::SourceSnapshot;
 use crate::Error;
 use uuid::Uuid;
 

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
 use std::fs;
 
 use serde_json::json;
@@ -8,8 +7,6 @@ use serde_json::json;
 use super::persistence::recovered_terminal_from_result;
 use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
 use super::*;
-use crate::secret_env_plan::SecretEnvPlan;
-use crate::source_snapshot::SourceSnapshot;
 use uuid::Uuid;
 
 #[test]

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -1,17 +1,11 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
 use std::fs;
 
 use serde_json::json;
 
-use super::persistence::recovered_terminal_from_result;
-use super::store::{LinkedDurableRunResolution, RecoveredTerminalJob};
 use super::*;
 use crate::observation::{ArtifactRecord, RunRecord};
-use crate::secret_env_plan::SecretEnvPlan;
-use crate::source_snapshot::SourceSnapshot;
-use uuid::Uuid;
 
 #[test]
 fn remote_runner_job_claim_returns_oldest_matching_job() {

--- a/crates/homeboy-core/src/hygiene.rs
+++ b/crates/homeboy-core/src/hygiene.rs
@@ -110,17 +110,6 @@ pub struct DependencyHygieneOptions {
     pub allow_stale: bool,
 }
 
-// Thin wrapper over `require_dependency_hygiene_for_source_with_settings`, kept for
-// callers that do not need settings; currently exercised only by tests.
-#[cfg(test)]
-pub(crate) fn require_dependency_hygiene_for_source(
-    source_path: &Path,
-    extension_path: Option<&Path>,
-    options: DependencyHygieneOptions,
-) -> Result<Vec<CheckoutHygieneSnapshot>> {
-    require_dependency_hygiene_for_source_with_settings(source_path, extension_path, &[], options)
-}
-
 pub fn require_dependency_hygiene_for_source_with_settings(
     source_path: &Path,
     extension_path: Option<&Path>,

--- a/crates/homeboy-extension/src/capability.rs
+++ b/crates/homeboy-extension/src/capability.rs
@@ -56,9 +56,7 @@ pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<Exten
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy_core::component::{Component, ScopedExtensionConfig};
     use homeboy_core::extension_execution::resolve_execution_context_for_project;
-    use homeboy_core::project::Project;
     use homeboy_extension_contract::ExtensionCapability;
     use std::path::Path;
 
@@ -72,24 +70,6 @@ mod tests {
             ),
         )
         .expect("extension manifest");
-    }
-
-    fn component_with_extensions(extension_ids: &[&str]) -> Component {
-        let extensions = extension_ids
-            .iter()
-            .map(|extension_id| {
-                (
-                    (*extension_id).to_string(),
-                    ScopedExtensionConfig::default(),
-                )
-            })
-            .collect();
-
-        Component {
-            id: "consumer".to_string(),
-            extensions: Some(extensions),
-            ..Default::default()
-        }
     }
 
     #[test]

--- a/crates/homeboy-extension/src/lifecycle/mod.rs
+++ b/crates/homeboy-extension/src/lifecycle/mod.rs
@@ -368,8 +368,6 @@ pub fn uninstall(extension_id: &str) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use homeboy_core::extension_update_check::{read_source_revision, read_source_url};
-
     use super::{
         install, install_for_component, install_with_revision, is_extension_update_workdir_clean,
         load_extension, refresh, shared_assets_for_extension_source, source_metadata, update,

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -2,8 +2,6 @@ pub use homeboy_audit_contract::test_mapping::{
     BehaviorScenarioNames, IncludeWrapperPolicy, PackageNameSource, TestMappingConfig,
     TestVacuityPolicy,
 };
-#[cfg(test)]
-use homeboy_core::config::ConfigEntity;
 use homeboy_core::error::{Error, Result};
 pub use homeboy_extension_contract::extension_contract_producer::{
     ExtensionContractProducer, ExtensionContractProducerInvocation,

--- a/crates/homeboy-extension/src/trace/canonicality.rs
+++ b/crates/homeboy-extension/src/trace/canonicality.rs
@@ -1271,34 +1271,6 @@ mod tests {
         (source, remote, snapshot, lab)
     }
 
-    struct TraceEnvGuard(Vec<(String, Option<String>)>);
-
-    impl TraceEnvGuard {
-        fn set(env: std::collections::HashMap<String, String>) -> Self {
-            let previous = env
-                .into_iter()
-                .map(|(name, value)| {
-                    let previous = std::env::var(&name).ok();
-                    unsafe { std::env::set_var(&name, value) };
-                    (name, previous)
-                })
-                .collect();
-            Self(previous)
-        }
-    }
-
-    impl Drop for TraceEnvGuard {
-        fn drop(&mut self) {
-            for (name, value) in self.0.drain(..) {
-                if let Some(value) = value {
-                    unsafe { std::env::set_var(name, value) };
-                } else {
-                    unsafe { std::env::remove_var(name) };
-                }
-            }
-        }
-    }
-
     fn init_bare_repo(path: &std::path::Path) {
         git(path, &["init", "--bare", "-b", "main"]);
     }

--- a/crates/homeboy-lab-runner/src/apply.rs
+++ b/crates/homeboy-lab-runner/src/apply.rs
@@ -307,7 +307,6 @@ fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy_core::source_snapshot::SourceSnapshot;
 
     #[test]
     fn test_apply_workspace_patch() {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -28,9 +28,6 @@ use super::{
     RunnerFileTransfer, RunnerKind,
 };
 
-#[cfg(test)]
-pub(super) use super::{extension_materialization, Runner};
-
 const DEFAULT_HOMEBOY_REMOTE: &str = "https://github.com/Extra-Chill/homeboy.git";
 const DEFAULT_HOMEBOY_REF: &str = "main";
 const DISCONNECTED_SSH_REFRESH_TIMEOUT: Duration = Duration::from_secs(20 * 60);

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
@@ -5,8 +5,6 @@ mod part_b;
 mod part_c;
 
 use super::*;
-use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
-use homeboy_core::test_support;
 
 pub(super) fn ssh_bootstrap_plan() -> HomeboyBinaryRefreshPlan {
     HomeboyBinaryRefreshPlan {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 use std::time::{Duration, Instant};
 

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/part_a.rs
@@ -1,9 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::RunnerKind;
-use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
+use homeboy_core::server::RunnerSecretEnvRef;
 
 #[test]
 fn declared_agent_task_secret_env_parses_repeated_and_equals_args() {

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/part_b.rs
@@ -1,9 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::RunnerKind;
-use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
+use homeboy_core::server::RunnerSecretEnvRef;
 
 #[test]
 fn declared_agent_task_secret_env_includes_provider_config_secrets() {

--- a/crates/homeboy-lab-runner/src/lab_apply.rs
+++ b/crates/homeboy-lab-runner/src/lab_apply.rs
@@ -129,8 +129,6 @@ fn read_lab_patch_artifact(path: &str) -> Result<String> {
 mod tests {
     use std::path::Path;
 
-    use homeboy_core::source_snapshot::SourceSnapshot;
-
     use super::*;
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -1057,7 +1057,6 @@ mod provider_config_remap_tests {
 
 mod provider_config_default_injection_tests {
     use super::*;
-    use homeboy_agents::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy;
 
     #[test]
     fn injects_default_provider_config_for_agent_task_cook() {

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -183,11 +183,7 @@ pub fn controller_workspace_materialization_identity(
 ) -> homeboy_core::error::Result<String> {
     workspace::snapshot_identity(path, &[], &[])
 }
-// Only test code (extension::trace::canonicality) still calls verify_lab_workspace
-// directly; production goes through the LabWorkspaceProvenanceProvider hook.
 pub(crate) use workspace::update_workspace_resource_lifecycle;
-#[cfg(test)]
-pub(crate) use workspace::verify_lab_workspace;
 #[cfg(test)]
 pub(crate) use workspace::workspace_resource_lifecycle;
 
@@ -271,8 +267,6 @@ pub use lab::{
     execute_lab_offload, LabJobOverrides, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
     LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
 };
-#[cfg(test)]
-pub(crate) use lab_env::build_lab_offload_env;
 pub use lab_offload_provider::register as register_runner_lab_offload_provider;
 pub use lab_selection::prepare_explicit_lab_runner_for_offload;
 pub use lab_staging_controller::enable_production_routing as enable_production_lab_staging;

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/mod.rs
@@ -1,14 +1,11 @@
 use super::*;
 use crate::{
-    Runner, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerKind, RunnerRequiredTool,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+    Runner, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerKind, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerStatusReport,
 };
-use homeboy_core::build_identity;
 use homeboy_core::server::RunnerSettings;
 use homeboy_core::Result;
-use homeboy_upgrade::upgrade::current_version;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
-use homeboy_upgrade::upgrade::InstallMethod;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_a.rs
@@ -2,20 +2,13 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{
-    Runner, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerKind, RunnerRequiredTool,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-};
+use crate::RunnerRequiredTool;
 use homeboy_core::build_identity;
-use homeboy_core::server::RunnerSettings;
-use homeboy_core::Result;
 use homeboy_upgrade::upgrade::current_version;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
 thread_local! {
     static LOCAL_VERSION_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -2,20 +2,12 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{
-    Runner, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerKind, RunnerRequiredTool,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-};
 use homeboy_core::build_identity;
-use homeboy_core::server::RunnerSettings;
-use homeboy_core::Result;
 use homeboy_upgrade::upgrade::current_version;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
 thread_local! {
     static LOCAL_VERSION_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
 }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -2,20 +2,10 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{
-    Runner, RunnerActiveJobState, RunnerExecMode, RunnerExecOutput, RunnerKind, RunnerRequiredTool,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
-};
-use homeboy_core::build_identity;
-use homeboy_core::server::RunnerSettings;
-use homeboy_core::Result;
-use homeboy_upgrade::upgrade::current_version;
-use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
 thread_local! {
     static LOCAL_VERSION_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
 }

--- a/crates/homeboy-refactor/Cargo.toml
+++ b/crates/homeboy-refactor/Cargo.toml
@@ -10,6 +10,12 @@ publish = false
 name = "homeboy_refactor"
 path = "src/lib.rs"
 
+[features]
+# Opt-in tier for the full-pipeline audit/refactor regressions that scan real
+# fixture checkouts. Excluded from the default unit gate; see
+# docs/internals/test-tiers.md.
+slow-tests = []
+
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -4,7 +4,6 @@ use crate::daemon::controller_job_driver::{self, ControllerJobDriver};
 use crate::error::Result;
 use crate::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
-use base64::Engine;
 use serde_json::Value;
 #[cfg(unix)]
 use std::process::Command;


### PR DESCRIPTION
Closes #11501

## Why

#11453 turned on `-Dwarnings` enforcement in CI. Its verification was scoped to `cargo build -p homeboy --bin homeboy` plus one focused test — that scope is clean, but the rest of the workspace's `(lib test)` targets were never cleaned. The gate went live against an unclean tree.

Result: **`homeboy / Workspace Tests Compile` and `homeboy / Warning Clean` fail on every PR branched from main.** Ten open PRs (#11472, #11484, #11486, #11487, #11488, #11490, #11492, #11493, #11499, #11500) are red without touching any of the offending files. Reviewers currently cannot distinguish "this PR broke something" from "this PR exists".

This is a good gate that shipped one step early. The fix is to finish the cleanup, not remove the gate.

## What

Clears **88 warnings** across six crates (the other 2 from the CI run were already resolved by later commits on main):

| Crate | Cleared |
|---|---|
| homeboy-lab-runner | 39 |
| homeboy-core | 23 |
| homeboy-cli | 12 |
| homeboy-code-audit | 7 |
| homeboy-extension | 6 |
| homeboy-refactor | 1 |

### Unused imports (the bulk)
Removed only the symbols rustc named. Verified per file by counting real usages rather than trusting line numbers, since main had moved since the CI run.

Notable: the three `commands/infra/route/tests/` files each carried **two** `use super::*;` statements. Rustc flagged the second in each case; the first is what child-module name resolution actually goes through, so the second was removed and the first kept.

### Dead code — all verified unreferenced before deletion
- `require_dependency_hygiene_for_source` (homeboy-core) — `#[cfg(test)]` *and* `pub(crate)`; its own definition was the only reference. The other grep hits are the distinct `_with_settings` function.
- `TraceEnvGuard` + its `set` (homeboy-extension) — searched `*.rs`/`*.md`/`*.toml`/`*.sh` workspace-wide; three hits, all declaration or impl, zero construction sites. Deleted with **both** impl blocks so no impl is left on a missing type.
- `component_with_extensions` (homeboy-extension) — 17 workspace hits, but every call site is a same-named *local copy* in homeboy-core, not a caller. Deleting it also orphaned its test import, removed too.

### `private_interfaces` (2)
Raised `LinkedDurableRunResolution` from `pub(super)` to `pub(crate)`. Lowering the methods instead would have required `pub(in crate::api_jobs)` — an odd form against twelve sibling `pub(crate)` seams in the same file — and plain `pub(super)` would have broken the tests that call them. The identical neighbouring pattern (`reconcile_terminal_linked_daemon_jobs_with_resolver`) is warning-free precisely because its payload type is already public. The enum stays `#[cfg(test)]`.

### Undeclared `slow-tests` feature (7)
`homeboy-code-audit` and `homeboy-refactor` gate code on `#[cfg(feature = "slow-tests")]` without declaring the feature, so `check-cfg` warns the condition can never be true.

**Declared the feature** in both manifests (matching the bare `slow-tests = []` in root and homeboy-core) rather than removing the attributes. This tier is documented by name in `docs/internals/test-tiers.md` and gates real full-pipeline audit/refactor regressions. Declaring a feature does not enable it — the cfg still evaluates false by default. Removing the attributes would have silently pulled known-slow broad-machinery tests into the default CI gate.

`EXPECTED_FINDINGS` (homeboy-code-audit) was gated to the same tier rather than `#[allow(dead_code)]`, matching the convention already used by `run_fixture_audit` sixty lines above it in the same file.

## Constraints honored

- No test deleted or `#[ignore]`d.
- No blanket `#![allow(...)]` at module or crate level.
- No behavior change.

## Verification

`cargo fmt --check` passes. **Nothing was compiled locally** — this host routes builds to CI (see #11481). Every edit was verified by symbol-usage counting and cross-referencing rustc's own per-file verdict, which matched exactly. CI is the gate.

Known follow-up, not fixed here: root `Cargo.toml`'s `slow-tests` does not forward to the member crates, so the documented `cargo test --lib --features slow-tests` invocation is stale post-extraction. That is a pre-existing plumbing gap, not a warning.

🤖 Authored by chubes-bot