### PR TITLE
fix(observation): make truncated run pages detectable and paginable

### DIFF
--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -476,13 +476,30 @@ pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
     Ok(read_records_with_health()?.0)
 }
 
+/// Bound on a single source run's retry lineage. Deliberately far above any
+/// plausible retry count: an exceeded lineage is reported as an error, and this
+/// is the threshold at which "this is a runaway, not a lineage" becomes true.
+const RETRY_SUCCESSOR_SCAN_LIMIT: usize = 256;
+
+/// Read every retry successor of `source_run_id`.
+///
+/// Callers treat an empty or non-matching result as "no reservation exists"
+/// and then create one, so a truncated lineage would silently double-book a
+/// retry. The page is therefore read with an explicit truncation signal and a
+/// truncated lineage fails loudly rather than answering wrongly (#11177).
 pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTaskRunRecord>> {
-    let runs = ObservationStore::open_initialized()?.list_runs_by_retry_of(
+    let page = ObservationStore::open_initialized()?.list_runs_by_retry_of_page(
         "agent-task",
         source_run_id,
-        16,
+        RETRY_SUCCESSOR_SCAN_LIMIT,
     )?;
-    runs.iter().map(record_from_run).collect()
+    if page.truncated {
+        return Err(Error::internal_unexpected(format!(
+            "retry lineage for {source_run_id} exceeded {RETRY_SUCCESSOR_SCAN_LIMIT} successors; \
+             refusing to answer from a truncated lineage"
+        )));
+    }
+    page.runs.iter().map(record_from_run).collect()
 }
 
 pub(super) fn read_records_with_health(

--- a/crates/homeboy-cli/src/commands/runs/compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/compare.rs
@@ -91,6 +91,7 @@ pub(super) fn compare_runs(args: RunsCompareArgs) -> CmdResult<RunsOutput> {
         status: args.status.clone(),
         rig_id: args.rig.clone(),
         limit: Some(limit),
+        ..RunListFilter::default()
     })?;
 
     let mut rows = Vec::new();

--- a/crates/homeboy-cli/src/commands/runs/distribution.rs
+++ b/crates/homeboy-cli/src/commands/runs/distribution.rs
@@ -85,6 +85,7 @@ pub fn runs_distribution(
             status: args.status.clone(),
             rig_id: args.rig.clone(),
             limit: Some(limit),
+            ..RunListFilter::default()
         })?
         .into_iter()
         .filter(|run| {

--- a/crates/homeboy-cli/src/commands/runs/drift.rs
+++ b/crates/homeboy-cli/src/commands/runs/drift.rs
@@ -124,6 +124,7 @@ pub fn runs_drift(args: RunsDriftArgs) -> CmdResult<RunsOutput> {
         status: None,
         rig_id: None,
         limit: Some(5000),
+        ..RunListFilter::default()
     };
 
     let window_rows = load_artifact_rows(&store, filter.clone(), Some(&args.window))?.rows;

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -64,6 +64,7 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         // counts canonical rows the caller actually sees, not mirrors that get
         // collapsed away. The store already caps growth via retention.
         limit: Some(list_prefetch_limit(&args)),
+        ..RunListFilter::default()
     })?;
 
     let run_records = run_records

--- a/crates/homeboy-cli/src/commands/runs/latest.rs
+++ b/crates/homeboy-cli/src/commands/runs/latest.rs
@@ -81,5 +81,6 @@ pub(crate) fn run_filter_from_latest_args(args: RunsLatestRunArgs) -> RunListFil
         status: args.status,
         rig_id: args.rig,
         limit: Some(1),
+        ..RunListFilter::default()
     }
 }

--- a/crates/homeboy-cli/src/commands/runs/query.rs
+++ b/crates/homeboy-cli/src/commands/runs/query.rs
@@ -139,6 +139,7 @@ pub fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
         status: None,
         rig_id: None,
         limit: Some(args.limit.clamp(1, 5000)),
+        ..RunListFilter::default()
     };
     let loaded = load_artifact_rows(&store, filter, args.since.as_deref())?;
     let rows = loaded.rows;

