### PR TITLE
refactor(core): move three single-consumer modules out of homeboy-core (113 -> 110 pub mod)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ name = "homeboy-release"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "fs4",
  "glob",
  "glob-match",
  "homeboy-core",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1477,7 +1477,7 @@ fn preflight_hot_command(
 
 fn review_test_runner_requirements(
     cli: &Cli,
-) -> Option<homeboy::core::deferred_workload::DeferredWorkloadRequirements> {
+) -> Option<homeboy::deferred_workload::DeferredWorkloadRequirements> {
     let Commands::Review(review) = &cli.command else {
         return None;
     };
@@ -1486,7 +1486,7 @@ fn review_test_runner_requirements(
     };
     let contract = test.lab_contract();
     contract.is_portable().then(
-        || homeboy::core::deferred_workload::DeferredWorkloadRequirements {
+        || homeboy::deferred_workload::DeferredWorkloadRequirements {
             required_runtimes: ["homeboy".to_string()].into(),
             required_capabilities: contract
                 .extra_required_capabilities

--- a/crates/homeboy-cli/src/commands/contract/loop_lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/contract/loop_lifecycle.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::artifact_contract::ArtifactContract;
+use homeboy_core::artifact_contract::ArtifactContract;
 
 pub const LOOP_RUN_SCHEMA: &str = "homeboy/loop-run/v1";
 pub const LOOP_ITERATION_SCHEMA: &str = "homeboy/loop-iteration/v1";

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -1,3 +1,7 @@
+// Loop lifecycle record contracts. Lived in homeboy-core until #11143; this
+// validator is their only consumer.
+pub mod loop_lifecycle;
+
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -17,6 +21,10 @@ use crate::command_contract::{
     RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA, RUNNER_ARTIFACT_MANIFEST_SCHEMA,
     RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUN_LOCATION_INDEX_SCHEMA,
 };
+use crate::commands::contract::loop_lifecycle::{
+    LoopEvidenceRecord, LoopIterationRecord, LoopRunRecord, LOOP_EVIDENCE_SCHEMA,
+    LOOP_ITERATION_SCHEMA, LOOP_RUN_SCHEMA,
+};
 use crate::commands::{adapter, CmdResult};
 use crate::core::artifact_ref::{validate_reviewer_facing_artifact_ref, ArtifactReference};
 use crate::core::artifacts::{validate_artifact_postprocess_plan, ArtifactManifest};
@@ -24,10 +32,6 @@ use crate::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA}
 use crate::core::host_mutation_lifecycle::{
     HostMutationLifecycle, HostMutationRevertStrategy, HostMutationStatus,
     HOST_MUTATION_LIFECYCLE_SCHEMA,
-};
-use crate::core::loop_lifecycle::{
-    LoopEvidenceRecord, LoopIterationRecord, LoopRunRecord, LOOP_EVIDENCE_SCHEMA,
-    LOOP_ITERATION_SCHEMA, LOOP_RUN_SCHEMA,
 };
 use crate::core::resource_cleanup_intent::{
     ResourceCleanupIntentContract, RESOURCE_CLEANUP_INTENT_SCHEMA,

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use homeboy::core::deferred_workload;
+use homeboy::deferred_workload;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::process::{Command, Stdio};

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -195,7 +195,7 @@ pub fn route_after_parse_with_provenance(
         && deferred_resource_admission_refused()
         && std::env::var_os("HOMEBOY_DEFERRED_WORKLOAD_REPLAY").is_none()
     {
-        let deferred = homeboy::core::deferred_workload::defer(deferred_workload_input(
+        let deferred = homeboy::deferred_workload::defer(deferred_workload_input(
             cli,
             &portable_deferred_args(&normalized_args),
             deferred_requirements.expect("review tests always resolve deferred requirements"),
@@ -277,7 +277,7 @@ pub fn route_after_parse_with_provenance(
         .as_deref()
         .filter(|_| review_test_can_defer(cli))
         .map(|runner_id| {
-            homeboy::core::deferred_workload::claim(
+            homeboy::deferred_workload::claim(
                 &deferred_workload_input(
                     cli,
                     &portable_deferred_args(&normalized_args),
@@ -468,7 +468,7 @@ pub fn route_after_parse_with_provenance(
     match outcome {
         LabRouteOutcome::RunLocal => {
             if let Some(record) = deferred_claim.as_ref() {
-                homeboy::core::deferred_workload::terminalize(&record.id, false)?;
+                homeboy::deferred_workload::terminalize(&record.id, false)?;
             }
             if destructive_fuzz_requires_lab(&cli.command) {
                 return Err(destructive_fuzz_local_execution_error());
@@ -482,7 +482,7 @@ pub fn route_after_parse_with_provenance(
         }
         LabRouteOutcome::InFlight(output) | LabRouteOutcome::Offloaded(output) => {
             if let Some(record) = deferred_claim.as_ref() {
-                homeboy::core::deferred_workload::terminalize(&record.id, output.exit_code == 0)?;
+                homeboy::deferred_workload::terminalize(&record.id, output.exit_code == 0)?;
             }
             if !output.stderr.is_empty() {
                 eprint!("{}", output.stderr);
@@ -1851,9 +1851,9 @@ fn review_test_can_defer(cli: &Cli) -> bool {
 fn deferred_workload_input(
     cli: &Cli,
     args: &[String],
-    test_requirements: homeboy::core::deferred_workload::DeferredWorkloadRequirements,
-) -> homeboy::core::Result<homeboy::core::deferred_workload::DeferredWorkloadInput> {
-    Ok(homeboy::core::deferred_workload::DeferredWorkloadInput {
+    test_requirements: homeboy::deferred_workload::DeferredWorkloadRequirements,
+) -> homeboy::core::Result<homeboy::deferred_workload::DeferredWorkloadInput> {
+    Ok(homeboy::deferred_workload::DeferredWorkloadInput {
         command_label: "review test".to_string(),
         args: args.to_vec(),
         placement: match cli.placement {
@@ -1884,7 +1884,7 @@ fn deferred_workload_input(
 
 fn review_test_deferred_requirements(
     cli: &Cli,
-) -> Option<homeboy::core::deferred_workload::DeferredWorkloadRequirements> {
+) -> Option<homeboy::deferred_workload::DeferredWorkloadRequirements> {
     let Commands::Review(review) = &cli.command else {
         return None;
     };
@@ -1893,7 +1893,7 @@ fn review_test_deferred_requirements(
     };
     let contract = test.lab_contract();
     contract.is_portable().then(
-        || homeboy::core::deferred_workload::DeferredWorkloadRequirements {
+        || homeboy::deferred_workload::DeferredWorkloadRequirements {
             required_runtimes: ["homeboy".to_string()].into(),
             required_capabilities: contract
                 .extra_required_capabilities

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1014,7 +1014,7 @@ fn lab_job_overrides_reject_invalid_env_shapes() {
 #[test]
 fn deferred_plan_persists_public_env_and_runner_secret_identity_without_plaintext() {
     crate::test_support::with_isolated_home(|_| {
-        let input = homeboy::core::deferred_workload::DeferredWorkloadInput {
+        let input = homeboy::deferred_workload::DeferredWorkloadInput {
             command_label: "review test".to_string(),
             args: vec![
                 "homeboy".to_string(),
@@ -1028,7 +1028,7 @@ fn deferred_plan_persists_public_env_and_runner_secret_identity_without_plaintex
             ci_alternative: "CI".to_string(),
             resolved_contract: serde_json::json!({}),
             resolved_resources: serde_json::json!({}),
-            test_requirements: homeboy::core::deferred_workload::DeferredWorkloadRequirements {
+            test_requirements: homeboy::deferred_workload::DeferredWorkloadRequirements {
                 required_runtimes: ["homeboy".to_string()].into(),
                 required_capabilities: Default::default(),
             },
@@ -1042,7 +1042,7 @@ fn deferred_plan_persists_public_env_and_runner_secret_identity_without_plaintex
                 workspace_root: None,
             },
         };
-        let deferred = homeboy::core::deferred_workload::defer(input).expect("defer fixture");
+        let deferred = homeboy::deferred_workload::defer(input).expect("defer fixture");
         assert_eq!(deferred.job_overrides.env["DB_SERVICE_HOST"], "db.fixture");
         assert_eq!(deferred.job_overrides.env["DB_SERVICE_PORT"], "3306");
         assert!(!deferred
@@ -1068,7 +1068,7 @@ fn deferred_plan_persists_public_env_and_runner_secret_identity_without_plaintex
 
 #[test]
 fn deferred_status_redacts_all_settings_arguments() {
-    let mut record = homeboy::core::deferred_workload::DeferredWorkload {
+    let mut record = homeboy::deferred_workload::DeferredWorkload {
         id: "deferred-settings".to_string(),
         fingerprint: "fixture".to_string(),
         command_label: "review test".to_string(),
@@ -1087,12 +1087,12 @@ fn deferred_status_redacts_all_settings_arguments() {
         ci_alternative: "CI".to_string(),
         resolved_contract: serde_json::json!({}),
         resolved_resources: serde_json::json!({}),
-        test_requirements: homeboy::core::deferred_workload::DeferredWorkloadRequirements {
+        test_requirements: homeboy::deferred_workload::DeferredWorkloadRequirements {
             required_runtimes: ["homeboy".to_string()].into(),
             required_capabilities: Default::default(),
         },
         job_overrides: Default::default(),
-        state: homeboy::core::deferred_workload::DeferredWorkloadState::Deferred,
+        state: homeboy::deferred_workload::DeferredWorkloadState::Deferred,
         created_at_ms: 0,
         updated_at_ms: 0,
         runner_id: None,
@@ -1151,7 +1151,7 @@ fn manifest_resolved_portable_db_service_warm_defers_and_dispatches_secret_ident
         assert_eq!(overrides.env["DB_SERVICE_HOST"], "db.fixture");
         assert_eq!(overrides.env["DB_SERVICE_PORT"], "3306");
         assert_eq!(overrides.secret_env_names, ["DB_SERVICE_PASSWORD"]);
-        let deferred = homeboy::core::deferred_workload::defer(
+        let deferred = homeboy::deferred_workload::defer(
             deferred_workload_input(
                 &cli,
                 &[
@@ -1197,8 +1197,8 @@ fn manifest_resolved_portable_db_service_warm_defers_and_dispatches_secret_ident
         )
         .expect("compatible runner dispatch");
         assert_eq!(
-            homeboy::core::deferred_workload::records().expect("records")[0].state,
-            homeboy::core::deferred_workload::DeferredWorkloadState::Dispatched
+            homeboy::deferred_workload::records().expect("records")[0].state,
+            homeboy::deferred_workload::DeferredWorkloadState::Dispatched
         );
     });
 }

--- a/crates/homeboy-cli/src/deferred_workload.rs
+++ b/crates/homeboy-cli/src/deferred_workload.rs
@@ -1,7 +1,7 @@
 //! Controller-owned durable deferral for portable workloads that have no runner yet.
 
-use crate::error::{Error, Result};
 use fs4::fs_std::FileExt;
+use homeboy_core::error::{Error, Result};
 use homeboy_engine_primitives::content_hash::sha256_hex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -27,7 +27,7 @@ pub struct DeferredWorkload {
     pub resolved_resources: serde_json::Value,
     #[serde(default)]
     pub test_requirements: DeferredWorkloadRequirements,
-    pub job_overrides: crate::lab_offload::LabJobOverrides,
+    pub job_overrides: homeboy_core::lab_offload::LabJobOverrides,
     pub state: DeferredWorkloadState,
     pub created_at_ms: u64,
     pub updated_at_ms: u64,
@@ -57,7 +57,7 @@ pub struct DeferredWorkloadInput {
     pub resolved_contract: serde_json::Value,
     pub resolved_resources: serde_json::Value,
     pub test_requirements: DeferredWorkloadRequirements,
-    pub job_overrides: crate::lab_offload::LabJobOverrides,
+    pub job_overrides: homeboy_core::lab_offload::LabJobOverrides,
 }
 
 /// Exact runner admission requirements persisted with a deferred workload.
@@ -303,7 +303,7 @@ pub fn records() -> Result<Vec<DeferredWorkload>> {
 }
 
 pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
-    let root = crate::paths::homeboy()?;
+    let root = homeboy_core::paths::homeboy()?;
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -339,7 +339,7 @@ pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
 }
 
 pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
-    let root = crate::paths::homeboy()?;
+    let root = homeboy_core::paths::homeboy()?;
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -396,24 +396,28 @@ pub fn worker_is_live(status: &DeferredWorkloadWorkerStatus) -> bool {
     }
     worker_identity_is_live(
         status,
-        crate::process::process_identity_state,
+        homeboy_core::process::process_identity_state,
         |pid, token| {
-            crate::process::pid_has_ownership_token(pid, "HOMEBOY_DEFERRED_WORKLOAD_OWNER", token)
-                .unwrap_or(false)
+            homeboy_core::process::pid_has_ownership_token(
+                pid,
+                "HOMEBOY_DEFERRED_WORKLOAD_OWNER",
+                token,
+            )
+            .unwrap_or(false)
         },
     )
 }
 
 fn worker_identity_is_live(
     status: &DeferredWorkloadWorkerStatus,
-    inspect_process: impl FnOnce(u32, Option<u64>) -> crate::process::ProcessIdentityState,
+    inspect_process: impl FnOnce(u32, Option<u64>) -> homeboy_core::process::ProcessIdentityState,
     owns_token: impl FnOnce(u32, &str) -> bool,
 ) -> bool {
     if cfg!(target_os = "linux") && status.linux_starttime_ticks.is_none() {
         return false;
     }
     inspect_process(status.pid, status.linux_starttime_ticks)
-        == crate::process::ProcessIdentityState::Live
+        == homeboy_core::process::ProcessIdentityState::Live
         && owns_token(status.pid, &status.owner_token)
 }
 
@@ -427,9 +431,11 @@ pub fn write_worker_status(
         schema: "homeboy/deferred-workload-worker-status/v1".to_string(),
         pid: std::process::id(),
         owner_token: owner_token.to_string(),
-        linux_starttime_ticks: crate::process::linux_process_starttime_ticks(std::process::id())
-            .ok()
-            .flatten(),
+        linux_starttime_ticks: homeboy_core::process::linux_process_starttime_ticks(
+            std::process::id(),
+        )
+        .ok()
+        .flatten(),
         state: state.to_string(),
         updated_at_ms: now_ms(),
         detail: detail.into(),
@@ -478,7 +484,7 @@ fn fingerprint(input: &DeferredWorkloadInput) -> Result<String> {
 }
 
 fn store_path() -> Result<PathBuf> {
-    Ok(crate::paths::homeboy()?.join("deferred-workloads.json"))
+    Ok(homeboy_core::paths::homeboy()?.join("deferred-workloads.json"))
 }
 
 fn update<T>(mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>) -> Result<T> {
@@ -625,13 +631,13 @@ mod tests {
                 required_runtimes: ["homeboy".to_string()].into(),
                 required_capabilities: ["review test".to_string()].into(),
             },
-            job_overrides: crate::lab_offload::LabJobOverrides::default(),
+            job_overrides: homeboy_core::lab_offload::LabJobOverrides::default(),
         }
     }
 
     #[test]
     fn deferred_workload_is_idempotent_and_survives_restart_before_claim() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let first = defer(input()).expect("defer workload");
             let replay = defer(input()).expect("replay deferred workload");
             assert_eq!(first.id, replay.id);
@@ -650,7 +656,7 @@ mod tests {
 
     #[test]
     fn reading_an_absent_store_does_not_create_runtime_state() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let path = store_path().expect("store path");
 
             assert!(records().expect("read absent store").is_empty());
@@ -664,7 +670,7 @@ mod tests {
 
     #[test]
     fn terminalized_workload_does_not_reappear_as_a_ghost() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let deferred = defer(input()).expect("defer workload");
             let claimed = claim(&input(), "warm-lab", "owner")
                 .expect("claim workload")
@@ -684,7 +690,7 @@ mod tests {
 
     #[test]
     fn expired_claim_is_reclaimed_after_a_post_claim_crash() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             defer(input()).expect("defer workload");
             let claimed = claim(&input(), "first-lab", "crashed-owner")
                 .expect("claim workload")
@@ -709,7 +715,7 @@ mod tests {
 
     #[test]
     fn next_claim_heartbeats_and_publishes_durable_worker_status() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let deferred = defer(input()).expect("defer workload");
             let claimed = claim_next("ready-runner", "worker-a")
                 .expect("claim next")
@@ -732,7 +738,7 @@ mod tests {
 
     #[test]
     fn matching_claim_skips_a_live_claimed_head_for_a_later_deferred_record() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let first = defer(input()).expect("first workload");
             let mut later_input = input();
             later_input.args.push("later".to_string());
@@ -765,14 +771,14 @@ mod tests {
 
         assert!(!worker_identity_is_live(
             &status,
-            |_, _| crate::process::ProcessIdentityState::IdentityMismatch,
+            |_, _| homeboy_core::process::ProcessIdentityState::IdentityMismatch,
             |_, _| true,
         ));
     }
 
     #[test]
     fn worker_lock_survives_replacement_of_the_legacy_adjacent_lock_file() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let owner = try_acquire_worker_lock()
                 .expect("acquire worker lock")
                 .expect("first worker owns lock");
@@ -874,7 +880,7 @@ mod tests {
 
     #[test]
     fn corrupt_store_fails_closed_without_resetting_records() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let path = store_path().expect("store path");
             std::fs::create_dir_all(path.parent().expect("store parent")).expect("create parent");
             std::fs::write(&path, b"not-json").expect("write corrupt store");
@@ -888,7 +894,7 @@ mod tests {
 
     #[test]
     fn refuses_inline_values_for_runner_secret_identities() {
-        crate::test_support::with_isolated_home(|_| {
+        homeboy_core::test_support::with_isolated_home(|_| {
             let mut input = input();
             input.job_overrides.env.insert(
                 "DB_SERVICE_PASSWORD".to_string(),

--- a/crates/homeboy-cli/src/lib.rs
+++ b/crates/homeboy-cli/src/lib.rs
@@ -44,6 +44,9 @@ pub mod command_contract;
     reason = "CLI commands retain optional operator and recovery workflows."
 )]
 pub mod commands;
+// Controller-owned durable deferral for portable workloads that have no runner
+// yet. Lived in homeboy-core until #11143; the CLI is its only consumer.
+pub mod deferred_workload;
 pub mod help_topics;
 
 // Test-only fixtures / hermetic process contexts live in homeboy-core (the whole

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -91,7 +91,6 @@ pub use homeboy_lifecycle_contract::cook_status;
     reason = "Daemon recovery helpers are invoked by lifecycle paths."
 )]
 pub mod daemon;
-pub mod deferred_workload;
 pub mod deps;
 pub mod engine;
 pub use homeboy_lab_contract::env_materialization_plan;
@@ -135,9 +134,7 @@ pub mod keychain;
 pub mod lab_offload;
 pub mod lab_routing;
 pub mod lab_workspace_provenance;
-pub mod operation_record;
 pub use homeboy_lifecycle_contract::lifecycle;
-pub mod loop_lifecycle;
 pub mod markdown;
 pub use homeboy_lab_contract::materialization_currency;
 pub mod matrix_artifact_summary;

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -431,7 +431,7 @@ pub fn pid_has_environment_value(pid: u32, key: &str, value: &str) -> Result<boo
 /// Prove that a process owns a persisted startup token before it is signaled.
 /// Linux reads the authoritative environment; other Unix platforms inspect the
 /// explicit `--startup-token` daemon argument with `ps`.
-pub(crate) fn pid_has_ownership_token(pid: u32, key: &str, value: &str) -> Result<bool> {
+pub fn pid_has_ownership_token(pid: u32, key: &str, value: &str) -> Result<bool> {
     #[cfg(target_os = "linux")]
     {
         return pid_has_environment_value(pid, key, value);

--- a/crates/homeboy-release/Cargo.toml
+++ b/crates/homeboy-release/Cargo.toml
@@ -20,6 +20,7 @@ homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }
 homeboy-release-contract = { version = "0.1.0", path = "../contracts/homeboy-release-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+fs4 = "0.13"
 regex = "1.11"
 zip = "0.6"
 chrono = "0.4"

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -7,6 +7,9 @@ mod execution_dispatch;
 mod execution_plan;
 mod execution_projection;
 mod executor;
+// Durable operation/finalization records. Lived in homeboy-core until #11143;
+// the release workspace finalizer is their only consumer.
+pub mod operation_record;
 mod orchestrator;
 mod package_recovery;
 mod pipeline;

--- a/crates/homeboy-release/src/release/operation_record.rs
+++ b/crates/homeboy-release/src/release/operation_record.rs
@@ -7,7 +7,7 @@ use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{paths, Error, Result};
+use homeboy_core::{paths, Error, Result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OperationRecord {
@@ -76,10 +76,10 @@ impl OperationRecordStore {
         let json = serde_json::to_vec_pretty(&next).map_err(|error| {
             Error::internal_json(error.to_string(), Some(owner_run_ref.to_string()))
         })?;
-        crate::io::write_output_file_atomically(
+        homeboy_core::io::write_output_file_atomically(
             &path,
             [json, b"\n".to_vec()].concat(),
-            crate::io::OutputWriteOptions::artifact(),
+            homeboy_core::io::OutputWriteOptions::artifact(),
         )
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
         Ok(next)
@@ -285,7 +285,7 @@ fn read_path(path: &Path) -> Result<Option<OperationRecord>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::with_isolated_home;
+    use homeboy_core::test_support::with_isolated_home;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Barrier,

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
+use crate::release::operation_record::{FinalizationClaim, OperationRecord, OperationRecordStore};
 use homeboy_core::component::Component;
 use homeboy_core::defaults;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
-use homeboy_core::operation_record::{FinalizationClaim, OperationRecord, OperationRecordStore};
 use homeboy_core::worktree_providers::{
     finalize_apply_enabled_worktree_provider_from_config,
     provision_apply_enabled_worktree_provider_with_lifecycle_from_config,
@@ -512,12 +512,12 @@ fn verify_staging_workspace(
 #[cfg(test)]
 mod tests {
     use super::{finalize_record, in_place_eligible, reconcile_pending};
+    use crate::release::operation_record::{OperationRecord, OperationRecordStore};
     use homeboy_core::component::Component;
     use homeboy_core::defaults::{
         save_config, HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig,
         WorktreeProviderKind,
     };
-    use homeboy_core::operation_record::{OperationRecord, OperationRecordStore};
     use homeboy_core::worktree_providers::{
         WorktreeProviderCleanupPolicy, WorktreeProviderHandle, WorktreeProviderHandleSafety,
         WorktreeProviderLifecycleIntent, WorktreeProviderResolution,


### PR DESCRIPTION
Continues #11143 after the first pass (#11541). Does **not** redo that pass's moves, and honors its two corrections — `matrix_artifact_summary` (live `super::` edge from `artifacts.rs` into core's own `observation/evidence_report.rs`) and `performance_hotspots` (consumed by `homeboy-lab-runner`, which does not depend on `homeboy-cli`) are both left alone.

## Candidate selection

I swept **all 113** top-level `pub mod` in `crates/homeboy-core/src/lib.rs` for the reverse-edge condition, checking `crate::` **and** `super::` (the `artifacts.rs` sibling-reach pattern), then resolved the consumer crate set for every module that came back clean. 36 modules had zero reverse edges; only 7 of those had a single consumer crate; 3 survived closer inspection.

## Moves

### 1. `deferred_workload` -> `homeboy-cli` (903 LOC)
`crates/homeboy-core/src/deferred_workload.rs` -> `crates/homeboy-cli/src/deferred_workload.rs`

```
$ grep -rn 'crate::deferred_workload\b' crates/homeboy-core/src | grep -v '/deferred_workload'
$ grep -rn 'super::deferred_workload\b' crates/homeboy-core/src | grep -v '/deferred_workload'
$ grep -rn '\bdeferred_workload\b' crates/homeboy-core/src | grep -v '/deferred_workload'
crates/homeboy-core/src/lib.rs:94:pub mod deferred_workload;      <- the only mention in all of core
```
Consumer crates for `DeferredWorkloadRequirements` / `DeferredWorkloadState` / `DeferredWorkloadWorkerStatus`: `homeboy-cli` only (4 files).

### 2. `loop_lifecycle` -> `homeboy-cli` (260 LOC)
`crates/homeboy-core/src/loop_lifecycle.rs` -> `crates/homeboy-cli/src/commands/contract/loop_lifecycle.rs`

```
$ grep -rn '\bloop_lifecycle\b' crates/homeboy-core/src | grep -v '/loop_lifecycle'
crates/homeboy-core/src/lib.rs:140:pub mod loop_lifecycle;        <- the only mention in all of core
```
Consumer of `LoopRunRecord` / `LoopIterationRecord` / `LoopEvidenceRecord` / `LOOP_*_SCHEMA`: exactly one file, `homeboy-cli/src/commands/contract/mod.rs`. Placed next to that validator.

### 3. `operation_record` -> `homeboy-release` (381 LOC)
`crates/homeboy-core/src/operation_record.rs` -> `crates/homeboy-release/src/release/operation_record.rs`

```
$ grep -rn '\boperation_record\b' crates/homeboy-core/src | grep -v '/operation_record'
crates/homeboy-core/src/lib.rs:138:pub mod operation_record;      <- the only mention in all of core
```
Consumer of `OperationRecord` / `OperationRecordStore` / `FinalizationClaim`: exactly one file, `homeboy-release/src/release/workspace.rs`. Core does not depend on homeboy-release (it reaches it via the `release_provider` hook), so this is a downward move, not a dependency inversion.

Post-move proof — zero occurrences of any of the three names anywhere under `crates/homeboy-core/`:
```
$ grep -rn 'deferred_workload\|loop_lifecycle\|operation_record' crates/homeboy-core/ --include=*.rs
$
```

## No facade re-exports

Per the #11541 finding that counting `pub mod` alone understates the surface, **no `pub use` was added to core**. Every consumer import was repointed at the module's new home. Root `pub use` count is byte-identical before and after.

## Counts

| metric (`crates/homeboy-core/src/lib.rs`, column 0) | before | after |
|---|---|---|
| `pub mod` | 113 | **110** |
| root `pub use` | 29 | **29** |
| total declared surface | 142 | **139** |

(29, not the ~20 estimated in #11541 — the 4 `pub use` inside the nested `pub mod lab_contract { .. }` block are indented and correctly excluded from the root count.)

## Sites swept

13 files. Every reference to the three modules across `crates/` **and** root `tests/`:

- `homeboy-cli/src/lib.rs` — `pub mod deferred_workload;`
- `homeboy-cli/src/cli_runtime.rs` — 2 sites
- `homeboy-cli/src/commands/deferred_workload.rs` — the `use`
- `homeboy-cli/src/commands/infra/route.rs` — 9 sites
- `homeboy-cli/src/commands/infra/route/tests/dispatch.rs` — 9 sites
- `homeboy-cli/src/commands/contract/mod.rs` — `pub mod` + repointed `use`
- `homeboy-release/src/release/mod.rs` — `pub mod operation_record;`
- `homeboy-release/src/release/workspace.rs` — 2 sites
- `homeboy-core/src/lib.rs` — 3 `pub mod` lines removed
- `homeboy-core/src/process.rs` — visibility widening
- the 3 moved files

Also checked and clean: `#[path]` attributes workspace-wide (none reference these files), root `tests/`, `homeboy.json`, and all `.json`/`.md`/`.toml`/`.sh`/`.yml`.

Not moved despite passing the reverse-edge check:
- `release_set` — single consumer (`homeboy-cli`) but it is a published contract schema with `owner: "homeboy-core"` and `rust_type: "homeboy_core::release_set::ReleaseSetManifest"` recorded in `command_contract/registry.rs`. Moving it changes a declared contract ownership string; that is a separate decision, not a mechanical relocation.
- `harvest`, `http_request`, `setup` — bare-name greps looked single-consumer but resolve to multiple crates.
- The `*_provider.rs` cluster — all except `refactor_transform_provider` / `rig_toolchain_provider` have live core call sites (`http_api.rs`, `scope.rs`, `setup.rs`, `hygiene.rs`, `deps.rs`, `cleanup.rs`, `secret_env.rs`, `trace_secrets.rs`). They are dependency-inversion registries core calls into; moving them would invert a crate dependency. The two clean ones have two consumer crates each (registrar + caller), which is exactly the coupling the registry exists to avoid.
- `resources` — two consumer crates (`homeboy-cli` + `homeboy-lab-runner`).

Per instruction, the `artifact_*` cluster and the feature subsystems (`daemon/`, `api_jobs/`, `cleanup/`, `worktree/`, `fleet/`, `schedule/`, `http_api/`) were not attempted.

## Visibility change

`homeboy-core/src/process.rs`: `pid_has_ownership_token` widens `pub(crate)` -> `pub`, since `deferred_workload` now calls it across a crate boundary. It remains in use by core's own `daemon/control.rs` and `daemon/stop.rs`, so nothing is orphaned. All other core symbols the moved files reach (`lab_offload::LabJobOverrides`, `paths::homeboy`, `process::{process_identity_state, ProcessIdentityState, linux_process_starttime_ticks}`, `artifact_contract::ArtifactContract`, `io::{write_output_file_atomically, OutputWriteOptions}`, `test_support::with_isolated_home`) were already `pub`.

## Tests

All three modules carry `#[cfg(test)] mod tests` and moved intact — nothing deleted or `#[ignore]`d. Their `use super::*;` stays correct at the new depth. `homeboy_core::test_support::with_isolated_home` is reachable in both destinations: `homeboy-cli` and `homeboy-release` each already enable `homeboy-core`'s `test-support` feature as a dev-dependency.

One depth bug was caught and fixed during the sweep: `workspace.rs:520` is inside `mod tests`, where `super::` resolves to `workspace`, not `release`. Both import sites use the depth-independent absolute `crate::release::operation_record::` instead.

## Compile risk

**I could not compile this** — build/test is prohibited on the shared VPS this ran on. `cargo fmt` is the only verification performed. It exits 0 and is stable across two runs, and it reformatted all three moved files (rustfmt silently skips unreachable files, so this is positive proof the new `mod` wiring reaches them). Residual risk is a `pub(crate)` core symbol I did not identify — I enumerated every `homeboy_core::` path in the moved files and checked each one's declared visibility, and found exactly one (`pid_has_ownership_token`). Please let CI run `cargo check --workspace --tests`.

Refs #11143