### PR TITLE
fix(ci): report live ruleset enforcement instead of implying it

### DIFF
--- a/.github/required-gates-ruleset.json
+++ b/.github/required-gates-ruleset.json
@@ -17,7 +17,7 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "homeboy / Required Gates Policy", "integration_id": 15368 },
+          { "context": "homeboy / Required Gates Declaration", "integration_id": 15368 },
           { "context": "homeboy / Workspace Tests Compile", "integration_id": 15368 },
           { "context": "homeboy / Windows Compile", "integration_id": 15368 },
           { "context": "homeboy / Rustfmt", "integration_id": 15368 },

--- a/.github/validate-required-gates.sh
+++ b/.github/validate-required-gates.sh
@@ -1,16 +1,86 @@
 #!/usr/bin/env bash
-# Validate the versioned main-branch gate contract. `--github` additionally
-# proves the live ruleset has the exact configured required-check set.
+#
+# Main-branch gate contract validator.
+#
+# ── Two claims, not one (#11084) ──
+#
+# This script can answer two questions, and they are NOT the same question:
+#
+#   declaration - every context named by the versioned payload is emitted by
+#                 `.github/workflows/ci.yml` on every pull request. This is
+#                 repository content, so a PR can both break it and fix it, and
+#                 it is checked from the checkout with no network.
+#   enforcement - GitHub actually *requires* those contexts before `main` can be
+#                 updated. This is repository STATE. A pull request cannot
+#                 change it and, until #10795's payload is installed by an
+#                 administrator, it can be false while the declaration is
+#                 perfect.
+#
+# Before #11084 the CI job ran `--local` and reported a plain green tick named
+# "Required Gates Policy". That tick asserted the second claim while only ever
+# checking the first: on 2026-08-01 PR #11069 merged nine minutes before its
+# final `homeboy / Test` verdict (which was red) while this check was green,
+# because `repos/Extra-Chill/homeboy/rules/branches/main` carried no
+# required-status-check rule at all.
+#
+# The repair is reporting, not enforcement. This repository merges fast on
+# purpose and a post-merge guard was removed on purpose; making merges block
+# would re-litigate a settled design decision. What is not acceptable is a check
+# that *claims* a guarantee nobody installed. So `--report` states the live
+# enforcement outcome loudly and exits 0 regardless: nothing here can newly
+# block a pull request.
+#
+# ── Modes ──
+#
+#   --local   Declaration only. Fails closed. No network.
+#   --report  Declaration fails closed; enforcement is PROBED and REPORTED and
+#             never enforced. Always exits 0 once the declaration passes. This
+#             is what CI runs, so its green tick claims only what it checked.
+#   --github  Declaration and enforcement both fail closed. The administrator
+#             verification path from docs/operations/required-ci-gates.md, run
+#             by a human after applying the payload — deliberately not CI.
+#
+# ── Enforcement outcomes ──
+#
+# Vocabulary deliberately mirrors `.github/release-quality-policy.sh`, which
+# already had to learn that "the check passed" and "the check measured
+# something" are different facts:
+#
+#   enforced    live required contexts == declared set, strict policy on.
+#   bypassable  as `enforced`, but actors can bypass the ruleset.
+#   divergent   a required-status-checks rule exists and disagrees.
+#   unenforced  live state is readable and requires NO checks. A measured zero.
+#   unverified  live state could not be read. NEVER reported as enforced.
+#
+# ── Fixture hooks ──
+#
+# REQUIRED_GATES_CONFIG / REQUIRED_GATES_WORKFLOW override the declaration
+# inputs; REQUIRED_GATES_LIVE_RULES / REQUIRED_GATES_LIVE_RULESET substitute a
+# JSON file for the two live API reads; REQUIRED_GATES_HEAD_SHA pins the
+# recorded head. `tests/required_gates_policy_test.rs` uses them to pin every
+# outcome above without a network or a token.
+
 set -euo pipefail
 
 mode="${1:---local}"
-config=".github/required-gates-ruleset.json"
-ci_workflow=".github/workflows/ci.yml"
+
+case "${mode}" in
+  --local | --report | --github) ;;
+  *)
+    echo "usage: bash .github/validate-required-gates.sh [--local|--report|--github]" >&2
+    exit 2
+    ;;
+esac
+
+config="${REQUIRED_GATES_CONFIG:-.github/required-gates-ruleset.json}"
+ci_workflow="${REQUIRED_GATES_WORKFLOW:-.github/workflows/ci.yml}"
 
 if [ ! -f "${config}" ] || [ ! -f "${ci_workflow}" ]; then
   echo "required-gates validation must run from the repository root" >&2
   exit 1
 fi
+
+# ── Claim 1: declaration ─────────────────────────────────────────────────────
 
 contexts=()
 while IFS= read -r context; do
@@ -67,25 +137,205 @@ if [ "${mode}" = "--local" ]; then
   exit 0
 fi
 
-if [ "${mode}" != "--github" ]; then
-  echo "usage: bash .github/validate-required-gates.sh [--local|--github]" >&2
-  exit 2
-fi
+# ── Claim 2: enforcement ─────────────────────────────────────────────────────
 
 repo="${GH_REPO:-Extra-Chill/homeboy}"
 ruleset_id="${GH_RULESET_ID:-13680120}"
