### PR TITLE
fix(runner): report unverifiable daemons as unverified, not healthy

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
+++ b/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
@@ -488,7 +488,14 @@ fn lab_homeboy_provenance_from_parts(
     if let Some(stale_daemon) = stale_daemon {
         diagnostics.push(LabHomeboyProvenanceDiagnostic {
             severity: stale_daemon.severity,
-            code: "runner_stale_daemon",
+            // A report that compared nothing is not a stale-daemon claim
+            // (#11106); giving it the same code would make the two
+            // indistinguishable to anything reading the diagnostic stream.
+            code: if stale_daemon.is_unverified() {
+                "runner_daemon_unverified"
+            } else {
+                "runner_stale_daemon"
+            },
             message: stale_daemon.message.clone(),
             action: stale_daemon.refresh_command.clone(),
         });

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -305,8 +305,15 @@ pub(super) fn operator_summary(report: &RunnerStatusReport) -> RunnerOperatorSum
     if !report.connected {
         risk.push("disconnected".to_string());
     }
-    if report.stale_daemon.is_some() {
-        risk.push("stale_daemon".to_string());
+    // "unverified" is its own risk, distinct from a proven mismatch. Rendering
+    // both as `stale_daemon` would make "I could not check" indistinguishable
+    // from "it is stale" (#11106).
+    if let Some(warning) = report.stale_daemon.as_ref() {
+        risk.push(if warning.is_unverified() {
+            "unverified_daemon".to_string()
+        } else {
+            "stale_daemon".to_string()
+        });
     }
     if report.active_job_count > 0 {
         risk.push(format!("{} active job(s)", report.active_job_count));

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -260,8 +260,10 @@ fn runner_runtime_input(runner: Runner, status: Option<&RunnerStatusReport>) -> 
         .and_then(|report| report.session.as_ref());
     let daemon_version = session.map(|session| session.homeboy_version.clone());
     let daemon_build_identity = session.and_then(|session| session.homeboy_build_identity.clone());
+    // Drift is an observed mismatch. A report that compared nothing is not
+    // drift — it is an unverified runner (#11106).
     let daemon_drift = status
-        .map(|report| report.stale_daemon.is_some())
+        .map(|report| report.admission_blocking_stale_daemon().is_some())
         .unwrap_or(false);
 
     RunnerRuntimeInput {

--- a/crates/homeboy-lab-runner/src/availability_provider.rs
+++ b/crates/homeboy-lab-runner/src/availability_provider.rs
@@ -14,19 +14,30 @@ pub struct RunnerAvailability;
 impl RunnerAvailabilityProvider for RunnerAvailability {
     fn controller_runner_availability(&self, runner_id: &str) -> AgentTaskLoopRunnerAvailability {
         match crate::status(runner_id) {
+            // A report that established nothing does not block execution — it
+            // is surfaced as `daemon_verification` so the operator can see the
+            // gap without the runner dropping out of service (#11106).
             Ok(status)
                 if status.connected
-                    && status.stale_daemon.is_none()
+                    && status.admission_blocking_stale_daemon().is_none()
                     && status.active_job_state == RunnerActiveJobState::Available =>
             {
                 AgentTaskLoopRunnerAvailability::Available
             }
             Ok(status) => AgentTaskLoopRunnerAvailability::Unavailable {
                 reason: format!(
-                    "runner `{runner_id}` is not available for controller action execution: state={:?}, connected={}, stale_daemon={}, active_job_state={:?}",
+                    "runner `{runner_id}` is not available for controller action execution: state={:?}, connected={}, stale_daemon={}, daemon_verification={}, active_job_state={:?}",
                     status.state,
                     status.connected,
-                    status.stale_daemon.is_some(),
+                    status.admission_blocking_stale_daemon().is_some(),
+                    status
+                        .stale_daemon
+                        .as_ref()
+                        .map_or("compared", |warning| if warning.is_unverified() {
+                            "unverified"
+                        } else {
+                            "compared"
+                        }),
                     status.active_job_state
                 ),
             },

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -31,6 +31,7 @@ use super::session::{
     RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence, RunnerSession,
     RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStaleRuntimePath,
     RunnerStatusReport, RunnerTunnelMode, RunnerTunnelProcessStartIdentity,
+    REVERSE_UNVERIFIED_REASON,
 };
 use super::{load, remote_runner_homeboy_path, Runner, RunnerKind};
 use homeboy_core::broker_auth;
@@ -2785,29 +2786,82 @@ pub(crate) fn local_live_session(
     Ok(session_is_live_with_timeout(&session, timeout).then_some(session))
 }
 
+/// A connected reverse session has no controller-side identity probe.
+///
+/// The direct-SSH path reads the runner's configured binary over SSH; a reverse
+/// runner is reached only through the broker, which exposes no equivalent
+/// identity endpoint today. Reporting `None` here meant "no warning", which
+/// every consumer reads as healthy — so a reverse lab running an arbitrarily
+/// old binary stayed fully eligible with nothing ever checked (#11106).
+///
+/// This names the gap instead. It performs no probing: the verdict is derived
+/// entirely from the session record already in hand, so it adds no request to
+/// the probe budget (#11080). When the broker grows an identity endpoint, this
+/// becomes a real comparison and the `Unavailable` verdict disappears on its
+/// own.
+fn tunnel_verification_gap(
+    runner: &Runner,
+    session: &RunnerSession,
+) -> Option<RunnerStaleDaemonWarning> {
+    if session.mode != RunnerTunnelMode::Reverse {
+        return None;
+    }
+    let reported = session
+        .homeboy_build_identity
+        .as_deref()
+        .unwrap_or(&session.homeboy_version);
+    Some(RunnerStaleDaemonWarning::verification_unavailable(
+        &runner.id,
+        session.homeboy_version.clone(),
+        session.homeboy_build_identity.clone(),
+        REVERSE_UNVERIFIED_REASON,
+        format!(
+            "reverse-connected runner `{}` reports `{reported}`, but this controller has no path to verify it: the identity probe runs over SSH and a reverse session is reached through the broker. Its daemon compatibility is UNVERIFIED — not proven fresh and not proven stale. Confirm it out of band with `homeboy runner doctor {} --scope lab-offload`.",
+            runner.id, runner.id,
+        ),
+    ))
+}
+
 fn stale_daemon_warning(
     runner: &Runner,
     session: Option<&RunnerSession>,
     connected: bool,
 ) -> Result<Option<RunnerStaleDaemonWarning>> {
-    if !connected || runner.kind != RunnerKind::Ssh {
+    if !connected {
         return Ok(None);
     }
     let Some(session) = session else {
         return Ok(None);
     };
-    if session.mode != RunnerTunnelMode::DirectSsh {
+    // The verification gap is a property of the tunnel, not of the runner
+    // transport kind, so it is decided before the SSH-only probe path below.
+    if let Some(gap) = tunnel_verification_gap(runner, session) {
+        return Ok(Some(gap));
+    }
+    if runner.kind != RunnerKind::Ssh || session.mode != RunnerTunnelMode::DirectSsh {
         return Ok(None);
     }
     let homeboy = remote_runner_homeboy_path(runner, "runner status stale-daemon diagnostics")?;
     let Some((_server_id, _server, client)) = resolve_ssh_runner(runner)? else {
         return Ok(None);
     };
-    let current_identity = bounded_remote_homeboy_identity(&client, homeboy, Some(&runner.id))
-        .unwrap_or_else(|_| RemoteHomeboyIdentity {
-            version: session.homeboy_version.clone(),
-            build_identity: None,
-        });
+    // A failed probe read nothing, so there is nothing to compare. Substituting
+    // the session's own version here made `versions_match` trivially true and
+    // published a fabricated "current version" alongside a vague unverifiable
+    // message, hiding the actual SSH failure (#11106).
+    let current_identity = match bounded_remote_homeboy_identity(&client, homeboy, Some(&runner.id))
+    {
+        Ok(identity) => identity,
+        Err(probe_error) => {
+            return Ok(Some(RunnerStaleDaemonWarning::probe_failed(
+                &runner.id,
+                session.homeboy_version.clone(),
+                session.homeboy_build_identity.clone(),
+                homeboy,
+                probe_error,
+            )));
+        }
+    };
     let current_version = current_identity.version.clone();
     let controller_identity = homeboy_product_identity::build_identity();
     let observed_session_version = session

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 
-use crate::RunnerAvailability;
+use crate::{RunnerAvailability, RunnerDaemonVerification};
 
 use super::*;
 
@@ -1266,6 +1266,122 @@ fn runtime_path_warning_uses_rebuild_specific_message() {
         warning.recovery_commands,
         ["homeboy runner refresh-homeboy homeboy-lab --ref same --reconnect"]
     );
+}
+
+/// #11106 failure mode 1: the identity probe's error was discarded and the
+/// unread "current" version was replaced with the session's own recorded
+/// version, which made `versions_match` trivially true and published a
+/// fabricated current version. The failure must now be the report.
+#[test]
+fn failed_identity_probe_reports_the_error_instead_of_the_session_version() {
+    let probe_error = "ssh: connect to host lab port 22: Connection refused";
+    let warning = RunnerStaleDaemonWarning::probe_failed(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        Some("homeboy 0.328.0+session".to_string()),
+        "/opt/homeboy/bin/homeboy",
+        probe_error.to_string(),
+    );
+
+    assert_eq!(warning.probe_error.as_deref(), Some(probe_error));
+    assert!(
+        warning.message.contains(probe_error),
+        "the real probe failure must be visible: {}",
+        warning.message
+    );
+    // The unread side is a sentinel, never a copy of the side it failed to
+    // compare against.
+    assert_eq!(warning.current_homeboy_version, "unverified");
+    assert_ne!(
+        warning.current_homeboy_version,
+        warning.session_homeboy_version
+    );
+    assert!(warning.current_homeboy_build_identity.is_none());
+    assert_eq!(warning.severity, "unknown");
+    assert_eq!(warning.verification, RunnerDaemonVerification::ProbeFailed);
+    assert_eq!(
+        warning.compatibility_reason,
+        Some("identity_probe_failed"),
+        "the vague `with_identity_unverifiable` message is not the diagnosis"
+    );
+    assert!(warning.is_unverified());
+    // A probe that failed on a runner that *has* a probe is a real anomaly and
+    // still fences admission, exactly as the fabricated warning did.
+    assert!(warning.blocks_admission());
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner doctor homeboy-lab --scope lab-offload"],
+        "the answer to an unread binary is to re-probe it, not to replace it"
+    );
+}
+
+/// #11106 failure mode 2: `stale_daemon_warning` returned `None` for every
+/// non-direct-SSH session, so a reverse-connected lab on an arbitrarily old
+/// binary read as healthy with nothing ever checked.
+#[test]
+fn reverse_session_is_checked_and_reports_an_unverified_verdict() {
+    let runner = Runner {
+        id: "homeboy-lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: None,
+        workspace_root: Some("/srv/homeboy".to_string()),
+        settings: Default::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: Default::default(),
+    };
+    let session = super::reverse_controller_session();
+
+    let warning = tunnel_verification_gap(&runner, &session).expect(
+        "a reverse session has no controller-side identity probe and must say so, not stay silent",
+    );
+
+    assert_eq!(warning.severity, "unknown");
+    assert_eq!(warning.verification, RunnerDaemonVerification::Unavailable);
+    assert_eq!(warning.compatibility_reason, Some("reverse_unverified"));
+    assert!(warning.is_unverified());
+    assert!(warning.message.contains("homeboy test+abc123"));
+    assert!(warning.message.contains("UNVERIFIED"));
+    // The counter-property (#11101): unverified is not stale. Fencing every
+    // reverse lab would trade this bug for the opposite one.
+    assert!(!warning.blocks_admission());
+    assert_eq!(
+        warning.recovery_commands,
+        ["homeboy runner doctor homeboy-lab --scope lab-offload"]
+    );
+
+    let mut direct = session.clone();
+    direct.mode = RunnerTunnelMode::DirectSsh;
+    assert!(
+        tunnel_verification_gap(&runner, &direct).is_none(),
+        "a direct-SSH session has a real probe and must be compared, not excused"
+    );
+}
+
+/// The three states must be distinguishable by every admission consumer, not
+/// collapsed back into "there is a warning".
+#[test]
+fn unverified_reports_fence_nothing_while_compared_mismatches_still_do() {
+    let unverified = RunnerStaleDaemonWarning::verification_unavailable(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        None,
+        "reverse_unverified",
+        "no probe".to_string(),
+    );
+    let mismatch = RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "0.328.0".to_string(),
+        "0.329.0".to_string(),
+        Some("homeboy 0.328.0+a".to_string()),
+        Some("homeboy 0.329.0+b".to_string()),
+    );
+
+    assert!(!mismatch.is_unverified());
+    assert!(mismatch.blocks_admission());
+    assert!(unverified.is_unverified());
+    assert!(!unverified.blocks_admission());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1140,7 +1140,10 @@ fn verify_refreshed_daemon_status(
             "runner `{runner_id}` reconnect did not persist an active daemon session"
         )));
     }
-    if let Some(stale_daemon) = &status.stale_daemon {
+    // A refresh must prove convergence. An observed mismatch and a failed probe
+    // both fail that proof; only a runner with no verification path at all is
+    // excused, and it never reaches this SSH-only path (#11106).
+    if let Some(stale_daemon) = status.admission_blocking_stale_daemon() {
         return Err(Error::internal_unexpected(format!(
             "runner `{runner_id}` reconnect retained a stale daemon: {}",
             stale_daemon.message

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2878,6 +2878,8 @@ mod tests {
         let mut status = runner_status(true);
         status.stale_daemon = Some(RunnerStaleDaemonWarning {
             severity: "warning",
+            verification: crate::RunnerDaemonVerification::Compared,
+            probe_error: None,
             mismatch_predicate: "active_daemon_control_plane_version != job_command_binary_version",
             session_homeboy_version: "0.289.1".to_string(),
             current_homeboy_version: "0.289.3".to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -400,7 +400,12 @@ pub(crate) fn lab_runner_homeboy_has_blocking_drift_against_configured_identity(
     // Build-identity drift within the runner (active daemon control plane vs the
     // configured job command binary) is an internal-inconsistency signal that is
     // always blocking regardless of the controller↔runner version policy.
-    if status.stale_daemon.is_some() {
+    //
+    // Drift is an *observed* inconsistency. A report that compared nothing
+    // observed no drift, and this branch is exactly where every reverse runner
+    // now lands (#11106) — blocking on it would take the whole class out of
+    // service on the strength of a gap rather than a mismatch.
+    if status.admission_blocking_stale_daemon().is_some() {
         return true;
     }
     match classify_runner_homeboy_version_drift(status) {

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -301,10 +301,10 @@ pub use session::{
     LabRunnerHandoff, ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,
     RunnerActiveJobState, RunnerActiveJobsSnapshot, RunnerAdmissionSummary, RunnerArtifactRef,
     RunnerAvailability, RunnerChangedRuntimePath, RunnerConnectReport,
-    RunnerDaemonGenerationStatus, RunnerDisconnectReport, RunnerFailureKind, RunnerJob,
-    RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence, RunnerLifecycleOwner,
-    RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerRecoveryState, RunnerResult,
-    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerDaemonGenerationStatus, RunnerDaemonVerification, RunnerDisconnectReport,
+    RunnerFailureKind, RunnerJob, RunnerLeaselessRecoveryContract, RunnerLeaselessRecoveryEvidence,
+    RunnerLifecycleOwner, RunnerMutationArtifacts, RunnerNamedWorkspaceLease, RunnerRecoveryState,
+    RunnerResult, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
     RunnerStaleRuntimePath, RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceLease,
     RunnerWorkspaceLeaseSet,
 };
@@ -743,7 +743,8 @@ pub fn lab_runner_readiness() -> Result<LabRunnerReadiness> {
                 mode,
                 connected: status.connected,
                 capacity: runner.settings.concurrency_limit,
-                stale_daemon: status.stale_daemon.is_some(),
+                stale_daemon: status.admission_blocking_stale_daemon().is_some(),
+                unverified_daemon: status.unverified_daemon().is_some(),
                 admission_fresh: status.daemon_fresh_for_admission(),
                 admission_remediation: status
                     .admission_action()
@@ -786,7 +787,8 @@ pub fn refresh_detached_queue_runner() -> Result<Option<String>> {
             mode,
             connected: status.connected,
             capacity: runner.settings.concurrency_limit,
-            stale_daemon: status.stale_daemon.is_some(),
+            stale_daemon: status.admission_blocking_stale_daemon().is_some(),
+            unverified_daemon: status.unverified_daemon().is_some(),
             admission_fresh: status.daemon_fresh_for_admission(),
             admission_remediation: status
                 .admission_action()
@@ -894,7 +896,13 @@ struct DefaultLabRunnerCandidate {
     mode: RunnerTunnelMode,
     connected: bool,
     capacity: Option<usize>,
+    /// A *proven* compatibility mismatch, or a probe that failed on a runner
+    /// that has one. Hard-fences selection.
     stale_daemon: bool,
+    /// The runner has no controller-side verification path at all, so its
+    /// freshness was never established. Deliberately not a fence — see
+    /// `DefaultLabRunnerCandidate::readiness`.
+    unverified_daemon: bool,
     admission_fresh: bool,
     admission_remediation: Option<String>,
     active_jobs: usize,
@@ -907,6 +915,11 @@ struct DefaultLabRunnerReadiness {
     eligible: bool,
     score: i32,
 }
+
+/// How far an unverified runner ranks below an otherwise identical verified
+/// one. Large enough that any verified candidate wins, small enough that the
+/// score stays positive so the runner remains eligible.
+const UNVERIFIED_DAEMON_SELECTION_PENALTY: i32 = 50;
 
 impl DefaultLabRunnerCandidate {
     fn availability(&self) -> RunnerAvailability {
@@ -927,6 +940,11 @@ impl DefaultLabRunnerCandidate {
                 .reasons
                 .push("daemon_freshness_unavailable".to_string());
             availability.accepts_jobs = false;
+        }
+        // Named, not fenced: an unverifiable runner keeps accepting work, but
+        // an operator reading availability can see that nothing checked it.
+        if self.unverified_daemon {
+            availability.reasons.push("daemon_unverified".to_string());
         }
         availability
     }
@@ -969,6 +987,14 @@ impl DefaultLabRunnerCandidate {
         if self.mode == RunnerTunnelMode::DirectSsh {
             score += 5;
         }
+        // A runner whose freshness was never established ranks below every
+        // verified peer but stays selectable. Excluding it would take every
+        // reverse-connected lab out of service the moment the gap is reported,
+        // which trades this bug for #11101's — an unverified runner is neither
+        // healthy nor stale, and the ordering is where that shows up.
+        if self.unverified_daemon {
+            score -= UNVERIFIED_DAEMON_SELECTION_PENALTY;
+        }
         score -= self.active_jobs.min(50) as i32;
 
         DefaultLabRunnerReadiness {
@@ -997,7 +1023,8 @@ pub(crate) fn default_lab_runner_availability() -> Result<Vec<RunnerAvailability
                 mode,
                 connected: status.connected,
                 capacity: runner.settings.concurrency_limit,
-                stale_daemon: status.stale_daemon.is_some(),
+                stale_daemon: status.admission_blocking_stale_daemon().is_some(),
+                unverified_daemon: status.unverified_daemon().is_some(),
                 admission_fresh: status.daemon_fresh_for_admission(),
                 admission_remediation: status
                     .admission_action()
@@ -1488,6 +1515,7 @@ mod tests {
             connected,
             capacity: None,
             stale_daemon: false,
+            unverified_daemon: false,
             admission_fresh: true,
             admission_remediation: None,
             active_jobs: 0,
@@ -1514,6 +1542,53 @@ mod tests {
         );
         assert_eq!(refreshed.state, LabRunnerReadinessState::ConnectedReady);
         assert_eq!(refreshed.selected_runner_id.as_deref(), Some("lab-a"));
+    }
+
+    /// #11106's counter-property. Reverse runners now report an `unverified`
+    /// daemon where they previously reported nothing at all. That must rank
+    /// them below a verified peer without fencing them, because fencing every
+    /// reverse lab is #11101's failure mode wearing this fix's clothes.
+    #[test]
+    fn unverified_runner_ranks_below_verified_without_dropping_out() {
+        let mut unverified =
+            default_lab_candidate("lab-unverified", RunnerTunnelMode::Reverse, true);
+        unverified.unverified_daemon = true;
+
+        let readiness = unverified.readiness();
+        assert!(
+            readiness.eligible,
+            "an unverified runner is not a stale runner and must stay selectable"
+        );
+        let verified = default_lab_candidate("lab-verified", RunnerTunnelMode::Reverse, true);
+        assert!(
+            readiness.score < verified.readiness().score,
+            "unverified must rank strictly below an otherwise identical verified runner"
+        );
+        assert!(readiness.score > 0);
+
+        // Alone, it is still the default: a deprioritized runner is not an
+        // absent one.
+        assert_eq!(
+            resolve_default_lab_runner_from_candidates(None, vec![unverified.clone()]).as_deref(),
+            Some("lab-unverified")
+        );
+        // Against a verified peer, the verified one wins.
+        assert_eq!(
+            resolve_default_lab_runner_from_candidates(None, vec![unverified.clone(), verified])
+                .as_deref(),
+            Some("lab-verified")
+        );
+
+        // And it is reported, not silent.
+        let readiness = lab_runner_readiness_from_candidates(None, vec![unverified]);
+        assert_eq!(readiness.state, LabRunnerReadinessState::ConnectedReady);
+        assert!(readiness.reasons.contains(&"daemon_unverified".to_string()));
+        assert_eq!(readiness.available_runner_ids, ["lab-unverified"]);
+
+        // A *proven* mismatch still fences, so the two states never converge.
+        let mut stale = default_lab_candidate("lab-stale", RunnerTunnelMode::Reverse, true);
+        stale.stale_daemon = true;
+        assert!(!stale.readiness().eligible);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -108,8 +108,15 @@ impl RuntimeMaterializationStatus {
                 format!("active daemon build `{active}`, job command build `{job}`")
             })
             .unwrap_or_else(|| "inspect the runner stale-daemon diagnostic".to_string());
+        // A severity of `unknown` means nothing was compared, so calling it a
+        // stale daemon would report a mismatch that was never observed.
+        let headline = if severity == crate::session::RUNNER_DAEMON_SEVERITY_UNKNOWN {
+            "daemon compatibility UNVERIFIED"
+        } else {
+            "stale daemon"
+        };
         Some(format!(
-            "Runner `{}` stale daemon severity={severity}: {reason}; active daemon control plane is `{active_daemon}`, job command binary is `{job_binary}`. Refresh with `{refresh}` before using runner/Lab status as version evidence.",
+            "Runner `{}` {headline} severity={severity}: {reason}; active daemon control plane is `{active_daemon}`, job command binary is `{job_binary}`. Run `{refresh}` before using runner/Lab status as version evidence.",
             self.runner_id
         ))
     }

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -678,11 +678,35 @@ impl RunnerStatusReport {
         self.state == RunnerSessionState::Connected
     }
 
+    /// The stale-daemon report that fences admission.
+    ///
+    /// `None` when the runner carries no report at all *or* when the only
+    /// report present records that this runner class cannot be verified. The
+    /// latter is deliberately not a fence: see
+    /// [`RunnerStaleDaemonWarning::blocks_admission`].
+    pub fn admission_blocking_stale_daemon(&self) -> Option<&RunnerStaleDaemonWarning> {
+        self.stale_daemon
+            .as_ref()
+            .filter(|warning| warning.blocks_admission())
+    }
+
+    /// The report that records an unverifiable runner, as opposed to a proven
+    /// mismatch. Present exactly when freshness was never established.
+    pub fn unverified_daemon(&self) -> Option<&RunnerStaleDaemonWarning> {
+        self.stale_daemon
+            .as_ref()
+            .filter(|warning| !warning.blocks_admission())
+    }
+
     /// The daemon freshness fence shared by status, placement, and dispatch.
     /// A compatibility warning or a daemon's own non-fresh observation both
     /// prohibit new work; rotation safety is evaluated separately.
+    ///
+    /// A report that established nothing is not a fence — it is surfaced as
+    /// `unverified` and scored down instead, so an unprobeable runner is
+    /// neither silently healthy nor uniformly stale.
     pub fn daemon_fresh_for_admission(&self) -> bool {
-        self.stale_daemon.is_none()
+        self.admission_blocking_stale_daemon().is_none()
             && self
                 .daemon_freshness
                 .as_ref()
@@ -696,7 +720,7 @@ impl RunnerStatusReport {
         let mut availability = RunnerAvailability::from_status_parts(
             self.runner_id.clone(),
             self.is_connected(),
-            self.stale_daemon.is_some(),
+            self.admission_blocking_stale_daemon().is_some(),
             // Aggregate accounting can retain unresolved generations while the
             // typed view can transiently be ahead of it. Capacity must respect
             // either owner without duplicating #9474's accounting policy.
@@ -704,11 +728,17 @@ impl RunnerStatusReport {
             &self.active_job_state,
             capacity,
         );
-        if !self.daemon_fresh_for_admission() && self.stale_daemon.is_none() {
+        if !self.daemon_fresh_for_admission() && self.admission_blocking_stale_daemon().is_none() {
             availability
                 .reasons
                 .push("daemon_freshness_unavailable".to_string());
             availability.accepts_jobs = false;
+        }
+        // A runner whose freshness was never established is named, not fenced.
+        // The reason travels with the availability record so an operator can
+        // see *why* it was deprioritized without it dropping out of service.
+        if self.unverified_daemon().is_some() {
+            availability.reasons.push("daemon_unverified".to_string());
         }
         availability
     }
@@ -865,7 +895,7 @@ impl RunnerStatusReport {
     pub fn recovery_state(&self) -> RunnerRecoveryState {
         if !self.is_connected() {
             RunnerRecoveryState::Disconnected
-        } else if self.stale_daemon.is_some() {
+        } else if self.admission_blocking_stale_daemon().is_some() {
             RunnerRecoveryState::StaleDaemon {
                 active_job_count: self.active_job_count,
             }
@@ -1107,6 +1137,8 @@ mod status_serialization_tests {
         report.active_job_state = RunnerActiveJobState::Available;
         report.stale_daemon = Some(RunnerStaleDaemonWarning {
             severity: "error",
+            verification: RunnerDaemonVerification::Compared,
+            probe_error: None,
             mismatch_predicate: "active_daemon_control_plane_version != job_command_binary_version",
             session_homeboy_version: "0.299.0".to_string(),
             current_homeboy_version: "0.299.2".to_string(),
@@ -1347,9 +1379,73 @@ mod status_serialization_tests {
     }
 }
 
+/// Whether a stale-daemon report is evidence of an observed mismatch or an
+/// admission that nothing could be compared at all.
+///
+/// A compatibility gate has three answers, not two: fresh, stale, and *not
+/// established*. Collapsing the third into either of the other two is how the
+/// signal becomes untrustworthy — silently fresh (#11106) or uniformly stale
+/// (#11101). The same three-state shape is already used by
+/// `runtime_overlay_freshness::RuntimeOverlayBuildStatus`, whose
+/// `UnknownProbeFailed` variant exists because a failed probe once certified a
+/// stale build as current.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerDaemonVerification {
+    /// The runner's configured identity was read and compared. Everything in
+    /// the warning body is an observation.
+    Compared,
+    /// A verification path exists for this runner, but the probe that feeds it
+    /// failed. Nothing was compared; `probe_error` carries the reason.
+    ProbeFailed,
+    /// This runner has no controller-side identity probe at all, so no
+    /// comparison could be attempted for any reason.
+    Unavailable,
+}
+
+impl RunnerDaemonVerification {
+    /// Whether this verdict rests on an actual comparison.
+    pub fn is_compared(self) -> bool {
+        self == Self::Compared
+    }
+}
+
+/// Reported in the version fields of a warning that compared nothing.
+///
+/// The previous behaviour substituted the session's own recorded version for
+/// the one it failed to read, which guaranteed the version comparison passed
+/// and published a fabricated "current version" (#11106). A sentinel that
+/// cannot be mistaken for a release is the honest alternative.
+pub const UNVERIFIED_HOMEBOY_VERSION: &str = "unverified";
+
+/// Severity of a report that established neither freshness nor staleness.
+pub const RUNNER_DAEMON_SEVERITY_UNKNOWN: &str = "unknown";
+
+/// `compatibility_reason` for a reverse-connected session, which the controller
+/// has no path to probe. See [`RunnerStaleDaemonWarning::verification_unavailable`].
+pub const REVERSE_UNVERIFIED_REASON: &str = "reverse_unverified";
+
+/// `compatibility_reason` for a runner whose identity probe failed outright.
+pub const IDENTITY_PROBE_FAILED_REASON: &str = "identity_probe_failed";
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunnerStaleDaemonWarning {
     pub severity: &'static str,
+    /// Whether this report compared anything at all.
+    ///
+    /// [`RunnerDaemonVerification::Compared`] for every warning derived from an
+    /// observed version/identity comparison. The other two variants mark a
+    /// report that is neither "fresh" nor "stale" but *unverified*, and are the
+    /// only states for which the version fields are sentinels rather than
+    /// observations.
+    pub verification: RunnerDaemonVerification,
+    /// The verbatim probe failure, when one is what prevented verification.
+    ///
+    /// Previously discarded by an `unwrap_or_else` that replaced the failure
+    /// with the session's own version, so an unreachable runner rendered as a
+    /// vague identity warning instead of the real SSH error (#11106).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub probe_error: Option<String>,
     /// The exact machine-field predicate that made this warning reject admission.
     /// The compared raw fields are serialized alongside this predicate.
     pub mismatch_predicate: &'static str,
@@ -1453,6 +1549,8 @@ impl RunnerStaleDaemonWarning {
         };
         Self {
             severity: "warning",
+            verification: RunnerDaemonVerification::Compared,
+            probe_error: None,
             mismatch_predicate,
             active_daemon_control_plane_version: session_homeboy_version.clone(),
             job_command_binary_version: current_homeboy_version.clone(),
@@ -1472,6 +1570,125 @@ impl RunnerStaleDaemonWarning {
             recovery_commands,
             recovery_actions,
         }
+    }
+
+    /// The honest verdict when reading the runner's configured identity failed.
+    ///
+    /// The probe error is carried verbatim instead of being swallowed, and the
+    /// unread "current" version stays a sentinel rather than a copy of the
+    /// session's own version — the substitution that made an unreachable runner
+    /// satisfy its own version comparison (#11106).
+    pub fn probe_failed(
+        runner_id: &str,
+        session_homeboy_version: String,
+        session_homeboy_build_identity: Option<String>,
+        configured_executable: &str,
+        probe_error: String,
+    ) -> Self {
+        let message = format!(
+            "runner `{runner_id}` daemon compatibility is UNVERIFIED: reading the configured job command binary `{configured_executable}` failed ({probe_error}); neither a match nor a mismatch was established, so this runner's freshness is unknown rather than proven"
+        );
+        Self::unverified(
+            runner_id,
+            RunnerDaemonVerification::ProbeFailed,
+            IDENTITY_PROBE_FAILED_REASON,
+            session_homeboy_version,
+            session_homeboy_build_identity,
+            Some(probe_error),
+            message,
+        )
+    }
+
+    /// The honest verdict for a runner this controller has no way to probe.
+    ///
+    /// A reverse-connected session is reached through the broker, not over SSH,
+    /// so the direct identity probe has nothing to run against. That absence
+    /// used to be reported as no warning at all, which reads as healthy and let
+    /// an arbitrarily old reverse runner stay fully eligible (#11106). It is a
+    /// verification gap, so it is reported as one — visibly, and distinctly
+    /// from a proven mismatch, which is what keeps it from fencing every
+    /// reverse lab out of selection.
+    pub fn verification_unavailable(
+        runner_id: &str,
+        session_homeboy_version: String,
+        session_homeboy_build_identity: Option<String>,
+        compatibility_reason: &'static str,
+        message: String,
+    ) -> Self {
+        Self::unverified(
+            runner_id,
+            RunnerDaemonVerification::Unavailable,
+            compatibility_reason,
+            session_homeboy_version,
+            session_homeboy_build_identity,
+            None,
+            message,
+        )
+    }
+
+    /// Shared body of the two unverified verdicts.
+    ///
+    /// Nothing here is a comparison: the "current"/"job command binary" fields
+    /// hold [`UNVERIFIED_HOMEBOY_VERSION`] so no downstream reader can mistake
+    /// them for something that was read off the runner, and the recovery is a
+    /// read-only re-probe rather than a mutating refresh — replacing a binary
+    /// is not the answer to "I could not look at it".
+    fn unverified(
+        runner_id: &str,
+        verification: RunnerDaemonVerification,
+        compatibility_reason: &'static str,
+        session_homeboy_version: String,
+        session_homeboy_build_identity: Option<String>,
+        probe_error: Option<String>,
+        message: String,
+    ) -> Self {
+        let controller = homeboy_product_identity::build_identity();
+        let mut warning = Self {
+            severity: RUNNER_DAEMON_SEVERITY_UNKNOWN,
+            verification,
+            probe_error,
+            mismatch_predicate: match verification {
+                RunnerDaemonVerification::ProbeFailed => "daemon_identity_probe == failed",
+                _ => "daemon_identity_probe == unavailable",
+            },
+            active_daemon_control_plane_version: session_homeboy_version.clone(),
+            job_command_binary_version: UNVERIFIED_HOMEBOY_VERSION.to_string(),
+            active_daemon_control_plane_build_identity: session_homeboy_build_identity.clone(),
+            job_command_binary_build_identity: None,
+            session_homeboy_version,
+            current_homeboy_version: UNVERIFIED_HOMEBOY_VERSION.to_string(),
+            session_homeboy_build_identity,
+            current_homeboy_build_identity: None,
+            controller_homeboy_version: Some(controller.version),
+            controller_homeboy_build_identity: Some(controller.display),
+            compatibility_reason: Some(compatibility_reason),
+            refresh_command: String::new(),
+            message,
+            stale_runtime_paths: Vec::new(),
+            changed_runtime_paths: Vec::new(),
+            recovery_commands: Vec::new(),
+            recovery_actions: Vec::new(),
+        };
+        warning.set_recovery(vec![crate::daemon_repair::diagnose_action(runner_id)]);
+        warning
+    }
+
+    /// `true` when this report compared nothing, so it proves neither freshness
+    /// nor staleness.
+    pub fn is_unverified(&self) -> bool {
+        !self.verification.is_compared()
+    }
+
+    /// Whether this report may fence admission.
+    ///
+    /// An observed mismatch does, and so does a failed probe on a runner that
+    /// *has* a probe — "I tried and could not verify" is a real anomaly on a
+    /// path that normally answers. A runner with no verification path at all is
+    /// reported and deprioritized instead: fencing it would take every
+    /// reverse-connected lab out of service, which is the opposite failure
+    /// (#11101) rather than a fix.
+    pub fn blocks_admission(&self) -> bool {
+        self.verification != RunnerDaemonVerification::Unavailable
     }
 
     /// The one place a recovery is assigned.

--- a/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
@@ -24,7 +24,12 @@ pub fn runner_stale_daemon(
     runner: &Runner,
     status: &impl Fn(&str) -> Result<RunnerStatusReport>,
 ) -> Option<RunnerDaemonDriftEntry> {
-    let warning = status(&runner.id).ok()?.stale_daemon?;
+    // Drift is a claim about two observed versions. A report that compared
+    // nothing has no versions to name, so it is not drift (#11106).
+    let warning = status(&runner.id)
+        .ok()?
+        .stale_daemon
+        .filter(|warning| !warning.is_unverified())?;
     Some(RunnerDaemonDriftEntry {
         session_homeboy_version: warning.session_homeboy_version,
         current_homeboy_version: warning.current_homeboy_version,

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -556,6 +556,30 @@ paths. `homeboy runner status <runner-id>` surfaces those differences in
 development runner with `homeboy runner disconnect <runner-id>` followed by
 `homeboy runner connect <runner-id>` after rebuilding runner-side runtime code.
 
+### Daemon compatibility has three states, not two
+
+`stale_daemon.verification` names which question the report answered:
+
+- `compared` — the runner's configured identity was read and compared. The
+  version and build-identity fields are observations, and a mismatch fences
+  admission.
+- `probe_failed` — the identity probe itself failed. Nothing was compared;
+  `stale_daemon.probe_error` carries the verbatim failure and
+  `current_homeboy_version` is the sentinel `unverified` rather than a
+  substituted value. A runner that *has* a probe and could not answer it is
+  still fenced.
+- `unavailable` — this runner has no controller-side identity probe at all.
+  Reverse-connected sessions are reached through the broker, which exposes no
+  identity endpoint, so their compatibility is reported as
+  `compatibility_reason: reverse_unverified`. This is surfaced and ranked below
+  every verified runner in default Lab selection, but it does **not** fence
+  admission — fencing an entire runner class on the strength of a gap rather
+  than a mismatch would take every reverse lab out of service.
+
+Reports with either unverified verdict carry `severity: unknown` and a read-only
+`homeboy runner doctor <runner-id> --scope lab-offload` recovery: replacing a
+binary is not the answer to "I could not look at it".
+
 ### Controller identity and a dirty working tree
 
 Runner convergence is normally proven by comparing the controller's embedded


### PR DESCRIPTION
Closes #11106.

## The bug

Lab staleness detection failed **open** in two independent ways, both in `stale_daemon_warning`.

**1. Swallowed probe errors.** The SSH identity probe's error was discarded:

```rust
bounded_remote_homeboy_identity(...).unwrap_or_else(|_| RemoteHomeboyIdentity {
    version: session.homeboy_version.clone(),   // ← the value it failed to read
    build_identity: None,
})
```

Substituting the session's own version guaranteed `versions_match(current, session)` passed and published a *fabricated* "current version". A warning was still raised — but the vague `with_identity_unverifiable` one, never the actual SSH error.

**2. Reverse runners were never checked at all.** `if session.mode != RunnerTunnelMode::DirectSsh { return Ok(None) }`. `None` reads as healthy at every consumer, so a reverse-connected lab on an arbitrarily old binary stayed fully eligible.

## The three-state distinction

`RunnerStaleDaemonWarning` now carries `verification: RunnerDaemonVerification` and `probe_error: Option<String>`. This follows the shape already in the tree — `runtime_overlay_freshness::RuntimeOverlayBuildStatus::UnknownProbeFailed`, which exists because a failed git probe once certified a stale build as `Fresh`.

| verdict | meaning | fences admission? | selection |
|---|---|---|---|
| `compared` | identity was read and compared; fields are observations | yes, on mismatch | ineligible on mismatch |
| `probe_failed` | the probe on a runner that *has* one failed; `probe_error` carries it verbatim | **yes** | ineligible |
| `unavailable` | this runner class has no controller-side probe (reverse/broker) | **no** | eligible, ranked below every verified peer |

Two properties this pins down:

- The unread side is the sentinel `"unverified"`, **never** a copy of the side it failed to compare against. No downstream reader can mistake it for something read off the runner.
- Recovery for both unverified verdicts is the read-only `homeboy runner doctor <id> --scope lab-offload`, not a mutating `refresh-homeboy`. Replacing a binary is not the answer to "I could not look at it".

`probe_failed` deliberately still fences — that path already produced a (fabricated) blocking warning, so this is no behaviour change, just an honest one. Only `unavailable` is non-blocking, because fencing the entire reverse class on the strength of a *gap* rather than a *mismatch* would take every reverse lab out of service. That is #11101's failure mode wearing this fix's clothes, and #11106's own risk note calls for exactly this ranking (`below Fresh but above ineligible`). `DefaultLabRunnerCandidate` gained an `unverified_daemon` field with a `-50` selection penalty; it is reported as a `daemon_unverified` availability reason so an operator can see *why* it was deprioritized.

No new probing was added — the reverse verdict is derived entirely from the session record already in hand, so nothing lands on the probe budget (#11080). When the broker grows an identity endpoint, `unavailable` becomes a real comparison and disappears on its own.

## Interaction with the concurrent #11101 fix

They are complementary and touch adjacent code without overlapping:

- **#11101 owns the comparison logic** — `compare_identities` / `compare_build_commits` / `IdentityComparison` in `connection/remote_daemon.rs`, and distinguishing "controller identity cannot be compared" from "runner is stale". **I did not touch any of it.** The `IdentityComparison::Unverifiable` → `with_identity_unverifiable` path is untouched and still runs for every `compared` warning.
- **This PR owns error handling and the reverse gap** — what happens when the probe never returns a value to compare, and what happens when there is no probe.

Where they meet: both make an "unknown" state visible instead of collapsing it. If #11101 lands first, its comparison verdicts flow through `RunnerStaleDaemonWarning::new`, which keeps `verification: Compared` — its changes are unaffected. If this lands first, its work sits inside the `Ok(identity)` arm that #11101 edits. The likely textual conflict is the `let current_identity = ...` block in `stale_daemon_warning` and the import list at the top of `connection.rs`; both are mechanical.

One thing worth coordinating: if #11101 makes controller-identity comparison *fail closed* somewhere, it should route through `blocks_admission()` rather than re-checking `stale_daemon.is_some()`, or reverse runners will start being fenced again by the back door.

## Consumers swept

`stale_daemon.is_some()` was the de facto admission fence in several places and would have blocked every reverse runner the moment the gap became visible. Each was repointed at `admission_blocking_stale_daemon()`:

- `RunnerStatusReport::daemon_fresh_for_admission`, `admission_availability`, `recovery_state`
- `availability_provider` controller-action gate (now also emits `daemon_verification=` in the unavailable reason)
- `lab/offload/metadata.rs::lab_runner_homeboy_has_blocking_drift_against_configured_identity` — this branch is exactly where reverse runners land
- `homeboy_refresh::verify_refreshed_daemon_status` — a failed probe after a refresh is still a failure to prove convergence
- `upgrade_runners::reporting::runner_stale_daemon` — drift is a claim about two observed versions; a report that compared nothing has none
- `lib.rs` candidate construction (3 sites)

Display surfaces made honest rather than gated: `operator_summary` risk (`unverified_daemon` vs `stale_daemon`), `refresh_plan` diagnostic code (`runner_daemon_unverified`), `stale_daemon_hint` headline, `self_cmd` `daemon_drift`.

## Tests

- `failed_identity_probe_reports_the_error_instead_of_the_session_version` — the swallowed error now surfaces verbatim, the sentinel is not the session version, and the recovery is read-only.
- `reverse_session_is_checked_and_reports_an_unverified_verdict` — a reverse session produces a verdict instead of silence, carries `reverse_unverified`, does not fence, and a direct-SSH session is still routed to the real probe.
- `unverified_reports_fence_nothing_while_compared_mismatches_still_do` — the three states stay distinguishable.
- `unverified_runner_ranks_below_verified_without_dropping_out` — the counter-property: eligible, strictly lower-scored, still the default when alone, loses to a verified peer, reported in `reasons`, and a *proven* mismatch still fences.

No tests deleted or `#[ignore]`d.

## Compile risk

**I could not compile this.** Local `cargo build/test/check/clippy` is prohibited on this box (five agents share 15Gi); only `cargo fmt` was run, and it parsed every touched file clean.

Swept by hand:

- **Structs changed.** `RunnerStaleDaemonWarning` +2 fields — grepped every literal (`RunnerStaleDaemonWarning {`): exactly two, both in tests (`session.rs`, `lab/offload/inner.rs`), both updated. Every other construction goes through `::new`. `DefaultLabRunnerCandidate` +1 field — all four literals updated (2 in `lab_runner_readiness`/`refresh_detached_queue_runner`, 1 in `default_lab_runner_availability`, 1 test helper).
- **Enum added.** `RunnerDaemonVerification` is new, so no existing `match` can be made non-exhaustive. The one internal `match` uses a `_` arm.
- **Signatures.** No existing signature changed. All additions are new methods/functions/constants: `admission_blocking_stale_daemon`, `unverified_daemon`, `probe_failed`, `verification_unavailable`, `unverified` (private, 7 params — at the `too_many_arguments` threshold, not over), `is_unverified`, `blocks_admission`, `tunnel_verification_gap`.
- **Root `tests/`** — grepped for `stale_daemon` / `RunnerStaleDaemonWarning`; the only hit is an unrelated `daemon_test.rs` test name.
- **Serde.** The warning derives `Serialize` only, so new fields cannot break any deserialization. `probe_error` is `skip_serializing_if = "Option::is_none"`.
- **Rustdoc.** Intra-doc links to private items (`runtime_overlay_freshness::RuntimeOverlayBuildStatus`, `DefaultLabRunnerCandidate::readiness`) were deliberately left as plain code spans to avoid `private_intra_doc_links`.

Residual risk is behavioural, not structural: reverse runners now carry a `stale_daemon` field where they previously carried none. I traced every consumer of that field, but a display-only assertion somewhere I did not find could shift.