### PR TITLE
fix(agents): repair five contract regressions and their stale fixtures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -13,15 +13,20 @@ pub(crate) fn diagnose_run(
     } else {
         "run `homeboy agent-task reconcile-records --dry-run` to inspect repair evidence"
     };
-    let record = store::record_from_run(run).map_err(|_| AgentTaskRecordHealthItem {
-        run_id: run.id.clone(),
-        reason: if run.metadata_json.get("agent_task_run").is_none() {
-            AgentTaskRecordHealthReason::MissingMetadata
-        } else {
-            AgentTaskRecordHealthReason::MalformedMetadata
-        },
-        quarantined,
-        remediation: remediation.to_string(),
+    // Diagnosis must be able to read a legacy record in order to classify it as
+    // LegacySchema; the strict guard would report it as malformed metadata and
+    // send it to quarantine instead of migration.
+    let record = store::record_from_run_allowing_legacy_schema(run).map_err(|_| {
+        AgentTaskRecordHealthItem {
+            run_id: run.id.clone(),
+            reason: if run.metadata_json.get("agent_task_run").is_none() {
+                AgentTaskRecordHealthReason::MissingMetadata
+            } else {
+                AgentTaskRecordHealthReason::MalformedMetadata
+            },
+            quarantined,
+            remediation: remediation.to_string(),
+        }
     })?;
     let reason = if record.lab_handoff_validation_error().is_some() {
         Some(AgentTaskRecordHealthReason::MalformedMetadata)
@@ -118,7 +123,7 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
             store::write_record(&reconstruct_record(&run)?)?;
             report.migrated += 1;
         } else if item.reason == AgentTaskRecordHealthReason::LegacySchema {
-            let mut record = store::record_from_run(&run)?;
+            let mut record = store::record_from_run_allowing_legacy_schema(&run)?;
             let original = serde_json::to_value(&record).unwrap_or(Value::Null);
             record.schema = schemas::RUN.to_string();
             record.lifecycle.schema = RUN_LIFECYCLE_RECORD_SCHEMA.to_string();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1967,9 +1967,15 @@ fn cancel_run_signals_live_running_record() {
 fn record_health_migrates_legacy_and_quarantines_conflicting_projections() {
     with_isolated_home(|_| {
         submit_plan(&test_plan(), Some("legacy-record")).expect("submitted");
-        rewrite_record_for_test("legacy-record", |record| {
-            record.schema = "homeboy/agent-task-run/v0".to_string();
-        })
+        // #11446 made the typed writer reject unsupported schemas, which is the
+        // point of the guard but also blocks planting the very legacy record
+        // this test migrates. Use the raw injector built for that.
+        crate::agent_task_lifecycle::inject_raw_record_metadata_for_corruption_test(
+            "legacy-record",
+            |value| {
+                value["agent_task_run"]["schema"] = json!("homeboy/agent-task-run/v0");
+            },
+        )
         .expect("legacy stored");
         let legacy = reconcile_record_health(false).expect("legacy migrated");
         assert_eq!(legacy.migrated, 1);

--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -605,6 +605,27 @@ pub(crate) fn run_provider_command(
     run_provider_command_with_timeout(invocation, request, PROMOTION_PROVIDER_TIMEOUT)
 }
 
+/// Terminate a promotion provider and every descendant it spawned.
+///
+/// Killing only the direct child leaves an escaped grandchild holding the
+/// inherited stdout/stderr pipes, so the capture threads never see EOF and the
+/// bounded timeout becomes as long as the grandchild runs.
+#[cfg(unix)]
+fn kill_provider_process_group(process: &mut std::process::Child) {
+    if process.id() <= i32::MAX as u32 {
+        unsafe {
+            libc::kill(-(process.id() as i32), libc::SIGKILL);
+        }
+    } else {
+        let _ = process.kill();
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_provider_process_group(process: &mut std::process::Child) {
+    let _ = process.kill();
+}
+
 pub(super) fn run_provider_command_with_timeout(
     invocation: &CommandInvocation,
     request: &AgentTaskPromotionApplyRequest,
@@ -635,6 +656,15 @@ pub(super) fn run_provider_command_with_timeout(
     command_builder.args(&args);
     if let Some(cwd) = invocation.cwd.as_deref() {
         command_builder.current_dir(cwd);
+    }
+    // A provider owns its whole process tree. Give it its own process group so
+    // a timeout can reap descendants: killing only the direct child leaves an
+    // escaped grandchild holding the stdout/stderr pipes, and the capture
+    // threads then block until *it* exits, which defeats the timeout entirely.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command_builder.process_group(0);
     }
 
     let mut process = command_builder
@@ -701,12 +731,7 @@ pub(super) fn run_provider_command_with_timeout(
             })? {
                 break status;
             }
-            process.kill().map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("terminate oversized agent-task promotion provider response".to_string()),
-                )
-            })?;
+            kill_provider_process_group(&mut process);
             break process.wait().map_err(|error| {
                 Error::internal_io(
                     error.to_string(),
@@ -724,12 +749,7 @@ pub(super) fn run_provider_command_with_timeout(
         }
         if started_at.elapsed() >= timeout {
             timed_out = true;
-            process.kill().map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some("terminate timed out agent-task promotion provider command".to_string()),
-                )
-            })?;
+            kill_provider_process_group(&mut process);
             break process.wait().map_err(|error| {
                 Error::internal_io(
                     error.to_string(),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -67,17 +67,19 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
         let marker = tempfile::NamedTempFile::new().expect("provider marker");
         let marker_path = marker.into_temp_path();
         std::fs::remove_file(&marker_path).expect("remove provider marker");
-        let provider = tempfile::NamedTempFile::new().expect("provider command");
+        let provider = tempfile::NamedTempFile::new()
+            .expect("provider command")
+            .into_temp_path();
         std::fs::write(
-            provider.path(),
+            &provider,
             format!("#!/bin/sh\ntouch '{}'\nexit 23\n", marker_path.display()),
         )
         .expect("write rejecting provider");
-        let mut permissions = std::fs::metadata(provider.path())
+        let mut permissions = std::fs::metadata(&provider)
             .expect("provider metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
 
         worktree::adopt(WorktreeAdoptOptions {
             handle: "fixture@adopted".to_string(),
@@ -97,10 +99,7 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
                 lookup_timeout_ms: 10_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
-                    resolve: Some(vec![
-                        provider.path().display().to_string(),
-                        "{handle}".to_string(),
-                    ]),
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(WorktreeProviderListResultMapping {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -256,9 +256,11 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
 #[test]
 fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination() {
     let (_temp, repo, _base, candidate) = adopted_commit_repo();
-    let provider = tempfile::NamedTempFile::new().expect("provider command");
+    let provider = tempfile::NamedTempFile::new()
+        .expect("provider command")
+        .into_temp_path();
     std::fs::write(
-        provider.path(),
+        &provider,
         format!(
             "#!/bin/sh\nprintf '%s\\n' '{}'\n",
             serde_json::json!({
@@ -275,11 +277,11 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(provider.path())
+        let mut permissions = std::fs::metadata(&provider)
             .expect("provider metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
     }
     let mut config = HomeboyConfig::default();
     config.worktree_providers.insert(
@@ -291,10 +293,7 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
             lookup_timeout_ms: 10_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
-                resolve: Some(vec![
-                    provider.path().display().to_string(),
-                    "{handle}".to_string(),
-                ]),
+                resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
                 ..Default::default()
             },
             list_result_mapping: Some(WorktreeProviderListResultMapping {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -256,45 +256,55 @@ fn scheduler_dispatches_extension_provider_command() {
 
 #[test]
 fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests() {
-    let runner_root = homeboy_core::artifacts::root().expect("runner artifact root");
-    {
-        let controller_root = tempfile::tempdir().expect("controller root");
-        let command = format!(
+    // The point of this test is that artifacts land in the runner-local root
+    // rather than the controller root, which an isolated home preserves: it
+    // just moves the runner root somewhere hermetic. Without it the test wrote
+    // a durable provider reservation into the developer's real Homeboy state
+    // and failed on every subsequent run with "provider execution was already
+    // reserved by an interrupted controller".
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let runner_root = homeboy_core::artifacts::root().expect("runner artifact root");
+        {
+            let controller_root = tempfile::tempdir().expect("controller root");
+            let command = format!(
             "node {}",
             script("let fs=require('fs'); let path=require('path'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let valid=path.isAbsolute(req.artifacts_path)&&fs.statSync(req.artifacts_path).isDirectory()&&req.artifacts_path_provenance.owner==='homeboy'&&req.artifacts_path_provenance.locality==='runner'&&!req.artifacts_path.startsWith(req.executor.config.controller_root); fs.writeFileSync(path.join(req.artifacts_path, req.task_id+'.txt'),'captured'); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:valid?(req.executor.config.no_op?'no_op':'succeeded'):'failed',summary:req.artifacts_path,artifacts:[]}));")
         );
-        let (mut no_op, provider) = request("task-no-op", command);
-        no_op.executor.config = json!({
-            "controller_root": controller_root.path(),
-            "no_op": true
-        });
-        let mut editing = no_op.clone();
-        editing.task_id = "task-editing".to_string();
-        editing.executor.config["no_op"] = json!(false);
-        let scheduler =
-            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                provider,
-            ]))
-            .with_run_id("runner-local-artifact-run");
+            let (mut no_op, provider) = request("task-no-op", command);
+            no_op.executor.config = json!({
+                "controller_root": controller_root.path(),
+                "no_op": true
+            });
+            let mut editing = no_op.clone();
+            editing.task_id = "task-editing".to_string();
+            editing.executor.config["no_op"] = json!(false);
+            let scheduler =
+                AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                    provider,
+                ]))
+                .with_run_id("runner-local-artifact-run");
 
-        let aggregate = scheduler.run(AgentTaskPlan::new(
-            "runner-local-artifact-plan",
-            vec![no_op, editing],
-        ));
+            // Recording a provider execution is durable, so the run it belongs
+            // to has to exist before the scheduler dispatches it.
+            let plan = AgentTaskPlan::new("runner-local-artifact-plan", vec![no_op, editing]);
+            crate::agent_task_lifecycle::submit_plan(&plan, Some("runner-local-artifact-run"))
+                .expect("durable run record");
+            let aggregate = scheduler.run(plan);
 
-        assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::NoOp);
-        assert_eq!(
-            aggregate.outcomes[1].status,
-            AgentTaskOutcomeStatus::Succeeded
-        );
-        for outcome in &aggregate.outcomes {
-            let path = PathBuf::from(outcome.summary.as_deref().expect("artifacts path"));
-            assert!(path.starts_with(&runner_root));
-            assert!(!path.starts_with(controller_root.path()));
-            assert!(path.join(format!("{}.txt", outcome.task_id)).is_file());
+            assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::NoOp);
+            assert_eq!(
+                aggregate.outcomes[1].status,
+                AgentTaskOutcomeStatus::Succeeded
+            );
+            for outcome in &aggregate.outcomes {
+                let path = PathBuf::from(outcome.summary.as_deref().expect("artifacts path"));
+                assert!(path.starts_with(&runner_root));
+                assert!(!path.starts_with(controller_root.path()));
+                assert!(path.join(format!("{}.txt", outcome.task_id)).is_file());
+            }
+            assert_ne!(aggregate.outcomes[0].summary, aggregate.outcomes[1].summary);
         }
-        assert_ne!(aggregate.outcomes[0].summary, aggregate.outcomes[1].summary);
-    }
+    });
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -770,12 +770,42 @@ where
                     // late artifacts to this exact execution before selecting a
                     // recoverable candidate for promotion.
                     finalize_candidate_artifacts(&mut outcome, &running_task);
+                    // CandidateRecoverable means "a controller must handle this
+                    // candidate", and rotation deliberately refuses to act on it
+                    // (#8809). Both the timeout downgrade below and the
+                    // base-bound patch retention set that status, so an
+                    // explicitly configured rotation policy was being disabled
+                    // for exactly the providers that produce patches. Decide
+                    // eligibility from the pre-downgrade outcome and give
+                    // rotation first refusal; both retentions are the fallback
+                    // for when nothing will rotate.
+                    let rotation_takes_over =
+                        AgentTaskScheduleSupport::rotation_policy_for_request(
+                            &running_task.request,
+                            plan.options.rotation.as_ref(),
+                        )
+                        .is_some_and(|policy| {
+                            let mut eligible = outcome.clone();
+                            if running_task.timeout_cancel_requested {
+                                eligible.status = AgentTaskOutcomeStatus::Timeout;
+                                eligible.failure_classification =
+                                    Some(AgentTaskFailureClassification::Timeout);
+                            }
+                            AgentTaskScheduleSupport::should_rotate_provider(
+                                &eligible,
+                                &policy,
+                                running_task.rotation_index,
+                                result.attempt,
+                                execution_budget.max_provider_executions,
+                                execution_budget.max_provider_rotations,
+                            )
+                        });
                     if running_task.timeout_cancel_requested {
                         // Cancellation was requested at the deadline and this
                         // result proves the provider no longer owns the checkout.
                         // Harvest above is therefore race-free.
                         let recovered = outcome.artifacts.iter().any(is_actionable_patch_artifact);
-                        outcome.status = if recovered {
+                        outcome.status = if recovered && !rotation_takes_over {
                             AgentTaskOutcomeStatus::CandidateRecoverable
                         } else {
                             AgentTaskOutcomeStatus::Timeout
@@ -815,9 +845,11 @@ where
                             );
                         }
                     }
-                    AgentTaskScheduleSupport::preserve_base_bound_patch_after_provider_failure(
-                        &mut outcome,
-                    );
+                    if !rotation_takes_over {
+                        AgentTaskScheduleSupport::preserve_base_bound_patch_after_provider_failure(
+                            &mut outcome,
+                        );
+                    }
                     let state = AgentTaskScheduleSupport::state_for_outcome(&outcome);
                     events.push(event(
                         &outcome.task_id,

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -632,7 +632,10 @@ pub(super) mod concurrency_tests {
             })
             .and_then(|artifact| artifact.path.as_deref())
             .expect("deferred cleanup action path");
-        let deadline = Instant::now() + Duration::from_secs(2);
+        // Deferred cleanup is asynchronous; the assertion is that it recovers,
+        // not that it recovers within any particular fraction of a second. A 2s
+        // bound made this a wall-clock race on a loaded machine.
+        let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             let action: Value = serde_json::from_str(
                 &fs::read_to_string(cleanup_action).expect("deferred cleanup action"),

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -374,6 +374,10 @@ mod provider_rotation_tests {
         }]));
         enable_rotation(&mut plan);
 
+        // Recording a provider execution is durable, so the run it belongs to
+        // has to exist before the scheduler dispatches it.
+        crate::agent_task_lifecycle::submit_plan(&plan, Some("run-adopt"))
+            .expect("durable run record");
         let aggregate = AgentTaskScheduler::new(scheduler)
             .with_run_id("run-adopt")
             .run(plan);
@@ -631,7 +635,7 @@ mod provider_rotation_tests {
                 );
                 if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
                     fs::write(&self.scratch_index, "{ stale").expect("corrupt stale index");
-                    std::thread::sleep(Duration::from_millis(25));
+                    std::thread::sleep(Duration::from_millis(100));
                     return outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded);
                 }
                 outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
@@ -653,9 +657,16 @@ mod provider_rotation_tests {
         })
         .with_run_id(run_id);
         let mut plan = plan_with_tasks(1);
-        plan.tasks[0].limits.timeout_ms = Some(1);
+        // The first attempt must exceed its timeout and still return inside
+        // timeout_with_grace (timeout + 100ms), and the second must finish
+        // within the timeout. A 1ms budget made the second a race that any
+        // loaded machine lost, because the scheduler's own dispatch and
+        // finalization are charged to the attempt. 60ms timeout with a 100ms
+        // provider sleep keeps both orderings with ~40ms of margin either way.
+        plan.tasks[0].limits.timeout_ms = Some(60);
         plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
         enable_rotation(&mut plan);
+        crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("durable run record");
 
         let aggregate = scheduler.run(plan);
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1546,7 +1546,18 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         let mut applied_run_id = None;
         for attempt in recipe.attempts.iter().rev() {
             if persisted_promotion_for_attempt(&attempt.run_id)?.is_some_and(|promotion| {
-                promotion.gate_outcome().status == AgentTaskPromotionStatus::Applied
+                // #11460 stopped flattening an explicitly accepted inherited
+                // baseline failure into Applied, so selecting only on Applied
+                // made recovery unable to find the very attempt it exists to
+                // recover. Selection is permissive on purpose: finalization
+                // still enforces finalization_eligible against the cook's own
+                // accept_inherited_failures, so a candidate the operator has
+                // not accepted still fails there, with its specific reason
+                // instead of "no attempt with an applied promotion".
+                let outcome = promotion.gate_outcome();
+                outcome.status == AgentTaskPromotionStatus::Applied
+                    || (outcome.status == AgentTaskPromotionStatus::GateFailed
+                        && promotion.finalization_eligible(true))
             }) {
                 applied_run_id = Some(attempt.run_id.clone());
                 break;
@@ -1569,15 +1580,22 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             None,
         )
     })?;
-    if promotion.gate_outcome().status != AgentTaskPromotionStatus::Applied {
+    let options = super::cook_recipe::reconstruct_adoption_options(&recipe)?;
+    // An explicitly accepted inherited baseline failure is finalizable (#11460),
+    // so it is recoverable too. Judge it with the cook's own
+    // accept_inherited_failures rather than requiring a green-gate Applied.
+    let recovery_outcome = promotion.gate_outcome();
+    if recovery_outcome.status != AgentTaskPromotionStatus::Applied
+        && !(recovery_outcome.status == AgentTaskPromotionStatus::GateFailed
+            && promotion.finalization_eligible(options.gates.accept_inherited_failures))
+    {
         return Err(Error::validation_invalid_argument(
             "latest_promotion.status",
-            "recovery requires an applied promotion with green gates",
+            "recovery requires an applied promotion with green gates or an explicitly accepted inherited baseline failure",
             Some(run_id),
             None,
         ));
     }
-    let options = super::cook_recipe::reconstruct_adoption_options(&recipe)?;
     let finalization = cook_finalization_options(&options, &run_id, &promotion, overrides)?;
     if !preflight {
         agent_task_lifecycle::record_promotion(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6841,9 +6841,12 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
         accepted.status,
         crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
     );
+    // #11460 preserves the inherited-failure truth instead of flattening it to
+    // Failed; the sibling assertion in this file was updated there, this one was
+    // missed.
     assert_eq!(
         accepted.gate_results[0].status,
-        homeboy_core::gate::HomeboyGateStatus::Failed
+        homeboy_core::gate::HomeboyGateStatus::AcceptedInheritedFailure
     );
     assert!(!accepted.has_visible_passed_gate_for_command(command));
 
@@ -7873,6 +7876,10 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         options.head = Some("fix/8058".to_string());
         options.gates = VerifyGateOptions {
             verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            // The fixture below marks the gate AcceptedInheritedFailure, which
+            // is only a finalizable (and therefore recoverable) state when the
+            // cook actually accepted inherited failures.
+            accept_inherited_failures: true,
             ..Default::default()
         };
         persist_initial_recipe(&options).unwrap();
@@ -7907,8 +7914,15 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
         let preflight =
             recover_cook_pr_with_backend(cook_id, Vec::new(), true, &mut preflight_backend)
                 .expect_err("recovery without an executed model fails closed");
-        assert_eq!(preflight.details["field"], "provider_model");
-        assert!(preflight.message.contains("no concrete executed model"));
+        // #11460 stopped treating an accepted inherited failure as a passed
+        // gate (asserted directly in
+        // adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe),
+        // so recovery now fails closed before the executed-model check: an
+        // inherited red baseline cannot back a published test claim.
+        assert_eq!(preflight.details["field"], "verification");
+        assert!(preflight
+            .message
+            .contains("without matching successful visible durable gate evidence"));
         assert!(!preflight_backend.committed);
         assert!(!preflight_backend.pushed);
         assert!(!preflight_backend.created);
@@ -7933,8 +7947,10 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
             false,
             &mut publish_backend,
         )
-        .expect_err("publication without an executed model fails closed");
-        assert_eq!(publish.details["field"], "provider_model");
+        .expect_err("publication without backing gate evidence fails closed");
+        // Same reason as the preflight above: the accepted inherited failure is
+        // not a passed gate, so the claim is refused before the model check.
+        assert_eq!(publish.details["field"], "verification");
         assert!(!publish_backend.committed);
         assert!(!publish_backend.pushed);
         assert!(!publish_backend.created);
@@ -8171,9 +8187,14 @@ fn cook_rejects_test_claim_without_matching_durable_gate() {
             attempt_dispatcher: None,
             harvest_context: crate::agent_task_scheduler::HarvestExecutionContext::default(),
         };
+        // Finalization eligibility is checked before the test-claim contract and
+        // requires a non-empty gate set, so clearing the gates outright never
+        // reaches the check this test names. Keep the gate green but private:
+        // eligible to finalize, yet not visible evidence that can back a
+        // published test claim.
         let mut unsupported = promotion(run_id);
-        unsupported.deterministic_gates.clear();
-        unsupported.gate_results.clear();
+        unsupported.deterministic_gates[0].visibility =
+            homeboy_core::gate::HomeboyGateVisibility::Private;
         let error = finalize_cook_pr_with_backend(
             &options,
             run_id,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -551,6 +551,26 @@ fn merge_observation_metadata(mut existing: Value, typed: Value) -> Value {
 }
 
 pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    record_from_run_with_schema_policy(run, true)
+}
+
+/// Read a durable record without enforcing the supported-schema guard.
+///
+/// Record health reconciliation exists to migrate legacy schemas, so it is the
+/// one caller that must be able to read one. #11446 added the guard inside
+/// `record_from_run`, which is exactly what the migration branch calls, making
+/// legacy migration unreachable: the reconciler reported the unsupported-schema
+/// diagnostic instead of migrating.
+pub(super) fn record_from_run_allowing_legacy_schema(
+    run: &RunRecord,
+) -> Result<AgentTaskRunRecord> {
+    record_from_run_with_schema_policy(run, false)
+}
+
+fn record_from_run_with_schema_policy(
+    run: &RunRecord,
+    enforce_schema: bool,
+) -> Result<AgentTaskRunRecord> {
     let value = run.metadata_json.get("agent_task_run").ok_or_else(|| {
         Error::new(
             ErrorCode::InternalJsonError,
@@ -568,7 +588,7 @@ pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
                 Some(format!("parse agent-task run {}", run.id)),
             )
         })?;
-    if record.schema != super::records::schemas::RUN {
+    if enforce_schema && record.schema != super::records::schemas::RUN {
         return Err(Error::validation_invalid_argument(
             "agent_task_run.schema",
             format!(


### PR DESCRIPTION
`cargo test -p homeboy-agents --lib`: **8 failures → 2.**

Four of these are product regressions where a recent change moved a contract and
left the paths that depend on it behind. The tests were right.

## Product fixes

**Provider rotation was disabled for every provider that produces a patch.**
`should_rotate_provider` has refused `CandidateRecoverable` since #8809, and
#11282 rewrote provider failures to exactly that status *before* rotation was
consulted — so an explicitly configured rotation policy silently never fired
(`provider_rotation_index: 0`, one outcome, the second provider never called).
Rotation eligibility is now decided from the pre-downgrade outcome and gets
first refusal; both retentions remain the fallback when nothing rotates. The
timeout path sets the same status directly, so it is gated the same way.

**Promotion provider timeouts were unbounded.** `kill()` reaped only the direct
child, so an escaped grandchild kept the inherited stdout/stderr pipes open and
the capture threads blocked until *it* exited. A 100ms timeout against
`sh -c 'sleep 2'` took **2 seconds**. Now spawned into its own process group and
SIGKILLed as a group, matching what the acceptance verifier already does. That
test went from 2.00s to **0.10s** — the assertion it was failing was correct and
worth keeping.

**Cook recovery could not recover an accepted inherited baseline failure.**
#11460 stopped flattening that state into `Applied`, but both the attempt
selection and the `latest_promotion.status` check still required `Applied`, so
recovery reported "no attempt with an applied promotion" for the very attempt it
exists to recover. Selection is permissive deliberately; the status check uses
the cook's own `accept_inherited_failures`, so an unaccepted candidate still
fails with its specific reason rather than a misleading one.

**Legacy record migration was unreachable.** #11446 put the supported-schema
guard inside `record_from_run` — which is what *both* health diagnosis and the
migration branch call — so a legacy record could never be read and therefore
never migrated. `reconcile_record_health` reported the unsupported-schema
diagnostic instead of migrating. Added a lenient read used only by
reconciliation; the strict guard is unchanged everywhere else.

## Fixture repairs

Each tracks a deliberate contract change that landed without updating them:

- #11460 preserves the inherited-failure truth. One `gate_results` assertion was
  updated in that PR and one was missed. Recovery now fails closed at
  `verification` instead of `provider_model`, because an accepted inherited
  failure is explicitly *not* a passed gate
  (asserted directly by `adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe`)
  and so cannot back a published test claim.
- `cook_rejects_test_claim_without_matching_durable_gate` cleared its gates
  outright, which now trips finalization eligibility before the claim check it
  names. A green but **private** gate is eligible to finalize yet cannot back a
  claim, which reaches the intended check.
- Two rotation fixtures never submitted a durable plan (recording a provider
  execution is durable), and one raced a **1ms** timeout that the scheduler's own
  dispatch and finalization cannot meet. 60ms timeout against a 100ms provider
  sleep keeps both orderings — the attempt must exceed its timeout *and* return
  inside `timeout_with_grace` — with ~40ms margin either way.
- `record_health_migrates_legacy` planted its legacy record through the typed
  writer that now rejects it. The raw corruption injector exists for exactly
  this; it operates on `metadata_json`, so the schema lives at
  `value["agent_task_run"]["schema"]`.
- The deferred-cleanup poll asserted recovery within 2s. It recovers in 5.66s on
  a loaded machine, so the behaviour is right and only the bound was wrong.

## What is left

Two: `bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently`
and `bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending`.

Both pass individually and at module scope — `agent_task_promotion` is **95/0**
on this branch — and fail only in a full-crate run, single-threaded, so it is
sequential state left by an earlier module rather than concurrency. Both already
use `with_isolated_home`, so it is not the ambient home. Pre-existing and
unrelated to anything here; I did not want to hold the other eight for it.