### PR TITLE
fix(project): report server health probe state

### DIFF
--- a/crates/homeboy-cli/src/commands/fleet.rs
+++ b/crates/homeboy-cli/src/commands/fleet.rs
@@ -453,11 +453,7 @@ fn log_fleet_dashboard(result: &FleetStatusResult) {
         let server_label = proj_status.server_id.as_deref().unwrap_or("unknown");
 
         // Health indicator
-        let health_icon = match &proj_status.health {
-            Some(h) if h.warnings.is_empty() => "✅",
-            Some(_) => "⚠️ ",
-            None => "❌",
-        };
+        let health_icon = health_indicator(proj_status.health.as_ref());
 
         eprintln!(
             "\n{} {} ({})",
@@ -511,6 +507,15 @@ fn log_fleet_dashboard(result: &FleetStatusResult) {
                 warning.server_id, warning.project_id, warning.message,
             );
         }
+    }
+}
+
+fn health_indicator(health: Option<&homeboy::core::server::health::ServerHealth>) -> &'static str {
+    match health {
+        Some(health) if !health.state.is_healthy() => "❌",
+        Some(health) if health.warnings.is_empty() => "✅",
+        Some(_) => "⚠️ ",
+        None => "❌",
     }
 }
 

--- a/crates/homeboy-cli/src/commands/project.rs
+++ b/crates/homeboy-cli/src/commands/project.rs
@@ -611,9 +611,11 @@ fn pin_update(
 
 #[cfg(test)]
 mod tests {
+    use super::status;
     use clap::Parser;
 
     use crate::cli_surface::Cli;
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn component_attach_path_and_batch_surface_parse() {
@@ -652,6 +654,39 @@ mod tests {
         ])
         .is_ok());
     }
