### PR TITLE
fix(daemon): skip duplicate recovery in internal startup

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -121,6 +121,17 @@ pub fn classify(args: &[String]) -> CommandCapability {
 /// already-durable aggregate unavailable during a Lab outage.
 pub fn requires_startup_reconciliation(args: &[String]) -> bool {
     classify(args) == CommandCapability::Mutation
+        // The lifecycle command that launches these internal processes already
+        // performs startup recovery. Repeating it here delays lease publication
+        // and can make the supervisor kill an otherwise healthy cold start.
+        && !args
+            .get(1..)
+            .unwrap_or_default()
+            .windows(2)
+            .any(|args| {
+                matches!(args, [command, subcommand]
+                    if command == "daemon" && matches!(subcommand.as_str(), "supervise" | "serve"))
+            })
         && !args
             .get(1..)
             .unwrap_or_default()
@@ -227,5 +238,39 @@ mod tests {
             "run-1",
             "--run",
         ])));
+    }
+
+    #[test]
+    fn internal_daemon_processes_publish_their_lease_without_repeating_recovery() {
+        for command in [
+            args(&[
+                "homeboy",
+                "daemon",
+                "supervise",
+                "--addr",
+                "127.0.0.1:0",
+                "--startup-token",
+                "token",
+            ]),
+            args(&[
+                "homeboy",
+                "daemon",
+                "serve",
+                "--addr",
+                "127.0.0.1:0",
+                "--startup-token",
+                "token",
+            ]),
+        ] {
+            assert_eq!(classify(&command), CommandCapability::Mutation);
+            assert!(!requires_startup_reconciliation(&command));
+        }
+
+        for command in [
+            args(&["homeboy", "daemon", "start"]),
+            args(&["homeboy", "daemon", "ensure-running"]),
+        ] {
+            assert!(requires_startup_reconciliation(&command));
+        }
     }
 }

--- a/tests/daemon_ensure_running_cli.rs
+++ b/tests/daemon_ensure_running_cli.rs
@@ -1,0 +1,38 @@
+use std::fs;
+
+use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary};
+
+#[test]
+fn ensure_running_observes_the_isolated_daemon_startup_lease() {
+    let context = HermeticTestContext::new();
+    let mut ensure = context.command(TestBinary::HomeboyFixture);
+    ensure.args(["daemon", "ensure-running"]);
+    let ensure_output = bounded_output(ensure);
+
+    let state = fs::read_to_string(context.daemon_dir().join("state.json"));
+
+    let mut stop = context.command(TestBinary::HomeboyFixture);
+    stop.args(["daemon", "stop"]);
+    let stop_output = bounded_output(stop);
+
+    assert!(
+        ensure_output.status.success(),
+        "daemon ensure-running failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&ensure_output.stdout),
+        String::from_utf8_lossy(&ensure_output.stderr),
+    );
+    let state = state.expect("ensure-running must publish daemon state before returning");
+    let state: serde_json::Value = serde_json::from_str(&state).expect("daemon state is JSON");
+    assert!(
+        state["startup_token"]
+            .as_str()
+            .is_some_and(|token| !token.is_empty()),
+        "daemon state must retain the isolated startup token: {state}"
+    );
+    assert!(
+        stop_output.status.success(),
+        "daemon stop failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop_output.stdout),
+        String::from_utf8_lossy(&stop_output.stderr),
+    );
+}


### PR DESCRIPTION
Closes #11571

## Summary

- skip terminal runner-evidence reconciliation in internal `daemon supervise` and `daemon serve` processes
- preserve startup reconciliation for operator-facing `daemon start` and `daemon ensure-running` commands
- add classifier coverage and an end-to-end startup-token lease handoff test

## Root cause

The parent lifecycle command already performed startup reconciliation, but the supervised child repeated it before binding and writing `state.json`. With retained Lab evidence, that duplicate pass took about 35 seconds, so the supervisor exhausted its five-second isolated-token budget and killed an otherwise healthy daemon.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli command_capability::tests`
- `cargo test --test daemon_ensure_running_cli`
- candidate `target/debug/homeboy daemon ensure-running` against the operator state that reproduced the failure: succeeded with a valid lease, then stopped cleanly

## Baseline limitations

- `cargo clippy -p homeboy-cli --all-targets -- -D warnings` is blocked by eight unrelated existing Rust 1.95 warnings in `homeboy-engine-primitives`
- the full `cargo test -p homeboy-cli` exceeded 15 minutes and exposed unrelated existing failures in `aggregate_runtime_tmp_failure_returns_partial_json_and_continues` and `generic_lab_profile_expands_safe_destructive_evidence_defaults`; the affected bounded suites pass

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the startup sequencing failure, implemented the focused fix, and added regression coverage. Chris Huber reviewed and owns the change.