### PR TITLE
fix(core): migrate observation and process clippy idioms

### DIFF
--- a/crates/homeboy-core/src/activity/collector.rs
+++ b/crates/homeboy-core/src/activity/collector.rs
@@ -33,7 +33,7 @@ impl ActivityCollector {
         for item in &mut items {
             finalize_item(item);
         }
-        items.sort_by(|left, right| item_sort_key(right).cmp(&item_sort_key(left)));
+        items.sort_by_key(|item| std::cmp::Reverse(item_sort_key(item)));
         if scope == ActivityScope::ActiveRecent {
             items.retain(|item| is_active(item.state) || item.finished_at.is_some());
         }

--- a/crates/homeboy-core/src/fleet/mod.rs
+++ b/crates/homeboy-core/src/fleet/mod.rs
@@ -166,12 +166,12 @@ pub fn resolve_fleet_projects(fleet: &Fleet) -> Result<FleetProjectResolution> {
     Ok(resolution)
 }
 
-pub fn component_usage_with_resolution(
-    fleet_id: &str,
-) -> Result<(
+pub type FleetComponentUsage = (
     std::collections::HashMap<String, Vec<String>>,
     Vec<FleetProjectResolutionError>,
-)> {
+);
+
+pub fn component_usage_with_resolution(fleet_id: &str) -> Result<FleetComponentUsage> {
     let fleet = load(fleet_id)?;
     let mut usage: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();

--- a/crates/homeboy-core/src/fleet/status.rs
+++ b/crates/homeboy-core/src/fleet/status.rs
@@ -151,7 +151,7 @@ pub fn collect_status(
             if let Some(cached_health) = server_health_cache.get(server_id) {
                 cached_health.clone()
             } else {
-                let h = health::collect_project_health(&proj);
+                let h = health::collect_project_health(proj);
                 server_health_cache.insert(server_id.clone(), h.clone());
                 h
             }
@@ -204,7 +204,7 @@ pub fn collect_status(
 
         // Collect component status: version drift + release state
         let component_statuses =
-            collect_project_component_statuses(project_id, &proj, &mut summary.components);
+            collect_project_component_statuses(project_id, proj, &mut summary.components);
 
         project_statuses.push(FleetProjectStatus {
             project_id: project_id.clone(),
@@ -247,8 +247,8 @@ fn collect_cached_status(
         summary.projects.healthy += 1; // Can't know health without SSH
 
         let mut component_statuses = Vec::new();
-        for component_id in project::project_component_ids(&proj) {
-            let local_version = match project::resolve_project_component(&proj, &component_id) {
+        for component_id in project::project_component_ids(proj) {
+            let local_version = match project::resolve_project_component(proj, &component_id) {
                 Ok(comp) => release_provider::get_component_version(&comp),
                 Err(_) => None,
             };

--- a/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/persisted_cleanup.rs
@@ -183,8 +183,8 @@ pub fn remove_persisted_artifact_record_bytes(
 /// validated cleanup plan. This deliberately leaves its database record for a
 /// higher-level lifecycle transaction to remove with its owning run.
 pub fn remove_persisted_artifact_bytes(path: &Path, artifact_root: &Path) -> Result<()> {
-    if let Some(metadata) = symlink_metadata_if_exists(&path)? {
-        if metadata.file_type().is_symlink() || !path_is_within_root(&path, artifact_root) {
+    if let Some(metadata) = symlink_metadata_if_exists(path)? {
+        if metadata.file_type().is_symlink() || !path_is_within_root(path, artifact_root) {
             return Err(Error::validation_invalid_argument(
                 "path",
                 "artifact path failed cleanup safety revalidation",
@@ -193,9 +193,9 @@ pub fn remove_persisted_artifact_bytes(path: &Path, artifact_root: &Path) -> Res
             ));
         }
         if metadata.is_dir() {
-            fs::remove_dir_all(&path).map_err(|err| persisted_artifact_remove_error(&path, err))?;
+            fs::remove_dir_all(path).map_err(|err| persisted_artifact_remove_error(path, err))?;
         } else {
-            fs::remove_file(&path).map_err(|err| persisted_artifact_remove_error(&path, err))?;
+            fs::remove_file(path).map_err(|err| persisted_artifact_remove_error(path, err))?;
         }
     }
     Ok(())

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -325,11 +325,8 @@ pub(crate) fn refresh_selected_mirrored_daemon_evidence(
     store: &ObservationStore,
     run: &RunRecord,
 ) -> Option<Error> {
-    let Some((runner_id, job_id)) =
-        runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
-    else {
-        return None;
-    };
+    let (runner_id, job_id) =
+        runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))?;
 
     match runner_evidence::with_runner_evidence(|p| p.refresh_mirrored_daemon_evidence(&run.id)) {
         Ok(_) => None,

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -527,6 +527,8 @@ impl ObservationStore {
 
     /// Persist an opened file under a stable lifecycle identity after verifying
     /// the exact descriptor-copied bytes against the supplied digest.
+    // This established storage API carries the verified identity and digest separately.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_verified_artifact_from_open_file_with_id(
         &self,
         run_id: &str,
@@ -611,6 +613,8 @@ impl ObservationStore {
     /// Import bytes whose stable identity and integrity metadata were published
     /// by another durable store. Validate before publishing so a mirror never
     /// turns an advertised artifact into controller-owned corrupt evidence.
+    // This established storage API carries the verified identity and digest separately.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_verified_artifact_with_id(
         &self,
         run_id: &str,
@@ -1059,27 +1063,36 @@ impl ObservationStore {
     pub fn list_artifacts(&self, run_id: &str) -> Result<Vec<ArtifactRecord>> {
         validate_required("run_id", run_id)?;
         let columns = self.artifact_columns_for_read()?;
-        let artifact_type = columns
-            .contains("artifact_type")
-            .then_some("artifact_type")
-            .unwrap_or("'file'");
-        let url = columns.contains("url").then_some("url").unwrap_or("NULL");
-        let public_url = columns
-            .contains("public_url")
-            .then_some("public_url")
-            .unwrap_or("NULL");
-        let viewer_url = columns
-            .contains("viewer_url")
-            .then_some("viewer_url")
-            .unwrap_or("NULL");
-        let viewer_links = columns
-            .contains("viewer_links_json")
-            .then_some("viewer_links_json")
-            .unwrap_or("'[]'");
-        let metadata = columns
-            .contains("metadata_json")
-            .then_some("metadata_json")
-            .unwrap_or("'{}'");
+        let artifact_type = if columns.contains("artifact_type") {
+            "artifact_type"
+        } else {
+            "'file'"
+        };
+        let url = if columns.contains("url") {
+            "url"
+        } else {
+            "NULL"
+        };
+        let public_url = if columns.contains("public_url") {
+            "public_url"
+        } else {
+            "NULL"
+        };
+        let viewer_url = if columns.contains("viewer_url") {
+            "viewer_url"
+        } else {
+            "NULL"
+        };
+        let viewer_links = if columns.contains("viewer_links_json") {
+            "viewer_links_json"
+        } else {
+            "'[]'"
+        };
+        let metadata = if columns.contains("metadata_json") {
+            "metadata_json"
+        } else {
+            "'{}'"
+        };
         let mut statement = self
             .connection
             .prepare(&format!(

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -324,7 +324,7 @@ impl ObservationStore {
             return Ok(None);
         }
 
-        Ok(self.get_run(run_id)?)
+        self.get_run(run_id)
     }
 
     pub fn update_run_metadata(
@@ -418,21 +418,21 @@ impl ObservationStore {
         let probe = limit + 1;
         let mut predicates = Vec::new();
         let mut values: Vec<&dyn ToSql> = Vec::new();
-        if filter.kind.is_some() {
+        if let Some(kind) = filter.kind.as_ref() {
             predicates.push("kind = ?");
-            values.push(filter.kind.as_ref().expect("checked"));
+            values.push(kind);
         }
-        if filter.component_id.is_some() {
+        if let Some(component_id) = filter.component_id.as_ref() {
             predicates.push("component_id = ?");
-            values.push(filter.component_id.as_ref().expect("checked"));
+            values.push(component_id);
         }
-        if filter.status.is_some() {
+        if let Some(status) = filter.status.as_ref() {
             predicates.push("status = ?");
-            values.push(filter.status.as_ref().expect("checked"));
+            values.push(status);
         }
-        if filter.rig_id.is_some() {
+        if let Some(rig_id) = filter.rig_id.as_ref() {
             predicates.push("rig_id = ?");
-            values.push(filter.rig_id.as_ref().expect("checked"));
+            values.push(rig_id);
         }
         if let Some(cursor) = filter.after.as_ref() {
             // Keyset resume in the canonical `started_at DESC, id DESC` order.

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -285,12 +285,12 @@ pub fn process_identity_state_with_start_identity(
             Ok(None) => return ProcessIdentityState::Dead,
             Err(_) => return ProcessIdentityState::Unverifiable,
         };
-        return match expected_start_identity {
+        match expected_start_identity {
             Some(expected) if expected != &actual => ProcessIdentityState::IdentityMismatch,
             Some(_) => ProcessIdentityState::Live,
             None if expected_linux_starttime_ticks.is_some() => ProcessIdentityState::Unverifiable,
             None => ProcessIdentityState::Live,
-        };
+        }
     }
 
     #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
@@ -358,10 +358,10 @@ pub fn process_start_identity(
         if read != std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int {
             return Err(format!("inspect process {pid}: incomplete proc_bsdinfo"));
         }
-        return Ok(Some(ProcessStartIdentity::Macos {
+        Ok(Some(ProcessStartIdentity::Macos {
             start_seconds: info.pbi_start_tvsec,
             start_microseconds: info.pbi_start_tvusec,
-        }));
+        }))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -470,11 +470,11 @@ pub fn pid_has_ownership_token(pid: u32, key: &str, value: &str) -> Result<bool>
         if !output.status.success() {
             return Ok(false);
         }
-        return Ok(command_has_option_value(
+        Ok(command_has_option_value(
             &String::from_utf8_lossy(&output.stdout),
             "--startup-token",
             value,
-        ));
+        ))
     }
 
     #[cfg(not(unix))]
@@ -683,7 +683,7 @@ pub fn isolated_process_group_is_running(pgid: u32) -> std::result::Result<bool,
 
     #[cfg(unix)]
     unsafe {
-        return Ok(libc::kill(-(pgid as libc::pid_t), 0) == 0);
+        Ok(libc::kill(-(pgid as libc::pid_t), 0) == 0)
     }
 
     #[cfg(not(unix))]
@@ -741,7 +741,7 @@ pub fn terminate_isolated_process_group(owner_pid: u32) -> Result<()> {
                 let _ = libc::kill(-(owner_pid as libc::pid_t), libc::SIGKILL);
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]
@@ -803,11 +803,11 @@ pub fn force_terminate_process_tree_bounded(pid: u32, timeout: Duration) -> Resu
         if survivors.is_empty() {
             return Ok(());
         }
-        return Err(Error::internal_unexpected(format!(
+        Err(Error::internal_unexpected(format!(
             "owned process tree {pid} did not exit within {} ms; surviving pids: {}",
             timeout.as_millis(),
             join_pids(&survivors)
-        )));
+        )))
     }
 
     #[cfg(target_os = "windows")]
@@ -990,7 +990,7 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
             recovery_commands.push(format!("kill -KILL {}", join_pids(&surviving_pids)));
         }
 
-        return Ok(ProcessTreeTermination {
+        Ok(ProcessTreeTermination {
             owner_pid,
             descendant_pids,
             signalled_pids: targets,
@@ -998,7 +998,7 @@ pub fn terminate_process_tree(owner_pid: u32) -> Result<ProcessTreeTermination> 
             killed_pids,
             surviving_pids,
             recovery_commands,
-        });
+        })
     }
 
     #[cfg(not(unix))]

--- a/crates/homeboy-core/src/project/component/attachments.rs
+++ b/crates/homeboy-core/src/project/component/attachments.rs
@@ -264,14 +264,17 @@ fn rebase_monorepo_component_paths_unlocked(
         if id == &root_id || has_component(&project, id) {
             selected.insert(id.clone());
             let path = paths[0].to_string_lossy().to_string();
-            let status = project
+            let status = if project
                 .components
                 .iter()
                 .find(|component| component.id == *id)
                 .map(|component| component.local_path == path)
                 .unwrap_or(false)
-                .then_some(MonorepoComponentPathStatus::Unchanged)
-                .unwrap_or(MonorepoComponentPathStatus::Attached);
+            {
+                MonorepoComponentPathStatus::Unchanged
+            } else {
+                MonorepoComponentPathStatus::Attached
+            };
             if status == MonorepoComponentPathStatus::Attached {
                 preserve_remote_path_on_reattach(&mut project, id, &path);
                 if let Some(component) = project

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -304,21 +304,21 @@ pub fn attach_component_paths_report(
     const SUMMARY_LIMIT: usize = 8;
     let summary: Vec<_> = items
         .iter()
-        .filter_map(|item| match item.status {
-            BatchComponentAttachmentItemStatus::Attached => Some(format!("attached {}", item.path)),
-            BatchComponentAttachmentItemStatus::Skipped => Some(format!(
+        .map(|item| match item.status {
+            BatchComponentAttachmentItemStatus::Attached => format!("attached {}", item.path),
+            BatchComponentAttachmentItemStatus::Skipped => format!(
                 "skipped {}: {}",
                 item.path,
                 item.skip_reason.as_deref().unwrap_or("skipped")
-            )),
-            BatchComponentAttachmentItemStatus::Failed => Some(format!(
+            ),
+            BatchComponentAttachmentItemStatus::Failed => format!(
                 "failed {} [{}]",
                 item.path,
                 item.error
                     .as_ref()
                     .map(|error| error.code.as_str())
                     .unwrap_or("unknown")
-            )),
+            ),
         })
         .take(SUMMARY_LIMIT)
         .collect();

--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -279,7 +279,7 @@ pub fn resolve_path(path: &Path) -> Result<ProjectPathResolutionReport> {
         }
     }
 
-    matches.sort_by(|(_, a), (_, b)| b.to_string_lossy().len().cmp(&a.to_string_lossy().len()));
+    matches.sort_by_key(|(_, base)| std::cmp::Reverse(base.to_string_lossy().len()));
 
     let (project, matched_base_path) = matches.into_iter().next().ok_or_else(|| {
         Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -72,7 +72,7 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
             // readiness signal, and this closure has no error channel. Treat
             // it as "not deployable" here; `build`/`deploy` surface the
             // actionable ambiguity error when the component is used.
-            let has_artifact = component::resolve_artifact(&comp).ok().flatten().is_some();
+            let has_artifact = component::resolve_artifact(comp).ok().flatten().is_some();
             has_provider || is_git || has_artifact
         });
 


### PR DESCRIPTION
Refs #11580

Rust 1.95 migration layer for the assigned Homeboy core Observation, Process, Project, and Fleet modules. Resolves 37 diagnostics with semantics-preserving idioms while retaining public artifact storage signatures and process-tree cleanup behavior.

Verification:
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo fmt --check`: pass
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-core`: pass
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo clippy -p homeboy-core --all-targets -- -D warnings`: assigned 37 diagnostics cleared; remains red on 56 diagnostics owned by the other migration layers
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-core observation && ... process && ... project && ... fleet`: blocked before tests start by three pre-existing `ManagedSshSession` test initializers missing `persist_source` in `server/client/tests.rs`, `server/ssh_args.rs`, and `server/transfer.rs`

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode inspected Rust 1.95 Clippy diagnostics, applied semantics-preserving migrations, and ran the listed verification. Chris Huber reviewed and owns the change.