### PR TITLE
fix(runner): bound and share runner readiness probing (#11080)

### DIFF
--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -107,6 +107,17 @@ fn client_connection_args(
         push_option(&mut args, "StrictHostKeyChecking=no");
     }
 
+    // Connection multiplexing is enabled only when a managed session exists,
+    // and `SshClient::from_server` populates one only for
+    // `ServerAuthMode::KeyPlusPasswordControlmaster`. So multiplexing is coupled
+    // to a password-recovery auth mode rather than to connection reuse: an
+    // ordinary key-authenticated server gets no `ControlPath` and every command
+    // pays a full connect plus key exchange. That is why 55 concurrent probe
+    // connections reached one Lab runner despite this block existing (#11080).
+    // Probe volume is bounded at the source in
+    // `homeboy_lab_runner::runner_probe_gate`; decoupling multiplexing from the
+    // auth mode is a separate change with its own blast radius (control-socket
+    // lifetime, forwarding, interactive sessions).
     if let Some(session) = auth {
         push_option(&mut args, "ControlMaster=auto");
         push_option(&mut args, format!("ControlPath={}", session.control_path));

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
-use std::collections::{BTreeSet, HashMap};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use homeboy_core::engine::shell;
 use homeboy_core::error::{Error, Result};
@@ -8,7 +9,11 @@ use homeboy_core::server::{
     self, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout, SshClient,
 };
 
+use super::runner_probe_gate::deduplicated_probe;
 use super::{remote_runner_homeboy_path, Runner, RunnerKind, RunnerToolRegistry};
+
+/// Stable label for the remote capability probe in the probe-gate ledger.
+pub(crate) const RUNNER_CAPABILITY_PROBE: &str = "runner_capability_batch";
 
 // The lab-runner capability cluster (preflight, prepared/contract types, gate
 // mode/decision) now lives in the shared runner-contract crate as behavior-free
@@ -353,17 +358,31 @@ impl RunnerCapabilitySnapshot {
             &capability_probes,
             &preflight.required_toolchain_probes,
         );
-        let output = preflight
-            .timeout
-            .map(|timeout| client.execute_with_timeout(&script, timeout))
-            .unwrap_or_else(|| client.execute(&script));
-        Ok(parse_batch_probe_output(
-            &output.stdout,
-            &tool_commands,
-            &command_names,
-            &capability_probes,
-            &preflight.required_toolchain_probes,
-        ))
+        // Every controller surface that asks "is this runner ready" lands here,
+        // and each answer used to cost its own `ssh` connection — 55 of them at
+        // once during two cooks (#11080). The question is identical whenever the
+        // script and the environment it runs under are identical, so collapse
+        // concurrent askers onto one connection and cap how many can be open to
+        // this runner at all.
+        let fingerprint = batch_probe_fingerprint(&script, &client.env);
+        deduplicated_probe(
+            &runner.id,
+            RUNNER_CAPABILITY_PROBE,
+            &fingerprint,
+            move || {
+                let output = preflight
+                    .timeout
+                    .map(|timeout| client.execute_with_timeout(&script, timeout))
+                    .unwrap_or_else(|| client.execute(&script));
+                Ok(parse_batch_probe_output(
+                    &output.stdout,
+                    &tool_commands,
+                    &command_names,
+                    &capability_probes,
+                    &preflight.required_toolchain_probes,
+                ))
+            },
+        )
     }
 
     fn local_batch_probe(
@@ -432,7 +451,9 @@ impl RunnerCapabilitySnapshot {
     }
 }
 
-#[derive(Debug, Default)]
+// `Clone` so one probe's answer can be handed to every caller that coalesced
+// onto it instead of each opening its own connection (#11080).
+#[derive(Debug, Clone, Default)]
 struct RunnerCapabilityProbeResult {
     tools: BTreeSet<RunnerRequiredTool>,
     commands: BTreeSet<String>,
@@ -446,6 +467,22 @@ struct RunnerToolCapabilityProbe {
     command: String,
     env: Vec<String>,
     capability: String,
+}
+
+/// Identity of a remote capability probe: the exact script plus the exact
+/// environment it runs under. Two probes with the same fingerprint are asking
+/// the same question of the same runner and may share one connection; two with
+/// different fingerprints may not, and are only bounded by the concurrency cap.
+fn batch_probe_fingerprint(script: &str, env: &HashMap<String, String>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(script.as_bytes());
+    for (key, value) in env.iter().collect::<BTreeMap<_, _>>() {
+        hasher.update([0x1f]);
+        hasher.update(key.as_bytes());
+        hasher.update([b'=']);
+        hasher.update(value.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
 }
 
 fn batch_probe_script(
@@ -794,6 +831,46 @@ mod tests {
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }
+    }
+
+    /// The probe gate collapses concurrent callers that share a fingerprint, so
+    /// the fingerprint must be stable for one question and different for
+    /// another — otherwise two different probes would share one answer, or an
+    /// identical probe would still storm the runner (#11080).
+    #[test]
+    fn capability_probe_fingerprint_identifies_the_question_not_the_caller() {
+        let env: HashMap<String, String> = HashMap::from([
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("HOMEBOY_TOKEN".to_string(), "abc".to_string()),
+        ]);
+        // Same map, different insertion order: still the same question.
+        let reordered: HashMap<String, String> = HashMap::from([
+            ("HOMEBOY_TOKEN".to_string(), "abc".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ]);
+
+        let baseline = batch_probe_fingerprint("command -v git", &env);
+        assert_eq!(baseline, batch_probe_fingerprint("command -v git", &env));
+        assert_eq!(
+            baseline,
+            batch_probe_fingerprint("command -v git", &reordered)
+        );
+
+        assert_ne!(baseline, batch_probe_fingerprint("command -v cargo", &env));
+
+        let mut changed_env = env.clone();
+        changed_env.insert("HOMEBOY_TOKEN".to_string(), "def".to_string());
+        assert_ne!(
+            baseline,
+            batch_probe_fingerprint("command -v git", &changed_env)
+        );
+
+        let mut extra_env = env.clone();
+        extra_env.insert("EXTRA".to_string(), String::new());
+        assert_ne!(
+            baseline,
+            batch_probe_fingerprint("command -v git", &extra_env)
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -135,6 +135,7 @@ mod resource_metrics;
 mod rig_materialization;
 mod rolling_generation;
 mod runner_cache;
+pub mod runner_probe_gate;
 mod runtime_materialization_status;
 pub mod runtime_materializer;
 mod runtime_overlay_freshness;
@@ -151,6 +152,10 @@ mod validation_dependencies;
 pub use runner_cache::{
     prune_homeboy_binary_cache, RunnerBinaryCachePruneEntry, RunnerBinaryCachePruneOptions,
     RunnerBinaryCachePruneOutput,
+};
+pub use runner_probe_gate::{
+    invalidate_runner_probes, reset_runner_probe_gate, runner_probe_metrics, RunnerProbeMetrics,
+    PROBE_CACHE_TTL_ENV, PROBE_CONCURRENCY_ENV, PROBE_WAIT_ENV,
 };
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
 pub mod runners;

--- a/crates/homeboy-lab-runner/src/runner_probe_gate.rs
+++ b/crates/homeboy-lab-runner/src/runner_probe_gate.rs
@@ -1,0 +1,691 @@
+//! Deduplicated, concurrency-capped remote runner probing (#11080).
+//!
+//! Readiness probing is *read-mostly* information — which binaries exist on a
+//! runner, whether its toolchain answers — that many independent controller
+//! call sites ask for. `lab_runner_readiness`, `default_lab_runner_availability`,
+//! `refresh_detached_queue_runner`, dispatch preflight, and the CLI capability
+//! surfaces each probe the same runner, and every one of them opened its own
+//! `ssh` process. During two concurrent cooks that produced **55 simultaneous**
+//! `ssh -o BatchMode=yes` children against a single Lab host: a self-inflicted
+//! denial of service against the one runner, and on a host with `MaxStartups`
+//! limits the refused connections read back as *runner unavailability*, which
+//! then cascades into the staleness/availability logic.
+//!
+//! ### Why SSH multiplexing did not already prevent this
+//!
+//! `ssh_args::client_connection_args` does inject
+//! `ControlMaster=auto` / `ControlPath` / `ControlPersist` — but only when
+//! `SshClient::auth` is `Some`, and `SshClient::from_server` only populates
+//! `auth` for servers whose `auth.mode` is
+//! [`ServerAuthMode::KeyPlusPasswordControlmaster`](homeboy_core::server::ServerAuthMode).
+//! Multiplexing is therefore coupled to a *password-recovery auth mode*, not to
+//! connection reuse. An ordinary key-authenticated Lab runner — the common
+//! shape, and the one in the incident — gets **no** `ControlPath` at all, so
+//! every probe is a full TCP connect plus key exchange plus a login shell. The
+//! multiplexing that exists is real; it simply is not on the code path that
+//! stormed. Decoupling multiplexing from the auth mode is a separate change
+//! with its own blast radius (control-socket lifetime, forwarding, interactive
+//! sessions); this module bounds the storm at the source instead — fewer
+//! connections beats cheaper connections.
+//!
+//! ### What this module guarantees
+//!
+//! 1. **Single-flight.** Concurrent callers asking the same question of the
+//!    same runner collapse onto one in-flight probe; the others await its
+//!    result instead of opening their own connection.
+//! 2. **A short-lived cache.** A repeat of an identical probe inside the TTL is
+//!    answered from memory with no connection at all. Failures are cached far
+//!    more briefly than successes, so a runner that recovers is re-probed
+//!    promptly (a long negative cache would deepen #11106, not relieve it).
+//! 3. **A hard concurrency cap per runner.** However many distinct probes the
+//!    controller wants, at most `HOMEBOY_RUNNER_PROBE_CONCURRENCY` of them are
+//!    in flight to one runner at a time; the rest queue.
+//! 4. **Observability.** [`runner_probe_metrics`] reports dispatched /
+//!    coalesced / cache-hit / throttled counts and the observed peak
+//!    concurrency per (runner, probe), so a recurrence is visible as data
+//!    rather than as a `ps` listing.
+//!
+//! Every bound fails *open*: if the in-flight probe outlives the wait budget
+//! the waiter takes over rather than hanging, because an unbounded wait would
+//! trade a connection storm for a wedged controller.
+
+use std::any::Any;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock, PoisonError};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+use homeboy_core::error::{Error, Result};
+
+/// How long a successful probe answer stays reusable without reconnecting.
+pub const DEFAULT_PROBE_CACHE_TTL: Duration = Duration::from_secs(30);
+/// How long a *failed* probe answer suppresses re-probing. Deliberately much
+/// shorter than the success TTL: a failure must not become sticky
+/// unavailability (cross-ref #11106).
+pub const DEFAULT_PROBE_FAILURE_TTL: Duration = Duration::from_secs(5);
+/// Maximum probes in flight to a single runner, across all callers.
+pub const DEFAULT_PROBE_CONCURRENCY: usize = 2;
+/// How long a coalesced caller waits on the in-flight probe before taking over.
+pub const DEFAULT_PROBE_WAIT: Duration = Duration::from_secs(60);
+
+/// Override for [`DEFAULT_PROBE_CACHE_TTL`], in whole seconds. `0` disables
+/// caching while leaving single-flight and the concurrency cap intact.
+pub const PROBE_CACHE_TTL_ENV: &str = "HOMEBOY_RUNNER_PROBE_CACHE_TTL_SECONDS";
+/// Override for [`DEFAULT_PROBE_CONCURRENCY`]. Clamped to at least 1.
+pub const PROBE_CONCURRENCY_ENV: &str = "HOMEBOY_RUNNER_PROBE_CONCURRENCY";
+/// Override for [`DEFAULT_PROBE_WAIT`], in whole seconds. Clamped to at least 1.
+pub const PROBE_WAIT_ENV: &str = "HOMEBOY_RUNNER_PROBE_WAIT_SECONDS";
+
+/// Per-(runner, probe) counters describing how the probe path behaved.
+///
+/// `dispatched` is the number of probes that actually opened a connection;
+/// `coalesced` + `cache_hits` is the number of connections this module
+/// prevented. A healthy controller shows `dispatched` far below their sum.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct RunnerProbeMetrics {
+    pub runner_id: String,
+    pub probe: String,
+    /// Probes that ran, i.e. opened a connection to the runner.
+    pub dispatched: u64,
+    /// Callers that awaited another caller's in-flight probe.
+    pub coalesced: u64,
+    /// Callers answered from the TTL cache without any wait.
+    pub cache_hits: u64,
+    /// Probes that had to queue because the runner's concurrency cap was full.
+    pub throttled: u64,
+    /// Coalesced callers whose wait budget expired and that took over.
+    pub wait_timeouts: u64,
+    /// Highest number of probes observed in flight to this runner at once.
+    pub peak_concurrency: usize,
+    /// The cap in force when these counters were recorded.
+    pub concurrency_limit: usize,
+}
+
+/// Resolve the success TTL from a raw override value.
+fn probe_cache_ttl_from(raw: Option<&str>) -> Duration {
+    match raw.map(str::trim).map(str::parse::<u64>) {
+        Some(Ok(seconds)) => Duration::from_secs(seconds),
+        _ => DEFAULT_PROBE_CACHE_TTL,
+    }
+}
+
+/// Failures never outlive successes, and never exceed the failure default.
+fn probe_failure_ttl_from(success_ttl: Duration) -> Duration {
+    success_ttl.min(DEFAULT_PROBE_FAILURE_TTL)
+}
+
+/// Resolve the per-runner concurrency cap. A cap of zero would deadlock every
+/// probe, so it is clamped to 1.
+fn probe_concurrency_from(raw: Option<&str>) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_PROBE_CONCURRENCY)
+        .max(1)
+}
+
+/// Resolve the coalesced-caller wait budget. Never zero: a zero budget would
+/// defeat single-flight entirely and restore the storm.
+fn probe_wait_from(raw: Option<&str>) -> Duration {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_PROBE_WAIT)
+}
+
+fn probe_cache_ttl() -> Duration {
+    probe_cache_ttl_from(std::env::var(PROBE_CACHE_TTL_ENV).ok().as_deref())
+}
+
+fn probe_concurrency() -> usize {
+    probe_concurrency_from(std::env::var(PROBE_CONCURRENCY_ENV).ok().as_deref())
+}
+
+fn probe_wait() -> Duration {
+    probe_wait_from(std::env::var(PROBE_WAIT_ENV).ok().as_deref())
+}
+
+/// A probe answer, type-erased so one registry can serve every probe shape.
+type ProbeOutcome = std::result::Result<Arc<dyn Any + Send + Sync>, Error>;
+
+struct CachedProbe {
+    captured: Instant,
+    outcome: ProbeOutcome,
+}
+
+impl CachedProbe {
+    fn is_fresh(&self, success_ttl: Duration) -> bool {
+        let ttl = match &self.outcome {
+            Ok(_) => success_ttl,
+            Err(_) => probe_failure_ttl_from(success_ttl),
+        };
+        !ttl.is_zero() && self.captured.elapsed() < ttl
+    }
+
+    fn clone_outcome(&self) -> ProbeOutcome {
+        match &self.outcome {
+            Ok(value) => Ok(Arc::clone(value)),
+            Err(error) => Err(error.clone()),
+        }
+    }
+}
+
+#[derive(Default)]
+struct SlotInner {
+    in_flight: bool,
+    cached: Option<CachedProbe>,
+}
+
+/// One question asked of one runner: `(runner_id, probe, fingerprint)`.
+#[derive(Default)]
+struct ProbeSlot {
+    inner: Mutex<SlotInner>,
+    ready: Condvar,
+}
+
+#[derive(Default)]
+struct BudgetInner {
+    active: usize,
+    peak: usize,
+}
+
+/// The connection budget for a single runner, shared by every probe against it.
+#[derive(Default)]
+struct RunnerBudget {
+    inner: Mutex<BudgetInner>,
+    released: Condvar,
+}
+
+#[derive(Default)]
+struct GateState {
+    slots: HashMap<String, Arc<ProbeSlot>>,
+    budgets: HashMap<String, Arc<RunnerBudget>>,
+    metrics: BTreeMap<(String, String), RunnerProbeMetrics>,
+}
+
+static GATE: OnceLock<Mutex<GateState>> = OnceLock::new();
+
+fn gate() -> MutexGuard<'static, GateState> {
+    GATE.get_or_init(|| Mutex::new(GateState::default()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn slot_for(key: &str) -> Arc<ProbeSlot> {
+    let mut gate = gate();
+    Arc::clone(gate.slots.entry(key.to_string()).or_default())
+}
+
+fn budget_for(runner_id: &str) -> Arc<RunnerBudget> {
+    let mut gate = gate();
+    Arc::clone(gate.budgets.entry(runner_id.to_string()).or_default())
+}
+
+fn record(runner_id: &str, probe: &str, apply: impl FnOnce(&mut RunnerProbeMetrics)) {
+    let mut gate = gate();
+    let entry = gate
+        .metrics
+        .entry((runner_id.to_string(), probe.to_string()))
+        .or_insert_with(|| RunnerProbeMetrics {
+            runner_id: runner_id.to_string(),
+            probe: probe.to_string(),
+            ..RunnerProbeMetrics::default()
+        });
+    apply(entry);
+}
+
+/// Snapshot of the probe counters, sorted by (runner, probe).
+pub fn runner_probe_metrics() -> Vec<RunnerProbeMetrics> {
+    gate().metrics.values().cloned().collect()
+}
+
+/// Clear cached answers and counters. Used by tests and by long-lived
+/// controller processes that want a clean observation window.
+pub fn reset_runner_probe_gate() {
+    let mut gate = gate();
+    gate.slots.clear();
+    gate.budgets.clear();
+    gate.metrics.clear();
+}
+
+/// Drop every cached answer for one runner, leaving counters and other runners
+/// alone. Call this after deliberately changing what a runner would answer —
+/// installing a binary, refreshing its homeboy build — so the next readiness
+/// question re-probes instead of replaying a now-wrong cached answer.
+pub fn invalidate_runner_probes(runner_id: &str) {
+    let prefix = format!("{runner_id}\u{1f}");
+    let mut gate = gate();
+    gate.slots.retain(|key, _| !key.starts_with(&prefix));
+}
+
+/// Releases a runner's probe slot when dropped, including on panic.
+struct ProbePermit {
+    budget: Arc<RunnerBudget>,
+}
+
+impl Drop for ProbePermit {
+    fn drop(&mut self) {
+        {
+            let mut inner = lock(&self.budget.inner);
+            inner.active = inner.active.saturating_sub(1);
+        }
+        self.budget.released.notify_one();
+    }
+}
+
+/// Block until this runner has a free connection slot, then take it.
+fn acquire_permit(runner_id: &str, probe: &str, limit: usize) -> ProbePermit {
+    let budget = budget_for(runner_id);
+    let mut throttled = false;
+    let peak;
+    {
+        let mut inner = lock(&budget.inner);
+        while inner.active >= limit {
+            throttled = true;
+            inner = budget
+                .released
+                .wait(inner)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+        inner.active += 1;
+        inner.peak = inner.peak.max(inner.active);
+        peak = inner.peak;
+    }
+    if throttled {
+        homeboy_core::log_status!(
+            "runner-probe",
+            "runner '{runner_id}' probe `{probe}` queued behind the {limit}-connection cap"
+        );
+    }
+    record(runner_id, probe, |metrics| {
+        metrics.concurrency_limit = limit;
+        metrics.peak_concurrency = metrics.peak_concurrency.max(peak);
+        if throttled {
+            metrics.throttled += 1;
+        }
+    });
+    ProbePermit { budget }
+}
+
+/// Clears the in-flight marker even if the probe panics, so a panicking probe
+/// cannot wedge every future caller behind a flag that is never lowered.
+struct InFlightGuard {
+    slot: Arc<ProbeSlot>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        {
+            let mut inner = lock(&self.slot.inner);
+            inner.in_flight = false;
+        }
+        self.slot.ready.notify_all();
+    }
+}
+
+fn materialize<T: Clone + 'static>(outcome: ProbeOutcome) -> Result<T> {
+    match outcome {
+        Ok(value) => value.downcast_ref::<T>().cloned().ok_or_else(|| {
+            Error::internal_unexpected(
+                "runner probe cache returned an answer of an unexpected type; the probe key is shared by two different probe result types",
+            )
+        }),
+        Err(error) => Err(error),
+    }
+}
+
+/// Run `probe` at most once per (runner, probe, fingerprint) per TTL window,
+/// with a hard cap on concurrent connections to `runner_id`.
+///
+/// `fingerprint` must capture everything that would change the answer (the
+/// script, the environment it runs under). Two callers with the same
+/// fingerprint are, by definition, asking the same question and are safe to
+/// collapse; two callers with different fingerprints still contend for the same
+/// bounded connection budget.
+pub fn deduplicated_probe<T, F>(
+    runner_id: &str,
+    probe: &str,
+    fingerprint: &str,
+    run: F,
+) -> Result<T>
+where
+    T: Clone + Send + Sync + 'static,
+    F: FnOnce() -> Result<T>,
+{
+    let ttl = probe_cache_ttl();
+    let wait = probe_wait();
+    let limit = probe_concurrency();
+    let key = format!("{runner_id}\u{1f}{probe}\u{1f}{fingerprint}");
+    let slot = slot_for(&key);
+
+    let mut waited = false;
+    let mut timed_out_waiting = false;
+    let mut inner = lock(&slot.inner);
+    loop {
+        // Materialize the cached answer *before* releasing the guard so no
+        // borrow of `inner` outlives the `drop` below.
+        let fresh = inner
+            .cached
+            .as_ref()
+            .filter(|cached| cached.is_fresh(ttl))
+            .map(CachedProbe::clone_outcome);
+        if let Some(outcome) = fresh {
+            drop(inner);
+            record(runner_id, probe, |metrics| {
+                if waited {
+                    metrics.coalesced += 1;
+                } else {
+                    metrics.cache_hits += 1;
+                }
+            });
+            return materialize(outcome);
+        }
+        if !inner.in_flight {
+            inner.in_flight = true;
+            break;
+        }
+        waited = true;
+        let (guard, timeout) = slot
+            .ready
+            .wait_timeout(inner, wait)
+            .unwrap_or_else(PoisonError::into_inner);
+        inner = guard;
+        if timeout.timed_out() {
+            // Fail open. The owner is slower than the wait budget; opening one
+            // extra connection beats blocking the caller indefinitely.
+            timed_out_waiting = true;
+            inner.in_flight = true;
+            break;
+        }
+    }
+    drop(inner);
+
+    if timed_out_waiting {
+        record(runner_id, probe, |metrics| metrics.wait_timeouts += 1);
+    }
+
+    let _in_flight = InFlightGuard {
+        slot: Arc::clone(&slot),
+    };
+    let permit = acquire_permit(runner_id, probe, limit);
+    record(runner_id, probe, |metrics| metrics.dispatched += 1);
+    let outcome = run();
+    drop(permit);
+
+    let cached = CachedProbe {
+        captured: Instant::now(),
+        outcome: match &outcome {
+            Ok(value) => Ok(Arc::new(value.clone()) as Arc<dyn Any + Send + Sync>),
+            Err(error) => Err(error.clone()),
+        },
+    };
+    {
+        let mut inner = lock(&slot.inner);
+        inner.cached = Some(cached);
+    }
+    // `_in_flight` lowers the flag and wakes every waiter on drop.
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
+
+    /// The gate is process-global, so tests that assert on counters must not
+    /// interleave. One lock, held for the body of each such test.
+    static SERIALIZE: Mutex<()> = Mutex::new(());
+
+    fn serialized() -> MutexGuard<'static, ()> {
+        let guard = SERIALIZE.lock().unwrap_or_else(PoisonError::into_inner);
+        reset_runner_probe_gate();
+        guard
+    }
+
+    fn metrics_for(runner_id: &str, probe: &str) -> RunnerProbeMetrics {
+        runner_probe_metrics()
+            .into_iter()
+            .find(|metrics| metrics.runner_id == runner_id && metrics.probe == probe)
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn concurrent_callers_asking_the_same_question_open_one_connection() {
+        let _serialized = serialized();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let callers = 16;
+        let barrier = Arc::new(Barrier::new(callers));
+
+        let handles: Vec<_> = (0..callers)
+            .map(|_| {
+                let connections = Arc::clone(&connections);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    deduplicated_probe("lab", "capabilities", "fingerprint", || {
+                        connections.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(60));
+                        Ok("ready".to_string())
+                    })
+                    .expect("probe answer")
+                })
+            })
+            .collect();
+        for handle in handles {
+            assert_eq!(handle.join().expect("probe thread"), "ready");
+        }
+
+        // The storm in #11080 was 55 connections for one question. The
+        // invariant is that a *bounded* number answer all callers, not that
+        // every caller connects.
+        let opened = connections.load(Ordering::SeqCst);
+        assert!(
+            opened < callers,
+            "{opened} connections for {callers} identical concurrent probes"
+        );
+        let metrics = metrics_for("lab", "capabilities");
+        assert_eq!(metrics.dispatched as usize, opened);
+        assert_eq!(
+            metrics.dispatched + metrics.coalesced + metrics.cache_hits,
+            callers as u64
+        );
+    }
+
+    #[test]
+    fn a_repeated_probe_inside_the_ttl_opens_no_connection() {
+        let _serialized = serialized();
+        let connections = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..5 {
+            let connections = Arc::clone(&connections);
+            let answer: String = deduplicated_probe("lab", "cached", "fingerprint", || {
+                connections.fetch_add(1, Ordering::SeqCst);
+                Ok("ready".to_string())
+            })
+            .expect("probe answer");
+            assert_eq!(answer, "ready");
+        }
+
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        let metrics = metrics_for("lab", "cached");
+        assert_eq!(metrics.dispatched, 1);
+        assert_eq!(metrics.cache_hits, 4);
+    }
+
+    #[test]
+    fn different_questions_are_not_collapsed_into_one_answer() {
+        let _serialized = serialized();
+
+        let first: String =
+            deduplicated_probe("lab", "capabilities", "script-a", || Ok("a".to_string()))
+                .expect("first answer");
+        let second: String =
+            deduplicated_probe("lab", "capabilities", "script-b", || Ok("b".to_string()))
+                .expect("second answer");
+
+        assert_eq!(first, "a");
+        assert_eq!(second, "b");
+        assert_eq!(metrics_for("lab", "capabilities").dispatched, 2);
+    }
+
+    #[test]
+    fn distinct_probes_to_one_runner_never_exceed_the_concurrency_cap() {
+        let _serialized = serialized();
+        let limit = probe_concurrency();
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let observed_peak = Arc::new(AtomicUsize::new(0));
+        let callers = 24;
+        let barrier = Arc::new(Barrier::new(callers));
+
+        let handles: Vec<_> = (0..callers)
+            .map(|index| {
+                let in_flight = Arc::clone(&in_flight);
+                let observed_peak = Arc::clone(&observed_peak);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    // A distinct fingerprint per caller defeats single-flight,
+                    // leaving the concurrency cap as the only thing standing
+                    // between the controller and 24 simultaneous connections.
+                    let fingerprint = format!("script-{index}");
+                    deduplicated_probe("lab", "capped", &fingerprint, || {
+                        let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        observed_peak.fetch_max(now, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(10));
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        Ok(index)
+                    })
+                    .expect("probe answer")
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("probe thread");
+        }
+
+        assert!(
+            observed_peak.load(Ordering::SeqCst) <= limit,
+            "peak concurrency {} exceeded the cap of {limit}",
+            observed_peak.load(Ordering::SeqCst)
+        );
+        let metrics = metrics_for("lab", "capped");
+        assert_eq!(metrics.dispatched, callers as u64);
+        assert!(metrics.peak_concurrency <= limit);
+        assert_eq!(metrics.concurrency_limit, limit);
+    }
+
+    #[test]
+    fn a_failed_probe_is_briefly_cached_instead_of_reconnecting() {
+        let _serialized = serialized();
+
+        let error = deduplicated_probe("lab", "failing", "fingerprint", || {
+            Err::<String, _>(Error::internal_unexpected("runner refused the connection"))
+        })
+        .expect_err("probe failure surfaces");
+        assert!(error.message.contains("refused the connection"));
+
+        // A cached failure is short-lived by design, but within its window it
+        // must not re-open a connection to a runner that is already refusing.
+        let second = deduplicated_probe("lab", "failing", "fingerprint", || {
+            Err::<String, _>(Error::internal_unexpected("second connection"))
+        })
+        .expect_err("cached failure surfaces");
+        assert!(second.message.contains("refused the connection"));
+        assert_eq!(metrics_for("lab", "failing").dispatched, 1);
+    }
+
+    #[test]
+    fn a_panicking_probe_does_not_wedge_the_next_caller() {
+        let _serialized = serialized();
+
+        let panicked = std::thread::spawn(|| {
+            deduplicated_probe("lab", "panicking", "fingerprint", || -> Result<String> {
+                panic!("probe blew up")
+            })
+        })
+        .join();
+        assert!(panicked.is_err());
+
+        let answer: String =
+            deduplicated_probe(
+                "lab",
+                "panicking",
+                "fingerprint",
+                || Ok("ready".to_string()),
+            )
+            .expect("the slot is reusable after a panic");
+        assert_eq!(answer, "ready");
+    }
+
+    #[test]
+    fn invalidating_one_runner_leaves_other_runners_cached() {
+        let _serialized = serialized();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let probe = |runner: &str| {
+            let connections = Arc::clone(&connections);
+            deduplicated_probe(runner, "inventory", "fingerprint", move || {
+                connections.fetch_add(1, Ordering::SeqCst);
+                Ok("ready".to_string())
+            })
+            .expect("probe answer")
+        };
+
+        probe("lab-a");
+        probe("lab-b");
+        assert_eq!(connections.load(Ordering::SeqCst), 2);
+
+        invalidate_runner_probes("lab-a");
+        probe("lab-a");
+        probe("lab-b");
+
+        // Only the invalidated runner re-probed.
+        assert_eq!(connections.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn probe_bounds_are_never_degenerate() {
+        assert_eq!(probe_cache_ttl_from(None), DEFAULT_PROBE_CACHE_TTL);
+        assert_eq!(
+            probe_cache_ttl_from(Some("nonsense")),
+            DEFAULT_PROBE_CACHE_TTL
+        );
+        // An explicit "0" disables caching; single-flight and the cap remain.
+        assert_eq!(probe_cache_ttl_from(Some("0")), Duration::ZERO);
+        assert_eq!(probe_cache_ttl_from(Some(" 90 ")), Duration::from_secs(90));
+
+        // A cap of zero would deadlock every probe.
+        assert_eq!(probe_concurrency_from(Some("0")), 1);
+        assert_eq!(probe_concurrency_from(None), DEFAULT_PROBE_CONCURRENCY);
+        assert_eq!(probe_concurrency_from(Some("8")), 8);
+
+        // A zero wait budget would defeat single-flight and restore the storm.
+        assert_eq!(probe_wait_from(Some("0")), DEFAULT_PROBE_WAIT);
+        assert_eq!(probe_wait_from(Some("5")), Duration::from_secs(5));
+
+        // Failures never linger as long as successes.
+        assert_eq!(
+            probe_failure_ttl_from(DEFAULT_PROBE_CACHE_TTL),
+            DEFAULT_PROBE_FAILURE_TTL
+        );
+        assert_eq!(
+            probe_failure_ttl_from(Duration::from_secs(1)),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn a_zero_ttl_disables_the_cache_without_disabling_single_flight() {
+        // Exercised through the freshness predicate rather than the process
+        // environment, which is shared by every test thread.
+        let cached = CachedProbe {
+            captured: Instant::now(),
+            outcome: Ok(Arc::new("ready".to_string()) as Arc<dyn Any + Send + Sync>),
+        };
+        assert!(!cached.is_fresh(Duration::ZERO));
+        assert!(cached.is_fresh(DEFAULT_PROBE_CACHE_TTL));
+    }
+}


### PR DESCRIPTION
Closes #11080.

## The failure

During two concurrently active cooks, `ps` showed **55 simultaneous** `ssh -o BatchMode=yes -o ConnectTimeout=10 …` children from controller runtimes to a single Lab runner, each running small `command -v …` probes. That is a self-inflicted denial of service against the one runner: on a host with `MaxStartups`/`MaxSessions` limits the refused connections come back as *runner unavailability*, which then cascades into the staleness/availability logic (cross-ref #11106, #11101).

Every one of those connections was asking a question whose answer changes rarely — which binaries exist, whether a toolchain answers — and asking it independently. `lab_runner_readiness`, `default_lab_runner_availability`, `refresh_detached_queue_runner`, the dispatch preflight (`execution/daemon.rs`, `execution/worker.rs`), `lab/offload`, `lab_selection`, and three CLI surfaces all funnel into `RunnerCapabilitySnapshot::from_runner_probe`, and it opened a fresh `ssh` per call with no sharing, no cache, and no ceiling.

## Why SSH multiplexing did not prevent this

`ssh_args.rs` really does inject `ControlMaster=auto` / `ControlPath` / `ControlPersist` — **but only when `SshClient::auth` is `Some`**, and `SshClient::from_server` populates `auth` only for servers whose `auth.mode` is `ServerAuthMode::KeyPlusPasswordControlmaster`:

```rust
let auth = match &server.auth {
    Some(auth) if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster => {
        Some(ManagedSshSession::from_auth(auth))
    }
    _ => None,
};
```

So multiplexing is coupled to a **password-recovery auth mode**, not to connection reuse. An ordinary key-authenticated Lab runner — the common shape, and the one in the incident — gets **no `ControlPath` at all**, so every probe pays a full TCP connect, key exchange, and login shell. The multiplexing that exists is real; it simply is not on the code path that stormed. It is not that probes used *distinct* control paths — they used *none*.

Decoupling multiplexing from the auth mode is a separate change with its own blast radius (control-socket lifetime, `ExitOnForwardFailure`/forwarding, interactive sessions, socket-path length limits, cleanup of orphaned masters). This PR bounds probe volume at the source instead: **fewer connections beats cheaper connections**, and the two fixes compose rather than compete. The diagnosis is recorded as a comment at the `ControlMaster` block so the next reader does not have to re-derive it.

## What changed

New `crates/homeboy-lab-runner/src/runner_probe_gate.rs`:

1. **Single-flight** per `(runner_id, probe, fingerprint)`. Concurrent callers asking the same question collapse onto one in-flight probe and await its answer instead of opening their own connection.
2. **A short-lived cache** (30s default, `HOMEBOY_RUNNER_PROBE_CACHE_TTL_SECONDS`). A repeat inside the TTL costs no connection at all. **Failures are cached for at most 5s** — deliberately far shorter than successes, so a runner that recovers is re-probed promptly. A long negative cache would deepen #11106 rather than relieve it; a *zero* negative cache would let a refusing runner storm again through the waiters.
3. **A hard per-runner concurrency cap** (2 by default, `HOMEBOY_RUNNER_PROBE_CONCURRENCY`). However many *distinct* probes the controller wants, at most N are in flight to one runner; the rest queue. This is the bound that holds even when single-flight cannot apply.
4. **Observability.** `runner_probe_metrics()` reports per-(runner, probe) `dispatched` / `coalesced` / `cache_hits` / `throttled` / `wait_timeouts` / `peak_concurrency` / `concurrency_limit`. A healthy controller shows `dispatched` far below `coalesced + cache_hits`; a recurrence is visible as data rather than as a `ps` listing. Queuing also emits a `[runner-probe]` status line.

Every bound **fails open**: a coalesced caller whose wait budget (60s, `HOMEBOY_RUNNER_PROBE_WAIT_SECONDS`) expires takes over and probes itself rather than hanging, and an `InFlightGuard` clears the in-flight marker on panic so one blown probe cannot wedge every later caller. Trading a connection storm for a wedged controller would not be an improvement.

`RunnerCapabilitySnapshot::batch_probe` — the `command -v` path in the report — now runs through the gate, fingerprinted by SHA-256 of the exact script plus the exact environment it runs under, so two genuinely different questions are never served one answer.

## Scope deliberately left out

- **The remote/SSH probe only.** `local_batch_probe` is untouched: local probing was not the DoS and gating it would change semantics for no benefit.
- **In-process.** The gate is process-global, not cross-process. If the 55 connections spanned several controller processes, this bounds each process rather than the machine. A cross-process bound needs a file-lock or broker-mediated budget and is a larger change.
- **`invalidate_runner_probes(runner_id)` is exported but not yet wired into a mutation path.** Anything that deliberately changes what a runner would answer (installing a binary, `refresh-homeboy`) should call it; picking those call sites correctly needs a compile I could not run here, so it is left as an explicit follow-up rather than a guess.
- **Multiplexing itself is unchanged**, per the reasoning above.
- #9486 (declarative executable requirements) would remove most of these probes at the contract level. This is the bounded subset, not that.

## Tests

`runner_probe_gate` tests: 16 identical concurrent probes open strictly fewer connections than callers and the counters account for every caller; a repeated probe inside the TTL opens exactly one connection; different fingerprints are not collapsed; 24 concurrent probes with *distinct* fingerprints never exceed the cap; a failed probe is served from the short negative cache instead of reconnecting; a panicking probe does not wedge the next caller; invalidating one runner leaves other runners cached; and every resolved bound is non-degenerate (a `0` cap becomes 1, a `0` wait becomes the default, failures never outlive successes). `capabilities` gains a fingerprint test: stable across `HashMap` ordering, distinct across script and environment changes.

No test was deleted or `#[ignore]`d.

## Compile risk

**I could not compile.** This VPS runs five agents on shared RAM and cargo builds are prohibited here; only `cargo fmt` was run (clean). CI is the gate.

Signature changes: **none.** Struct field changes: **none** — the only type change is adding `Clone` to the private `RunnerCapabilityProbeResult` derive, which adds no field and needs no call-site sweep. `RunnerCapabilitySnapshot::batch_probe` keeps its exact signature and return type; the change is internal to its body. New public surface is additive (`runner_probe_gate` module plus five re-exports from `homeboy-lab-runner`).

Residual risk is concentrated in the new file: trait-bound plumbing on the type-erased `Arc<dyn Any + Send + Sync>` cache and `Condvar`/`MutexGuard` borrow shapes in `deduplicated_probe`.