### PR TITLE
fix(core): satisfy Rust 1.95 platform clippy

### DIFF
--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -358,17 +358,12 @@ fn default_runtime_freshness() -> String {
     "unverifiable".to_string()
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentRuntimeFreshness {
     Pinned,
+    #[default]
     Unverifiable,
-}
-
-impl Default for AgentRuntimeFreshness {
-    fn default() -> Self {
-        Self::Unverifiable
-    }
 }
 
 pub fn runtime_materialization_plan(
@@ -725,7 +720,7 @@ fn discover_standalone_agent_runtime_catalog_in(
     for entry in entries.flatten() {
         match load_standalone_agent_runtime_manifest(&entry.path(), manifest_path_for) {
             StandaloneAgentRuntimeManifestLoad::Loaded(manifest) => {
-                catalog.manifests.push(manifest)
+                catalog.manifests.push(*manifest)
             }
             StandaloneAgentRuntimeManifestLoad::Skipped => {}
             StandaloneAgentRuntimeManifestLoad::Invalid(diagnostic) => {
@@ -737,7 +732,7 @@ fn discover_standalone_agent_runtime_catalog_in(
 }
 
 enum StandaloneAgentRuntimeManifestLoad {
-    Loaded(AgentRuntimeManifest),
+    Loaded(Box<AgentRuntimeManifest>),
     Skipped,
     Invalid(AgentRuntimeDiscoveryDiagnostic),
 }
@@ -782,7 +777,7 @@ fn load_standalone_agent_runtime_manifest(
                 class: class.to_string(),
                 message: error
                     .validation_json_error()
-                    .unwrap_or_else(|| error.message.as_str())
+                    .unwrap_or(error.message.as_str())
                     .to_string(),
                 runtime_id: Some(id),
                 extension_id: None,
@@ -819,7 +814,7 @@ fn load_standalone_agent_runtime_manifest(
     ) {
         return StandaloneAgentRuntimeManifestLoad::Invalid(diagnostic);
     }
-    StandaloneAgentRuntimeManifestLoad::Loaded(manifest)
+    StandaloneAgentRuntimeManifestLoad::Loaded(Box::new(manifest))
 }
 
 pub(crate) fn discover_agent_runtime_catalog_from_extensions(

--- a/crates/homeboy-core/src/deps_provider.rs
+++ b/crates/homeboy-core/src/deps_provider.rs
@@ -294,13 +294,14 @@ impl AdapterDependencyProvider {
             return Ok(Vec::new());
         }
         let adapter = read_installed_dependency_adapter(&manifest_path)?;
-        Ok(adapter
-            .matches(path)
-            .then(|| adapter.providers(path))
-            .unwrap_or_default()
-            .into_iter()
-            .map(|adapter| Self { adapter })
-            .collect())
+        Ok((if adapter.matches(path) {
+            adapter.providers(path)
+        } else {
+            Default::default()
+        })
+        .into_iter()
+        .map(|adapter| Self { adapter })
+        .collect())
     }
 
     fn load(path: &Path) -> Result<Vec<Self>> {
@@ -1337,10 +1338,11 @@ fn run_adapter_command(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let status = output.status.code();
-    let allowed = success_exit_codes
-        .is_empty()
-        .then(|| output.status.success())
-        .unwrap_or_else(|| status.is_some_and(|code| success_exit_codes.contains(&code)));
+    let allowed = if success_exit_codes.is_empty() {
+        output.status.success()
+    } else {
+        status.is_some_and(|code| success_exit_codes.contains(&code))
+    };
     if !allowed {
         return Err(Error::validation_invalid_argument(
             "dependency_provider",

--- a/crates/homeboy-core/src/engine/symbol_graph.rs
+++ b/crates/homeboy-core/src/engine/symbol_graph.rs
@@ -530,7 +530,7 @@ fn apply_rewrites(rewrites: &[ImportRewrite], root: &Path) {
 
         // Apply rewrites in reverse line order to avoid index shifting
         let mut sorted_rewrites: Vec<&&ImportRewrite> = file_rewrites.iter().collect();
-        sorted_rewrites.sort_by(|a, b| b.line.cmp(&a.line));
+        sorted_rewrites.sort_by_key(|rewrite| std::cmp::Reverse(rewrite.line));
 
         for rewrite in sorted_rewrites {
             let idx = rewrite.line.saturating_sub(1);

--- a/crates/homeboy-core/src/extension_update_check.rs
+++ b/crates/homeboy-core/src/extension_update_check.rs
@@ -87,12 +87,12 @@ pub fn read_source_revision_at(extension_dir: &Path) -> Option<String> {
     }
 
     // Try .git first (single-extension repos and linked extensions)
-    if let Some(rev) = git::head_sha(&extension_dir) {
+    if let Some(rev) = git::head_sha(extension_dir) {
         return Some(rev);
     }
 
     // Fall back to source metadata files (monorepo installs and staged linked installs).
-    read_source_metadata_value(&extension_dir, "revision")
+    read_source_metadata_value(extension_dir, "revision")
 }
 
 pub fn read_source_metadata_value(extension_dir: &Path, kind: &str) -> Option<String> {

--- a/crates/homeboy-core/src/git/pr_land.rs
+++ b/crates/homeboy-core/src/git/pr_land.rs
@@ -221,7 +221,7 @@ impl GhPrLandClient {
 
 impl PrLandClient for GhPrLandClient {
     fn view_pr(&mut self, _repo: &str, number: u64) -> Result<PrView> {
-        let raw = self.gh.run(&vec![
+        let raw = self.gh.run(&[
             "pr".to_string(),
             "view".to_string(),
             number.to_string(),

--- a/crates/homeboy-core/src/keychain.rs
+++ b/crates/homeboy-core/src/keychain.rs
@@ -30,7 +30,7 @@ fn entry(project_id: &str, variable_name: &str) -> Result<Entry> {
 pub fn set(project_id: &str, variable_name: &str, value: &str) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
-        return macos::set(project_id, variable_name, value);
+        macos::set(project_id, variable_name, value)
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -52,7 +52,7 @@ pub fn get(project_id: &str, variable_name: &str) -> Result<Option<String>> {
 pub fn remove(project_id: &str, variable_name: &str) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
-        return macos::remove(project_id, variable_name);
+        macos::remove(project_id, variable_name)
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -281,7 +281,7 @@ mod macos {
         let descriptor = unsafe {
             CFStringCreateWithCString(
                 kCFAllocatorDefault,
-                b"homeboy\0".as_ptr().cast(),
+                c"homeboy".as_ptr(),
                 kCFStringEncodingUTF8,
             )
         };

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -666,7 +666,7 @@ fn attach_in_flight_handoff_metadata(metadata: &mut serde_json::Value, stdout: &
         }
         let resolved = paths
             .iter()
-            .find_map(|path| metadata_path_string(&value, *path));
+            .find_map(|path| metadata_path_string(&value, path));
         if let Some(resolved) = resolved {
             object.insert(target.to_string(), serde_json::Value::String(resolved));
         }

--- a/crates/homeboy-core/src/release_set.rs
+++ b/crates/homeboy-core/src/release_set.rs
@@ -154,6 +154,7 @@ impl NormalizedReleaseSet {
 
     /// Runs all validation before invoking a mutation closure. A red comparison
     /// never calls `mutate`, which makes the boundary directly testable by callers.
+    #[allow(clippy::result_large_err)] // Public result layout is a caller contract.
     pub fn mutate_if_ready<T>(
         &self,
         observations: &[ReleaseSetObservation],

--- a/crates/homeboy-core/src/resource_cleanup_intent.rs
+++ b/crates/homeboy-core/src/resource_cleanup_intent.rs
@@ -4,17 +4,12 @@ use crate::{Error, Result};
 
 pub const RESOURCE_CLEANUP_INTENT_SCHEMA: &str = "homeboy/resource-cleanup-intent/v1";
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceCleanupIntent {
+    #[default]
     DryRun,
     Apply,
-}
-
-impl Default for ResourceCleanupIntent {
-    fn default() -> Self {
-        Self::DryRun
-    }
 }
 
 impl ResourceCleanupIntent {

--- a/crates/homeboy-core/src/resource_lifecycle_index.rs
+++ b/crates/homeboy-core/src/resource_lifecycle_index.rs
@@ -141,16 +141,11 @@ pub enum ResourceLifecycleResourceStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceLifecycleCleanupOperation {
+    #[default]
     Delete,
-}
-
-impl Default for ResourceLifecycleCleanupOperation {
-    fn default() -> Self {
-        Self::Delete
-    }
 }
 
 impl std::fmt::Display for ResourceLifecycleCleanupOperation {

--- a/crates/homeboy-core/src/server/connection.rs
+++ b/crates/homeboy-core/src/server/connection.rs
@@ -3,6 +3,8 @@ use crate::project::{self, Project};
 
 use super::Server;
 
+type ResolvedServerContext = (String, Option<String>, String, Server, Option<String>);
+
 /// Arguments for SSH context resolution
 #[derive(Default)]
 pub struct SshResolveArgs {
@@ -65,10 +67,7 @@ pub fn resolve_context(args: &SshResolveArgs) -> Result<SshResolveResult> {
     })
 }
 
-#[allow(clippy::type_complexity)]
-fn resolve_internal(
-    args: &SshResolveArgs,
-) -> Result<(String, Option<String>, String, Server, Option<String>)> {
+fn resolve_internal(args: &SshResolveArgs) -> Result<ResolvedServerContext> {
     // --project flag: force project resolution
     if let Some(project_id) = &args.project {
         let project = project::load(project_id)?;
@@ -100,9 +99,7 @@ fn resolve_internal(
     ))
 }
 
-fn resolve_project_context(
-    project: Project,
-) -> Result<(String, Option<String>, String, Server, Option<String>)> {
+fn resolve_project_context(project: Project) -> Result<ResolvedServerContext> {
     let base_path = project.base_path.clone();
     let (server_id, server) = resolve_from_project(&project)?;
     Ok((

--- a/crates/homeboy-core/src/server/health.rs
+++ b/crates/homeboy-core/src/server/health.rs
@@ -15,22 +15,17 @@ const PROJECT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 // Types
 // ============================================================================
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ServerHealthState {
     Healthy,
     Unhealthy,
+    #[default]
     NotChecked,
 }
 
 impl ServerHealthState {
     pub fn is_healthy(self) -> bool {
         self == Self::Healthy
-    }
-}
-
-impl Default for ServerHealthState {
-    fn default() -> Self {
-        Self::NotChecked
     }
 }
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -456,6 +456,12 @@ impl AuditGuard {
     }
 }
 
+impl Default for AuditGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AuditHomeGuard {
     pub fn new() -> Self {
         let home = HomeGuard::new();
@@ -464,6 +470,12 @@ impl AuditHomeGuard {
             _guard: guard,
             home,
         }
+    }
+}
+
+impl Default for AuditHomeGuard {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -541,6 +553,12 @@ impl HomeGuard {
             context,
             _guard: guard,
         }
+    }
+}
+
+impl Default for HomeGuard {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/homeboy-core/src/trace_secrets.rs
+++ b/crates/homeboy-core/src/trace_secrets.rs
@@ -9,10 +9,9 @@ pub struct TraceSecretEnvStatus {
     pub source: String,
 }
 
-pub fn resolve_secret_env(
-    names: &[String],
-    project_id: Option<&str>,
-) -> Result<(Vec<(String, String)>, Vec<TraceSecretEnvStatus>)> {
+type ResolvedSecretEnv = (Vec<(String, String)>, Vec<TraceSecretEnvStatus>);
+
+pub fn resolve_secret_env(names: &[String], project_id: Option<&str>) -> Result<ResolvedSecretEnv> {
     let names = normalize_names(names);
     let mut resolved = Vec::new();
     let mut statuses = Vec::new();


### PR DESCRIPTION
## Summary
- resolve the owned Rust 1.95 diagnostics in core platform, contracts, and support code
- preserve serialized enum defaults and the public ReleaseSet result layout
- use typed macOS C strings and aliases for internal complex tuples

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-core --lib`
- focused clippy has no remaining diagnostics in this PR's owned files; the command remains blocked by 74 diagnostics assigned elsewhere
- focused manifest test compilation is blocked by three inherited `ManagedSshSession` test fixtures missing `persist_source`

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode implemented the Rust 1.95 clippy migration; Chris remains responsible for every line.