### PR TITLE
fix(runner): stop a dirty controller marking every Lab runner stale

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -819,8 +819,13 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
     assert_eq!(output.active_daemon_version.as_deref(), Some("0.262.0"));
 }
 
+/// A dirty controller alongside a genuinely version-skewed runner: the skew is
+/// the reportable fact and keeps its runner-side recovery. The controller's
+/// dirty tree only removes the *stronger* exact-commit proof, so it must not
+/// rename the finding or replace the remediation with `homeboy upgrade
+/// --force` (#11101).
 #[test]
-fn compact_status_prioritizes_dirty_controller_before_runner_convergence() {
+fn compact_status_names_runner_version_skew_when_the_controller_is_dirty() {
     let report = RunnerStatusReport {
         runner_id: "homeboy-lab".to_string(),
         connected: true,
@@ -903,20 +908,29 @@ fn compact_status_prioritizes_dirty_controller_before_runner_convergence() {
     assert!(summary
         .risk
         .iter()
-        .any(|risk| risk.contains("controller_dirty")));
+        .any(|risk| risk.contains("controller_configured_version_skew")));
     assert!(summary
         .risk
         .iter()
         .any(|risk| risk.contains("homeboy 0.321.1+configured-dirty")));
-    assert_eq!(summary.next_action, "homeboy upgrade --force");
-    assert!(!summary.next_action.contains("refresh-homeboy"));
-    assert!(!summary.next_action.contains("--ref"));
+    // The remediation converges the runner, which is what is actually skewed.
+    // Telling an operator with uncommitted work to reinstall the controller
+    // answers a question nobody asked.
+    assert!(summary.next_action.contains("refresh-homeboy"));
+    assert!(!summary.next_action.contains("upgrade --force"));
     let warning = report.stale_daemon.as_ref().expect("stale daemon warning");
     assert_eq!(
         warning.recovery_commands,
-        vec!["homeboy upgrade --force".to_string()]
+        vec!["homeboy runner refresh-homeboy homeboy-lab --ref configured --reconnect".to_string()]
     );
-    assert!(warning.message.contains("rerun `homeboy runner status`"));
+    assert_eq!(
+        warning.compatibility_reason,
+        Some("controller_configured_version_skew")
+    );
+    // The dirty tree is still reported — it is why the exact-commit proof is
+    // missing — but it is not the finding.
+    assert!(warning.message.contains("dirty"));
+    assert!(warning.message.contains("different Homeboy version"));
     assert!(
         report.connected,
         "liveness remains independently observable"

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -2848,11 +2848,13 @@ fn stale_daemon_warning(
         &stale_runtime_paths,
         &changed_runtime_paths,
     );
-    let controller_matches_configured =
-        versions_match(&current_version, &controller_identity.version)
-            && controller_commit_comparison == IdentityComparison::Match
-            && controller_identity.git_dirty != Some(true);
+    let controller_reference = ControllerReference::for_identity(&controller_identity);
     let controller_version_matches = versions_match(&current_version, &controller_identity.version);
+    let controller_matches_configured = controller_runtime_is_current(
+        controller_reference,
+        controller_version_matches,
+        controller_commit_comparison,
+    );
     if daemon_matches_configured && controller_matches_configured {
         return Ok(None);
     }
@@ -2875,7 +2877,7 @@ fn stale_daemon_warning(
             controller_identity.display,
             controller_version_matches,
             daemon_matches_configured,
-            controller_identity.git_dirty == Some(true),
+            controller_reference == ControllerReference::Unverifiable,
         )
         .with_runtime_paths(&runner.id, stale_runtime_paths, changed_runtime_paths)
         .with_persisted_session_version(&runner.id, session.homeboy_version.clone()),
@@ -2961,6 +2963,60 @@ fn daemon_runtime_is_current(
         && identity_comparison == IdentityComparison::Match
         && stale_runtime_paths.is_empty()
         && changed_runtime_paths.is_empty()
+}
+
+/// Whether the controller's own build identity can serve as the reference a
+/// runner is compared against.
+///
+/// A controller built from a dirty working tree embeds the *last commit*, not
+/// the tree it was actually built from, so its commit names no reproducible
+/// build. Comparing any runner's commit against it can never match — not
+/// because the runner is behind, but because there is nothing well-defined to
+/// compare with. Rendering that as staleness marked every Lab runner
+/// permanently stale on any development controller (#11101).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControllerReference {
+    /// The controller names a reproducible build. Commit comparison against it
+    /// is authoritative.
+    Comparable,
+    /// The controller cannot name the build it is running, so commit
+    /// comparison is *impossible* rather than *failed*.
+    Unverifiable,
+}
+
+impl ControllerReference {
+    fn for_identity(identity: &homeboy_product_identity::BuildIdentity) -> Self {
+        if identity.git_dirty == Some(true) {
+            Self::Unverifiable
+        } else {
+            Self::Comparable
+        }
+    }
+}
+
+/// Controller↔runner convergence, the mirror of [`daemon_runtime_is_current`]
+/// for the other half of the comparison.
+///
+/// Version equality is enforced in **both** states: the crate version is
+/// compiled in and a dirty working tree does not make the controller misreport
+/// it. So a genuinely stale runner — one whose configured job command binary is
+/// a different Homeboy version — is still caught with a dirty controller, and
+/// the runner-internal daemon↔configured-binary check is untouched. Only the
+/// commit comparison is skipped when the controller cannot name its own build,
+/// because that comparison has no defined answer, not a negative one. Skipping
+/// it never widens the gate past version equality.
+fn controller_runtime_is_current(
+    controller_reference: ControllerReference,
+    controller_version_matches: bool,
+    controller_commit_comparison: IdentityComparison,
+) -> bool {
+    controller_version_matches
+        && match controller_reference {
+            ControllerReference::Comparable => {
+                controller_commit_comparison == IdentityComparison::Match
+            }
+            ControllerReference::Unverifiable => true,
+        }
 }
 
 fn unverifiable_configured_identity_message(homeboy: &str) -> String {

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -764,14 +764,26 @@ fn controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions()
     );
 
     let dirty_diagnostics = serde_json::to_value(&dirty).expect("serialize dirty controller");
+    // A dirty controller cannot compare; that is not a claim about the runner,
+    // so it must not serialize as a staleness predicate (#11101).
     assert_eq!(
         dirty_diagnostics["mismatch_predicate"],
-        "controller_git_dirty == true"
+        "controller_build_commit == unverifiable(controller_git_dirty)"
     );
     assert_eq!(
-        dirty_diagnostics["recovery_commands"][0],
-        "homeboy upgrade --force"
+        dirty_diagnostics["compatibility_reason"],
+        "controller_identity_unverifiable"
     );
+    // "Your working tree is dirty" has no correct automated remediation, and
+    // `homeboy upgrade --force` is a destructive answer to a question nobody
+    // asked. Offer none rather than the wrong one.
+    assert!(dirty_diagnostics["recovery_commands"]
+        .as_array()
+        .expect("serialized recovery command list")
+        .is_empty());
+    assert!(!dirty.message.contains("upgrade --force"));
+    assert!(dirty.message.contains("dirty working tree"));
+    assert!(dirty.message.contains("unavailable, not failed"));
 
     let version_diagnostics =
         serde_json::to_value(&version_skew).expect("serialize controller version skew");
@@ -783,6 +795,151 @@ fn controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions()
         .as_array()
         .expect("serialized recovery command list")
         .is_empty());
+}
+
+fn controller_identity(
+    version: &str,
+    commit: &str,
+    dirty: bool,
+) -> homeboy_product_identity::BuildIdentity {
+    homeboy_product_identity::BuildIdentity {
+        version: version.to_string(),
+        git_commit: Some(commit.to_string()),
+        git_dirty: Some(dirty),
+        display: if dirty {
+            format!("homeboy {version}+{commit}-dirty")
+        } else {
+            format!("homeboy {version}+{commit}")
+        },
+    }
+}
+
+/// The reported bug: a controller with uncommitted work — the normal state of a
+/// development controller — made every commit comparison unmatchable, so every
+/// Lab runner read as stale and the whole fleet became ineligible (#11101).
+#[test]
+fn dirty_controller_does_not_mark_a_converged_runner_stale() {
+    let dirty = controller_identity("0.328.0", "1e63f1ae0369", true);
+    assert_eq!(
+        ControllerReference::for_identity(&dirty),
+        ControllerReference::Unverifiable
+    );
+
+    // The runner is on the controller's version but, because the controller
+    // was built from a dirty tree, its commit can equal nothing.
+    assert!(controller_runtime_is_current(
+        ControllerReference::for_identity(&dirty),
+        true,
+        IdentityComparison::Mismatch,
+    ));
+    assert!(controller_runtime_is_current(
+        ControllerReference::for_identity(&dirty),
+        true,
+        IdentityComparison::Unverifiable,
+    ));
+}
+
+/// The safety property this must not trade away: an unavailable commit proof
+/// removes only the *stronger* check. A runner on a different Homeboy version
+/// is conclusively stale whatever the controller's tree looks like, so it is
+/// still caught.
+#[test]
+fn dirty_controller_still_catches_a_version_skewed_runner() {
+    let dirty = controller_identity("0.328.0", "1e63f1ae0369", true);
+
+    assert!(!controller_runtime_is_current(
+        ControllerReference::for_identity(&dirty),
+        false,
+        IdentityComparison::Mismatch,
+    ));
+    // Even a commit that happens to match cannot rescue a version skew.
+    assert!(!controller_runtime_is_current(
+        ControllerReference::for_identity(&dirty),
+        false,
+        IdentityComparison::Match,
+    ));
+}
+
+/// A clean controller keeps the full exact-commit gate. The dirty-tree path is
+/// a fallback for an impossible comparison, never a general relaxation.
+#[test]
+fn clean_controller_still_requires_an_exact_commit_match() {
+    let clean = controller_identity("0.328.0", "1e63f1ae0369", false);
+    assert_eq!(
+        ControllerReference::for_identity(&clean),
+        ControllerReference::Comparable
+    );
+
+    assert!(controller_runtime_is_current(
+        ControllerReference::for_identity(&clean),
+        true,
+        IdentityComparison::Match,
+    ));
+    assert!(!controller_runtime_is_current(
+        ControllerReference::for_identity(&clean),
+        true,
+        IdentityComparison::Mismatch,
+    ));
+    assert!(!controller_runtime_is_current(
+        ControllerReference::for_identity(&clean),
+        true,
+        IdentityComparison::Unverifiable,
+    ));
+}
+
+/// A build with no recorded dirty flag is treated as comparable, because its
+/// commit is still the best available reference. Only a *proven* dirty tree
+/// downgrades the comparison.
+#[test]
+fn unknown_controller_dirty_state_keeps_the_exact_commit_gate() {
+    let unknown = homeboy_product_identity::BuildIdentity {
+        version: "0.328.0".to_string(),
+        git_commit: Some("1e63f1ae0369".to_string()),
+        git_dirty: None,
+        display: "homeboy 0.328.0+1e63f1ae0369".to_string(),
+    };
+
+    assert_eq!(
+        ControllerReference::for_identity(&unknown),
+        ControllerReference::Comparable
+    );
+    assert!(!controller_runtime_is_current(
+        ControllerReference::for_identity(&unknown),
+        true,
+        IdentityComparison::Mismatch,
+    ));
+}
+
+/// A dirty controller must not hijack a real runner-side fault. When the live
+/// daemon disagrees with its own configured binary, that finding and its
+/// runner-side recovery own the report.
+#[test]
+fn dirty_controller_preserves_a_runner_side_daemon_recovery() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.327.9".to_string(),
+        "0.328.0".to_string(),
+        Some("homeboy 0.327.9+aaaaaaaaaaaa".to_string()),
+        Some("homeboy 0.328.0+1e63f1ae0369".to_string()),
+    )
+    .with_controller_compatibility(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "homeboy 0.328.0+1e63f1ae0369-dirty".to_string(),
+        true,
+        false,
+        true,
+    );
+
+    assert_eq!(
+        warning.mismatch_predicate,
+        "active_daemon_control_plane_version != job_command_binary_version"
+    );
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
+    );
+    assert!(!warning.message.contains("upgrade --force"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1497,6 +1497,13 @@ impl RunnerStaleDaemonWarning {
             .or_else(|| action_from_refresh_command(&self.refresh_command))
     }
 
+    /// Fold the controller↔runner comparison into this warning.
+    ///
+    /// `controller_identity_unverifiable` means the controller cannot name the
+    /// build it is running — today, a dirty working tree. That is a *different
+    /// state* from a skewed runner and must never be rendered as one: it says
+    /// nothing about the runner, is true of every runner simultaneously, and
+    /// has no runner-side remediation (#11101).
     pub fn with_controller_compatibility(
         mut self,
         runner_id: &str,
@@ -1504,58 +1511,80 @@ impl RunnerStaleDaemonWarning {
         controller_build_identity: String,
         controller_version_matches: bool,
         daemon_matches_configured: bool,
-        controller_dirty: bool,
+        controller_identity_unverifiable: bool,
     ) -> Self {
         self.controller_homeboy_version = Some(controller_version.clone());
         self.controller_homeboy_build_identity = Some(controller_build_identity.clone());
-        if controller_dirty {
-            self.compatibility_reason = Some("controller_dirty");
-            self.mismatch_predicate = "controller_git_dirty == true";
-            self.message = format!(
-                "controller `{controller_build_identity}` is dirty and cannot prove compatibility with runner `{}`; rebuild or upgrade the controller first, then rerun `homeboy runner status` to derive runner convergence from the upgraded controller identity",
-                self.job_command_binary_build_identity
-                    .as_deref()
-                    .unwrap_or(&self.job_command_binary_version),
-            );
-            self.set_recovery(vec![ExecutableAction::new(
-                "upgrade.force",
-                "rebuild the controller binary".to_string(),
-                "homeboy",
-                ["upgrade".to_string(), "--force".to_string()],
-                ActionSafety::Mutating,
-            )]);
-        } else if daemon_matches_configured {
-            self.compatibility_reason = Some(if controller_version_matches {
-                "controller_configured_identity_skew"
-            } else {
-                "controller_configured_version_skew"
-            });
-            self.mismatch_predicate = if controller_version_matches {
-                "controller_build_commit != job_command_binary_build_commit"
-            } else {
-                "controller_version != job_command_binary_version"
-            };
-            self.message = format!(
-                "connected runner configured job command binary `{}` is incompatible with controller `{controller_build_identity}`; the daemon matches the configured binary, but controller compatibility requires convergence before admission",
-                self.job_command_binary_build_identity
-                    .as_deref()
-                    .unwrap_or(&self.job_command_binary_version),
-            );
+        if !daemon_matches_configured {
+            // The runner's live daemon disagrees with its own configured
+            // binary. That is a runner-side fact with a runner-side recovery,
+            // already established by `new`; controller-side advice must not
+            // overwrite it — least of all with a controller upgrade, which
+            // would not converge the daemon at all.
+            return self;
+        }
+        let configured_binary = self
+            .job_command_binary_build_identity
+            .clone()
+            .unwrap_or_else(|| self.job_command_binary_version.clone());
+        if controller_identity_unverifiable {
             if controller_version_matches {
-                if let Some(controller_commit) =
-                    homeboy_upgrade::upgrade::parse_build_identity_display(
-                        &controller_build_identity,
-                    )
+                // Nothing about the runner is known to be wrong: the versions
+                // agree and only the exact-commit proof is unavailable.
+                //
+                // `stale_daemon_warning` does not construct a warning at all in
+                // this state — it is the case that used to fail every runner
+                // closed. This branch exists so that any other caller renders
+                // "cannot compare" honestly instead of inheriting a staleness
+                // message and a mutating recovery.
+                self.compatibility_reason = Some("controller_identity_unverifiable");
+                self.mismatch_predicate =
+                    "controller_build_commit == unverifiable(controller_git_dirty)";
+                self.message = format!(
+                    "controller `{controller_build_identity}` was built from a dirty working tree, so its recorded commit does not name the build that is running and cannot be compared against runner `{runner_id}`'s configured job command binary `{configured_binary}`; the comparison is unavailable, not failed — the versions agree and no runner drift is known. Commit or stash the controller working tree, then rerun `homeboy runner status {runner_id}` to restore the exact-commit proof."
+                );
+                // "Your working tree is dirty" has no safe automated fix: every
+                // candidate command either discards the operator's work or
+                // replaces the binary under test. Report no recovery command
+                // rather than a confidently wrong one.
+                self.set_recovery(Vec::new());
+            } else {
+                // The version difference is conclusive on its own, so a runner
+                // that really is behind is still caught here — the unavailable
+                // commit proof only removes the *stronger* check.
+                self.compatibility_reason = Some("controller_configured_version_skew");
+                self.mismatch_predicate = "controller_version != job_command_binary_version";
+                self.message = format!(
+                    "connected runner configured job command binary `{configured_binary}` is a different Homeboy version from controller `{controller_build_identity}`; the controller working tree is dirty so the exact-commit proof is unavailable, but the version difference is conclusive by itself and blocks admission until the runner converges"
+                );
+            }
+            return self;
+        }
+        self.compatibility_reason = Some(if controller_version_matches {
+            "controller_configured_identity_skew"
+        } else {
+            "controller_configured_version_skew"
+        });
+        self.mismatch_predicate = if controller_version_matches {
+            "controller_build_commit != job_command_binary_build_commit"
+        } else {
+            "controller_version != job_command_binary_version"
+        };
+        self.message = format!(
+            "connected runner configured job command binary `{configured_binary}` is incompatible with controller `{controller_build_identity}`; the daemon matches the configured binary, but controller compatibility requires convergence before admission"
+        );
+        if controller_version_matches {
+            if let Some(controller_commit) =
+                homeboy_upgrade::upgrade::parse_build_identity_display(&controller_build_identity)
                     .filter(|identity| identity.git_dirty != Some(true))
                     .and_then(|identity| identity.git_commit)
-                {
-                    self.set_recovery(vec![
-                        crate::daemon_repair::refresh_homeboy_downgrade_action(
-                            runner_id,
-                            &controller_commit,
-                        ),
-                    ]);
-                }
+            {
+                self.set_recovery(vec![
+                    crate::daemon_repair::refresh_homeboy_downgrade_action(
+                        runner_id,
+                        &controller_commit,
+                    ),
+                ]);
             }
         }
         self

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -556,6 +556,28 @@ paths. `homeboy runner status <runner-id>` surfaces those differences in
 development runner with `homeboy runner disconnect <runner-id>` followed by
 `homeboy runner connect <runner-id>` after rebuilding runner-side runtime code.
 
+### Controller identity and a dirty working tree
+
+Runner convergence is normally proven by comparing the controller's embedded
+build commit against the runner's configured job command binary. A controller
+built from a **dirty working tree** records the last commit, not the tree it was
+actually built from, so that commit names no reproducible build and can equal no
+runner's — which is "the comparison is unavailable", not "this runner is stale".
+Homeboy reports the two states separately:
+
+- The controller↔runner **version** check still applies in full. A runner whose
+  configured binary is a different Homeboy version is still refused, with
+  `stale_daemon.compatibility_reason = "controller_configured_version_skew"` and
+  a runner-side `homeboy runner refresh-homeboy` recovery.
+- The **exact-commit** check is skipped while the controller cannot name its own
+  build, so a dirty controller no longer marks every runner stale. The
+  runner-internal check (its live daemon against its own configured binary) is
+  untouched and still blocking.
+- `stale_daemon.compatibility_reason = "controller_identity_unverifiable"`
+  reports an unavailable comparison. It carries no recovery command, because the
+  remediation is to commit or stash the controller working tree and rerun
+  `homeboy runner status <runner-id>` — not to reinstall the controller.
+
 ```json
 {
   "success": true,


### PR DESCRIPTION
Closes #11101 (P0).

## The bug

`stale_daemon_warning` proved runner convergence by comparing the controller's embedded build commit against the runner's configured job command binary, and folded "the controller is dirty" into the same boolean as "the commits differ":

```rust
let controller_matches_configured =
    versions_match(&current_version, &controller_identity.version)
        && controller_commit_comparison == IdentityComparison::Match
        && controller_identity.git_dirty != Some(true);
```

A controller built from a dirty working tree records the *last commit*, not the tree it was actually built from. That commit names no reproducible build, so it can equal no runner's — for every runner, simultaneously, however current. The result: every Lab runner reported `stale_daemon`, which makes it ineligible for offload (`lib.rs` readiness) and a hard rejection in `lab_selection`. And the only recovery offered was `homeboy upgrade --force`, which neither addresses uncommitted work nor converges anything. A development controller is dirty by definition while you work, so the entire fleet read as unusable.

## The state distinction

`ControllerReference` (`connection.rs`) names whether the controller can serve as a comparison reference at all:

- `Comparable` — the controller names a reproducible build; commit comparison is authoritative.
- `Unverifiable` — the controller cannot name the build it is running, so commit comparison is **impossible**, not **failed**.

`controller_runtime_is_current` is the mirror of the existing `daemon_runtime_is_current` for the controller half of the comparison, and is where the two states diverge. This follows the precedent already on main: `ControllerCurrency::Unknown` in `homeboy-upgrade/src/controller_staleness.rs` is explicitly *not* `is_behind()` — an unestablished verdict must not manufacture a warning.

The rendering is separated too. `RunnerStaleDaemonWarning::with_controller_compatibility` now reports `compatibility_reason = "controller_identity_unverifiable"` with predicate `controller_build_commit == unverifiable(controller_git_dirty)` — never a staleness predicate, and never `homeboy upgrade --force`.

## Why a genuinely stale runner is still caught

This is deliberately **not** fixed by making the check pass. Three facts stay enforced:

1. **Version equality is enforced in both states.** The crate version is compiled in; a dirty working tree does not make the controller misreport it. A runner whose configured job command binary is a different Homeboy version is still refused, now under `controller_configured_version_skew` with a runner-side `refresh-homeboy` recovery. Test: `dirty_controller_still_catches_a_version_skewed_runner` asserts this even when the commit *does* match.
2. **The runner-internal check is untouched.** The live daemon vs its own configured binary (`daemon_runtime_is_current`, including runtime-path drift) is unchanged and still blocking. New: a dirty controller no longer *overwrites* that finding and its runner-side recovery with controller-side advice — previously `upgrade --force` replaced a real `refresh-homeboy` recovery that would actually have converged the daemon (`dirty_controller_preserves_a_runner_side_daemon_recovery`).
3. **A clean controller keeps the full exact-commit gate.** `clean_controller_still_requires_an_exact_commit_match` pins `Mismatch` and `Unverifiable` both still failing, and `unknown_controller_dirty_state_keeps_the_exact_commit_gate` pins that only a *proven* dirty tree downgrades the comparison — a missing `git_dirty` flag does not.

So the widening is bounded to exactly one predicate — the exact-commit comparison — and only while that comparison has no defined answer.

## Remediation that fits the cause

`controller_identity_unverifiable` carries **no** recovery command. Every automated candidate for "your working tree is dirty" either discards the operator's work or replaces the binary under test, so the message says to commit or stash and rerun `homeboy runner status <runner-id>`. Reporting no command beats a confidently wrong one.

## Interaction with #11106

#11106 (probe errors swallowed / fail-open) is being fixed concurrently in the same crate. The two are opposite failure modes and the changes are disjoint:

- #11106 is about a **probe that could not run** being treated as a pass. This PR does not touch any probe, error path, or `unwrap_or_else` fallback in `stale_daemon_warning`; the identity/version/runtime-path reads it depends on are unchanged.
- This PR is about a **comparison that has no defined answer** being treated as a failure. It changes only how the controller identity is compared once already gathered, plus the warning text.

They are compatible by construction: #11106 makes an unobserved fact fail closed, while this makes an *observed and complete* fact — "the controller is dirty" — stop masquerading as a different observed fact. Nothing here makes an unknown probe result pass; the one relaxation is guarded by version equality, which is always known. Likely textual conflict surface is `connection.rs` `stale_daemon_warning` and `session.rs` `RunnerStaleDaemonWarning`; both are contained edits.

## Files changed

- `crates/homeboy-lab-runner/src/connection.rs` — `ControllerReference`, `controller_runtime_is_current`, wired into `stale_daemon_warning`.
- `crates/homeboy-lab-runner/src/session.rs` — `with_controller_compatibility` renders the unverifiable state distinctly and no longer preempts a runner-side daemon finding.
- `crates/homeboy-lab-runner/src/connection/tests/session.rs` — 5 new tests; existing dirty-controller serialization test updated to the new contract.
- `crates/homeboy-cli/src/commands/runner/tests/status.rs` — compact-status test updated and renamed to the behavior it now pins.
- `docs/commands/runner.md` — operator documentation for the two states.

No tests were deleted or `#[ignore]`d.

## Compile risk

**I could not compile this** — this VPS runs several agents in parallel and cannot absorb a cargo build, so only `cargo fmt` was run. Sweep performed:

- **No signature changed.** `with_controller_compatibility` keeps its arity and types; only the last parameter was *renamed* `controller_dirty` → `controller_identity_unverifiable`, which is positional and invisible to its 7 call sites (1 production + 6 test).
- **No struct field or enum variant added to any existing type**, so there are no literal or `match` sweeps. `ControllerReference` is a new fieldless private enum used at 2 production sites and in tests; `controller_runtime_is_current` is a new private fn with 1 production caller.
- Residual risk is confined to the new test module: `homeboy_product_identity::BuildIdentity` is written fully qualified (it is a dependency but not imported into `connection.rs`), and `ControllerReference` / `controller_runtime_is_current` reach the tests through the same `use super::*` chain that already exposes `daemon_runtime_is_current` to that file.