### PR TITLE
fix: unbreak main — restore compilation and fix the gate artifact-root guard

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate_executor.rs
+++ b/crates/homeboy-agents/src/agent_task_gate_executor.rs
@@ -569,8 +569,16 @@ mod tests {
                 .join("repo-local-gates")
                 .join("gate-task");
             assert_eq!(execution.artifact_root, expected);
-            assert!(
-                !execution.artifact_root.starts_with(std::env::temp_dir()),
+            // The regression this guards is the pre-#11128 fallback shape, not
+            // "lives under the temp dir": an isolated test home is itself a temp
+            // directory, so a `starts_with(temp_dir())` check cannot tell the
+            // fallback apart from correct isolation and fails for every caller
+            // that sets one.
+            assert_ne!(
+                execution.artifact_root,
+                std::env::temp_dir()
+                    .join("homeboy-repo-local-gates")
+                    .join("gate-task"),
                 "gate artifacts must not fall back to the process temp dir"
             );
         });

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -753,6 +753,7 @@ fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
         auth: Some(ManagedSshSession {
             control_path: "/tmp/homeboy-%h-%p-%r".to_string(),
             persist: "4h".to_string(),
+            persist_source: super::super::ManagedSshSessionPersistSource::Configured,
         }),
         is_local: false,
         env: HashMap::new(),

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -208,6 +208,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: control_path.to_string_lossy().to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -568,6 +568,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: "/tmp/homeboy-control".to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),


### PR DESCRIPTION
**`main` does not compile.** Every open PR's Test gate fails before running a
single test.

```
error[E0063]: missing field `persist_source` in initializer of
              `server::session::ManagedSshSession`
  crates/homeboy-core/src/server/client/tests.rs:753
  crates/homeboy-core/src/server/ssh_args.rs:208
  crates/homeboy-core/src/server/transfer.rs:568

error: could not compile `homeboy-core` (lib test) due to 3 previous errors
```

A semantic merge conflict — one change made `persist_source` required, another
added these three construction sites, and the two merged cleanly without
compiling together. Neither PR's own CI would have caught it.

All three sites are test fixtures building a configured managed session, so all
three take `Configured`, matching the existing initializers beside them.

## Also: `gate_artifact_root_defaults_under_the_configured_artifact_root`

Fails everywhere, including locally, and was in the `agent_task_gate` cluster on
main's Test job.

```rust
assert!(
    !execution.artifact_root.starts_with(std::env::temp_dir()),
    "gate artifacts must not fall back to the process temp dir"
);
```

`with_isolated_home` puts the home *inside* the temp directory, so
`artifacts::root()` legitimately starts with it. The check cannot distinguish
the pre-#11128 fallback it polices from correct test isolation, and fails for
every caller that isolates.

The `assert_eq!` immediately above already proves the contract — that the root
is derived from the configured artifact root. The residual guard now names the
exact fallback shape it exists to prevent
(`temp_dir()/homeboy-repo-local-gates/<task>`), which is both stronger and
isolation-safe.

## Verification

```
cargo check --workspace --tests   clean
cargo fmt --all --check           clean
agent_task_gate                   54 passed, 0 failed
```

The other seven `agent_task_gate` / `agent_task_process_containment` failures in
main's Test log all pass locally at 54/0 and 4/0; they were recorded before
#11549 (the death-guard fd leak) landed, which is the same descendant-reaping
and reader-join territory. Worth re-checking once main compiles again and a
clean run exists.