### PR TITLE
fix(core): migrate job and daemon clippy diagnostics

### DIFF
--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -13,9 +13,9 @@ use homeboy_api_jobs_contract::types;
 pub use crate::runner_job_execution_context::RunnerJobExecutionContext;
 pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
-    JobArtifactMetadata, RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
-    RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
-    RunnerJobProjectionCancelRequest,
+    JobArtifactMetadata, RemoteRunnerClaimProtocols, RemoteRunnerJobClaim, RemoteRunnerJobRequest,
+    RemoteRunnerJobResult, RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup,
+    RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,
 };
 pub(crate) use runner_job_preparation::with_runner_job_preparation;
 pub use runner_job_preparation::{
@@ -26,6 +26,7 @@ pub(crate) use store::ControllerJobState;
 pub(crate) use store::ControllerJobSubmissionOutcome;
 pub(crate) use store::LocalChildStartDiscriminator;
 pub(crate) use store::LocalRunnerJob;
+pub(crate) use store::LocalRunnerJobRequest;
 pub use store::{JobHandle, JobRunner, JobStore, RecoveredTerminalJob};
 pub use summary::{active_runner_job_run_summary, active_runner_job_run_summary_if_durable};
 pub use types::{

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -44,9 +44,16 @@ pub struct RunnerJobProjectionCancelRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum RemoteRunnerSubmissionLookup {
-    Accepted { job: Job },
+    Accepted { job: Box<Job> },
     Expired { job_id: Uuid },
     Absent,
+}
+
+/// Protocol capabilities advertised by a remote runner before it claims work.
+pub struct RemoteRunnerClaimProtocols<'a> {
+    pub execution: Option<&'a crate::runner_job_execution_context::RunnerJobExecutionProtocol>,
+    pub workspace_claim: Option<&'a crate::workspace_claim::WorkspaceClaimProtocol>,
+    pub workspace_owner_lease: Option<&'a crate::workspace_claim::WorkspaceOwnerLeaseProtocol>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -659,7 +666,7 @@ impl JobStore {
         if let Some(submission) = inner.submission_keys.get(submission_key) {
             if let Some(stored) = inner.jobs.get(&submission.job_id) {
                 return RemoteRunnerSubmissionLookup::Accepted {
-                    job: stored.job.clone(),
+                    job: Box::new(stored.job.clone()),
                 };
             }
         }
@@ -923,9 +930,13 @@ impl JobStore {
             project_id,
             lease_ms,
             concurrency_limit,
-            execution_protocol,
-            Some(&crate::workspace_claim::WorkspaceClaimProtocol::current()),
-            Some(&crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current()),
+            RemoteRunnerClaimProtocols {
+                execution: execution_protocol,
+                workspace_claim: Some(&crate::workspace_claim::WorkspaceClaimProtocol::current()),
+                workspace_owner_lease: Some(
+                    &crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+                ),
+            },
         )
     }
 
@@ -937,14 +948,13 @@ impl JobStore {
         project_id: Option<&str>,
         lease_ms: u64,
         concurrency_limit: Option<usize>,
-        execution_protocol: Option<
-            &crate::runner_job_execution_context::RunnerJobExecutionProtocol,
-        >,
-        workspace_claim_protocol: Option<&crate::workspace_claim::WorkspaceClaimProtocol>,
-        workspace_owner_lease_protocol: Option<
-            &crate::workspace_claim::WorkspaceOwnerLeaseProtocol,
-        >,
+        protocols: RemoteRunnerClaimProtocols<'_>,
     ) -> Result<Option<RemoteRunnerJobClaim>> {
+        let RemoteRunnerClaimProtocols {
+            execution: execution_protocol,
+            workspace_claim: workspace_claim_protocol,
+            workspace_owner_lease: workspace_owner_lease_protocol,
+        } = protocols;
         if runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
                 "runner_id",
@@ -1085,8 +1095,7 @@ impl JobStore {
         };
         let execution_protocol = execution_context
             .as_ref()
-            .map(|_| execution_protocol.cloned())
-            .flatten();
+            .and_then(|_| execution_protocol.cloned());
         let workspace_claim_protocol = request
             .requires_workspace_claim_protocol()
             .then(crate::workspace_claim::WorkspaceClaimProtocol::current);

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -221,10 +221,21 @@ pub struct JobRunner {
     pub handle: JoinHandle<()>,
 }
 
+/// Durable inputs shared by local-runner job creation and capacity admission.
+#[derive(Clone)]
+pub(crate) struct LocalRunnerJobRequest {
+    pub(crate) operation: String,
+    pub(crate) source_snapshot: Option<SourceSnapshot>,
+    pub(crate) metadata: Option<Value>,
+    pub(crate) path_materialization_plan: Option<PathMaterializationPlan>,
+    pub(crate) local_runner: Option<LocalRunnerJob>,
+    pub(crate) admission_idempotency_key: Option<String>,
+}
+
 /// The durable result of a controller submission lookup or admission.
 pub(crate) enum ControllerJobSubmissionOutcome {
     Submitted(Uuid),
-    Existing(Job),
+    Existing(Box<Job>),
 }
 
 pub(crate) enum ControllerJobStartOutcome {
@@ -268,6 +279,8 @@ impl JobStore {
             .read(true)
             .write(true)
             .create(true)
+            // This persistent lock has no payload; opening it must retain any existing bytes.
+            .truncate(false)
             .open(&path)
             .map_err(|error| {
                 Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
@@ -810,14 +823,14 @@ impl JobStore {
         path_materialization_plan: Option<PathMaterializationPlan>,
         local_runner: Option<LocalRunnerJob>,
     ) -> Job {
-        self.create_or_reuse_active_local_runner_job(
-            operation,
+        self.create_or_reuse_active_local_runner_job(LocalRunnerJobRequest {
+            operation: operation.into(),
             source_snapshot,
             metadata,
             path_materialization_plan,
             local_runner,
-            None,
-        )
+            admission_idempotency_key: None,
+        })
         .0
     }
 
@@ -929,14 +942,14 @@ impl JobStore {
         metadata: Value,
         idempotency_key: &str,
     ) -> (Job, bool) {
-        self.create_or_reuse_active_local_runner_job(
-            "runner.admission",
-            None,
-            Some(metadata),
-            None,
-            None,
-            Some(idempotency_key.to_string()),
-        )
+        self.create_or_reuse_active_local_runner_job(LocalRunnerJobRequest {
+            operation: "runner.admission".to_string(),
+            source_snapshot: None,
+            metadata: Some(metadata),
+            path_materialization_plan: None,
+            local_runner: None,
+            admission_idempotency_key: Some(idempotency_key.to_string()),
+        })
     }
 
     fn create_admission_inner(
@@ -950,19 +963,21 @@ impl JobStore {
     ) -> Result<AdmissionReservation> {
         let (job, created) = self.create_or_reuse_active_local_runner_job_inner(
             inner,
-            "runner.admission",
-            None,
-            Some(metadata),
-            None,
-            Some(LocalRunnerJob {
-                runner_id: "admission".to_string(),
-                command: Vec::new(),
-                cwd: None,
-                lifecycle: None,
-                workspace_claim_binding,
-                workspace_owner_lease: workspace_owner_lease.clone(),
-            }),
-            idempotency_key.clone(),
+            LocalRunnerJobRequest {
+                operation: "runner.admission".to_string(),
+                source_snapshot: None,
+                metadata: Some(metadata),
+                path_materialization_plan: None,
+                local_runner: Some(LocalRunnerJob {
+                    runner_id: "admission".to_string(),
+                    command: Vec::new(),
+                    cwd: None,
+                    lifecycle: None,
+                    workspace_claim_binding,
+                    workspace_owner_lease: workspace_owner_lease.clone(),
+                }),
+                admission_idempotency_key: idempotency_key.clone(),
+            },
         )?;
         let stored = inner.jobs.get_mut(&job.id).expect("admission exists");
         if !created {
@@ -1311,23 +1326,10 @@ impl JobStore {
     /// spawning a duplicate worker for it.
     fn create_or_reuse_active_local_runner_job(
         &self,
-        operation: impl Into<String>,
-        source_snapshot: Option<SourceSnapshot>,
-        metadata: Option<Value>,
-        path_materialization_plan: Option<PathMaterializationPlan>,
-        local_runner: Option<LocalRunnerJob>,
-        admission_idempotency_key: Option<String>,
+        request: LocalRunnerJobRequest,
     ) -> (Job, bool) {
         self.durable_transaction(|inner| {
-            self.create_or_reuse_active_local_runner_job_inner(
-                inner,
-                operation,
-                source_snapshot,
-                metadata,
-                path_materialization_plan,
-                local_runner,
-                admission_idempotency_key,
-            )
+            self.create_or_reuse_active_local_runner_job_inner(inner, request)
         })
         .expect("local runner job creation must persist")
     }
@@ -1335,15 +1337,17 @@ impl JobStore {
     fn create_or_reuse_active_local_runner_job_inner(
         &self,
         inner: &mut JobStoreInner,
-        operation: impl Into<String>,
-        source_snapshot: Option<SourceSnapshot>,
-        metadata: Option<Value>,
-        path_materialization_plan: Option<PathMaterializationPlan>,
-        local_runner: Option<LocalRunnerJob>,
-        admission_idempotency_key: Option<String>,
+        request: LocalRunnerJobRequest,
     ) -> Result<(Job, bool)> {
         let now = timestamp_ms();
-        let operation = operation.into();
+        let LocalRunnerJobRequest {
+            operation,
+            source_snapshot,
+            metadata,
+            path_materialization_plan,
+            local_runner,
+            admission_idempotency_key,
+        } = request;
         let runner_job_projection = metadata
             .as_ref()
             .and_then(|metadata| metadata.get("runner_job_projection"))
@@ -1879,7 +1883,7 @@ impl JobStore {
             let job = inner.jobs.get(&existing.job_id).ok_or_else(|| {
                 Error::internal_unexpected("controller submission index points at a missing job")
             })?;
-                return Ok(ControllerJobSubmissionOutcome::Existing(job.job.clone()));
+                return Ok(ControllerJobSubmissionOutcome::Existing(Box::new(job.job.clone())));
         }
         if inner
             .expired_controller_submissions
@@ -1893,7 +1897,7 @@ impl JobStore {
                 return Err(controller_idempotency_conflict(&idempotency_key));
             }
             if let Some(job) = submission.terminal_job.clone() {
-                return Ok(ControllerJobSubmissionOutcome::Existing(job));
+                return Ok(ControllerJobSubmissionOutcome::Existing(Box::new(job)));
             }
             return Err(Error::validation_invalid_argument(
                 "idempotency_key",
@@ -1919,7 +1923,7 @@ impl JobStore {
                 return Err(controller_idempotency_conflict(&idempotency_key));
             }
             if let Some(job) = tombstone.terminal_job {
-                return Ok(ControllerJobSubmissionOutcome::Existing(job));
+                return Ok(ControllerJobSubmissionOutcome::Existing(Box::new(job)));
             }
             return Err(Error::validation_invalid_argument(
                 "idempotency_key",
@@ -2250,12 +2254,7 @@ impl JobStore {
         F,
     >(
         &self,
-        operation: impl Into<String>,
-        source_snapshot: Option<SourceSnapshot>,
-        metadata: Option<Value>,
-        path_materialization_plan: Option<PathMaterializationPlan>,
-        local_runner: LocalRunnerJob,
-        admission_idempotency_key: Option<String>,
+        request: LocalRunnerJobRequest,
         capacity: usize,
         run: F,
     ) -> JobRunner
@@ -2264,12 +2263,7 @@ impl JobStore {
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
         self.try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            operation,
-            source_snapshot,
-            metadata,
-            path_materialization_plan,
-            local_runner,
-            admission_idempotency_key,
+            request,
             capacity,
             run,
         )
@@ -2283,12 +2277,7 @@ impl JobStore {
         F,
     >(
         &self,
-        operation: impl Into<String>,
-        source_snapshot: Option<SourceSnapshot>,
-        metadata: Option<Value>,
-        path_materialization_plan: Option<PathMaterializationPlan>,
-        local_runner: LocalRunnerJob,
-        admission_idempotency_key: Option<String>,
+        request: LocalRunnerJobRequest,
         capacity: usize,
         run: F,
     ) -> Result<JobRunner>
@@ -2297,15 +2286,7 @@ impl JobStore {
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
         let (job, created) = self.durable_transaction(|inner| {
-            self.create_or_reuse_active_local_runner_job_inner(
-                inner,
-                operation,
-                source_snapshot,
-                metadata,
-                path_materialization_plan,
-                Some(local_runner.clone()),
-                admission_idempotency_key,
-            )
+            self.create_or_reuse_active_local_runner_job_inner(inner, request.clone())
         })?;
         let job_id = job.id;
         // An idempotent resubmission reused an already-enqueued job that already
@@ -2329,7 +2310,11 @@ impl JobStore {
                 }
                 match worker_store.reserve_local_child_with_runner_capacity(
                     job_id,
-                    &local_runner.runner_id,
+                    &request
+                        .local_runner
+                        .as_ref()
+                        .expect("capacity admission requires a local runner")
+                        .runner_id,
                     capacity,
                 ) {
                     Ok(true) => break,

--- a/crates/homeboy-core/src/api_jobs/tests/part_a.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_a.rs
@@ -404,12 +404,7 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
     let (release_first_tx, release_first_rx) = mpsc::channel();
     let first_starts = Arc::clone(&starts);
     let first = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-        "runner.exec",
-        None,
-        None,
-        None,
-        local_runner(),
-        None,
+        super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(local_runner()), admission_idempotency_key: None },
         1,
         move |job| {
             job.start_with_reserved_child_identity(
@@ -432,12 +427,7 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
     let (second_started_tx, second_started_rx) = mpsc::channel();
     let second_starts = Arc::clone(&starts);
     let second = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-        "runner.exec",
-        None,
-        None,
-        None,
-        local_runner(),
-        None,
+        super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(local_runner()), admission_idempotency_key: None },
         1,
         move |job| {
             job.start_with_reserved_child_identity(
@@ -477,19 +467,14 @@ fn capacity_queued_agent_task_spawns_once_after_claiming_an_idle_slot() {
 fn capacity_queued_agent_task_persists_typed_failure_before_child_identity() {
     let store = JobStore::default();
     let runner = store.run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-        "runner.exec",
-        None,
-        None,
-        None,
-        super::store::LocalRunnerJob {
+        super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(super::store::LocalRunnerJob {
             runner_id: "homeboy-lab".to_string(),
             command: vec!["homeboy".to_string(), "agent-task".to_string()],
             cwd: Some("/runner/worktree".to_string()),
             lifecycle: None,
             workspace_claim_binding: None,
             workspace_owner_lease: None,
-        },
-        None,
+        }), admission_idempotency_key: None },
         1,
         move |_job| {
             Err::<serde_json::Value, _>(Error::internal_io(
@@ -809,12 +794,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
 
     let first = store
         .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            "runner.exec",
-            None,
-            None,
-            None,
-            local_runner("dup-run"),
-            None,
+            super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(local_runner("dup-run")), admission_idempotency_key: None },
             usize::MAX,
             {
                 let wait = wait;
@@ -828,12 +808,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
     // Resubmit the same durable run id while the first job is still active.
     let second = store
         .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            "runner.exec",
-            None,
-            None,
-            None,
-            local_runner("dup-run"),
-            None,
+            super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(local_runner("dup-run")), admission_idempotency_key: None },
             usize::MAX,
             move |_job| Ok(serde_json::json!({})),
         );
@@ -856,12 +831,7 @@ fn capacity_queued_local_runner_enqueue_dedupes_on_durable_run_id() {
     // A different durable run id enqueues a distinct job.
     let other = store
         .run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            "runner.exec",
-            None,
-            None,
-            None,
-            local_runner("other-run"),
-            None,
+            super::store::LocalRunnerJobRequest { operation: "runner.exec".to_string(), source_snapshot: None, metadata: None, path_materialization_plan: None, local_runner: Some(local_runner("other-run")), admission_idempotency_key: None },
             usize::MAX,
             move |_job| Ok(serde_json::json!({})),
         );

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -457,7 +457,17 @@ fn workspace_bound_reverse_jobs_reject_old_or_missing_worker_capability() {
     let job = store.submit_remote_runner_job(request).expect("job queues");
 
     assert!(store
-        .claim_remote_runner_job_with_protocols("homeboy-lab", None, 30_000, None, None, None, None)
+        .claim_remote_runner_job_with_protocols(
+            "homeboy-lab",
+            None,
+            30_000,
+            None,
+            super::remote_runner::RemoteRunnerClaimProtocols {
+                execution: None,
+                workspace_claim: None,
+                workspace_owner_lease: None
+            }
+        )
         .is_err());
     assert_eq!(
         store.get(job.id).expect("queued job").status,
@@ -474,9 +484,13 @@ fn workspace_bound_reverse_jobs_reject_old_or_missing_worker_capability() {
             None,
             30_000,
             None,
-            Some(&crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()),
-            Some(&old),
-            None,
+            super::remote_runner::RemoteRunnerClaimProtocols {
+                execution: Some(
+                    &crate::runner_job_execution_context::RunnerJobExecutionProtocol::current()
+                ),
+                workspace_claim: Some(&old),
+                workspace_owner_lease: None
+            },
         )
         .is_err());
     assert_eq!(

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -775,6 +775,28 @@ where
     }
 }
 
+struct MissingLeaseStateRecoveryRequest {
+    lease_id: String,
+    recorded_pid: u32,
+    recorded_endpoint: SocketAddr,
+}
+
+struct MissingLeaseStateRecoveryOperations<
+    Status,
+    PidIsRunning,
+    ProbeEndpoint,
+    AcquireOwner,
+    Reconcile,
+    Start,
+> {
+    status: Status,
+    pid_is_running: PidIsRunning,
+    probe_endpoint: ProbeEndpoint,
+    acquire_owner: AcquireOwner,
+    reconcile: Reconcile,
+    start: Start,
+}
+
 fn recover_missing_lease_state_with_operations<
     Status,
     PidIsRunning,
@@ -784,15 +806,15 @@ fn recover_missing_lease_state_with_operations<
     Reconcile,
     Start,
 >(
-    lease_id: &str,
-    recorded_pid: u32,
-    recorded_endpoint: SocketAddr,
-    status: Status,
-    pid_is_running: PidIsRunning,
-    probe_endpoint: ProbeEndpoint,
-    acquire_owner: AcquireOwner,
-    reconcile: Reconcile,
-    start: Start,
+    request: MissingLeaseStateRecoveryRequest,
+    operations: MissingLeaseStateRecoveryOperations<
+        Status,
+        PidIsRunning,
+        ProbeEndpoint,
+        AcquireOwner,
+        Reconcile,
+        Start,
+    >,
 ) -> Result<super::DaemonStateLossRecoveryResult>
 where
     Status: FnOnce() -> Result<super::DaemonStatus>,
@@ -802,6 +824,19 @@ where
     Reconcile: FnOnce() -> Result<(PathBuf, crate::api_jobs::DaemonLeaseJobDiagnostics)>,
     Start: FnOnce() -> Result<super::DaemonStartResult>,
 {
+    let MissingLeaseStateRecoveryRequest {
+        lease_id,
+        recorded_pid,
+        recorded_endpoint,
+    } = request;
+    let MissingLeaseStateRecoveryOperations {
+        status,
+        pid_is_running,
+        probe_endpoint,
+        acquire_owner,
+        reconcile,
+        start,
+    } = operations;
     let status = status()?;
     if status.state.is_some()
         || status.freshness.stale_reason_code != Some(DaemonStaleReasonCode::LeaseMissing)
@@ -841,7 +876,7 @@ where
                 reconciled.protected_count(),
                 reconciled.protected_job_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "),
             ),
-            Some(lease_id.to_string()),
+            Some(lease_id.clone()),
             Some(vec!["Wait for the recorded child process to finish, then retry recovery.".to_string()]),
         ));
     }
@@ -849,7 +884,7 @@ where
         return Err(Error::validation_invalid_argument(
             "lease_id",
             format!("no active durable jobs belong to exact lease `{lease_id}`"),
-            Some(lease_id.to_string()),
+            Some(lease_id.clone()),
             None,
         ));
     }
@@ -1286,18 +1321,36 @@ pub fn reconcile_dead_lease_orphans(
     let _lock = acquire_daemon_operation_lock()?;
     reconcile_dead_lease_orphans_with_operations(
         lease_id,
-        job_ids,
-        read_status,
-        pid_is_running,
-        try_acquire_daemon_owner_lock,
-        || prove_no_daemon_owner(addr),
-        |pid| {
-            let store =
-                super::JobStore::open_without_reconciliation(crate::paths::daemon_jobs_file()?)?;
-            store.reconcile_exact_daemon_loss_jobs(lease_id, job_ids, pid)
+        DeadLeaseOrphanRecoveryOperations {
+            status: read_status,
+            pid_is_running,
+            acquire_owner: try_acquire_daemon_owner_lock,
+            prove_no_owner: || prove_no_daemon_owner(addr),
+            reconcile: |pid| {
+                let store = super::JobStore::open_without_reconciliation(
+                    crate::paths::daemon_jobs_file()?,
+                )?;
+                store.reconcile_exact_daemon_loss_jobs(lease_id, job_ids, pid)
+            },
+            start: || start_or_return_live_unlocked(addr),
         },
-        || start_or_return_live_unlocked(addr),
     )
+}
+
+struct DeadLeaseOrphanRecoveryOperations<
+    Status,
+    PidIsRunning,
+    AcquireOwner,
+    ProveNoOwner,
+    Reconcile,
+    Start,
+> {
+    status: Status,
+    pid_is_running: PidIsRunning,
+    acquire_owner: AcquireOwner,
+    prove_no_owner: ProveNoOwner,
+    reconcile: Reconcile,
+    start: Start,
 }
 
 fn reconcile_dead_lease_orphans_with_operations<
@@ -1310,13 +1363,14 @@ fn reconcile_dead_lease_orphans_with_operations<
     Start,
 >(
     lease_id: &str,
-    _job_ids: &[uuid::Uuid],
-    status: Status,
-    pid_is_running: PidIsRunning,
-    acquire_owner: AcquireOwner,
-    prove_no_owner: ProveNoOwner,
-    reconcile: Reconcile,
-    start: Start,
+    operations: DeadLeaseOrphanRecoveryOperations<
+        Status,
+        PidIsRunning,
+        AcquireOwner,
+        ProveNoOwner,
+        Reconcile,
+        Start,
+    >,
 ) -> Result<DaemonExactOrphanRecoveryResult>
 where
     Status: FnOnce() -> Result<super::DaemonStatus>,
@@ -1326,6 +1380,14 @@ where
     Reconcile: FnOnce(u32) -> Result<crate::api_jobs::DaemonLeaseJobDiagnostics>,
     Start: FnOnce() -> Result<super::DaemonStartResult>,
 {
+    let DeadLeaseOrphanRecoveryOperations {
+        status,
+        pid_is_running,
+        acquire_owner,
+        prove_no_owner,
+        reconcile,
+        start,
+    } = operations;
     let status = status()?;
     let state = status.state.ok_or_else(|| {
         Error::validation_invalid_argument(

--- a/crates/homeboy-core/src/daemon/controller_job_driver.rs
+++ b/crates/homeboy-core/src/daemon/controller_job_driver.rs
@@ -89,10 +89,11 @@ impl ControllerJobHandle {
     }
 }
 
-fn drivers() -> &'static Mutex<HashMap<(String, u32), Arc<dyn ControllerJobDriver>>> {
-    static DRIVERS: std::sync::OnceLock<
-        Mutex<HashMap<(String, u32), Arc<dyn ControllerJobDriver>>>,
-    > = std::sync::OnceLock::new();
+type ControllerJobDriverKey = (String, u32);
+type ControllerJobDrivers = Mutex<HashMap<ControllerJobDriverKey, Arc<dyn ControllerJobDriver>>>;
+
+fn drivers() -> &'static ControllerJobDrivers {
+    static DRIVERS: std::sync::OnceLock<ControllerJobDrivers> = std::sync::OnceLock::new();
     DRIVERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 

--- a/crates/homeboy-core/src/daemon/daemon_lease.rs
+++ b/crates/homeboy-core/src/daemon/daemon_lease.rs
@@ -71,7 +71,7 @@ pub(crate) fn validate_lease_file(path: &Path) -> Result<DaemonLeaseValidation> 
         });
     }
 
-    let content = fs::read_to_string(&path)
+    let content = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
     let state: DaemonState = match serde_json::from_str(&content) {
         Ok(state) => state,

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use crate::api_jobs::{
     ControllerJobState, DaemonActiveJobRecoveryEvidence, JobStatus, JobStore, LocalRunnerJob,
-    RunnerJobLifecycleMetadata,
+    LocalRunnerJobRequest, RunnerJobLifecycleMetadata,
 };
 use crate::build_identity;
 use crate::error::{Error, ExecutableAction, RemoteCommandFailedDetails, Result, TargetDetails};
@@ -1717,7 +1717,7 @@ fn reserve_admission(
     let workspace_owner_request = body
         .get("workspace_owner_request")
         .cloned()
-        .map(|value| serde_json::from_value::<WorkspaceOwnerRegisterRequest>(value))
+        .map(serde_json::from_value::<WorkspaceOwnerRegisterRequest>)
         .transpose()
         .map_err(|error| {
             Error::validation_invalid_argument(
@@ -2788,14 +2788,16 @@ fn enqueue_exec_job(
     let workspace_owner_renewal_store = (*job_store).clone();
     let runner = match job_store
         .try_run_capacity_queued_local_child_background_with_source_snapshot_metadata_path_materialization_and_local_runner(
-            operation,
-            source_snapshot.clone(),
-            Some(run_ref_metadata),
-            path_materialization_plan.clone(),
-            local_runner,
-            lifecycle
-                .as_ref()
-                .and_then(|lifecycle| lifecycle.durable_run_id.clone()),
+            LocalRunnerJobRequest {
+                operation,
+                source_snapshot: source_snapshot.clone(),
+                metadata: Some(run_ref_metadata),
+                path_materialization_plan: path_materialization_plan.clone(),
+                local_runner: Some(local_runner),
+                admission_idempotency_key: lifecycle
+                    .as_ref()
+                    .and_then(|lifecycle| lifecycle.durable_run_id.clone()),
+            },
             capacity,
             move |job| {
                 let mut plan = plan;
@@ -3126,7 +3128,7 @@ fn enqueue_controller_job(
         }
         crate::api_jobs::ControllerJobSubmissionOutcome::Existing(job) => {
             let compacted = job_store.get(job.id).is_err();
-            (job, compacted)
+            (*job, compacted)
         }
     };
     let job_id = job.id;
@@ -3567,7 +3569,8 @@ fn daemon_job_store() -> &'static JobStore {
 mod tests {
     use super::*;
     use crate::daemon::runner_exec_driver::{
-        self, DaemonExecOutput, PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
+        self, DaemonExecOutput, PreparedDaemonExec, PreparedDaemonExecRequest, RunnerExecDriver,
+        RunnerExecPrepareRequest,
     };
 
     /// Round-trip the envelope through the exact functions that build it on the
@@ -4744,19 +4747,23 @@ mod tests {
     impl RunnerExecDriver for EnqueueTestDriver {
         fn prepare(&self, request: RunnerExecPrepareRequest) -> Result<PreparedDaemonExec> {
             let cwd = request.cwd.unwrap_or_else(|| "/tmp".to_string());
-            Ok(PreparedDaemonExec::new(
-                request.runner_id.clone(),
-                cwd.clone(),
-                request.command,
-                request.env,
-                request.secret_env_names,
-                crate::source_snapshot::existing_remote(&request.runner_id, &cwd, None),
-                request.require_paths,
-                Some(1),
-                crate::server::HeartbeatOnlyStallPolicy::default(),
-                serde_json::Value::Null,
-                Arc::new(()),
-            ))
+            Ok(PreparedDaemonExec::new(PreparedDaemonExecRequest {
+                runner_id: request.runner_id.clone(),
+                cwd: cwd.clone(),
+                command: request.command,
+                env: request.env,
+                secret_env_names: request.secret_env_names,
+                source_snapshot: crate::source_snapshot::existing_remote(
+                    &request.runner_id,
+                    &cwd,
+                    None,
+                ),
+                require_paths: request.require_paths,
+                concurrency_limit: Some(1),
+                heartbeat_only_stall: crate::server::HeartbeatOnlyStallPolicy::default(),
+                extension_env_provenance: serde_json::Value::Null,
+                plan_token: Arc::new(()),
+            }))
         }
 
         fn execute(
@@ -5288,6 +5295,7 @@ pub(super) fn acquire_daemon_operation_lock() -> Result<DaemonOperationLock> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(&path)
         .map_err(|error| {
             Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
@@ -5319,6 +5327,7 @@ pub(super) fn try_acquire_daemon_owner_lock() -> Result<Option<DaemonOwnerLock>>
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(parent.join("owner.lock"))
         .map_err(|error| {
             Error::internal_io(

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -622,9 +622,11 @@ fn claim(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) ->
         request.project_id.as_deref(),
         request.lease_ms.unwrap_or(30_000),
         concurrency_limit,
-        request.execution_protocol.as_ref(),
-        request.workspace_claim_protocol.as_ref(),
-        request.workspace_owner_lease_protocol.as_ref(),
+        crate::api_jobs::RemoteRunnerClaimProtocols {
+            execution: request.execution_protocol.as_ref(),
+            workspace_claim: request.workspace_claim_protocol.as_ref(),
+            workspace_owner_lease: request.workspace_owner_lease_protocol.as_ref(),
+        },
     )?;
     Ok(json!({
         "command": "api.runner.jobs.claim",

--- a/crates/homeboy-core/src/daemon/runner_exec_driver.rs
+++ b/crates/homeboy-core/src/daemon/runner_exec_driver.rs
@@ -72,22 +72,38 @@ pub struct PreparedDaemonExec {
     plan_token: Arc<dyn std::any::Any + Send + Sync>,
 }
 
+/// The daemon-visible process plan prepared by a runner-specific driver.
+pub struct PreparedDaemonExecRequest {
+    pub runner_id: String,
+    pub cwd: String,
+    pub command: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
+    pub source_snapshot: SourceSnapshot,
+    pub require_paths: Vec<String>,
+    pub concurrency_limit: Option<usize>,
+    pub heartbeat_only_stall: HeartbeatOnlyStallPolicy,
+    pub extension_env_provenance: Value,
+    pub plan_token: Arc<dyn std::any::Any + Send + Sync>,
+}
+
 impl PreparedDaemonExec {
     /// Construct a prepared exec. `plan_token` is the driver's private full
     /// plan; the daemon-visible fields are the process descriptor.
-    pub fn new(
-        runner_id: String,
-        cwd: String,
-        command: Vec<String>,
-        env: HashMap<String, String>,
-        secret_env_names: Vec<String>,
-        source_snapshot: SourceSnapshot,
-        require_paths: Vec<String>,
-        concurrency_limit: Option<usize>,
-        heartbeat_only_stall: HeartbeatOnlyStallPolicy,
-        extension_env_provenance: Value,
-        plan_token: Arc<dyn std::any::Any + Send + Sync>,
-    ) -> Self {
+    pub fn new(request: PreparedDaemonExecRequest) -> Self {
+        let PreparedDaemonExecRequest {
+            runner_id,
+            cwd,
+            command,
+            env,
+            secret_env_names,
+            source_snapshot,
+            require_paths,
+            concurrency_limit,
+            heartbeat_only_stall,
+            extension_env_provenance,
+            plan_token,
+        } = request;
         Self {
             runner_id,
             cwd,

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use homeboy_core::daemon::runner_exec_driver::{
     DaemonExecOutput, ExecCancellationProbe, ExecChildStarted, ExecProgressSink,
-    PreparedDaemonExec, RunnerExecDriver, RunnerExecPrepareRequest,
+    PreparedDaemonExec, PreparedDaemonExecRequest, RunnerExecDriver, RunnerExecPrepareRequest,
 };
 use homeboy_core::error::Result;
 use homeboy_core::runner_job_execution_context::RunnerJobExecutionContext;
@@ -86,25 +86,25 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             require_paths: request.require_paths,
             validate_require_paths_on_host: request.validate_require_paths_on_host,
         })?;
-        Ok(PreparedDaemonExec::new(
-            plan.runner.id.clone(),
-            plan.cwd.clone(),
-            plan.command.clone(),
-            plan.env.clone(),
-            plan.secret_env_names.clone(),
-            plan.source_snapshot.clone(),
-            plan.require_paths.clone(),
-            plan.runner.settings.concurrency_limit,
-            plan.runner.settings.heartbeat_only_stall.clone(),
+        Ok(PreparedDaemonExec::new(PreparedDaemonExecRequest {
+            runner_id: plan.runner.id.clone(),
+            cwd: plan.cwd.clone(),
+            command: plan.command.clone(),
+            env: plan.env.clone(),
+            secret_env_names: plan.secret_env_names.clone(),
+            source_snapshot: plan.source_snapshot.clone(),
+            require_paths: plan.require_paths.clone(),
+            concurrency_limit: plan.runner.settings.concurrency_limit,
+            heartbeat_only_stall: plan.runner.settings.heartbeat_only_stall.clone(),
             // This is a durable declaration, not provider output. The provider
             // itself is resolved only after the authenticated context arrives
             // at `execute`.
-            serde_json::json!({ "providers": request.extension_env_providers.clone() }),
-            Arc::new(DaemonPreparedPlan {
+            extension_env_provenance: serde_json::json!({ "providers": request.extension_env_providers.clone() }),
+            plan_token: Arc::new(DaemonPreparedPlan {
                 plan,
                 extension_env_providers: request.extension_env_providers,
             }),
-        ))
+        }))
     }
 
     fn execute(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1237,48 +1237,50 @@ fn exact_no_pid_recovery_requires_unexpected_termination_and_refuses_process_con
     let daemon = fake_daemon(4242, "lease-dead");
     let mismatch = super::reconcile_dead_lease_orphans_with_operations(
         "other-lease",
-        &[uuid::Uuid::new_v4()],
-        || Ok(dead_status_with_unexpected_termination(daemon.clone())),
-        |_| false,
-        || Ok(Some(())),
-        || unreachable!("lease mismatch blocks owner probe"),
-        |_| unreachable!("lease mismatch blocks mutation"),
-        || unreachable!("lease mismatch blocks replacement"),
+        super::DeadLeaseOrphanRecoveryOperations {
+            status: || Ok(dead_status_with_unexpected_termination(daemon.clone())),
+            pid_is_running: |_| false,
+            acquire_owner: || Ok(Some(())),
+            prove_no_owner: || unreachable!("lease mismatch blocks owner probe"),
+            reconcile: |_| unreachable!("lease mismatch blocks mutation"),
+            start: || unreachable!("lease mismatch blocks replacement"),
+        },
     )
     .expect_err("mismatched lease is refused");
     assert!(mismatch.message.contains("does not match"));
 
     let missing = super::reconcile_dead_lease_orphans_with_operations(
         "lease-dead",
-        &[uuid::Uuid::new_v4()],
-        || Ok(fake_dead_status(daemon.clone())),
-        |_| false,
-        || Ok(Some(())),
-        || Ok(vec!["no owner".to_string()]),
-        |_| unreachable!("missing evidence blocks mutation"),
-        || unreachable!("missing evidence blocks replacement"),
+        super::DeadLeaseOrphanRecoveryOperations {
+            status: || Ok(fake_dead_status(daemon.clone())),
+            pid_is_running: |_| false,
+            acquire_owner: || Ok(Some(())),
+            prove_no_owner: || Ok(vec!["no owner".to_string()]),
+            reconcile: |_| unreachable!("missing evidence blocks mutation"),
+            start: || unreachable!("missing evidence blocks replacement"),
+        },
     )
     .expect_err("missing unexpected-exit evidence is refused");
     assert!(missing.message.contains("unexpected-termination evidence"));
 
-    let job = uuid::Uuid::new_v4();
     let status = dead_status_with_unexpected_termination(daemon.clone());
     let contradiction = super::reconcile_dead_lease_orphans_with_operations(
         "lease-dead",
-        &[job],
-        || Ok(status),
-        |_| false,
-        || Ok(Some(())),
-        || {
-            Err(crate::error::Error::validation_invalid_argument(
-                "owner_probe",
-                "live workload process evidence contradicts operator confirmation",
-                None,
-                None,
-            ))
+        super::DeadLeaseOrphanRecoveryOperations {
+            status: || Ok(status),
+            pid_is_running: |_| false,
+            acquire_owner: || Ok(Some(())),
+            prove_no_owner: || {
+                Err(crate::error::Error::validation_invalid_argument(
+                    "owner_probe",
+                    "live workload process evidence contradicts operator confirmation",
+                    None,
+                    None,
+                ))
+            },
+            reconcile: |_| unreachable!("contradictory process evidence blocks mutation"),
+            start: || unreachable!("contradictory process evidence blocks replacement"),
         },
-        |_| unreachable!("contradictory process evidence blocks mutation"),
-        || unreachable!("contradictory process evidence blocks replacement"),
     )
     .expect_err("contradictory process evidence is refused");
     assert!(contradiction.message.contains("contradicts"));
@@ -1290,19 +1292,20 @@ fn exact_no_pid_recovery_starts_only_after_reconciliation() {
     let job = uuid::Uuid::new_v4();
     let result = super::reconcile_dead_lease_orphans_with_operations(
         "lease-dead",
-        &[job],
-        || Ok(dead_status_with_unexpected_termination(daemon)),
-        |_| false,
-        || Ok(Some(())),
-        || Ok(vec!["owner lock acquired".to_string()]),
-        |_| {
-            Ok(crate::api_jobs::DaemonLeaseJobDiagnostics {
-                expected_lease_id: "lease-dead".to_string(),
-                matching_job_ids: vec![job],
-                ..Default::default()
-            })
+        super::DeadLeaseOrphanRecoveryOperations {
+            status: || Ok(dead_status_with_unexpected_termination(daemon)),
+            pid_is_running: |_| false,
+            acquire_owner: || Ok(Some(())),
+            prove_no_owner: || Ok(vec!["owner lock acquired".to_string()]),
+            reconcile: |_| {
+                Ok(crate::api_jobs::DaemonLeaseJobDiagnostics {
+                    expected_lease_id: "lease-dead".to_string(),
+                    matching_job_ids: vec![job],
+                    ..Default::default()
+                })
+            },
+            start: || Ok(fake_daemon(4343, "replacement")),
         },
-        || Ok(fake_daemon(4343, "replacement")),
     )
     .expect("exact reconciliation succeeds before replacement");
     assert_eq!(result.reconciled_job_ids, vec![job]);
@@ -1716,52 +1719,61 @@ fn state_loss_exact_lease_recovery_terminalizes_only_matching_jobs_and_starts_on
         #[cfg(not(target_os = "linux"))]
         {
             let blocked = super::recover_missing_lease_state_with_operations(
-                "exact-lease",
-                4242,
-                recorded_endpoint(),
-                || Ok(leaseless_status(1)),
-                |_| false,
-                |_| Ok("recorded endpoint was unreachable".to_string()),
-                || Ok(Some(())),
-                || {
-                    let raw = std::fs::read(&path).expect("store bytes");
-                    let snapshot = super::snapshot_job_store(&path, &raw).expect("snapshot");
-                    let recovered = JobStore::open_without_reconciliation_from_bytes(&path, &raw)
-                        .expect("recovery store");
-                    Ok((
-                        snapshot,
-                        recovered.reconcile_dead_daemon_lease_jobs("exact-lease")?,
-                    ))
+                super::MissingLeaseStateRecoveryRequest {
+                    lease_id: "exact-lease".to_string(),
+                    recorded_pid: 4242,
+                    recorded_endpoint: recorded_endpoint(),
                 },
-                || unreachable!("unsupported identity must block replacement"),
+                super::MissingLeaseStateRecoveryOperations {
+                    status: || Ok(leaseless_status(1)),
+                    pid_is_running: |_| false,
+                    probe_endpoint: |_| Ok("recorded endpoint was unreachable".to_string()),
+                    acquire_owner: || Ok(Some(())),
+                    reconcile: || {
+                        let raw = std::fs::read(&path).expect("store bytes");
+                        let snapshot = super::snapshot_job_store(&path, &raw).expect("snapshot");
+                        let recovered =
+                            JobStore::open_without_reconciliation_from_bytes(&path, &raw)
+                                .expect("recovery store");
+                        Ok((
+                            snapshot,
+                            recovered.reconcile_dead_daemon_lease_jobs("exact-lease")?,
+                        ))
+                    },
+                    start: || unreachable!("unsupported identity must block replacement"),
+                },
             )
             .expect_err("unsupported process identity blocks recovery");
             assert!(blocked.message.contains("active child process"));
             return;
         }
         let result = super::recover_missing_lease_state_with_operations(
-            "exact-lease",
-            4242,
-            recorded_endpoint(),
-            || Ok(leaseless_status(1)),
-            |_| false,
-            |_| Ok("recorded endpoint was unreachable".to_string()),
-            || Ok(Some(())),
-            || {
-                let raw = std::fs::read(&path).expect("store bytes");
-                let snapshot = super::snapshot_job_store(&path, &raw).expect("snapshot");
-                let recovered = JobStore::open_without_reconciliation_from_bytes(&path, &raw)
-                    .expect("recovery store");
-                let diagnostics = recovered.daemon_lease_job_diagnostics("exact-lease");
-                assert!(diagnostics.other_lease_job_ids.is_empty());
-                Ok((
-                    snapshot,
-                    recovered.reconcile_dead_daemon_lease_jobs("exact-lease")?,
-                ))
+            super::MissingLeaseStateRecoveryRequest {
+                lease_id: "exact-lease".to_string(),
+                recorded_pid: 4242,
+                recorded_endpoint: recorded_endpoint(),
             },
-            move || {
-                *start_count.lock().expect("starts") += 1;
-                Ok(fake_daemon(4343, "replacement"))
+            super::MissingLeaseStateRecoveryOperations {
+                status: || Ok(leaseless_status(1)),
+                pid_is_running: |_| false,
+                probe_endpoint: |_| Ok("recorded endpoint was unreachable".to_string()),
+                acquire_owner: || Ok(Some(())),
+                reconcile: || {
+                    let raw = std::fs::read(&path).expect("store bytes");
+                    let snapshot = super::snapshot_job_store(&path, &raw).expect("snapshot");
+                    let recovered = JobStore::open_without_reconciliation_from_bytes(&path, &raw)
+                        .expect("recovery store");
+                    let diagnostics = recovered.daemon_lease_job_diagnostics("exact-lease");
+                    assert!(diagnostics.other_lease_job_ids.is_empty());
+                    Ok((
+                        snapshot,
+                        recovered.reconcile_dead_daemon_lease_jobs("exact-lease")?,
+                    ))
+                },
+                start: move || {
+                    *start_count.lock().expect("starts") += 1;
+                    Ok(fake_daemon(4343, "replacement"))
+                },
             },
         )
         .expect("exact recovery");
@@ -1783,15 +1795,19 @@ fn state_loss_exact_lease_recovery_terminalizes_only_matching_jobs_and_starts_on
 fn state_loss_exact_recovery_refuses_live_pid_lock_endpoint_and_mixed_lease() {
     let refusal = |status: DaemonStatus, pid_live: bool, owner_available: bool| {
         super::recover_missing_lease_state_with_operations(
-            "exact-lease",
-            4242,
-            recorded_endpoint(),
-            || Ok(status),
-            move |_| pid_live,
-            |_| Ok("recorded endpoint was unreachable".to_string()),
-            move || Ok(owner_available.then_some(())),
-            || unreachable!("refused recovery must not mutate jobs"),
-            || unreachable!("refused recovery must not start a daemon"),
+            super::MissingLeaseStateRecoveryRequest {
+                lease_id: "exact-lease".to_string(),
+                recorded_pid: 4242,
+                recorded_endpoint: recorded_endpoint(),
+            },
+            super::MissingLeaseStateRecoveryOperations {
+                status: || Ok(status),
+                pid_is_running: move |_| pid_live,
+                probe_endpoint: |_| Ok("recorded endpoint was unreachable".to_string()),
+                acquire_owner: move || Ok(owner_available.then_some(())),
+                reconcile: || unreachable!("refused recovery must not mutate jobs"),
+                start: || unreachable!("refused recovery must not start a daemon"),
+            },
         )
         .expect_err("unsafe state must fail closed")
     };
@@ -1807,15 +1823,19 @@ fn state_loss_exact_recovery_refuses_live_pid_lock_endpoint_and_mixed_lease() {
         .message
         .contains("unreachable endpoint"));
     let replay = super::recover_missing_lease_state_with_operations(
-        "exact-lease",
-        4242,
-        recorded_endpoint(),
-        || Ok(fake_dead_status(fake_daemon(4343, "replacement"))),
-        |_| false,
-        |_| Ok("recorded endpoint was unreachable".to_string()),
-        || Ok(Some(())),
-        || unreachable!("replay must not reconcile jobs"),
-        || unreachable!("replay must not start another daemon"),
+        super::MissingLeaseStateRecoveryRequest {
+            lease_id: "exact-lease".to_string(),
+            recorded_pid: 4242,
+            recorded_endpoint: recorded_endpoint(),
+        },
+        super::MissingLeaseStateRecoveryOperations {
+            status: || Ok(fake_dead_status(fake_daemon(4343, "replacement"))),
+            pid_is_running: |_| false,
+            probe_endpoint: |_| Ok("recorded endpoint was unreachable".to_string()),
+            acquire_owner: || Ok(Some(())),
+            reconcile: || unreachable!("replay must not reconcile jobs"),
+            start: || unreachable!("replay must not start another daemon"),
+        },
     )
     .expect_err("replacement state makes recovery replay fail closed");
     assert!(replay.message.contains("absent daemon state"));
@@ -1833,29 +1853,33 @@ fn state_loss_exact_recovery_refuses_live_pid_lock_endpoint_and_mixed_lease() {
         let other_job = other.create("runner.exec");
         other.start(other_job.id).expect("start other");
         let error = super::recover_missing_lease_state_with_operations(
-            "exact-lease",
-            4242,
-            recorded_endpoint(),
-            || Ok(leaseless_status(2)),
-            |_| false,
-            |_| Ok("recorded endpoint was unreachable".to_string()),
-            || Ok(Some(())),
-            || {
-                let raw = std::fs::read(&path).expect("store bytes");
-                let recovered =
-                    JobStore::open_without_reconciliation_from_bytes(&path, &raw).expect("store");
-                let diagnostics = recovered.daemon_lease_job_diagnostics("exact-lease");
-                if !diagnostics.other_lease_job_ids.is_empty() {
-                    return Err(crate::Error::validation_invalid_argument(
-                        "lease_id",
-                        "mixed exact leases",
-                        None,
-                        None,
-                    ));
-                }
-                unreachable!("mixed lease must not reconcile")
+            super::MissingLeaseStateRecoveryRequest {
+                lease_id: "exact-lease".to_string(),
+                recorded_pid: 4242,
+                recorded_endpoint: recorded_endpoint(),
             },
-            || unreachable!("mixed lease must not start"),
+            super::MissingLeaseStateRecoveryOperations {
+                status: || Ok(leaseless_status(2)),
+                pid_is_running: |_| false,
+                probe_endpoint: |_| Ok("recorded endpoint was unreachable".to_string()),
+                acquire_owner: || Ok(Some(())),
+                reconcile: || {
+                    let raw = std::fs::read(&path).expect("store bytes");
+                    let recovered = JobStore::open_without_reconciliation_from_bytes(&path, &raw)
+                        .expect("store");
+                    let diagnostics = recovered.daemon_lease_job_diagnostics("exact-lease");
+                    if !diagnostics.other_lease_job_ids.is_empty() {
+                        return Err(crate::Error::validation_invalid_argument(
+                            "lease_id",
+                            "mixed exact leases",
+                            None,
+                            None,
+                        ));
+                    }
+                    unreachable!("mixed lease must not reconcile")
+                },
+                start: || unreachable!("mixed lease must not start"),
+            },
         )
         .expect_err("mixed leases must fail closed");
         assert!(error.message.contains("mixed exact leases"));


### PR DESCRIPTION
## Summary
- migrate the core job and daemon Rust 1.95 Clippy findings to cohesive request and capability contexts
- make lock-file open behavior explicitly non-truncating
- preserve job wire and persisted schemas while boxing large in-memory variants

Refs #11580

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-core -p homeboy-lab-runner`
- Focused `api_jobs`/`daemon` tests compile through migrated callers, but the crate test build remains blocked by the unrelated missing `ManagedSshSession.persist_source` initializers in `server/client/tests.rs`, `server/ssh_args.rs`, and `server/transfer.rs` (expected upstream #11576).
- Scoped Clippy confirms the migrated areas; whole-crate Rust 1.95 Clippy remains blocked by diagnostics outside this owned migration layer.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode migrated the Rust 1.95 Clippy diagnostics, updated direct callers, and ran the listed checks. Chris remains responsible for every line.