### PR TITLE
Fix bounded detached runner-exec recovery

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -24,6 +24,7 @@ use homeboy_core::extension_readiness::READY_CHECK_SKIPPED_REASON;
 use homeboy_upgrade::upgrade;
 
 const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
+const RUNNER_EXEC_RECOVERY_OWNER_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER";
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
@@ -356,18 +357,11 @@ impl CliRuntime {
         }
 
         register_startup_providers_before_reconcile();
-        // Recover completed generic runner-exec jobs before a mutating invocation
-        // can evict their evidence. Read-only commands must not mutate durable
-        // state during startup.
-        if requires_startup_reconciliation(&normalized)
-            && !normalized
-                .windows(2)
-                .any(|args| args == ["agent-task", "promotion-provider"])
-            && !normalized
-                .windows(3)
-                .any(|args| args == ["agent-task", "tool", "dispatch"])
-        {
-            let _ = crate::runner::reconcile_terminal_runner_exec_runs();
+        if let Some(owner_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_OWNER_ENV) {
+            let _ = crate::runner::run_scheduled_terminal_runner_exec_recovery(
+                &owner_id.to_string_lossy(),
+            );
+            return std::process::ExitCode::SUCCESS;
         }
         let config = crate::core::defaults::load_config();
         if let Err(error) = register_startup_providers_after_reconcile(&config.agent_task) {
@@ -652,6 +646,12 @@ impl CliRuntime {
                 command_provenance,
             )
         });
+        // The command's initial outcome is now durable and returned. Historical
+        // runner evidence is a separately owned
+        // best-effort recovery concern and cannot delay that boundary.
+        if requires_startup_reconciliation(&normalized) {
+            schedule_runner_exec_recovery();
+        }
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
     }
 
@@ -682,6 +682,25 @@ impl CliRuntime {
         self.extension_discovery
             .get_or_init(collect_extension_cli_info_metadata_only)
     }
+}
+
+fn schedule_runner_exec_recovery() {
+    let Ok(Some(schedule)) = crate::runner::schedule_terminal_runner_exec_recovery() else {
+        return;
+    };
+    eprintln!(
+        "runner-exec recovery accepted: owner_id={} deferred_count={} budget_ms={} inspect=`{}`",
+        schedule.owner_id, schedule.deferred_count, schedule.budget_ms, schedule.inspection_action
+    );
+    let Ok(executable) = std::env::current_exe() else {
+        return;
+    };
+    let _ = ProcessCommand::new(executable)
+        .env(RUNNER_EXEC_RECOVERY_OWNER_ENV, &schedule.owner_id)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
 }
 
 /// A cook has no durable run record until controller admission. Re-exec before

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -692,15 +692,25 @@ fn schedule_runner_exec_recovery() {
         "runner-exec recovery accepted: owner_id={} deferred_count={} budget_ms={} inspect=`{}`",
         schedule.owner_id, schedule.deferred_count, schedule.budget_ms, schedule.inspection_action
     );
+    if !schedule.is_new_owner {
+        return;
+    }
     let Ok(executable) = std::env::current_exe() else {
         return;
     };
-    let _ = ProcessCommand::new(executable)
+    let mut command = ProcessCommand::new(executable);
+    command
         .env(RUNNER_EXEC_RECOVERY_OWNER_ENV, &schedule.owner_id)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
+        .stderr(std::process::Stdio::null());
+    crate::core::process::detach_from_caller_session(&mut command);
+    if let Err(error) = command.spawn() {
+        let _ = crate::runner::record_scheduled_terminal_runner_exec_recovery_spawn_failure(
+            &schedule.owner_id,
+            &error,
+        );
+    }
 }
 
 /// A cook has no durable run record until controller admission. Re-exec before

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -243,6 +243,16 @@ const MIGRATIONS: &[Migration] = &[
             WHERE NOT EXISTS (SELECT 1 FROM runs WHERE runs.id = trace_runs.run_id);
         "#,
     },
