### PR TITLE
refactor(core): move three single-consumer modules out of homeboy-core

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
@@ -28,7 +28,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use homeboy_core::process_activity::{self, DescendantActivity};
+use super::process_activity::{self, DescendantActivity};
 
 /// A single sample of what a running Cook's provider is doing.
 ///

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -15,6 +15,13 @@ mod cook_promotion;
 mod cook_recipe;
 mod discovery;
 mod execution;
+/// Read-only process-tree activity sampling for a running Cook.
+///
+/// Lived in `homeboy-core` as a top-level module even though `cook_activity`
+/// here was its only consumer anywhere in the workspace (#11143). Kept `pub`
+/// so the sampling primitives stay addressable evidence rather than becoming
+/// unreachable internals.
+pub mod process_activity;
 mod promotion_service;
 mod reconcile;
 mod status_support;

--- a/crates/homeboy-agents/src/agent_task_service/process_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/process_activity.rs
@@ -1,13 +1,13 @@
 //! Read-only process-tree activity sampling.
 //!
-//! [`crate::process`] owns the *lifecycle* half of the process tree (signalling,
+//! [`homeboy_core::process`] owns the *lifecycle* half of the process tree (signalling,
 //! scopes, termination). This module owns the *observability* half: answering
 //! "what is this process tree actually doing right now?" without changing it.
 //!
 //! The motivating case is diagnosing a stalled Cook. Before this existed the
 //! only way to learn that a provider agent was compiling instead of editing was
 //! `ps aux | grep` on the host (#11482). The same `ps -axo` walk that
-//! [`crate::process`] already uses for descendant discovery answers it, so the
+//! [`homeboy_core::process`] already uses for descendant discovery answers it, so the
 //! sampling is a plain read of the process table with no signals, no /proc
 //! assumptions, and no platform-specific parsing beyond `ps` itself.
 //!

--- a/crates/homeboy-cli/src/commands/report.rs
+++ b/crates/homeboy-cli/src/commands/report.rs
@@ -30,7 +30,8 @@ pub use performance_digest::{
     PerformanceDigestReport,
 };
 pub use report_compare::{
-    compare_report_artifacts_from_args, render_report_compare_from_args, ReportCompareArgs,
+    compare_report_artifacts, compare_report_artifacts_from_args,
+    compare_report_artifacts_with_store, render_report_compare_from_args, ReportCompareArgs,
     ReportCompareReport,
 };
 

