### PR TITLE
fix(cleanup): route production temp_dir scratch through the artifact root

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate_executor.rs
+++ b/crates/homeboy-agents/src/agent_task_gate_executor.rs
@@ -104,15 +104,20 @@ fn build_execution(request: &AgentTaskRequest) -> Result<RepoLocalGateExecution>
                 .collect()
         })
         .unwrap_or_default();
-    let artifact_root = config
-        .get("artifact_root")
-        .and_then(Value::as_str)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            std::env::temp_dir()
-                .join("homeboy-repo-local-gates")
-                .join(safe_path_segment(&request.task_id))
-        });
+    // An explicit `artifact_root` wins; otherwise the gate writes under the
+    // configured artifact root. The fallback used to be
+    // `std::env::temp_dir().join("homeboy-repo-local-gates")`, which discarded
+    // the operator's artifact-root configuration entirely and wrote gate
+    // evidence to a path with no owner record, no pin, and no cleanup category
+    // -- invisible to `cleanup --include runtime-tmp` and every other reaper
+    // (#11128). If the artifact root cannot be resolved, that is the error to
+    // report, not a directory to invent.
+    let artifact_root = match config.get("artifact_root").and_then(Value::as_str) {
+        Some(configured) => PathBuf::from(configured),
+        None => homeboy_core::artifacts::root()?
+            .join("repo-local-gates")
+            .join(safe_path_segment(&request.task_id)),
+    };
 
     Ok(RepoLocalGateExecution {
         execution_kind,
@@ -509,35 +514,89 @@ mod tests {
 
     #[test]
     fn repo_local_gate_materializes_inputs_and_typed_outputs() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let script = temp.path().join("gate.mjs");
-        fs::write(
-            &script,
-            "import fs from 'node:fs'; const input = JSON.parse(fs.readFileSync(process.env.INPUT_PACKET_PATH, 'utf8')); fs.writeFileSync(process.env.GATE_RESULT_PATH, JSON.stringify({publish_allowed: input.ok}));",
-        )
-        .expect("write script");
-        let request = request(
-            temp.path(),
-            json!({
-                "execution_kind": "repo_local_gate",
-                "script": "gate.mjs",
-                "inputs": { "input_packet": { "ok": true } },
-                "artifact_outputs": {
-                    "gate_result": { "schema": "example/GateResult/v1", "type": "GateResult" }
-                }
-            }),
-        );
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let script = temp.path().join("gate.mjs");
+            fs::write(
+                &script,
+                "import fs from 'node:fs'; const input = JSON.parse(fs.readFileSync(process.env.INPUT_PACKET_PATH, 'utf8')); fs.writeFileSync(process.env.GATE_RESULT_PATH, JSON.stringify({publish_allowed: input.ok}));",
+            )
+            .expect("write script");
+            let request = request(
+                temp.path(),
+                json!({
+                    "execution_kind": "repo_local_gate",
+                    "script": "gate.mjs",
+                    "inputs": { "input_packet": { "ok": true } },
+                    "artifact_outputs": {
+                        "gate_result": { "schema": "example/GateResult/v1", "type": "GateResult" }
+                    }
+                }),
+            );
 
-        let outcome = run_repo_local_gate_task(&request);
+            let outcome = run_repo_local_gate_task(&request);
 
-        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
-        assert_eq!(outcome.outputs["gate_result"]["publish_allowed"], true);
-        assert_eq!(outcome.typed_artifacts.len(), 1);
-        assert_eq!(outcome.typed_artifacts[0].name, "gate_result");
-        assert_eq!(
-            outcome.typed_artifacts[0].artifact_schema.as_deref(),
-            Some("example/GateResult/v1")
-        );
+            assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+            assert_eq!(outcome.outputs["gate_result"]["publish_allowed"], true);
+            assert_eq!(outcome.typed_artifacts.len(), 1);
+            assert_eq!(outcome.typed_artifacts[0].name, "gate_result");
+            assert_eq!(
+                outcome.typed_artifacts[0].artifact_schema.as_deref(),
+                Some("example/GateResult/v1")
+            );
+        });
+    }
+
+    /// The default gate artifact root is derived from the configured artifact
+    /// root, not from `std::env::temp_dir()` (#11128). Before this, a gate with
+    /// no explicit `artifact_root` silently discarded the operator's
+    /// artifact-root configuration and wrote its evidence to a process temp
+    /// path that no cleanup surface could see.
+    #[test]
+    fn gate_artifact_root_defaults_under_the_configured_artifact_root() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            fs::write(temp.path().join("gate.mjs"), "").expect("write script");
+            let request = request(
+                temp.path(),
+                json!({ "execution_kind": "repo_local_gate", "script": "gate.mjs" }),
+            );
+
+            let execution = build_execution(&request).expect("execution");
+
+            let expected = homeboy_core::artifacts::root()
+                .expect("artifact root")
+                .join("repo-local-gates")
+                .join("gate-task");
+            assert_eq!(execution.artifact_root, expected);
+            assert!(
+                !execution.artifact_root.starts_with(std::env::temp_dir()),
+                "gate artifacts must not fall back to the process temp dir"
+            );
+        });
+    }
+
+    /// An explicit `artifact_root` still wins over the artifact-root default,
+    /// so an operator or caller that pins a location keeps it.
+    #[test]
+    fn explicit_gate_artifact_root_overrides_the_artifact_root_default() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            fs::write(temp.path().join("gate.mjs"), "").expect("write script");
+            let pinned = temp.path().join("pinned-gate-artifacts");
+            let request = request(
+                temp.path(),
+                json!({
+                    "execution_kind": "repo_local_gate",
+                    "script": "gate.mjs",
+                    "artifact_root": pinned.display().to_string()
+                }),
+            );
+
+            let execution = build_execution(&request).expect("execution");
+
+            assert_eq!(execution.artifact_root, pinned);
+        });
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -216,7 +216,13 @@ pub(crate) fn materialize_initial_candidate_baseline(
         ],
         &[("GIT_INDEX_FILE", &index_path)],
     )?;