-live="$(gh api "repos/${repo}/rulesets/${ruleset_id}")"
-expected="$(jq -S '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' "${config}")"
-actual="$(jq -S '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context] | sort' <<<"${live}")"
-
-if [ "${actual}" != "${expected}" ]; then
-  echo "live ruleset ${ruleset_id} required checks differ from ${config}" >&2
-  echo "expected: ${expected}" >&2
-  echo "actual:   ${actual}" >&2
-  exit 1
+branch="${GH_TARGET_BRANCH:-main}"
+# The checkout wins over `GITHUB_SHA`: on a `pull_request` event that variable
+# is the synthetic merge commit, while `ci.yml` checks this job out at
+# `pull_request.head.sha`. Evidence naming "the exact head SHA" should name the
+# commit that was actually inspected.
+head_sha="${REQUIRED_GATES_HEAD_SHA:-}"
+if [ -z "${head_sha}" ]; then
+  head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+fi
+if [ -z "${head_sha}" ]; then
+  head_sha="${GITHUB_SHA:-unknown}"
 fi
 
-if ! jq -e '.rules[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy == true' <<<"${live}" >/dev/null; then
-  echo "live ruleset ${ruleset_id} does not require checks on the current PR head" >&2
-  exit 1
+live_rules=''
+live_ruleset=''
+probe_error=''
+
+# The effective-rules endpoint, not the ruleset endpoint, is the source of truth
+# for "what actually gates this branch": it returns every active rule that
+# applies regardless of the level it was configured at (repository OR
+# organization), and it omits rulesets in `evaluate`/`disabled` enforcement. The
+# ruleset endpoint below is read only for bypass evidence, and only a caller
+# with write access gets `bypass_actors` back at all — hence its failure is
+# tolerated rather than fatal.
+read_live_rules() {
+  local source="${REQUIRED_GATES_LIVE_RULES:-}"
+  local payload=''
+
+  if [ -n "${source}" ]; then
+    if [ ! -f "${source}" ]; then
+      probe_error="live-rules fixture ${source} does not exist"
+      return 1
+    fi
+    payload="$(cat "${source}")"
+  else
+    if ! command -v gh >/dev/null 2>&1; then
+      probe_error="gh is not installed, so live branch rules could not be read"
+      return 1
+    fi
+    if ! payload="$(gh api "repos/${repo}/rules/branches/${branch}" 2>&1)"; then
+      probe_error="gh api repos/${repo}/rules/branches/${branch} failed: $(printf '%s' "${payload}" | tr '\n' ' ')"
+      return 1
+    fi
+  fi
+
+  if ! jq -e 'type == "array"' >/dev/null 2>&1 <<< "${payload}"; then
+    probe_error="live branch rules for ${branch} were not a JSON array"
+    return 1
+  fi
+
+  live_rules="${payload}"
+}
+
+read_live_ruleset() {
+  local source="${REQUIRED_GATES_LIVE_RULESET:-}"
+  local payload=''
+
+  if [ -n "${source}" ]; then
+    [ -f "${source}" ] || return 1
+    payload="$(cat "${source}")"
+  else
+    command -v gh >/dev/null 2>&1 || return 1
+    payload="$(gh api "repos/${repo}/rulesets/${ruleset_id}" 2>/dev/null)" || return 1
+  fi
+
+  jq -e 'type == "object"' >/dev/null 2>&1 <<< "${payload}" || return 1
+  live_ruleset="${payload}"
+}
+
+declared_contexts="$(jq -c '
+  [.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context]
+  | sort
+' "${config}")"
+declared_count="${#contexts[@]}"
+
+# Every live field starts at `unknown`, not at a plausible-looking zero. A
+# report that cannot read GitHub must not print `live=0 strict=false`, which a
+# reader would take for a measured absence rather than an absent measurement.
+live_contexts='unknown'
+live_count='unknown'
+live_rule_count='unknown'
+live_strict='unknown'
+bypass_count='unknown'
+bypass_current_user='unknown'
+outcome='unverified'
+
+if read_live_rules; then
+  live_contexts="$(jq -c '
+    [.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context]
+    | sort
+  ' <<< "${live_rules}")"
+  live_count="$(jq 'length' <<< "${live_contexts}")"
+  live_rule_count="$(jq '[.[] | select(.type == "required_status_checks")] | length' <<< "${live_rules}")"
+  live_strict='false'
+  if jq -e 'any(.[]; .type == "required_status_checks" and (.parameters.strict_required_status_checks_policy == true))' \
+    >/dev/null <<< "${live_rules}"; then
+    live_strict='true'
+  fi
+
+  if read_live_ruleset; then
+    bypass_count="$(jq '(.bypass_actors // []) | length' <<< "${live_ruleset}")"
+    bypass_current_user="$(jq -r '.current_user_can_bypass // "unknown"' <<< "${live_ruleset}")"
+  fi
+
+  if [ "${live_rule_count}" -eq 0 ]; then
+    outcome='unenforced'
+  elif [ "${live_contexts}" != "${declared_contexts}" ] || [ "${live_strict}" != 'true' ]; then
+    outcome='divergent'
+  elif { [ "${bypass_count}" != 'unknown' ] && [ "${bypass_count}" -gt 0 ]; } \
+    || { [ "${bypass_current_user}" != 'unknown' ] && [ "${bypass_current_user}" != 'never' ]; }; then
+    outcome='bypassable'
+  else
+    outcome='enforced'
+  fi
 fi
