### PR TITLE
refactor(version): collapse the three version-target readers into one spine (#11144)

### DIFF
--- a/crates/homeboy-version/src/lib.rs
+++ b/crates/homeboy-version/src/lib.rs
@@ -56,13 +56,24 @@ mod tests {
     /// `pipeline` facade alongside the same check for `executor.rs`.
     #[test]
     fn version_core_stays_ecosystem_agnostic() {
-        let source = include_str!("version.rs");
-        let runtime_source = source.split("#[cfg(test)]").next().unwrap_or(source);
-        for term in ["Cargo", "cargo", "Rust", "rust"] {
-            assert!(
-                !runtime_source.contains(term),
-                "version core must not branch on ecosystem-specific term {term:?}"
-            );
+        // `component_version.rs` carries the single version-read spine that
+        // used to be three copies inside `version.rs` (#11144), so it is held
+        // to the same contract.
+        let sources = [
+            ("version.rs", include_str!("version.rs")),
+            (
+                "version/component_version.rs",
+                include_str!("version/component_version.rs"),
+            ),
+        ];
+        for (file, source) in sources {
+            let runtime_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+            for term in ["Cargo", "cargo", "Rust", "rust"] {
+                assert!(
+                    !runtime_source.contains(term),
+                    "version core ({file}) must not branch on ecosystem-specific term {term:?}"
+                );
+            }
         }
     }
 }

--- a/crates/homeboy-version/src/version.rs
+++ b/crates/homeboy-version/src/version.rs
@@ -1,16 +1,21 @@
+pub mod component_version;
 mod default_pattern_for_file;
 mod types;
 
+// The single component-version read spine (#11144). Everything that reads a
+// declared version target goes through `component_version`; the names below are
+// the historical spellings every caller already uses.
+pub use component_version::{
+    read as read_component_version, read_by_id as read_version,
+    read_snapshot as read_component_snapshot, read_target, require_targets, TargetRead,
+};
 // These were `pub(crate)` while version lived inside the release crate. They
 // are now read across a crate boundary by `homeboy-release` (version_guard,
 // planner) and `homeboy-deploy` (preflight, planning), so they must be `pub`.
+use default_pattern_for_file::replace_since_tag_placeholders;
+pub use default_pattern_for_file::{build_init_warnings, resolve_version_file_path};
 pub use default_pattern_for_file::{
-    build_init_warnings, read_component_snapshot, resolve_version_file_path,
-};
-use default_pattern_for_file::{build_version_parse_error, replace_since_tag_placeholders};
-pub use default_pattern_for_file::{
-    default_pattern_for_file, parse_versions, read_component_version, read_version,
-    resolve_target_pattern,
+    default_pattern_for_file, parse_versions, resolve_target_pattern,
 };
 #[cfg(test)]
 use types::DEFAULT_SINCE_PLACEHOLDER;
@@ -20,7 +25,7 @@ pub use types::{
 };
 
 use crate::changelog;
-use homeboy_core::component::{self, Component, VersionTarget};
+use homeboy_core::component::{Component, VersionTarget};
 use homeboy_core::error::{Error, Result};
 
 use homeboy_core::config::{from_str, set_json_pointer, to_string_pretty};
@@ -99,16 +104,11 @@ pub fn get_component_version(component: &Component) -> Option<String> {
 
 pub fn validate_component_versions(components: &[Component]) -> Result<()> {
     for component in components {
-        let Some(targets) = component.version_targets.as_ref() else {
+        // The lenient half of the shared reader: an unversioned component is
+        // skipped, an explicitly empty `versionTargets` is still rejected.
+        let Some(targets) = component_version::declared_targets(component)? else {
             continue;
         };
-        if targets.is_empty() {
-            return Err(Error::config_invalid_value(
-                "versionTargets",
-                None,
-                format!("Component '{}' has empty versionTargets", component.id),
-            ));
-        }
 
         let mut observed = Vec::new();
         for target in targets {
@@ -282,20 +282,7 @@ pub fn validate_version_targets_at(
     component: &Component,
     expected_version: &str,
 ) -> Result<Vec<VersionTargetInfo>> {
-    component::validate_local_path(component)?;
-
-    let targets = component
-        .version_targets
-        .as_ref()
-        .ok_or_else(|| Error::config_missing_key("versionTargets", Some(component.id.clone())))?;
-
-    if targets.is_empty() {
-        return Err(Error::config_invalid_value(
-            "versionTargets",
-            None,
-            format!("Component '{}' has empty versionTargets", component.id),
-        ));
-    }
+    let targets = component_version::require_targets(component)?;
 
     validate_version_targets(targets, &component.local_path, expected_version)
 }
@@ -308,20 +295,12 @@ fn validate_version_targets(
     let mut target_infos = Vec::new();
 
     for target in targets {
-        let version_pattern = resolve_target_pattern(target)?;
-        let full_path = resolve_version_file_path(local_path, &target.file);
-        let content = local_files::local().read(Path::new(&full_path))?;
+        let read = component_version::read_target(local_path, target)?;
 
-        let versions = parse_versions(&content, &version_pattern).ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "versionPattern",
-                format!("Invalid version regex pattern '{}'", version_pattern),
-                None,
-                Some(vec![version_pattern.clone()]),
-            )
-        })?;
-
-        if versions.is_empty() {
+        // This path keeps its own terse diagnostic: it is validating a version
+        // the caller already knows, so the detailed file-preview error the
+        // primary-target readers use would be noise here.
+        if read.is_empty() {
             return Err(Error::internal_unexpected(format!(
                 "Could not find version in {}",
                 target.file
@@ -329,7 +308,7 @@ fn validate_version_targets(
         }
 
         // Validate all versions in this file match expected
-        let found = text::require_identical(&versions, &target.file)?;
+        let found = read.require_identical()?;
         if found != expected_version {
             return Err(Error::validation_invalid_argument(
                 "version",
@@ -351,13 +330,7 @@ fn validate_version_targets(
             ));
         }
 
-        target_infos.push(VersionTargetInfo {
-            file: target.file.clone(),
-            pattern: version_pattern,
-            full_path,
-            match_count: versions.len(),
-            warning: None,
-        });
+        target_infos.push(read.into_target_info(None));
     }
 
     Ok(target_infos)
@@ -533,46 +506,18 @@ pub fn bump_component_version_with_changelog(
     changelog_entries: Option<&std::collections::HashMap<String, Vec<String>>>,
     finalized_changelog: Option<&ChangelogValidationResult>,
 ) -> Result<BumpResult> {
-    // Validate local_path is absolute and exists before any file operations
-    component::validate_local_path(component)?;
-
-    let targets = component
-        .version_targets
-        .as_ref()
-        .ok_or_else(|| Error::config_missing_key("versionTargets", Some(component.id.clone())))?;
-
-    if targets.is_empty() {
-        return Err(Error::config_invalid_value(
-            "versionTargets",
-            None,
-            format!("Component '{}' has empty versionTargets", component.id),
-        ));
-    }
+    // Validates local_path before any file operation, then requires a
+    // non-empty versionTargets — the same guard every version read uses.
+    let targets = component_version::require_targets(component)?;
 
     // Read current version from primary target
-    let primary = &targets[0];
-    let primary_pattern = resolve_target_pattern(primary)?;
-    let primary_full_path = resolve_version_file_path(&component.local_path, &primary.file);
+    let primary = component_version::read_target(&component.local_path, &targets[0])?;
 
-    let primary_content = local_files::local().read(Path::new(&primary_full_path))?;
-    let primary_versions = parse_versions(&primary_content, &primary_pattern).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "versionPattern",
-            format!("Invalid version regex pattern '{}'", primary_pattern),
-            None,
-            Some(vec![primary_pattern.clone()]),
-        )
-    })?;
-
-    if primary_versions.is_empty() {
-        return Err(build_version_parse_error(
-            &primary.file,
-            &primary_pattern,
-            &primary_content,
-        ));
+    if primary.is_empty() {
+        return Err(primary.parse_error());
     }
 
-    let old_version = text::require_identical(&primary_versions, &primary.file)?;
+    let old_version = primary.require_identical()?;
     let new_version = increment_version(&old_version, bump_type).ok_or_else(|| {
         Error::validation_invalid_argument(
             "version",

--- a/crates/homeboy-version/src/version/component_version.rs
+++ b/crates/homeboy-version/src/version/component_version.rs
@@ -1,0 +1,623 @@
+//! The single component-version read spine (#11144).
+//!
+//! Three call paths used to read a component's `versionTargets` config
+//! independently — `read_component_version`, `validate_version_targets_at`, and
+//! `bump_component_version_with_changelog` — each repeating the same
+//! local-path validation, the same `config_missing_key("versionTargets", ..)`,
+//! and the same empty-targets rejection, and two of them additionally
+//! repeating the same "resolve pattern, resolve path, read file, parse
+//! versions" block. Three copies meant three places for the contract to drift
+//! silently.
+//!
+//! Everything that reads a declared version target now goes through
+//! [`require_targets`] / [`declared_targets`] (the config read) and
+//! [`read_target`] (the file read). Where the callers genuinely differ they
+//! differ *after* the read, on the [`TargetRead`] they get back:
+//!
+//! - `read` and the bump path treat a non-matching primary target as a hard
+//!   error with a file preview ([`TargetRead::parse_error`]);
+//! - `validate_version_targets` treats it as a terse "Could not find version
+//!   in <file>";
+//! - `read`'s non-primary targets treat it as a warning, not an error.
+//!
+//! That divergence is a property of the caller, not of the read, so it stays
+//! at the call site instead of being encoded as three readers.
+
+use homeboy_core::component::{self, Component, VersionTarget};
+use homeboy_core::engine::local_files;
+use homeboy_core::engine::text;
+use homeboy_core::error::{Error, Result};
+use std::path::Path;
+
+use super::default_pattern_for_file::{
+    build_version_parse_error, parse_versions, resolve_target_pattern, resolve_version_file_path,
+};
+use super::types::{ComponentVersionInfo, ComponentVersionSnapshot, VersionTargetInfo};
+
+/// One version target, read from disk.
+///
+/// `versions` may be empty: the pattern compiled and the file was readable but
+/// nothing matched. That is an error for some callers and a warning for
+/// others, so this type reports it rather than deciding it.
+#[derive(Debug, Clone)]
+pub struct TargetRead {
+    /// The target's configured file, as written in `versionTargets`.
+    pub file: String,
+    /// The resolved (and normalized) pattern actually used to parse.
+    pub pattern: String,
+    /// The absolute path the pattern was applied to.
+    pub full_path: String,
+    /// File contents, retained so a parse failure can render a preview.
+    pub content: String,
+    /// Every version the pattern matched, in file order.
+    pub versions: Vec<String>,
+}
+
+impl TargetRead {
+    /// The pattern compiled and the file was read, but nothing matched.
+    pub fn is_empty(&self) -> bool {
+        self.versions.is_empty()
+    }
+
+    /// The detailed "could not parse version" error, with hints and a preview.
+    pub fn parse_error(&self) -> Error {
+        build_version_parse_error(&self.file, &self.pattern, &self.content)
+    }
+
+    /// The single version this target declares, rejecting a file that declares
+    /// more than one distinct version.
+    pub fn require_identical(&self) -> Result<String> {
+        text::require_identical(&self.versions, &self.file)
+    }
+
+    /// Project into the reportable target info callers return to operators.
+    pub fn into_target_info(self, warning: Option<String>) -> VersionTargetInfo {
+        VersionTargetInfo {
+            match_count: self.versions.len(),
+            file: self.file,
+            pattern: self.pattern,
+            full_path: self.full_path,
+            warning,
+        }
+    }
+}
+
+/// Read a component's declared version targets without requiring them.
+///
+/// - no `versionTargets` key → `Ok(None)` (the component is unversioned)
+/// - `versionTargets: []` → hard error; an explicitly empty list is a
+///   misconfiguration, not "unversioned"
+///
+/// Deliberately does **not** validate `local_path`: callers that tolerate an
+/// absent config (`validate_component_versions` sweeps every component in a
+/// deploy) must not fail on a component they were going to skip anyway.
+pub fn declared_targets(component: &Component) -> Result<Option<&[VersionTarget]>> {
+    let Some(targets) = component.version_targets.as_deref() else {
+        return Ok(None);
+    };
+
+    if targets.is_empty() {
+        return Err(Error::config_invalid_value(
+            "versionTargets",
+            None,
+            format!("Component '{}' has empty versionTargets", component.id),
+        ));
+    }
+
+    Ok(Some(targets))
+}
+
+/// Read a component's version targets, requiring them.
+///
+/// The canonical entry point for every path that is about to read or write a
+/// version: validates `local_path` before any file operation, then requires a
+/// non-empty `versionTargets`. The returned slice is guaranteed non-empty, so
+/// callers may index `[0]` for the primary target.
+pub fn require_targets(component: &Component) -> Result<&[VersionTarget]> {
+    // Validate local_path is absolute and exists before any file operations.
+    component::validate_local_path(component)?;
+
+    declared_targets(component)?
+        .ok_or_else(|| Error::config_missing_key("versionTargets", Some(component.id.clone())))
+}
+
+/// Read one version target from disk.
+///
+/// Resolves the pattern (explicit, else the extension default) and the file
+/// path, reads the file, and parses every match. An unusable regex is an
+/// error; zero matches is not — see [`TargetRead::is_empty`].
+pub fn read_target(local_path: &str, target: &VersionTarget) -> Result<TargetRead> {
+    let pattern = resolve_target_pattern(target)?;
+    let full_path = resolve_version_file_path(local_path, &target.file);
+    let content = local_files::local().read(Path::new(&full_path))?;
+
+    let versions = parse_versions(&content, &pattern).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "versionPattern",
+            format!("Invalid version regex pattern '{}'", pattern),
+            None,
+            Some(vec![pattern.clone()]),
+        )
+    })?;
+
+    Ok(TargetRead {
+        file: target.file.clone(),
+        pattern,
+        full_path,
+        content,
+        versions,
+    })
+}
+
+/// Read the current version from a component's version targets.
+///
+/// The primary (first) target decides the version and must match. Remaining
+/// targets are reported with a warning when they do not match, which is what
+/// makes this usable for status output on a partially configured component.
+pub fn read(component: &Component) -> Result<ComponentVersionInfo> {
+    let targets = require_targets(component)?;
+
+    let primary = read_target(&component.local_path, &targets[0])?;
+    if primary.is_empty() {
+        return Err(primary.parse_error());
+    }
+
+    let version = primary.require_identical()?;
+    let mut target_infos = vec![primary.into_target_info(None)];
+
+    // Add info for all remaining targets
+    for target in targets.iter().skip(1) {
+        let read = read_target(&component.local_path, target)?;
+
+        let warning = if read.is_empty() {
+            homeboy_core::log_status!(
+                "warning",
+                "Version target {}: pattern '{}' did not match any content",
+                read.file,
+                read.pattern
+            );
+            Some(format!(
+                "Pattern did not match any content in {}",
+                read.file
+            ))
+        } else {
+            None
+        };
+
+        target_infos.push(read.into_target_info(warning));
+    }
+
+    Ok(ComponentVersionInfo {
+        version,
+        targets: target_infos,
+    })
+}
+
+/// Read version by component ID.
+/// If component_id is None, returns homeboy binary's own version.
+pub fn read_by_id(component_id: Option<&str>) -> Result<ComponentVersionInfo> {
+    // If no component_id, return homeboy binary's own version
+    let id = match component_id {
+        None => {
+            let version = homeboy_product_identity::product_version().to_string();
+            return Ok(ComponentVersionInfo {
+                version,
+                targets: vec![],
+            });
+        }
+        Some(id) => id,
+    };
+
+    let component = component::load(id)?;
+    read(&component)
+}
+
+/// Read a component's version as a snapshot carrying the component id.
+pub fn read_snapshot(component: &Component) -> Result<ComponentVersionSnapshot> {
+    let info = read(component)?;
+    Ok(ComponentVersionSnapshot {
+        component_id: component.id.clone(),
+        version: info.version,
+        targets: info.targets,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::version::{
+        bump_component_version_with_changelog, validate_component_versions,
+        validate_version_targets_at,
+    };
+    use homeboy_core::error::ErrorCode;
+    use std::fs;
+
+    fn component_at(temp_dir: &tempfile::TempDir) -> Component {
+        Component {
+            id: "test-component".to_string(),
+            local_path: temp_dir.path().to_string_lossy().to_string(),
+            remote_path: String::new(),
+            changelog_target: Some("CHANGELOG.md".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn package_json_target() -> VersionTarget {
+        VersionTarget {
+            file: "package.json".to_string(),
+            pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+            artifact_path: None,
+        }
+    }
+
+    fn write_package_json(temp_dir: &tempfile::TempDir, version: &str) {
+        fs::write(
+            temp_dir.path().join("package.json"),
+            format!("{{\n  \"version\": \"{version}\"\n}}\n"),
+        )
+        .unwrap();
+    }
+
+    // ========================================================================
+    // The config read: one reader, three former call sites
+    // ========================================================================
+
+    #[test]
+    fn require_targets_rejects_missing_version_targets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let component = component_at(&temp_dir);
+
+        let error = require_targets(&component).expect_err("missing versionTargets");
+        assert_eq!(error.code, ErrorCode::ConfigMissingKey);
+        assert_eq!(error.details["key"], "versionTargets");
+        assert_eq!(error.details["path"], "test-component");
+    }
+
+    #[test]
+    fn require_targets_rejects_empty_version_targets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![]);
+
+        let error = require_targets(&component).expect_err("empty versionTargets");
+        assert_eq!(error.code, ErrorCode::ConfigInvalidValue);
+        assert_eq!(error.details["key"], "versionTargets");
+        assert_eq!(
+            error.details["problem"],
+            "Component 'test-component' has empty versionTargets"
+        );
+    }
+
+    /// `local_path` is validated *before* the config is inspected, so a
+    /// component pointing at a path that does not exist reports that rather
+    /// than a confusing missing-key error. All three former readers called
+    /// `validate_local_path` first; the shared reader must keep that order.
+    #[test]
+    fn require_targets_validates_local_path_before_reading_config() {
+        let component = Component {
+            id: "test-component".to_string(),
+            local_path: "/nonexistent/homeboy/version/spine".to_string(),
+            version_targets: None,
+            ..Default::default()
+        };
+
+        let error = require_targets(&component).expect_err("missing local_path");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(
+            error.message.contains("local_path"),
+            "expected a local_path diagnostic, got: {}",
+            error.message
+        );
+    }
+
+    /// Every former call site must now produce the *same* missing-key error,
+    /// because they share one reader. This is the regression that made the
+    /// three copies worth collapsing.
+    #[test]
+    fn all_version_read_paths_share_one_missing_targets_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let component = component_at(&temp_dir);
+
+        let from_read = read(&component).expect_err("read requires targets");
+        let from_validate = validate_version_targets_at(&component, "1.0.0")
+            .expect_err("validate requires targets");
+        let from_bump = bump_component_version_with_changelog(&component, "patch", None, None)
+            .expect_err("bump requires targets");
+
+        for error in [&from_read, &from_validate, &from_bump] {
+            assert_eq!(error.code, ErrorCode::ConfigMissingKey);
+            assert_eq!(error.details["key"], "versionTargets");
+            assert_eq!(error.details["path"], "test-component");
+        }
+    }
+
+    /// Same for the empty-list rejection.
+    #[test]
+    fn all_version_read_paths_share_one_empty_targets_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![]);
+
+        let from_read = read(&component).expect_err("read rejects empty");
+        let from_validate =
+            validate_version_targets_at(&component, "1.0.0").expect_err("validate rejects empty");
+        let from_bump = bump_component_version_with_changelog(&component, "patch", None, None)
+            .expect_err("bump rejects empty");
+        let from_sweep =
+            validate_component_versions(&[component.clone()]).expect_err("sweep rejects empty");
+
+        for error in [&from_read, &from_validate, &from_bump, &from_sweep] {
+            assert_eq!(error.code, ErrorCode::ConfigInvalidValue);
+            assert_eq!(error.details["key"], "versionTargets");
+            assert_eq!(
+                error.details["problem"],
+                "Component 'test-component' has empty versionTargets"
+            );
+        }
+    }
+
+    /// The lenient reader is what lets the deploy-wide sweep skip unversioned
+    /// components. It must not borrow the strict reader's missing-key error,
+    /// and must not touch `local_path`.
+    #[test]
+    fn declared_targets_treats_absent_config_as_unversioned() {
+        let component = Component {
+            id: "test-component".to_string(),
+            local_path: "/nonexistent/homeboy/version/spine".to_string(),
+            ..Default::default()
+        };
+
+        assert!(declared_targets(&component)
+            .expect("absent config is not an error")
+            .is_none());
+        // The sweep over the same component is a no-op, not a failure.
+        validate_component_versions(&[component]).expect("unversioned components are skipped");
+    }
+
+    // ========================================================================
+    // The file read
+    // ========================================================================
+
+    #[test]
+    fn read_target_reports_resolved_pattern_path_and_matches() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "1.2.3");
+
+        let target = package_json_target();
+        let read = read_target(&temp_dir.path().to_string_lossy(), &target).expect("read target");
+
+        assert_eq!(read.file, "package.json");
+        assert_eq!(read.versions, vec!["1.2.3".to_string()]);
+        assert_eq!(
+            read.full_path,
+            temp_dir.path().join("package.json").to_string_lossy()
+        );
+        assert!(read.content.contains("1.2.3"));
+        assert!(!read.is_empty());
+        assert_eq!(read.require_identical().unwrap(), "1.2.3");
+    }
+
+    /// A pattern that compiles but matches nothing is not a read failure — the
+    /// callers decide. Keeping that decision out of the reader is what allows
+    /// one reader to serve a hard-error caller and a warn-only caller.
+    #[test]
+    fn read_target_reports_no_matches_without_failing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("VERSION"), "no version here\n").unwrap();
+
+        let target = VersionTarget {
+            file: "VERSION".to_string(),
+            pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+            artifact_path: None,
+        };
+        let read = read_target(&temp_dir.path().to_string_lossy(), &target).expect("read target");
+
+        assert!(read.is_empty());
+        let error = read.parse_error();
+        assert!(
+            error
+                .message
+                .contains("Could not parse version from VERSION"),
+            "expected the detailed parse error, got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("no version here"),
+            "parse error must include a file preview, got: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn read_target_rejects_an_uncompilable_pattern() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "1.2.3");
+
+        let target = VersionTarget {
+            file: "package.json".to_string(),
+            pattern: Some("([0-9".to_string()),
+            artifact_path: None,
+        };
+        let error =
+            read_target(&temp_dir.path().to_string_lossy(), &target).expect_err("bad pattern");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("Invalid version regex pattern"));
+    }
+
+    // ========================================================================
+    // Caller-specific behavior preserved on top of the shared read
+    // ========================================================================
+
+    #[test]
+    fn read_reports_primary_version_and_warns_on_non_matching_secondary() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "1.2.3");
+        fs::write(temp_dir.path().join("plugin.php"), "<?php\n// nothing\n").unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![
+            package_json_target(),
+            VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
+            },
+        ]);
+
+        let info = read(&component).expect("primary target decides the version");
+        assert_eq!(info.version, "1.2.3");
+        assert_eq!(info.targets.len(), 2);
+        assert_eq!(info.targets[0].match_count, 1);
+        assert!(info.targets[0].warning.is_none());
+        assert_eq!(info.targets[1].match_count, 0);
+        assert_eq!(
+            info.targets[1].warning.as_deref(),
+            Some("Pattern did not match any content in plugin.php")
+        );
+    }
+
+    /// The primary target is the one that hard-fails, with the detailed
+    /// preview error rather than the terse one.
+    #[test]
+    fn read_fails_with_a_preview_when_the_primary_target_does_not_match() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            "{\n  \"name\": \"x\"\n}\n",
+        )
+        .unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![package_json_target()]);
+
+        let error = read(&component).expect_err("primary target must match");
+        assert!(
+            error
+                .message
+                .contains("Could not parse version from package.json"),
+            "got: {}",
+            error.message
+        );
+    }
+
+    /// `validate_version_targets_at` keeps its own terse diagnostic for a
+    /// non-matching target — that divergence is deliberate, and the shared
+    /// reader must not have flattened it into the preview error.
+    #[test]
+    fn validate_version_targets_at_keeps_its_terse_no_version_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            "{\n  \"name\": \"x\"\n}\n",
+        )
+        .unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![package_json_target()]);
+
+        let error =
+            validate_version_targets_at(&component, "1.2.3").expect_err("target must match");
+        assert_eq!(
+            error.message, "Could not find version in package.json",
+            "the validate path keeps its terse diagnostic"
+        );
+    }
+
+    #[test]
+    fn validate_version_targets_at_reports_every_target_when_all_agree() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "1.2.3");
+        fs::write(
+            temp_dir.path().join("plugin.php"),
+            "<?php\n/* Version: 1.2.3 */\n",
+        )
+        .unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![
+            package_json_target(),
+            VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
+            },
+        ]);
+
+        let infos = validate_version_targets_at(&component, "1.2.3").expect("targets agree");
+        assert_eq!(infos.len(), 2);
+        assert!(infos.iter().all(|info| info.match_count == 1));
+        assert!(infos.iter().all(|info| info.warning.is_none()));
+    }
+
+    #[test]
+    fn validate_version_targets_at_rejects_a_target_at_a_different_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "1.2.3");
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![package_json_target()]);
+
+        let error = validate_version_targets_at(&component, "9.9.9").expect_err("version mismatch");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(
+            error.message.contains("Version mismatch in package.json"),
+            "got: {}",
+            error.message
+        );
+    }
+
+    /// The bump path reads the primary target through the same reader, so the
+    /// version it bumps from is the version `read` reports.
+    #[test]
+    fn bump_reads_the_same_primary_version_the_shared_reader_reports() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        write_package_json(&temp_dir, "0.1.0");
+        fs::write(
+            temp_dir.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## Unreleased\n\n",
+        )
+        .unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![package_json_target()]);
+
+        let observed = read(&component).expect("read version").version;
+
+        let mut entries: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        entries.insert("fixed".to_string(), vec!["shared version read".to_string()]);
+
+        let result =
+            bump_component_version_with_changelog(&component, "patch", Some(&entries), None)
+                .expect("bump from the shared read");
+
+        assert_eq!(result.old_version, observed);
+        assert_eq!(result.new_version, "0.1.1");
+    }
+
+    /// The bump path also keeps the detailed preview error on a non-matching
+    /// primary target, and must not have picked up the validate path's terse
+    /// one when the two were merged.
+    #[test]
+    fn bump_keeps_the_detailed_parse_error_on_a_non_matching_primary() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            "{\n  \"name\": \"x\"\n}\n",
+        )
+        .unwrap();
+
+        let mut component = component_at(&temp_dir);
+        component.version_targets = Some(vec![package_json_target()]);
+
+        let error = bump_component_version_with_changelog(&component, "patch", None, None)
+            .expect_err("primary target must match");
+        assert!(
+            error
+                .message
+                .contains("Could not parse version from package.json"),
+            "got: {}",
+            error.message
+        );
+    }
+}

