### PR TITLE
fix(ssh): bound managed session operations

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -362,6 +362,10 @@ impl SshClient {
         let control_path = args
             .windows(2)
             .find_map(|pair| (pair[0] == "-S").then(|| pair[1].clone()))
+            .or_else(|| {
+                args.iter()
+                    .find_map(|arg| arg.strip_prefix("ControlPath=").map(str::to_string))
+            })
             .unwrap_or_default();
         let mut command = Command::new(program);
         command

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -203,7 +203,7 @@ impl SshClient {
         )
     }
 
-    fn build_session_control_args(&self, operation: &str) -> Result<Vec<String>> {
+    pub(super) fn build_session_control_args(&self, operation: &str) -> Result<Vec<String>> {
         let session = self.auth.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "auth.mode",
@@ -335,19 +335,41 @@ impl SshClient {
         args: Vec<String>,
         expect_live_on_success: bool,
     ) -> ManagedSshSessionOutput {
+        self.run_managed_session_command_with_timeout(
+            args,
+            expect_live_on_success,
+            MANAGED_SESSION_OPERATION_TIMEOUT,
+        )
+    }
+
+    pub(super) fn run_managed_session_command_with_timeout(
+        &self,
+        args: Vec<String>,
+        expect_live_on_success: bool,
+        timeout: Duration,
+    ) -> ManagedSshSessionOutput {
+        self.run_managed_session_command_with_program(args, expect_live_on_success, timeout, "ssh")
+    }
+
+    pub(super) fn run_managed_session_command_with_program(
+        &self,
+        args: Vec<String>,
+        expect_live_on_success: bool,
+        timeout: Duration,
+        program: impl AsRef<std::ffi::OsStr>,
+    ) -> ManagedSshSessionOutput {
         let target = args.last().cloned().unwrap_or_default();
         let control_path = args
             .windows(2)
             .find_map(|pair| (pair[0] == "-S").then(|| pair[1].clone()))
             .unwrap_or_default();
-        let mut command = Command::new("ssh");
+        let mut command = Command::new(program);
         command
             .args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
-        let output =
-            execute_command_with_stdin_timeout(command, None, MANAGED_SESSION_OPERATION_TIMEOUT);
+        let output = execute_command_with_stdin_timeout(command, None, timeout);
         let mut stderr = output.stderr;
         if output.timed_out {
             if !stderr.is_empty() && !stderr.ends_with('\n') {
@@ -616,15 +638,27 @@ fn collect_stream(receiver: Option<Receiver<String>>) -> String {
         .unwrap_or_default()
 }
 
-fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Duration) -> (String, bool) {
+fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Instant) -> (String, bool) {
     match receiver {
-        Some(receiver) => match receiver.recv_timeout(deadline) {
-            Ok(output) => (output, false),
-            Err(RecvTimeoutError::Timeout) => (String::new(), true),
-            Err(RecvTimeoutError::Disconnected) => (String::new(), false),
-        },
+        Some(receiver) => {
+            match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+                Ok(output) => (output, false),
+                Err(RecvTimeoutError::Timeout) => (String::new(), true),
+                Err(RecvTimeoutError::Disconnected) => (String::new(), false),
+            }
+        }
         None => (String::new(), false),
     }
+}
+
+fn collect_streams_before(
+    stdout: Option<Receiver<String>>,
+    stderr: Option<Receiver<String>>,
+    deadline: Instant,
+) -> (String, String, bool) {
+    let (stdout, stdout_stalled) = collect_stream_before(stdout, deadline);
+    let (stderr, stderr_stalled) = collect_stream_before(stderr, deadline);
+    (stdout, stderr, stdout_stalled || stderr_stalled)
 }
 
 fn ssh_process_error(error: std::io::Error) -> CommandOutput {
@@ -751,17 +785,22 @@ pub(super) fn execute_command_with_stdin_source_timeout(
     let stderr = child.stderr.take().map(read_stream);
     let mut timed_out = false;
     let mut interrupted_signal = None;
+    let mut cleanup_deadline = None;
     let status = loop {
         if let Some(signal) = crate::server::process_cleanup::active_cleanup_signal() {
             interrupted_signal = Some(signal);
-            break terminate_process_group_with_deadline(&mut child, pid);
+            let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
+            cleanup_deadline = Some(deadline);
+            break terminate_process_group_with_deadline(&mut child, pid, deadline);
         }
         match child.try_wait() {
             Ok(Some(status)) => break Some(status),
             Ok(None) if started.elapsed() < timeout => thread::sleep(Duration::from_millis(25)),
             Ok(None) => {
                 timed_out = true;
-                break terminate_process_group_with_deadline(&mut child, pid);
+                let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
+                cleanup_deadline = Some(deadline);
+                break terminate_process_group_with_deadline(&mut child, pid, deadline);
             }
             Err(_) => break None,
         }
@@ -769,11 +808,14 @@ pub(super) fn execute_command_with_stdin_source_timeout(
     let stdin_failed = writer
         .and_then(|writer| writer.finish_after_child())
         .is_some_and(|result| result.is_err());
-    let (stdout, stdout_stalled) = collect_stream_before(stdout, PROCESS_REAP_DEADLINE);
-    let (mut stderr, stderr_stalled) = collect_stream_before(stderr, PROCESS_REAP_DEADLINE);
-    if stdout_stalled || stderr_stalled {
+    let (stdout, mut stderr, streams_stalled) = collect_streams_before(
+        stdout,
+        stderr,
+        cleanup_deadline.unwrap_or_else(|| Instant::now() + PROCESS_CLEANUP_ALLOWANCE),
+    );
+    if streams_stalled {
         timed_out = true;
-        terminate_process_group_with_deadline(&mut child, pid);
+        terminate_unreaped_process_group(pid);
         if !stderr.is_empty() && !stderr.ends_with('\n') {
             stderr.push('\n');
         }
@@ -913,6 +955,7 @@ where
     let mut stdin_failed = false;
     let mut interrupted_signal = None;
     let mut status = None;
+    let mut cleanup_deadline = None;
     loop {
         // `configure_process_group_cleanup` replaced the default SIGINT/SIGTERM
         // disposition with a recording handler, so a cancelled caller no longer
@@ -922,12 +965,16 @@ where
         // the operator's cancellation.
         if let Some(signal) = crate::server::process_cleanup::active_cleanup_signal() {
             interrupted_signal = Some(signal);
-            status = terminate_process_group_with_deadline(&mut child, pid);
+            let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
+            cleanup_deadline = Some(deadline);
+            status = terminate_process_group_with_deadline(&mut child, pid, deadline);
             break;
         }
         if matches!(writer_rx.try_recv(), Ok(Err(_))) {
             stdin_failed = true;
-            status = terminate_process_group_with_deadline(&mut child, pid);
+            let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
+            cleanup_deadline = Some(deadline);
+            status = terminate_process_group_with_deadline(&mut child, pid, deadline);
             break;
         }
         match child.try_wait() {
@@ -938,7 +985,9 @@ where
             Ok(None) if started.elapsed() < timeout => thread::sleep(Duration::from_millis(25)),
             Ok(None) => {
                 timed_out = true;
-                status = terminate_process_group_with_deadline(&mut child, pid);
+                let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
+                cleanup_deadline = Some(deadline);
+                status = terminate_process_group_with_deadline(&mut child, pid, deadline);
                 break;
             }
             Err(_) => break,
@@ -947,11 +996,14 @@ where
     if let Some(writer) = writer {
         let _ = writer.join();
     }
-    let (stdout, stdout_stalled) = collect_stream_before(stdout, PROCESS_REAP_DEADLINE);
-    let (mut stderr, stderr_stalled) = collect_stream_before(stderr, PROCESS_REAP_DEADLINE);
-    if stdout_stalled || stderr_stalled {
+    let (stdout, mut stderr, streams_stalled) = collect_streams_before(
+        stdout,
+        stderr,
+        cleanup_deadline.unwrap_or_else(|| Instant::now() + PROCESS_CLEANUP_ALLOWANCE),
+    );
+    if streams_stalled {
         timed_out = true;
-        terminate_process_group_with_deadline(&mut child, pid);
+        terminate_unreaped_process_group(pid);
         if !stderr.is_empty() && !stderr.ends_with('\n') {
             stderr.push('\n');
         }
@@ -1097,8 +1149,11 @@ mod bounded_probe_output_tests {
     }
 }
 
+/// One shared allowance covers process termination and both output streams after
+/// a timed SSH command's deadline. It is deliberately smaller than the polling
+/// interval callers commonly use for their own process deadlines.
+const PROCESS_CLEANUP_ALLOWANCE: Duration = Duration::from_millis(250);
 const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
-const PROCESS_REAP_DEADLINE: Duration = Duration::from_millis(250);
 
 /// Run a timed SSH command in a remote session that Homeboy explicitly owns.
 /// The remote shell, rather than the controller's local `ssh` process group,
@@ -1113,6 +1168,7 @@ pub(super) fn wrap_timed_remote_command(command: &str) -> String {
 fn terminate_process_group_with_deadline(
     child: &mut std::process::Child,
     pid: u32,
+    deadline: Instant,
 ) -> Option<std::process::ExitStatus> {
     #[cfg(unix)]
     unsafe {
@@ -1122,7 +1178,8 @@ fn terminate_process_group_with_deadline(
     {
         let _ = child.kill();
     }
-    if let Some(status) = poll_child_until(child, PROCESS_TERMINATION_GRACE) {
+    let graceful_deadline = std::cmp::min(deadline, Instant::now() + PROCESS_TERMINATION_GRACE);
+    if let Some(status) = poll_child_until(child, graceful_deadline) {
         return Some(status);
     }
     #[cfg(unix)]
@@ -1133,18 +1190,24 @@ fn terminate_process_group_with_deadline(
     {
         let _ = child.kill();
     }
-    poll_child_until(child, PROCESS_REAP_DEADLINE)
+    poll_child_until(child, deadline)
+}
+
+fn terminate_unreaped_process_group(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
 }
 
 fn poll_child_until(
     child: &mut std::process::Child,
-    deadline: Duration,
+    deadline: Instant,
 ) -> Option<std::process::ExitStatus> {
-    let started = Instant::now();
     loop {
         match child.try_wait() {
             Ok(Some(status)) => return Some(status),
-            Ok(None) if started.elapsed() < deadline => thread::sleep(Duration::from_millis(10)),
+            Ok(None) if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
             Ok(None) | Err(_) => return None,
         }
     }

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -27,6 +28,7 @@ use super::{CommandOutput, SshClient};
 /// Sentinel terminating the secret-env block streamed over the SSH channel's
 /// stdin. Chosen to never collide with an env var name or a `NAME=VALUE` line.
 pub(crate) const SECRET_ENV_STDIN_SENTINEL: &str = "__HOMEBOY_SECRET_ENV_END__";
+const MANAGED_SESSION_OPERATION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Where a command's stdin bytes come from when it is dispatched over SSH (or
 /// the localhost fast path).
@@ -333,15 +335,31 @@ impl SshClient {
         args: Vec<String>,
         expect_live_on_success: bool,
     ) -> ManagedSshSessionOutput {
-        let output = Command::new("ssh").args(&args).output();
-        let (stdout, stderr, exit_code) = match output {
-            Ok(out) => (
-                String::from_utf8_lossy(&out.stdout).to_string(),
-                String::from_utf8_lossy(&out.stderr).to_string(),
-                out.status.code().unwrap_or(-1),
-            ),
-            Err(err) => (String::new(), format!("SSH error: {}", err), -1),
-        };
+        let target = args.last().cloned().unwrap_or_default();
+        let control_path = args
+            .windows(2)
+            .find_map(|pair| (pair[0] == "-S").then(|| pair[1].clone()))
+            .unwrap_or_default();
+        let mut command = Command::new("ssh");
+        command
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+        let output =
+            execute_command_with_stdin_timeout(command, None, MANAGED_SESSION_OPERATION_TIMEOUT);
+        let mut stderr = output.stderr;
+        if output.timed_out {
+            if !stderr.is_empty() && !stderr.ends_with('\n') {
+                stderr.push('\n');
+            }
+            stderr.push_str(&format!(
+                "Managed SSH control operation timed out during mux control; target={target}; configured_host={}; control_path={control_path}.",
+                self.host,
+            ));
+        }
+        let stdout = output.stdout;
+        let exit_code = output.exit_code;
         let success = exit_code == 0;
 
         ManagedSshSessionOutput {
@@ -547,12 +565,8 @@ pub(super) fn run_command_with_stdin_source(
     let stdin_failed = writer
         .and_then(|writer| writer.finish_after_child())
         .is_some_and(|result: std::io::Result<()>| result.is_err());
-    let stdout = stdout
-        .and_then(|reader| reader.join().ok())
-        .unwrap_or_default();
-    let mut stderr = stderr
-        .and_then(|reader| reader.join().ok())
-        .unwrap_or_default();
+    let stdout = collect_stream(stdout);
+    let mut stderr = collect_stream(stderr);
     if stdin_failed {
         if !stderr.is_empty() && !stderr.ends_with('\n') {
             stderr.push('\n');
@@ -586,12 +600,31 @@ pub(super) fn run_command_with_stdin_source(
     }
 }
 
-fn read_stream(mut pipe: impl Read + Send + 'static) -> thread::JoinHandle<String> {
+fn read_stream(mut pipe: impl Read + Send + 'static) -> Receiver<String> {
+    let (sender, receiver) = std::sync::mpsc::channel();
     thread::spawn(move || {
         let mut bytes = Vec::new();
         let _ = pipe.read_to_end(&mut bytes);
-        String::from_utf8_lossy(&bytes).to_string()
-    })
+        let _ = sender.send(String::from_utf8_lossy(&bytes).to_string());
+    });
+    receiver
+}
+
+fn collect_stream(receiver: Option<Receiver<String>>) -> String {
+    receiver
+        .and_then(|receiver| receiver.recv().ok())
+        .unwrap_or_default()
+}
+
+fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Duration) -> (String, bool) {
+    match receiver {
+        Some(receiver) => match receiver.recv_timeout(deadline) {
+            Ok(output) => (output, false),
+            Err(RecvTimeoutError::Timeout) => (String::new(), true),
+            Err(RecvTimeoutError::Disconnected) => (String::new(), false),
+        },
+        None => (String::new(), false),
+    }
 }
 
 fn ssh_process_error(error: std::io::Error) -> CommandOutput {
@@ -736,12 +769,16 @@ pub(super) fn execute_command_with_stdin_source_timeout(
     let stdin_failed = writer
         .and_then(|writer| writer.finish_after_child())
         .is_some_and(|result| result.is_err());
-    let stdout = stdout
-        .and_then(|reader| reader.join().ok())
-        .unwrap_or_default();
-    let stderr = stderr
-        .and_then(|reader| reader.join().ok())
-        .unwrap_or_default();
+    let (stdout, stdout_stalled) = collect_stream_before(stdout, PROCESS_REAP_DEADLINE);
+    let (mut stderr, stderr_stalled) = collect_stream_before(stderr, PROCESS_REAP_DEADLINE);
+    if stdout_stalled || stderr_stalled {
+        timed_out = true;
+        terminate_process_group_with_deadline(&mut child, pid);
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        stderr.push_str("Homeboy SSH stream drain exceeded its cleanup deadline; terminated child process group.");
+    }
     bounded_probe_output(
         stdout,
         stderr,
@@ -870,20 +907,8 @@ where
     };
     let pid = child.id();
     let (writer_rx, writer) = writer_factory(child.stdin.take(), stdin);
-    let stdout = child.stdout.take().map(|mut pipe| {
-        thread::spawn(move || {
-            let mut bytes = Vec::new();
-            let _ = pipe.read_to_end(&mut bytes);
-            String::from_utf8_lossy(&bytes).to_string()
-        })
-    });
-    let stderr = child.stderr.take().map(|mut pipe| {
-        thread::spawn(move || {
-            let mut bytes = Vec::new();
-            let _ = pipe.read_to_end(&mut bytes);
-            String::from_utf8_lossy(&bytes).to_string()
-        })
-    });
+    let stdout = child.stdout.take().map(read_stream);
+    let stderr = child.stderr.take().map(read_stream);
     let mut timed_out = false;
     let mut stdin_failed = false;
     let mut interrupted_signal = None;
@@ -922,12 +947,16 @@ where
     if let Some(writer) = writer {
         let _ = writer.join();
     }
-    let stdout = stdout
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default();
-    let stderr = stderr
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default();
+    let (stdout, stdout_stalled) = collect_stream_before(stdout, PROCESS_REAP_DEADLINE);
+    let (mut stderr, stderr_stalled) = collect_stream_before(stderr, PROCESS_REAP_DEADLINE);
+    if stdout_stalled || stderr_stalled {
+        timed_out = true;
+        terminate_process_group_with_deadline(&mut child, pid);
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        stderr.push_str("Homeboy SSH stream drain exceeded its cleanup deadline; terminated child process group.");
+    }
     bounded_probe_output(
         stdout,
         stderr,

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -661,9 +661,12 @@ fn managed_session_config_adds_controlmaster_args() {
     let client = SshClient::from_server(&server, "bastion").expect("client");
     let args = client.build_ssh_args(Some("uptime"), false);
 
-    assert!(args
-        .windows(2)
-        .any(|pair| { pair == ["-S".to_string(), "/tmp/homeboy-test-%h-%p-%r".to_string()] }));
+    assert!(args.windows(2).any(|pair| {
+        pair == [
+            "-o".to_string(),
+            "ControlPath=/tmp/homeboy-test-%h-%p-%r".to_string(),
+        ]
+    }));
     assert!(args.contains(&"ControlMaster=no".to_string()));
     assert!(args.contains(&"BatchMode=yes".to_string()));
     assert!(args.contains(&"2222".to_string()));
@@ -714,8 +717,69 @@ fn timed_command_does_not_wait_for_a_pipe_holding_descendant() {
 
     assert!(output.timed_out);
     assert_eq!(output.exit_code, 124);
-    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "timeout plus its single cleanup allowance must remain bounded"
+    );
     assert!(output.stderr.contains("stream drain exceeded"));
+}
+
+#[cfg(unix)]
+#[test]
+fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = tempfile::tempdir().expect("fixture directory");
+    let ssh = fixture.path().join("ssh");
+    let args_file = fixture.path().join("args");
+    std::fs::write(
+        &ssh,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\ncase \"$*\" in *'-O check'*) sleep 5 ;; *) printf reused ;; esac\n",
+            crate::engine::shell::quote_path(&args_file.to_string_lossy())
+        ),
+    )
+    .expect("fake ssh");
+    std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake ssh executable");
+    let client = SshClient {
+        host: "sandbox-alias".to_string(),
+        user: "deploy".to_string(),
+        port: 22,
+        identity_file: None,
+        auth: Some(ManagedSshSession {
+            control_path: "/tmp/homeboy-%h-%p-%r".to_string(),
+            persist: "4h".to_string(),
+        }),
+        is_local: false,
+        env: HashMap::new(),
+    };
+    let command = client.run_managed_session_command_with_program(
+        client.build_ssh_args(Some("true"), false),
+        true,
+        Duration::from_secs(1),
+        &ssh,
+    );
+    assert!(command.live, "{}", command.stderr);
+    assert_eq!(command.stdout, "reused");
+    let args = std::fs::read_to_string(&args_file).expect("fake SSH arguments");
+    assert!(args.contains("ControlPath=/tmp/homeboy-%h-%p-%r"));
+    assert!(args.contains("ControlMaster=no"));
+    assert!(args.contains("deploy@sandbox-alias"));
+
+    let started = Instant::now();
+    let status = client.run_managed_session_command_with_program(
+        client
+            .build_session_control_args("check")
+            .expect("control arguments"),
+        true,
+        Duration::from_millis(50),
+        &ssh,
+    );
+    assert!(!status.live);
+    assert_eq!(status.exit_code, 124);
+    assert!(started.elapsed() < Duration::from_millis(750));
+    assert!(status.stderr.contains("mux control"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -661,9 +661,10 @@ fn managed_session_config_adds_controlmaster_args() {
     let client = SshClient::from_server(&server, "bastion").expect("client");
     let args = client.build_ssh_args(Some("uptime"), false);
 
-    assert!(args.contains(&"ControlMaster=auto".to_string()));
-    assert!(args.contains(&"ControlPath=/tmp/homeboy-test-%h-%p-%r".to_string()));
-    assert!(args.contains(&"ControlPersist=4h".to_string()));
+    assert!(args
+        .windows(2)
+        .any(|pair| { pair == ["-S".to_string(), "/tmp/homeboy-test-%h-%p-%r".to_string()] }));
+    assert!(args.contains(&"ControlMaster=no".to_string()));
     assert!(args.contains(&"BatchMode=yes".to_string()));
     assert!(args.contains(&"2222".to_string()));
     assert_eq!(args.last().map(String::as_str), Some("uptime"));
@@ -696,6 +697,25 @@ fn managed_session_connect_builds_master_command() {
         args.last().map(String::as_str),
         Some("deploy@bastion.example.test")
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn timed_command_does_not_wait_for_a_pipe_holding_descendant() {
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "sleep 5 & exit 0"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+    let started = Instant::now();
+
+    let output = execute_command_with_stdin_timeout(command, None, Duration::from_millis(50));
+
+    assert!(output.timed_out);
+    assert_eq!(output.exit_code, 124);
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(output.stderr.contains("stream drain exceeded"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -757,7 +757,7 @@ fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
     let command = client.run_managed_session_command_with_program(
         client.build_ssh_args(Some("true"), false),
         true,
-        Duration::from_secs(1),
+        Duration::from_secs(3),
         &ssh,
     );
     assert!(command.live, "{}", command.stderr);

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -152,6 +152,7 @@ fn push_option(args: &mut Vec<String>, option: impl Into<String>) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::process::Command;
 
     use super::*;
 
@@ -183,5 +184,64 @@ mod tests {
         assert!(rendered.contains("-o 'ControlPath=/tmp/control path'"));
         assert!(rendered.contains("-o ControlMaster=no"));
         assert!(rendered.contains("-p 2222"));
+    }
+
+    #[test]
+    fn installed_openssh_expands_managed_controlpath_for_a_host_alias() {
+        // `ssh -G` parses configuration without opening a network connection. It
+        // proves that the actual OpenSSH client expands Homeboy's `%h/%p/%r`
+        // control path from an alias's configured HostName, port, and user.
+        let fixture = tempfile::tempdir().expect("SSH config fixture");
+        let config = fixture.path().join("ssh_config");
+        let control_path = fixture.path().join("control-%h-%p-%r");
+        std::fs::write(
+            &config,
+            "Host sandbox-alias\n  HostName resolved.example.test\n  Port 2222\n",
+        )
+        .expect("write SSH config");
+        let client = SshClient {
+            host: "sandbox-alias".to_string(),
+            user: "deploy".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: Some(ManagedSshSession {
+                control_path: control_path.to_string_lossy().to_string(),
+                persist: "4h".to_string(),
+            }),
+            is_local: false,
+            env: HashMap::new(),
+        };
+        let options = client_option_args(
+            &client,
+            SshArgOptions {
+                batch_mode: true,
+                ..SshArgOptions::default()
+            },
+        );
+
+        let output = Command::new("ssh")
+            .args(["-G", "-F"])
+            .arg(&config)
+            .args(options)
+            .arg("deploy@sandbox-alias")
+            .output()
+            .expect("installed OpenSSH client");
+        assert!(
+            output.status.success(),
+            "ssh -G failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let effective = String::from_utf8(output.stdout).expect("OpenSSH config output");
+        assert!(effective.contains("hostname resolved.example.test\n"));
+        assert!(effective.contains("port 2222\n"));
+        assert!(effective.contains("user deploy\n"));
+        assert!(effective.contains("controlmaster false\n"));
+        assert!(effective.contains(&format!(
+            "controlpath {}\n",
+            fixture
+                .path()
+                .join("control-resolved.example.test-2222-deploy")
+                .display()
+        )));
     }
 }

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -119,9 +119,11 @@ fn client_connection_args(
     // auth mode is a separate change with its own blast radius (control-socket
     // lifetime, forwarding, interactive sessions).
     if let Some(session) = auth {
-        push_option(&mut args, "ControlMaster=auto");
-        push_option(&mut args, format!("ControlPath={}", session.control_path));
-        push_option(&mut args, format!("ControlPersist={}", session.persist));
+        // A managed session is established explicitly by `server connect`. Command
+        // clients attach to that socket rather than starting a competing master.
+        args.push("-S".to_string());
+        args.push(session.control_path.clone());
+        push_option(&mut args, "ControlMaster=no");
     }
 
     if options.batch_mode && !options.interactive {
@@ -177,7 +179,8 @@ mod tests {
         ));
 
         assert!(rendered.contains("-i '/tmp/key with spaces'"));
-        assert!(rendered.contains("-o 'ControlPath=/tmp/control path'"));
+        assert!(rendered.contains("-S '/tmp/control path'"));
+        assert!(rendered.contains("-o ControlMaster=no"));
         assert!(rendered.contains("-p 2222"));
     }
 }

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -121,8 +121,9 @@ fn client_connection_args(
     if let Some(session) = auth {
         // A managed session is established explicitly by `server connect`. Command
         // clients attach to that socket rather than starting a competing master.
-        args.push("-S".to_string());
-        args.push(session.control_path.clone());
+        // `-o ControlPath` is understood by both ssh and scp; scp's `-S` means
+        // the SSH executable path rather than the control socket.
+        push_option(&mut args, format!("ControlPath={}", session.control_path));
         push_option(&mut args, "ControlMaster=no");
     }
 
@@ -179,7 +180,7 @@ mod tests {
         ));
 
         assert!(rendered.contains("-i '/tmp/key with spaces'"));
-        assert!(rendered.contains("-S '/tmp/control path'"));
+        assert!(rendered.contains("-o 'ControlPath=/tmp/control path'"));
         assert!(rendered.contains("-o ControlMaster=no"));
         assert!(rendered.contains("-p 2222"));
     }

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -471,7 +471,8 @@ mod tests {
     use crate::server::{self, Server};
     use crate::test_support::with_isolated_home;
 
-    use super::{parse_target, transfer, TransferConfig, TransferTarget};
+    use super::{parse_target, scp_args, transfer, TransferConfig, TransferTarget};
+    use crate::server::{ManagedSshSession, SshClient};
 
     fn save_server(id: &str) {
         server::save(&Server {
@@ -555,5 +556,32 @@ mod tests {
             assert!(out.compress);
             assert!(out.dry_run);
         });
+    }
+
+    #[test]
+    fn managed_scp_uses_controlpath_option_not_ssh_executable_flag() {
+        let client = SshClient {
+            host: "sandbox-alias".to_string(),
+            user: "deploy".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: Some(ManagedSshSession {
+                control_path: "/tmp/homeboy-control".to_string(),
+                persist: "4h".to_string(),
+            }),
+            is_local: false,
+            env: HashMap::new(),
+        };
+
+        let args = scp_args(&client);
+
+        assert!(args.windows(2).any(|pair| {
+            pair == [
+                "-o".to_string(),
+                "ControlPath=/tmp/homeboy-control".to_string(),
+            ]
+        }));
+        assert!(args.contains(&"ControlMaster=no".to_string()));
+        assert!(!args.contains(&"-S".to_string()));
     }
 }


### PR DESCRIPTION
Fixes #11564

## Summary
- Attach managed SSH and SCP commands exclusively to the socket created by `server connect` with portable `-o ControlPath=...` and `-o ControlMaster=no` options.
- Bound managed mux-control operations to 10 seconds and preserve credential-free target, configured-host, and control-path diagnostics on timeout.
- Bound timed SSH stream draining with one shared 250ms cleanup allowance so a descendant retaining an output pipe cannot outlive the command lifecycle.
- Verify Homeboy managed options through the installed OpenSSH client against a temporary `Host` alias with a distinct `HostName`.

## Evidence
- `cargo fmt --check` passed.
- `cargo test -p homeboy-core server::ssh_args::tests --lib` passed: 2 tests, including actual `ssh -G -F <temporary-config>` alias, token, and effective-option expansion.
- `cargo test -p homeboy-core server::client::tests --lib` passed: 38 tests, including a fake-SSH process fixture for host-alias managed reuse and wedged mux control.
- `cargo test -p homeboy-core server::transfer::tests --lib` passed: 4 tests, including the SCP control-path regression.
- `cargo test -p homeboy-core server:: --lib` ran 113 tests in 268.59 seconds: 101 passed, 11 environment-dependent tests ignored, and unrelated `server::client::tests::delegated_terminal_failure_stops_captured_wrapper` failed. The changed SSH client, transfer, and argument tests passed.
- `cargo clippy -p homeboy-core --lib -- -D warnings` is blocked by eight pre-existing warnings in transitive `homeboy-engine-primitives`.

## Residual verification
The real-client test requires only installed OpenSSH and makes no network connection. It proves OpenSSH alias/config token expansion; it does not establish a live ControlMaster because the repository has no portable hermetic sshd fixture. The fake process fixture covers Homeboy generated command execution, mux-control timeout, and cleanup.

## AI assistance
Model: OpenAI GPT-5.6 Sol
Tool: OpenCode
Used for test design, review remediation, implementation, verification, and PR drafting. Chris Huber remains responsible for the change.