### PR TITLE
feat(lab): make stale runtime-overlay escalation configurable per runner

### DIFF
--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -83,6 +83,15 @@ pub struct RunnerSettings {
     /// single run regardless of this setting.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub require_exact_homeboy_version: Option<bool>,
+    /// When `true`, a Lab runtime overlay whose built artifact is provably
+    /// behind its source checkout hard-refuses the offload instead of emitting
+    /// a stderr warning and shipping the old build. Default (unset/`false`)
+    /// warns and proceeds. The `HOMEBOY_REQUIRE_FRESH_RUNTIME_OVERLAY` env var
+    /// forces the strict behavior for a single run regardless of this setting.
+    /// Only builds proven stale escalate — an unverifiable overlay stays a
+    /// report, never a failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_fresh_runtime_overlay: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -408,6 +408,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         lab_runtime_overlays()?,
         &mut workspace_mapping,
         request.skip_deps_hydration,
+        &runner.settings,
     )?;
     let runtime_overlay_env = runtime_overlay_env_overrides(&synced_runtime_overlays);
     let runtime_overlay_metadata = lab_runtime_overlay_metadata(&synced_runtime_overlays);

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -480,6 +480,7 @@ pub(super) fn sync_lab_runtime_overlays(
     overlays: Vec<RuntimeOverlay>,
     workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
     skip_deps_hydration: bool,
+    runner_settings: &homeboy_core::server::RunnerSettings,
 ) -> Result<Vec<SyncedRuntimeOverlay>> {
     if overlays.is_empty() {
         return Ok(Vec::new());
@@ -500,6 +501,11 @@ pub(super) fn sync_lab_runtime_overlays(
         // reflects (derived from its on-disk build time). A stale dist would
         // silently ship old code to the runner (#6965). Computed on the
         // controller-local artifact dir, where mtimes are authoritative.
+        //
+        // A proven-stale build warns by default and hard-refuses when the
+        // runner is configured strict or the per-run env override is set
+        // (#11110); the runner's own settings carry that choice, so escalation
+        // is not env-only.
         let build_provenance =
             super::runtime_overlay_freshness::assess_runtime_overlay_build_freshness(&local_path);
         if let Some(warning) = super::runtime_overlay_freshness::stale_runtime_overlay_warning(
@@ -507,7 +513,7 @@ pub(super) fn sync_lab_runtime_overlays(
             &local_path.display().to_string(),
             &build_provenance,
         ) {
-            if super::runtime_overlay_freshness::require_fresh_runtime_overlay() {
+            if super::runtime_overlay_freshness::require_fresh_runtime_overlay(runner_settings) {
                 return Err(Error::validation_invalid_argument(
                     "runtime_overlay",
                     warning,

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
@@ -182,6 +182,7 @@ fn empty_overlay_list_is_a_no_op_and_leaves_mapping_unchanged() {
         Vec::new(),
         &mut mapping,
         false,
+        &homeboy_core::server::RunnerSettings::default(),
     )
     .expect("no-op overlay sync");
 
@@ -226,9 +227,93 @@ fn skips_declared_overlay_dependency_hydration_only_when_opted_out() {
             overlays,
             &mut mapping,
             true,
+            &homeboy_core::server::RunnerSettings::default(),
         )
         .expect("opt-out bypasses the declared dependency command");
         assert_eq!(synced[0].dependency_hydration["status"], "not_applied");
         assert_eq!(synced[0].dependency_hydration["reason"], "opt_out");
     });
+}
+
+/// A stale overlay refuses the offload on runner CONFIGURATION alone, with no
+/// environment variable involved. Before #11110 the only way to reach this
+/// branch was an undocumented env var, so the durable answer to "never ship a
+/// stale build to this runner" did not exist.
+///
+/// The freshness check runs before the overlay is snapshotted, so the refusal
+/// happens without contacting a runner. Only the escalating direction is
+/// asserted: a concurrently running test may have the per-run env override set,
+/// and that override can only push toward refusal.
+#[test]
+fn stale_overlay_refuses_the_sync_from_runner_configuration_alone() {
+    let repo = tempfile::tempdir().expect("repo");
+    init_stale_overlay_checkout(repo.path());
+    let primary = tempfile::tempdir().expect("primary tempdir");
+    let mut mapping = Vec::new();
+    let overlays = parse_runtime_overlays(vec![RuntimeOverlaySpec {
+        path: repo.path().join("dist").display().to_string(),
+        role: Some("cli-runtime".to_string()),
+        snapshot_includes: Vec::new(),
+        install: None,
+        expose_remote_path_env: None,
+    }])
+    .expect("parse overlay");
+
+    let error = sync_lab_runtime_overlays(
+        "unreachable-runner",
+        &primary.path().display().to_string(),
+        overlays,
+        &mut mapping,
+        false,
+        &homeboy_core::server::RunnerSettings {
+            require_fresh_runtime_overlay: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect_err("a runner configured strict refuses a stale overlay build");
+
+    let message = error.to_string();
+    assert!(message.contains("STALE"), "unexpected refusal: {message}");
+    // Refused before any sync, so the mapping never gained the stale overlay.
+    assert!(mapping.is_empty());
+}
+
+/// Build a checkout whose `dist/` (mtime ≈ now) predates commits dated in the
+/// future, which is what the mtime-vs-commit-date heuristic reads as stale.
+fn init_stale_overlay_checkout(path: &std::path::Path) {
+    let git = |args: &[&str], date: Option<&str>| {
+        let mut command = std::process::Command::new("git");
+        command.args(args).current_dir(path);
+        if let Some(date) = date {
+            command
+                .env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_DATE", date);
+        }
+        let output = command.output().expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    let iso =
+        |offset_days: i64| (chrono::Utc::now() + chrono::Duration::days(offset_days)).to_rfc3339();
+
+    git(&["init", "-b", "main"], None);
+    git(&["config", "user.email", "homeboy@example.test"], None);
+    git(&["config", "user.name", "Homeboy Test"], None);
+    git(&["config", "commit.gpgsign", "false"], None);
+
+    std::fs::write(path.join("a.txt"), "a").expect("write source");
+    git(&["add", "a.txt"], None);
+    git(&["commit", "-m", "a"], Some(&iso(-3)));
+
+    let dist = path.join("dist");
+    std::fs::create_dir_all(&dist).expect("dist dir");
+    std::fs::write(dist.join("index.js"), "built").expect("write dist");
+
+    std::fs::write(path.join("b.txt"), "b").expect("write source");
+    git(&["add", "b.txt"], None);
+    git(&["commit", "-m", "b"], Some(&iso(2)));
 }

--- a/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
+++ b/crates/homeboy-lab-runner/src/runtime_overlay_freshness.rs
@@ -63,10 +63,15 @@ use super::workspace::git_output;
 const MTIME_WALK_SKIPPED_DIRECTORY_NAMES: &[&str] = &[".git", "node_modules"];
 
 /// Env var that escalates a stale runtime-overlay build from a warning to a hard
-/// error for a single run. Accepts the usual truthy spellings (`1`, `true`,
-/// `yes`, `on`). Mirrors the opt-in gate style already used for the
-/// controller↔runner version check.
+/// error for a single run, regardless of per-runner configuration. Accepts the
+/// usual truthy spellings (`1`, `true`, `yes`, `on`). Mirrors the opt-in gate
+/// style already used for the controller↔runner version check.
 pub(super) const REQUIRE_FRESH_RUNTIME_OVERLAY_ENV: &str = "HOMEBOY_REQUIRE_FRESH_RUNTIME_OVERLAY";
+
+/// Runner setting that escalates a stale runtime-overlay build for every offload
+/// dispatched to that runner. Named here so operator-facing messages can point
+/// at the durable control instead of only the per-run env var.
+pub(super) const REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING: &str = "require_fresh_runtime_overlay";
 
 /// Build provenance for a runtime overlay's artifact directory. Folded into the
 /// synced-overlay record so a stale build is auditable from `homeboy runs`.
@@ -176,10 +181,22 @@ impl RuntimeOverlayBuildProvenance {
     }
 }
 
-/// Whether a stale runtime-overlay build should hard-fail this run instead of
-/// warning, per the [`REQUIRE_FRESH_RUNTIME_OVERLAY_ENV`] opt-in.
-pub(super) fn require_fresh_runtime_overlay() -> bool {
-    std::env::var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV)
+/// Resolve whether a stale runtime-overlay build should hard-fail the run
+/// instead of warning. Defaults to warn-and-proceed (`false`). Operators opt
+/// into the strict behavior either per-runner (the
+/// [`REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING`] runner setting) or for a single run
+/// via [`REQUIRE_FRESH_RUNTIME_OVERLAY_ENV`].
+///
+/// Precedence deliberately mirrors the controller↔runner version gate
+/// (`require_exact_runner_version`): a truthy env var escalates regardless of
+/// configuration, and anything else falls through to the runner setting, whose
+/// unset default is `false`. The env var is an escalation override only — it
+/// cannot relax a runner that is configured strict, because a falsy value there
+/// is indistinguishable from "not set for this run".
+pub(super) fn require_fresh_runtime_overlay(
+    settings: &homeboy_core::server::RunnerSettings,
+) -> bool {
+    if std::env::var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV)
         .ok()
         .is_some_and(|value| {
             matches!(
@@ -187,6 +204,10 @@ pub(super) fn require_fresh_runtime_overlay() -> bool {
                 "1" | "true" | "yes" | "on"
             )
         })
+    {
+        return true;
+    }
+    settings.require_fresh_runtime_overlay.unwrap_or(false)
 }
 
 /// Assess the build freshness of a controller-local runtime-overlay artifact
@@ -308,7 +329,8 @@ pub(super) fn stale_runtime_overlay_warning(
         "Lab offload: runtime overlay `{role}` build at `{local_path}` is STALE ({behind}): \
          built dist reflects source `{built}` but the source checkout is at `{head}`. \
          The offload will run the old build. Rebuild the overlay artifact (re-run its build step) \
-         before retrying, or export `{REQUIRE_FRESH_RUNTIME_OVERLAY_ENV}=1` to fail instead of warn."
+         before retrying. Set runner setting `{REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING}` or export \
+         `{REQUIRE_FRESH_RUNTIME_OVERLAY_ENV}=1` to fail instead of warn."
     ))
 }
 
@@ -361,11 +383,12 @@ mod tests {
     use chrono::{Duration, Utc};
 
     use homeboy_core::materialization_currency::{Currency, CurrencyEvidence};
+    use homeboy_core::server::RunnerSettings;
 
     use super::{
         assess_runtime_overlay_build_freshness, require_fresh_runtime_overlay,
         stale_runtime_overlay_warning, RuntimeOverlayBuildStatus,
-        REQUIRE_FRESH_RUNTIME_OVERLAY_ENV,
+        REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING,
     };
 
     fn git(path: &Path, args: &[&str]) {
@@ -543,17 +566,73 @@ mod tests {
         assert!(!CurrencyEvidence::BuildTimestamp.proves_content_equality());
     }
 
+    fn strict_settings() -> RunnerSettings {
+        RunnerSettings {
+            require_fresh_runtime_overlay: Some(true),
+            ..RunnerSettings::default()
+        }
+    }
+
+    /// The full precedence matrix for the escalation gate.
+    ///
+    /// Deliberately one test rather than three: every assertion here mutates the
+    /// same process-wide environment variable, and `cargo test` runs a module's
+    /// tests on parallel threads. Splitting these would let one case observe
+    /// another's env write.
     #[test]
     fn require_fresh_env_opt_in_parses_truthy_values() {
-        temp_env_var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, Some("1"), || {
-            assert!(require_fresh_runtime_overlay());
-        });
-        temp_env_var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, Some("false"), || {
-            assert!(!require_fresh_runtime_overlay());
-        });
+        let default_settings = RunnerSettings::default();
+
+        // Env override escalates a runner with no opinion configured.
+        for truthy in ["1", "true", "yes", "on"] {
+            temp_env_var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, Some(truthy), || {
+                assert!(
+                    require_fresh_runtime_overlay(&default_settings),
+                    "expected `{truthy}` to escalate"
+                );
+            });
+        }
+
+        // No env var: the runner setting decides, and unset means warn-only.
         temp_env_var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, None, || {
-            assert!(!require_fresh_runtime_overlay());
+            assert!(!require_fresh_runtime_overlay(&default_settings));
+            // Escalation is configurable, not env-only — this is the durable
+            // "never ship a stale build to this runner" answer that #11110 was
+            // missing.
+            assert!(require_fresh_runtime_overlay(&strict_settings()));
+            assert!(!require_fresh_runtime_overlay(&RunnerSettings {
+                require_fresh_runtime_overlay: Some(false),
+                ..RunnerSettings::default()
+            }));
         });
+
+        // A falsy env value is not a relaxation: it is indistinguishable from
+        // "not set for this run", so it falls through to configuration and a
+        // runner configured strict stays strict.
+        for falsy in ["false", "off"] {
+            temp_env_var(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV, Some(falsy), || {
+                assert!(!require_fresh_runtime_overlay(&default_settings));
+                assert!(require_fresh_runtime_overlay(&strict_settings()));
+            });
+        }
+    }
+
+    /// The stale warning must name both durable and per-run controls, or the
+    /// escalation stays undiscoverable to the operator reading stderr.
+    #[test]
+    fn stale_warning_names_both_escalation_controls() {
+        let repo = tempfile::tempdir().expect("repo");
+        init_repo(repo.path());
+        commit_at(repo.path(), "a.txt", "a", &iso(-3));
+        let dist = write_dist(repo.path());
+        commit_at(repo.path(), "b.txt", "b", &iso(2));
+
+        let provenance = assess_runtime_overlay_build_freshness(&dist);
+        let warning = stale_runtime_overlay_warning("cli", "/local/dist", &provenance)
+            .expect("stale warning");
+
+        assert!(warning.contains(REQUIRE_FRESH_RUNTIME_OVERLAY_SETTING));
+        assert!(warning.contains(REQUIRE_FRESH_RUNTIME_OVERLAY_ENV));
     }
 
     fn temp_env_var<F: FnOnce()>(key: &str, value: Option<&str>, run: F) {

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -24,6 +24,8 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "daemon": boolean,
     "concurrency_limit": number,
     "artifact_policy": "string",
+    "require_exact_homeboy_version": boolean,
+    "require_fresh_runtime_overlay": boolean,
     "policy": {
       "snapshot_excludes": ["string"]
     },
@@ -118,6 +120,28 @@ Use `runner.secret_env` for values that must be read at execution time instead o
 ```
 
 Homeboy rejects likely credential names in newly persisted `runner.env` entries. Use `secret_env` for those values; it is also the explicit sensitivity declaration for non-obvious names. Existing legacy entries can be inspected without values using `homeboy runner doctor <id> --scope secret-env` and migrated into OS keychain-backed references with `--repair`. Homeboy command output redacts sensitive names in `env` and keeps `secret_env` as references only. Secret file contents and referenced environment variable values are not printed by runner config/status diagnostics.
+
+### Lab Offload Safety Gates
+
+Two runner settings decide whether detected drift warns or refuses a Lab offload. Both default to unset, which means warn-and-proceed, and both have a per-run environment override:
+
+| Setting | Env override | Default (unset) | When `true` |
+| --- | --- | --- | --- |
+| `require_exact_homeboy_version` | `HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION` | Patch drift within the same `MAJOR.MINOR` proceeds with a warning; `MAJOR`/`MINOR` drift refuses | The controller↔runner version gate requires a byte-identical Homeboy version on the runner |
+| `require_fresh_runtime_overlay` | `HOMEBOY_REQUIRE_FRESH_RUNTIME_OVERLAY` | A stale runtime-overlay build warns on stderr and the offload runs the old build | A runtime overlay whose built artifact is provably behind its source checkout refuses the offload |
+
+```json
+{
+  "runner": {
+    "require_exact_homeboy_version": true,
+    "require_fresh_runtime_overlay": true
+  }
+}
+```
+
+Precedence for both is the same: a truthy environment value (`1`, `true`, `yes`, `on`) escalates that single run regardless of configuration; anything else — including a falsy value, which is indistinguishable from "not set for this run" — falls through to the runner setting, whose unset default is `false`. The environment variables are escalation overrides only, so neither can relax a runner configured strict.
+
+`require_fresh_runtime_overlay` escalates only builds *proven* stale. An overlay whose freshness cannot be established — no containing checkout, no artifacts, or an unreadable source history — is reported as unknown and never refused. Freshness itself is derived from the artifact's newest file mtime against the containing checkout's history, which is an indication rather than a proof: a freshly created checkout rewrites mtimes and makes every artifact in it look newly built. Set this on runners where silently executing a stale build is worse than a failed dispatch.
 
 ## Managed SSH Sessions
 

--- a/docs/workflows/set-up-lab-runners.md
+++ b/docs/workflows/set-up-lab-runners.md
@@ -87,6 +87,34 @@ homeboy runner doctor <runner-id> --scope lab-offload --repair
 
 More invasive fixes such as upgrading binaries, refreshing caches, or rewriting runner paths remain explicit operator actions.
 
+### Decide What Drift Refuses The Offload
+
+Two runner settings turn a drift warning into a refusal. Both default to warn-and-proceed:
+
+```bash
+homeboy runner set <runner-id> --json '{"require_exact_homeboy_version":true,"require_fresh_runtime_overlay":true}'
+```
+
+For an SSH runner these persist under the server's `runner` capability in `servers/<id>.json`:
+
+```json
+{
+  "runner": {
+    "require_exact_homeboy_version": true,
+    "require_fresh_runtime_overlay": true
+  }
+}
+```
+
+`require_fresh_runtime_overlay` covers runtime overlays — built artifact directories synced to the runner. When the built artifact is provably behind the source checkout that contains it, the default behavior prints a stderr warning and the offload runs the old build; with this setting the dispatch refuses instead. Escalate a single run without changing configuration by exporting the override:
+
+```bash
+HOMEBOY_REQUIRE_FRESH_RUNTIME_OVERLAY=1 homeboy --runner <runner-id> review <component-id>
+HOMEBOY_REQUIRE_EXACT_RUNNER_VERSION=1 homeboy --runner <runner-id> review <component-id>
+```
+
+Environment values escalate only. Neither variable can relax a runner already configured strict. See [Server schema](../reference/schemas/server-schema.md#lab-offload-safety-gates) for the full precedence rules.
+
 ## 6. Refresh Runner Homeboy Deliberately
 
 Runner proof depends on the Homeboy binary actually used by the runner:
@@ -130,6 +158,7 @@ homeboy runs artifacts <run-id>
 ## Reference
 
 - [runner command](../commands/runner.md)
+- [Server schema](../reference/schemas/server-schema.md)
 - [Use runners](use-runners.md)
 - [Release-gate proof path](../operations/release-gate-proof-path.md)
 - [Artifact loop for runner and matrix workflows](../operations/artifact-loop-runner-matrix.md)


### PR DESCRIPTION
Closes #11110.

## Already fixed on main — not redone here

Item 1 of the issue (the `concat!("HOME", "BOY_...")` string-splitting that hid the env var name from the grep-based audit gate) is **already resolved on `origin/main`**. `runtime_overlay_freshness.rs` and `lab_workspaces/mod.rs` now carry plain string literals. This PR touches none of that.

## What this PR adds — item 2

Escalation was still opt-in through an undocumented environment variable and nothing else. `RunnerSettings` had `require_exact_homeboy_version` but no freshness equivalent, so there was no durable way to say "never ship a stale build to this runner" — the default outcome stayed a stderr warning while the offload ran the old code.

- **New field.** `require_fresh_runtime_overlay: Option<bool>` on `RunnerSettings`, following the exact shape, serde attributes (`#[serde(default, skip_serializing_if = "Option::is_none")]`), and doc-comment conventions of the neighbouring `require_exact_homeboy_version`.
- **Threading.** `&RunnerSettings` flows through `sync_lab_runtime_overlays` into `require_fresh_runtime_overlay(...)`. The one production call site passes `&runner.settings`, which was already loaded in that function.
- **Precedence** deliberately mirrors `require_exact_runner_version` rather than inventing a new rule: a truthy env var (`1`/`true`/`yes`/`on`) escalates that single run regardless of configuration; anything else falls through to the runner setting, whose unset default is `false`. A falsy env value is *not* a relaxation — it is indistinguishable from "not set for this run" — so the env var cannot loosen a runner configured strict. This is documented explicitly because it is the non-obvious half.
- **Discoverability.** The stale warning now names the runner setting alongside the env var, so an operator reading stderr sees the durable control and not just the per-run one.

## Docs — item 3

The env var appeared nowhere under `docs/`. Added:

- `docs/reference/schemas/server-schema.md` — the field in the schema block plus a "Lab Offload Safety Gates" section: a setting/env-override/default/strict table covering **both** gates (the version gate was equally undocumented and belongs in the same table), the shared precedence rules, and the honest caveat that only *proven*-stale builds escalate while unverifiable ones stay unknown.
- `docs/workflows/set-up-lab-runners.md` — a "Decide What Drift Refuses The Offload" step under Lab-offload readiness with the `runner set` invocation and the per-run env escalation.

## Declined — item 3 of the issue (content-hash evidence)

Not implemented, on purpose. The module header at `runtime_overlay_freshness.rs:24-47` argues the opposite case and it is correct: an artifact and its source are different bytes by construction, so no digest computed over either can be compared against the other. A derivation can only be bound by evidence recorded *at build time by the build step*, and that step is opaque and outside this product's control — there is nothing to ask for a source identity and nowhere to have asked it. Adding a hash would produce a confident-looking verdict with no more evidence behind it than the timestamp already carries. The issue itself flags this as optional and conditional on the build being Homeboy-driven, which it is not.

## Tests

- `require_fresh_env_opt_in_parses_truthy_values` (extended) — full precedence matrix: env escalation across all truthy spellings, config-driven escalation with no env var present, and a falsy env value falling through to a strict runner instead of relaxing it. Kept as **one** test on purpose: every assertion mutates the same process-wide env var and `cargo test` runs a module's tests on parallel threads, so splitting them would let one case observe another's write.
- `stale_warning_names_both_escalation_controls` — the warning names both controls, pinning discoverability.
- `stale_overlay_refuses_the_sync_from_runner_configuration_alone` — end-to-end through `sync_lab_runtime_overlays` against a git fixture whose `dist/` predates future-dated commits. Proves the threading is real: refusal comes from configuration alone, with no env var involved. Only the escalating direction is asserted, since a concurrent test may have the override set and that can only push toward refusal.

No tests deleted or `#[ignore]`d. Two pre-existing call sites gained `&RunnerSettings::default()`, preserving their behavior.

## Compilation uncertainty

**I could not compile or run tests locally** — this VPS runs several agents in parallel and cargo builds have caused OOM kills, so builds are prohibited here. Only `cargo fmt --check` was run, and it passes. CI is the gate for compilation and test results.

Mechanical risks I checked by inspection instead: every `RunnerSettings` literal in the tree already uses `..Default::default()`, so the new field breaks no initializer; all three call sites of the two changed signatures are updated; `homeboy_core::server::RunnerSettings`, `chrono`, and `tempfile` are already dependencies of `homeboy-lab-runner`; and `Error`'s `Display` writes `message`, which `validation_invalid_argument` builds from the problem string the new test asserts on.