--- a/crates/homeboy-cli/src/commands/runs/refs.rs
+++ b/crates/homeboy-cli/src/commands/runs/refs.rs
@@ -119,6 +119,7 @@ pub fn runs_refs(args: RunsRefsArgs) -> CmdResult<RunsOutput> {
         status: args.status.clone(),
         rig_id: args.rig.clone(),
         limit: Some(args.limit.clamp(1, 5000)),
+        ..RunListFilter::default()
     };
     let runs = if let Some(raw_since) = args.since.as_deref() {
         let threshold = since_threshold(raw_since)?;

--- a/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
+++ b/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
@@ -341,6 +341,7 @@ mod tests {
                 status: None,
                 rig_id: None,
                 limit: Some(limit as i64),
+                ..RunListFilter::default()
             }) else {
                 return Vec::new();
             };

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -13,7 +13,7 @@ use crate::api_jobs::{self, ActiveRunnerJobSummary, JobStore, RunnerJobProjectio
 use crate::error::{Error, Result};
 use crate::observation::{
     run_owner_pid, running_status_note, FindingListFilter, ObservationStore, RunListFilter,
-    RunRecord, RunStatus,
+    RunRecord, RunStatus, MAX_RUN_PAGE_LIMIT,
 };
 use crate::{activity, component, git, paths};
 
@@ -575,7 +575,13 @@ fn list_runs(
         rig_id: query_value(path, "rig").or_else(|| query_value(path, "rig_id")),
         limit: query_value(path, "limit")
             .and_then(|value| value.parse::<i64>().ok())
-            .map(|limit| limit.clamp(1, 1000)),
+            .map(|limit| limit.clamp(1, MAX_RUN_PAGE_LIMIT)),
+        // A page ceiling with no way past it is a hard wall; an offset makes
+        // the rows beyond it reachable (#11177).
+        offset: query_value(path, "offset")
+            .and_then(|value| value.parse::<i64>().ok())
+            .map(|offset| offset.max(0)),
+        ..RunListFilter::default()
     };
 
     let mut runs: Vec<RunSummary> = store

--- a/crates/homeboy-core/src/observation/audit_artifact_provider.rs
+++ b/crates/homeboy-core/src/observation/audit_artifact_provider.rs
@@ -26,6 +26,7 @@ impl AuditRecordedArtifactProvider for StoreArtifactProvider {
             status: None,
             rig_id: None,
             limit: Some(limit as i64),
+            ..RunListFilter::default()
         }) else {
             return Vec::new();
         };

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -54,14 +54,16 @@ pub use records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, ArtifactViewerLink,
     FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder,
     NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder,