+    Migration {
+        // A running runner-exec recovery is a controller-wide singleton. The
+        // unique partial index makes the durable record itself the atomic claim.
+        version: 14,
+        sql: r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_one_running_runner_exec_recovery
+            ON runs(kind)
+            WHERE kind = 'runner_exec_recovery' AND status = 'running';
+        "#,
+    },
 ];
 
 /// The schema version a freshly initialized store lands on.

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -123,8 +123,9 @@ pub(crate) use daemon_api::daemon_api_post_for_session;
 pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
 pub use recovery::{
-    reconcile_terminal_runner_exec_runs, run_scheduled_terminal_runner_exec_recovery,
-    schedule_terminal_runner_exec_recovery,
+    reconcile_terminal_runner_exec_runs,
+    record_scheduled_terminal_runner_exec_recovery_spawn_failure,
+    run_scheduled_terminal_runner_exec_recovery, schedule_terminal_runner_exec_recovery,
 };
 
 /// Retire a completed direct daemon generation only after controller-owned

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -122,7 +122,10 @@ pub use daemon_api::daemon_api_post;
 pub(crate) use daemon_api::daemon_api_post_for_session;
 pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
-pub use recovery::reconcile_terminal_runner_exec_runs;
+pub use recovery::{
+    reconcile_terminal_runner_exec_runs, run_scheduled_terminal_runner_exec_recovery,
+    schedule_terminal_runner_exec_recovery,
+};
 
 /// Retire a completed direct daemon generation only after controller-owned
 /// evidence has been checkpointed and projected.

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -15,6 +15,7 @@ pub struct RunnerExecRecoverySchedule {
     pub deferred_count: usize,
     pub budget_ms: u64,
     pub inspection_action: String,
+    pub is_new_owner: bool,
 }
 
 /// Reserve a durable, independently inspectable owner before a background
@@ -37,14 +38,14 @@ pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecov
             .get("deferred_count")
             .and_then(Value::as_u64)
             .unwrap_or(0) as usize;
-        return Ok(Some(recovery_schedule(&existing.id, deferred_count)));
+        return Ok(Some(recovery_schedule(&existing.id, deferred_count, false)));
     }
     let candidates = recovery_candidates(&store)?;
     if candidates.is_empty() {
         return Ok(None);
     }
     let owner_id = format!("runner-exec-recovery-{}", Uuid::new_v4());
-    store.start_run_with_id(
+    let new_owner = store.start_run_with_id(
         NewRunRecord::builder(RECOVERY_KIND)
             .metadata(json!({
                 "phase": "accepted",
@@ -54,16 +55,41 @@ pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecov
             }))
             .build(),
         owner_id.clone(),
-    )?;
-    Ok(Some(recovery_schedule(&owner_id, candidates.len())))
+    );
+    if new_owner.is_err() {
+        let existing = store
+            .list_runs(RunListFilter {
+                kind: Some(RECOVERY_KIND.to_string()),
+                status: Some(RunStatus::Running.as_str().to_string()),
+                limit: Some(1),
+                ..RunListFilter::default()
+            })?
+            .into_iter()
+            .next();
+        if let Some(existing) = existing {
+            let deferred_count = existing
+                .metadata_json
+                .get("deferred_count")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            return Ok(Some(recovery_schedule(&existing.id, deferred_count, false)));
+        }
+        new_owner?;
+    }
+    Ok(Some(recovery_schedule(&owner_id, candidates.len(), true)))
 }
 
-fn recovery_schedule(owner_id: &str, deferred_count: usize) -> RunnerExecRecoverySchedule {
+fn recovery_schedule(
+    owner_id: &str,
+    deferred_count: usize,
+    is_new_owner: bool,
+) -> RunnerExecRecoverySchedule {
     RunnerExecRecoverySchedule {
         owner_id: owner_id.to_string(),
         deferred_count,
         budget_ms: STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64,
         inspection_action: format!("homeboy runs show {owner_id}"),
+        is_new_owner,
     }
 }
 
@@ -254,6 +280,22 @@ pub fn run_scheduled_terminal_runner_exec_recovery(owner_id: &str) -> Result<()>
     metadata["budget_ms"] = json!(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64);
     metadata["inspection_action"] = json!(format!("homeboy runs show {owner_id}"));
     store.finish_running_run(owner_id, RunStatus::Pass, Some(metadata))?;
+    Ok(())
+}
+
+pub fn record_scheduled_terminal_runner_exec_recovery_spawn_failure(
+    owner_id: &str,
+    error: &std::io::Error,
+) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(owner) = store.get_run(owner_id)? else {
+        return Ok(());
+    };
+    let mut metadata = owner.metadata_json;
+    metadata["phase"] = json!("spawn_failed");
+    metadata["spawn_error"] = json!(error.to_string());
+    metadata["inspection_action"] = json!(format!("homeboy runs show {owner_id}"));
+    store.finish_running_run(owner_id, RunStatus::Error, Some(metadata))?;
     Ok(())
 }
 

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -1,24 +1,95 @@
 //! Recovery of generic runner-exec evidence after a controller interruption.
 
 use super::*;
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
 
 const STARTUP_RUNNER_EXEC_RECOVERY_LIMIT: i64 = 100;