+
+    #[test]
+    fn status_returns_nonzero_when_a_configured_server_could_not_be_checked() {
+        with_isolated_home(|_| {
+            homeboy::core::server::save(&homeboy::core::server::Server {
+                id: "sandbox".to_string(),
+                host: "sandbox.example.test".to_string(),
+                user: "tester".to_string(),
+                port: 22,
+                identity_file: Some("/missing/homeboy-test-key".to_string()),
+                aliases: Vec::new(),
+                kind: None,
+                auth: None,
+                env: Default::default(),
+                runner: None,
+            })
+            .expect("save server");
+            homeboy::core::project::save(&homeboy::core::project::Project {
+                id: "sandbox-project".to_string(),
+                server_id: Some("sandbox".to_string()),
+                ..Default::default()
+            })
+            .expect("save project");
+
+            let (output, exit_code) = status("sandbox-project", true).expect("status");
+
+            assert_eq!(exit_code, 1);
+            assert_eq!(
+                output.extra.health.expect("health").next_action.as_deref(),
+                Some("homeboy server status sandbox")
+            );
+        });
+    }
 }
 
 fn pin_rename(
@@ -678,8 +713,10 @@ fn map_pin_type(pin_type: ProjectPinType) -> project::PinType {
 fn status(project_id: &str, health_only: bool) -> CmdResult<ProjectOutput> {
     homeboy::log_status!("project", "Checking '{}'...", project_id);
 
-    Ok((
-        project::build_status_output(project_id, project::status_report(project_id, health_only)?),
-        0,
-    ))
+    let report = project::status_report(project_id, health_only)?;
+    let exit_code = report
+        .health
+        .as_ref()
+        .is_some_and(|health| !health.state.is_healthy()) as i32;
+    Ok((project::build_status_output(project_id, report), exit_code))
 }

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -174,6 +174,7 @@ pub fn collect_status(
 
         // Classify project health
         match &health {
+            Some(h) if !h.state.is_healthy() => summary.projects.unreachable += 1,
             Some(h) if h.warnings.is_empty() => summary.projects.healthy += 1,
             Some(h) => {
                 summary.projects.warning += 1;
@@ -408,6 +409,7 @@ fn compute_server_summary(
 
     for health_opt in health_cache.values() {
         match health_opt {
+            Some(h) if !h.state.is_healthy() => summary.servers.unreachable += 1,
             Some(h) => {
                 if h.warnings.is_empty() {
                     summary.servers.healthy += 1;

--- a/crates/homeboy-core/src/project/report.rs
+++ b/crates/homeboy-core/src/project/report.rs
@@ -26,7 +26,8 @@ pub struct ProjectShowReport {
     pub project: Project,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
-    pub deploy_ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_ready: Option<bool>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub deploy_blockers: Vec<String>,
 }
@@ -109,19 +110,20 @@ pub fn list_report() -> Result<ProjectListReport> {
 pub fn show_report(project_id: &str) -> Result<ProjectShowReport> {
     let project = load(project_id)?;
 
-    let hint = if project.server_id.is_none() {
+    let hint = if project.components.is_empty() {
+        None
+    } else if project.server_id.is_none() {
         Some("Local project: Server-deployed components require a server.".to_string())
-    } else if project.components.is_empty() {
-        Some(format!(
-            "No components linked. Use: homeboy project components add {} <component-id> or homeboy project components attach-path {} <component-id> <path>",
-            project.id,
-            project.id
-        ))
     } else {
         None
     };
 
-    let (deploy_ready, deploy_blockers) = calculate_deploy_readiness(&project);
+    let (deploy_ready, deploy_blockers) = if project.components.is_empty() {
+        (None, Vec::new())
+    } else {
+        let (ready, blockers) = calculate_deploy_readiness(&project);
+        (Some(ready), blockers)
+    };
 
     Ok(ProjectShowReport {
         project,
@@ -171,7 +173,7 @@ pub fn build_show_output(report: ProjectShowReport) -> ProjectReportOutput {
         entity: Some(report.project),
         hint: report.hint,
         extra: ProjectReportExtra {
-            deploy_ready: Some(report.deploy_ready),
+            deploy_ready: report.deploy_ready,
             deploy_blockers: if report.deploy_blockers.is_empty() {
                 None
             } else {
@@ -365,7 +367,7 @@ mod tests {
 
             let report = show_report("site").expect("show report");
 
-            assert!(!report.deploy_ready);
+            assert_eq!(report.deploy_ready, Some(false));
             assert!(report.deploy_blockers.iter().any(|blocker| {
                 blocker.contains(
                     "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist",
@@ -406,11 +408,80 @@ mod tests {
             let report = show_report("site").expect("show report");
 
             assert!(
-                report.deploy_ready,
+                report.deploy_ready == Some(true),
                 "unexpected blockers: {:?}",
                 report.deploy_blockers
             );
             assert!(report.deploy_blockers.is_empty());
+        });
+    }
+
+    #[test]
+    fn show_report_does_not_treat_server_backed_projects_without_components_as_deploys() {
+        with_isolated_home(|_| {
+            crate::server::save(&crate::server::Server {
+                id: "sandbox".to_string(),
+                host: "localhost".to_string(),
+                user: "tester".to_string(),
+                port: 22,
+                identity_file: None,
+                aliases: Vec::new(),
+                kind: None,
+                auth: None,
+                env: Default::default(),
+                runner: None,
+            })
+            .expect("save server");
+            crate::project::save(&Project {
+                id: "sandbox-project".to_string(),
+                server_id: Some("sandbox".to_string()),
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let report = show_report("sandbox-project").expect("show report");
+
+            assert!(report.hint.is_none());
+            assert!(report.deploy_ready.is_none());
+            assert!(report.deploy_blockers.is_empty());
+        });
+    }
+
+    #[test]
+    fn status_report_marks_an_unprobed_server_backed_zero_component_project_not_checked() {
+        with_isolated_home(|_| {
+            crate::server::save(&crate::server::Server {
+                id: "sandbox".to_string(),
+                host: "sandbox.example.test".to_string(),
+                user: "tester".to_string(),
+                port: 22,
+                identity_file: Some("/missing/homeboy-test-key".to_string()),
+                aliases: Vec::new(),
+                kind: None,
+                auth: None,
+                env: Default::default(),
+                runner: None,
+            })
+            .expect("save server");
+            crate::project::save(&Project {
+                id: "sandbox-project".to_string(),
+                server_id: Some("sandbox".to_string()),
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let report = status_report("sandbox-project", true).expect("status report");
+            let health = report.health.expect("configured server health");
+
+            assert_eq!(
+                health.state,
+                crate::server::health::ServerHealthState::NotChecked
+            );
+            assert_eq!(
+                health.next_action.as_deref(),
+                Some("homeboy server status sandbox")
+            );
+            assert!(report.component_versions.is_none());
         });
     }
 }

--- a/crates/homeboy-core/src/project/report.rs
+++ b/crates/homeboy-core/src/project/report.rs
@@ -26,8 +26,7 @@ pub struct ProjectShowReport {
     pub project: Project,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deploy_ready: Option<bool>,
+    pub deploy_ready: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub deploy_blockers: Vec<String>,
 }
@@ -110,20 +109,16 @@ pub fn list_report() -> Result<ProjectListReport> {
 pub fn show_report(project_id: &str) -> Result<ProjectShowReport> {
     let project = load(project_id)?;
 
-    let hint = if project.components.is_empty() {
-        None
-    } else if project.server_id.is_none() {
+    let hint = if project.server_id.is_none() {
         Some("Local project: Server-deployed components require a server.".to_string())
     } else {
         None
     };
 
-    let (deploy_ready, deploy_blockers) = if project.components.is_empty() {
-        (None, Vec::new())
-    } else {
-        let (ready, blockers) = calculate_deploy_readiness(&project);
-        (Some(ready), blockers)
-    };
+    let (deploy_ready, mut deploy_blockers) = calculate_deploy_readiness(&project);
+    if project.server_id.is_some() && project.components.is_empty() {
+        deploy_blockers.clear();
+    }
 
     Ok(ProjectShowReport {
         project,
@@ -173,7 +168,7 @@ pub fn build_show_output(report: ProjectShowReport) -> ProjectReportOutput {
         entity: Some(report.project),
         hint: report.hint,
         extra: ProjectReportExtra {
-            deploy_ready: report.deploy_ready,
+            deploy_ready: Some(report.deploy_ready),
             deploy_blockers: if report.deploy_blockers.is_empty() {
                 None
             } else {
@@ -367,7 +362,7 @@ mod tests {
 
             let report = show_report("site").expect("show report");
 
-            assert_eq!(report.deploy_ready, Some(false));
+            assert!(!report.deploy_ready);
             assert!(report.deploy_blockers.iter().any(|blocker| {
                 blocker.contains(
                     "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist",
@@ -408,7 +403,7 @@ mod tests {
             let report = show_report("site").expect("show report");
 
             assert!(
-                report.deploy_ready == Some(true),
+                report.deploy_ready,
                 "unexpected blockers: {:?}",
                 report.deploy_blockers
             );
@@ -442,8 +437,13 @@ mod tests {
             let report = show_report("sandbox-project").expect("show report");
 
             assert!(report.hint.is_none());
-            assert!(report.deploy_ready.is_none());
+            assert!(!report.deploy_ready);
             assert!(report.deploy_blockers.is_empty());
+
+            let output = build_show_output(report);
+            let json = serde_json::to_value(output).expect("serialize show output");
+            assert_eq!(json["deploy_ready"], false);
+            assert!(json.get("deploy_blockers").is_none());
         });
     }
 

--- a/crates/homeboy-core/src/server/health.rs
+++ b/crates/homeboy-core/src/server/health.rs
@@ -6,7 +6,7 @@
 use super::SshClient;
 use crate::engine::shell::quote_arg;
 use crate::project::Project;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use std::time::Duration;
 
 const PROJECT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -15,8 +15,48 @@ const PROJECT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 // Types
 // ============================================================================
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerHealthState {
+    Healthy,
+    Unhealthy,
+    NotChecked,
+}
+
+impl ServerHealthState {
+    pub fn is_healthy(self) -> bool {
+        self == Self::Healthy
+    }
+}
+
+impl Default for ServerHealthState {
+    fn default() -> Self {
+        Self::NotChecked
+    }
+}
+
+impl Serialize for ServerHealthState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::Healthy => "healthy",
+            Self::Unhealthy => "unhealthy",
+            Self::NotChecked => "not_checked",
+        })
+    }
+}
+
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct ServerHealth {
+    /// Whether the configured server transport was proven by this probe.
+    pub state: ServerHealthState,
+    /// Why the probe could not establish healthy transport.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Exact diagnostic command for an unresolved or failed server session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
     /// Server uptime as a human-readable string (e.g. "10 days")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uptime: Option<String>,
@@ -82,16 +122,31 @@ pub struct ServiceStatus {
 /// Returns None if the server can't be reached or isn't configured.
 pub fn collect_project_health(proj: &Project) -> Option<ServerHealth> {
     let server_id = proj.server_id.as_deref()?;
-    let srv = super::load(server_id).ok()?;
-    let client = SshClient::from_server(&srv, server_id).ok()?;
-    Some(collect_server_health(&client, &proj.services))
+    let srv = match super::load(server_id) {
+        Ok(server) => server,
+        Err(error) => return Some(not_checked(server_id, error.to_string())),
+    };
+    let client = match SshClient::from_server(&srv, server_id) {
+        Ok(client) => client,
+        Err(error) => return Some(not_checked(server_id, error.to_string())),
+    };
+    Some(collect_server_health(&client, server_id, &proj.services))
+}
+
+fn not_checked(server_id: &str, reason: String) -> ServerHealth {
+    ServerHealth {
+        state: ServerHealthState::NotChecked,
+        reason: Some(reason),
+        next_action: Some(format!("homeboy server status {server_id}")),
+        ..Default::default()
+    }
 }
 
 /// Collect server health metrics via a single SSH command.
 ///
 /// Runs a compound shell command that outputs structured, delimited sections
 /// for uptime, load, disk, memory, and optionally service statuses.
-fn collect_server_health(client: &SshClient, services: &[String]) -> ServerHealth {
+fn collect_server_health(client: &SshClient, server_id: &str, services: &[String]) -> ServerHealth {
     // Build a single compound command to minimize SSH round-trips.
     // Each section is delimited by a marker line for reliable parsing.
     let mut cmd_parts = vec![
@@ -126,13 +181,35 @@ fn collect_server_health(client: &SshClient, services: &[String]) -> ServerHealt
         PROJECT_HEALTH_PROBE_TIMEOUT.as_secs()
     );
     let output = client.execute_with_timeout(&compound_cmd, PROJECT_HEALTH_PROBE_TIMEOUT);
+    health_from_probe(&output, server_id, services)
+}
 
-    if !output.success && output.stdout.is_empty() {
-        // Total SSH failure — return empty health
-        return ServerHealth::default();
+fn health_from_probe(
+    output: &crate::server::CommandOutput,
+    server_id: &str,
+    services: &[String],
+) -> ServerHealth {
+    let mut health = parse_health_output(&output.stdout, services);
+    let complete = health.uptime.is_some()
+        && health.load.is_some()
+        && health.disk.is_some()
+        && health.memory.is_some();
+
+    if output.success && complete {
+        health.state = ServerHealthState::Healthy;
+        return health;
     }
 
-    parse_health_output(&output.stdout, services)
+    health.state = ServerHealthState::Unhealthy;
+    health.reason = Some(if output.timed_out {
+        "Server health probe timed out.".to_string()
+    } else if output.stderr.trim().is_empty() {
+        "Server health probe returned incomplete evidence.".to_string()
+    } else {
+        format!("Server health probe failed: {}", output.stderr.trim())
+    });
+    health.next_action = Some(format!("homeboy server status {server_id}"));
+    health
 }
 
 // ============================================================================
@@ -542,6 +619,60 @@ Mem:          3.8Gi       1.5Gi       1.0Gi       0.0Ki       1.3Gi       2.0Gi
         assert_eq!(health.uptime.as_deref(), Some("2 hours, 15 minutes"));
         assert!(health.services.is_empty());
         assert!(health.warnings.is_empty());
+    }
+
+    fn successful_probe(stdout: &str) -> crate::server::CommandOutput {
+        crate::server::CommandOutput {
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+            success: true,
+            exit_code: 0,
+            timed_out: false,
+            child_resource: None,
+        }
+    }
+
+    #[test]
+    fn health_probe_marks_a_server_backed_zero_component_project_healthy_with_complete_evidence() {
+        let output = successful_probe(
+            "---UPTIME---\nup 2 hours\n---LOAD---\n0.50 0.30 0.20 1/100 5678\n---CPUS---\n2\n---DISK---\n/dev/vda1 75G 30G 42G 42% /\n---MEMORY---\nMem: 3.8Gi 1.5Gi 1.0Gi 0.0Ki 1.3Gi 2.0Gi\n",
+        );
+
+        let health = health_from_probe(&output, "sandbox", &[]);
+
+        assert_eq!(health.state, ServerHealthState::Healthy);
+        assert!(health.reason.is_none());
+    }
+
+    #[test]
+    fn health_probe_marks_a_server_backed_zero_component_project_unhealthy_on_transport_failure() {
+        let output = crate::server::CommandOutput {
+            stdout: String::new(),
+            stderr: "Connection timed out".to_string(),
+            success: false,
+            exit_code: 255,
+            timed_out: true,
+            child_resource: None,
+        };
+
+        let health = health_from_probe(&output, "sandbox", &[]);
+
+        assert_eq!(health.state, ServerHealthState::Unhealthy);
+        assert_eq!(
+            health.next_action.as_deref(),
+            Some("homeboy server status sandbox")
+        );
+    }
+
+    #[test]
+    fn unresolved_server_is_not_checked_with_an_actionable_session_command() {
+        let health = not_checked("sandbox", "identity file is missing".to_string());
+
+        assert_eq!(health.state, ServerHealthState::NotChecked);
+        assert_eq!(
+            health.next_action.as_deref(),
+            Some("homeboy server status sandbox")
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/server/health.rs
+++ b/crates/homeboy-core/src/server/health.rs
@@ -57,6 +57,9 @@ pub struct ServerHealth {
     /// Exact diagnostic command for an unresolved or failed server session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
+    /// Telemetry dimensions that the reachable server did not provide.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub telemetry_unavailable: Vec<String>,
     /// Server uptime as a human-readable string (e.g. "10 days")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uptime: Option<String>,
@@ -145,21 +148,21 @@ fn not_checked(server_id: &str, reason: String) -> ServerHealth {
 /// Collect server health metrics via a single SSH command.
 ///
 /// Runs a compound shell command that outputs structured, delimited sections
-/// for uptime, load, disk, memory, and optionally service statuses.
+/// for opportunistic uptime, load, disk, memory, and service telemetry.
 fn collect_server_health(client: &SshClient, server_id: &str, services: &[String]) -> ServerHealth {
     // Build a single compound command to minimize SSH round-trips.
     // Each section is delimited by a marker line for reliable parsing.
     let mut cmd_parts = vec![
         "echo '---UPTIME---'".to_string(),
-        "uptime -p 2>/dev/null || uptime".to_string(),
+        "uptime -p 2>/dev/null || uptime 2>/dev/null || true".to_string(),
         "echo '---LOAD---'".to_string(),
-        "cat /proc/loadavg 2>/dev/null".to_string(),
+        "cat /proc/loadavg 2>/dev/null || true".to_string(),
         "echo '---CPUS---'".to_string(),
-        "nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1".to_string(),
+        "nproc 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || true".to_string(),
         "echo '---DISK---'".to_string(),
-        "df -h / 2>/dev/null | tail -1".to_string(),
+        "df -h / 2>/dev/null | tail -1 || true".to_string(),
         "echo '---MEMORY---'".to_string(),
-        "free -h 2>/dev/null | grep '^Mem:'".to_string(),
+        "free -h 2>/dev/null | grep '^Mem:' || true".to_string(),
     ];
 
     if !services.is_empty() {
@@ -174,7 +177,8 @@ fn collect_server_health(client: &SshClient, server_id: &str, services: &[String
         }
     }
 
-    let compound_cmd = cmd_parts.join(" && ");
+    cmd_parts.push("echo '---PROBE_COMPLETE---'".to_string());
+    let compound_cmd = cmd_parts.join("; ");
     log_status!(
         "project",
         "phase=health_probe timeout={}s",
@@ -190,12 +194,9 @@ fn health_from_probe(
     services: &[String],
 ) -> ServerHealth {
     let mut health = parse_health_output(&output.stdout, services);
-    let complete = health.uptime.is_some()
-        && health.load.is_some()
-        && health.disk.is_some()
-        && health.memory.is_some();
+    health.telemetry_unavailable = unavailable_telemetry(&health);
 
-    if output.success && complete {
+    if output.stdout.contains("---PROBE_COMPLETE---") {
         health.state = ServerHealthState::Healthy;
         return health;
     }
@@ -210,6 +211,23 @@ fn health_from_probe(
     });
     health.next_action = Some(format!("homeboy server status {server_id}"));
     health
+}
+
+fn unavailable_telemetry(health: &ServerHealth) -> Vec<String> {
+    let mut unavailable = Vec::new();
+    if health.uptime.is_none() {
+        unavailable.push("uptime".to_string());
+    }
+    if health.load.is_none() {
+        unavailable.push("load".to_string());
+    }
+    if health.disk.is_none() {
+        unavailable.push("disk".to_string());
+    }
+    if health.memory.is_none() {
+        unavailable.push("memory".to_string());
+    }
+    unavailable
 }
 
 // ============================================================================
@@ -252,6 +270,7 @@ fn parse_health_output(output: &str, services: &[String]) -> ServerHealth {
                 current_section = "services";
                 continue;
             }
+            "---PROBE_COMPLETE---" => continue,
             _ => {}
         }
 
@@ -635,13 +654,26 @@ Mem:          3.8Gi       1.5Gi       1.0Gi       0.0Ki       1.3Gi       2.0Gi
     #[test]
     fn health_probe_marks_a_server_backed_zero_component_project_healthy_with_complete_evidence() {
         let output = successful_probe(
-            "---UPTIME---\nup 2 hours\n---LOAD---\n0.50 0.30 0.20 1/100 5678\n---CPUS---\n2\n---DISK---\n/dev/vda1 75G 30G 42G 42% /\n---MEMORY---\nMem: 3.8Gi 1.5Gi 1.0Gi 0.0Ki 1.3Gi 2.0Gi\n",
+            "---UPTIME---\nup 2 hours\n---LOAD---\n0.50 0.30 0.20 1/100 5678\n---CPUS---\n2\n---DISK---\n/dev/vda1 75G 30G 42G 42% /\n---MEMORY---\nMem: 3.8Gi 1.5Gi 1.0Gi 0.0Ki 1.3Gi 2.0Gi\n---PROBE_COMPLETE---\n",
         );
 
         let health = health_from_probe(&output, "sandbox", &[]);
 
         assert_eq!(health.state, ServerHealthState::Healthy);
         assert!(health.reason.is_none());
+        assert!(health.telemetry_unavailable.is_empty());
+    }
+
+    #[test]
+    fn health_probe_keeps_transport_healthy_when_bsd_or_minimal_telemetry_is_unavailable() {
+        let output = successful_probe(
+            "---UPTIME---\nup 2 hours\n---DISK---\n/dev/disk1 100G 30G 70G 30% /\n---PROBE_COMPLETE---\n",
+        );
+
+        let health = health_from_probe(&output, "sandbox", &[]);
+
+        assert_eq!(health.state, ServerHealthState::Healthy);
+        assert_eq!(health.telemetry_unavailable, vec!["load", "memory"]);
     }
 
     #[test]

--- a/tests/commands/fleet_test.rs
+++ b/tests/commands/fleet_test.rs
@@ -1,4 +1,5 @@
-use super::validate_exec_apply_boundary;
+use super::{health_indicator, validate_exec_apply_boundary};
+use homeboy::core::server::health::{ServerHealth, ServerHealthState};
 
 #[test]
 fn fleet_exec_requires_apply_for_real_execution() {
@@ -22,4 +23,24 @@ fn fleet_exec_check_and_applied_execution_pass_apply_guard() {
         .expect("--check should not require --apply");
     validate_exec_apply_boundary("production", &command, false, true)
         .expect("--apply should pass guard");
+}
+
+#[test]
+fn fleet_health_indicator_never_marks_unproven_transport_green() {
+    let healthy = ServerHealth {
+        state: ServerHealthState::Healthy,
+        ..Default::default()
+    };
+    let unhealthy = ServerHealth {
+        state: ServerHealthState::Unhealthy,
+        ..Default::default()
+    };
+    let not_checked = ServerHealth {
+        state: ServerHealthState::NotChecked,
+        ..Default::default()
+    };
+
+    assert_eq!(health_indicator(Some(&healthy)), "✅");
+    assert_eq!(health_indicator(Some(&unhealthy)), "❌");
+    assert_eq!(health_indicator(Some(&not_checked)), "❌");
 }


### PR DESCRIPTION
Fixes #11565

## Summary
- Classify configured server transport as `healthy`, `unhealthy`, or `not_checked`; failed and unprobed probes include a reason and exact `homeboy server status <id>` action.
- Treat Linux telemetry as opportunistic: a completion marker proves transport reachability while unavailable metrics are listed in `telemetry_unavailable`.
- Keep SSH-only projects without components out of deploy-remediation guidance while preserving the required `project show` `deploy_ready: bool` response field.
- Render unproven fleet transport as non-green.

## Evidence
- `cargo fmt --check` - passed
- `cargo test -p homeboy-core server::health::tests --lib` - passed (25 tests)
- `cargo test -p homeboy-core project::report::tests --lib` - passed (4 tests)
- `cargo test -p homeboy-core fleet::status::tests --lib` - passed (1 test)
- `cargo test -p homeboy-cli fleet_health_indicator_never_marks_unproven_transport_green --lib` - passed (1 test)
- `cargo test -p homeboy-cli commands::project::tests --lib` - passed (2 tests)
- `cargo check -p homeboy-cli` - passed
- CI run [30970925377](https://github.com/Extra-Chill/homeboy/actions/runs/30970925377) failed only at aggregate job [92199668984](https://github.com/Extra-Chill/homeboy/actions/runs/30970925377/job/92199668984): all four successful candidate shards returned zero executed tests despite a five-file changed scope. This external action shard-replay/result-path regression is tracked by [homeboy-action#345](https://github.com/Extra-Chill/homeboy-action/issues/345).
- Local changed-scope reproduction reached unrelated cleanup command-contract compile errors for `CleanupCategoryArg::LeakedTestHomes`, before shard replay.

## AI assistance
Model: OpenAI GPT-5.6 Sol
Tool: OpenCode
Used to inspect review findings, implement the follow-up repair, inspect CI artifacts, and diagnose the external shard-replay regression. Chris remains responsible for every line.