--- a/crates/homeboy-version/src/version/default_pattern_for_file.rs
+++ b/crates/homeboy-version/src/version/default_pattern_for_file.rs
@@ -1,8 +1,12 @@
 //! default_pattern_for_file — extracted from version.rs.
+//!
+//! Pattern resolution and path resolution only. The readers that used to live
+//! here (`read_component_version` and friends) moved to
+//! [`super::component_version`], which is now the single place a component's
+//! `versionTargets` config is read (#11144).
 
 use homeboy_core::component::{self, Component, VersionTarget};
 use homeboy_core::engine::codebase_scan;
-use homeboy_core::engine::local_files;
 use homeboy_core::engine::text;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension_execution::{resolve_owner, SINCE_TAG_SURFACE};
@@ -14,10 +18,7 @@ use std::fs;
 use std::path::Path;
 
 use super::find_version_pattern_in_extension;
-use super::types::{
-    ComponentVersionInfo, ComponentVersionSnapshot, UnconfiguredPattern, VersionTargetInfo,
-    DEFAULT_SINCE_PLACEHOLDER,
-};
+use super::types::{UnconfiguredPattern, DEFAULT_SINCE_PLACEHOLDER};
 
 /// Parse all versions from content using regex pattern.
 /// Content is trimmed to handle trailing newlines in VERSION files.