-    NewTriageItemRecord, RecordedHomeboyFinding, RunEvidenceCommands, RunListFilter, RunRecord,
-    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
+    NewTriageItemRecord, RecordedHomeboyFinding, RunCursor, RunEvidenceCommands, RunListFilter,
+    RunPage, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
+    TriagePullRequestSignals,
 };
 pub use run_failure_causes::{nested_failure_causes_from_run_detail, RunFailureCause};
 pub use store::{
     directory_tree_sha256, ArtifactPublication, ArtifactPublicationType, ObservationDbStatus,
-    ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV,
-    PREVIEW_PUBLIC_URL_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
+    ObservationStore, CURRENT_SCHEMA_VERSION, DEFAULT_RUN_PAGE_LIMIT, LAB_OFFLOAD_METADATA_ENV,
+    MAX_EXHAUSTIVE_RUN_ROWS, MAX_RUN_PAGE_LIMIT, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+    SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub use test_findings::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,

--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -81,6 +81,27 @@ pub struct RunRecord {
     pub metadata_json: serde_json::Value,
 }
 
+/// Keyset position of the last row a page returned, in the store's canonical
+/// `ORDER BY started_at DESC, id DESC` order.
+///
+/// Preferred over `RunListFilter::offset` for walking pages: rows inserted
+/// while a caller paginates shift every offset, so an offset walk can skip or
+/// repeat rows on a live store. A keyset cursor is stable under insertion.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunCursor {
+    pub started_at: String,
+    pub id: String,
+}
+
+impl RunCursor {
+    pub fn from_run(run: &RunRecord) -> Self {
+        Self {
+            started_at: run.started_at.clone(),
+            id: run.id.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RunListFilter {
     pub kind: Option<String>,
@@ -88,6 +109,44 @@ pub struct RunListFilter {
     pub status: Option<String>,
     pub rig_id: Option<String>,
     pub limit: Option<i64>,
+    /// Rows to skip before the page begins. Simple to reason about, but see
+    /// `after` — an offset walk is not stable while rows are being inserted.
+    pub offset: Option<i64>,
+    /// Resume strictly after this keyset position. Takes effect in addition to
+    /// `offset`; callers normally set one or the other.
+    pub after: Option<RunCursor>,
+}
+
+/// A page of run rows carrying the signal that a bare `Vec<RunRecord>` cannot:
+/// whether the store stopped at the page boundary with more rows still matching
+/// the filter (#11177).
+///
+/// A caller whose logic treats "absent from this page" as "does not exist" —
+/// completion tracking, lineage walks, reconciliation — must consult
+/// `truncated` and either paginate via `next_cursor` or fail loudly. Ignoring
+/// it is how #11116 silently reported live runs as completed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunPage {
+    pub runs: Vec<RunRecord>,
+    /// True when more rows matched the filter than the applied limit returned.
+    pub truncated: bool,
+    /// The limit the store actually applied, after clamping the request into
+    /// `[1, MAX_RUN_PAGE_LIMIT]`. Compare against the requested limit to see
+    /// whether the request itself was reduced.
+    pub applied_limit: i64,
+    /// Keyset position to resume from, `Some` only when `truncated`.
+    pub next_cursor: Option<RunCursor>,
+    /// Offset to resume from, `Some` only when `truncated`. Prefer
+    /// `next_cursor` on a store that is being written to concurrently.
+    pub next_offset: Option<i64>,
+}
+
+impl RunPage {
+    /// Consume the page, discarding the truncation signal. Named so that
+    /// dropping the signal is a visible decision at the call site.
+    pub fn into_runs(self) -> Vec<RunRecord> {
+        self.runs
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -67,6 +67,7 @@ pub fn related_lab_artifacts_for_runner_job(
         status: None,
         rig_id: None,
         limit: Some(1000),
+        ..RunListFilter::default()
     })? {
         if candidate.id == run.id {
             continue;

--- a/crates/homeboy-core/src/observation/runs_service/runner_downloads.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_downloads.rs
@@ -681,23 +681,23 @@ impl LivenessVeto {
         let Ok(store) = ObservationStore::open_initialized() else {
             return Self { running: None };
         };
-        // One row over the bound is read so truncation is detectable rather
-        // than silently dropping vetoes.
-        let probe = i64::try_from(RUNNING_RUN_SCAN_LIMIT.saturating_add(1)).unwrap_or(i64::MAX);
-        let Ok(running) = store.list_runs(RunListFilter {
+        // Truncation must be detectable: an unseen running run could own any
+        // candidate. The store reports it directly now, so the bound is asked
+        // for as itself rather than hand-probed one row over (#11177).
+        let scan_limit = i64::try_from(RUNNING_RUN_SCAN_LIMIT).unwrap_or(i64::MAX);
+        let Ok(page) = store.list_runs_page(RunListFilter {
             status: Some(RunStatus::Running.as_str().to_string()),
-            limit: Some(probe),
+            limit: Some(scan_limit),
             ..RunListFilter::default()
         }) else {
             return Self { running: None };
         };
-        if running.len() > RUNNING_RUN_SCAN_LIMIT {
-            // An unseen running run could own any candidate, so degrade to
-            // "retain everything" rather than to "veto nothing".
+        if page.truncated {
+            // Degrade to "retain everything" rather than to "veto nothing".
             return Self { running: None };
         }
         Self {
-            running: Some(running),
+            running: Some(page.runs),
         }
     }
 

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -18,12 +18,13 @@ pub use super::context::{
 use super::records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
-    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
-    TriageItemRecord, TriagePullRequestSignals,
+    NewTriageItemRecord, RunCursor, RunListFilter, RunPage, RunRecord, RunStatus, TraceRunRecord,
+    TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 use crate::{paths, Error, Result};
 pub use artifacts::directory_tree_sha256;
 pub use artifacts::{ArtifactPublication, ArtifactPublicationType};
+pub use runs::{DEFAULT_RUN_PAGE_LIMIT, MAX_EXHAUSTIVE_RUN_ROWS, MAX_RUN_PAGE_LIMIT};
 
 pub(crate) use helpers::*;
 

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -5,6 +5,48 @@ use uuid::Uuid;
 
 use super::*;
 
+/// Rows returned when a caller does not ask for a specific page size.
+pub const DEFAULT_RUN_PAGE_LIMIT: i64 = 100;
+
+/// Largest page a single run query will materialize. A request above this is
+/// reduced to it — but the reduction is reported through `RunPage::truncated`
+/// and `RunPage::applied_limit` rather than being silent (#11177).
+pub const MAX_RUN_PAGE_LIMIT: i64 = 1000;
+
+/// Ceiling on an exhaustive walk, above which
+/// [`ObservationStore::list_runs_all`] errors instead of returning a partial
+/// answer. A wrong answer is worse than a loud one.
+pub const MAX_EXHAUSTIVE_RUN_ROWS: i64 = 100_000;
+
+/// Turn a probe read of `limit + 1` rows into a page plus its resume position.
+///
+/// The extra row is the whole mechanism: it is the difference between "the
+/// page ended because the data ended" and "the page ended because the limit
+/// did", which a bare `Vec` cannot express.
+fn run_page_from_probe(mut runs: Vec<RunRecord>, limit: i64, offset: i64) -> RunPage {
+    let truncated = runs.len() as i64 > limit;
+    if truncated {
+        runs.truncate(limit.max(0) as usize);
+    }
+    let next_cursor = if truncated {
+        runs.last().map(RunCursor::from_run)
+    } else {
+        None
+    };
+    let next_offset = if truncated {
+        Some(offset + limit)
+    } else {
+        None
+    };
+    RunPage {
+        runs,
+        truncated,
+        applied_limit: limit,
+        next_cursor,
+        next_offset,
+    }
+}
+
 impl ObservationStore {
     /// Open and lazily initialize the local observed-state database.
     pub fn open_initialized() -> Result<Self> {
@@ -324,8 +366,36 @@ impl ObservationStore {
         }
     }
 
+    /// List runs, discarding any signal that the page was cut short.
+    ///
+    /// The returned `Vec` is indistinguishable from a complete answer even when
+    /// more rows matched the filter, so this is a **display-path** accessor.
+    /// Any caller whose logic treats "absent from this list" as "does not
+    /// exist" must use [`ObservationStore::list_runs_page`] and honour
+    /// `RunPage::truncated`, or [`ObservationStore::list_runs_all`] to walk
+    /// every matching row. See #11177 (and #11116, the outage it caused).
     pub fn list_runs(&self, filter: RunListFilter) -> Result<Vec<RunRecord>> {
-        let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
+        Ok(self.list_runs_page(filter)?.runs)
+    }
+
+    /// List a page of runs together with an explicit truncation signal and the
+    /// position to resume from.
+    ///
+    /// The applied page size is clamped into `[1, MAX_RUN_PAGE_LIMIT]`; a
+    /// request above that ceiling is reduced, but the reduction is now
+    /// observable through `RunPage::applied_limit` and `RunPage::truncated`
+    /// instead of being silent (#11177). Truncation is detected by reading one
+    /// row past the page, so a result that exactly fills the limit is not
+    /// mistaken for a truncated one.
+    pub fn list_runs_page(&self, filter: RunListFilter) -> Result<RunPage> {
+        let limit = filter
+            .limit
+            .unwrap_or(DEFAULT_RUN_PAGE_LIMIT)
+            .clamp(1, MAX_RUN_PAGE_LIMIT);
+        let offset = filter.offset.unwrap_or(0).max(0);
+        // Read one row past the page so "ended on the boundary" and "there is
+        // more" are distinguishable rather than conflated.
+        let probe = limit + 1;
         let mut predicates = Vec::new();
         let mut values: Vec<&dyn ToSql> = Vec::new();
         if filter.kind.is_some() {
@@ -344,12 +414,22 @@ impl ObservationStore {
             predicates.push("rig_id = ?");
             values.push(filter.rig_id.as_ref().expect("checked"));
         }
+        if let Some(cursor) = filter.after.as_ref() {
+            // Keyset resume in the canonical `started_at DESC, id DESC` order.
+            // Expanded rather than written as a row-value comparison so the
+            // predicate does not depend on the linked SQLite version.
+            predicates.push("(started_at < ? OR (started_at = ? AND id < ?))");
+            values.push(&cursor.started_at);
+            values.push(&cursor.started_at);
+            values.push(&cursor.id);
+        }
         let where_clause = if predicates.is_empty() {
             String::new()
         } else {
             format!("WHERE {}", predicates.join(" AND "))
         };
-        values.push(&limit);
+        values.push(&probe);
+        values.push(&offset);
         let mut statement = self
             .connection
             .prepare(&format!(
@@ -359,7 +439,7 @@ impl ObservationStore {
                 FROM runs
                 {where_clause}
                 ORDER BY started_at DESC, id DESC
-                LIMIT ?
+                LIMIT ? OFFSET ?
                 "#,
             ))
             .map_err(sqlite_error("prepare list run records"))?;
@@ -367,18 +447,71 @@ impl ObservationStore {
             .query_map(params_from_iter(values), row_to_run_record)
             .map_err(sqlite_error("list run records"))?;
 
-        collect_rows(rows, "collect run records")
+        let runs = collect_rows(rows, "collect run records")?;
+        Ok(run_page_from_probe(runs, limit, offset))
+    }
+
+    /// Walk every run matching `filter`, paginating internally so the answer is
+    /// complete rather than silently cut at the page ceiling.
+    ///
+    /// `filter.limit` is ignored — completeness is the point. Pagination uses a
+    /// keyset cursor, so rows inserted mid-walk cannot shift the window and
+    /// cause a row to be skipped. If the result would exceed
+    /// `MAX_EXHAUSTIVE_RUN_ROWS` the call **fails loudly** instead of returning
+    /// a quietly partial set (#11177).
+    pub fn list_runs_all(&self, filter: RunListFilter) -> Result<Vec<RunRecord>> {
+        let mut page_filter = RunListFilter {
+            limit: Some(MAX_RUN_PAGE_LIMIT),
+            offset: None,
+            ..filter
+        };
+        let mut collected: Vec<RunRecord> = Vec::new();
+        loop {
+            let page = self.list_runs_page(page_filter.clone())?;
+            collected.extend(page.runs);
+            if !page.truncated {
+                return Ok(collected);
+            }
+            if collected.len() as i64 >= MAX_EXHAUSTIVE_RUN_ROWS {
+                return Err(Error::internal_unexpected(format!(
+                    "run listing exceeded the {MAX_EXHAUSTIVE_RUN_ROWS} row exhaustive-walk ceiling; \
+                     narrow the filter or paginate explicitly with list_runs_page"
+                )));
+            }
+            // `truncated` implies a non-empty page, so a missing cursor would be
+            // a store bug; stop rather than loop forever on it.
+            let Some(cursor) = page.next_cursor else {
+                return Ok(collected);
+            };
+            page_filter.after = Some(cursor);
+        }
     }
 
     /// Return a bounded set of runs linked to the given retry predecessor.
     /// The literal JSON path matches the `idx_runs_metadata_retry_of` index.
+    ///
+    /// Truncation is invisible in the returned `Vec`. A caller reasoning about
+    /// retry *lineage* — where a missing sibling is a wrong answer, not a slow
+    /// one — must use [`ObservationStore::list_runs_by_retry_of_page`] (#11177).
     pub fn list_runs_by_retry_of(
         &self,
         kind: &str,
         retry_of: &str,
         limit: usize,
     ) -> Result<Vec<RunRecord>> {
-        let limit = i64::try_from(limit.clamp(1, 1000)).expect("bounded run query limit");
+        Ok(self.list_runs_by_retry_of_page(kind, retry_of, limit)?.runs)
+    }
+
+    /// Retry-lineage siblings with an explicit truncation signal.
+    pub fn list_runs_by_retry_of_page(
+        &self,
+        kind: &str,
+        retry_of: &str,
+        limit: usize,
+    ) -> Result<RunPage> {
+        let limit = i64::try_from(limit.clamp(1, MAX_RUN_PAGE_LIMIT as usize))
+            .expect("bounded run query limit");
+        let probe = limit + 1;
         let mut statement = self
             .connection
             .prepare(
@@ -394,9 +527,10 @@ impl ObservationStore {
             )
             .map_err(sqlite_error("prepare metadata-indexed run query"))?;
         let rows = statement
-            .query_map(params![kind, retry_of, limit], row_to_run_record)
+            .query_map(params![kind, retry_of, probe], row_to_run_record)
             .map_err(sqlite_error("query metadata-indexed run records"))?;
-        collect_rows(rows, "collect metadata-indexed run records")
+        let runs = collect_rows(rows, "collect metadata-indexed run records")?;
+        Ok(run_page_from_probe(runs, limit, 0))
     }
 
     /// List every currently running run so callers can retain active work when
@@ -726,5 +860,354 @@ impl ObservationStore {
             )
         })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    /// Seed rows with explicit ids and timestamps so the canonical
+    /// `started_at DESC, id DESC` order is deterministic rather than dependent
+    /// on how fast the inserts happened to run. Returns the ids in the order
+    /// queries hand them back: newest first.
+    fn seed_runs(store: &ObservationStore, kind: &str, count: usize) -> Vec<String> {
+        let mut ids: Vec<String> = (0..count)
+            .map(|index| {
+                let id = format!("{kind}-{index:03}");
+                seed_run(
+                    store,
+                    kind,
+                    &id,
+                    &format!("2026-01-01T00:{index:02}:00+00:00"),
+                    None,
+                );
+                id
+            })
+            .collect();
+        ids.reverse();
+        ids
+    }
+
+    fn seed_run(
+        store: &ObservationStore,
+        kind: &str,
+        id: &str,
+        started_at: &str,
+        retry_of: Option<&str>,
+    ) {
+        let metadata_json = match retry_of {
+            Some(retry_of) => serde_json::json!({
+                "agent_task_run": { "metadata": { "retry_of": retry_of } }
+            }),
+            None => serde_json::json!({}),
+        };
+        store
+            .import_run(&RunRecord {
+                id: id.to_string(),
+                kind: kind.to_string(),
+                started_at: started_at.to_string(),
+                status: RunStatus::Running.as_str().to_string(),
+                metadata_json,
+                ..RunRecord::default()
+            })
+            .expect("seed run");
+    }
+
+    fn ids(runs: &[RunRecord]) -> Vec<String> {
+        runs.iter().map(|run| run.id.clone()).collect()
+    }
+
+    /// The whole defect is that a cut-short page looked exactly like a complete
+    /// one. A page that merely ends on its limit boundary must not claim
+    /// truncation, or the signal is noise and callers learn to ignore it.
+    #[test]
+    fn a_page_that_ends_because_the_data_ended_is_not_truncated() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            seed_runs(&store, "page-exact", 3);
+
+            let page = store
+                .list_runs_page(RunListFilter {
+                    kind: Some("page-exact".to_string()),
+                    limit: Some(3),
+                    ..RunListFilter::default()
+                })
+                .expect("page");
+
+            assert_eq!(page.runs.len(), 3);
+            assert!(!page.truncated, "an exact fit is a complete answer");
+            assert_eq!(page.next_cursor, None);
+            assert_eq!(page.next_offset, None);
+        });
+    }
+
+    /// And a page that ended because the limit did must say so, and must say
+    /// where to resume — otherwise the caller can detect the boundary but not
+    /// cross it.
+    #[test]
+    fn a_page_cut_short_by_its_limit_reports_truncation_and_a_resume_point() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seeded = seed_runs(&store, "page-cut", 5);
+
+            let page = store
+                .list_runs_page(RunListFilter {
+                    kind: Some("page-cut".to_string()),
+                    limit: Some(2),
+                    ..RunListFilter::default()
+                })
+                .expect("page");
+
+            assert_eq!(ids(&page.runs), seeded[..2].to_vec());
+            assert!(page.truncated);
+            assert_eq!(page.applied_limit, 2);
+            assert_eq!(page.next_offset, Some(2));
+            assert_eq!(
+                page.next_cursor,
+                page.runs.last().map(RunCursor::from_run),
+                "the resume point is the last row handed out"
+            );
+        });
+    }
+
+    /// A request above the page ceiling is still reduced — but the reduction is
+    /// now reported instead of silent, which is the #11177 contract.
+    #[test]
+    fn a_request_above_the_page_ceiling_reports_the_limit_it_actually_applied() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            seed_runs(&store, "page-ceiling", 2);
+
+            let page = store
+                .list_runs_page(RunListFilter {
+                    kind: Some("page-ceiling".to_string()),
+                    limit: Some(5_000),
+                    ..RunListFilter::default()
+                })
+                .expect("page");
+
+            assert_eq!(page.applied_limit, MAX_RUN_PAGE_LIMIT);
+            assert!(!page.truncated);
+            assert_eq!(page.runs.len(), 2);
+        });
+    }
+
+    /// Offset pagination has to actually reach past the first page, or the
+    /// truncation signal is a dead end.
+    #[test]
+    fn offset_pagination_reaches_the_rows_past_the_first_page() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seeded = seed_runs(&store, "page-offset", 5);
+            let filter = |offset: Option<i64>| RunListFilter {
+                kind: Some("page-offset".to_string()),
+                limit: Some(2),
+                offset,
+                ..RunListFilter::default()
+            };
+
+            let first = store.list_runs_page(filter(None)).expect("first page");
+            let second = store
+                .list_runs_page(filter(first.next_offset))
+                .expect("second page");
+            let third = store
+                .list_runs_page(filter(second.next_offset))
+                .expect("third page");
+
+            let walked: Vec<String> = ids(&first.runs)
+                .into_iter()
+                .chain(ids(&second.runs))
+                .chain(ids(&third.runs))
+                .collect();
+
+            assert_eq!(walked, seeded, "an offset walk must visit every row once");
+            assert!(!third.truncated, "the walk must terminate");
+        });
+    }
+
+    /// Cursor pagination is the one that stays correct while rows are being
+    /// inserted, so it must cover the same ground as the offset walk.
+    #[test]
+    fn cursor_pagination_visits_every_row_exactly_once() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seeded = seed_runs(&store, "page-cursor", 5);
+
+            let mut walked = Vec::new();
+            let mut after = None;
+            loop {
+                let page = store
+                    .list_runs_page(RunListFilter {
+                        kind: Some("page-cursor".to_string()),
+                        limit: Some(2),
+                        after: after.clone(),
+                        ..RunListFilter::default()
+                    })
+                    .expect("cursor page");
+                walked.extend(ids(&page.runs));
+                if !page.truncated {
+                    break;
+                }
+                after = page.next_cursor;
+            }
+
+            assert_eq!(walked, seeded);
+        });
+    }
+
+    /// A row inserted mid-walk shifts every offset. That is the case an offset
+    /// walk gets wrong and a keyset cursor walk does not.
+    #[test]
+    fn a_cursor_walk_survives_an_insert_that_would_shift_an_offset_walk() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seeded = seed_runs(&store, "page-shift", 4);
+            let filter = |after: Option<RunCursor>, offset: Option<i64>| RunListFilter {
+                kind: Some("page-shift".to_string()),
+                limit: Some(2),
+                offset,
+                after,
+                ..RunListFilter::default()
+            };
+
+            let first = store
+                .list_runs_page(filter(None, None))
+                .expect("first page");
+            // A newer row sorts ahead of everything the first page returned.
+            seed_run(
+                &store,
+                "page-shift",
+                "page-shift-newer",
+                "2026-01-01T23:00:00+00:00",
+                None,
+            );
+
+            let by_cursor = store
+                .list_runs_page(filter(first.next_cursor.clone(), None))
+                .expect("cursor page");
+            let by_offset = store
+                .list_runs_page(filter(None, first.next_offset))
+                .expect("offset page");
+
+            let cursor_walk: Vec<String> = ids(&first.runs)
+                .into_iter()
+                .chain(ids(&by_cursor.runs))
+                .collect();
+            assert_eq!(
+                cursor_walk, seeded,
+                "a cursor walk must not skip a row because a newer one arrived"
+            );
+            assert_ne!(
+                ids(&by_offset.runs),
+                ids(&by_cursor.runs),
+                "the offset walk is expected to be the one that shifts; if it stops \
+                 shifting this test no longer proves anything"
+            );
+        });
+    }
+
+    /// The exhaustive accessor exists so a correctness-sensitive caller can ask
+    /// for completeness explicitly; a display limit must not silently cap it.
+    #[test]
+    fn the_exhaustive_walk_ignores_the_display_limit_and_returns_every_row() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let seeded = seed_runs(&store, "page-all", 7);
+            seed_runs(&store, "page-all-other", 3);
+
+            let runs = store
+                .list_runs_all(RunListFilter {
+                    kind: Some("page-all".to_string()),
+                    limit: Some(2),
+                    ..RunListFilter::default()
+                })
+                .expect("exhaustive walk");
+
+            assert_eq!(
+                ids(&runs),
+                seeded,
+                "the filter still applies; the limit does not"
+            );
+        });
+    }
+
+    /// The bounded accessor keeps its historical shape so the existing call
+    /// sites are unaffected: same rows, signal dropped.
+    #[test]
+    fn the_bounded_accessor_returns_the_same_rows_as_the_page() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            seed_runs(&store, "page-parity", 4);
+            let filter = RunListFilter {
+                kind: Some("page-parity".to_string()),
+                limit: Some(3),
+                ..RunListFilter::default()
+            };
+
+            let rows = store.list_runs(filter.clone()).expect("rows");
+            let page = store.list_runs_page(filter).expect("page");
+
+            assert_eq!(rows, page.runs);
+            assert_eq!(rows.len(), 3);
+            assert!(page.truncated);
+        });
+    }
+
+    /// The default page size is unchanged for callers that ask for nothing.
+    #[test]
+    fn an_unspecified_limit_still_applies_the_historical_default() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            seed_runs(&store, "page-default", 2);
+
+            let page = store
+                .list_runs_page(RunListFilter {
+                    kind: Some("page-default".to_string()),
+                    ..RunListFilter::default()
+                })
+                .expect("page");
+
+            assert_eq!(page.applied_limit, DEFAULT_RUN_PAGE_LIMIT);
+        });
+    }
+
+    /// Retry lineage carried the identical unsignalled clamp. A truncated
+    /// lineage is a wrong answer, not a slow one.
+    #[test]
+    fn a_truncated_retry_lineage_reports_truncation() {
+        with_isolated_home(|_home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            for index in 0..3 {
+                seed_run(
+                    &store,
+                    "agent-task",
+                    &format!("retry-{index:03}"),
+                    &format!("2026-01-01T00:{index:02}:00+00:00"),
+                    Some("source-run"),
+                );
+            }
+
+            let cut = store
+                .list_runs_by_retry_of_page("agent-task", "source-run", 2)
+                .expect("lineage page");
+            assert_eq!(cut.runs.len(), 2);
+            assert!(cut.truncated);
+            assert_eq!(cut.applied_limit, 2);
+
+            let complete = store
+                .list_runs_by_retry_of_page("agent-task", "source-run", 8)
+                .expect("lineage page");
+            assert_eq!(complete.runs.len(), 3);
+            assert!(!complete.truncated);
+            assert_eq!(
+                store
+                    .list_runs_by_retry_of("agent-task", "source-run", 8)
+                    .expect("lineage rows"),
+                complete.runs,
+                "the bounded accessor keeps returning the same rows"
+            );
+        });
     }
 }

