### PR TITLE
fix(cleanup): retain runtime temp storage under pressure

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1551,13 +1551,35 @@ fn automatic_retention() -> CmdResult<Value> {
             state_path: state_path.display().to_string(),
             resume_command: "homeboy cleanup automatic-retention".to_string(),
             cargo_targets: None,
+            runtime_tmp: None,
         }
     } else {
         cleanup::run_automatic_cargo_retention()?
     };
+    let runtime_tmp = if deadline.is_some_and(|deadline| SystemTime::now() >= deadline) {
+        serde_json::json!({ "status": "partial" })
+    } else {
+        match cleanup::run_automatic_runtime_temp_retention() {
+            Ok(output) => serde_json::to_value(output.runtime_tmp).map_err(|error| {
+                homeboy::core::Error::internal_json(
+                    error.to_string(),
+                    Some("serialize automatic runtime-temp retention".to_string()),
+                )
+            })?,
+            Err(error) => serde_json::json!({ "status": "retained", "reason": error.message }),
+        }
+    };
     let cleanup_exit_code = cleanup.exit_code;
     let status = if cleanup_exit_code == 0 {
-        cargo_targets.status
+        if runtime_tmp["status"] == "retained" {
+            "partial_failure"
+        } else if runtime_tmp["continuation_required"] == true
+            && cargo_targets.status == "completed"
+        {
+            "partial"
+        } else {
+            cargo_targets.status
+        }
     } else {
         "partial_failure"
     };
@@ -1571,6 +1593,7 @@ fn automatic_retention() -> CmdResult<Value> {
         cleanup: serde_json::json!({
             "categories": cleanup.output,
             "cargo_targets": cargo_targets,
+            "runtime_tmp": runtime_tmp,
         }),
     };
     let value = serde_json::to_value(&output).map_err(|error| {
@@ -1594,7 +1617,7 @@ fn automatic_retention() -> CmdResult<Value> {
             Some("write automatic retention state".to_string()),
         )
     })?;
