### PR TITLE
fix(test-support): clear the runner-evidence provider between hermetic tests

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -232,6 +232,23 @@ homeboy_engine_primitives::provider_registry! {
     with: pub fn with_runner_evidence,
 }
 
+/// Clear any registered runner-evidence provider.
+///
+/// Registration is process-global and permanent, which is correct in a binary
+/// (the runner layer registers once at startup) but wrong in a test binary,
+/// where every test shares one process. A test that registers a fake provider
+/// otherwise keeps serving every later test in the run, so a fake's
+/// expectations leak into unrelated tests and the failure surfaces in whichever
+/// test happens to sort after it. Hermetic test setup calls this so each test
+/// starts from the unregistered no-op state.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) fn reset_runner_evidence_provider_for_test() {
+    let mut slot = provider_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+}
+
 /// Refresh runner-owned evidence and return its authenticated runner/job
 /// identities without exposing runner-specific metadata to consumers.
 pub fn mirrored_runner_job_identities(run_id: &str) -> Result<Vec<(String, String)>> {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1003,6 +1003,7 @@ pub fn register_test_cache_reset_hook(hook: fn()) {
 
 fn reset_cached_test_state() {
     crate::defaults::reset_config_cache_for_test();
+    crate::observation::runs_service::runner_evidence::reset_runner_evidence_provider_for_test();
     let hooks = TEST_CACHE_RESET_HOOKS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())


### PR DESCRIPTION
Two `agent_task_promotion` tests fail in a full-crate run and pass individually
or at module scope:

```
agent_task_promotion::tests::part_b::bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_idempotently
agent_task_promotion::tests::part_c::bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending
```

The tell is the panic site — a file neither test is in:

```
panicked at crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs:1652:
assertion `left == right` failed
  left: "runner-artifact://homeboy-lab/recovered-typed-lab-run/transcript"
 right: "runner-artifact://local/detached-run/patch"
```

## Cause

`register_runner_evidence_provider` writes a process-global slot, and the
`provider_registry!` macro emits no way to clear it. That is right in a binary —
the runner layer registers once at startup — and wrong in a test binary, where
every test shares one process.

`timed_out_recoverable_lab_candidate_hydrates_a_pathless_patch_idempotently`
registers a fake whose `download_remote_artifact` asserts the requested path is
exactly its own:

```rust
fn download_remote_artifact(&self, path: &str, ...) {
    assert_eq!(path, "runner-artifact://local/detached-run/patch");
```

That fake outlives its test and keeps serving every later one. The promotion
tests legitimately request a different artifact and trip another test's
assertion. `agent_task_lifecycle` sorts before `agent_task_promotion`, which is
why ordering decides it — and why the failure lands on innocent tests while the
one that caused it stays green.

## Fix

`HomeGuard::new` already calls `reset_cached_test_state`, the seam where
hermetic setup drops cached global state (config cache, plus hooks registered by
layers above core). A global provider registry is exactly that kind of state, so
it goes there. Each test now starts from the unregistered no-op provider, and a
fake's expectations stay inside the test that installed them.

Scoped deliberately to the registry that demonstrably leaks. There are 35
`provider_registry!` sites; most live in crates core cannot see, and the
existing `register_test_cache_reset_hook` is the intended route for those. Doing
all of them is a separate change with its own blast radius, not a bug fix.

## Verification

| | before | after |
|---|---|---|
| `homeboy-agents --lib --test-threads=1` | 1431 passed, **2 failed** | **1433 passed, 0 failed** |

`homeboy-core --lib --test-threads=1` reports 27 failures — daemon, procfs,
and sqlite tests that fail the same way on this host with the patch reverted
from the same tree. 26 match exactly; the odd one out is a swap between two
run-to-run flaky environment tests
(`candidate_attribution_reads_command_env_store_identity_from_procfs` and
`publication_is_no_clobber_and_idempotent`), neither touching runner evidence.
No new failures.

`cargo check --workspace --tests` and `cargo fmt --all --check` clean.