--- a/crates/homeboy-triage/src/observation.rs
+++ b/crates/homeboy-triage/src/observation.rs
@@ -32,6 +32,7 @@ impl TriageObservation {
                 status: None,
                 rig_id: None,
                 limit: Some(1),
+                ..RunListFilter::default()
             })
             .ok()
             .flatten()

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -771,6 +771,7 @@ fn test_list_runs() {
                 status: Some("pass".to_string()),
                 rig_id: Some("studio".to_string()),
                 limit: Some(10),
+                ..RunListFilter::default()
             })
             .expect("list filtered");
 


### PR DESCRIPTION
Closes #11177.

## The defect

`list_runs` clamped its limit to `1000` and returned a bare `Vec<RunRecord>`. A page cut short by the limit was **indistinguishable from a complete answer**, and `RunListFilter` had no offset or cursor, so the rows past the ceiling were not reachable at all. Every caller whose logic treats "absent from this list" as "does not exist" inherited the trap — which is exactly what produced #11116.

## Option chosen: A (make truncation detectable), not B (change the return type)

I looked at all ~29 `.list_runs(` sites (~20 production) before deciding. Option B is more correct in the abstract, but it is a large mechanical change across five crates that **cannot be compile-verified here** (eight agents share this VPS; `cargo build/test/check` is prohibited, see below). A half-migrated Option B would be a worse outcome than a complete Option A.

