### PR TITLE
fix(core): migrate filesystem runtime cleanup clippy

### DIFF
--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -256,7 +256,7 @@ fn filesystem_available_bytes(path: &Path) -> Option<u64> {
     let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
     (unsafe { libc::statvfs(path.as_ptr(), stat.as_mut_ptr()) } == 0).then(|| unsafe {
         let stat = stat.assume_init();
-        (stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64)
+        (stat.f_bavail as u64).saturating_mul(stat.f_frsize)
     })
 }
 

--- a/crates/homeboy-core/src/cleanup/automatic_retention.rs
+++ b/crates/homeboy-core/src/cleanup/automatic_retention.rs
@@ -94,6 +94,7 @@ fn run_automatic_cargo_retention_in(
         .map_err(|error| io_error(error, "create retention state directory"))?;
     let lock = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(data.join(LOCK_FILE))
@@ -165,6 +166,7 @@ fn run_automatic_runtime_temp_retention_in(
         .map_err(|error| io_error(error, "create retention state directory"))?;
     let lock = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(data.join(RUNTIME_TMP_LOCK_FILE))

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -152,6 +152,7 @@ pub(crate) fn acquire_shared_cargo_target_in(
         .map_err(|error| io_error(error, "create shared Cargo target"))?;
     let lock = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(target_dir.join(LOCK_FILE))

--- a/crates/homeboy-core/src/cleanup/degraded.rs
+++ b/crates/homeboy-core/src/cleanup/degraded.rs
@@ -265,11 +265,9 @@ pub fn degraded_cleanup(
     store: StoreAvailability,
     reason: impl Into<String>,
 ) -> DegradedCleanupOutcome {
-    let mut categories = Vec::new();
-
     // The only category that genuinely reclaims with the store shut. It never
     // consults the database in either direction.
-    categories.push(
+    let categories = vec![
         match runs_service::cleanup_orphaned_artifact_bytes(OrphanedArtifactBytesCleanupOptions {
             apply: options.apply,
             limit: options.limit,
@@ -286,12 +284,9 @@ pub fn degraded_cleanup(
             },
             Err(error) => DegradedCleanupCategory::failed("orphaned-artifact-bytes", true, error),
         },
-    );
-
-    // Ownership is a filename prefix plus a liveness probe on the owning PID.
-    // Neither reads a row, and both stay available on a filesystem that has
-    // nothing left to give.
-    categories.push(
+        // Ownership is a filename prefix plus a liveness probe on the owning PID.
+        // Neither reads a row, and both stay available on a filesystem that has
+        // nothing left to give.
         match cleanup_leaked_test_homes(LeakedTestHomeCleanupOptions {
             apply: options.apply,
             min_age: options.leaked_test_home_min_age,
@@ -311,11 +306,8 @@ pub fn degraded_cleanup(
             },
             Err(error) => DegradedCleanupCategory::failed("leaked-test-homes", true, error),
         },
-    );
-
-    // Its store read is an advisory protection that fails open, and its real
-    // liveness signals (owner PID, invocation lease) are filesystem-local.
-    categories.push(
+        // Its store read is an advisory protection that fails open, and its real
+        // liveness signals (owner PID, invocation lease) are filesystem-local.
         match temp::cleanup_runtime_tmp_bounded(RuntimeTempCleanupOptions {
             apply: options.apply,
             older_than_days: options.runtime_tmp_days,
@@ -338,12 +330,9 @@ pub fn degraded_cleanup(
             },
             Err(error) => DegradedCleanupCategory::failed("runtime-tmp", true, error),
         },
-    );
-
-    // Runs safely, reclaims nothing: its liveness veto fails closed, so a
-    // closed store retains every candidate. Reported so the retained bytes stay
-    // visible instead of vanishing from the degraded report entirely.
-    categories.push(
+        // Runs safely, reclaims nothing: its liveness veto fails closed, so a
+        // closed store retains every candidate. Reported so the retained bytes stay
+        // visible instead of vanishing from the degraded report entirely.
         match runs_service::cleanup_runner_downloads(RunnerDownloadCleanupOptions {
             apply: options.apply,
             runner: None,
@@ -363,7 +352,7 @@ pub fn degraded_cleanup(
             },
             Err(error) => DegradedCleanupCategory::failed("runner-downloads", false, error),
         },
-    );
+    ];
 
     DegradedCleanupOutcome {
         command: "cleanup.degraded",

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -144,6 +144,8 @@ pub fn with_config_lock_for<T>(
 
     let lock_file = OpenOptions::new()
         .create(true)
+        // Lock contents identify the current holder, so opening must preserve them.
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&lock_path)

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -259,7 +259,7 @@ fn retention_report_with_references_at(
     let mut retained = BTreeSet::new();
 
     for path in referenced {
-        if content_addressed_pin_path(&root, &path) {
+        if content_addressed_pin_path(&root, path) {
             retained.insert(path.clone());
         }
     }
@@ -663,7 +663,7 @@ fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
     let pinned_path = pinned_path(identity, &digest)?;
     publish_pin(executable, &pinned_path, &digest)?;
 
-    let runtime = runtime_pin(&identity, executable, &pinned_path, &digest);
+    let runtime = runtime_pin(identity, executable, &pinned_path, &digest);
     validate_pin(&runtime)?;
     Ok(runtime)
 }
@@ -1154,6 +1154,7 @@ fn acquire_admission_lock_for(path: &Path, request_id: &str) -> Result<Admission
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(path)
         .map_err(|error| {
             Error::internal_io(
@@ -1506,6 +1507,7 @@ fn claim_admission_owner(
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(queue_lock_path(lock_path))
         .map_err(|error| {
             Error::internal_io(
@@ -1577,6 +1579,7 @@ fn update_admission_queue(lock_path: &Path, mutate: impl FnOnce(&mut Value)) -> 
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(queue_lock_path(lock_path))
         .map_err(|error| {
             Error::internal_io(
@@ -1683,6 +1686,7 @@ fn admission_lock_is_held(path: &Path) -> bool {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(path)
     else {
         return true;

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -453,16 +453,11 @@ pub struct WorktreeProviderListResultMapping {
     pub task_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorktreeProviderKind {
+    #[default]
     Command,
-}
-
-impl Default for WorktreeProviderKind {
-    fn default() -> Self {
-        Self::Command
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -553,6 +553,7 @@ pub fn pin_cook_generation(cook_id: &str) -> Result<RuntimeGenerationPinGuard> {
 fn open_admission_lock(root: &Path) -> Result<fs::File> {
     fs::OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(root.join(ADMISSION_LOCK_FILE))
@@ -922,8 +923,8 @@ fn wait_for_foreign_generation_pins(
             .filter_map(|content| serde_json::from_str::<RuntimeGenerationPin>(&content).ok())
             .any(|pin| {
                 pin.pid != pid
-                    && !subprocess_capability
-                        .is_some_and(|capability| capability.owner_pid == pin.pid)
+                    && subprocess_capability
+                        .is_none_or(|capability| capability.owner_pid != pin.pid)
             });
         if !foreign_pin {
             return Ok(());

--- a/crates/homeboy-core/src/workspace_claim.rs
+++ b/crates/homeboy-core/src/workspace_claim.rs
@@ -705,6 +705,7 @@ impl WorkspaceClaimStore {
         sync_dir(&self.root)?;
         let lock = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(self.lock_path(workspace))

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -91,14 +91,12 @@ pub fn persist_terminal_workspace_authority(
             ));
         }
         match &record.terminal_workspace_authority {
-            Some(existing) if existing != &proof => {
-                return Err(Error::validation_invalid_argument(
-                    "terminal_workspace_authority",
-                    "terminal workspace authority proof conflicts with immutable manifest evidence",
-                    Some(id.to_string()),
-                    None,
-                ))
-            }
+            Some(existing) if existing != &proof => Err(Error::validation_invalid_argument(
+                "terminal_workspace_authority",
+                "terminal workspace authority proof conflicts with immutable manifest evidence",
+                Some(id.to_string()),
+                None,
+            )),
             Some(_) => Ok(()),
             None => {
                 record.terminal_workspace_authority = Some(proof);
@@ -373,6 +371,7 @@ fn open_task_worktree_registry_lock() -> Result<std::fs::File> {
     })?;
     OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(parent.join("task-worktrees.lock"))

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -26,17 +26,12 @@ pub enum CleanupPolicy {
     PreserveOnFailure,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BranchCleanupIntent {
+    #[default]
     DeleteWhenMerged,
     Preserve,
-}
-
-impl Default for BranchCleanupIntent {
-    fn default() -> Self {
-        Self::DeleteWhenMerged
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -250,6 +245,7 @@ pub struct AdoptedWorkspaceRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)] // Registry records are returned by value.
 pub enum WorkspaceRefRecord {
     Task(TaskWorktreeRecord),
     Adopted(AdoptedWorkspaceRecord),


### PR DESCRIPTION
Refs #11580

Resolves the Rust 1.95 Clippy migration diagnostics owned by the core filesystem, cleanup, runtime, workspace-claim, and worktree layer. Advisory lock opens now explicitly preserve existing contents; the controller admission owner continues to truncate only after it validates the prior owner record.

Verification:
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo fmt --all --check`: pass
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-core --lib`: pass
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-core cleanup`: blocked before tests execute by three non-owned `ManagedSshSession` initializers missing `persist_source` in `server/client/tests.rs`, `server/ssh_args.rs`, and `server/transfer.rs`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo clippy -p homeboy-core --lib -- -D warnings`: 73 remaining diagnostics, all outside this owned layer

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode reviewed file-open contracts, applied Rust 1.95 Clippy fixes, and ran verification. Chris Huber reviewed and owns the change.