### PR TITLE
fix(daemon): record actual terminal signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       scope: auto
       differential-gating: 'false'
       baseline-commands: none
-      test-shards: '8'
+      test-shards: '16'
       execution-timeout-seconds: '1800'
       test-timeout-seconds: '1500'
       comment-section-key: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       scope: auto
       differential-gating: 'false'
       baseline-commands: none
-      test-shards: '4'
+      test-shards: '8'
       execution-timeout-seconds: '1800'
       test-timeout-seconds: '1500'
       comment-section-key: test

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -106,17 +106,16 @@ impl ExecutorArtifactRootIdentity {
             ));
         }
         #[cfg(unix)]
-        let res = {
+        {
             use std::os::unix::fs::MetadataExt;
-            current.dev() != self.device || current.ino() != self.inode
-        };
-        if res {
-            return Err(Error::validation_invalid_argument(
-                "artifacts_path",
-                "Homeboy executor artifact root changed during provider execution",
-                Some(self.path.display().to_string()),
-                None,
-            ));
+            if current.dev() != self.device || current.ino() != self.inode {
+                return Err(Error::validation_invalid_argument(
+                    "artifacts_path",
+                    "Homeboy executor artifact root changed during provider execution",
+                    Some(self.path.display().to_string()),
+                    None,
+                ));
+            }
         }
         #[cfg(windows)]
         {

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -138,6 +138,7 @@ fn supervise_child(mut child: std::process::Child) -> Result<()> {
         resource_evidence: "unavailable: launcher does not collect OS resource snapshots".to_string(),
         os_evidence: "unavailable: no OS evidence collected; exit status and signal are launcher observations only".to_string(),
         exit_code, signal,
+        supervisor_signal: None,
         stdout, stderr, stop_requested,
     };
     super::write_termination_evidence(&evidence)
@@ -2632,6 +2633,7 @@ mod termination_tests {
             os_evidence: "unavailable: fixture has no OS evidence".to_string(),
             exit_code: Some(23),
             signal: None,
+            supervisor_signal: None,
             stdout: None,
             stderr: Some("panic: fixture".to_string()),
             stop_requested: false,

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -467,7 +467,7 @@ pub struct DaemonTerminationEvidence {
     pub exit_code: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signal: Option<i32>,
-    /// Signal used to terminate the supervising process, if escalation needed
+    /// Signal used to terminate the supervising process, if escalation needs
     /// one. This is additive: older evidence deserializes without it and `None`
     /// remains omitted from serialized evidence.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -467,6 +467,11 @@ pub struct DaemonTerminationEvidence {
     pub exit_code: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signal: Option<i32>,
+    /// Signal used to terminate the supervising process, if escalation needed
+    /// one. This is additive: older evidence deserializes without it and `None`
+    /// remains omitted from serialized evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervisor_signal: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stdout: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -114,9 +114,10 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
         active_jobs: 0,
         resource_evidence: "unavailable: forced stop does not collect OS resource snapshots"
             .to_string(),
-        os_evidence: termination,
+        os_evidence: termination.os_evidence(state.pid),
         exit_code: None,
-        signal: Some(SIGNAL_TERMINATE),
+        signal: termination.child_signal,
+        supervisor_signal: termination.supervisor_signal,
         stdout: None,
         stderr: None,
         stop_requested: true,
@@ -135,16 +136,44 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
 /// Stop the serving child first, allowing its supervisor to record the exit and
 /// leave normally. Every signal is preceded by fresh lease, zero-job, and token
 /// checks so a reused PID cannot be killed between the grace window and SIGKILL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SupervisedDaemonTermination {
+    child_signal: Option<i32>,
+    supervisor_signal: Option<i32>,
+}
+
+impl SupervisedDaemonTermination {
+    fn os_evidence(self, child_pid: u32) -> String {
+        let child_signal = signal_name(self.child_signal);
+        let supervisor_signal = self.supervisor_signal.map_or_else(
+            || "exited after child or was not observed".to_string(),
+            |signal| signal_name(Some(signal)).to_string(),
+        );
+        format!(
+            "exact startup-token ownership revalidated immediately before every signal; daemon pid {child_pid} stopped with {child_signal}; supervisor {supervisor_signal}"
+        )
+    }
+}
+
+fn signal_name(signal: Option<i32>) -> &'static str {
+    match signal {
+        Some(SIGNAL_TERMINATE) => "SIGTERM",
+        Some(SIGNAL_KILL) => "SIGKILL",
+        None => "no signal sent",
+        Some(_) => "unknown signal",
+    }
+}
+
 fn terminate_exact_supervised_daemon(
     path: &std::path::Path,
     identity: &DaemonLeaseIdentity,
     state: &DaemonState,
-) -> Result<String> {
+) -> Result<SupervisedDaemonTermination> {
     let supervisor = supervised_parent_pid(state.pid, &state.startup_token)?;
     revalidate_exact_termination_target(path, identity, state)?;
     signal_pid(state.pid, SIGNAL_TERMINATE)?;
     let child_signal = if wait_for_pid_exit(state.pid, TERM_GRACE) {
-        "SIGTERM"
+        Some(SIGNAL_TERMINATE)
     } else {
         revalidate_exact_termination_target(path, identity, state)?;
         signal_pid(state.pid, SIGNAL_KILL)?;
@@ -154,19 +183,19 @@ fn terminate_exact_supervised_daemon(
                 state.pid
             )));
         }
-        "SIGKILL"
+        Some(SIGNAL_KILL)
     };
 
     // The supervisor observes its child exit and normally leaves on its own.
     // If it remains, prove its matching token before applying the same bounded
     // escalation; an unrelated reparented process is never signaled.
     let supervisor_signal = match supervisor {
-        Some(pid) if wait_for_pid_exit(pid, TERM_GRACE) => "exited after child",
+        Some(pid) if wait_for_pid_exit(pid, TERM_GRACE) => None,
         Some(pid) => {
             revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
             signal_pid(pid, SIGNAL_TERMINATE)?;
             if wait_for_pid_exit(pid, TERM_GRACE) {
-                "SIGTERM"
+                Some(SIGNAL_TERMINATE)
             } else {
                 revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
                 signal_pid(pid, SIGNAL_KILL)?;
@@ -175,15 +204,15 @@ fn terminate_exact_supervised_daemon(
                         "daemon supervisor pid {pid} survived bounded SIGTERM-to-SIGKILL escalation"
                     )));
                 }