So: the hole is closed at the source, the bounded accessor keeps its exact historical behaviour, and the migration is opt-in and evidence-driven.

- **`ObservationStore::list_runs_page(filter) -> RunPage`** — carries `truncated`, `applied_limit`, `next_offset`, `next_cursor`. Truncation is measured by reading **one row past the page**, so a result that exactly fills the limit is not misreported as truncated. A signal that fires on a complete answer is noise, and callers learn to ignore noise.
- **`list_runs`** keeps its signature and delegates. Same rows, same clamp, zero blast radius. Its doc comment now names it a *display-path* accessor and points correctness-sensitive callers at `list_runs_page` / `list_runs_all`.
- **`list_runs_all(filter)`** — walks every matching row via keyset pagination, ignores `filter.limit`, and **errors** above `MAX_EXHAUSTIVE_RUN_ROWS` rather than quietly returning a partial set.
- **`list_runs_by_retry_of`** carried the identical unsignalled clamp; it gains the same `_page` sibling and delegates.

## Pagination

`RunListFilter` gains `offset` and a keyset `after: Option<RunCursor>`. Both work; the cursor is preferred and documented as such, because an offset walk skips rows when something is inserted mid-walk and a keyset walk on `(started_at, id)` does not. There is a test that pins exactly that difference. The HTTP runs endpoint now accepts `?offset=`, so the ceiling is reachable from the API too.

