### PR TITLE
fix(runner): bound shared status projections

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -410,7 +410,7 @@ fn connect_with_orphan_adoption_and_live_lease(
     let mut replacement_operation_id = None;
     if let Some(pending) = pending_replacement.as_ref() {
         if let Ok(mut observed) = remote_daemon_status(&client, homeboy) {
-            probe_remote_daemon_endpoint(&client, &mut observed);
+            probe_remote_daemon_endpoint(&client, &mut observed, Some(runner_id));
             let exact = observed.daemon.as_ref().is_some_and(|daemon| {
                 daemon.lease_id == pending.remote_daemon_lease_id
                     && daemon.pid == pending.remote_daemon_pid
@@ -1037,7 +1037,7 @@ fn verify_live_lease_adoption(
         return Ok(());
     };
     let mut status = remote_daemon_status(client, homeboy).map_err(Error::internal_unexpected)?;
-    probe_remote_daemon_endpoint(client, &mut status);
+    probe_remote_daemon_endpoint(client, &mut status, None);
     let daemon = status.daemon.ok_or_else(|| {
         Error::validation_invalid_argument(
             "adopt_live_lease",
@@ -2187,7 +2187,7 @@ fn remote_daemon_recovery_freshness(
     };
     match bounded_remote_daemon_status(&client, homeboy, runner_id) {
         Ok(mut status) => {
-            remote_daemon::probe_remote_daemon_endpoint(&client, &mut status);
+            remote_daemon::probe_remote_daemon_endpoint(&client, &mut status, Some(runner_id));
             Some(remote_daemon_recovery_freshness_from_status(
                 runner_id, &status,
             ))
@@ -2243,21 +2243,42 @@ fn runner_jobs(
             "runner `{runner_id}` is connected but has no active-job status endpoint"
         )));
     };
-    let active_jobs = parse_runner_jobs(
-        &body,
-        "active_runner_jobs",
-        "parse active runner jobs",
-        runner_id,
-        source,
-    )?;
-    let stale_jobs = parse_runner_jobs(
-        &body,
-        "stale_runner_jobs",
-        "parse stale runner jobs",
-        runner_id,
-        source,
-    )?;
-    Ok((active_jobs, stale_jobs))
+    let result: Result<(Vec<ActiveRunnerJobSummary>, Vec<ActiveRunnerJobSummary>)> = (|| {
+        let active_jobs = parse_runner_jobs(
+            &body,
+            "active_runner_jobs",
+            "parse active runner jobs",
+            runner_id,
+            source,
+        )?;
+        let stale_jobs = parse_runner_jobs(
+            &body,
+            "stale_runner_jobs",
+            "parse stale runner jobs",
+            runner_id,
+            source,
+        )?;
+        Ok((active_jobs, stale_jobs))
+    })();
+    if let Err(error) = &result {
+        let timeout = crate::readonly_probe::readonly_probe_timeout();
+        let timed_out = error.message.to_ascii_lowercase().contains("timed out");
+        crate::readonly_probe::record_degradation(crate::readonly_probe::ReadOnlyProbeDegradation {
+            probe: "runner_typed_jobs".to_string(),
+            runner_id: Some(runner_id.to_string()),
+            reason_code: if timed_out {
+                crate::readonly_probe::REASON_PROBE_TIMEOUT
+            } else {
+                crate::readonly_probe::REASON_PROBE_UNAVAILABLE
+            },
+            timeout_seconds: timed_out.then_some(timeout.as_secs()).unwrap_or(0),
+            detail: format!(
+                "read-only typed-job probe for runner `{runner_id}` did not complete; active-job state is partial: {}",
+                error.message
+            ),
+        });
+    }
+    result
 }
 
 fn orphaned_child_run_jobs(

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1467,8 +1467,8 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     // must be reported as disconnected rather than triggering tunnel recovery.
     // Recovery can wait on shared control-plane state and may open a tunnel, so
     // it belongs to explicit connect/admission operations instead.
-    let session = read_session_or_live_peer(runner_id)?;
-    let state = session_state(session.as_ref());
+    let session = read_session_for_status(runner_id)?;
+    let state = status_session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected)?;
     let local_daemon_freshness = runner_daemon_freshness(&runner, session.as_ref(), connected)?;
@@ -1611,8 +1611,8 @@ pub fn reconcile_status(runner_id: &str) -> Result<RunnerStatusReport> {
 /// probing a daemon, or reconciling generation state.
 pub fn persisted_status(runner_id: &str) -> Result<RunnerStatusReport> {
     let session_path = session_path(runner_id)?;
-    let session = read_session_or_live_peer(runner_id)?;
-    let state = session_state(session.as_ref());
+    let session = read_session_for_status(runner_id)?;
+    let state = status_session_state(session.as_ref());
     Ok(RunnerStatusReport {
         runner_id: runner_id.to_string(),
         connected: state == RunnerSessionState::Connected,
@@ -2211,7 +2211,7 @@ fn runner_jobs(
     session: &RunnerSession,
 ) -> Result<(Vec<ActiveRunnerJobSummary>, Vec<ActiveRunnerJobSummary>)> {
     let client = Client::builder()
-        .timeout(Duration::from_secs(10))
+        .timeout(crate::readonly_probe::readonly_probe_timeout())
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build active job client: {err}")))?;
     let (body, source) = if let Some(local_url) = session.local_url.as_deref() {
@@ -3163,8 +3163,8 @@ pub fn statuses_indexed() -> Result<Vec<RunnerActiveJobsSnapshot>> {
     for runner in super::list()? {
         // Indexed inspection is read-only: reconnecting here can start SSH work
         // and makes controller discovery depend on the unhealthy runner.
-        let session = read_session_or_live_peer(&runner.id)?;
-        let connected = session_state(session.as_ref()) == RunnerSessionState::Connected;
+        let session = read_session_for_status(&runner.id)?;
+        let connected = status_session_state(session.as_ref()) == RunnerSessionState::Connected;
         let (active_jobs, active_job_state, active_job_error) = if connected {
             match session.as_ref() {
                 Some(session) => match runner_jobs(&runner.id, session) {
@@ -3220,6 +3220,7 @@ mod status_read_purity_tests {
             "generation_store::reconcile_admission_session",
             "write_session(",
             "adopt",
+            "read_session_or_live_peer",
         ] {
             assert!(
                 !status.contains(mutation),

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -616,7 +616,7 @@ pub(super) fn ensure_remote_daemon(
     registry_lock_held: bool,
 ) -> std::result::Result<RemoteDaemon, String> {
     let mut status = remote_daemon_status(client, homeboy)?;
-    probe_remote_daemon_endpoint(client, &mut status);
+    probe_remote_daemon_endpoint(client, &mut status, Some(runner_id));
     if let Some(lease_id) = orphan_lease_id {
         if let Some(fence) = admission_fence {
             return Err(format!(
@@ -1251,7 +1251,11 @@ mod tests {
     }
 }
 
-pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut RemoteDaemonStatus) {
+pub(super) fn probe_remote_daemon_endpoint(
+    client: &SshClient,
+    status: &mut RemoteDaemonStatus,
+    runner_id: Option<&str>,
+) {
     if !status.reachable {
         return;
     }
@@ -1273,7 +1277,7 @@ pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut Remo
     let output = client.execute_with_timeout(&command, timeout);
     crate::readonly_probe::record_probe_outcome(
         "runner_remote_endpoint_identity",
-        None,
+        runner_id,
         timeout,
         &output,
     );
@@ -1316,7 +1320,13 @@ pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut Remo
         "curl --fail --silent --show-error --max-time 2 {}/jobs",
         shell::quote_arg(&format!("http://{}", daemon.address))
     );
-    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
+    let output = client.execute_with_timeout(&command, timeout);
+    crate::readonly_probe::record_probe_outcome(
+        "runner_remote_typed_jobs",
+        runner_id,
+        timeout,
+        &output,
+    );
     if !output.success {
         status.endpoint_probe_error = Some(command_failure_message(
             "remote daemon typed job probe failed",
@@ -1581,7 +1591,7 @@ fn verify_remote_daemon_replacement(
     configured_identity: &str,
 ) -> std::result::Result<RemoteDaemon, String> {
     let mut status = remote_daemon_status(client, homeboy)?;
-    probe_remote_daemon_endpoint(client, &mut status);
+    probe_remote_daemon_endpoint(client, &mut status, None);
     let daemon = status.daemon.ok_or_else(|| {
         "remote stale-daemon replacement re-probe returned no daemon state".to_string()
     })?;

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -1269,7 +1269,14 @@ pub(super) fn probe_remote_daemon_endpoint(client: &SshClient, status: &mut Remo
         "curl --fail --silent --show-error --max-time 2 {}/version",
         shell::quote_arg(&format!("http://{}", daemon.address))
     );
-    let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
+    let timeout = crate::readonly_probe::readonly_probe_timeout();
+    let output = client.execute_with_timeout(&command, timeout);
+    crate::readonly_probe::record_probe_outcome(
+        "runner_remote_endpoint_identity",
+        None,
+        timeout,
+        &output,
+    );
     if !output.success {
         status.endpoint_probe_error = Some(command_failure_message(
             "remote daemon endpoint identity probe failed",

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -176,11 +176,109 @@ pub(super) fn read_session(runner_id: &str) -> Result<Option<RunnerSession>> {
     read_session_for_controller(runner_id, &controller_id())
 }
 
-/// Status is a projection of this controller's durable session. Peer discovery
-/// performs one liveness probe per historical controller record, so it belongs
-/// to handoff/admission paths rather than a read-only status command.
+/// Status reads the current controller session first, then performs a bounded
+/// projection of peer-owned direct tunnels. This preserves a usable shared
+/// tunnel without allowing historical session directories to turn status into
+/// an unbounded liveness scan.
 pub(super) fn read_session_for_status(runner_id: &str) -> Result<Option<RunnerSession>> {
-    read_session(runner_id)
+    let controller_id = controller_id();
+    let session = read_session_for_controller(runner_id, &controller_id)?;
+    if session
+        .as_ref()
+        .is_some_and(|session| status_session_state(Some(session)) == RunnerSessionState::Connected)
+    {
+        return Ok(session);
+    }
+    let directory = paths::runner_sessions_dir()?.join(runner_id);
+    match status_peer_session_in(&directory, &controller_id)? {
+        StatusPeerSession::One(peer) => Ok(Some(peer)),
+        StatusPeerSession::None => Ok(session),
+        StatusPeerSession::Ambiguous => {
+            crate::readonly_probe::record_degradation(
+                crate::readonly_probe::ReadOnlyProbeDegradation {
+                    probe: "runner_peer_session".to_string(),
+                    runner_id: Some(runner_id.to_string()),
+                    reason_code: crate::readonly_probe::REASON_PROBE_AMBIGUOUS,
+                    timeout_seconds: 0,
+                    detail: format!(
+                        "multiple live direct-SSH peer sessions for runner `{runner_id}` disagree on daemon identity; status is partial. Run `homeboy runner reconcile {runner_id}` to select or repair the authoritative session."
+                    ),
+                },
+            );
+            Ok(session)
+        }
+    }
+}
+
+enum StatusPeerSession {
+    None,
+    One(RunnerSession),
+    Ambiguous,
+}
+
+/// Status observes at most this many persisted peers. The current controller
+/// session is always inspected separately above, so this is only historical
+/// shared state and never an admission scan.
+const STATUS_PEER_SESSION_LIMIT: usize = 8;
+const STATUS_PEER_SESSION_TIMEOUT: Duration = Duration::from_secs(1);
+
+fn status_peer_session_in(directory: &PathBuf, controller_id: &str) -> Result<StatusPeerSession> {
+    status_peer_session_in_with(directory, controller_id, |session| {
+        session_is_live_with_timeout(session, STATUS_PEER_SESSION_TIMEOUT)
+    })
+}
+
+fn status_peer_session_in_with(
+    directory: &PathBuf,
+    controller_id: &str,
+    is_live: impl Fn(&RunnerSession) -> bool,
+) -> Result<StatusPeerSession> {
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(StatusPeerSession::None)
+        }
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some("read runner controller sessions".to_string()),
+            ))
+        }
+    };
+    let mut paths = entries
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read runner controller session".to_string()),
+            )
+        })?;
+    paths.sort();
+    let mut peer: Option<RunnerSession> = None;
+    for path in paths
+        .into_iter()
+        .filter(|path| is_controller_session_file(path))
+        .take(STATUS_PEER_SESSION_LIMIT)
+    {
+        let Some(candidate) = read_session_at(&path)? else {
+            continue;
+        };
+        if candidate.controller_id.as_deref() == Some(controller_id)
+            || candidate.mode != RunnerTunnelMode::DirectSsh
+            || !is_live(&candidate)
+        {
+            continue;
+        }
+        if peer
+            .as_ref()
+            .is_some_and(|peer| !same_direct_daemon_identity(peer, &candidate))
+        {
+            return Ok(StatusPeerSession::Ambiguous);
+        }
+        peer = Some(candidate);
+    }
+    Ok(peer.map_or(StatusPeerSession::None, StatusPeerSession::One))
 }
 
 /// Keep the local tunnel observation inside the same explicit read-only budget
@@ -1033,6 +1131,43 @@ mod tests {
         assert_eq!(
             read_session_at(&path).expect("read stored session"),
             Some(peer)
+        );
+    }
+
+    #[test]
+    fn status_projects_one_live_peer_without_creating_a_local_session() {
+        let root = TempDir::new().expect("session directory");
+        let peer = session("peer-controller", "lease-live");
+        write_session_at(&root.path().join("peer-controller.json"), &peer)
+            .expect("write peer session");
+
+        let projected =
+            status_peer_session_in_with(&root.path().to_path_buf(), "current-controller", |_| true)
+                .expect("project peer session");
+
+        assert!(matches!(projected, StatusPeerSession::One(session) if session == peer));
+        assert!(root.path().join("peer-controller.json").exists());
+        assert!(!root.path().join("current-controller.json").exists());
+    }
+
+    #[test]
+    fn status_peer_projection_refuses_ambiguous_live_daemons_without_mutation() {
+        let root = TempDir::new().expect("session directory");
+        let first = session("peer-a", "lease-a");
+        let second = session("peer-b", "lease-b");
+        write_session_at(&root.path().join("peer-a.json"), &first).expect("write first peer");
+        write_session_at(&root.path().join("peer-b.json"), &second).expect("write second peer");
+
+        let peer = status_peer_session_in_with(&root.path().to_path_buf(), "current", |_| true)
+            .expect("scan live peers");
+        assert!(matches!(peer, StatusPeerSession::Ambiguous));
+        assert_eq!(
+            read_session_at(&root.path().join("peer-a.json")).expect("read first"),
+            Some(first)
+        );
+        assert_eq!(
+            read_session_at(&root.path().join("peer-b.json")).expect("read second"),
+            Some(second)
         );
     }
 

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -176,6 +176,42 @@ pub(super) fn read_session(runner_id: &str) -> Result<Option<RunnerSession>> {
     read_session_for_controller(runner_id, &controller_id())
 }
 
+/// Status is a projection of this controller's durable session. Peer discovery
+/// performs one liveness probe per historical controller record, so it belongs
+/// to handoff/admission paths rather than a read-only status command.
+pub(super) fn read_session_for_status(runner_id: &str) -> Result<Option<RunnerSession>> {
+    read_session(runner_id)
+}
+
+/// Keep the local tunnel observation inside the same explicit read-only budget
+/// as remote identity and active-job probes. A failed check is disconnected,
+/// not a trigger to scan peers or reconcile a tunnel.
+pub(super) fn status_session_state(session: Option<&RunnerSession>) -> RunnerSessionState {
+    match session {
+        Some(session)
+            if session.mode == RunnerTunnelMode::Reverse
+                && session.role == RunnerSessionRole::Controller =>
+        {
+            if reverse_controller_session_is_live(session) {
+                RunnerSessionState::Connected
+            } else {
+                RunnerSessionState::Recorded
+            }
+        }
+        Some(session) if session.mode == RunnerTunnelMode::Reverse => RunnerSessionState::Recorded,
+        Some(session)
+            if session_is_live_with_timeout(
+                session,
+                crate::readonly_probe::readonly_probe_timeout(),
+            ) =>
+        {
+            RunnerSessionState::Connected
+        }
+        Some(_) => RunnerSessionState::Disconnected,
+        None => RunnerSessionState::Disconnected,
+    }
+}
+
 /// Resolve this controller's session, or borrow a peer's live direct-SSH
 /// tunnel for an in-process handoff. Borrowing never writes a controller
 /// record, so only the original controller may later tear down that tunnel.

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -1889,6 +1889,76 @@ fn status_lists_reverse_session_records() {
 }
 
 #[test]
+fn full_status_projection_leaves_large_legacy_shared_state_and_observation_db_unchanged() {
+    test_support::with_isolated_home(|home| {
+        crate::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false).expect("create runner");
+        homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("initialize shared observation database");
+        let session = direct_ssh_session("lease-000");
+        write_session(&session).expect("write disconnected direct session");
+        let mut generations = crate::RollingGenerations::new("lease-000", session.clone());
+        for index in 1..=70 {
+            let generation = format!("lease-{index:03}");
+            let mut endpoint = session.clone();
+            endpoint.remote_daemon_lease_id = Some(generation.clone());
+            generations.begin(generation, endpoint);
+        }
+        crate::generation_store::write("homeboy-lab", &generations)
+            .expect("write generation registry");
+        let registry_path = homeboy_core::paths::runner_sessions_dir()
+            .expect("runner sessions directory")
+            .join("homeboy-lab/generations.json");
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&registry_path).expect("read registry"))
+                .expect("parse registry");
+        legacy
+            .as_object_mut()
+            .expect("registry object")
+            .remove("runner_id");
+        std::fs::write(
+            &registry_path,
+            serde_json::to_vec_pretty(&legacy).expect("serialize legacy registry"),
+        )
+        .expect("write legacy registry");
+        let before = snapshot_directory(home.path());
+
+        let report = status("homeboy-lab").expect("full runner status projection");
+
+        assert!(!report.connected);
+        assert_eq!(report.active_job_count, 0);
+        assert_eq!(snapshot_directory(home.path()), before);
+    });
+}
+
+fn snapshot_directory(
+    root: &std::path::Path,
+) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {
+    fn collect(
+        root: &std::path::Path,
+        directory: &std::path::Path,
+        snapshot: &mut std::collections::BTreeMap<std::path::PathBuf, Vec<u8>>,
+    ) {
+        for entry in std::fs::read_dir(directory).expect("read data directory") {
+            let path = entry.expect("read data entry").path();
+            if path.is_dir() {
+                collect(root, &path, snapshot);
+            } else {
+                snapshot.insert(
+                    path.strip_prefix(root)
+                        .expect("relative data path")
+                        .to_path_buf(),
+                    std::fs::read(&path).expect("read data file"),
+                );
+            }
+        }
+    }
+
+    let mut snapshot = std::collections::BTreeMap::new();
+    collect(root, root, &mut snapshot);
+    snapshot
+}
+
+#[test]
 fn status_marks_connected_reverse_active_jobs_unavailable_without_broker_url() {
     test_support::with_isolated_home(|_| {
         crate::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false).expect("create runner");

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -270,7 +270,7 @@ fn probe_authoritative_daemon_status(runner_id: &str) -> Result<remote_daemon::R
             None,
         )
     })?;
-    remote_daemon::probe_remote_daemon_endpoint(&client, &mut status);
+    remote_daemon::probe_remote_daemon_endpoint(&client, &mut status, Some(runner_id));
     Ok(status)
 }
 

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -298,6 +298,41 @@ pub(crate) fn read(
     }
 }
 
+/// Read generation state for an observation without acquiring a writer lock or
+/// repairing a legacy registry. Status must describe legacy state, not migrate
+/// it: a concurrent writer owns that repair through the normal mutation path.
+fn read_projection(
+    runner_id: &str,
+    legacy: Option<&RunnerSession>,
+) -> Result<Option<RollingGenerations<RunnerSession>>> {
+    let path = path(runner_id)?;
+    if !path.exists() {
+        return Ok(legacy
+            .map(|session| RollingGenerations::new(legacy_generation(session), session.clone())));
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+    validate_registry_shape(&value)?;
+    match serde_json::from_value::<GenerationRegistry<RunnerSession>>(value.clone()) {
+        Ok(registry) if registry.runner_id == runner_id => Ok(Some(registry.generations)),
+        Ok(registry) => Err(Error::config_invalid_value(
+            "runner_id",
+            Some(registry.runner_id),
+            format!("generation registry must match runner-scoped path `{runner_id}`"),
+        )),
+        // This is the precise legacy shape the mutating reader repairs. Keep it
+        // readable here so status remains a projection even while a writer owns
+        // the registry lock.
+        Err(_) => Ok(Some(
+            serde_json::from_value::<RollingGenerations<RunnerSession>>(value)
+                .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?,
+        )),
+    }
+}
+
 /// Read while the caller already holds this runner's registry lock. Legacy
 /// migration stays inside that transaction instead of attempting a re-entrant
 /// `flock` acquisition.
@@ -850,7 +885,7 @@ pub(crate) fn status_projection(
     legacy: Option<&RunnerSession>,
 ) -> Result<Vec<RunnerDaemonGenerationStatus>> {
     Ok(
-        read(runner_id, legacy)?.map_or_else(Vec::new, |generations| {
+        read_projection(runner_id, legacy)?.map_or_else(Vec::new, |generations| {
             generations
                 .generations
                 .into_iter()
@@ -1159,6 +1194,67 @@ impl SshGenerationEndpointOperations<'_> {
 
 fn daemon_health_data(health: &serde_json::Value) -> &serde_json::Value {
     health.get("data").unwrap_or(health)
+}
+
+#[cfg(test)]
+mod projection_tests {
+    use super::*;
+    use crate::{RunnerSessionRole, RunnerTunnelMode};
+
+    fn session(lease_id: &str) -> RunnerSession {
+        RunnerSession {
+            runner_id: "shared-lab".to_string(),
+            mode: RunnerTunnelMode::DirectSsh,
+            role: RunnerSessionRole::Controller,
+            server_id: Some("unreachable-lab".to_string()),
+            controller_id: Some("shared-controller".to_string()),
+            broker_url: None,
+            remote_daemon_address: Some("127.0.0.1:49152".to_string()),
+            local_port: Some(49153),
+            local_url: Some("http://127.0.0.1:49153".to_string()),
+            tunnel_pid: Some(u32::MAX),
+            tunnel_process_start_identity: None,
+            remote_daemon_pid: Some(4242),
+            remote_daemon_lease_id: Some(lease_id.to_string()),
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: Some("homeboy test+shared".to_string()),
+            connected_at: "2026-08-05T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }
+    }
+
+    #[test]
+    fn shared_status_projects_a_large_legacy_registry_without_repairing_it() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut generations = RollingGenerations::new("lease-000", session("lease-000"));
+            for index in 1..=70 {
+                let generation = format!("lease-{index:03}");
+                generations.begin(generation.clone(), session(&generation));
+            }
+            write("shared-lab", &generations).expect("write generation registry");
+            let path = path("shared-lab").expect("generation registry path");
+            let mut legacy: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&path).expect("read registry"))
+                    .expect("parse registry");
+            legacy
+                .as_object_mut()
+                .expect("registry object")
+                .remove("runner_id");
+            let legacy = serde_json::to_vec_pretty(&legacy).expect("serialize legacy registry");
+            std::fs::write(&path, &legacy).expect("write legacy registry");
+
+            let started = Instant::now();
+            let projection = status_projection("shared-lab", Some(&session("lease-000")))
+                .expect("project legacy generation registry");
+
+            assert_eq!(projection.len(), 71);
+            assert!(started.elapsed() < Duration::from_secs(3));
+            assert_eq!(std::fs::read(&path).expect("read after status"), legacy);
+        });
+    }
 }
 
 impl GenerationEndpointOperations for SshGenerationEndpointOperations<'_> {

--- a/crates/homeboy-lab-runner/src/readonly_probe.rs
+++ b/crates/homeboy-lab-runner/src/readonly_probe.rs
@@ -78,6 +78,9 @@ pub const REASON_PROBE_INTERRUPTED: &str = "readonly_probe.interrupted";
 /// read-only command can drop the ambient failure from its *streams* without
 /// dropping it from its *answer* (#10525).
 pub const REASON_PROBE_UNAVAILABLE: &str = "readonly_probe.unavailable";
+/// Several persisted peer sessions claimed different live direct-SSH daemon
+/// identities, so status intentionally declined to select one.
+pub const REASON_PROBE_AMBIGUOUS: &str = "readonly_probe.ambiguous";
 
 // Per-thread ledger, mirroring the existing `ACTIVE_PROBE_LIMITS` design in
 // `homeboy-core`'s SSH client. Inspection commands probe and drain on the same


### PR DESCRIPTION
## Summary
- Project legacy generation state during status reads without migration, locking, or writes.
- Limit runner status to the current controller session and the shared read-only probe budget.
- Record endpoint identity timeout degradation and retain the explicit reconciliation path for mutation.

Fixes #10436

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p homeboy-lab-runner shared_status_projects_a_large_legacy_registry_without_repairing_it
- cargo test -p homeboy-lab-runner status_has_no_lifecycle_mutation_path
- cargo test -p homeboy-lab-runner idle_stale_replacement_refuses_a_post_stop_identity_change
- cargo test -p homeboy-cli --lib commands::agent_task::status (47 passed)
- cargo check -p homeboy-lab-runner

cargo test -p homeboy-lab-runner exceeded the local 120-second command ceiling after 1668 tests had started; its one observed failure passed when rerun directly. cargo clippy -p homeboy-lab-runner --tests -- -D warnings is blocked by eight existing warnings in homeboy-engine-primitives.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the shared status reader, implemented the read-only projection, ran focused and broad verification, and drafted this PR. Chris Huber remains responsible for every line.