--- a/crates/homeboy-cli/src/commands/report/report_compare/engine.rs
+++ b/crates/homeboy-cli/src/commands/report/report_compare/engine.rs
@@ -6,10 +6,11 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::observation::runs_service;
-use crate::observation::{ArtifactRecord, ObservationStore};
-use crate::report_compare_render::render_markdown;
-use crate::Error;
+use homeboy_core::observation::runs_service;
+use homeboy_core::observation::{ArtifactRecord, ObservationStore};
+use homeboy_core::Error;
+
+use super::render::render_markdown;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ReportCompareReport {
@@ -103,7 +104,7 @@ struct FindingAggregate {
 pub fn compare_report_artifacts(
     old_input: &str,
     new_input: &str,
-) -> crate::Result<ReportCompareReport> {
+) -> homeboy_core::Result<ReportCompareReport> {
     compare_report_artifacts_with_store(None, old_input, new_input)
 }
 
@@ -111,7 +112,7 @@ pub fn compare_report_artifacts_with_store(
     store: Option<&ObservationStore>,
     old_input: &str,
     new_input: &str,
-) -> crate::Result<ReportCompareReport> {
+) -> homeboy_core::Result<ReportCompareReport> {
     let old = read_artifact_input(store, old_input)?;
     let new = read_artifact_input(store, new_input)?;
     let old_aggregate = aggregate_findings(&old.value);
@@ -144,7 +145,7 @@ pub fn compare_report_artifacts_with_store(
 fn read_artifact_input(
     store: Option<&ObservationStore>,
     input: &str,
-) -> crate::Result<ArtifactInput> {
+) -> homeboy_core::Result<ArtifactInput> {
     let path = PathBuf::from(input);
     if path.is_file() {
         let value = read_json_file(&path)?;
@@ -181,7 +182,7 @@ fn split_artifact_ref(input: &str) -> Option<(&str, &str)> {
 fn select_json_artifact_for_run(
     store: &ObservationStore,
     run_id: &str,
-) -> crate::Result<ArtifactRecord> {
+) -> homeboy_core::Result<ArtifactRecord> {
     let artifacts = runs_service::list_artifacts_for_run(store, run_id)?;
     artifacts
         .into_iter()
@@ -216,7 +217,7 @@ fn is_report_json_artifact(artifact: &ArtifactRecord) -> bool {
                 .is_some_and(|mime| mime.contains("json")))
 }
 
-fn read_artifact_record(artifact: ArtifactRecord) -> crate::Result<(String, Value)> {
+fn read_artifact_record(artifact: ArtifactRecord) -> homeboy_core::Result<(String, Value)> {
     match runs_service::classify_artifact_storage(&artifact) {
         runs_service::ArtifactStorage::LocalFile => {
             let path = PathBuf::from(&artifact.path);
@@ -274,7 +275,7 @@ fn read_artifact_record(artifact: ArtifactRecord) -> crate::Result<(String, Valu
     }
 }
 
-fn read_json_file(path: &Path) -> crate::Result<Value> {
+fn read_json_file(path: &Path) -> homeboy_core::Result<Value> {
     let raw = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
     serde_json::from_str(&raw).map_err(|e| {

--- a/crates/homeboy-cli/src/commands/report/report_compare/mod.rs
+++ b/crates/homeboy-cli/src/commands/report/report_compare/mod.rs
@@ -11,8 +11,7 @@ mod render;
 use clap::Args;
 
 pub use engine::{
-    compare_report_artifacts, compare_report_artifacts_with_store, BeforeAfterCount, CountDelta,
-    IdentityDelta, NamedCountDelta, ReportArtifactSummary, ReportCompareReport,
+    compare_report_artifacts, compare_report_artifacts_with_store, ReportCompareReport,
 };
 
 #[derive(Args, Debug, Clone)]

--- a/crates/homeboy-cli/src/commands/report/report_compare/mod.rs
+++ b/crates/homeboy-cli/src/commands/report/report_compare/mod.rs
@@ -1,6 +1,19 @@
+//! `homeboy report compare` — the clap surface plus the artifact-diff engine.
+//!
+//! The engine and its markdown renderer used to sit in `homeboy-core` as two
+//! top-level modules (`report_compare`, `report_compare_render`) even though
+//! this command was their only consumer and the renderer was already
+//! `pub(crate)`. They live with their caller now (#11143).
+
+mod engine;
+mod render;
+
 use clap::Args;
 
-pub use homeboy::core::report_compare::ReportCompareReport;
+pub use engine::{
+    compare_report_artifacts, compare_report_artifacts_with_store, BeforeAfterCount, CountDelta,
+    IdentityDelta, NamedCountDelta, ReportArtifactSummary, ReportCompareReport,
+};
 
 #[derive(Args, Debug, Clone)]
 pub struct ReportCompareArgs {
@@ -24,5 +37,5 @@ pub fn render_report_compare_from_args(args: &ReportCompareArgs) -> homeboy::cor
 pub fn compare_report_artifacts_from_args(
     args: &ReportCompareArgs,
 ) -> homeboy::core::Result<ReportCompareReport> {
-    homeboy::core::report_compare::compare_report_artifacts(&args.old, &args.new)
+    compare_report_artifacts(&args.old, &args.new)
 }

--- a/crates/homeboy-cli/src/commands/report/report_compare/render.rs
+++ b/crates/homeboy-cli/src/commands/report/report_compare/render.rs
@@ -1,5 +1,6 @@
-use crate::markdown::escape_markdown_table_cell;
-use crate::report_compare::{NamedCountDelta, ReportCompareReport};
+use homeboy_core::markdown::escape_markdown_table_cell;
+
+use super::engine::{NamedCountDelta, ReportCompareReport};
 
 pub(crate) fn render_markdown(report: &ReportCompareReport) -> String {
     let mut out = String::new();

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -135,7 +135,6 @@ pub mod keychain;
 pub mod lab_offload;
 pub mod lab_routing;
 pub mod lab_workspace_provenance;
-pub mod local_permissions;
 pub mod operation_record;
 pub use homeboy_lifecycle_contract::lifecycle;
 pub mod loop_lifecycle;
@@ -158,7 +157,6 @@ pub mod performance_hotspots;
 pub use homeboy_engine_primitives::phase_timing;
 pub use homeboy_gate_contract::plan;
 pub mod process;
-pub mod process_activity;
 // product_identity moved to the internal `homeboy-product-identity` crate.
 // Re-exported so `crate::product_identity::*` call sites keep working.
 pub use homeboy_product_identity as product_identity;
@@ -172,8 +170,6 @@ pub use homeboy_redaction as redaction;
 pub mod refactor_transform_provider;
 pub mod release_provider;
 pub mod release_set;
-pub mod report_compare;
-pub(crate) mod report_compare_render;
 pub mod repository_integrity;
 pub mod resource_cleanup_intent;
 pub mod resource_lifecycle_index;

--- a/crates/homeboy-extension/src/build/local_permissions.rs
+++ b/crates/homeboy-extension/src/build/local_permissions.rs
@@ -2,13 +2,17 @@
 //!
 //! Ensures files in a local component checkout have group read/write before
 //! they're archived, so the build zip carries correct permissions (some tools
-//! create files with restrictive 600 perms). Used by the extension build path;
-//! lives at core level (not under `deploy`) so build doesn't depend on deploy.
+//! create files with restrictive 600 perms).
+//!
+//! Was a top-level `homeboy-core` module whose only consumer anywhere in the
+//! workspace was the extension build path right next to it (#11143). The
+//! original comment justified core placement as "so build doesn't depend on
+//! deploy" — living inside build satisfies that without costing core a module.
 
 use std::process::Command;
 
-use crate::defaults;
-use crate::engine::shell;
+use homeboy_core::defaults;
+use homeboy_engine_primitives::shell;
 
 /// Fix local file permissions before build.
 ///
@@ -18,7 +22,7 @@ pub fn fix_local_permissions(local_path: &str) {
     let quoted_path = shell::quote_path(local_path);
     let perms = defaults::load_defaults().permissions.local;
 
-    log_status!(
+    homeboy_core::log_status!(
         "build",
         "Fixing local file permissions in {} (files: {}, dirs: {})",
         local_path,

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -9,12 +9,13 @@ use homeboy_core::component::{self, Component};
 use homeboy_core::config::{is_json_input, parse_bulk_ids};
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{Error, Result};
-use homeboy_core::local_permissions;
 use homeboy_core::output::{BulkResult, BulkResultBuilder};
 use homeboy_core::paths;
 use homeboy_core::server::execute_local_command_in_dir;
 use homeboy_engine_primitives::command::CapturedOutput;
 use homeboy_engine_primitives::shell;
+
+mod local_permissions;
 
 const DEFAULT_BUILD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const BUILD_TIMEOUT_ENV: &str = "HOMEBOY_BUILD_TIMEOUT_SECS";

--- a/tests/report_compare_test.rs
+++ b/tests/report_compare_test.rs
@@ -1,8 +1,9 @@
 use std::fs;
 
-use homeboy::commands::report::{compare_report_artifacts_from_args, ReportCompareArgs};
+use homeboy::commands::report::{
+    compare_report_artifacts_from_args, compare_report_artifacts_with_store, ReportCompareArgs,
+};
 use homeboy::core::observation::{NewRunRecord, ObservationStore};
-use homeboy::core::report_compare::compare_report_artifacts_with_store;
 
 #[path = "support/mod.rs"]
 mod support;


### PR DESCRIPTION
Partial progress on #11143. Three verified single-consumer modules relocated to their actual consumers. No behavior change — pure relocation.

## Modules moved, with reverse-edge evidence

The decider for every candidate was: **nothing in `homeboy-core` outside the module's own file may reference it.** I checked both the module path (`crate::<mod>` *and* `super::<mod>` — the `super::` form matters, it is how `artifacts.rs` re-exports its siblings from the crate root) and every one of the module's public symbols by name across all of `crates/homeboy-core/src`.

### 1. `report_compare` + `report_compare_render` → `homeboy-cli`

`crates/homeboy-core/src/report_compare.rs` → `crates/homeboy-cli/src/commands/report/report_compare/engine.rs`
`crates/homeboy-core/src/report_compare_render.rs` → `.../report_compare/render.rs`

Symbol-level reverse-edge scan across core (`BeforeAfterCount`, `compare_report_artifacts`, `compare_report_artifacts_with_store`, `CountDelta`, `IdentityDelta`, `NamedCountDelta`, `ReportArtifactSummary`, `ReportCompareReport`) returned **only the two files' references to each other**:

```
report_compare_render.rs:2: use crate::report_compare::{NamedCountDelta, ReportCompareReport};
report_compare.rs:11:      use crate::report_compare_render::render_markdown;
```

Both moved together, so the pair is self-contained. `report_compare_render` was already `pub(crate)` — it was core-private code that no core file could ever call. Sole consumer: `crates/homeboy-cli/src/commands/report/report_compare.rs`.

### 2. `process_activity` → `homeboy-agents`

`crates/homeboy-core/src/process_activity.rs` → `crates/homeboy-agents/src/agent_task_service/process_activity.rs`

Zero reverse edges. Zero `crate::` dependencies on core at all, beyond two rustdoc links to `crate::process` (rewritten to `homeboy_core::process`). Sole consumer in the entire workspace:

```
crates/homeboy-agents/src/agent_task_service/cook_activity.rs:31:
    use homeboy_core::process_activity::{self, DescendantActivity};
```

It now lives directly beside that consumer, and the import is `use super::process_activity::…`. Declared `pub mod` rather than `mod` so the sampling primitives stay addressable public API instead of silently becoming unreachable internals (which would also have started producing `dead_code` warnings for the fields only tests read).

### 3. `local_permissions` → `homeboy-extension`

`crates/homeboy-core/src/local_permissions.rs` → `crates/homeboy-extension/src/build/local_permissions.rs`

42 lines, one public function, zero reverse edges. Sole consumer:

```
crates/homeboy-extension/src/build/mod.rs:12:  use homeboy_core::local_permissions;
crates/homeboy-extension/src/build/mod.rs:504: local_permissions::fix_local_permissions(&local_path_str);
```

Its own doc comment justified core placement as *"lives at core level (not under `deploy`) so build doesn't depend on deploy"*. Living **inside** `build` satisfies that constraint without core paying for a module. Its two core dependencies (`defaults::load_defaults`, `engine::shell`) are both public and are reached as `homeboy_core::defaults` / `homeboy_engine_primitives::shell` — the latter is what `build/mod.rs` already imports directly.

## Counts

| | before | after |
|---|---|---|
| `homeboy-core` top-level `pub mod` | 116 | **113** |
| `homeboy-core` top-level `pub(crate) mod` | 4 | 3 |
| cross-crate `pub use` re-exports at core root | 20 | **20** |

No core method needed widening from `pub(crate)` to `pub`; every API the moved code calls across the new crate boundary was already `pub`. No test was deleted or `#[ignore]`d — all tests moved with their modules (8 in `process_activity`, 1 in `report_compare/engine.rs`), and `tests/report_compare_test.rs` was repointed from `homeboy::core::report_compare` to `homeboy::commands::report`.

## Two candidates the issue lists as single-consumer that are NOT

Worth correcting in #11143 rather than letting the next pass trip over them:

- **`matrix_artifact_summary`** (issue: "cli bench"). It has a live reverse edge into core's own observation subsystem. `crates/homeboy-core/src/observation/evidence_report.rs:28` imports `generic_matrix_summary_from_artifacts` and `GenericMatrixSummary` (used at `:62` and `:800-801`), reached through the `artifacts.rs` facade re-export at `artifacts.rs:40`, and `observation/runs_service/tests.rs:425,431` calls `summarize_matrix_artifacts`. Not movable as-is.
- **`performance_hotspots`** (issue: "cli fuzz+bench, lab-runner uses only the schema const"). The schema const consumer is real: `crates/homeboy-lab-runner/src/execution/artifact_promotion.rs:20`. `homeboy-lab-runner` does **not** depend on `homeboy-cli`, so moving this to the CLI would invert a crate dependency. It needs the const split out first, which is a design decision, not a mechanical move.

## On the re-export count going 14 → 20

Confirmed and worth flagging. Core's root now carries 20 `pub use homeboy_*` lines, and the growth is concentrated in **contract crates**: `homeboy_lab_contract` ×7, `homeboy_lifecycle_contract` ×3, `homeboy_gate_contract` ×2. They sit interleaved alphabetically among the `pub mod` lines, so `homeboy_core::<name>` still resolves exactly as it did when `<name>` was a real core module.

That is the shape of the trade: the module left core, but core kept presenting it, so no downstream call site had to change and core's *namespace* did not actually shrink. Counting `pub mod` alone understates the surface — the honest metric is `pub mod` + root `pub use`, which is 133, not 113.

The three moves in this PR add **zero** re-exports. Each consumer's import was repointed at the new location (`super::process_activity`, `super::engine`, in-module `local_permissions`) instead of being papered over with a facade. That is the pattern that actually reduces core, and I'd suggest it be the rule for the remaining moves.

## Not attempted

Per scope: the `artifact_*` cluster (11 modules) and the entangled feature subsystems (`daemon/`, `api_jobs/`, `cleanup/`, `worktree/`, `fleet/`, `schedule/`, `http_api/`) were left alone.

Remaining verified-clean single-consumer candidates for a follow-up, from a full reverse-edge sweep of all 116 top-level modules (zero core reverse edges, exactly one consumer crate): `deferred_workload` → cli, `harvest` → cli, `loop_lifecycle` → cli, `setup` → cli, `release_set` → cli, `operation_record` → homeboy-release. Also `browser_evidence` (430 lines), which appears to have **no consumer at all** outside core and may simply be dead.

## Verification

**I could not compile locally** — this VPS runs eight parallel agents alongside MariaDB and PHP-FPM, and concurrent `cargo` builds OOM the box. `cargo build` / `test` / `check` / `clippy` were not run. **CI is the gate for this PR.**

What I *did* verify locally:

- `cargo fmt` — clean, exit 0.
- **Module wiring proven, not assumed.** `cargo fmt` only reaches files reachable from a crate root through `mod` declarations, so a mis-wired `mod` is silent. I appended a deliberately mis-formatted `fn __fmt_probe(  )->u8{1}` to all five new/moved files and confirmed `cargo fmt --check` reported a diff in **all five** — proving `commands/report.rs → report_compare/mod.rs → {engine,render}`, `agent_task_service/mod.rs → process_activity`, and `build/mod.rs → local_permissions` all resolve. Probes removed; `cargo fmt --check` is clean.
- Grepped the whole tree (`.rs`, `.md`, `.json`, `.toml`, `.yml`, `.sh`) for residual references to the moved paths — none remain.
- Confirmed every cross-boundary API is already `pub`: `homeboy_core::{Error, Result}`, `markdown::escape_markdown_table_cell`, `observation::runs_service::{resolve_artifact_for_run, list_artifacts_for_run, classify_artifact_storage, download_remote_artifact, download_public_artifact, ArtifactStorage}`, `ObservationStore::open_initialized`, `defaults::load_defaults`, `engine::shell`.
- Confirmed `tempfile`, `serde`, `serde_json` are already direct dependencies of `homeboy-cli`. **No `Cargo.toml` changes were needed for any of the three moves** — every consumer already depended on everything the moved code needs.

Residual uncertainty is ordinary type-check risk on code I could not compile, concentrated in `report_compare/engine.rs` where `crate::` → `homeboy_core::` was rewritten mechanically.

## One note for the reviewer

`homeboy.json` line 919 registers an audit baseline fingerprint against `crates/homeboy-core/src/local_permissions.rs` (a `core-agnostic-source` leak: the word "claude" in a comment). I left it untouched. Since the file left core, the `core-agnostic-source` policy no longer scans it, so this fingerprint should now surface as **resolved**, not as new drift — `baseline::compare` only sets `drift_increased` when *new* items appear, and stale entries land in `resolved_fingerprints`. Pruning it is a separate, safe cleanup; I didn't want to hand-edit a baseline's `item_count` in a refactor PR.

Refs #11143