-    Ok((value, cleanup_exit_code))
+    Ok((value, (status == "partial_failure") as i32))
 }
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<CleanupInventoryResult> {

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -22,7 +22,10 @@ pub use cargo_targets::{
     CargoTargetCleanupOutput, CargoTargetStorageStatus, SharedCargoTargetLease,
 };
 mod automatic_retention;
-pub use automatic_retention::{run_automatic_cargo_retention, AutomaticRetentionOutput};
+pub use automatic_retention::{
+    run_automatic_cargo_retention, run_automatic_runtime_temp_retention, AutomaticRetentionOutput,
+    RuntimeTempRetentionOutput,
+};
 pub mod degraded;
 pub use degraded::{
     degraded_cleanup, observation_store_availability, DegradedCleanupCategory,

--- a/crates/homeboy-core/src/cleanup/automatic_retention.rs
+++ b/crates/homeboy-core/src/cleanup/automatic_retention.rs
@@ -8,10 +8,15 @@ use serde::{Deserialize, Serialize};
 
 use super::{cleanup_shared_cargo_targets, CargoTargetCleanupOptions, CargoTargetCleanupOutput};
 use crate::defaults::RetentionConfig;
+use crate::engine::temp::{
+    cleanup_runtime_tmp_bounded, RuntimeTempCleanupOptions, RuntimeTempCleanupOutput,
+};
 use crate::{Error, Result};
 
 const STATE_FILE: &str = "automatic-retention.json";
 const LOCK_FILE: &str = "automatic-retention.lock";
+const RUNTIME_TMP_STATE_FILE: &str = "automatic-runtime-tmp-retention.json";
+const RUNTIME_TMP_LOCK_FILE: &str = "automatic-runtime-tmp-retention.lock";
 
 // POSIX advisory locks are process-scoped, so a second thread in this process
 // can otherwise re-enter the file lock. The file lock covers other processes.
@@ -27,6 +32,22 @@ pub struct AutomaticRetentionOutput {
     pub resume_command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cargo_targets: Option<CargoTargetCleanupOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_tmp: Option<RuntimeTempRetentionOutput>,
+}
+
+/// Bounded runtime-temp retention facts for the one root Homeboy allocates into.
+#[derive(Debug, Serialize)]
+pub struct RuntimeTempRetentionOutput {
+    pub root: String,
+    pub managed_bytes: u64,
+    pub protected_bytes: u64,
+    pub reclaimable_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub continuation_required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    pub cleanup: RuntimeTempCleanupOutput,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -34,6 +55,7 @@ struct AutomaticRetentionState {
     last_started_unix_ms: u64,
     last_finished_unix_ms: u64,
     cursor: Option<String>,
+    runtime_tmp_cursor: Option<String>,
     status: String,
 }
 
@@ -41,6 +63,14 @@ pub fn run_automatic_cargo_retention() -> Result<AutomaticRetentionOutput> {
     let retention = crate::defaults::load_config().retention;
     let data = homeboy_paths::homeboy_data()?;
     run_automatic_cargo_retention_in(&retention, &data, None, SystemTime::now())
+}
+
+/// Run the runtime-temp owner before allocating more temporary storage when its
+/// filesystem is under configured capacity pressure.
+pub fn run_automatic_runtime_temp_retention() -> Result<AutomaticRetentionOutput> {
+    let retention = crate::defaults::load_config().retention;
+    let data = homeboy_paths::homeboy_data()?;
+    run_automatic_runtime_temp_retention_in(&retention, &data, SystemTime::now())
 }
 
 fn run_automatic_cargo_retention_in(
@@ -80,7 +110,7 @@ fn run_automatic_cargo_retention_in(
     state.status = "running".to_string();
     write_state(&state_path, &state)?;
 
-    let output = cleanup_shared_cargo_targets(CargoTargetCleanupOptions {
+    let cargo_targets = cleanup_shared_cargo_targets(CargoTargetCleanupOptions {
         root: cargo_root,
         apply: true,
         older_than: Duration::from_secs(retention.shared_store_days.saturating_mul(86_400)),
@@ -93,11 +123,11 @@ fn run_automatic_cargo_retention_in(
             retention.automatic_retention_max_run_seconds,
         )),
     })?;
-    state.cursor = output.next_cursor.clone();
+    state.cursor = cargo_targets.next_cursor.clone();
     state.last_finished_unix_ms = unix_ms(SystemTime::now());
-    state.status = if output.applied_count == 0 && output.continuation_required {
+    state.status = if cargo_targets.applied_count == 0 && cargo_targets.continuation_required {
         "no_progress".to_string()
-    } else if output.continuation_required {
+    } else if cargo_targets.continuation_required {
         "partial".to_string()
     } else {
         "completed".to_string()
@@ -110,8 +140,104 @@ fn run_automatic_cargo_retention_in(
     };
     Ok(AutomaticRetentionOutput {
         status,
-        cargo_targets: Some(output),
+        cargo_targets: Some(cargo_targets),
         ..base
+    })
+}
+
+fn run_automatic_runtime_temp_retention_in(
+    retention: &RetentionConfig,
+    data: &Path,
+    now: SystemTime,
+) -> Result<AutomaticRetentionOutput> {
+    let state_path = data.join(RUNTIME_TMP_STATE_FILE);
+    let base = output_base(retention, &state_path);
+    let admission = IN_PROCESS_ADMISSION
+        .get_or_init(|| Mutex::new(()))
+        .try_lock();
+    let Ok(_admission) = admission else {
+        return Ok(AutomaticRetentionOutput {
+            status: "busy",
+            ..base
+        });
+    };
+    fs::create_dir_all(data)
+        .map_err(|error| io_error(error, "create retention state directory"))?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(data.join(RUNTIME_TMP_LOCK_FILE))
+        .map_err(|error| io_error(error, "open automatic retention lock"))?;
+    if lock.try_lock_exclusive().is_err() {
+        return Ok(AutomaticRetentionOutput {
+            status: "busy",
+            ..base
+        });
+    }
+
+    let mut state = read_state(&state_path);
+    state.last_started_unix_ms = unix_ms(now);
+    state.status = "running".to_string();
+    write_state(&state_path, &state)?;
+    let runtime_tmp =
+        cleanup_runtime_tmp_retention(retention, state.runtime_tmp_cursor.as_deref())?;
+    state.runtime_tmp_cursor = runtime_tmp.next_cursor.clone();
+    state.last_finished_unix_ms = unix_ms(SystemTime::now());
+    state.status = if runtime_tmp.reclaimed_bytes == 0 && runtime_tmp.continuation_required {
+        "no_progress".to_string()
+    } else if runtime_tmp.continuation_required {
+        "partial".to_string()
+    } else {
+        "completed".to_string()
+    };
+    write_state(&state_path, &state)?;
+    Ok(AutomaticRetentionOutput {
+        status: match state.status.as_str() {
+            "no_progress" => "no_progress",
+            "partial" => "partial",
+            _ => "completed",
+        },
+        runtime_tmp: Some(runtime_tmp),
+        ..base
+    })
+}
+
+fn cleanup_runtime_tmp_retention(
+    retention: &RetentionConfig,
+    cursor: Option<&str>,
+) -> Result<RuntimeTempRetentionOutput> {
+    let cleanup = cleanup_runtime_tmp_bounded(RuntimeTempCleanupOptions {
+        apply: true,
+        older_than_days: retention.runtime_tmp_days,
+        managed_older_than_days: None,
+        prefix: None,
+        limit: usize::try_from(retention.limit).unwrap_or(0),
+        run_max_bytes: retention.runtime_run_max_bytes,
+        run_max_count: retention.runtime_run_max_count,
+        cursor,
+    })?;
+    let managed_bytes = cleanup
+        .rows
+        .iter()
+        .filter(|row| row.owner_id.is_some())
+        .map(|row| row.size_bytes)
+        .sum();
+    let protected_bytes = cleanup
+        .rows
+        .iter()
+        .filter(|row| row.protection_reason.is_some())
+        .map(|row| row.size_bytes)
+        .sum();
+    Ok(RuntimeTempRetentionOutput {
+        root: cleanup.runtime_tmp_root.clone(),
+        managed_bytes,
+        protected_bytes,
+        reclaimable_bytes: cleanup.totals.planned_size_bytes,
+        reclaimed_bytes: cleanup.totals.removed_size_bytes,
+        continuation_required: cleanup.has_more,
+        next_cursor: cleanup.next_cursor.clone(),
+        cleanup,
     })
 }
 
@@ -124,6 +250,7 @@ fn output_base(retention: &RetentionConfig, state_path: &Path) -> AutomaticReten
         state_path: state_path.display().to_string(),
         resume_command: "homeboy cleanup automatic-retention".to_string(),
         cargo_targets: None,
+        runtime_tmp: None,
     }
 }
 
@@ -242,6 +369,49 @@ mod tests {
         assert!(lease.target_dir().exists());
         assert!(other.exists());
         assert!(data.path().join(STATE_FILE).exists());
+    }
+
+    #[test]
+    fn runtime_temp_retention_reclaims_stale_roots_and_protects_live_owners() {
+        let _serial = TEST_SERIAL
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let data = TempDir::new().unwrap();
+        let runtime = TempDir::new().unwrap();
+        let env_name = crate::product_identity::PRODUCT_IDENTITY.env_var("RUNTIME_TMPDIR");
+        std::env::set_var(&env_name, runtime.path());
+        let stale = runtime.path().join("stale-ownerless");
+        fs::create_dir(&stale).unwrap();
+        fs::write(stale.join("payload"), b"stale payload").unwrap();
+        fs::File::open(&stale)
+            .unwrap()
+            .set_modified(SystemTime::now() - Duration::from_secs(1))
+            .unwrap();
+        let live = crate::engine::temp::RuntimeTempOwner::allocate("live", "test").unwrap();
+        fs::write(live.path().join("payload"), b"live payload").unwrap();
+        let mut config = enabled_retention();
+        config.runtime_tmp_days = 0;
+        config.limit = 1;
+
+        let first =
+            run_automatic_runtime_temp_retention_in(&config, data.path(), SystemTime::now())
+                .unwrap();
+        let first_runtime = first.runtime_tmp.unwrap();
+        assert!(live.path().exists());
+        assert!(first_runtime.protected_bytes >= b"live payload".len() as u64);
+        assert!(first_runtime.continuation_required);
+        assert_eq!(first_runtime.root, runtime.path().display().to_string());
+
+        let second =
+            run_automatic_runtime_temp_retention_in(&config, data.path(), SystemTime::now())
+                .unwrap();
+        let second_runtime = second.runtime_tmp.unwrap();
+        assert!(!stale.exists());
+        assert!(live.path().exists());
+        assert!(second_runtime.reclaimable_bytes >= b"stale payload".len() as u64);
+        assert!(second_runtime.reclaimed_bytes >= b"stale payload".len() as u64);
+        std::env::remove_var(env_name);
     }
 
     #[test]

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -1343,9 +1343,12 @@ fn cleanup_runtime_tmp_root(
     let unmanaged_end = unmanaged_start
         .saturating_add(unmanaged_capacity)
         .min(unmanaged_len);
-    let unmanaged_last_name = unmanaged
-        .get(unmanaged_end.saturating_sub(1))
-        .map(|entry| entry.file_name().to_string_lossy().to_string());
+    let unmanaged_last_name = (unmanaged_end > unmanaged_start).then(|| {
+        unmanaged[unmanaged_end - 1]
+            .file_name()
+            .to_string_lossy()
+            .to_string()
+    });
     for entry in unmanaged
         .into_iter()
         .skip(unmanaged_start)
@@ -1744,6 +1747,20 @@ fn ensure_runtime_tmp_dir() -> Result<PathBuf> {
             Some("create homeboy runtime tmp directory".to_string()),
         )
     })?;
+    let preflight = crate::capacity::preflight_capacity(
+        &runtime_dir,
+        "runtime temporary storage",
+        crate::capacity::CapacityReserve::configured(),
+    );
+    if preflight.status != crate::capacity::CapacityStatus::Ok {
+        crate::cleanup::run_automatic_runtime_temp_retention()?;
+    }
+    crate::capacity::preflight_capacity(
+        &runtime_dir,
+        "runtime temporary storage",
+        crate::capacity::CapacityReserve::configured(),
+    )
+    .into_result()?;
     Ok(runtime_dir)
 }
 


### PR DESCRIPTION
## Summary
- add locked, cursor-persisted automatic retention for managed runtime-temp storage
- protect live owners while reclaiming stale roots under configured byte and count bounds
- run pressure admission before allocating new managed temp storage
- report runtime-temp reclaimed and retained bytes through cleanup output, including partial failures

Closes #11523.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core runtime_temp_retention_reclaims_stale_roots_and_protects_live_owners`
- `cargo test -p homeboy-core concurrent_pass_is_admission_rejected_without_mutating_state`
- `cargo test -p homeboy-core unmanaged_only_cleanup_pages_with_cursor`
- `cargo test -p homeboy-cli automatic_retention_propagates_aggregate_partial_failure`
- `git diff --check`

## AI Assistance
GPT-5.6 Sol via OpenCode implemented and reviewed resumable runtime-temp retention, pressure admission, reporting, and focused regression tests under Chris Huber’s direction. Chris remains responsible for every line.