+
+# One machine-readable provenance line in every branch, so a log reader can tell
+# a verified enforcement from an unverified one without inferring it from the
+# exit code — the same reason `release-quality-policy.sh` emits its measurement
+# line before its verdict.
+echo "::notice::required-gates enforcement basis=live-branch-rules repo=${repo} branch=${branch} ruleset=${ruleset_id} head=${head_sha} declared=${declared_count} live=${live_count} rules=${live_rule_count} strict=${live_strict} bypass_actors=${bypass_count} current_user_can_bypass=${bypass_current_user} outcome=${outcome}"
+
+apply_hint="Apply .github/required-gates-ruleset.json to ruleset ${ruleset_id} (gh api --method PUT repos/${repo}/rulesets/${ruleset_id} --input .github/required-gates-ruleset.json), then verify with 'bash .github/validate-required-gates.sh --github'. See docs/operations/required-ci-gates.md."
+
+case "${outcome}" in
+  enforced)
+    headline="GitHub requires all ${declared_count} declared contexts on ${branch}."
+    echo "::notice::required-gates: ${headline}"
+    ;;
+  bypassable)
+    headline="GitHub requires all ${declared_count} declared contexts on ${branch}, but the ruleset can be BYPASSED (bypass_actors=${bypass_count}, current_user_can_bypass=${bypass_current_user}). A merge by a bypass actor is not gated by these checks."
+    echo "::warning::required-gates: ${headline}"
+    ;;
+  divergent)
+    headline="GitHub's required checks on ${branch} DISAGREE with the declared policy. declared=${declared_contexts} live=${live_contexts} strict=${live_strict}. ${apply_hint}"
+    echo "::warning::required-gates: ${headline}"
+    ;;
+  unenforced)
+    headline="GitHub requires NO status checks on ${branch}. The ${declared_count} contexts in .github/required-gates-ruleset.json are declared but NOT enforced: a pull request can merge before any of them reports, exactly as PR #11069 did (#11084). This check verified the declaration only. ${apply_hint}"
+    echo "::warning::required-gates: ${headline}"
+    ;;
+  unverified)
+    headline="Live enforcement on ${branch} could NOT be verified (${probe_error}). This check verified the declaration only; treat enforcement as unproven, not as present. Re-run with a token that can read repository rules."
+    echo "::warning::required-gates: ${headline}"
+    ;;
+esac
+
+echo "required-gates-live-status=${outcome}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "live-status=${outcome}"
+    echo "declared-contexts=${declared_contexts}"
+    echo "live-contexts=${live_contexts}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Required gates"
+    echo
+    echo "| claim | result |"
+    echo "| --- | --- |"
+    echo "| declaration (\`ci.yml\` emits every declared context) | **verified** |"
+    echo "| enforcement (GitHub requires them on \`${branch}\`) | **${outcome}** |"
+    echo
+    echo "${headline}"
+    echo
+    echo "| evidence | value |"
+    echo "| --- | --- |"
+    echo "| repository | \`${repo}\` |"
+    echo "| target branch | \`${branch}\` |"
+    echo "| ruleset id | \`${ruleset_id}\` |"
+    echo "| head sha | \`${head_sha}\` |"
+    echo "| declared contexts | \`${declared_contexts}\` |"
+    echo "| live required contexts | \`${live_contexts}\` |"
+    echo "| strict (require latest head) | \`${live_strict}\` |"
+    echo "| bypass actors | \`${bypass_count}\` |"
+    echo "| current user can bypass | \`${bypass_current_user}\` |"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if [ "${mode}" = "--report" ]; then
+  # Reporting must never become enforcement (#11084). The declaration check
+  # above already failed closed; the enforcement outcome is evidence only, so no
+  # pull request becomes newly blocked by anything below this line.
+  exit 0
+fi
+
+case "${outcome}" in
+  enforced | bypassable)
+    exit 0
+    ;;
+  *)
+    echo "required-gates enforcement is ${outcome} for ${repo}@${branch}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,26 @@ permissions:
   issues: write
 
 jobs:
-  required-gates-policy:
-    name: homeboy / Required Gates Policy
+  # Named for what a green tick here actually proves: the DECLARATION is intact.
+  # It used to be called "Required Gates Policy" and run `--local`, which reads
+  # as "GitHub requires these checks" while only proving "ci.yml emits these
+  # job names" — PR #11069 merged nine minutes ahead of a red `homeboy / Test`
+  # under a green tick from this job, because the live ruleset requires nothing
+  # (#11084). `--report` additionally probes the live ruleset and annotates the
+  # enforcement outcome loudly, but never fails on it: enforcement is repository
+  # state a PR cannot change, and this repository merges fast on purpose, so
+  # this stays reporting and no PR is newly blocked by it.
+  required-gates-declaration:
+    name: homeboy / Required Gates Declaration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Validate required check contexts
-        run: bash .github/validate-required-gates.sh --local
+      - name: Validate required check contexts and report live enforcement
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/validate-required-gates.sh --report
 
   # Non-differential safety net for crate-topology changes. The `review test`
   # gate below is changed-file scoped, so a crate extraction that orphans a

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -1,17 +1,63 @@
 # Required CI Gates
 