@@ -91,129 +92,6 @@ pub(crate) fn build_version_parse_error(file: &str, pattern: &str, content: &str
         "Could not parse version from {} using pattern: {}{}\n\nFile preview (first 500 chars):\n{}",
         file, pattern, hints_text, preview
     ))
-}
-
-/// Read the current version from a component's version targets.
-pub fn read_component_version(component: &Component) -> Result<ComponentVersionInfo> {
-    // Validate local_path is absolute and exists before any file operations
-    component::validate_local_path(component)?;
-
-    let targets = component
-        .version_targets
-        .as_ref()
-        .ok_or_else(|| Error::config_missing_key("versionTargets", Some(component.id.clone())))?;
-
-    if targets.is_empty() {
-        return Err(Error::config_invalid_value(
-            "versionTargets",
-            None,
-            format!("Component '{}' has empty versionTargets", component.id),
-        ));
-    }
-
-    let primary = &targets[0];
-    let primary_pattern = resolve_target_pattern(primary)?;
-    let primary_full_path = resolve_version_file_path(&component.local_path, &primary.file);
-
-    let content = local_files::local().read(Path::new(&primary_full_path))?;
-    let versions = parse_versions(&content, &primary_pattern).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "versionPattern",
-            format!("Invalid version regex pattern '{}'", primary_pattern),
-            None,
-            Some(vec![primary_pattern.clone()]),
-        )
-    })?;
-
-    if versions.is_empty() {
-        return Err(build_version_parse_error(
-            &primary.file,
-            &primary_pattern,
-            &content,
-        ));
-    }
-
-    let version = text::require_identical(&versions, &primary.file)?;
-
-    // Build target info for primary
-    let mut target_infos = vec![VersionTargetInfo {
-        file: primary.file.clone(),
-        pattern: primary_pattern,
-        full_path: primary_full_path,
-        match_count: versions.len(),
-        warning: None,
-    }];
-
-    // Add info for all remaining targets
-    for target in targets.iter().skip(1) {
-        let pattern = resolve_target_pattern(target)?;
-        let full_path = resolve_version_file_path(&component.local_path, &target.file);
-        let content = local_files::local().read(Path::new(&full_path))?;
-        let target_versions = parse_versions(&content, &pattern).ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "versionPattern",
-                format!("Invalid version regex pattern '{}'", pattern),
-                None,
-                Some(vec![pattern.clone()]),
-            )
-        })?;
-
-        let warning = if target_versions.is_empty() {
-            homeboy_core::log_status!(
-                "warning",
-                "Version target {}: pattern '{}' did not match any content",
-                target.file,
-                pattern
-            );
-            Some(format!(
-                "Pattern did not match any content in {}",
-                target.file
-            ))
-        } else {
-            None
-        };
-
-        target_infos.push(VersionTargetInfo {
-            file: target.file.clone(),
-            pattern,
-            full_path,
-            match_count: target_versions.len(),
-            warning,
-        });
-    }
-
-    Ok(ComponentVersionInfo {
-        version,
-        targets: target_infos,
-    })
-}
-
-/// Read version by component ID.
-/// If component_id is None, returns homeboy binary's own version.
-pub fn read_version(component_id: Option<&str>) -> Result<ComponentVersionInfo> {
-    // If no component_id, return homeboy binary's own version
-    let id = match component_id {
-        None => {
-            let version = homeboy_product_identity::product_version().to_string();
-            return Ok(ComponentVersionInfo {
-                version,
-                targets: vec![],
-            });
-        }
-        Some(id) => id,
-    };
-
-    let component = component::load(id)?;
-    read_component_version(&component)
-}
-
-pub fn read_component_snapshot(component: &Component) -> Result<ComponentVersionSnapshot> {
-    let info = read_component_version(component)?;
-    Ok(ComponentVersionSnapshot {
-        component_id: component.id.clone(),
-        version: info.version,
-        targets: info.targets,
-    })
 }
 
 pub fn build_init_warnings(component: &Component) -> Vec<String> {


### PR DESCRIPTION
Delivers **ask 2** of #11144 — the version-read dedupe.

## What was already done

Ask 1 (`homeboy-deploy` extraction) has already landed on `main`: `crates/homeboy-deploy/` exists with `planning.rs`, `preparation.rs`, `orchestration/`, `execution/`, `version_overrides.rs`, `safety_and_artifact.rs`. Nothing in this PR touches it.

Ask 2 had **not** been done. A `crates/homeboy-version` crate now exists, but the version code was *relocated, not deduped* — it still carried three independent `config_missing_key("versionTargets", ...)` readers:

| former reader | location |
|---|---|
| `validate_version_targets_at` | `version.rs:290` |
| `bump_component_version_with_changelog` | `version.rs:542` |
| `read_component_version` | `version/default_pattern_for_file.rs:104` |

Each repeated `component::validate_local_path`, the same missing-key error, and the same empty-list rejection. Two of them additionally repeated the same "resolve pattern → resolve path → read file → parse versions" block, and `validate_component_versions` carried a fourth copy of the empty-list check.

## What this PR does

New module `version::component_version`, owning both halves of a version read:

- **The config read.** `require_targets(component)` — validates `local_path` *before any file operation*, then requires a non-empty `versionTargets`; the returned slice is guaranteed non-empty so callers may index `[0]`. Its lenient sibling `declared_targets(component) -> Result<Option<&[VersionTarget]>>` returns `Ok(None)` for a component with no `versionTargets` key, which is what lets the deploy-wide `validate_component_versions` sweep keep skipping unversioned components without inheriting the strict path's missing-key error, and without touching `local_path`.
- **The file read.** `read_target(local_path, target) -> Result<TargetRead>` — resolves the pattern (explicit, else extension default), resolves the path, reads, and parses every match. An uncompilable regex is an error; **zero matches is not**.

All four call sites route through it. Where the callers genuinely diverge, they now diverge *after* the read, on the returned `TargetRead`, rather than through duplicate readers:

- `read` and the bump path treat a non-matching **primary** target as a hard error with the detailed file-preview diagnostic (`TargetRead::parse_error`);
- `validate_version_targets` keeps its terse `Could not find version in <file>` — it is checking a version the caller already knows, so the preview would be noise;
- non-primary targets in `read` still degrade to a warning rather than an error.

That is a property of the caller, not of the read, so it stays at the call site.

**No public API change.** `read_component_version`, `read_version`, and `read_component_snapshot` are re-exported under their original names from `version`, so every `homeboy-release`, `homeboy-deploy`, and CLI caller is untouched.

## Test coverage

15 tests in the new module, including the three the task asked for explicitly:

- `all_version_read_paths_share_one_missing_targets_error` and `all_version_read_paths_share_one_empty_targets_error` — every former call site now produces one identical error (code, `details.key`, `details.path` / `details.problem`).
- `require_targets_validates_local_path_before_reading_config` — pins the ordering all three former readers had.
- `validate_version_targets_at_keeps_its_terse_no_version_error`, `read_fails_with_a_preview_when_the_primary_target_does_not_match`, `bump_keeps_the_detailed_parse_error_on_a_non_matching_primary` — pin the deliberate divergence, so the shared reader cannot silently flatten one caller's diagnostic into another's.
- `read_reports_primary_version_and_warns_on_non_matching_secondary`, `declared_targets_treats_absent_config_as_unversioned`, plus `read_target` behavior tests.

`lib.rs`'s `version_core_stays_ecosystem_agnostic` assertion is extended to cover the new file, since the read spine moved into it.

Net: −166 lines across the three existing files, with the reader logic consolidated into one place.

## Explicitly out of scope

**Ask 3 remains**: collapsing `deploy`'s `orchestration_ref_checkout` / `orchestration_tag_checkout` and `release`'s `checkout_guard.rs` into one ref-checkout implementation. That is a separate, larger change and was deliberately not attempted here.

Also deliberately left alone:

- `read_local_version` (the lenient `Option`-returning local reader) does **not** normalize its pattern via `resolve_target_pattern`, unlike every other reader. Routing it through `read_target` would be a behavior change for double-escaped patterns, so it is noted rather than fixed.
- `homeboy-deploy`'s `execution/preflight.rs:310` and `version_overrides.rs:138` read version targets out of *artifacts / remote content*, not local disk, and return `Ok(())`/`None` where the local readers error. They are not candidates for this reader.

## Compilation

**I could not compile locally** — this VPS runs eight parallel agents alongside MariaDB and PHP-FPM, and cargo builds have OOM-killed in-flight work, so `cargo build`/`check`/`test`/`clippy` were prohibited for this task. `cargo fmt` and `cargo fmt --check` both pass clean, which confirms every touched file parses, but type-checking and the new tests are unverified until CI runs. Known risk areas if CI does complain: the borrow of `&[VersionTarget]` out of `require_targets` held across the bump path, and the `serde_json::Value` index comparisons in the new error-shape assertions.

Refs #11144