+pub const STARTUP_RUNNER_EXEC_RECOVERY_BUDGET: Duration = Duration::from_secs(5);
+const RECOVERY_KIND: &str = "runner_exec_recovery";
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RunnerExecRecoverySchedule {
+    pub owner_id: String,
+    pub deferred_count: usize,
+    pub budget_ms: u64,
+    pub inspection_action: String,
+}
+
+/// Reserve a durable, independently inspectable owner before a background
+/// recovery worker is spawned. Scheduling only reads local evidence; remote
+/// reconciliation belongs to the owner, never to the mutating caller.
+pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecoverySchedule>> {
+    let store = ObservationStore::open_initialized()?;
+    if let Some(existing) = store
+        .list_runs(RunListFilter {
+            kind: Some(RECOVERY_KIND.to_string()),
+            status: Some(RunStatus::Running.as_str().to_string()),
+            limit: Some(1),
+            ..RunListFilter::default()
+        })?
+        .into_iter()
+        .next()
+    {
+        let deferred_count = existing
+            .metadata_json
+            .get("deferred_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        return Ok(Some(recovery_schedule(&existing.id, deferred_count)));
+    }
+    let candidates = recovery_candidates(&store)?;
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    let owner_id = format!("runner-exec-recovery-{}", Uuid::new_v4());
+    store.start_run_with_id(
+        NewRunRecord::builder(RECOVERY_KIND)
+            .metadata(json!({
+                "phase": "accepted",
+                "deferred_count": candidates.len(),
+                "budget_ms": STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64,
+                "inspection_action": format!("homeboy runs show {owner_id}"),
+            }))
+            .build(),
+        owner_id.clone(),
+    )?;
+    Ok(Some(recovery_schedule(&owner_id, candidates.len())))
+}
+
+fn recovery_schedule(owner_id: &str, deferred_count: usize) -> RunnerExecRecoverySchedule {
+    RunnerExecRecoverySchedule {
+        owner_id: owner_id.to_string(),
+        deferred_count,
+        budget_ms: STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64,
+        inspection_action: format!("homeboy runs show {owner_id}"),
+    }
+}
 
 /// Scan durable generic runner-exec runs, query their exact accepted runner-job
 /// binding, then retain declared evidence before terminal projection. This runs
 /// before command dispatch so a new daemon operation cannot evict a completed
 /// job while its controller checkpoint is still pending.
 pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
+    reconcile_terminal_runner_exec_runs_with_budget(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET)
+        .map(|(reconciled, _)| reconciled)
+}
+
+/// Reconcile under one owner-wide wall-clock budget. A failed endpoint is not
+/// retried for each historical job: all later records on that runner are
+/// deferred with their evidence intact for a later owner.
+pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Result<(usize, usize)> {
     let store = ObservationStore::open_initialized()?;
     let mut reconciled = 0;
-    for run in store.list_runs(RunListFilter {
-        kind: Some("runner_execution".to_string()),
-        status: Some(RunStatus::Running.as_str().to_string()),
-        limit: Some(STARTUP_RUNNER_EXEC_RECOVERY_LIMIT),
-        ..RunListFilter::default()
-    })? {
-        if run.metadata_json.get("kind").and_then(Value::as_str) != Some("runner_exec") {
-            continue;
+    let mut deferred = 0;
+    let mut unavailable_runners = BTreeSet::new();
+    let deadline = Instant::now() + budget;
+    let candidates = recovery_candidates(&store)?;
+    for (index, run) in candidates.iter().enumerate() {
+        if Instant::now() >= deadline {
+            deferred += candidates.len() - index;
+            break;
         }
         let (Some(runner_id), Some(job_id), Some(cwd)) = (
             run.metadata_json.get("runner_id").and_then(Value::as_str),
@@ -29,10 +100,30 @@ pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
         ) else {
             continue;
         };
+        if unavailable_runners.contains(runner_id) {
+            deferred += 1;
+            continue;
+        }
         let snapshot = match crate::evidence::runner_job_log_snapshot(runner_id, job_id) {
             Ok(snapshot) => snapshot,
             Err(error) => {
                 record_evicted_evidence_loss(&store, &run, &error)?;
+                // A 404 is a durable per-job result. Other failures describe the
+                // endpoint, so avoid amplifying one unavailable daemon into N probes.
+                if error.details.get("http_status").and_then(Value::as_u64) != Some(404) {
+                    unavailable_runners.insert(runner_id.to_string());
+                    deferred += candidates
+                        .iter()
+                        .skip(index + 1)
+                        .filter(|candidate| {
+                            candidate
+                                .metadata_json
+                                .get("runner_id")
+                                .and_then(Value::as_str)
+                                == Some(runner_id)
+                        })
+                        .count();
+                }
                 continue;
             }
         };
@@ -137,7 +228,61 @@ pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
         homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(&run.id, &snapshot)?;
         reconciled += 1;
     }
-    Ok(reconciled)
+    Ok((reconciled, deferred))
+}
+
+/// Complete one accepted recovery owner and leave deferred source records
+/// running, preserving their remote-evidence recovery opportunity.
+pub fn run_scheduled_terminal_runner_exec_recovery(owner_id: &str) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(owner) = store.get_run(owner_id)? else {
+        return Ok(());
+    };
+    if owner.kind != RECOVERY_KIND || owner.status != RunStatus::Running.as_str() {
+        return Ok(());
+    }
+    let (reconciled, deferred_count) =
+        reconcile_terminal_runner_exec_runs_with_budget(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET)?;
+    let mut metadata = owner.metadata_json;
+    metadata["phase"] = json!(if deferred_count == 0 {
+        "completed"
+    } else {
+        "deferred"
+    });
+    metadata["reconciled_count"] = json!(reconciled);
+    metadata["deferred_count"] = json!(deferred_count);
+    metadata["budget_ms"] = json!(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64);
+    metadata["inspection_action"] = json!(format!("homeboy runs show {owner_id}"));
+    store.finish_running_run(owner_id, RunStatus::Pass, Some(metadata))?;
+    Ok(())
+}
+
+fn recovery_candidates(
+    store: &ObservationStore,
+) -> Result<Vec<homeboy_core::observation::RunRecord>> {
+    Ok(store
+        .list_runs(RunListFilter {
+            kind: Some("runner_execution".to_string()),
+            status: Some(RunStatus::Running.as_str().to_string()),
+            limit: Some(STARTUP_RUNNER_EXEC_RECOVERY_LIMIT),
+            ..RunListFilter::default()
+        })?
+        .into_iter()
+        .filter(|run| {
+            run.metadata_json.get("kind").and_then(Value::as_str) == Some("runner_exec")
+                && run
+                    .metadata_json
+                    .get("runner_id")
+                    .and_then(Value::as_str)
+                    .is_some()
+                && run
+                    .metadata_json
+                    .get("runner_job_id")
+                    .and_then(Value::as_str)
+                    .is_some()
+                && run.cwd.is_some()
+        })
+        .collect())
 }
 
 fn recovered_output(
@@ -285,7 +430,7 @@ mod tests {
             }
             connection
                 .execute(
-                    "INSERT INTO runs(id, kind, started_at, status, metadata_json) VALUES ('outside-budget', 'runner_execution', '2026-01-01T00:00:00Z', 'running', 'invalid-json')",
+                    "INSERT INTO runs(id, kind, started_at, status, metadata_json) VALUES ('outside-budget', 'runner_execution', '2026-01-01T00:00:00Z', 'running', '{\"kind\":\"runner_exec\"}')",
                     [],
                 )
                 .expect("insert outside-budget candidate");
@@ -295,6 +440,54 @@ mod tests {
                 reconcile_terminal_runner_exec_runs().expect("bounded recovery"),
                 0
             );
+        });
+    }
+
+    #[test]
+    fn recovery_owner_accepts_a_hundred_historical_jobs_without_remote_reconciliation() {
+        with_isolated_home(|_| {
+            for index in 0..STARTUP_RUNNER_EXEC_RECOVERY_LIMIT {
+                homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                    &format!("stale-{index}"),
+                    "unavailable-runner",
+                    &format!("job-{index}"),
+                    "/workspace",
+                    &["true".to_string()],
+                )
+                .expect("historical runner job");
+            }
+
+            let schedule = schedule_terminal_runner_exec_recovery()
+                .expect("schedule recovery")
+                .expect("historical jobs need an owner");
+            assert_eq!(
+                schedule.deferred_count,
+                STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize
+            );
+            assert_eq!(
+                schedule.budget_ms,
+                STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64
+            );
+            assert_eq!(
+                schedule.inspection_action,
+                format!("homeboy runs show {}", schedule.owner_id)
+            );
+
+            // A zero owner budget is a deterministic interruption boundary: no
+            // daemon endpoint is contacted and every source record remains
+            // recoverable for the next owner.
+            assert_eq!(
+                reconcile_terminal_runner_exec_runs_with_budget(Duration::ZERO)
+                    .expect("bounded recovery"),
+                (0, STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize)
+            );
+            let store = ObservationStore::open_initialized().expect("store");
+            assert!(store
+                .get_run("stale-0")
+                .expect("read")
+                .expect("historical record")
+                .status
+                .eq("running"));
         });
     }
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -244,6 +244,7 @@ pub use execution::{
     daemon_api_get, daemon_api_post, exec, promote_runner_exec_artifact_dirs,
     promote_runner_exec_artifacts, promote_runner_exec_summaries, promoted_output,
     reconcile_runner_generation_after_evidence, reconcile_terminal_runner_exec_runs,
+    record_scheduled_terminal_runner_exec_recovery_spawn_failure,
     run_scheduled_terminal_runner_exec_recovery, runner_exec_failure_error,
     runner_exec_structured_summary, runner_job_cancel, runner_job_cancel_for_session,
     runner_job_cancel_projection, schedule_terminal_runner_exec_recovery, RunnerExecDiagnostics,

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -244,8 +244,9 @@ pub use execution::{
     daemon_api_get, daemon_api_post, exec, promote_runner_exec_artifact_dirs,
     promote_runner_exec_artifacts, promote_runner_exec_summaries, promoted_output,
     reconcile_runner_generation_after_evidence, reconcile_terminal_runner_exec_runs,
-    runner_exec_failure_error, runner_exec_structured_summary, runner_job_cancel,
-    runner_job_cancel_for_session, runner_job_cancel_projection, RunnerExecDiagnostics,
+    run_scheduled_terminal_runner_exec_recovery, runner_exec_failure_error,
+    runner_exec_structured_summary, runner_job_cancel, runner_job_cancel_for_session,
+    runner_job_cancel_projection, schedule_terminal_runner_exec_recovery, RunnerExecDiagnostics,
     RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerExecPromotedOutput,
     RunnerExecStructuredSummary,
 };


### PR DESCRIPTION
Fixes #11156

## Summary
- move historical runner-exec reconciliation behind a durable detached recovery owner after command acceptance/handoff
- bound each owner to one recovery budget and stop repeat probes for an unavailable runner endpoint
- retain source records for deferred recovery and expose owner ID, deferred count, budget, and `homeboy runs show <owner-id>` inspection action
- add deterministic coverage for 100 stale runner-exec records and an interruption boundary that preserves recovery evidence

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-lab-runner recovery --lib` (122 passed)
- `cargo test -p homeboy-lab-runner recovery_owner_accepts_a_hundred_historical_jobs_without_remote_reconciliation --lib`

## Known verification blockers
- `cargo test -p homeboy-cli cli_runtime --lib` has one existing Lab-dependent fixture failure: `global_runner_for_runs_artifact_get_is_absorbed_into_command_option` reaches `runner subsystem is unavailable: cannot execute a Lab offload`.
- `cargo clippy -p homeboy-cli -p homeboy-lab-runner -- -D warnings` fails on pre-existing warnings in `homeboy-engine-primitives`.

AI assistance: OpenAI GPT-5.6 Sol via OpenCode inspected the startup/recovery architecture and related issues, implemented the durable recovery owner and bounded worker, and ran focused verification. Chris Huber remains responsible for every line.