### PR TITLE
fix(sidecar): validate declared sidecar payloads after a run (#11121)

### DIFF
--- a/crates/homeboy-core/src/engine/run_dir.rs
+++ b/crates/homeboy-core/src/engine/run_dir.rs
@@ -174,6 +174,22 @@ impl RunDir {
         ("ANNOTATIONS_DIR", Some("annotations")),
     ];
 
+    /// The registry keys core exports a legacy sidecar env var for, whether or
+    /// not any manifest declares them.
+    ///
+    /// This is the measurable form of the narrowing question in #11121: as long
+    /// as a shipped extension's runner reads one of these without declaring it,
+    /// filtering [`Self::legacy_env_vars_for`] down to declared keys breaks
+    /// that extension. `homeboy-extension` pins the current gap against the
+    /// shipped manifest fixtures, so the day the gap closes the pin fails and
+    /// says so.
+    pub fn legacy_env_sidecar_keys() -> Vec<&'static str> {
+        Self::LEGACY_SIDECAR_ENV_KEYS
+            .iter()
+            .filter_map(|(_, key)| *key)
+            .collect()
+    }
+
     /// Generate backward-compatible env var pairs for extension scripts.
     ///
     /// Returns `(key, value)` pairs that map the legacy product-prefixed
@@ -200,7 +216,14 @@ impl RunDir {
     /// `"test.coverage": false`, `wordpress` reads `ANNOTATIONS_DIR` while
     /// declaring `"annotations": false`, and three extensions read
     /// `FIX_RESULTS_FILE`, which has no sidecar key at all). Narrowing before
-    /// those declarations are corrected would break shipped extensions.
+    /// those declarations are corrected would break shipped extensions, and an
+    /// extension declaring no sidecars at all would lose the whole set.
+    ///
+    /// That precondition is now measured rather than asserted in prose:
+    /// [`Self::legacy_env_sidecar_keys`] exposes what core exports
+    /// unconditionally, and `homeboy-extension` pins the undeclared remainder
+    /// against the shipped manifest fixtures. When that pin reports an empty
+    /// gap, this may become a filter.
     ///
     /// Declared paths that are absolute or contain `..` are ignored — a
     /// manifest is extension-authored config and this hands the result to a

--- a/crates/homeboy-core/src/structured_sidecar.rs
+++ b/crates/homeboy-core/src/structured_sidecar.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::Serialize;
 use serde_json::Value;
 
@@ -245,6 +247,66 @@ pub fn validate_payload(key: &str, payload: &Value) -> Result<()> {
     }
 }
 