-    let parent = std::env::temp_dir().join("homeboy-cook-initial-baselines");
+    // A Cook baseline is a full `git worktree` checkout of the candidate tree.
+    // Placing it in `std::env::temp_dir()` put a whole working tree outside
+    // every cleanup surface -- no owner record, no pin, no run binding, and
+    // invisible to the retained-storage report -- and broke outright on a
+    // `noexec` `/tmp` (#11128). The artifact root is the volume the operator
+    // already sized for run bytes.
+    let parent = homeboy_core::artifacts::root()?.join("cook-baseline");
     std::fs::create_dir_all(&parent).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -592,7 +598,10 @@ fn materialize_follow_up_baseline_at(
     let path = match target_path {
         Some(p) => p.to_path_buf(),
         None => {
-            let parent = std::env::temp_dir().join("homeboy-cook-follow-up-baselines");
+            // Same reasoning as the initial-candidate baseline above: a whole
+            // working-tree checkout belongs under the artifact root, not in
+            // the process temp dir where nothing can see or reap it (#11128).
+            let parent = homeboy_core::artifacts::root()?.join("cook-baseline");
             std::fs::create_dir_all(&parent).map_err(|error| {
                 Error::internal_io(
                     error.to_string(),

--- a/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/orphaned_artifact_bytes/tests.rs
@@ -163,6 +163,29 @@ fn subsystem_owned_artifact_root_subtrees_are_never_candidates() {
         fs::create_dir_all(&path).expect("subsystem tree");
         fs::write(path.join("evidence.json"), b"{}").expect("subsystem bytes");
     }
+    // Owners that moved off `std::env::temp_dir()` and onto the artifact root
+    // in #11128. Each writer removes its own scratch; none of them is a
+    // candidate for this sweep, so routing them here must not put live state in
+    // front of a reaper. `deploy-ref` and `cook-baseline` hold whole `git`
+    // worktrees, which is exactly the shape a row-join reaper would eat.
+    for owned in [
+        "deploy-ref/00000000-0000-4000-8000-00000000000a",
+        "deploy-payload/00000000-0000-4000-8000-00000000000b",
+        "cook-baseline/baseline-00000000-0000-4000-8000-00000000000c",
+        "repo-local-gates/gate-task",
+    ] {
+        let path = root.join(owned);
+        fs::create_dir_all(&path).expect("relocated tree");
+        fs::write(path.join("evidence.json"), b"{}").expect("relocated bytes");
+    }
+    // The rig lifecycle index stages a plain *file* at depth two, which is the
+    // same depth and entry type as the staging family. It survives because the
+    // name is not staging-shaped, not because files are exempt.
+    let rig_staging = root
+        .join("rig-resource-lifecycle")
+        .join("homeboy-rig-resource-lifecycle-run-1-42.json");
+    fs::create_dir_all(rig_staging.parent().expect("rig parent")).expect("rig tree");
+    fs::write(&rig_staging, b"{}").expect("rig bytes");
     // A published artifact that has not yet been inserted is the create-then-
     // register window. It must survive too.
     let run_dir = root.join("run-1");
@@ -174,6 +197,7 @@ fn subsystem_owned_artifact_root_subtrees_are_never_candidates() {
     assert_eq!(outcome.inspected_count, 0, "{:#?}", outcome.rows);
     assert_eq!(outcome.removed_count, 0);
     assert!(published.exists());
+    assert!(rig_staging.exists(), "rig lifecycle staging was reaped");
     for owned in [
         "runner",
         "runner-attach",
@@ -184,6 +208,11 @@ fn subsystem_owned_artifact_root_subtrees_are_never_candidates() {
         "recovered-runner-artifacts",
         "executor-finalized",
         "preview-consumer",
+        "deploy-ref",
+        "deploy-payload",
+        "cook-baseline",
+        "repo-local-gates",
+        "rig-resource-lifecycle",
     ] {
         assert!(root.join(owned).exists(), "{owned} was reaped");
     }
@@ -292,6 +321,157 @@ fn owned_name_shapes_match_their_constructors() {
         "scratch-after-{id}"
     )));
     assert!(!is_patch_capture_scratch_name("patch-"));
+}
+
+/// The module docstring's headline invariant: size is advisory and never gates
+/// removal. `best_effort_size` gives up past `MAX_DEPTH` and returns `None`,
+/// which is the same shape a failed `read_dir` produces. The candidate must
+/// still be removed, with `size_measured: false` marking the number as a floor
+/// rather than a fact -- the opposite of the lab workspace pruner, which
+/// silently became a no-op whenever `du` failed.
+#[test]
+fn an_unmeasurable_candidate_is_still_removed_and_reported_as_unmeasured() {
+    let home = tempfile::tempdir().expect("home");
+    let root = home.path();
+    let scratch = root.join("_scratch").join(scratch_name("baseline"));
+    // Past the 64-level walk bound, so the size walk returns `None`.
+    let mut deep = scratch.clone();
+    for level in 0..70 {
+        deep = deep.join(format!("d{level}"));
+    }
+    fs::create_dir_all(&deep).expect("deep tree");
+    fs::write(deep.join("leaf"), b"unreachable by the size walk").expect("leaf bytes");
+
+    let dry = aged_sweep(root, false);
+    assert_eq!(dry.planned_count, 1);
+    assert_eq!(dry.rows.len(), 1);
+    assert_eq!(dry.rows[0].action, "remove");
+    assert!(
+        !dry.rows[0].size_measured,
+        "a walk that gave up must not claim a measurement"
+    );
+    assert_eq!(dry.rows[0].size_bytes, 0);
+    assert_eq!(dry.planned_size_bytes, 0);
+    assert!(scratch.exists(), "dry run must not delete");
+
+    let applied = aged_sweep(root, true);
+    assert_eq!(applied.removed_count, 1, "{:#?}", applied.rows);
+    assert_eq!(applied.skipped_count, 0);
+    assert!(!applied.rows[0].size_measured);
+    assert_eq!(applied.removed_size_bytes, 0);
+    assert!(
+        !scratch.exists(),
+        "an unmeasurable candidate is still reaped"
+    );
+}
+
+/// A missing artifact root is an empty sweep, but an *unreadable* one is an
+/// error. The two must not collapse: reporting "nothing to reap" for a root
+/// that could not be read would hide the leak the sweep exists to surface.
+#[test]
+fn an_artifact_root_that_is_not_a_directory_is_an_error_not_an_empty_sweep() {
+    let home = tempfile::tempdir().expect("home");
+    let not_a_directory = home.path().join("artifacts");
+    fs::write(&not_a_directory, b"an operator put a file here").expect("root file");
+
+    let error = sweep(
+        &not_a_directory,
+        options(true),
+        ORPHANED_ARTIFACT_BYTES_MIN_AGE,
+        clock_past_the_floor(),
+    )
+    .expect_err("an unreadable artifact root is an error");
+    assert_eq!(error.code, crate::ErrorCode::InternalIoError);
+    assert!(
+        error.details["context"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("artifact root"),
+        "the error must name the artifact root it could not read: {:?}",
+        error.details
+    );
+    // The contrast that matters: absence is not failure.
+    let absent = aged_sweep(&home.path().join("never-created"), true);
+    assert_eq!(absent.inspected_count, 0);
+}
+
+fn presentable_row(index: usize) -> OrphanedArtifactBytesRow {
+    OrphanedArtifactBytesRow {
+        path: format!("/artifacts/_scratch/patch-baseline-{index}"),
+        owner: "patch-capture-scratch",
+        entry_type: "directory",
+        age_seconds: 90_000,
+        size_bytes: 4096,
+        size_measured: true,
+        action: "remove".to_string(),
+        reason: "crash-orphaned scratch owned by a single private constructor".to_string(),
+    }
+}
+
+fn presentable_outcome(row_count: usize) -> OrphanedArtifactBytesCleanupOutcome {
+    OrphanedArtifactBytesCleanupOutcome {
+        dry_run: true,
+        artifact_root: PathBuf::from("/artifacts"),
+        min_age_seconds: ORPHANED_ARTIFACT_BYTES_MIN_AGE.as_secs(),
+        inspected_count: row_count,
+        planned_count: row_count,
+        removed_count: 0,
+        skipped_count: 0,
+        planned_size_bytes: 4096 * row_count as u64,
+        removed_size_bytes: 0,
+        truncated: false,
+        rows: (0..row_count).map(presentable_row).collect(),
+        row_detail: None,
+    }
+}
+
+/// The default reader is bounded: more candidates than `OutputBudget::COLLECTION`
+/// allows are trimmed, and the omission is reported with a continue command
+/// rather than silently dropped.
+#[test]
+fn the_default_presentation_bounds_rows_and_reports_the_omission() {
+    let row_count = OutputBudget::COLLECTION.max_items + 5;
+    let mut outcome = presentable_outcome(row_count);
+
+    present_orphaned_artifact_bytes_cleanup(&mut outcome, false, "export".to_string())
+        .expect("present");
+
+    assert_eq!(outcome.rows.len(), OutputBudget::COLLECTION.max_items);
+    let detail = outcome.row_detail.expect("row detail");
+    assert_eq!(detail.presentation, OutputPresentation::BoundedCollection);
+    assert_eq!(detail.total_items, row_count);
+    assert_eq!(detail.returned_items, OutputBudget::COLLECTION.max_items);
+    assert_eq!(detail.omitted_items, 5);
+    assert!(detail.truncated);
+    assert!(
+        !detail.total_bytes_known,
+        "a trimmed page cannot know the total"
+    );
+    assert_eq!(detail.export_command, "export");
+    // The counts describe the whole sweep, not the trimmed page: an operator
+    // must not read a bounded reader as "only 20 paths leaked".
+    assert_eq!(outcome.planned_count, row_count);
+}
+
+/// An explicit export is lossless: every row is returned and nothing is
+/// reported as omitted, so `truncated` cannot be true on the export path.
+#[test]
+fn the_export_presentation_returns_every_row_untruncated() {
+    let row_count = OutputBudget::COLLECTION.max_items + 5;
+    let mut outcome = presentable_outcome(row_count);
+
+    present_orphaned_artifact_bytes_cleanup(&mut outcome, true, "export".to_string())
+        .expect("present");
+
+    assert_eq!(outcome.rows.len(), row_count, "export must not drop rows");
+    let detail = outcome.row_detail.expect("row detail");
+    assert_eq!(detail.presentation, OutputPresentation::LosslessExport);
+    assert_eq!(detail.returned_items, row_count);
+    assert_eq!(detail.omitted_items, 0);
+    assert_eq!(detail.omitted_bytes, 0);
+    assert!(!detail.truncated);
+    assert!(detail.total_bytes_known);
+    assert!(detail.total_bytes > 0);
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -102,10 +102,17 @@ impl ExactRefCheckout {
         };
         ensure_resolved_commit_is_available(&source_root, component, &identity)?;
         let component_prefix = git::get_component_path_prefix(&component.local_path);
-        let parent = std::env::temp_dir().join("homeboy-deploy-ref");
+        // The exact-ref worktree is a full source checkout. It used to land in
+        // `std::env::temp_dir()`, which put it outside every cleanup surface --
+        // no owner record, no pin, no run binding, invisible to
+        // `cleanup --include runtime-tmp` and to the retained-storage report --
+        // and broke outright on a `noexec` `/tmp` (#11128). The artifact root
+        // is the volume the operator already sized for run bytes, so it is
+        // where a checkout this large belongs.
+        let parent = homeboy_core::artifacts::root()?.join("deploy-ref");
         std::fs::create_dir_all(&parent).map_err(|err| {
             Error::internal_io(
-                format!("Failed to create exact-ref deploy temp directory: {err}"),
+                format!("Failed to create exact-ref deploy checkout directory: {err}"),
                 Some("deploy.ref.temp".to_string()),
             )
         })?;

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -587,8 +587,12 @@ fn prepare_payload(
 }
 
 fn copy_prepared_artifact(source: &Path) -> Result<(PathBuf, PreparedArtifactCleanup)> {
-    let directory = std::env::temp_dir()
-        .join("homeboy-deploy-payload")
+    // Prepared payloads are whole release artifacts. Staging them in
+    // `std::env::temp_dir()` left them with no owner record, no pin, and no
+    // cleanup category, so a crash between the copy and `PreparedArtifactCleanup`
+    // leaked them permanently and invisibly (#11128).
+    let directory = homeboy_core::artifacts::root()?
+        .join("deploy-payload")
         .join(uuid::Uuid::new_v4().to_string());
     std::fs::create_dir_all(&directory).map_err(|error| {
         Error::internal_io(

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -1536,7 +1536,20 @@ impl RigRunObserver {
         index: &ResourceLifecycleIndex,
         pipeline: Option<&PipelineOutcome>,
     ) -> Result<()> {
-        let path = std::env::temp_dir().join(format!(
+        // Staged under the artifact root, not `std::env::temp_dir()`. The
+        // record-then-unlink below is the only thing that ever removed this
+        // file, so a crash between the write and the unlink leaked it to a path
+        // with no owner record, no pin, and no cleanup category (#11128).
+        // Recording it also copies it into the artifact root, so resolving the
+        // root here fails no case that would otherwise have succeeded.
+        let directory = homeboy_core::artifacts::root()?.join("rig-resource-lifecycle");
+        fs::create_dir_all(&directory).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", directory.display())),
+            )
+        })?;
+        let path = directory.join(format!(
             "homeboy-rig-resource-lifecycle-{}-{}.json",
             self.run_id,
             std::process::id()


### PR DESCRIPTION
Asks 1 and 3 of #11128. Ask 2 (rig log rotation) already landed.

## Ask 3 — `temp_dir()` sites routed through the artifact root

Each site now resolves `homeboy_core::artifacts::root()?` and writes under a
named top-level subtree, following the already-converted
`homeboy-tunnel/src/preview_consumer.rs`.

| Site | New subtree | Note |
|---|---|---|
| `homeboy-rig/src/runner.rs` | `rig-resource-lifecycle/` | record-then-unlink staging; a crash between the two leaked it |
| `homeboy-deploy/src/orchestration_ref_checkout.rs` | `deploy-ref/` | **whole `git` worktree checkout** |
| `homeboy-deploy/src/preparation.rs` | `deploy-payload/` | whole release artifact copy |
| `homeboy-agents/src/agent_task_gate_executor.rs` | `repo-local-gates/` | fallback **silently discarded a configured artifact root**; now propagates the error |
| `homeboy-agents/.../cook_baseline.rs` (x2) | `cook-baseline/` | **whole working-tree checkouts** |

The gate executor was the sharpest case, and got the same treatment
`preview_consumer.rs` got: an explicit `artifact_root` still wins, but the
fallback no longer invents a directory when the configured root cannot be
resolved.

`orchestration_ref_checkout.rs` also gets a one-word error-message fix — it
still said "temp directory".

### Sites skipped, and why

**Seven of the ~13 sites named in the issue are `#[cfg(test)]` helpers, not
production writers.** They never run on an operator's machine, so they are
outside the cleanup problem entirely, and converting them to
`tempfile::tempdir()` changes fixture lifetimes in ways I could not verify
without compiling (see below). Left alone:

- `homeboy-core/src/engine/undo/{snapshot.rs:507,516, entry.rs:95, rollback.rs:75}` — test helpers (`#[cfg(test)]` at `snapshot.rs:495`, `entry.rs:84`, `rollback.rs:63`)
- `homeboy-cli/src/commands/audit.rs:543` — `fn tmp_dir` inside `#[cfg(test)]` at `:497`
- `homeboy-code-audit/src/descriptor_runtime.rs:308,373` — `#[cfg(test)]` at `:276`
- `homeboy-release/src/release/executor.rs:1287` — `#[cfg(test)]` at `:506`
- `homeboy-agents/src/agent_task_provider/command_runner.rs` — the only `temp_dir()` left in that file is `fn test_executor_request`, itself `#[cfg(test)]`

Not touched because they are correct as-is: `homeboy-core/src/cleanup/self_artifacts.rs:392` *scans* the temp dir (that is the point), and `homeboy-extension/src/runtime_helper.rs:171,293` are runtime-helper paths, not artifact bytes — a separate family from this ask.

## Ask 1 — the "never reaped" gap

`subsystem_owned_artifact_root_subtrees_are_never_candidates` now also pins the
five subtrees this PR introduces. That coupling is the point: routing live
`git` worktrees under the artifact root must not put them in front of a reaper,
and `deploy-ref`/`cook-baseline` are exactly the shape a row-join reaper would
eat. The rig case is asserted as a *file* at depth two — same depth and entry
type as the staging family — so it is clear it survives because the name is not
staging-shaped, not because files are exempt.

Three branches of the sweep gain first coverage:

- **`an_unmeasurable_candidate_is_still_removed_and_reported_as_unmeasured`** — the module's headline invariant ("size is advisory and never gates removal") had no test. A tree nested past `best_effort_size`'s 64-level bound makes the measurement return `None`; the candidate must still be reaped, with `size_measured: false`. This is the exact failure mode the docstring cites from the lab workspace pruner, where a failed `du` silently turned prune into a no-op.
- **`an_artifact_root_that_is_not_a_directory_is_an_error_not_an_empty_sweep`** — a missing root is an empty sweep, but an unreadable one must not collapse into the same answer; reporting "nothing to reap" would hide the leak the sweep exists to surface.
- **`the_default_presentation_bounds_rows_and_reports_the_omission` / `the_export_presentation_returns_every_row_untruncated`** — `present_orphaned_artifact_bytes_cleanup` had no coverage at all on either path.

Gate-executor tests gain `gate_artifact_root_defaults_under_the_configured_artifact_root` and `explicit_gate_artifact_root_overrides_the_artifact_root_default`, and the existing execution test moves inside `with_isolated_home` so it no longer writes into the real `$HOME` now that the default resolves to the artifact root.

No tests were deleted or `#[ignore]`d.

## Ask 4 is blocked on a human decision — deliberately not done

`--include-untagged` for `runs artifact cleanup-downloads` is **not** in this PR.
Its current behavior is pinned by
`runner_downloads/tests.rs` `an_untagged_cache_is_retained_forever_no_matter_how_old`.
A test that pins an absence is a design decision, not an oversight, and
un-pinning it needs an explicit call from a human. Ask 2 (rig log rotation)
already landed separately.

## Compile risk

**I could not compile this** — the VPS runs five agents on 15Gi and cannot
absorb `cargo build`/`check`. Only `cargo fmt` was run. CI is the gate.

Reviewed by hand instead:

- **Signatures changed: none. Structs changed: none. Enums changed: none. New public API: none.** Every change is inside a function body or a test.
- All six converted sites are in functions already returning `homeboy_core::Result`, so `?` is valid at each; each file already imports `Result` from `homeboy_core` (`homeboy_core::{Error, Result}` or `homeboy_core::error::{Error, Result}`), and all three crates already depend on `homeboy-core`.
- `homeboy-rig` needed an added `create_dir_all` (the temp dir always existed, the artifact-root subtree does not); `fs` and `Error` were already in scope in that function.
- The gate executor's `unwrap_or_else` became a `match` because the fallback is now fallible; `PathBuf` and `safe_path_segment` are both still used.
- `homeboy_core::test_support` is already a dev-dependency feature of `homeboy-agents` and is used by its existing tests.
- Assertions on `Error` use `error.code` and `error.details["context"]`, not `to_string()` — `Display for Error` renders only `message` ("IO error"), so a string match there would have failed.