-`main` is protected by the versioned ruleset payload in
-[`../../.github/required-gates-ruleset.json`](../../.github/required-gates-ruleset.json).
-Every listed context must be emitted by `.github/workflows/ci.yml` on every pull
-request. `homeboy / Required Gates Policy` runs the local validator; a renamed,
-removed, duplicate, or path-filtered required job fails before it can weaken the
-declared contract.
+Two different things can be true or false here, and conflating them is what
+caused #11084:
+
+- **Declaration** — every context named by
+  [`../../.github/required-gates-ruleset.json`](../../.github/required-gates-ruleset.json)
+  is emitted by `.github/workflows/ci.yml` on every pull request. This is
+  repository *content*, so a pull request can break it and a pull request can
+  fix it.
+- **Enforcement** — GitHub actually requires those contexts before `main` can be
+  updated. This is repository *state*. A pull request cannot change it, and it
+  can be false while the declaration is perfect.
+
+`homeboy / Required Gates Declaration` runs
+`bash .github/validate-required-gates.sh --report`. It **fails closed on the
+declaration** — a renamed, removed, duplicate, or path-filtered required job
+turns the check red — and it **reports, but never enforces, the live
+enforcement outcome**. Nothing in this check can newly block a pull request.
+
+## What The Check Reports
+
+Every run emits one machine-readable provenance line plus a job summary
+recording the target branch, ruleset id, head SHA, declared contexts, live
+required contexts, strict setting, and bypass actors:
+
+```
+::notice::required-gates enforcement basis=live-branch-rules repo=… branch=main
+  ruleset=… head=… declared=7 live=0 rules=0 strict=false bypass_actors=0
+  current_user_can_bypass=never outcome=unenforced
+```
+
+| outcome | meaning |
+| --- | --- |
+| `enforced` | live required contexts equal the declared set, strict policy on |
+| `bypassable` | as `enforced`, but actors can bypass the ruleset — a bypassing merge is not gated |
+| `divergent` | a required-status-checks rule exists and disagrees with the payload |
+| `unenforced` | live state is readable and requires **no** checks at all |
+| `unverified` | live state could not be read; enforcement is unproven, never assumed |
+
+Anything other than `enforced` is a loud `::warning::` annotation naming the
+exact GitHub setting that must change. `unverified` is deliberately its own
+outcome: the live read needs a token that can read repository rules, and a
+failure to read must never be reported as a pass.
+
+Prior to #11084 this job was named `homeboy / Required Gates Policy` and ran
+`--local`, so a green tick asserted enforcement it had never checked. On
+2026-08-01, PR #11069 merged nine minutes ahead of a red `homeboy / Test` under
+that green tick, because `repos/Extra-Chill/homeboy/rules/branches/main` carried
+no required-status-check rule at all.
+
+This is a reporting fix on purpose. The repository merges fast by design and a
+post-merge guard was removed by design; the defect was the false assurance, not
+the absence of a block.
 
 ## Apply And Verify
 
 The GitHub ruleset is repository state, so it cannot be changed by a pull
-request. After this change merges, a repository administrator applies the
-versioned payload to the existing `main` ruleset and verifies the result:
+request. A repository administrator applies the versioned payload to the
+existing `main` ruleset and verifies the result:
 
 ```bash
 gh api --method PUT repos/Extra-Chill/homeboy/rulesets/13680120 \
@@ -20,11 +66,17 @@ bash .github/validate-required-gates.sh --github
 gh api repos/Extra-Chill/homeboy/rulesets/13680120
 ```
 
+`--github` is the administrator verification path and is the one mode that
+**fails closed on enforcement** — `divergent`, `unenforced`, and `unverified`
+all exit non-zero. It is deliberately not what CI runs.
+
 The final command is review evidence. Its `required_status_checks` rule must
 contain exactly the seven contexts in the payload and set
 `strict_required_status_checks_policy` to `true`. Test the installation with a
 PR that leaves `homeboy / Test`, `homeboy / Lint`, or `homeboy / Audit` pending;
-GitHub must report the PR as blocked until the check succeeds.
+GitHub must report the PR as blocked until the check succeeds. Until that apply
+happens, the CI job reports `unenforced` on every pull request, which is the
+honest answer rather than a silent green tick.
 
 ## Emergency Path
 
@@ -39,4 +91,7 @@ the merge, then restores the checked-in payload with the apply command above.
 The owner attaches the `--github` verification output and post-merge check
 outcomes to the issue, then closes it. The current ruleset has no bypass actors;
 keeping bypass access out of the standing policy makes every exception a visible,
-time-bounded repository-admin action in GitHub's audit trail.
+time-bounded repository-admin action in GitHub's audit trail. If bypass actors
+are ever added intentionally, the check reports `bypassable` rather than
+`enforced`, and names both the actor count and whether the current actor can
+bypass, so the exception stays visible on every pull request.

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -1,4 +1,5 @@
-use std::process::Command;
+use std::path::PathBuf;
+use std::process::{Command, Output};
 
 fn ruleset() -> &'static str {
     include_str!("../.github/required-gates-ruleset.json")
