### PR TITLE
fix(ci): start Rust 1.95 clippy migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Compile all workspace test targets
         run: cargo check --workspace --tests --locked
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Build the shipped CLI without warnings
         run: RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy
       - name: Run a focused agent test without warnings
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Check all workspace crates for Windows
         run: cargo check --workspace --locked
 
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - name: Check workspace formatting

--- a/.github/workflows/command-contract-boundary.yml
+++ b/.github/workflows/command-contract-boundary.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Verify the focused command-contract dependency budget
         run: |
           cargo tree --locked -p homeboy-command-contract -e normal --prefix none > command-contract.tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,7 +365,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -658,7 +658,7 @@ jobs:
       # after bumping Cargo.toml version
       - name: Install Rust toolchain
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Preflight release workspace build
         if: inputs.release_tag == '' && needs.check.outputs.recovery-release != 'true'

--- a/crates/contracts/homeboy-lab-contract/src/lab/workload.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/workload.rs
@@ -171,12 +171,7 @@ impl LabRunnerWorkloadCommandFamily {
     pub fn from_command_label(label: &str) -> Self {
         match label {
             label if label.starts_with("agent-task") => Self::AgentTask,
-            label
-                if matches!(
-                    label,
-                    "review audit" | "review lint" | "review test" | "review build" | "review ci"
-                ) =>
-            {
+            "review audit" | "review lint" | "review test" | "review build" | "review ci" => {
                 Self::Quality
             }
             LINT_LAB_LABEL

--- a/crates/contracts/homeboy-lab-contract/src/secret_env_plan.rs
+++ b/crates/contracts/homeboy-lab-contract/src/secret_env_plan.rs
@@ -97,7 +97,7 @@ pub struct SecretEnvPlanDiagnosticError {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub undeclared_inherited_secret_env: Vec<String>,
     pub message: String,
-    pub diagnostics: SecretEnvPlanDiagnostics,
+    pub diagnostics: Box<SecretEnvPlanDiagnostics>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -200,8 +200,10 @@ pub struct SecretEnvHandoffEntry {
 
 pub struct SecretEnvValueProvider<'a> {
     source: String,
-    resolve: Box<dyn FnMut(&str) -> Option<String> + 'a>,
+    resolve: SecretEnvValueResolver<'a>,
 }
+
+type SecretEnvValueResolver<'a> = Box<dyn FnMut(&str) -> Option<String> + 'a>;
 
 impl<'a> SecretEnvValueProvider<'a> {
     pub fn new(
@@ -581,7 +583,7 @@ impl SecretEnvPlan {
                 ),
                 missing_required_secret_env,
                 undeclared_inherited_secret_env: Vec::new(),
-                diagnostics,
+                diagnostics: Box::new(diagnostics),
             })
         }
     }
@@ -614,7 +616,7 @@ impl SecretEnvPlan {
 
         let mut diagnostics = self
             .diagnose(self.status.clone())
-            .unwrap_or_else(|error| error.diagnostics);
+            .unwrap_or_else(|error| *error.diagnostics);
         diagnostics.inherited_env = inherited_env;
 
         if undeclared.is_empty() {
@@ -624,7 +626,7 @@ impl SecretEnvPlan {
                 message: format!("undeclared inherited secret env: {}", undeclared.join(", ")),
                 missing_required_secret_env: Vec::new(),
                 undeclared_inherited_secret_env: undeclared,
-                diagnostics,
+                diagnostics: Box::new(diagnostics),
             })
         }
     }
@@ -833,7 +835,7 @@ impl SecretEnvMaterializedHandoff {
         let status = normalize_status(status);
         let diagnostics = plan
             .diagnose(status.clone())
-            .unwrap_or_else(|error| error.diagnostics);
+            .unwrap_or_else(|error| *error.diagnostics);
         let missing_secret_env_names = diagnostics
             .status
             .iter()

--- a/crates/homeboy-code-audit/src/codebase_map.rs
+++ b/crates/homeboy-code-audit/src/codebase_map.rs
@@ -282,7 +282,7 @@ pub fn build_map(config: &MapConfig) -> Result<CodebaseMap, Error> {
             HierarchyEntry { parent, children }
         })
         .collect();
-    class_hierarchy.sort_by(|a, b| b.children.len().cmp(&a.children.len()));
+    class_hierarchy.sort_by_key(|entry| std::cmp::Reverse(entry.children.len()));
 
     // Build hook summary
     let mut action_count = 0usize;
@@ -304,7 +304,7 @@ pub fn build_map(config: &MapConfig) -> Result<CodebaseMap, Error> {
         }
     }
     let mut top_prefixes: Vec<(String, usize)> = prefix_counts.into_iter().collect();
-    top_prefixes.sort_by(|a, b| b.1.cmp(&a.1));
+    top_prefixes.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     top_prefixes.truncate(10);
 
     let total_files = all_fingerprints.len();

--- a/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
+++ b/crates/homeboy-code-audit/src/core_fingerprint/mod.rs
@@ -393,8 +393,8 @@ fn find_matching_brace(lines: &[&str], start_line: usize, _grammar: &Grammar) ->
     let mut depth: i32 = 0;
     let mut found_open = false;
 
-    for i in start_line..lines.len() {
-        for ch in lines[i].chars() {
+    for (i, line) in lines.iter().enumerate().skip(start_line) {
+        for ch in line.chars() {
             if ch == '{' {
                 depth += 1;
                 found_open = true;
@@ -537,8 +537,8 @@ fn extract_fn_body(lines: &[&str], start_idx: usize, _grammar: &Grammar) -> Stri
     let mut found_open = false;
     let mut body_lines = Vec::new();
 
-    for i in start_idx..lines.len() {
-        let trimmed = lines[i].trim();
+    for line in lines.iter().skip(start_idx) {
+        let trimmed = line.trim();
 
         // Trait method declarations end with `;` and have no body.
         // If we hit a semicolon before finding any `{`, this is a bodyless declaration.
@@ -546,7 +546,7 @@ fn extract_fn_body(lines: &[&str], start_idx: usize, _grammar: &Grammar) -> Stri
             return String::new();
         }
 
-        for ch in lines[i].chars() {
+        for ch in line.chars() {
             if ch == '{' {
                 depth += 1;
                 found_open = true;
@@ -554,7 +554,7 @@ fn extract_fn_body(lines: &[&str], start_idx: usize, _grammar: &Grammar) -> Stri
                 depth -= 1;
             }
         }
-        body_lines.push(lines[i]);
+        body_lines.push(*line);
         if found_open && depth == 0 {
             break;
         }

--- a/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
+++ b/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
@@ -48,7 +48,7 @@ pub(crate) fn run_report_with_config(
         run_window,
         ..Default::default()
     };
-    let runs = crate::recorded_artifacts::recent_recorded_runs(component_id, run_window as usize);
+    let runs = crate::recorded_artifacts::recent_recorded_runs(component_id, run_window);
     let artifact_root = homeboy_paths::artifact_root().ok();
     let path_policy = config.with_generic_defaults();
 
@@ -67,7 +67,7 @@ pub(crate) fn run_report_with_config(
             if artifact_path_is_portable(&artifact.path, artifact_root.as_deref(), &path_policy) {
                 continue;
             }
-            report.findings.push(artifact_path_finding(&run, &artifact));
+            report.findings.push(artifact_path_finding(&run, artifact));
         }
         let metadata_scan = metadata_path_findings(
             &run,

--- a/crates/homeboy-code-audit/src/detectors/shared_scaffolding.rs
+++ b/crates/homeboy-code-audit/src/detectors/shared_scaffolding.rs
@@ -26,6 +26,8 @@ use super::fingerprint::FileFingerprint;
 
 /// Minimum number of classes with identical shape to consider a group.
 const MIN_GROUP_SIZE: usize = 3;
+type SharedScaffoldingGroups<'a> =
+    HashMap<(String, Vec<(String, String)>), Vec<&'a ClassShape<'a>>>;
 
 /// Minimum mean per-method body similarity (0.0 – 1.0).
 const MIN_MEAN_SIMILARITY: f64 = 0.60;
@@ -70,7 +72,7 @@ fn detect_shared_scaffolding(fingerprints: &[&FileFingerprint]) -> Vec<Finding> 
     }
 
     // Group by (subtree, shape).
-    let mut groups: HashMap<(String, Vec<(String, String)>), Vec<&ClassShape>> = HashMap::new();
+    let mut groups: SharedScaffoldingGroups = HashMap::new();
     for cs in &shapes {
         groups
             .entry((cs.subtree.clone(), cs.shape.clone()))

--- a/crates/homeboy-code-audit/src/detectors/source_policy.rs
+++ b/crates/homeboy-code-audit/src/detectors/source_policy.rs
@@ -35,12 +35,14 @@ pub(crate) fn validate_source_roots(
     let missing = rules
         .iter()
         .flat_map(|rule| {
-            rule.include_path_contains.iter().filter_map(|root| {
-                (!fingerprints
-                    .iter()
-                    .any(|fingerprint| fingerprint.relative_path.contains(root)))
-                .then(|| format!("{}: {root}", rule.id))
-            })
+            rule.include_path_contains
+                .iter()
+                .filter(|root| {
+                    !fingerprints
+                        .iter()
+                        .any(|fingerprint| fingerprint.relative_path.contains(*root))
+                })
+                .map(|root| format!("{}: {root}", rule.id))
         })
         .collect::<Vec<_>>();
 

--- a/crates/homeboy-code-audit/src/discovery.rs
+++ b/crates/homeboy-code-audit/src/discovery.rs
@@ -107,7 +107,7 @@ pub(crate) fn auto_discover_groups_from_snapshot(
         let file_is_test = is_test_path(&fp.relative_path);
         let key = (
             parent,
-            fp.language.clone(),
+            fp.language,
             file_is_test,
             fp.convention_tags.clone(),
         );

--- a/crates/homeboy-code-audit/src/docs_audit/claims.rs
+++ b/crates/homeboy-code-audit/src/docs_audit/claims.rs
@@ -411,7 +411,7 @@ fn is_repo_directory_claim(path: &str) -> bool {
         "assets/",
         ".github/",
     ];
-    REPO_ROOTS.iter().any(|root| path == *root)
+    REPO_ROOTS.contains(&path)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -607,6 +607,7 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
 /// signature; enforced again here so the detector is robust to fingerprints
 /// produced by an older engine.
 const SKELETON_MIN_TOKENS: usize = 4;
+type SkeletonDuplicateGroups<'a> = HashMap<&'a str, Vec<(&'a str, &'a str, Option<&'a str>)>>;
 
 /// Maximum locations a skeleton group may span before it is treated as an
 /// idiomatic shape rather than a reimplemented primitive. A backbone shared by
@@ -695,7 +696,7 @@ pub(crate) fn detect_skeleton_duplicates(fingerprints: &[&FileFingerprint]) -> V
         .collect();
 
     // skeleton_hash -> [(file, name, structural_hash)]
-    let mut by_skeleton: HashMap<&str, Vec<(&str, &str, Option<&str>)>> = HashMap::new();
+    let mut by_skeleton: SkeletonDuplicateGroups = HashMap::new();
     for fp in fingerprints {
         for (name, raw) in &fp.skeleton_hashes {
             let Some((token_count, hash)) = parse_skeleton_value(raw) else {

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -42,6 +42,13 @@ const ROOT_ONLY_DETECTOR_IDS: &[&str] = &[
     "thin_command_adapter",
 ];
 
+pub(super) struct AuditExecution<'a> {
+    pub plan: &'a AuditExecutionPlan,
+    pub reference_paths: &'a [String],
+    pub extension_overrides: &'a [String],
+    pub dead_code_references: Option<DeadCodeReferenceAnalysis>,
+}
+
 /// Internal audit implementation supporting optional file scoping and impact tracing.
 ///
 /// `reference_paths` are external codebases whose fingerprints are included in
@@ -52,11 +59,14 @@ pub(super) fn audit_internal(
     source_path: &str,
     file_filter: Option<&[String]>,
     git_ref: Option<&str>,
-    reference_paths: &[String],
-    plan: &AuditExecutionPlan,
-    extension_overrides: &[String],
-    dead_code_references: Option<DeadCodeReferenceAnalysis>,
+    execution: AuditExecution<'_>,
 ) -> Result<AuditWithAnalysis> {
+    let AuditExecution {
+        plan,
+        reference_paths,
+        extension_overrides,
+        dead_code_references,
+    } = execution;
     let root = Path::new(source_path);
     let audit_config = audit_config_for(component_id, root, extension_overrides);
     let mut timing = AuditTiming::default();
@@ -340,8 +350,7 @@ pub(super) fn audit_internal(
                 .collect()
         });
     let policy_scan_fingerprints: &[&fingerprint::FileFingerprint] = scoped_policy_fingerprints
-        .as_ref()
-        .map(|subset| subset.as_slice())
+        .as_deref()
         .unwrap_or(policy_fingerprints.as_slice());
 
     let dead_code_references = dead_code_references.or_else(|| {

--- a/crates/homeboy-code-audit/src/entry.rs
+++ b/crates/homeboy-code-audit/src/entry.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use super::detectors::source_policy;
-use super::engine::audit_internal;
+use super::engine::{audit_internal, AuditExecution};
 use super::execution_plan::AuditExecutionPlan;
 use super::findings::Finding;
 use super::types::{AuditWithAnalysis, CodeAuditResult};
@@ -66,10 +66,12 @@ pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeA
         source_path,
         None,
         None,
-        &ref_paths,
-        &AuditExecutionPlan::full(),
-        &[],
-        None,
+        AuditExecution {
+            plan: &AuditExecutionPlan::full(),
+            reference_paths: &ref_paths,
+            extension_overrides: &[],
+            dead_code_references: None,
+        },
     )
     .map(|audit| audit.result)
 }
@@ -117,10 +119,12 @@ pub(crate) fn audit_path_with_id_with_plan_and_analysis(
         source_path,
         None,
         None,
-        reference_paths,
-        plan,
-        extension_overrides,
-        None,
+        AuditExecution {
+            plan,
+            reference_paths,
+            extension_overrides,
+            dead_code_references: None,
+        },
     )
 }
 
@@ -146,10 +150,12 @@ pub fn audit_path_scoped(
         source_path,
         Some(file_filter),
         git_ref,
-        &ref_paths,
-        &AuditExecutionPlan::full(),
-        &[],
-        None,
+        AuditExecution {
+            plan: &AuditExecutionPlan::full(),
+            reference_paths: &ref_paths,
+            extension_overrides: &[],
+            dead_code_references: None,
+        },
     )
     .map(|audit| audit.result)
 }
@@ -159,20 +165,14 @@ pub(crate) fn audit_path_scoped_with_plan_and_analysis(
     source_path: &str,
     file_filter: &[String],
     git_ref: Option<&str>,
-    plan: &AuditExecutionPlan,
-    reference_paths: &[String],
-    extension_overrides: &[String],
-    dead_code_references: Option<super::reference::DeadCodeReferenceAnalysis>,
+    execution: AuditExecution<'_>,
 ) -> Result<AuditWithAnalysis> {
     audit_internal(
         component_id,
         source_path,
         Some(file_filter),
         git_ref,
-        reference_paths,
-        plan,
-        extension_overrides,
-        dead_code_references,
+        execution,
     )
 }
 

--- a/crates/homeboy-code-audit/src/lib.rs
+++ b/crates/homeboy-code-audit/src/lib.rs
@@ -89,6 +89,7 @@ pub use homeboy_engine_primitives::test_path::is_test_path;
 pub use report::{AuditCommandOutput, AuditMeasurement};
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 
+pub(crate) use engine::AuditExecution;
 pub use entry::{
     audit_component, audit_path, audit_path_scoped, audit_path_with_id,
     source_policy_findings_for_path,

--- a/crates/homeboy-code-audit/src/report.rs
+++ b/crates/homeboy-code-audit/src/report.rs
@@ -211,7 +211,7 @@ pub enum AuditCommandOutput {
         #[serde(skip_serializing_if = "Option::is_none")]
         changed_since: Option<AuditChangedSinceSummary>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        summary: Option<AuditSummaryOutput>,
+        summary: Box<Option<AuditSummaryOutput>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         fixability: Option<AuditFixability>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -392,8 +392,7 @@ pub fn build_changed_since_summary(
 ///
 /// This must match the `#[serde(rename_all = "snake_case")]` on the enum so that
 /// `fixability.by_kind` keys align with the finding group keys in JSON output.
-/// Using `format!("{:?}", ...)` would produce Debug PascalCase (e.g. `compilerwarning`)
-
+/// Using `format!("{:?}", ...)` would produce Debug PascalCase (e.g. `compilerwarning`).
 /// Compute fixability metadata from an audit result without applying fixes.
 ///
 /// Runs the fix generator in dry-run mode and counts how many findings

--- a/crates/homeboy-code-audit/src/run.rs
+++ b/crates/homeboy-code-audit/src/run.rs
@@ -234,10 +234,12 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> homeboy_error::Result<Option<AuditW
             &args.source_path,
             &changed,
             Some(git_ref),
-            &plan,
-            &args.reference_paths,
-            &args.extension_overrides,
-            None,
+            crate::AuditExecution {
+                plan: &plan,
+                reference_paths: &args.reference_paths,
+                extension_overrides: &args.extension_overrides,
+                dead_code_references: None,
+            },
         )?))
     } else {
         Ok(Some(crate::audit_path_with_id_with_plan_and_analysis(
@@ -482,10 +484,12 @@ fn audit_reference_result(
         &reference_root.path().to_string_lossy(),
         &changed,
         None,
-        &audit_plan(args),
-        &args.reference_paths,
-        &args.extension_overrides,
-        dead_code_references,
+        crate::AuditExecution {
+            plan: &audit_plan(args),
+            reference_paths: &args.reference_paths,
+            extension_overrides: &args.extension_overrides,
+            dead_code_references,
+        },
     )?
     .result;
     apply_finding_filters(&mut reference, &args.only_kinds, &args.exclude_kinds);
@@ -591,7 +595,7 @@ fn build_comparison_output(
                 baseline_comparison: comparison,
                 measurement: measurement_for(args),
                 changed_since: changed_since_summary,
-                summary: None,
+                summary: Box::new(None),
                 fixability,
                 extension_phase_timings: Vec::new(),
                 actionable: None,

--- a/crates/homeboy-code-audit/src/signature_extraction.rs
+++ b/crates/homeboy-code-audit/src/signature_extraction.rs
@@ -64,7 +64,7 @@ pub fn extract_signatures_from_items(content: &str, language: &Language) -> Vec<
             Some(MethodSignature {
                 name,
                 signature,
-                language: language.clone(),
+                language: *language,
                 body,
             })
         })

--- a/crates/homeboy-engine-primitives/src/codebase_scan.rs
+++ b/crates/homeboy-engine-primitives/src/codebase_scan.rs
@@ -555,7 +555,7 @@ pub fn discover_casing(root: &Path, term: &str, config: &ScanConfig) -> Vec<(Str
     }
 
     let mut result: Vec<(String, usize)> = casing_counts.into_iter().collect();
-    result.sort_by(|a, b| b.1.cmp(&a.1)); // Most frequent first
+    result.sort_by_key(|entry| std::cmp::Reverse(entry.1)); // Most frequent first
     result
 }
 

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -65,10 +65,10 @@ impl ControllerChildGuard {
                 }
             }
             isolate_process_tree(command);
-            return Ok(Self {
+            Ok(Self {
                 controller_liveness_read_fd: fds[0],
                 controller_liveness_fd: fds[1],
-            });
+            })
         }
 
         #[cfg(not(unix))]
@@ -1012,7 +1012,7 @@ pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStat
                 ));
             }
         }
-        return status.map(Ok).unwrap_or_else(|| child.wait());
+        status.map(Ok).unwrap_or_else(|| child.wait())
     }
 
     #[cfg(not(unix))]

--- a/crates/homeboy-engine-primitives/src/edit_op_apply.rs
+++ b/crates/homeboy-engine-primitives/src/edit_op_apply.rs
@@ -354,6 +354,8 @@ pub fn resolve_anchor(content: &str, anchor: &InsertAnchor, language: &Language)
     }
 }
 
+type DeferredTransform = Box<dyn Fn(&str) -> Option<String>>;
+
 /// Apply edit operations to a content string (no I/O).
 ///
 /// This is the testable core. All 5 `EditOp` variants are handled:
@@ -375,7 +377,7 @@ pub fn apply_edit_ops_to_content(
     let mut insert_ops: Vec<(usize, &str)> = Vec::new(); // (resolved_line, code)
     let mut reexport_removals: Vec<&str> = Vec::new();
     // Deferred whole-content transformations (namespace replace, type conformance)
-    let mut deferred_transforms: Vec<Box<dyn Fn(&str) -> Option<String>>> = Vec::new();
+    let mut deferred_transforms: Vec<DeferredTransform> = Vec::new();
 
     for op in ops {
         match op {
@@ -410,7 +412,7 @@ pub fn apply_edit_ops_to_content(
                     InsertAnchor::FileTop => {
                         // For PHP namespace declarations, replace-if-exists
                         let code_clone = code.clone();
-                        let lang = language.clone();
+                        let lang = *language;
                         deferred_transforms.push(Box::new(move |c: &str| {
                             try_replace_namespace(c, &code_clone, &lang)
                         }));
@@ -418,7 +420,7 @@ pub fn apply_edit_ops_to_content(
                     InsertAnchor::TypeDeclaration => {
                         // For PHP/TS, inline type conformance modification
                         let code_clone = code.clone();
-                        let lang = language.clone();
+                        let lang = *language;
                         deferred_transforms.push(Box::new(move |c: &str| {
                             try_inline_type_conformance(c, &code_clone, &lang)
                         }));
@@ -468,7 +470,7 @@ pub fn apply_edit_ops_to_content(
     }
 
     // 3. Apply RemoveLines — sort bottom-to-top to avoid drift
-    remove_ops.sort_by(|a, b| b.0.cmp(&a.0));
+    remove_ops.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     for (start, end) in &remove_ops {
         let start_idx = start.saturating_sub(1);
         let end_idx = (*end).min(lines.len());
@@ -499,7 +501,7 @@ pub fn apply_edit_ops_to_content(
     }
 
     // 4. Apply InsertLines — sort bottom-to-top to avoid drift
-    insert_ops.sort_by(|a, b| b.0.cmp(&a.0));
+    insert_ops.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     for (target_line, code) in &insert_ops {
         let idx = target_line.saturating_sub(1).min(lines.len());
         // Split the code into individual lines and insert them

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Rust 1.95 migration layer 1.

- Pins local and CI Rust execution to 1.95.0.
- Resolves the original and immediately exposed Clippy findings in homeboy-engine-primitives, homeboy-lab-contract, and homeboy-code-audit.
- Removes unrelated CLI autofix churn.

Refs #11580

Verification:
- cargo fmt --all --check: pass
- cargo test -p homeboy-lab-contract: pass
- cargo test -p homeboy-code-audit: pass
- cargo test -p homeboy-engine-primitives: 246 passed; 3 pre-existing measurement-registry failures outside this layer
- cargo clippy -p homeboy-cli --all-targets -- -D warnings: advances to 96 remaining homeboy-core diagnostics, beginning with cleanup/automatic_retention.rs.

Next stacked boundary: crates/homeboy-core, starting with cleanup file-open semantics and daemon/runtime/process diagnostics.

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode inspected diagnostics, applied semantics-preserving fixes, ran verification, and prepared this PR. Chris Huber reviewed and owns the change.