The `1000` ceiling is deliberately kept — it is now *reported* (`applied_limit`, `truncated`) instead of silent, and it is now *crossable*.

## Callers migrated (2, both genuinely need exactness)

- **`LivenessVeto::read`** (`runs_service/runner_downloads.rs`) hand-rolled the `limit + 1` probe to detect truncation — and **the clamp silently defeated it**: it asked for `1001`, got `1000`, so `running.len() > 1000` could never be true. The degrade-to-retain-everything path was unreachable. It now reads `page.truncated`. This is a real behaviour fix, not a refactor.
- **`read_retry_successors`** (`homeboy-agents/lifecycle_store.rs`) backs `find_unbound_cook_retry_successor`, where `[] => Ok(None)` means "no reservation exists" and a new one gets created. A truncated lineage would double-book a retry. It now reads a page (bound raised 16 → 256) and returns an error on truncation instead of a wrong answer.

## Not migrated (deliberate)

Display, reconciliation and retention paths: `runs list/compare/refs/query/drift/distribution`, `reconcile_orphaned_running_runs`, `http_api` stale-running reconciliation, `artifact_links` sibling scan, the audit artifact providers, and all test call sites. These are idempotent, re-run, or human-facing; a bounded page is the right answer for them and the doc comment now says so. `terminal_run_ids_before` (retention) is unchanged for the same reason the issue gives.

