### PR TITLE
fix(runner): converge doctor repair with Lab admission

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -13,7 +13,14 @@ pub fn report(
         std::time::Duration::from_secs(60),
         "runner doctor",
     );
-    let persisted_status = runner::diagnostic_status(runner_id).ok();
+    // Lab admission uses the live status projection, including the daemon's
+    // typed freshness report. Doctor repair must make its decision from that
+    // same observation rather than treating a reachable endpoint as ready.
+    let persisted_status = if options.scope == RunnerDoctorScope::LabOffload {
+        runner::status(runner_id).ok()
+    } else {
+        runner::diagnostic_status(runner_id).ok()
+    };
     if options.scope == RunnerDoctorScope::LabOffload {
         match persisted_status.as_ref() {
             Some(status) if !status.connected => {
@@ -319,7 +326,7 @@ pub fn report(
         checks,
         secret_env_migration: None,
         diagnostics,
-        daemon_recovery: None,
+        daemon_recovery: persisted_status.and_then(|status| status.daemon_freshness),
         repairs: Vec::new(),
     }
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -69,7 +69,10 @@ pub fn apply(
         .checks
         .iter()
         .any(|check| check.id == "daemon.exec" && check.status == RunnerDoctorStatus::Error);
-    if !daemon_failed {
+    let daemon_admission_closed = runner::status(id)
+        .map(|status| !daemon_admission_ready(&status))
+        .unwrap_or(false);
+    if !daemon_failed && !daemon_admission_closed {
         report.repairs.push(RunnerRepair {
             id: "repair.daemon".to_string(),
             status: RunnerDoctorStatus::Ok,
@@ -94,17 +97,36 @@ pub fn apply(
             report
                 .checks
                 .extend(probes::connected_daemon_exec_checks(id, workspace_root));
-            report.repairs.push(RunnerRepair {
-                id: "repair.daemon".to_string(),
-                status: RunnerDoctorStatus::Ok,
-                message: match disconnect_error {
-                    Some(error) => format!(
-                        "Recovered the Lab runner daemon after bounded disconnect failed ({}) and reran the daemon exec probe",
+            let (status, message) = match runner::status(id) {
+                Ok(status) if daemon_admission_ready(&status) => (
+                    RunnerDoctorStatus::Ok,
+                    match disconnect_error {
+                        Some(error) => format!(
+                            "Recovered the Lab runner daemon after bounded disconnect failed ({}) and reran the daemon exec probe",
+                            error.message
+                        ),
+                        None => {
+                            "Reconnected the Lab runner daemon and reran the daemon exec probe"
+                                .to_string()
+                        }
+                    },
+                ),
+                Ok(_) => (
+                    RunnerDoctorStatus::Error,
+                    "Reconnected the Lab runner daemon, but Lab admission remains closed".to_string(),
+                ),
+                Err(error) => (
+                    RunnerDoctorStatus::Error,
+                    format!(
+                        "Reconnected the Lab runner daemon, but could not verify Lab admission: {}",
                         error.message
                     ),
-                    None => "Reconnected the Lab runner daemon and reran the daemon exec probe"
-                        .to_string(),
-                },
+                ),
+            };
+            report.repairs.push(RunnerRepair {
+                id: "repair.daemon".to_string(),
+                status,
+                message,
                 commands,
             });
         }
@@ -292,19 +314,44 @@ fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) ->
     }
 
     report.checks.retain(|check| check.id != "daemon.exec");
-    report.repairs.push(RunnerRepair {
-        id: "repair.daemon".to_string(),
-        status: RunnerDoctorStatus::Ok,
-        message: format!(
-            "Applied the reported daemon repair plan ({applied} step(s): {})",
-            plan.iter()
-                .map(|step| step.code.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
-        commands,
-    });
+    let steps = plan
+        .iter()
+        .map(|step| step.code.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    match runner::status(runner_id) {
+        Ok(status) if daemon_admission_ready(&status) => report.repairs.push(RunnerRepair {
+            id: "repair.daemon".to_string(),
+            status: RunnerDoctorStatus::Ok,
+            message: format!("Applied the reported daemon repair plan ({applied} step(s): {steps})"),
+            commands,
+        }),
+        Ok(_) => report.repairs.push(RunnerRepair {
+            id: "repair.daemon".to_string(),
+            status: RunnerDoctorStatus::Error,
+            message: format!(
+                "Applied the reported daemon repair plan ({applied} step(s): {steps}), but Lab admission remains closed"
+            ),
+            commands,
+        }),
+        Err(error) => report.repairs.push(RunnerRepair {
+            id: "repair.daemon".to_string(),
+            status: RunnerDoctorStatus::Error,
+            message: format!(
+                "Applied the reported daemon repair plan ({applied} step(s): {steps}), but could not verify Lab admission: {}",
+                error.message
+            ),
+            commands,
+        }),
+    }
     true
+}
+
+/// The same typed readiness decision rendered as `accepting_jobs` by runner
+/// status and used by Lab admission. Repair success is only valid when it is
+/// true after the final mutation.
+pub(super) fn daemon_admission_ready(status: &runner::RunnerStatusReport) -> bool {
+    status.admission_summary(0).accepting_jobs
 }
 
 fn connect_outcome(

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -436,3 +436,49 @@ mod repair_dispatch {
         );
     }
 }
+
+mod repair_readiness {
+    use super::super::super::repair::daemon_admission_ready;
+    use homeboy::runner::runners::{
+        RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+    };
+
+    fn status(stale_daemon: Option<RunnerStaleDaemonWarning>) -> RunnerStatusReport {
+        RunnerStatusReport {
+            runner_id: "homeboy-lab".to_string(),
+            connected: true,
+            state: RunnerSessionState::Connected,
+            session: None,
+            stale_daemon,
+            daemon_freshness: None,
+            active_jobs: Vec::new(),
+            active_runner_jobs: Vec::new(),
+            stale_runner_jobs: Vec::new(),
+            active_job_count: 0,
+            stale_runner_job_count: 0,
+            active_job_state: RunnerActiveJobState::Available,
+            active_job_source: None,
+            active_job_error: None,
+            active_job_recovery_evidence: None,
+            session_path: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn reachable_incompatible_daemon_is_not_admission_ready() {
+        let stale = RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "0.329.1".to_string(),
+            "0.329.1".to_string(),
+            Some("homeboy 0.329.1+ea98b7e9b4cc".to_string()),
+            Some("homeboy 0.329.1+98cc7876dd71".to_string()),
+        );
+
+        assert!(!daemon_admission_ready(&status(Some(stale))));
+    }
+
+    #[test]
+    fn repair_success_postcondition_requires_open_admission() {
+        assert!(daemon_admission_ready(&status(None)));
+    }
+}

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -1029,6 +1029,9 @@ fn connected_runner_not_ready_reason(
     runner_id: &str,
     status: &RunnerStatusReport,
 ) -> Option<String> {
+    if status.daemon_ready_for_admission() {
+        return None;
+    }
     if let Some(warning) = status.stale_daemon.as_ref() {
         let restart = daemon_repair_command(runner_id, status);
         if !warning.stale_runtime_paths.is_empty() || !warning.changed_runtime_paths.is_empty() {

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -675,6 +675,11 @@ impl RunnerStatusReport {
         self.state == RunnerSessionState::Connected
     }
 
+    /// Shared daemon compatibility predicate for Lab admission and repair.
+    pub fn daemon_ready_for_admission(&self) -> bool {
+        self.is_connected() && self.stale_daemon.is_none()
+    }
+
     /// Project the authoritative current-state admission summary.
     ///
     /// `draining_generation_count` is supplied by the caller from the same
@@ -695,7 +700,7 @@ impl RunnerStatusReport {
         draining_generation_count: usize,
     ) -> RunnerAdmissionSummary {
         let connected = self.is_connected();
-        let daemon_fresh = self.stale_daemon.is_none();
+        let daemon_fresh = self.daemon_ready_for_admission();
         let blocking_generation = generations
             .iter()
             .find(|generation| !generation.admission_owner && generation.active_job_count > 0)


### PR DESCRIPTION
## Summary
- evaluate doctor repair with the same readiness semantics as Lab admission
- repair reachable but incompatible daemon identities
- require open admission before reporting repair success

## Verification
- `cargo test -p homeboy-cli commands::runner::doctor::tests::daemon --lib` (18 passed)
- `cargo fmt --check`
- `git diff --check`

Closes #11506.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode implemented, tested, and prepared this PR. Chris Huber reviewed and remains responsible for every line.