### PR TITLE
fix: drop unused PlacementReadinessRequest import in offload tests

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/mod.rs
@@ -12,10 +12,10 @@ pub(super) use super::super::super::lab_workspaces::{
 pub(super) use super::*;
 pub(super) use crate::verify_lab_workspace_from_env;
 pub(super) use crate::{
-    compile_lab_admission_plan, PlacementReadinessRequest, RunnerActiveJobSource,
-    RunnerActiveJobState, RunnerAvailability, RunnerExecMode, RunnerExecOutput, RunnerRequiredTool,
-    RunnerSession, RunnerSessionState, RunnerStaleDaemonWarning, RunnerTunnelMode,
-    RunnerWorkspaceMaterializationPlan, RunnerWorkspaceSyncOutput,
+    compile_lab_admission_plan, RunnerActiveJobSource, RunnerActiveJobState, RunnerAvailability,
+    RunnerExecMode, RunnerExecOutput, RunnerRequiredTool, RunnerSession, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerTunnelMode, RunnerWorkspaceMaterializationPlan,
+    RunnerWorkspaceSyncOutput,
 };
 pub(super) use homeboy_core::engine::command::{CaptureMetadata, CommandCaptureMetadata};
 pub(super) use homeboy_core::observation::{


### PR DESCRIPTION
Follow-up to #11515 / refs #11501.

#11514 ("complete Lab readiness fixture migration") left `PlacementReadinessRequest` imported but unused in `crates/homeboy-lab-runner/src/lab/offload/tests/mod.rs`. It landed between #11515's CI run and its merge, so the warning survived the sweep.

Verified: the symbol appears exactly **once** anywhere under `lab/offload/` — the import itself. Its only real consumers are in `lab_selection.rs` (11 uses), which imports it independently.

This is the last warning standing between main and a green `Warning Clean` / `Workspace Tests Compile`.

`cargo fmt --check` passes. Not compiled locally (this host routes builds to CI, see #11481); the change is the removal of one name from a `use` group.

🤖 Authored by chubes-bot