### PR TITLE
fix(cleanup): enforce artifact reserve before cook

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2576,6 +2576,14 @@ where
             }
             let mut failed_dispatch_plan = None;
             let execution = (|| {
+                homeboy_core::cleanup::admit_reconstructable_artifact_work(
+                    plan.tasks
+                        .iter()
+                        .filter_map(|task| task.workspace.root.as_ref())
+                        .map(PathBuf::from)
+                        .collect(),
+                )
+                .map_err(|error| with_pre_execution_phase(error, "worktree_capacity_admission"))?;
                 let initial_baseline = if attempt == 1 {
                     materialize_initial_candidate_baseline(
                         &plan,

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::defaults::HomeboyConfig;
+use crate::error::StorageExhaustedDetails;
+use crate::observation::disk_budget::disk_budget;
 use crate::resource_cleanup_intent::ResourceCleanupIntent;
 use crate::worktree_providers::{
     cleanup_worktree_providers_from_config, WorktreeProviderCleanupOptions,
@@ -102,6 +104,85 @@ pub struct ArtifactCleanupOptions {
 pub fn run_automatic_artifact_retention(roots: Vec<PathBuf>) -> Result<ArtifactCleanupOutput> {
     let retention = crate::defaults::load_config().retention;
     run_automatic_artifact_retention_in(&roots, &retention, SystemTime::now())
+}
+
+/// Reclaim idle, reconstructable worktree artifacts before managed work writes
+/// into `roots`, then require the configured free-space reserve to be present.
+///
+/// This deliberately delegates removal to the existing automatic owner: its
+/// registry and process liveness checks remain the only authority for deciding
+/// whether an artifact is safe to remove. An unmeasurable filesystem is not
+/// rejected; that is distinct from a measured reserve breach.
+pub fn admit_reconstructable_artifact_work(roots: Vec<PathBuf>) -> Result<()> {
+    let retention = crate::defaults::load_config().retention;
+    let roots = existing_unique_roots(roots);
+    if roots.is_empty() || retention.reconstructable_artifact_reserve_bytes == 0 {
+        return Ok(());
+    }
+
+    if !roots.iter().any(|root| {
+        below_reconstructable_reserve(root, retention.reconstructable_artifact_reserve_bytes)
+    }) {
+        return Ok(());
+    }
+
+    run_automatic_artifact_retention_in(&roots, &retention, SystemTime::now())?;
+
+    for root in roots {
+        let budget = disk_budget(
+            &root,
+            "managed worktree",
+            "worktree capacity is not measurable on this platform",
+        );
+        if budget
+            .available_bytes
+            .is_some_and(|available| available < retention.reconstructable_artifact_reserve_bytes)
+        {
+            return Err(reconstructable_admission_error(
+                &root,
+                budget.available_bytes,
+                budget.available_inodes,
+                retention.reconstructable_artifact_reserve_bytes,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn existing_unique_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    roots
+        .into_iter()
+        .filter(|root| root.is_dir())
+        .filter(|root| seen.insert(canonical_or_owned(root)))
+        .collect()
+}
+
+fn below_reconstructable_reserve(root: &Path, reserve_bytes: u64) -> bool {
+    disk_budget(
+        root,
+        "managed worktree",
+        "worktree capacity is not measurable on this platform",
+    )
+    .available_bytes
+    .is_some_and(|available| available < reserve_bytes)
+}
+
+fn reconstructable_admission_error(
+    root: &Path,
+    available_bytes: Option<u64>,
+    available_inodes: Option<u64>,
+    reserve_bytes: u64,
+) -> Error {
+    Error::storage_exhausted_detailed(StorageExhaustedDetails {
+        error: "managed worktree filesystem remains below the reconstructable-artifact reserve after bounded retention".to_string(),
+        context: Some("admission before managed work".to_string()),
+        path: Some(root.display().to_string()),
+        available_bytes,
+        available_inodes,
+        reserve_bytes: Some(reserve_bytes),
+        reserve_inodes: None,
+    })
 }
 
 fn run_automatic_artifact_retention_in(
@@ -2133,6 +2214,38 @@ mod tests {
                 .iter()
                 .any(|row| row.reason.contains("active task worktree")));
         });
+    }
+
+    #[test]
+    fn pressure_admission_preserves_active_artifacts_and_refuses_when_reserve_remains_unmet() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = repo_with_ignored_artifacts();
+            write_file(&repo.path().join("target/debug/app"), "active artifact");
+            register_active_task_worktree(repo.path());
+            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+                retention: crate::defaults::RetentionConfig {
+                    reconstructable_artifact_reserve_bytes: u64::MAX,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .expect("save retention");
+
+            let error = admit_reconstructable_artifact_work(vec![repo.path().to_path_buf()])
+                .expect_err("a measured reserve breach must refuse new managed work");
+
+            assert!(error.is_storage_exhausted());
+            assert_eq!(error.details["reserve_bytes"], u64::MAX);
+            assert!(repo.path().join("target/debug/app").exists());
+        });
+    }
+
+    #[test]
+    fn reconstructable_artifact_reserve_has_a_safe_nonzero_default() {
+        assert_eq!(
+            crate::defaults::RetentionConfig::default().reconstructable_artifact_reserve_bytes,
+            20 * 1024 * 1024 * 1024
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -225,9 +225,9 @@ pub struct RetentionConfig {
     /// per-worktree build artifacts. This bounds rebuild churn after a build.
     #[serde(default = "default_reconstructable_artifact_retention_days")]
     pub reconstructable_artifact_days: u64,
-    /// Disabled when zero. When free space drops below this reserve, automatic
-    /// reconstructable-artifact retention may bypass its age floor.
-    #[serde(default)]
+    /// When free space drops below this reserve, automatic reconstructable-
+    /// artifact retention may bypass its age floor before managed work starts.
+    #[serde(default = "default_reconstructable_artifact_reserve_bytes")]
     pub reconstructable_artifact_reserve_bytes: u64,
     /// Cooperative wall-clock budget for one automatic pass. Category owners
     /// finish an in-progress safe mutation before the executor yields.
@@ -251,7 +251,8 @@ impl Default for RetentionConfig {
             shared_store_reserve_bytes: default_shared_store_reserve_bytes(),
             shared_store_reserve_inodes: default_shared_store_reserve_inodes(),
             reconstructable_artifact_days: default_reconstructable_artifact_retention_days(),
-            reconstructable_artifact_reserve_bytes: 0,
+            reconstructable_artifact_reserve_bytes: default_reconstructable_artifact_reserve_bytes(
+            ),
             automatic_retention_max_run_seconds: default_automatic_retention_max_run_seconds(),
         }
     }
@@ -307,6 +308,10 @@ fn default_shared_store_reserve_inodes() -> u64 {
 
 fn default_reconstructable_artifact_retention_days() -> u64 {
     7
+}
+
+fn default_reconstructable_artifact_reserve_bytes() -> u64 {
+    20 * 1024 * 1024 * 1024
 }
 
 fn default_automatic_retention_max_run_seconds() -> u64 {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,7 +111,7 @@ own arguments.
 - `shared_store_reserve_bytes` — Free bytes required on the shared Cargo target filesystem before a build starts (default: 5 GiB).
 - `shared_store_reserve_inodes` — Free inodes required on the shared Cargo target filesystem before a build starts (default: 100000).
 - `reconstructable_artifact_days` — Idle age required before automatic retention reclaims reconstructable per-worktree build artifacts (default: 7). Active task worktrees remain protected.
-- `reconstructable_artifact_reserve_bytes` — Free-space reserve that enables early reconstructable-artifact retention under pressure; `0` disables pressure cleanup (default).
+- `reconstructable_artifact_reserve_bytes` — Free-space reserve for reconstructable per-worktree artifacts (default: 20 GiB). Before managed work starts below this floor, Homeboy runs its bounded retention owner and admits work only when the reserve is restored. `0` explicitly disables this pressure admission.
 - `automatic_retention_max_run_seconds` — Cooperative wall-clock budget for one automatic pass (default: 60). The executor yields between stores; a category never interrupts an in-progress safe mutation.
 
 Runner-side age floors are deliberately *not* configuration keys. Both the


### PR DESCRIPTION
## Summary
- give reconstructable artifacts a safe 20 GiB reserve default
- run bounded artifact retention before Cook provider dispatch and reject admission while the reserve remains unmet
- preserve active worktrees and Cargo builds during pressure cleanup
- document the default and override contract

Closes #11031.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core pressure_admission_preserves_active_artifacts_and_refuses_when_reserve_remains_unmet`
- `cargo test -p homeboy-core reconstructable_artifact_reserve_has_a_safe_nonzero_default`
- `cargo test -p homeboy-agents --lib --no-run`
- `git diff --check`

## AI Assistance
GPT-5.6 Sol via OpenCode implemented and reviewed the pressure-admission change, focused tests, and documentation under Chris Huber’s direction. Chris remains responsible for every line.