### PR TITLE
fix(release): bootstrap checks with candidate binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,7 @@ jobs:
         if: inputs.release_tag == '' && steps.failed-release.outputs.blocked != 'true' && steps.stranded.outputs['stranded-tag'] == '' && steps.stranded.outputs['hold-reason'] == ''
         uses: Extra-Chill/homeboy-action@v2
         with:
+          source: '.'
           commands: release
           expected-commands: review audit,review lint,review test
           args: --skip-checks=audit,lint,test

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1585,6 +1585,24 @@ fn release_dry_run_establishes_its_branch_instead_of_claiming_release_head() {
     );
 }
 
+/// The release check parses the current extension manifests before the
+/// downstream build job exists. It must therefore run the candidate Homeboy
+/// contract, not the latest published binary, which may predate those manifests.
+#[test]
+fn release_dry_run_bootstraps_with_the_candidate_binary() {
+    let check = job_section(release_workflow(), "check");
+    let dry_run = release_step_block(check, "name: Dry-run release check");
+
+    assert!(
+        dry_run.contains("source: '.'"),
+        "the self-release check must build the candidate before installing current extensions"
+    );
+    assert!(
+        !dry_run.contains("version:"),
+        "the self-release check must not select a published binary"
+    );
+}
+
 /// The attach step's real git behaviour: attach at the tip, refuse otherwise.
 /// Asserting the effect, not the shape of the script.
 #[test]


### PR DESCRIPTION
## Summary

- build the Homeboy self-release dry run from the candidate source before installing current extensions
- prevent released parser schemas from deadlocking a release after an extension adopts a contract already merged to Homeboy `main`
- guard the candidate-bootstrap invariant in the release workflow tests

## Root cause

`v0.329.1` bootstrapped the release check and then installed `rust-v1.32.1`, whose structured `program`/`args` readiness probes require Homeboy #11473. Because #11473 is merged but unreleased, the old binary rejected the manifest before the workflow could build the compatible candidate.

## Verification

- `cargo test --test release_workflow_test` (46 passed)
- `cargo fmt --all --check`
- `git diff --check`
- candidate `target/debug/homeboy extension install-for-component --path . --source https://github.com/Extra-Chill/homeboy-extensions` installed current source revision `54bbd271` successfully in an isolated HOME

Closes #11545.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the cross-repository bootstrap deadlock, implemented the workflow repair and regression coverage, and performed the listed verification. Chris Huber remains responsible for every line.