@@ -8,26 +9,138 @@ fn ci_workflow() -> &'static str {
     include_str!("../.github/workflows/ci.yml")
 }
 
-#[test]
-fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
+fn declared_contexts() -> Vec<String> {
     let policy: serde_json::Value = serde_json::from_str(ruleset()).expect("valid ruleset JSON");
-    let checks = policy["rules"]
+    policy["rules"]
         .as_array()
         .expect("ruleset rules")
         .iter()
         .find(|rule| rule["type"] == "required_status_checks")
         .expect("required-status-checks rule")["parameters"]["required_status_checks"]
         .as_array()
-        .expect("required check list");
-    let contexts: Vec<&str> = checks
+        .expect("required check list")
         .iter()
-        .map(|check| check["context"].as_str().expect("check context"))
+        .map(|check| {
+            check["context"]
+                .as_str()
+                .expect("check context")
+                .to_string()
+        })
+        .collect()
+}
+
+/// A throwaway directory for live-state fixtures. The validator's live probe is
+/// file-substitutable precisely so these tests never need a network or a token.
+struct Scratch {
+    dir: PathBuf,
+}
+
+impl Scratch {
+    fn new(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "homeboy-required-gates-{}-{name}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch directory");
+        Self { dir }
+    }
+
+    fn write(&self, name: &str, body: &str) -> String {
+        let path = self.dir.join(name);
+        std::fs::write(&path, body).expect("fixture write");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn missing(&self, name: &str) -> String {
+        self.dir.join(name).to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// The shape `GET /repos/{owner}/{repo}/rules/branches/{branch}` returns: a flat
+/// array of effective rules, built here from the *declared* contexts so the
+/// fixture cannot drift away from the versioned payload.
+fn live_rules(contexts: &[String], strict: bool) -> String {
+    let checks: Vec<serde_json::Value> = contexts
+        .iter()
+        .map(|context| serde_json::json!({ "context": context, "integration_id": 15368 }))
         .collect();
+    serde_json::to_string_pretty(&serde_json::json!([
+        { "type": "deletion" },
+        { "type": "non_fast_forward" },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": strict,
+                "do_not_enforce_on_create": false,
+                "required_status_checks": checks,
+            }
+        }
+    ]))
+    .expect("live rules fixture")
+}
+
+fn no_required_checks() -> String {
+    serde_json::to_string_pretty(&serde_json::json!([
+        { "type": "deletion" },
+        { "type": "non_fast_forward" }
+    ]))
+    .expect("live rules fixture")
+}
+
+fn ruleset_detail(bypass_actors: serde_json::Value, current_user_can_bypass: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "id": 13680120,
+        "name": "main",
+        "enforcement": "active",
+        "bypass_actors": bypass_actors,
+        "current_user_can_bypass": current_user_can_bypass,
+    }))
+    .expect("ruleset fixture")
+}
+
+fn run_validator(mode: &str, env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new("bash");
+    command.args([".github/validate-required-gates.sh", mode]);
+    // Never inherit a real Actions environment: the validator appends evidence
+    // to these files when they are set.
+    command.env_remove("GITHUB_OUTPUT");
+    command.env_remove("GITHUB_STEP_SUMMARY");
+    command.env(
+        "REQUIRED_GATES_HEAD_SHA",
+        "0000000000000000000000000000000000000000",
+    );
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+        .output()
+        .expect("required-gates validator should run")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
+    let contexts = declared_contexts();
+    let policy: serde_json::Value = serde_json::from_str(ruleset()).expect("valid ruleset JSON");
 
     assert_eq!(
         contexts,
         [
-            "homeboy / Required Gates Policy",
+            "homeboy / Required Gates Declaration",
             "homeboy / Workspace Tests Compile",
             "homeboy / Windows Compile",
             "homeboy / Rustfmt",
@@ -50,7 +163,7 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
             && rule["parameters"]["strict_required_status_checks_policy"] == true
     }));
 
