### PR TITLE
fix(lab): settle detached handoffs instead of leaking phantom running runs

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -372,9 +372,14 @@ fn stale_run_summary(
         .filter(|run| {
             reconcile::stale_running_reason(run, &homeboy::core::process::pid_is_running).is_some()
                 // A direct daemon snapshot is authoritative for runner-backed
-                // rows. Never call one stale while that job is live or unknown.
+                // rows. Never call one stale while that job is live or unknown —
+                // but "unknown" cannot mean "forever". Past the reconciliation
+                // exemption ceiling, an absent snapshot stops being evidence of
+                // a live job and becomes evidence of a lost one (#11107).
                 && !active_durable_run_ids.contains(&run.id)
-                && (!reconcile::runner_backed_run(run) || active_runner_jobs_complete)
+                && (!reconcile::runner_backed_run(run)
+                    || active_runner_jobs_complete
+                    || reconcile::runner_backed_exemption_expired(run))
         })
         .map(|run| run.id.clone())
         .collect::<Vec<_>>();

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -15,6 +15,21 @@ use crate::commands::CmdResult;
 
 const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
 
+/// Upper bound on how long a runner-backed running record stays exempt from
+/// reconciliation.
+///
+/// The exemption itself is right: a live remote job is authoritative, and
+/// calling its record stale would contradict a job that is genuinely working.
+/// But the exemption keyed on the *presence* of a runner job id and on a
+/// `/lab/remote_job_status` field that nothing updates when a handoff dies, so
+/// it had no end. A record whose owner is gone kept its exemption forever,
+/// which is what made phantom `Running` rows permanent and unreachable by
+/// `homeboy runs reconcile` (#11107).
+///
+/// 24h is deliberately far beyond any real Lab job. Crossing it is not evidence
+/// that a job is slow; it is evidence that nothing is coming back.
+const RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 24 * 60;
+
 #[derive(Args, Clone, Default)]
 pub struct RunsReconcileArgs {
     /// Preview orphaned running records without mutating them
@@ -156,7 +171,10 @@ pub(crate) fn stale_running_reason<F>(run: &RunRecord, pid_is_alive: &F) -> Opti
 where
     F: Fn(u32) -> bool,
 {
-    if run_has_active_remote_job(run) {
+    // `/lab/remote_job_status` is written at dispatch and never corrected if
+    // the offload dies, so an unbounded read of it is a claim about the past.
+    // Honour it inside the exemption window, and stop honouring it after.
+    if run_has_active_remote_job(run) && !runner_backed_exemption_expired(run) {
         return None;
     }
 
@@ -164,20 +182,45 @@ where
         return (!pid_is_alive(owner_pid)).then_some("owner_process_not_running");
     }
 
-    ownerless_running_is_stale(run).then_some("owner_metadata_missing")
+    if ownerless_running_is_stale(run) {
+        return Some(if runner_backed_run(run) {
+            "runner_backed_run_exceeded_exemption"
+        } else {
+            "owner_metadata_missing"
+        });
+    }
+
+    None
 }
 
 fn ownerless_running_is_stale(run: &RunRecord) -> bool {
-    if runner_backed_run(run) {
-        return false;
-    }
+    // A runner-backed row still gets the benefit of the doubt — just not
+    // forever. Its window is the long one; everything else uses the short one.
+    let threshold = if runner_backed_run(run) {
+        RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES
+    } else {
+        OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES
+    };
 
+    run_started_at_least_minutes_ago(run, threshold)
+}
+
+/// Whether a runner-backed record has outlived its reconciliation exemption.
+///
+/// A record with an unparseable `started_at` is treated as still inside the
+/// window: reconciliation must not mark a run stale on the strength of a
+/// timestamp it could not read.
+pub(crate) fn runner_backed_exemption_expired(run: &RunRecord) -> bool {
+    run_started_at_least_minutes_ago(run, RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES)
+}
+
+fn run_started_at_least_minutes_ago(run: &RunRecord, minutes: i64) -> bool {
     chrono::DateTime::parse_from_rfc3339(&run.started_at)
         .map(|started_at| {
             chrono::Utc::now()
                 .signed_duration_since(started_at.with_timezone(&chrono::Utc))
                 .num_minutes()
-                >= OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES
+                >= minutes
         })
         .unwrap_or(false)
 }
@@ -374,6 +417,23 @@ mod tests {
         }
     }
 
+    /// The exact shape a lost Lab handoff leaves behind: no owner metadata, a
+    /// runner job id, and a `remote_job_status` frozen at whatever it was when
+    /// the offload was dispatched.
+    fn phantom_handoff_run(id: &str, started_at: String) -> RunRecord {
+        RunRecord {
+            metadata_json: serde_json::json!({
+                "runner_job_id": "job-7448",
+                "lab": { "remote_job_status": "running" },
+            }),
+            ..ownerless_running_run(id, started_at)
+        }
+    }
+
+    fn minutes_ago(minutes: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::minutes(minutes)).to_rfc3339()
+    }
+
     #[test]
     fn reconcile_marks_dead_owner_stale_and_preserves_artifacts() {
         with_isolated_home(|home| {
@@ -439,6 +499,104 @@ mod tests {
             assert_eq!(unchanged.status, "running");
             assert!(unchanged.finished_at.is_none());
         });
+    }
+
+    /// The exemption is still the default answer. A runner-backed row inside
+    /// its window is left alone even though its owner metadata is missing and
+    /// its remote status is unverifiable — calling a working job stale is the
+    /// worse error, and the ceiling exists to bound that deference, not to
+    /// remove it.
+    #[test]
+    fn reconcile_keeps_a_recent_runner_backed_running_record_running() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            store
+                .import_run(&phantom_handoff_run("recent-handoff-run", minutes_ago(90)))
+                .expect("import runner-backed run");
+
+            let reconciled =
+                reconcile_orphaned_running_runs(&store, 1000, false, |_| false).expect("reconcile");
+            let unchanged = store
+                .get_run("recent-handoff-run")
+                .expect("get run")
+                .expect("run exists");
+
+            assert!(reconciled.is_empty());
+            assert_eq!(unchanged.status, "running");
+        });
+    }
+
+    /// The leak this closes from the other end: a lost handoff leaves a row
+    /// whose `remote_job_status` nothing will ever correct and whose runner job
+    /// id used to buy it a permanent exemption. Past the ceiling it becomes
+    /// reconcilable, with a reason that names why.
+    #[test]
+    fn reconcile_marks_a_runner_backed_running_record_stale_past_the_ceiling() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            store
+                .import_run(&phantom_handoff_run(
+                    "phantom-handoff-run",
+                    minutes_ago(RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES + 60),
+                ))
+                .expect("import runner-backed run");
+
+            let reconciled =
+                reconcile_orphaned_running_runs(&store, 1000, false, |_| false).expect("reconcile");
+            let updated = store
+                .get_run("phantom-handoff-run")
+                .expect("get run")
+                .expect("run exists");
+
+            assert_eq!(reconciled.len(), 1);
+            assert_eq!(reconciled[0].id, "phantom-handoff-run");
+            assert_eq!(reconciled[0].reason, "runner_backed_run_exceeded_exemption");
+            assert_eq!(updated.status, "stale");
+            assert!(updated.finished_at.is_some());
+        });
+    }
+
+    /// The exemption ceiling is a property of the record's age, readable
+    /// without a store, and it must never fire on a timestamp it could not
+    /// parse — an unreadable `started_at` is not evidence of an old run.
+    #[test]
+    fn runner_backed_exemption_expires_only_on_a_readable_old_timestamp() {
+        assert!(!runner_backed_exemption_expired(&phantom_handoff_run(
+            "fresh",
+            minutes_ago(1),
+        )));
+        assert!(runner_backed_exemption_expired(&phantom_handoff_run(
+            "ancient",
+            minutes_ago(RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES + 1),
+        )));
+        assert!(!runner_backed_exemption_expired(&phantom_handoff_run(
+            "unreadable",
+            "not-a-timestamp".to_string(),
+        )));
+    }
+
+    /// A runner-backed row that still has a live owner process is not stale at
+    /// any age. The ceiling removes the blanket exemption; it does not override
+    /// direct evidence that the local owner is alive and working.
+    #[test]
+    fn a_live_owner_outranks_the_exemption_ceiling() {
+        let mut run = phantom_handoff_run(
+            "owned-long-runner",
+            minutes_ago(RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES + 600),
+        );
+        run.metadata_json = serde_json::json!({
+            "runner_job_id": "job-7448",
+            "lab": { "remote_job_status": "running" },
+            "homeboy_run_owner": { "pid": 4242 },
+        });
+
+        assert_eq!(stale_running_reason(&run, &|_pid: u32| true), None);
+        assert_eq!(
+            stale_running_reason(&run, &|_pid: u32| false),
+            Some("owner_process_not_running")
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -139,8 +139,13 @@ fn is_terminal_status(status: &str) -> bool {
 }
 
 /// Map a terminal run status to a process exit code: `pass`/`skipped` succeed,
-/// every other settled status (including `stale` ghosts and unknown statuses)
-/// fails.
+/// every other settled status (including `stale` ghosts, `handed_off`
+/// dispatches, and unknown statuses) fails.
+///
+/// `handed_off` deliberately fails. A handoff proves the dispatch succeeded, not
+/// that the dispatched command did, and reporting success for a command that
+/// completed nothing is the exact failure #11107 describes. A caller who wants
+/// the real outcome must watch the remote run the record names.
 fn exit_code_for_status(status: &str) -> i32 {
     match RunStatus::from_label(status) {
         Some(RunStatus::Pass) | Some(RunStatus::Skipped) => 0,
@@ -319,6 +324,21 @@ mod tests {
         let (output, exit_code) = build_output("run-1", result, None);
         assert_eq!(exit_code, 1);
         assert_eq!(output.status, "stale");
+    }
+
+    /// A detached Lab handoff settles to `handed_off`. The watch must exit
+    /// rather than hang — it used to hang, because the record was left
+    /// `running` forever (#11107) — and it must not report success: the
+    /// dispatch succeeded, the dispatched command proved nothing here.
+    #[test]
+    fn watch_surfaces_a_handed_off_dispatch_as_terminal_without_claiming_success() {
+        let poller = ScriptedPoller::new(&["running", "handed_off"]);
+        let result = run_loop(&poller, &config(None)).expect("loop");
+        assert_eq!(result.conclusion, WatchConclusion::Terminal);
+        let (output, exit_code) = build_output("run-1", result, None);
+        assert_eq!(exit_code, 1);
+        assert_eq!(output.status, "handed_off");
+        assert!(is_terminal_status("handed_off"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity/observation.rs
+++ b/crates/homeboy-core/src/activity/observation.rs
@@ -91,7 +91,13 @@ fn item_from_run(store: &ObservationStore, run: RunRecord) -> Result<ActivityIte
 pub(super) fn state_from_run_status(status: &str) -> ActivityState {
     match RunStatus::from_label(status) {
         Some(RunStatus::Running) => ActivityState::Running,
-        Some(RunStatus::Pass | RunStatus::Skipped) => ActivityState::Succeeded,
+        // A handed-off record is settled locally: the dispatch it observes
+        // succeeded. Its remote continuation surfaces in activity as the runner
+        // job it created, so reporting this row as still running would
+        // double-count one piece of work as two active items.
+        Some(RunStatus::Pass | RunStatus::Skipped | RunStatus::HandedOff) => {
+            ActivityState::Succeeded
+        }
         Some(RunStatus::Fail | RunStatus::Error) => ActivityState::Failed,
         Some(RunStatus::Stale) => ActivityState::Stale,
         None => ActivityState::Unknown,

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -1224,6 +1224,10 @@ fn reconciled_stale_status_note(run: &RunRecord) -> Option<String> {
             "running status had no owner metadata; run was marked stale during read reconciliation"
                 .to_string(),
         ),
+        "runner_backed_run_exceeded_exemption" => Some(
+            "a runner-backed run outlived its reconciliation exemption without recording a terminal outcome; run was marked stale"
+                .to_string(),
+        ),
         _ => None,
     }
 }

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -353,7 +353,26 @@ fn lab_offload_outcome_to_route_outcome(
             output_file_content,
             ..
         }) => {
-            let retrieval = observer.run_id().map(PersistedRunRetrieval::for_run);
+            // A detached handoff ends the *local* run. This process is about to
+            // exit and will never write to the record again, so leaving it
+            // `Running` created a phantom that nothing would ever close — and
+            // that reconciliation was then structurally forbidden to touch,
+            // pinning its run dir and artifacts forever (#11107).
+            //
+            // `HandedOff` states exactly what happened: the dispatch this run
+            // observes reached its end successfully, and the dispatched work
+            // continues under the remote handles carried across below.
+            let mut finish_metadata = json!({
+                "exit_code": exit_code,
+                "local_disposition": "handed_off",
+                "remote_work_continues": true,
+            });
+            attach_handoff_metadata(&mut finish_metadata, &stdout);
+            attach_in_flight_handoff_metadata(&mut finish_metadata, &stdout);
+            let retrieval = observer.finish(
+                RunStatus::HandedOff,
+                lab_dispatch_metadata(runner_id, "detached_handoff", finish_metadata),
+            );
             let stdout = stdout_with_in_flight_status(&stdout, retrieval.as_ref());
             let output_file_content = output_file_content
                 .as_deref()
@@ -481,6 +500,13 @@ fn bound_terminal_output(mut value: String) -> String {
     value
 }
 
+/// Render a detached-handoff envelope, annotating it with the remote work that
+/// continues and with the terminal disposition of the local record.
+///
+/// `status: "running"` describes the *remote* job, which really is running. The
+/// nested `local_observation` block is what stops a reader inferring that the
+/// controller-side run is also still open — it is not, and has not been since
+/// the handoff arm started finishing it as `handed_off` (#11107).
 fn stdout_with_in_flight_status(stdout: &str, retrieval: Option<&PersistedRunRetrieval>) -> String {
     let mut value = serde_json::from_str::<serde_json::Value>(stdout).unwrap_or_else(|_| {
         json!({
@@ -514,6 +540,15 @@ fn stdout_with_in_flight_status(stdout: &str, retrieval: Option<&PersistedRunRet
                 in_flight_object.insert(
                     "watch_command".to_string(),
                     serde_json::Value::String(format!("homeboy runs watch {}", retrieval.run_id)),
+                );
+                in_flight_object.insert(
+                    "local_observation".to_string(),
+                    json!({
+                        "run_id": retrieval.run_id,
+                        "status": RunStatus::HandedOff.as_str(),
+                        "terminal": true,
+                        "note": "The controller-side dispatch record is settled; the outcome of the dispatched command belongs to the remote work named here.",
+                    }),
                 );
             }
             if let (Some(runner_id), Some(runner_job_id)) = (runner_id, runner_job_id) {
@@ -566,6 +601,84 @@ fn attach_handoff_metadata(metadata: &mut serde_json::Value, stdout: &str) {
     }
     if let Some(evidence) = value.get("evidence") {
         object.insert("evidence".to_string(), evidence.clone());
+    }
+}
+
+/// Carry the remote handles of a detached handoff into the finish metadata of
+/// the local observation.
+///
+/// Three different in-flight envelopes reach the handoff arm — the runner-exec
+/// handoff schema, the daemon-disconnect envelope, and the staging-controller
+/// envelope — and [`attach_handoff_metadata`] only understands the first.
+/// Without the other two, a settled handoff record would name no remote
+/// continuation at all, which is the difference between a terminal state and a
+/// dead end.
+///
+/// Never overwrites a key an earlier extractor already resolved: the typed
+/// handoff schema is the more authoritative source when both are present.
+fn attach_in_flight_handoff_metadata(metadata: &mut serde_json::Value, stdout: &str) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) else {
+        return;
+    };
+    let Some(object) = metadata.as_object_mut() else {
+        return;
+    };
+
+    for (target, paths) in [
+        (
+            "durable_run_id",
+            &[
+                &["data", "durable_run_id"][..],
+                &["durable_run_id"][..],
+                &["identity", "run_id"][..],
+            ][..],
+        ),
+        (
+            "runner_job_id",
+            &[
+                &["identity", "runner_job_id"][..],
+                &["data", "job_id"][..],
+                &["job_id"][..],
+            ][..],
+        ),
+        (
+            "runner_id",
+            &[
+                &["identity", "runner_id"][..],
+                &["data", "runner_id"][..],
+                &["runner_id"][..],
+            ][..],
+        ),
+        (
+            "controller_job_id",
+            &[
+                &["data", "controller_job_id"][..],
+                &["controller_job_id"][..],
+            ][..],
+        ),
+        (
+            "remote_status",
+            &[&["data", "status"][..], &["status"][..]][..],
+        ),
+    ] {
+        if object.contains_key(target) {
+            continue;
+        }
+        let resolved = paths
+            .iter()
+            .find_map(|path| metadata_path_string(&value, *path));
+        if let Some(resolved) = resolved {
+            object.insert(target.to_string(), serde_json::Value::String(resolved));
+        }
+    }
+
+    if !object.contains_key("retrieval_commands") {
+        if let Some(commands) = value
+            .pointer("/data/retrieval_commands")
+            .or_else(|| value.get("retrieval_commands"))
+        {
+            object.insert("retrieval_commands".to_string(), commands.clone());
+        }
     }
 }
 
@@ -1128,8 +1241,17 @@ mod tests {
         assert!(stderr.is_empty());
     }
 
+    /// Renamed from `detached_handoff_maps_to_in_flight_output_and_leaves_run_running`,
+    /// which asserted `finished.is_none()` and so pinned the phantom-run leak in
+    /// place as if it were the contract (#11107).
+    ///
+    /// It is not the contract. The local dispatch record is finished by this
+    /// arm now, because the process that owns it is about to exit; every other
+    /// assertion in this test — the in-flight envelope, the watch commands, the
+    /// remote handles — is unchanged and still passes, which is the evidence
+    /// that the envelope contract was never what was broken.
     #[test]
-    fn detached_handoff_maps_to_in_flight_output_and_leaves_run_running() {
+    fn detached_handoff_maps_to_in_flight_output_and_finishes_run_as_handed_off() {
         let finished = std::sync::Arc::new(std::sync::Mutex::new(None));
         let observer = Box::new(RecordingObserver {
             run_id: Some("dispatch-run-7448".to_string()),
@@ -1181,7 +1303,128 @@ mod tests {
             json["homeboy_in_flight"]["runner_job_watch_command"],
             "homeboy runner job logs homeboy-lab job-7448 --follow"
         );
-        assert!(finished.lock().unwrap().is_none());
+
+        // The envelope must not leave a reader thinking the controller-side run
+        // is still open. It is settled, and says so next to the remote handles.
+        assert_eq!(
+            json["homeboy_in_flight"]["local_observation"]["status"],
+            "handed_off"
+        );
+        assert_eq!(
+            json["homeboy_in_flight"]["local_observation"]["terminal"],
+            true
+        );
+        assert_eq!(
+            json["homeboy_in_flight"]["local_observation"]["run_id"],
+            "dispatch-run-7448"
+        );
+
+        // The leak itself: this used to be `is_none()`.
+        let recorded = finished.lock().unwrap().clone();
+        let (status, metadata) = recorded.expect("handoff finishes the local observation");
+        assert_eq!(status, RunStatus::HandedOff);
+        assert!(status.is_terminal(), "a phantom row is not an outcome");
+        assert_eq!(metadata["lab_dispatch"]["status"], "detached_handoff");
+        assert_eq!(metadata["lab_dispatch"]["local_disposition"], "handed_off");
+        assert_eq!(metadata["lab_dispatch"]["remote_work_continues"], true);
+
+        // The settled record still has to say where the work went, or it is a
+        // dead end rather than a terminal state.
+        assert_eq!(metadata["lab_dispatch"]["runner_id"], "homeboy-lab");
+        assert_eq!(metadata["lab_dispatch"]["runner_job_id"], "job-7448");
+        assert_eq!(
+            metadata["lab_dispatch"]["durable_run_id"],
+            "agent-task-7448"
+        );
+        assert_eq!(
+            metadata["lab_dispatch"]["follow_commands"]["job_logs"],
+            "homeboy runner job logs homeboy-lab job-7448 --follow"
+        );
+    }
+
+    /// The daemon-disconnect envelope is not the typed handoff schema, so
+    /// `attach_handoff_metadata` cannot read it. Its remote handles still have
+    /// to survive into the terminal record — this is the envelope that produced
+    /// the `exit 0` / `"success": true` phantom in the field.
+    #[test]
+    fn daemon_disconnect_handoff_carries_its_remote_handles_into_the_terminal_record() {
+        let finished = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let observer = Box::new(RecordingObserver {
+            run_id: Some("dispatch-run-disconnect".to_string()),
+            finished: finished.clone(),
+        });
+        let stdout = r#"{
+            "success": true,
+            "data": {
+                "status": "remote_in_flight",
+                "durable_run_id": "agent-task-9001",
+                "runner_id": "homeboy-lab",
+                "job_id": "job-9001",
+                "retrieval_commands": {
+                    "status": "homeboy agent-task status agent-task-9001"
+                }
+            }
+        }"#;
+
+        let outcome = lab_offload_outcome_to_route_outcome(
+            Ok(crate::lab_offload::LabOffloadOutcome::InFlight {
+                plan: test_plan(),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+                output_file_content: Some(stdout.to_string()),
+            }),
+            Some("homeboy-lab"),
+            observer,
+        )
+        .expect("route outcome");
+
+        assert!(matches!(outcome, LabRouteOutcome::InFlight(_)));
+        let recorded = finished.lock().unwrap().clone();
+        let (status, metadata) = recorded.expect("handoff finishes the local observation");
+        assert_eq!(status, RunStatus::HandedOff);
+        assert_eq!(
+            metadata["lab_dispatch"]["durable_run_id"],
+            "agent-task-9001"
+        );
+        assert_eq!(metadata["lab_dispatch"]["runner_job_id"], "job-9001");
+        assert_eq!(metadata["lab_dispatch"]["runner_id"], "homeboy-lab");
+        assert_eq!(
+            metadata["lab_dispatch"]["remote_status"],
+            "remote_in_flight"
+        );
+        assert_eq!(
+            metadata["lab_dispatch"]["retrieval_commands"]["status"],
+            "homeboy agent-task status agent-task-9001"
+        );
+    }
+
+    /// A handoff with no observation started must not fabricate one. The Noop
+    /// observer returns no retrieval, and the envelope degrades to the remote
+    /// handles alone rather than claiming a local run id that does not exist.
+    #[test]
+    fn detached_handoff_without_an_observation_records_nothing_locally() {
+        let outcome = lab_offload_outcome_to_route_outcome(
+            Ok(crate::lab_offload::LabOffloadOutcome::InFlight {
+                plan: test_plan(),
+                stdout: r#"{"status":"running","job_id":"job-3","runner_id":"homeboy-lab"}"#
+                    .to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+                output_file_content: None,
+            }),
+            Some("homeboy-lab"),
+            Box::new(NoopLabDispatchObserver),
+        )
+        .expect("route outcome");
+
+        let LabRouteOutcome::InFlight(output) = outcome else {
+            panic!("expected in-flight outcome");
+        };
+        let json: serde_json::Value = serde_json::from_str(&output.stdout).expect("json stdout");
+        assert_eq!(json["homeboy_in_flight"]["status"], "running");
+        assert!(json["homeboy_in_flight"]["local_observation"].is_null());
+        assert!(json["homeboy_persisted_run"].is_null());
     }
 
     #[test]

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -904,7 +904,12 @@ pub fn derive_evidence_manifest(inputs: EvidenceManifestDerivation<'_>) -> Evide
         Some(RunStatus::Pass) => EvidenceManifestState::Passed,
         Some(RunStatus::Fail) | Some(RunStatus::Error) => EvidenceManifestState::Failed,
         Some(RunStatus::Stale) => EvidenceManifestState::Blocked,
-        Some(RunStatus::Skipped) | None => EvidenceManifestState::Unknown,
+        // A handoff settled this record without proving anything through it.
+        // `Unknown` is the honest read: the evidence exists, on the remote run
+        // this record points at, and the blocking condition below says so.
+        Some(RunStatus::Skipped) | Some(RunStatus::HandedOff) | None => {
+            EvidenceManifestState::Unknown
+        }
     };
     let terminal = matches!(
         status,
@@ -1076,6 +1081,12 @@ fn derived_blocking_conditions(
             severity: Some(BlockingSeverity::Warning),
             refs: refs.clone(),
         }),
+        Some(RunStatus::HandedOff) => conditions.push(BlockingCondition {
+            kind: "run_handed_off".to_string(),
+            summary: handed_off_blocking_summary(run),
+            severity: Some(BlockingSeverity::Warning),
+            refs: refs.clone(),
+        }),
         None => conditions.push(BlockingCondition {
             kind: "unknown_run_status".to_string(),
             summary: format!(
@@ -1097,6 +1108,45 @@ fn derived_blocking_conditions(
     }
 
     conditions
+}
+
+/// Name where a handed-off run's outcome actually lives.
+///
+/// A blocking condition that only says "handed off" leaves the reader stuck, so
+/// this reaches into the dispatch metadata the routing service wrote and names
+/// the remote run and runner job when they are recorded.
+fn handed_off_blocking_summary(run: &RunRecord) -> String {
+    let dispatch = run.metadata_json.get("lab_dispatch");
+    let durable_run_id = dispatch
+        .and_then(|dispatch| string_field(dispatch, "durable_run_id"))
+        .or_else(|| string_field(&run.metadata_json, "durable_run_id"));
+    let runner_job_id = dispatch
+        .and_then(|dispatch| {
+            string_field(dispatch, "runner_job_id").or_else(|| string_field(dispatch, "job_id"))
+        })
+        .or_else(|| string_field(&run.metadata_json, "runner_job_id"));
+
+    let mut summary = String::from(
+        "The run handed execution to a remote runner and settled locally, so it proves nothing by itself.",
+    );
+    match (durable_run_id, runner_job_id) {
+        (Some(run_id), _) => {
+            summary.push_str(&format!(
+                " The outcome belongs to remote run `{run_id}`; read it with `homeboy agent-task status {run_id}`."
+            ));
+        }
+        (None, Some(job_id)) => {
+            summary.push_str(&format!(
+                " The outcome belongs to runner job `{job_id}`; read it with `homeboy runner job show {job_id}`."
+            ));
+        }
+        (None, None) => {
+            summary.push_str(
+                " No remote handle was recorded, so the outcome is unrecoverable from this record.",
+            );
+        }
+    }
+    summary
 }
 
 fn is_evidence_manifest_artifact(artifact: &ArtifactRecord) -> bool {
@@ -1222,7 +1272,16 @@ mod tests {
     /// consumer of `homeboy/evidence-manifest/v1`.
     #[test]
     fn derived_manifest_satisfies_the_contract_for_every_status_label() {
-        for status in ["running", "pass", "fail", "error", "skipped", "stale", "?"] {
+        for status in [
+            "running",
+            "pass",
+            "fail",
+            "error",
+            "skipped",
+            "stale",
+            "handed_off",
+            "?",
+        ] {
             let mut run = sample_run();
             run.status = status.to_string();
             let manifest = derived_manifest(&run, &[url_artifact()]);
@@ -1245,6 +1304,7 @@ mod tests {
             ("error", EvidenceManifestState::Failed),
             ("stale", EvidenceManifestState::Blocked),
             ("skipped", EvidenceManifestState::Unknown),
+            ("handed_off", EvidenceManifestState::Unknown),
         ];
 
         for (status, expected) in cases {
@@ -1275,6 +1335,54 @@ mod tests {
             .blocking_conditions
             .iter()
             .any(|condition| condition.kind == "unknown_run_status"));
+    }
+
+    /// A handed-off run is terminal, so nothing will reopen it, but its outcome
+    /// is elsewhere. The manifest must say both, and name where "elsewhere" is,
+    /// or the reader is left with a settled record and no way to finish reading
+    /// it.
+    #[test]
+    fn derived_manifest_points_a_handed_off_run_at_its_remote_run() {
+        let mut run = sample_run();
+        run.status = "handed_off".to_string();
+        run.metadata_json = serde_json::json!({
+            "lab_dispatch": {
+                "phase": "route_lab_dispatch",
+                "status": "detached_handoff",
+                "runner_id": "homeboy-lab",
+                "runner_job_id": "job-7448",
+                "durable_run_id": "agent-task-7448",
+            }
+        });
+        let manifest = derived_manifest(&run, &[url_artifact()]);
+
+        assert_eq!(manifest.status.state, EvidenceManifestState::Unknown);
+        let condition = manifest
+            .blocking_conditions
+            .iter()
+            .find(|condition| condition.kind == "run_handed_off")
+            .expect("handed-off blocking condition");
+        assert!(condition.summary.contains("agent-task-7448"));
+        assert!(condition
+            .summary
+            .contains("homeboy agent-task status agent-task-7448"));
+    }
+
+    /// Without a recorded remote handle the outcome is genuinely unrecoverable.
+    /// Say that, rather than implying a lookup that cannot be performed.
+    #[test]
+    fn derived_manifest_admits_a_handed_off_run_with_no_remote_handle() {
+        let mut run = sample_run();
+        run.status = "handed_off".to_string();
+        run.metadata_json = serde_json::json!({ "lab_dispatch": { "status": "detached_handoff" } });
+        let manifest = derived_manifest(&run, &[url_artifact()]);
+
+        let condition = manifest
+            .blocking_conditions
+            .iter()
+            .find(|condition| condition.kind == "run_handed_off")
+            .expect("handed-off blocking condition");
+        assert!(condition.summary.contains("No remote handle was recorded"));
     }
 
     /// A pass that also recorded a gate failure is contradictory metadata. The

--- a/crates/homeboy-core/src/observation/records/run_status.rs
+++ b/crates/homeboy-core/src/observation/records/run_status.rs
@@ -8,6 +8,20 @@ pub enum RunStatus {
     Error,
     Skipped,
     Stale,
+    /// The locally observed work completed by handing execution to a remote
+    /// runner job, which continues after this process exits.
+    ///
+    /// Terminal for *this* record and only this record. The controller-side
+    /// work it observes — planning, materialization, dispatch — reached its own
+    /// end successfully, and no further write to this run will ever happen,
+    /// because the process that owned it is gone. The remote work is tracked by
+    /// its own runner job id and durable run id, both recorded in the run's
+    /// dispatch metadata alongside the commands that retrieve them.
+    ///
+    /// Distinct from `Pass` because a handoff proves the dispatch succeeded, not
+    /// that the dispatched command did. Distinct from `Running` because leaving
+    /// it open produces a phantom that nothing will ever close (#11107).
+    HandedOff,
 }
 
 impl RunStatus {
@@ -19,6 +33,7 @@ impl RunStatus {
             Self::Error => "error",
             Self::Skipped => "skipped",
             Self::Stale => "stale",
+            Self::HandedOff => "handed_off",
         }
     }
 
@@ -34,14 +49,25 @@ impl RunStatus {
             "error" => Some(Self::Error),
             "skipped" => Some(Self::Skipped),
             "stale" => Some(Self::Stale),
+            "handed_off" => Some(Self::HandedOff),
             _ => None,
         }
     }
 
     /// Whether the run has reached a terminal state. `Running` is the only
-    /// non-terminal status; every other status means the run is settled.
+    /// non-terminal status; every other status — including `HandedOff` — means
+    /// nothing further will be written to this record.
     pub fn is_terminal(self) -> bool {
         !matches!(self, Self::Running)
+    }
+
+    /// Whether the record settled without the observed work being proven here.
+    ///
+    /// `HandedOff` is terminal but its outcome lives on a remote run, so a
+    /// reader must be told where to look rather than reading terminality as a
+    /// verdict.
+    pub fn defers_outcome_to_a_remote_run(self) -> bool {
+        matches!(self, Self::HandedOff)
     }
 }
 
@@ -57,6 +83,7 @@ mod tests {
         assert_eq!(RunStatus::Error.as_str(), "error");
         assert_eq!(RunStatus::Skipped.as_str(), "skipped");
         assert_eq!(RunStatus::Stale.as_str(), "stale");
+        assert_eq!(RunStatus::HandedOff.as_str(), "handed_off");
     }
 
     #[test]
@@ -68,6 +95,7 @@ mod tests {
             RunStatus::Error,
             RunStatus::Skipped,
             RunStatus::Stale,
+            RunStatus::HandedOff,
         ] {
             assert_eq!(RunStatus::from_label(status.as_str()), Some(status));
         }
@@ -82,5 +110,29 @@ mod tests {
         assert!(RunStatus::Error.is_terminal());
         assert!(RunStatus::Skipped.is_terminal());
         assert!(RunStatus::Stale.is_terminal());
+        assert!(RunStatus::HandedOff.is_terminal());
+    }
+
+    /// A handoff is settled locally but proves nothing locally. Both halves of
+    /// that statement have to be readable, or a consumer will pick one and be
+    /// wrong: treat it as open (phantom) or treat it as a pass (false proof).
+    #[test]
+    fn handed_off_is_terminal_but_defers_its_outcome() {
+        assert!(RunStatus::HandedOff.is_terminal());
+        assert!(RunStatus::HandedOff.defers_outcome_to_a_remote_run());
+
+        for status in [
+            RunStatus::Running,
+            RunStatus::Pass,
+            RunStatus::Fail,
+            RunStatus::Error,
+            RunStatus::Skipped,
+            RunStatus::Stale,
+        ] {
+            assert!(
+                !status.defers_outcome_to_a_remote_run(),
+                "{status:?} owns its own outcome"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #11107.

## ⚠️ I changed a test that asserted the bug

`lab_routing.rs` had `detached_handoff_maps_to_in_flight_output_and_leaves_run_running`,
whose final line was:

```rust
assert!(finished.lock().unwrap().is_none());
```

That assertion **pinned the leak in place as if it were the contract** — it
required that the `InFlight` arm never finish its observation. It is now
`detached_handoff_maps_to_in_flight_output_and_finishes_run_as_handed_off`,
and asserts the opposite.

Why the new assertion is the correct one: the run record in question observes
the *controller-side dispatch*, and the process that owns it is about to exit.
Leaving it `Running` is not "still in progress", it is a record that nothing
will ever write to again. Every other assertion in that test — the in-flight
envelope, `status: "running"`, the watch commands, the runner-job follow
command — is **unchanged and still passes**, which is the evidence that the
envelope contract was never what was broken. Only the leak changed.

The test was not deleted and nothing was `#[ignore]`d.

## The bug

`crates/homeboy-core/src/lab_routing.rs` — the `InFlight` arm read
`observer.run_id()` and dropped the observer. Its sibling `Offloaded` arm
calls `observer.finish(...)`. Every detached Lab handoff therefore left a
permanent `Running` row.

Those rows were then structurally un-repairable, in two independent places in
`crates/homeboy-cli/src/commands/runs/reconcile.rs`:

- `stale_running_reason` returned early on `run_has_active_remote_job`, which
  reads `/lab/remote_job_status` — a field written at dispatch and never
  corrected when an offload dies.
- `ownerless_running_is_stale` returned `false` for any record carrying a
  runner job id, **with no age bound at all**.

Net effect: a CI step or `homeboy review` wrapping an offloaded task saw
`exit 0` + `"success": true`, and the ledger accumulated phantom rows that
pinned run dirs and artifacts forever (`is_terminal()` gates the persisted
cleanup).

## Design choice: terminal `HandedOff`, not a new non-terminal in-flight status

The issue offered both. I took the terminal one.

A detached handoff **is** terminal for the local record. The work that record
observes — planning, materialization, dispatch — reached its own end, and its
owner is gone. An in-flight status would have re-created the same problem in a
new shape: a non-terminal row that only an age ceiling could ever close, plus a
second status the `list_runs(status = "running")` sweep, `is_terminal()`, and
every terminality consumer would each have to learn about separately.

`HandedOff` is deliberately **not** `Pass`: a handoff proves the *dispatch*
succeeded, not that the dispatched command did. Consequences, all intentional:

| surface | behavior |
|---|---|
| `runs watch` | exits **1**, terminal. Previously it hung until timeout. Fails closed — never reports success for a command that completed nothing. |
| evidence manifest | `unknown` + a `run_handed_off` blocking condition naming the remote run and the command to read it |
| `activity` | `Succeeded` — the dispatch succeeded; the remote continuation surfaces as its own runner-job item rather than double-counting |
| persisted cleanup | now eligible, so run dirs stop being pinned |

The settled record carries its remote handles, extracted from **all three**
in-flight envelopes — the typed `homeboy/runner-exec-handoff/v1` schema (already
handled), plus the daemon-disconnect and staging-controller envelopes, which
`attach_handoff_metadata` silently skipped. Without that, a terminal handoff
record would be a dead end rather than a terminal state.

**Not in scope:** the exit code stays pass-through. Changing an observable exit
code (the issue suggests `EX_TEMPFAIL`/75) is a separate, announceable change;
this PR fixes the record and the envelope. `impl Drop for ActiveObservation`
(issue item 3) and reconcile cursor pagination (item 4) are also still open —
neither is a lab-routing concern.

## Age ceiling

`RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES = 24 * 60`, applied to both
exemptions, and to the `runs status` stale summary in `handlers.rs`.

The exemption remains the default answer — calling a genuinely working job stale
is the worse error, and the ceiling bounds that deference rather than removing
it. But "unknown" cannot mean "forever". Guards:

- an unparseable `started_at` **never** expires the exemption
- a live owner pid outranks the ceiling at any age
- the reason is distinct: `runner_backed_run_exceeded_exemption`, with matching
  read-reconciliation guidance in `http_api.rs`

## ⛔ Not compiled

Per the build prohibition on this host I ran **`cargo fmt` only** — no
`cargo build`/`check`/`test`/`clippy`. CI is the gate.

### Enum sweep (the main compile risk)

`RunStatus` gained the `HandedOff` variant. I grepped every `RunStatus::` and
`Self::` match arm across the workspace **including `tests/` at repo root**
(`tests/core/observation/store_test.rs`, `tests/core/http_api_test.rs` — value
uses only, no matches). Five exhaustive matches existed; **all five updated**:

| site | change |
|---|---|
| `records/run_status.rs` `as_str` | `HandedOff => "handed_off"` |
| `records/run_status.rs` `from_label` | `"handed_off" => Some(HandedOff)` |
| `activity/observation.rs:92` `state_from_run_status` | folded into the `Succeeded` arm |
| `evidence_report.rs:902` manifest state | folded into the `Unknown` arm |
| `evidence_report.rs:1059` `derived_blocking_conditions` | new `run_handed_off` arm |

Non-exhaustive / safe (verified individually): `run_status.rs::is_terminal`
(`matches!`, `HandedOff` → terminal, correct), `watch.rs:145` (`_ => 1`),
`notify.rs:179` (`matches!`, fails closed → `NeedsAttention`, correct),
`http_api.rs:1223` (`_ => None`, added an explicit arm anyway),
`rig/runner.rs` (`== RunStatus::Pass` guards). No SQLite `CHECK` constraint on
`runs.status`; no JSON schema enumerates run statuses.

### Signatures changed

- `stale_running_reason` — body only; **signature unchanged**, both call sites
  (`reconcile.rs`, `handlers.rs:373`) verified.
- `ownerless_running_is_stale` — body only, private, one caller.
- **New** `pub(crate) runner_backed_exemption_expired(&RunRecord) -> bool` and
  private `run_started_at_least_minutes_ago`. One external caller added
  (`handlers.rs:377`).
- **New** private `attach_in_flight_handoff_metadata` and
  `handed_off_blocking_summary`.
- `runner_backed_run` kept as-is; its `handlers.rs` call site is unchanged, only
  extended with an `||`.
- No struct fields added or removed anywhere.

The `InFlight` arm now calls `observer.finish(...)`, which consumes
`Box<dyn LabDispatchObserver>` — identical to the three sibling arms. Both real
implementors (`LabTraceDispatchObservation`, `AgentTaskFanoutLabDispatchObservation`)
and `NoopLabDispatchObserver` are status-generic, and `finish` already returned
the same `Option<PersistedRunRetrieval>` the arm previously built by hand, so the
rendered envelope is byte-identical apart from the new `local_observation` block.

## Tests added

`lab_routing.rs`
- `detached_handoff_maps_to_in_flight_output_and_finishes_run_as_handed_off` *(updated — see top)*
- `daemon_disconnect_handoff_carries_its_remote_handles_into_the_terminal_record` — the envelope that produced the field failure
- `detached_handoff_without_an_observation_records_nothing_locally`

`run_status.rs` — `handed_off_is_terminal_but_defers_its_outcome`, plus the three existing vocabulary tests extended

`evidence_report.rs` — `derived_manifest_points_a_handed_off_run_at_its_remote_run`, `derived_manifest_admits_a_handed_off_run_with_no_remote_handle`, plus both status-enumerating tests extended

`reconcile.rs` — `reconcile_keeps_a_recent_runner_backed_running_record_running` (the exemption still works), `reconcile_marks_a_runner_backed_running_record_stale_past_the_ceiling`, `runner_backed_exemption_expires_only_on_a_readable_old_timestamp`, `a_live_owner_outranks_the_exemption_ceiling`

`watch.rs` — `watch_surfaces_a_handed_off_dispatch_as_terminal_without_claiming_success`
