### PR TITLE
fix(agents): stop the controller death guard from holding the child's stdin

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -399,12 +399,20 @@ fn scheduler_reports_missing_provider_capability() {
         aggregate.outcomes[0].failure_classification,
         Some(AgentTaskFailureClassification::CapabilityMissing)
     );
+    // #11509 layered a selection-level check ahead of the per-provider one: when
+    // no provider for the backend advertises the capability at all, that is the
+    // more specific diagnosis. The failure classification is unchanged.
     assert_eq!(
         aggregate.outcomes[0].diagnostics[0].class,
         "agent_task.provider_capability_unavailable"
     );
+    // The selection-level diagnostic also names the layer it failed at.
     assert_eq!(
-        aggregate.outcomes[0].diagnostics[0].data["missing_capabilities"],
+        aggregate.outcomes[0].diagnostics[0].data["layer"],
+        json!("provider")
+    );
+    assert_eq!(
+        aggregate.outcomes[0].diagnostics[0].data["required_capabilities"],
         json!(["workspace_write"])
     );
 }

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -128,11 +128,54 @@ impl Drop for ControllerChildGuard {
     }
 }
 
+/// Close every descriptor this process inherited except `keep`.
+///
+/// Runs in a forked child, so it stays inside async-signal-safe libc calls and
+/// walks a bounded descriptor range rather than allocating to enumerate
+/// `/proc/self/fd`.
+#[cfg(unix)]
+fn close_inherited_descriptors_except(keep: RawFd) {
+    let max = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+    let max = if max > 0 { max as RawFd } else { 1024 };
+    for fd in 3..max {
+        if fd != keep {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
+    // stdio is replaced rather than simply closed so a later write in this
+    // process cannot land on a descriptor the kernel has since recycled.
+    let devnull = unsafe { libc::open(c"/dev/null".as_ptr(), libc::O_RDWR) };
+    if devnull >= 0 {
+        for fd in 0..3 {
+            if fd != keep {
+                unsafe {
+                    libc::dup2(devnull, fd);
+                }
+            }
+        }
+        if devnull > 2 && devnull != keep {
+            unsafe {
+                libc::close(devnull);
+            }
+        }
+    }
+}
+
 #[cfg(unix)]
 fn controller_death_guard_loop(read_fd: RawFd, write_fd: RawFd, process_group: u32) -> ! {
     unsafe {
         libc::close(write_fd);
     }
+    // `attach` forks after the child is spawned, so this guard inherits every
+    // descriptor the controller held at that moment — including the write end
+    // of the child's stdin pipe, which the controller has not yet written and
+    // dropped. Holding a duplicate of that end means the child never sees EOF
+    // on stdin: a provider that reads its request from stdin blocks until its
+    // timeout instead of running. Close everything except the liveness read
+    // end, which is the only descriptor this loop uses.
+    close_inherited_descriptors_except(read_fd);
     if unsafe { libc::setpgid(0, process_group as libc::pid_t) } != 0 {
         unsafe {
             libc::_exit(1);


### PR DESCRIPTION
> why the fuck are they red

Because **every agent-task provider that reads its request from stdin hangs
until its timeout instead of running.**

That is the whole `agent_task_provider` cluster: 19 red tests, and
`selection_tests` taking **199 seconds** to report 3 failures on an idle
machine.

## The bug

#11490 moved the death-guard fork to *after* spawn, deliberately, so the guard
could not inherit the standard library's private spawn error pipe:

```rust
/// Start the guard after the command is spawned so it cannot inherit the
/// standard library's private spawn error pipe.
pub fn attach(&self, child: &Child) -> io::Result<()> {
    match unsafe { libc::fork() } { ... }
```

But a fork inherits **every** descriptor the controller holds at that moment,
and `command_runner.rs` calls it well before it writes the request:

```
546:    if let Err(error) = containment.attach(&child) {      // fork() here
582:    if let Some(mut stdin) = child.stdin.take() {         // ...stdin still open
583:        let _ = Write::write_all(&mut stdin, &input);
584:    }                                                     // controller's copy dropped
```

So the guard holds a duplicate of the child's **stdin write end**. Dropping the
controller's copy at 584 does not close the pipe. The provider blocks forever in
its stdin read, and 60 seconds later Homeboy kills it:

```
status: Timeout
summary: "provider 'test.provider' exceeded timeout_ms=60000"
```

This is not test-only. Any provider agent that reads its request from stdin —
which is the contract — hangs for its entire timeout budget in production.

## The fix

Close every inherited descriptor in the forked guard except the liveness read
end it actually uses. stdio is replaced with `/dev/null` rather than left
closed, so a later write in the guard cannot land on a descriptor the kernel has
since recycled.

That keeps the post-spawn fork ordering #11490 needs while removing what it
accidentally captured, and is robust against any future stdio the controller
holds at attach time rather than special-casing stdin.

## Result

```
selection_tests      199s / 3 failed   ->   1.04s / 25 passed
agent_task_provider  19 failed         ->   157 passed, 0 failed
full crate           22 failed         ->   1410 passed, 3 failed
```

`cargo check --workspace --tests` clean, `cargo fmt --all --check` clean.

## Also in here

`scheduler_reports_missing_provider_capability` was made stale by #11509, which
layered a selection-level capability check ahead of the per-provider one. A
backend with no capable provider at all now reports the more specific
`agent_task.provider_capability_unavailable`, whose payload carries the required
capabilities and each candidate's advertised set rather than a per-provider
missing list. The failure classification is unchanged.

## Still red (3)

- `bridge_reconciliation_*` (2) — pass individually and at module scope, fail
  only full-crate single-threaded, so sequential state from an earlier module.
  Both already use `with_isolated_home`. Pre-existing.
- `agent_task_scheduler::postprocess::materializes_binary_dependency_and_records_postprocessed_artifact`
  — not yet investigated.