-    for context in contexts {
+    for context in &contexts {
         let matrix_title = context.trim_start_matches("homeboy / ");
         let reusable_test = context == "homeboy / Test"
             && ci_workflow()
@@ -87,13 +200,436 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
 
 #[test]
 fn shipped_validator_accepts_the_versioned_policy() {
-    let output = Command::new("bash")
-        .args([".github/validate-required-gates.sh", "--local"])
-        .output()
-        .expect("required-gates validator should run");
+    let output = run_validator("--local", &[]);
+    assert!(output.status.success(), "{}", stderr_of(&output));
+}
+
+/// The check's own name is half of the claim it makes. "Required Gates Policy"
+/// read as "GitHub requires these gates"; the job only ever proved the
+/// declaration, which is what its name now says (#11084).
+#[test]
+fn ci_job_claims_only_the_declaration_and_reports_live_enforcement() {
+    assert!(
+        ci_workflow().contains("name: homeboy / Required Gates Declaration"),
+        "the CI job must be named for the claim its green tick actually proves"
+    );
+    assert!(
+        !ci_workflow().contains("name: homeboy / Required Gates Policy"),
+        "'Required Gates Policy' asserts live enforcement this job does not verify"
+    );
+    assert!(
+        ci_workflow().contains("bash .github/validate-required-gates.sh --report"),
+        "CI must run the reporting mode so live enforcement is surfaced, not assumed"
+    );
+    assert!(
+        !ci_workflow().contains("bash .github/validate-required-gates.sh --local"),
+        "--local silently omits the live enforcement outcome from the run"
+    );
+}
+
+#[test]
+fn report_mode_reports_unenforced_when_the_live_ruleset_requires_no_checks() {
+    let scratch = Scratch::new("unenforced");
+    let rules = scratch.write("rules.json", &no_required_checks());
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            (
+                "REQUIRED_GATES_LIVE_RULESET",
+                scratch.missing("absent.json").as_str(),
+            ),
+        ],
+    );
+    let stdout = stdout_of(&output);
+
     assert!(
         output.status.success(),
+        "reporting must not block a pull request: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stdout.contains("required-gates-live-status=unenforced"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("outcome=unenforced"), "{stdout}");
+    assert!(
+        stdout.contains("::warning::required-gates:"),
+        "an unenforced ruleset must be loud, not a silent green tick: {stdout}"
+    );
+    assert!(
+        stdout.contains("requires NO status checks"),
+        "the annotation must state plainly that nothing is enforced: {stdout}"
+    );
+    assert!(
+        !stdout.contains("outcome=enforced"),
+        "an unenforced ruleset must never read as enforced: {stdout}"
+    );
+}
+
+/// Degrade honestly: no token, no `gh`, or an API error must report `unverified`
+/// and never `enforced`.
+#[test]
+fn report_mode_reports_unverified_when_live_state_cannot_be_read() {
+    let scratch = Scratch::new("unverified");
+    let output = run_validator(
+        "--report",
+        &[(
+            "REQUIRED_GATES_LIVE_RULES",
+            scratch.missing("absent.json").as_str(),
+        )],
+    );
+    let stdout = stdout_of(&output);
+
+    assert!(
+        output.status.success(),
+        "an unreadable live state must not block a pull request: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stdout.contains("required-gates-live-status=unverified"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("could NOT be verified"),
+        "unverified must be stated, not implied: {stdout}"
+    );
+    assert!(
+        !stdout.contains("outcome=enforced") && !stdout.contains("outcome=bypassable"),
+        "an unreadable live state must never be reported as enforcement: {stdout}"
+    );
+}
+
+#[test]
+fn report_mode_reports_enforced_only_when_live_rules_match_the_declaration() {
+    let scratch = Scratch::new("enforced");
+    let rules = scratch.write("rules.json", &live_rules(&declared_contexts(), true));
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(serde_json::json!([]), "never"),
+    );
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+        ],
+    );
+    let stdout = stdout_of(&output);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert!(
+        stdout.contains("required-gates-live-status=enforced"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains("::warning::required-gates:"),
+        "a genuinely enforced ruleset has nothing to warn about: {stdout}"
+    );
+}
+
+#[test]
+fn report_mode_reports_divergent_when_a_declared_context_is_not_required() {
+    let scratch = Scratch::new("divergent");
+    let mut contexts = declared_contexts();
+    contexts.pop();
+    let rules = scratch.write("rules.json", &live_rules(&contexts, true));
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(serde_json::json!([]), "never"),
+    );
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+        ],
+    );
+    let stdout = stdout_of(&output);
+
+    assert!(
+        output.status.success(),
+        "reporting divergence must not block a pull request: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stdout.contains("required-gates-live-status=divergent"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("::warning::required-gates:") && stdout.contains("DISAGREE"),
+        "{stdout}"
+    );
+}
+
+/// A ruleset the merging actor can step over enforces nothing for that actor,
+/// so it cannot report the same word as one nobody can bypass.
+#[test]
+fn report_mode_reports_bypassable_when_actors_can_bypass_the_ruleset() {
+    let scratch = Scratch::new("bypassable");
+    let rules = scratch.write("rules.json", &live_rules(&declared_contexts(), true));
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(
+            serde_json::json!([
+                { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+            ]),
+            "always",
+        ),
+    );
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+        ],
+    );
+    let stdout = stdout_of(&output);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert!(
+        stdout.contains("required-gates-live-status=bypassable"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("::warning::required-gates:")
+            && stdout.contains("current_user_can_bypass=always"),
+        "the merging actor's bypass ability must be surfaced: {stdout}"
+    );
+}
+
+/// The declaration half stays fail-closed in reporting mode: a renamed or
+/// missing job is repository content a pull request can and does break.
+#[test]
+fn report_mode_still_fails_closed_on_declaration_drift() {
+    let scratch = Scratch::new("drift");
+    let drifted = serde_json::json!({
+        "rules": [{
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": true,
+                "required_status_checks": [{ "context": "homeboy / Nonexistent Gate" }],
+            }
+        }]
+    });
+    let config = scratch.write(
+        "config.json",
+        &serde_json::to_string_pretty(&drifted).expect("config fixture"),
+    );
+    let rules = scratch.write("rules.json", &no_required_checks());
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_CONFIG", config.as_str()),
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "a context no CI job emits must still fail the declaration check"
+    );
+    assert!(
+        stderr_of(&output).contains("is not emitted by"),
         "{}",
-        String::from_utf8_lossy(&output.stderr)
+        stderr_of(&output)
+    );
+    assert!(
+        !stdout_of(&output).contains("required-gates-live-status="),
+        "a broken declaration must not be dressed up with an enforcement verdict"
+    );
+}
+
+/// Acceptance criterion: a workflow declaring `homeboy / Test` against a ruleset
+/// that requires no checks must fail the administrator verification path.
+#[test]
+fn github_mode_fails_closed_when_the_live_ruleset_requires_no_checks() {
+    let scratch = Scratch::new("github-unenforced");
+    let rules = scratch.write("rules.json", &no_required_checks());
+    let output = run_validator("--github", &[("REQUIRED_GATES_LIVE_RULES", rules.as_str())]);
+
+    assert!(
+        !output.status.success(),
+        "--github must fail closed when GitHub requires nothing: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("enforcement is unenforced"),
+        "{}",
+        stderr_of(&output)
+    );
+}
+
+/// Acceptance criterion: matching workflow and ruleset contexts must pass.
+#[test]
+fn github_mode_passes_when_live_enforcement_matches_the_declaration() {
+    let scratch = Scratch::new("github-enforced");
+    let rules = scratch.write("rules.json", &live_rules(&declared_contexts(), true));
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(serde_json::json!([]), "never"),
+    );
+    let output = run_validator(
+        "--github",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        stdout_of(&output),
+        stderr_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("required-gates-live-status=enforced"),
+        "{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn github_mode_fails_closed_when_live_state_cannot_be_read() {
+    let scratch = Scratch::new("github-unverified");
+    let output = run_validator(
+        "--github",
+        &[(
+            "REQUIRED_GATES_LIVE_RULES",
+            scratch.missing("absent.json").as_str(),
+        )],
+    );
+
+    assert!(
+        !output.status.success(),
+        "an unverifiable ruleset is not a verified one"
+    );
+    assert!(
+        stderr_of(&output).contains("enforcement is unverified"),
+        "{}",
+        stderr_of(&output)
+    );
+}
+
+/// Strictness is what forces a check to have run against the PR's own head. A
+/// ruleset with the right contexts and `strict` off is not the declared policy.
+#[test]
+fn strict_policy_off_is_reported_as_divergent() {
+    let scratch = Scratch::new("nonstrict");
+    let rules = scratch.write("rules.json", &live_rules(&declared_contexts(), false));
+    let output = run_validator("--report", &[("REQUIRED_GATES_LIVE_RULES", rules.as_str())]);
+    let stdout = stdout_of(&output);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert!(
+        stdout.contains("required-gates-live-status=divergent") && stdout.contains("strict=false"),
+        "{stdout}"
+    );
+}
+
+/// The issue asks for evidence, not just a verdict: target branch, ruleset id,
+/// declared and live contexts, bypass actors, and the exact head SHA.
+#[test]
+fn enforcement_evidence_records_branch_ruleset_bypass_and_head_sha() {
+    let scratch = Scratch::new("evidence");
+    let rules = scratch.write("rules.json", &no_required_checks());
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(serde_json::json!([]), "never"),
+    );
+    let output = run_validator(
+        "--report",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+            ("GH_TARGET_BRANCH", "main"),
+            ("GH_RULESET_ID", "13680120"),
+        ],
+    );
+    let stdout = stdout_of(&output);
+
+    for fragment in [
+        "basis=live-branch-rules",
+        "repo=Extra-Chill/homeboy",
+        "branch=main",
+        "ruleset=13680120",
+        "head=0000000000000000000000000000000000000000",
+        "declared=7",
+        "live=0",
+        "bypass_actors=0",
+        "current_user_can_bypass=never",
+        "outcome=unenforced",
+    ] {
+        assert!(
+            stdout.contains(fragment),
+            "enforcement evidence is missing {fragment:?}: {stdout}"
+        );
+    }
+}
+
+/// The constraint this change is built around: truthful reporting must never
+/// become enforcement. Every non-enforced outcome exits 0 in reporting mode, so
+/// no pull request is newly blocked by any of them.
+#[test]
+fn reporting_never_blocks_a_pull_request() {
+    let scratch = Scratch::new("nonblocking");
+    let mut short = declared_contexts();
+    short.pop();
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(
+            serde_json::json!([
+                { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+            ]),
+            "always",
+        ),
+    );
+
+    let cases = [
+        (
+            "unenforced",
+            scratch.write("none.json", &no_required_checks()),
+        ),
+        (
+            "divergent",
+            scratch.write("short.json", &live_rules(&short, true)),
+        ),
+        (
+            "bypassable",
+            scratch.write("full.json", &live_rules(&declared_contexts(), true)),
+        ),
+        ("unverified", scratch.missing("absent.json")),
+    ];
+
+    for (expected, rules) in cases {
+        let output = run_validator(
+            "--report",
+            &[
+                ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+                ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "reporting {expected} exited non-zero, which would newly block PRs: {}",
+            stderr_of(&output)
+        );
+        assert!(
+            stdout_of(&output).contains(&format!("required-gates-live-status={expected}")),
+            "expected {expected}: {}",
+            stdout_of(&output)
+        );
+    }
+}
+
+#[test]
+fn unknown_mode_is_refused() {
+    let output = run_validator("--sometimes", &[]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr_of(&output).contains("usage:"),
+        "{}",
+        stderr_of(&output)
     );
 }


### PR DESCRIPTION
Closes #11084.

## The defect

`homeboy / Required Gates Policy` ran `.github/validate-required-gates.sh --local`, which proves exactly one thing: every context named in `.github/required-gates-ruleset.json` is emitted by `.github/workflows/ci.yml`. Its green tick read as *"GitHub requires these gates"* — a guarantee nobody installed.

Verified live on this branch just now:

```
$ gh api repos/Extra-Chill/homeboy/rules/branches/main
[{"type":"deletion",...},{"type":"non_fast_forward",...}]
```

No required-status-check rule at all. That is why PR #11069 merged nine minutes ahead of a red `homeboy / Test` under a green Required Gates Policy tick. #10795 built the declaration validator and explicitly deferred the live ruleset install to an administrator; that deferral is fine, the check silently reading as full enforcement is not.

## This changes REPORTING, not ENFORCEMENT

**No pull request becomes newly blocked by this PR.** The repository merges fast on purpose and the post-merge Main Guard was removed on purpose; making merges block would re-litigate a settled design decision. The bug was the false assurance, so the fix is that the check tells the truth about which of two different things it verified:

- **declaration** — repository *content*: `ci.yml` emits every declared context. A PR can break and fix this, so it still **fails closed** exactly as before.
- **enforcement** — repository *state*: GitHub actually requires those contexts on `main`. A PR cannot change it. Now **probed and reported, never enforced** — always exit 0.

`reporting_never_blocks_a_pull_request` pins that constraint directly: every non-`enforced` outcome exits 0.

## What the check reports in each state

New `--report` mode (what CI runs) emits one machine-readable provenance line plus a job summary carrying target branch, ruleset id, head SHA, declared contexts, live required contexts, strict flag, and bypass actors — then annotates:

| outcome | annotation | exit |
| --- | --- | --- |
| `enforced` | `::notice::` — live set equals declared set, strict on | 0 |
| `bypassable` | `::warning::` — enforced but actors can bypass; names actor count and `current_user_can_bypass` | 0 |
| `divergent` | `::warning::` — prints declared vs live sets and the apply command | 0 |
| `unenforced` | `::warning::` — "GitHub requires NO status checks on main… This check verified the declaration only" | 0 |
| `unverified` | `::warning::` — live state unreadable; enforcement unproven, **never** reported as present | 0 |

Today's real state on `main` is `unenforced`, so every PR now carries that warning and a summary table instead of an unqualified green tick. Live fields default to `unknown`, not to a plausible-looking `0`, so an *absent measurement* can never be misread as a *measured absence*.

The vocabulary and the "emit provenance before the verdict" shape are lifted from `.github/release-quality-policy.sh`, which already had to learn that "the check passed" and "the check measured something" are different facts.

## Name honesty

The job is renamed `homeboy / Required Gates Policy` → `homeboy / Required Gates Declaration` (payload, workflow, docs, and test updated together). The name was half the false claim; a green tick there now says only what it proved. `--github` is unchanged as the fail-closed administrator verification path and is deliberately not what CI runs.

The enforcement probe uses `GET /repos/{o}/{r}/rules/branches/{branch}` — the *effective* rules for the branch, covering org-level rulesets too and excluding `evaluate`/`disabled` ones — with `GH_TOKEN: ${{ github.token }}`. The ruleset endpoint is read only for bypass evidence and its failure is tolerated, since `bypass_actors` only comes back for callers with write access. Any read failure ⇒ `unverified`.

## Tests

`tests/required_gates_policy_test.rs` grows from 2 tests to 14. No test deleted, none `#[ignore]`d. Fixture hooks (`REQUIRED_GATES_CONFIG` / `_WORKFLOW` / `_LIVE_RULES` / `_LIVE_RULESET` / `_HEAD_SHA`) make every case hermetic — no network, no token:

- acceptance: declared `homeboy / Test` against a ruleset requiring no checks ⇒ `--github` **fails**; matching contexts ⇒ `--github` **passes**
- `--github` also fails closed on `unverified` (an unverifiable ruleset is not a verified one)
- `--report` pins `unenforced`, `unverified`, `enforced`, `divergent`, `bypassable`, and strict-off ⇒ `divergent`
- declaration drift still fails closed in `--report`, and emits no enforcement verdict
- evidence line carries branch, ruleset id, head SHA, declared/live counts, bypass actors
- the CI job is named for the declaration and runs `--report`, never `--local`
- unknown mode exits 2

All five outcomes plus both `--github` verdicts were also exercised by hand against the real repository before commit.

## Compile risk

Low. Changes are one bash script, one workflow, one JSON payload, one doc, and one integration test that only shells out to `bash`. No signature, struct, or enum changed, so there are no call sites to sweep. `cargo fmt --all --check` is clean; `bash -n` is clean. Per this box's build prohibition, no cargo build/test/check was run locally.