+/// What a post-run check of one declared sidecar file found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarFileCheck {
+    /// Core has no registry contract for this key, so there is nothing to
+    /// judge. Declaring a vendor key is allowed; it simply buys no core
+    /// guarantees, the same reading `empty_payload` and `seeds_on_start` take.
+    Unknown,
+    /// Nothing to validate: no file was written, the file is empty, or the
+    /// declared path is a directory rather than a JSON document (`annotations`
+    /// and `trace.artifacts` are directories).
+    Absent,
+    /// The file was read and its payload satisfies the registry contract.
+    Valid,
+}
+
+/// Validate one declared sidecar's on-disk payload against the registry.
+///
+/// Until #11121 `validate_payload` had six callers, all of them parsers that
+/// had *already* decided to read a specific sidecar. Nothing checked declared
+/// sidecar output generically, so a runner could write a malformed
+/// `bench.results` and every consumer downstream simply saw nothing.
+///
+/// Absence is deliberately not a violation. A missing file is load-bearing for
+/// several keys (`test::run` treats a missing `test.results` as the signal to
+/// parse counts from stdout), and failing a run for a file that was never
+/// written is exactly the mistake that made the lint-findings evidence gate
+/// fail passing lints. This fails only on a payload that is *present and
+/// wrong*, which is an unambiguous contract violation by the producer.
+pub fn validate_sidecar_file(key: &str, path: &Path) -> Result<SidecarFileCheck> {
+    if schema(key).is_none() {
+        return Ok(SidecarFileCheck::Unknown);
+    }
+    if !path.is_file() {
+        return Ok(SidecarFileCheck::Absent);
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Ok(SidecarFileCheck::Absent);
+    };
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Ok(SidecarFileCheck::Absent);
+    }
+
+    let payload: Value = serde_json::from_str(trimmed).map_err(|err| {
+        Error::validation_invalid_argument(
+            "structured_sidecar",
+            format!(
+                "structured sidecar `{key}` at {} is not valid JSON: {err}",
+                path.display()
+            ),
+            None,
+            None,
+        )
+    })?;
+    validate_payload(key, &payload)?;
+
+    Ok(SidecarFileCheck::Valid)
+}
+
 fn validate_array_payload(schema: &StructuredSidecarSchema, payload: &Value) -> Result<()> {
     let Some(items) = payload.as_array() else {
         return Err(shape_error(schema, "JSON array"));
@@ -441,5 +503,81 @@ mod tests {
     fn accepts_test_failures_without_optional_fields() {
         validate_payload("test.failures", &json!([{ "test_id": "demo" }]))
             .expect("test failures may omit fields supplied by heterogeneous runners");
+    }
+
+    /// Post-run validation is not allowed to invent violations out of absence:
+    /// a sidecar that was never written, or whose declared path is a directory,
+    /// has nothing to check. (#11121)
+    #[test]
+    fn sidecar_file_validation_tolerates_absence_and_unknown_keys() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        assert_eq!(
+            validate_sidecar_file("lint.findings", &dir.path().join("never-written.json"))
+                .expect("missing file"),
+            SidecarFileCheck::Absent
+        );
+
+        let empty = dir.path().join("empty.json");
+        std::fs::write(&empty, "   \n").expect("empty file");
+        assert_eq!(
+            validate_sidecar_file("lint.findings", &empty).expect("empty file"),
+            SidecarFileCheck::Absent
+        );
+
+        let annotations = dir.path().join("annotations");
+        std::fs::create_dir(&annotations).expect("annotations dir");
+        assert_eq!(
+            validate_sidecar_file("annotations", &annotations).expect("directory sidecar"),
+            SidecarFileCheck::Absent
+        );
+
+        // A key core has no contract for is not core's to judge, however
+        // broken its contents are.
+        let vendor = dir.path().join("vendor.json");
+        std::fs::write(&vendor, "{ not json at all").expect("vendor file");
+        assert_eq!(
+            validate_sidecar_file("vendor.custom", &vendor).expect("unknown key"),
+            SidecarFileCheck::Unknown
+        );
+
+        let valid = dir.path().join("lint-findings.json");
+        std::fs::write(&valid, r#"[{"message":"boom"}]"#).expect("findings file");
+        assert_eq!(
+            validate_sidecar_file("lint.findings", &valid).expect("valid payload"),
+            SidecarFileCheck::Valid
+        );
+    }
+
+    /// A payload that is present and wrong is an unambiguous producer bug, and
+    /// this is the seam that finally notices it. (#11121)
+    #[test]
+    fn sidecar_file_validation_rejects_present_but_invalid_payloads() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        let malformed = dir.path().join("malformed.json");
+        std::fs::write(&malformed, "{ malformed").expect("malformed file");
+        let err =
+            validate_sidecar_file("lint.findings", &malformed).expect_err("malformed JSON payload");
+        assert!(err.to_string().contains("not valid JSON"), "{err}");
+
+        let wrong_shape = dir.path().join("wrong-shape.json");
+        std::fs::write(&wrong_shape, r#"{"message":"boom"}"#).expect("wrong shape file");
+        let err = validate_sidecar_file("lint.findings", &wrong_shape)
+            .expect_err("lint findings must be an array");
+        assert!(err.to_string().contains("JSON array"), "{err}");
+
+        let missing_field = dir.path().join("missing-field.json");
+        std::fs::write(&missing_field, r#"[{"rule":"demo"}]"#).expect("missing field file");
+        let err = validate_sidecar_file("lint.findings", &missing_field)
+            .expect_err("lint finding message is required");
+        assert!(err.to_string().contains("message"), "{err}");
+
+        // Browser-evidence keys keep their extra validation on this path too.
+        let bench = dir.path().join("bench-results.json");
+        std::fs::write(&bench, r#"{"network":"not-an-array"}"#).expect("bench file");
+        let err =
+            validate_sidecar_file("bench.results", &bench).expect_err("browser evidence shape");
+        assert!(err.to_string().contains("network"), "{err}");
     }
 }

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -310,8 +310,16 @@ impl ExtensionRunner {
             &extra_env_vars,
         )?;
 
+        // Resolved once and reused by both sidecar seams below. Without a run
+        // dir there are no sidecar files to seed or check, so the manifest
+        // reload is skipped entirely.
+        let declared_sidecars = if self.run_dir_path.is_some() {
+            self.declared_structured_sidecars()
+        } else {
+            Vec::new()
+        };
         if let Some(run_dir_path) = &self.run_dir_path {
-            initialize_structured_sidecars(run_dir_path, &self.declared_structured_sidecars())?;
+            initialize_structured_sidecars(run_dir_path, &declared_sidecars)?;
         }
 
         let output = self.execute_script(
@@ -330,6 +338,8 @@ impl ExtensionRunner {
                     &output,
                 )?;
             }
+        } else if let Some(run_dir_path) = &self.run_dir_path {
+            validate_declared_structured_sidecars(run_dir_path, &declared_sidecars)?;
         }
         if self.strict_validation_dependencies() {
             if let Some(message) =
@@ -692,6 +702,35 @@ fn initialize_structured_sidecars(
             continue;
         };
         write_json_sidecar(&path, &empty)?;
+    }
+    Ok(())
+}
+
+/// Check every structured sidecar *this extension declares* against core's
+/// registry contract once its runner has written them.
+///
+/// Before #11121 `validate_payload` was reached only by parsers that had
+/// already chosen to read one specific sidecar, so a declared sidecar nobody
+/// happened to parse could hold anything at all — a malformed `bench.results`
+/// simply disappeared. A declaration is a promise about output, and this is
+/// where the promise is finally checked.
+///
+/// Scope is deliberately narrow, because this can fail a run:
+/// - only declared keys, so an extension is judged on what it claimed;
+/// - only keys the registry knows, so a vendor key stays the vendor's business;
+/// - only payloads that are present and wrong — absence is never a violation
+///   (see `structured_sidecar::validate_sidecar_file`);
+/// - only after a *successful* run, because a failed one already has core's
+///   failure sidecars written over it and a real failure to report.
+fn validate_declared_structured_sidecars(
+    run_dir_path: &Path,
+    declared: &[crate::StructuredSidecarDeclaration],
+) -> Result<()> {
+    for declaration in declared {
+        let Some(path) = run_dir_relative_sidecar_path(run_dir_path, &declaration.path) else {
+            continue;
+        };
+        homeboy_core::structured_sidecar::validate_sidecar_file(&declaration.name, &path)?;
     }
     Ok(())
 }
@@ -1184,6 +1223,71 @@ mod tests {
             .expect("initialize");
 
         assert!(!run_dir.path().join("vendor.custom").exists());
+
+        run_dir.cleanup();
+    }
+
+    /// A declared sidecar's payload is checked against the registry contract
+    /// after a successful run. Declaring `lint.findings` and then writing an
+    /// object where the contract says array is a producer bug that nothing
+    /// noticed before #11121.
+    #[test]
+    fn validates_declared_sidecar_payloads_after_a_successful_run() {
+        let run_dir = RunDir::create().expect("run dir");
+        let findings = run_dir.step_file(run_dir::files::LINT_FINDINGS);
+
+        std::fs::write(&findings, r#"[{"message":"boom"}]"#).expect("valid findings");
+        validate_declared_structured_sidecars(run_dir.path(), &[declaration("lint.findings")])
+            .expect("a payload matching the declared contract passes");
+
+        std::fs::write(&findings, r#"{"message":"boom"}"#).expect("invalid findings");
+        let err =
+            validate_declared_structured_sidecars(run_dir.path(), &[declaration("lint.findings")])
+                .expect_err("an object is not the declared array shape");
+        assert!(err.to_string().contains("lint.findings"), "{err}");
+
+        run_dir.cleanup();
+    }
+
+    /// Validation judges an extension on what it declared, and only where core
+    /// has a contract. An undeclared file and a vendor key are both left alone.
+    #[test]
+    fn validation_ignores_undeclared_and_registry_unknown_sidecars() {
+        let run_dir = RunDir::create().expect("run dir");
+        std::fs::write(
+            run_dir.step_file(run_dir::files::LINT_FINDINGS),
+            "{ malformed",
+        )
+        .expect("malformed findings");
+        std::fs::write(run_dir.path().join("vendor.custom"), "{ malformed")
+            .expect("malformed vendor sidecar");
+
+        validate_declared_structured_sidecars(run_dir.path(), &[])
+            .expect("a manifest declaring nothing is judged on nothing");
+        validate_declared_structured_sidecars(run_dir.path(), &[declaration("vendor.custom")])
+            .expect("core has no contract for a vendor key");
+
+        run_dir.cleanup();
+    }
+
+    /// Absence is not a violation. Several sidecars are legitimately never
+    /// written (a missing `test.results` is what engages the stdout fallback),
+    /// and two declared paths are directories rather than JSON documents —
+    /// failing a run for any of those is the mistake that made the lint
+    /// evidence gate fail passing lints.
+    #[test]
+    fn validation_does_not_fail_on_absent_or_directory_sidecars() {
+        let run_dir = RunDir::create().expect("run dir");
+
+        validate_declared_structured_sidecars(
+            run_dir.path(),
+            &[
+                declaration("test.results"),
+                declaration("bench.results"),
+                declaration("annotations"),
+            ],
+        )
+        .expect("absent and directory sidecars are not contract violations");
 
         run_dir.cleanup();
     }

--- a/crates/homeboy-extension/src/tests.rs
+++ b/crates/homeboy-extension/src/tests.rs
@@ -257,6 +257,88 @@ fn extension_manifest_accepts_real_extension_fixture_shapes() {
     }
 }
 
+/// The shipped manifests are the reason `legacy_env_vars_for` is an override
+/// and not a filter (#11121).
+///
+/// Narrowing core's env-var export to declared sidecars is only safe once every
+/// shipped runner declares what it reads. This measures that precondition
+/// instead of asserting it in prose: it lists, per fixture, the sidecar keys
+/// core exports unconditionally that the manifest never declares. Each of those
+/// is a script that would lose its write target the moment narrowing lands.
+///
+/// This test is designed to retire itself. When the gap reaches zero the final
+/// assertion fails, and that failure is the signal that
+/// `RunDir::legacy_env_vars_for` may become a filter.
+#[test]
+fn shipped_manifests_do_not_yet_declare_every_exported_sidecar() {
+    let exported = homeboy_core::engine::run_dir::RunDir::legacy_env_sidecar_keys();
+    let mut gaps: Vec<(&str, &str)> = Vec::new();
+
+    for (fixture_id, raw) in [
+        (
+            "rust",
+            include_str!("../../../tests/fixtures/extension_manifests/rust.json"),
+        ),
+        (
+            "go",
+            include_str!("../../../tests/fixtures/extension_manifests/go.json"),
+        ),
+        (
+            "swift",
+            include_str!("../../../tests/fixtures/extension_manifests/swift.json"),
+        ),
+        (
+            "wordpress",
+            include_str!("../../../tests/fixtures/extension_manifests/wordpress.json"),
+        ),
+        (
+            "managed-preview",
+            include_str!("../../../tests/fixtures/extension_manifests/managed-preview.json"),
+        ),
+    ] {
+        let manifest: ExtensionManifest = serde_json::from_str(raw)
+            .unwrap_or_else(|err| panic!("{fixture_id} manifest should parse: {err}"));
+        let declared: Vec<String> = super::manifest::structured_sidecars(&manifest)
+            .into_iter()
+            .map(|declaration| declaration.name)
+            .collect();
+
+        for key in &exported {
+            if !declared.iter().any(|name| name.as_str() == *key) {
+                gaps.push((fixture_id, *key));
+            }
+        }
+    }
+
+    // The three cases the deferral comment on `legacy_env_vars_for` names.
+    assert!(
+        gaps.contains(&("rust", "test.coverage")),
+        "rust declares test.coverage:false while its runner reads COVERAGE_FILE"
+    );
+    assert!(
+        gaps.contains(&("wordpress", "annotations")),
+        "wordpress declares annotations:false while its runner reads ANNOTATIONS_DIR"
+    );
+    assert!(
+        gaps.contains(&("rust", "lint.producers")),
+        "rust never declares lint.producers yet lint evidence depends on it"
+    );
+    // An extension with no structured_sidecars at all would lose every key.
+    for key in &exported {
+        assert!(
+            gaps.contains(&("managed-preview", *key)),
+            "managed-preview declares no sidecars, so {key} is undeclared"
+        );
+    }
+
+    assert!(
+        !gaps.is_empty(),
+        "every shipped manifest now declares every exported sidecar — the \
+         precondition for narrowing legacy_env_vars_for to a filter is met, so \
+         land the other half of #11121 and delete this test"
+    );
+}
+
 #[test]
 fn executable_pruned_fields_remain_loadable_as_unknown_manifest_data() {
     let raw = include_str!("../../../tests/fixtures/extension_manifests/swift.json");


### PR DESCRIPTION
Refs #11121. Fixes 3 and 4 of that issue; 1 and 2 already landed on `main`.

## Already done before this branch

- **(1) shadow table deleted** — `manifest_sidecar.rs` now reads only `structured_sidecar::REGISTRY`; its five extra keys are registry entries.
- **(2) seeding is declaration-driven** — `runner.rs::initialize_structured_sidecars` loops manifest declarations instead of hardcoding `capability == Lint`.

## (4) Generic post-run payload validation — done

`validate_payload` had six callers, all parsers that had *already* chosen to read one specific sidecar. Nothing validated declared sidecar output generically, so a runner could declare `bench.results`, write garbage, and every consumer downstream just saw nothing.

- `homeboy_core::structured_sidecar::validate_sidecar_file(key, path) -> Result<SidecarFileCheck>` — reads one declared sidecar file and checks it against the registry (shape, required fields, and the browser-evidence validators for `bench.results` / `trace.results`).
- `homeboy_extension::runner::validate_declared_structured_sidecars` loops the manifest's declarations and calls it, from `ExtensionRunner::run`.

Scope is deliberately narrow, because this can fail a run:

- only **declared** keys — an extension is judged on what it claimed;
- only keys the **registry knows** — a vendor key stays the vendor's business (returns `Unknown`);
- only payloads that are **present and wrong** — missing file, empty file, and directory paths (`annotations`, `trace.artifacts`) all return `Absent`, never an error. Failing on absence is exactly the #10678 mistake that made the lint evidence gate fail *passing* lints;
- only after a **successful** run — a failed run already has core's failure sidecars written over it and a real failure to report.

## (3) Narrowing `legacy_env_vars_for` — deliberately NOT done, with evidence

The deferral comment still holds, and the shipped manifest fixtures confirm it. `RunDir::LEGACY_SIDECAR_ENV_KEYS` maps 10 registry keys; against `tests/fixtures/extension_manifests/`:

- `rust` declares `"test.coverage": false` while its runner reads `COVERAGE_FILE`;
- `rust` never declares `lint.producers` at all, yet lint evidence depends on that file;
- `wordpress` declares `"annotations": false` while its runner reads `ANNOTATIONS_DIR`;
- `go`/`swift` declare `"test.results": false`;
- `managed-preview` declares **no** `structured_sidecars` — narrowing would strip its entire env-var set;
- `FIX_RESULTS_FILE`, read by three extensions, has no sidecar key at all.

Filtering today breaks shipped extensions. Correcting those declarations is a `homeboy-extensions` change, and that repo has no PR CI, so it is not this PR's to make.

What this PR does instead is turn the blocker from prose into a measurement:

- `RunDir::legacy_env_sidecar_keys()` exposes what core exports unconditionally;
- `shipped_manifests_do_not_yet_declare_every_exported_sidecar` pins the current gap per fixture and **fails when the gap reaches zero** — that failure is the signal that narrowing is safe, with instructions to land it and delete the test.

No behaviour change to `legacy_env_vars_for`; it remains an override.

## Tests added

- `structured_sidecar.rs`: `sidecar_file_validation_tolerates_absence_and_unknown_keys`, `sidecar_file_validation_rejects_present_but_invalid_payloads`
- `runner.rs`: `validates_declared_sidecar_payloads_after_a_successful_run`, `validation_ignores_undeclared_and_registry_unknown_sidecars`, `validation_does_not_fail_on_absent_or_directory_sidecars`
- `extension/tests.rs`: `shipped_manifests_do_not_yet_declare_every_exported_sidecar`

No tests deleted or ignored.

## Compile note

**I could not compile this** — build/test is prohibited on the machine it was written on. Only `cargo fmt` was run. All changes are **additive**: no function signature changed, no struct field added, no item moved or renamed. The single edit to an existing body is in `ExtensionRunner::run`, hoisting `declared_structured_sidecars()` into a local and adding an `else` branch. CI is the gate.