-                "SIGKILL"
+                Some(SIGNAL_KILL)
             }
         }
-        None => "not observed",
+        None => None,
     };
-    Ok(format!(
-        "exact startup-token ownership revalidated immediately before every signal; daemon pid {} stopped with {child_signal}; supervisor {supervisor_signal}",
-        state.pid
-    ))
+    Ok(SupervisedDaemonTermination {
+        child_signal,
+        supervisor_signal,
+    })
 }
 
 fn revalidate_exact_termination_target(
@@ -465,9 +494,10 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
                 active_jobs: 0,
                 resource_evidence:
                     "unavailable: ordinary stop does not collect OS resource snapshots".to_string(),
-                os_evidence: termination,
+                os_evidence: termination.os_evidence(pid),
                 exit_code: None,
-                signal: Some(SIGNAL_TERMINATE),
+                signal: termination.child_signal,
+                supervisor_signal: termination.supervisor_signal,
                 stdout: None,
                 stderr: None,
                 stop_requested: true,
@@ -496,6 +526,7 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
                     .to_string(),
             exit_code: None,
             signal: None,
+            supervisor_signal: None,
             stdout: None,
             stderr: None,
             stop_requested: true,

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -1191,6 +1191,7 @@ mod tests {
                 os_evidence: "test".to_string(),
                 exit_code: None,
                 signal: None,
+                supervisor_signal: None,
                 stdout: None,
                 stderr: None,
                 stop_requested: true,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -2284,6 +2284,7 @@ fn dead_status_with_unexpected_termination(daemon: super::DaemonStartResult) -> 
         os_evidence: "test".to_string(),
         exit_code: None,
         signal: Some(libc::SIGTERM),
+        supervisor_signal: None,
         stdout: None,
         stderr: None,
         stop_requested: false,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2259,6 +2259,8 @@ fn force_stop_escalates_when_a_token_owned_daemon_ignores_sigterm() {
     assert!(result.stopped);
     let evidence = result.termination_evidence.expect("termination evidence");
     assert!(evidence.os_evidence.contains("SIGKILL"));
+    assert_eq!(evidence.signal, Some(libc::SIGKILL));
+    assert_eq!(evidence.supervisor_signal, None);
     assert!(!pid_is_running(pid));
 }
 
@@ -2311,6 +2313,8 @@ fn lease_bound_stop_converges_term_resistant_mixed_version_supervisor_and_daemon
     let evidence = result.termination_evidence.expect("termination evidence");
     assert!(evidence.os_evidence.contains("daemon pid"));
     assert!(evidence.os_evidence.contains("supervisor SIGKILL"));
+    assert_eq!(evidence.signal, Some(libc::SIGKILL));
+    assert_eq!(evidence.supervisor_signal, Some(libc::SIGKILL));
     assert!(!pid_is_running(daemon_pid));
     assert!(!pid_is_running(supervisor_pid));
     assert!(!state_path().expect("state path").exists());
@@ -2362,6 +2366,8 @@ fn ordinary_stop_escalates_a_fresh_term_resistant_supervised_daemon() {
     let evidence = result.termination_evidence.expect("termination evidence");
     assert!(evidence.os_evidence.contains("daemon pid"));
     assert!(evidence.os_evidence.contains("supervisor SIGKILL"));
+    assert_eq!(evidence.signal, Some(libc::SIGKILL));
+    assert_eq!(evidence.supervisor_signal, Some(libc::SIGKILL));
     assert!(!pid_is_running(daemon_pid));
     assert!(!pid_is_running(supervisor_pid));
 }


### PR DESCRIPTION
Closes #11579
Closes #11660
Closes #11661

## Summary
- return typed child and supervisor termination signals from the exact supervised stop primitive
- persist the actual daemon child terminal signal in signal and supervisor escalation separately in optional supervisor_signal
- render OS evidence from the typed outcome and assert TERM-resistant child/supervisor escalation evidence
- keep Unix artifact-root device/inode verification Unix-only so the existing Windows volume/file-ID verification compiles and runs independently
- increase Homeboy Test parallelism from four to sixteen deterministic shards while preserving the 1,500-second per-shard timeout and fail-closed aggregation

## Compatibility
supervisor_signal is an additive optional serialized field. Existing evidence remains deserializable through serde defaulting, and no field is emitted when no supervisor signal was sent. Consumers with strict response schemas must accept this new field when supervisor escalation occurs.

## Tests
- cargo fmt --all --check
- cargo check --workspace --tests --locked
- focused TERM-resistant daemon child and supervisor tests
- focused artifact-finalization replacement-root and canonical-store tests
- cargo clippy --locked -p homeboy-agents --lib -- -D warnings
- cargo clippy --locked -p homeboy-core --lib -- -D warnings
- actionlint .github/workflows/ci.yml
- Homeboy Action deterministic shard-plan and aggregate contract suite

## AI assistance
OpenAI openai/gpt-5.6-sol via OpenCode implemented the structured daemon termination evidence and focused test updates. OpenAI openai/gpt-5.6-terra via OpenCode traced and repaired the cross-platform artifact-finalization compile regression, analyzed retained CI capacity evidence, verified the sharding contract, and updated the caller shard count. Chris Huber reviewed and owns the change.