All ~29 `RunListFilter` literals were audited: every exhaustive one got `..RunListFilter::default()` so the two new fields do not break construction. A scripted scan confirms zero exhaustive literals remain.

## Tests

Nine new tests in `observation/store/runs.rs`, seeded through `import_run` with explicit ids and timestamps so the canonical `started_at DESC, id DESC` order is deterministic rather than dependent on insertion speed:

- a page that ends because the data ended is **not** truncated (the false-positive guard)
- a page cut short reports truncation, `applied_limit`, `next_offset` and the correct resume cursor
- a request above the ceiling reports the limit it actually applied
- offset pagination visits every row exactly once and terminates
- cursor pagination visits every row exactly once
- a cursor walk survives an insert that provably shifts the offset walk
- the exhaustive walk ignores the display limit and still honours the filter
- the bounded accessor returns the same rows as the page (no-regression for the 29 sites)
- the default page size is unchanged when no limit is given
- a truncated retry lineage reports truncation; a complete one does not

No tests were deleted or `#[ignore]`d.

## Compilation uncertainty

**I could not compile or test this locally.** This VPS runs eight parallel agents alongside MariaDB and PHP-FPM; `cargo build/test/check/clippy` is prohibited because concurrent cargo invocations have OOM-killed in-flight work. Only `cargo fmt` was run (clean, which at least proves every touched file parses).

Specific things CI should be watched for:
- the two new fields on `RunListFilter` breaking a struct literal I missed (I scanned brace-matched literal bodies across the workspace, but the scan is textual)
- borrow lifetimes on the new `&dyn ToSql` cursor bindings in `list_runs_page`
- the `Error::internal_unexpected` import path in `homeboy-agents/lifecycle_store.rs`