### PR TITLE
fix(runner): bound startup recovery ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "fs4",
  "glob",
  "glob-match",
  "homeboy-agents",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -25,6 +25,7 @@ use homeboy_upgrade::upgrade;
 
 const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
 const RUNNER_EXEC_RECOVERY_OWNER_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER";
+const RUNNER_EXEC_RECOVERY_CHILD_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_CHILD";
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
@@ -357,10 +358,46 @@ impl CliRuntime {
         }
 
         register_startup_providers_before_reconcile();
-        if let Some(owner_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_OWNER_ENV) {
-            let _ = crate::runner::run_scheduled_terminal_runner_exec_recovery(
-                &owner_id.to_string_lossy(),
+        if let Some(child_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_CHILD_ENV) {
+            let child_token =
+                std::env::var_os("HOMEBOY_RUNNER_EXEC_RECOVERY_CHILD_TOKEN").unwrap_or_default();
+            let _ = crate::runner::run_scheduled_terminal_runner_exec_recovery_child(
+                &child_id.to_string_lossy(),
+                &child_token.to_string_lossy(),
             );
+            return std::process::ExitCode::SUCCESS;
+        }
+        if let Some(owner_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_OWNER_ENV) {
+            let owner_token =
+                std::env::var_os("HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER_TOKEN").unwrap_or_default();
+            if let Ok(Some(work)) = crate::runner::run_scheduled_terminal_runner_exec_recovery(
+                &owner_id.to_string_lossy(),
+                &owner_token.to_string_lossy(),
+            ) {
+                let mut scheduled_count = 0;
+                let mut spawn_failed_count = 0;
+                let executable = std::env::current_exe();
+                for child in &work.children {
+                    let spawned = match &executable {
+                        Ok(executable) => spawn_runner_exec_recovery_child(executable, child),
+                        Err(error) => Err(std::io::Error::new(error.kind(), error.to_string())),
+                    };
+                    match spawned {
+                        Ok(()) => scheduled_count += 1,
+                        Err(error) => {
+                            spawn_failed_count += 1;
+                            let _ = crate::runner::record_scheduled_terminal_runner_exec_recovery_child_spawn_failure(child, &error);
+                        }
+                    }
+                }
+                let _ = crate::runner::finish_scheduled_terminal_runner_exec_recovery(
+                    &owner_id.to_string_lossy(),
+                    &owner_token.to_string_lossy(),
+                    scheduled_count,
+                    spawn_failed_count,
+                    work.deferred_count,
+                );
+            }
             return std::process::ExitCode::SUCCESS;
         }
         let config = crate::core::defaults::load_config();
@@ -695,12 +732,24 @@ fn schedule_runner_exec_recovery() {
     if !schedule.is_new_owner {
         return;
     }
-    let Ok(executable) = std::env::current_exe() else {
-        return;
+    let executable = match std::env::current_exe() {
+        Ok(executable) => executable,
+        Err(error) => {
+            let _ = crate::runner::record_scheduled_terminal_runner_exec_recovery_spawn_failure(
+                &schedule.owner_id,
+                &schedule.owner_token,
+                &error,
+            );
+            return;
+        }
     };
     let mut command = ProcessCommand::new(executable);
     command
         .env(RUNNER_EXEC_RECOVERY_OWNER_ENV, &schedule.owner_id)
+        .env(
+            "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER_TOKEN",
+            &schedule.owner_token,
+        )
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -708,9 +757,28 @@ fn schedule_runner_exec_recovery() {
     if let Err(error) = command.spawn() {
         let _ = crate::runner::record_scheduled_terminal_runner_exec_recovery_spawn_failure(
             &schedule.owner_id,
+            &schedule.owner_token,
             &error,
         );
     }
+}
+
+fn spawn_runner_exec_recovery_child(
+    executable: &std::path::Path,
+    child: &crate::runner::RunnerExecRecoveryChildSchedule,
+) -> std::io::Result<()> {
+    let mut command = ProcessCommand::new(executable);
+    command
+        .env(RUNNER_EXEC_RECOVERY_CHILD_ENV, &child.child_id)
+        .env(
+            "HOMEBOY_RUNNER_EXEC_RECOVERY_CHILD_TOKEN",
+            &child.child_token,
+        )
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    crate::core::process::detach_from_caller_session(&mut command);
+    command.spawn().map(|_| ())
 }
 
 /// A cook has no durable run record until controller admission. Re-exec before

--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -20,9 +20,9 @@
 //!   `command_safety_manifest_audit` is `report_only: true`, and a path with no
 //!   registry declaration resolves to `read_only()` by default.
 //! - `CommandCapability` is a per-INVOCATION runtime gate that must fail closed,
-//!   because `Mutation` is what authorizes `reconcile_terminal_runner_exec_runs`
-//!   (recovering completed runner-exec evidence before a mutating command can
-//!   evict it) and the deferred-workload worker restart.
+//!   because `Mutation` is what authorizes scheduling runner-exec recovery
+//!   children (before a mutating command can evict their source evidence) and
+//!   the deferred-workload worker restart.
 //!
 //! A per-path lookup cannot express the argument-conditional rows here at all:
 //! `status` is read-only until `--refresh`, and `project`/`rig`/`server` are

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -75,6 +75,24 @@ impl ObservationStore {
         Ok(store)
     }
 
+    /// Open the scheduler's scan connection. It is read-only and performs no
+    /// migrations, journal maintenance, or artifact-publication recovery.
+    pub fn open_scheduler_reader() -> Result<Self> {
+        Self::open_readonly()
+    }
+
+    /// Open the scheduler's bounded claim connection. It performs no startup
+    /// maintenance; callers use it only for short durable claim transitions.
+    pub fn open_scheduler_writer() -> Result<Self> {
+        let path = database_path()?;
+        let connection = schema::open_bounded_writer_connection(&path)?;
+        Ok(Self {
+            connection,
+            path,
+            readonly: false,
+        })
+    }
+
     /// Open an existing observation database without any initialization work.
     /// Metadata readers use this so they never contend for the global writer
     /// lock merely to inspect a persisted run.
@@ -128,6 +146,179 @@ impl ObservationStore {
             .clone()
             .with_missing_from(RunContext::subprocess_compatibility_from_env());
         self.start_run_with_context_and_id(run, context, Some(id))
+    }
+
+    /// Atomically claim a singleton running run. A live lease leaves the
+    /// existing owner untouched; an expired lease is taken over in the same
+    /// SQLite statement, so a crash between observation and replacement cannot
+    /// create two workers.
+    pub fn claim_expiring_singleton_run(
+        &self,
+        mut run: NewRunRecord,
+        id: String,
+        owner_token: &str,
+        lease_expires_at_ms: i64,
+    ) -> Result<Option<RunRecord>> {
+        validate_required("kind", &run.kind)?;
+        validate_required("id", &id)?;
+        validate_required("owner_token", owner_token)?;
+        run.metadata_json["owner_token"] = serde_json::Value::String(owner_token.to_string());
+        run.metadata_json["lease_expires_at_ms"] = serde_json::json!(lease_expires_at_ms);
+        let context = run
+            .run_context
+            .clone()
+            .with_missing_from(RunContext::subprocess_compatibility_from_env());
+        let metadata_json =
+            serialize_metadata(&with_run_context_metadata(run.metadata_json, &context))?;
+        let started_at = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now().timestamp_millis();
+        let rows = execute_with_retry("claim expiring singleton run", || {
+            self.connection.execute(
+                r#"
+                INSERT INTO runs(id, kind, component_id, started_at, status, command, cwd, homeboy_version, git_sha, rig_id, metadata_json)
+                VALUES (?1, ?2, ?3, ?4, 'running', ?5, ?6, ?7, ?8, ?9, ?10)
+                ON CONFLICT DO UPDATE SET
+                    started_at = excluded.started_at,
+                    finished_at = NULL,
+                    status = 'running',
+                    metadata_json = excluded.metadata_json
+                WHERE runs.kind = excluded.kind AND (
+                    runs.status != 'running'
+                    OR COALESCE(CAST(json_extract(runs.metadata_json, '$.lease_expires_at_ms') AS INTEGER), 0) < ?11
+                )
+                "#,
+                params![id, run.kind, run.component_id, started_at, run.command, run.cwd,
+                    run.homeboy_version, run.git_sha, run.rig_id, metadata_json, now],
+            )
+        })?;
+        if rows == 0 {
+            return Ok(None);
+        }
+        let claimed = self.get_run(&id)?;
+        Ok(claimed
+            .filter(|record| record.metadata_json["owner_token"].as_str() == Some(owner_token)))
+    }
+
+    /// Renew a singleton lease only for its exact live owner token.
+    pub fn renew_running_run_lease(
+        &self,
+        run_id: &str,
+        owner_token: &str,
+        lease_expires_at_ms: i64,
+    ) -> Result<bool> {
+        let rows = execute_with_retry("renew running run lease", || {
+            self.connection.execute(
+                "UPDATE runs SET metadata_json = json_set(metadata_json, '$.lease_expires_at_ms', ?1) WHERE id = ?2 AND status = 'running' AND json_extract(metadata_json, '$.owner_token') = ?3",
+                params![lease_expires_at_ms, run_id, owner_token],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
+    /// Terminalize a leased singleton only when its ownership token still
+    /// matches. A worker revived after a stale-owner takeover cannot overwrite
+    /// the replacement owner's outcome.
+    pub fn finish_running_run_with_owner_token(
+        &self,
+        run_id: &str,
+        owner_token: &str,
+        status: RunStatus,
+        metadata_json: serde_json::Value,
+    ) -> Result<bool> {
+        let metadata_json = serialize_metadata(&metadata_json)?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let rows = execute_with_retry("finish leased running run", || {
+            self.connection.execute(
+                "UPDATE runs SET finished_at = ?1, status = ?2, metadata_json = ?3 WHERE id = ?4 AND status = 'running' AND json_extract(metadata_json, '$.owner_token') = ?5",
+                params![
+                    finished_at,
+                    status.as_str(),
+                    metadata_json,
+                    run_id,
+                    owner_token,
+                ],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
+    /// Claim a running runner-exec source for one child identity. The child
+    /// token fences later source terminalization after a retry or takeover.
+    pub fn claim_running_runner_exec_recovery_source(
+        &self,
+        run_id: &str,
+        child_id: &str,
+        child_token: &str,
+        runner_job_id: &str,
+    ) -> Result<bool> {
+        let claim = serde_json::to_string(&serde_json::json!({
+            "owner_id": child_id,
+            "source_token": child_token,
+            "runner_job_id": runner_job_id,
+            "expires_at_ms": chrono::Utc::now().timestamp_millis() + 30_000,
+        }))
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize runner recovery source claim".to_string()),
+            )
+        })?;
+        let rows = execute_with_retry("claim runner recovery source", || {
+            self.connection.execute(
+                "UPDATE runs SET metadata_json = json_set(metadata_json, '$.runner_exec_source_lease', json(?1)) WHERE id = ?2 AND status = 'running' AND json_extract(metadata_json, '$.runner_job_id') = ?3 AND (json_extract(metadata_json, '$.runner_exec_source_lease.expires_at_ms') IS NULL OR CAST(json_extract(metadata_json, '$.runner_exec_source_lease.expires_at_ms') AS INTEGER) < ?4)",
+                params![claim, run_id, runner_job_id, chrono::Utc::now().timestamp_millis()],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
+    /// Terminalize evidence loss only for the child that still owns this exact
+    /// running source/job identity. A stale child cannot overwrite a retry or a
+    /// concurrently settled source record.
+    pub fn fail_running_runner_exec_recovery_source(
+        &self,
+        run_id: &str,
+        child_token: &str,
+        runner_job_id: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<bool> {
+        let metadata_json = serialize_metadata(&metadata_json)?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let rows = execute_with_retry("fail claimed runner recovery source", || {
+            self.connection.execute(
+                "UPDATE runs SET finished_at = ?1, status = 'fail', metadata_json = ?2 WHERE id = ?3 AND status = 'running' AND json_extract(metadata_json, '$.runner_job_id') = ?4 AND json_extract(metadata_json, '$.runner_exec_source_lease.source_token') = ?5",
+                params![finished_at, metadata_json, run_id, runner_job_id, child_token],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
+    pub fn renew_running_runner_exec_source_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+    ) -> Result<bool> {
+        let rows = execute_with_retry("renew runner exec source lease", || {
+            self.connection.execute(
+            "UPDATE runs SET metadata_json = json_set(metadata_json, '$.runner_exec_source_lease.expires_at_ms', ?1) WHERE id = ?2 AND status = 'running' AND json_extract(metadata_json, '$.runner_exec_source_lease.source_token') = ?3",
+            params![chrono::Utc::now().timestamp_millis() + 30_000, run_id, token],
+        )
+        })?;
+        Ok(rows == 1)
+    }
+
+    pub fn release_running_runner_exec_source_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+    ) -> Result<bool> {
+        let rows = execute_with_retry("release runner exec source lease", || {
+            self.connection.execute(
+            "UPDATE runs SET metadata_json = json_remove(metadata_json, '$.runner_exec_source_lease') WHERE id = ?1 AND status = 'running' AND json_extract(metadata_json, '$.runner_exec_source_lease.source_token') = ?2",
+            params![run_id, token],
+        )
+        })?;
+        Ok(rows == 1)
     }
 
     pub fn start_run_with_context(
@@ -1228,6 +1419,32 @@ mod tests {
                 complete.runs,
                 "the bounded accessor keeps returning the same rows"
             );
+        });
+    }
+
+    #[test]
+    fn singleton_claim_reads_back_its_exact_id_among_many_running_rows() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            for index in 0..100 {
+                store
+                    .start_run_with_id(
+                        NewRunRecord::builder("recovery-child").build(),
+                        format!("other-running-child-{index}"),
+                    )
+                    .expect("other running child");
+            }
+            let claimed = store
+                .claim_expiring_singleton_run(
+                    NewRunRecord::builder("recovery-child").build(),
+                    "target-child".to_string(),
+                    "target-token",
+                    chrono::Utc::now().timestamp_millis() + 60_000,
+                )
+                .expect("claim")
+                .expect("target claim");
+            assert_eq!(claimed.id, "target-child");
+            assert_eq!(claimed.metadata_json["owner_token"], "target-token");
         });
     }
 }

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -469,6 +469,24 @@ pub(crate) fn open_readonly_connection(path: &Path) -> Result<Connection> {
     Ok(connection)
 }
 
+/// Open an existing store for a bounded scheduler write. This deliberately
+/// avoids migrations, pragma maintenance, and artifact reconciliation: a
+/// scheduler may only claim or terminalize its own durable work.
+pub(crate) fn open_bounded_writer_connection(path: &Path) -> Result<Connection> {
+    const WRITE_TIMEOUT: Duration = Duration::from_millis(750);
+    let connection = Connection::open(path).map_err(sqlite_error(format!(
+        "open bounded observation scheduler store {}",
+        path.display()
+    )))?;
+    connection
+        .busy_timeout(WRITE_TIMEOUT)
+        .map_err(sqlite_error(
+            "configure bounded observation scheduler store",
+        ))?;
+    enforce_foreign_keys(&connection)?;
+    Ok(connection)
+}
+
 fn read_store_error(path: &Path, operation: &str, error: rusqlite::Error) -> crate::Error {
     if super::is_transient_lock_error(&error) {
         return crate::Error::observation_store_busy(path.to_string_lossy(), operation, 750);

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -26,6 +26,7 @@ homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "string"] }
+fs4 = "0.13"
 glob = "0.3"
 glob-match = "0.2"
 libc = "0.2"

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1610,9 +1610,22 @@ pub fn reconcile_status(runner_id: &str) -> Result<RunnerStatusReport> {
 /// Return the persisted controller-side session projection without reconnecting,
 /// probing a daemon, or reconciling generation state.
 pub fn persisted_status(runner_id: &str) -> Result<RunnerStatusReport> {
+    persisted_status_until(
+        runner_id,
+        std::time::Instant::now() + crate::readonly_probe::readonly_probe_timeout(),
+    )
+}
+
+/// Return the persisted session projection under one caller-owned deadline.
+/// This is intentionally observation-only: recovery may read a stale record,
+/// but every direct-session liveness probe receives only the time remaining.
+pub fn persisted_status_until(
+    runner_id: &str,
+    deadline: std::time::Instant,
+) -> Result<RunnerStatusReport> {
     let session_path = session_path(runner_id)?;
-    let session = read_session_for_status(runner_id)?;
-    let state = status_session_state(session.as_ref());
+    let session = read_session_for_status_until(runner_id, deadline)?;
+    let state = status_session_state_until(session.as_ref(), deadline);
     Ok(RunnerStatusReport {
         runner_id: runner_id.to_string(),
         connected: state == RunnerSessionState::Connected,

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::session::RunnerConnectFailureEvidence;
+use std::time::Instant;
 
 pub(super) fn session_is_live(session: &RunnerSession) -> bool {
     session_is_live_with_timeout(session, Duration::from_secs(2))
@@ -181,16 +182,27 @@ pub(super) fn read_session(runner_id: &str) -> Result<Option<RunnerSession>> {
 /// tunnel without allowing historical session directories to turn status into
 /// an unbounded liveness scan.
 pub(super) fn read_session_for_status(runner_id: &str) -> Result<Option<RunnerSession>> {
+    read_session_for_status_until(
+        runner_id,
+        Instant::now() + crate::readonly_probe::readonly_probe_timeout(),
+    )
+}
+
+/// Resolve the current or a peer session without allowing one runner's status
+/// observation to outlive the caller's absolute operation deadline.
+pub(super) fn read_session_for_status_until(
+    runner_id: &str,
+    deadline: Instant,
+) -> Result<Option<RunnerSession>> {
     let controller_id = controller_id();
     let session = read_session_for_controller(runner_id, &controller_id)?;
-    if session
-        .as_ref()
-        .is_some_and(|session| status_session_state(Some(session)) == RunnerSessionState::Connected)
-    {
+    if session.as_ref().is_some_and(|session| {
+        status_session_state_until(Some(session), deadline) == RunnerSessionState::Connected
+    }) {
         return Ok(session);
     }
     let directory = paths::runner_sessions_dir()?.join(runner_id);
-    match status_peer_session_in(&directory, &controller_id)? {
+    match status_peer_session_in_until(&directory, &controller_id, deadline)? {
         StatusPeerSession::One(peer) => Ok(Some(peer)),
         StatusPeerSession::None => Ok(session),
         StatusPeerSession::Ambiguous => {
@@ -223,8 +235,21 @@ const STATUS_PEER_SESSION_LIMIT: usize = 8;
 const STATUS_PEER_SESSION_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn status_peer_session_in(directory: &PathBuf, controller_id: &str) -> Result<StatusPeerSession> {
+    status_peer_session_in_until(
+        directory,
+        controller_id,
+        Instant::now() + STATUS_PEER_SESSION_TIMEOUT,
+    )
+}
+
+fn status_peer_session_in_until(
+    directory: &PathBuf,
+    controller_id: &str,
+    deadline: Instant,
+) -> Result<StatusPeerSession> {
     status_peer_session_in_with(directory, controller_id, |session| {
-        session_is_live_with_timeout(session, STATUS_PEER_SESSION_TIMEOUT)
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        !remaining.is_zero() && session_is_live_with_timeout(session, remaining)
     })
 }
 
@@ -285,6 +310,16 @@ fn status_peer_session_in_with(
 /// as remote identity and active-job probes. A failed check is disconnected,
 /// not a trigger to scan peers or reconcile a tunnel.
 pub(super) fn status_session_state(session: Option<&RunnerSession>) -> RunnerSessionState {
+    status_session_state_until(
+        session,
+        Instant::now() + crate::readonly_probe::readonly_probe_timeout(),
+    )
+}
+
+pub(super) fn status_session_state_until(
+    session: Option<&RunnerSession>,
+    deadline: Instant,
+) -> RunnerSessionState {
     match session {
         Some(session)
             if session.mode == RunnerTunnelMode::Reverse
@@ -298,10 +333,10 @@ pub(super) fn status_session_state(session: Option<&RunnerSession>) -> RunnerSes
         }
         Some(session) if session.mode == RunnerTunnelMode::Reverse => RunnerSessionState::Recorded,
         Some(session)
-            if session_is_live_with_timeout(
-                session,
-                crate::readonly_probe::readonly_probe_timeout(),
-            ) =>
+            if {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                !remaining.is_zero() && session_is_live_with_timeout(session, remaining)
+            } =>
         {
             RunnerSessionState::Connected
         }

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use std::ops::Deref;
+use std::time::Instant;
 
 use base64::Engine;
 use serde_json::{json, Value};
@@ -766,6 +767,49 @@ pub fn runner_job_log_snapshot_for_session(
         crate::execution::daemon_api_get_for_session(session, &format!("/jobs/{job_id}"))?;
     let events_data =
         crate::execution::daemon_api_get_for_session(session, &format!("/jobs/{job_id}/events"))?;
+    let job_body = canonical_daemon_body(&job_data, "daemon job response")?;
+    let events_body = canonical_daemon_body(&events_data, "daemon job events response")?;
+    Ok(RunnerJobLogSnapshot {
+        job: serde_json::from_value(job_body["job"].clone()).map_err(|error| {
+            Error::internal_json(error.to_string(), Some("parse daemon job".to_string()))
+        })?,
+        events: serde_json::from_value(events_body["events"].clone()).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse daemon job events".to_string()),
+            )
+        })?,
+    })
+}
+
+/// Read both job resources under one absolute recovery-owner deadline.
+pub fn runner_job_log_snapshot_for_session_until(
+    session: &crate::RunnerSession,
+    job_id: &str,
+    deadline: Instant,
+) -> Result<RunnerJobLogSnapshot> {
+    let remaining = || {
+        deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "recovery_budget",
+                    "runner-exec recovery owner deadline expired",
+                    None,
+                    None,
+                )
+            })
+    };
+    let job_data = crate::execution::daemon_api_get_for_session_with_timeout(
+        session,
+        &format!("/jobs/{job_id}"),
+        remaining()?,
+    )?;
+    let events_data = crate::execution::daemon_api_get_for_session_with_timeout(
+        session,
+        &format!("/jobs/{job_id}/events"),
+        remaining()?,
+    )?;
     let job_body = canonical_daemon_body(&job_data, "daemon job response")?;
     let events_body = canonical_daemon_body(&events_data, "daemon job events response")?;
     Ok(RunnerJobLogSnapshot {

--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -21,11 +21,11 @@ pub use download::{
 };
 
 pub use homeboy_core::api_jobs::RunnerJobLogSnapshot;
-pub use mirror::runner_job_log_snapshot_for_session;
 pub use mirror::{
     controller_artifact_metadata, mirror_connected_runner_run, mirror_daemon_evidence,
     mirror_daemon_job_progress, mirror_reverse_broker_evidence, mirror_reverse_broker_job_progress,
     mirrored_runner_job_identity, refresh_mirrored_daemon_evidence, runner_job_log_snapshot,
     terminalize_mirrored_daemon_job,
 };
+pub use mirror::{runner_job_log_snapshot_for_session, runner_job_log_snapshot_for_session_until};
 pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -237,6 +237,27 @@ pub(super) fn exec_via_daemon(
             )?;
         }
     }
+    let foreground_source_lease = run_id
+        .as_deref()
+        .map(|run_id| {
+            let token = uuid::Uuid::new_v4().to_string();
+            let store = ObservationStore::open_initialized()?;
+            if !store.claim_running_runner_exec_recovery_source(
+                run_id,
+                "foreground-runner-exec",
+                &token,
+                &job.id.to_string(),
+            )? {
+                return Err(Error::validation_invalid_argument(
+                    "runner_exec",
+                    "runner exec source is already owned by an active lifecycle",
+                    Some(run_id.to_string()),
+                    None,
+                ));
+            }
+            Ok::<_, Error>((run_id.to_string(), token))
+        })
+        .transpose()?;
     let persisted_run_id = mirror_evidence
         .then(|| {
             persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref(), None)
@@ -280,6 +301,10 @@ pub(super) fn exec_via_daemon(
             ));
         }
         std::thread::sleep(Duration::from_millis(200));
+        if let Some((run_id, token)) = &foreground_source_lease {
+            let _ = ObservationStore::open_initialized()?
+                .renew_running_runner_exec_source_lease(run_id, token)?;
+        }
         let job_id = job.id.to_string();
         let (refreshed_job, refreshed_endpoint) = fetch_daemon_job_resilient_with_endpoint_reload(
             &client,
@@ -346,6 +371,10 @@ pub(super) fn exec_via_daemon(
     } else {
         None
     };
+    if let Some((run_id, token)) = &foreground_source_lease {
+        let _ = ObservationStore::open_initialized()?
+            .release_running_runner_exec_source_lease(run_id, token)?;
+    }
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
     let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
     validate_generic_exec_mirror_run_id(

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -103,12 +103,22 @@ pub fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
 /// Query one known direct-daemon generation without re-resolving ownership.
 /// Generation reconciliation uses this only after a job lookup returned 404.
 pub(crate) fn daemon_api_get_for_session(session: &RunnerSession, path: &str) -> Result<Value> {
+    daemon_api_get_for_session_with_timeout(session, path, Duration::from_secs(10))
+}
+
+/// Query a known daemon generation under the caller's remaining wall-clock
+/// budget rather than allocating a fresh per-request timeout.
+pub(crate) fn daemon_api_get_for_session_with_timeout(
+    session: &RunnerSession,
+    path: &str,
+    timeout: Duration,
+) -> Result<Value> {
     let local_url = session.local_url.as_deref().ok_or_else(|| {
         Error::internal_unexpected("known daemon generation has no direct local endpoint")
     })?;
     let client = Client::builder()
         .no_proxy()
-        .timeout(Duration::from_secs(10))
+        .timeout(timeout)
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
     daemon_get(&client, local_url, path)

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -82,6 +82,7 @@ use policy::{preflight_remote_argv, remote_execution_preflight};
 use broker::*;
 use daemon::*;
 pub(crate) use daemon_api::daemon_api_get_for_session;
+pub(crate) use daemon_api::daemon_api_get_for_session_with_timeout;
 use daemon_api::*;
 use failure::*;
 use handoff::*;
@@ -123,9 +124,11 @@ pub(crate) use daemon_api::daemon_api_post_for_session;
 pub use failure::runner_exec_failure_error;
 pub use handoff::{runner_job_cancel, runner_job_cancel_projection};
 pub use recovery::{
-    reconcile_terminal_runner_exec_runs,
+    finish_scheduled_terminal_runner_exec_recovery,
+    record_scheduled_terminal_runner_exec_recovery_child_spawn_failure,
     record_scheduled_terminal_runner_exec_recovery_spawn_failure,
-    run_scheduled_terminal_runner_exec_recovery, schedule_terminal_runner_exec_recovery,
+    run_scheduled_terminal_runner_exec_recovery, run_scheduled_terminal_runner_exec_recovery_child,
+    schedule_terminal_runner_exec_recovery, RunnerExecRecoveryChildSchedule,
 };
 
 /// Retire a completed direct daemon generation only after controller-owned

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -1,51 +1,97 @@
 //! Recovery of generic runner-exec evidence after a controller interruption.
 
 use super::*;
-use std::collections::BTreeSet;
+use fs4::fs_std::FileExt;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, OpenOptions};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc,
+};
+use std::thread;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 const STARTUP_RUNNER_EXEC_RECOVERY_LIMIT: i64 = 100;
 pub const STARTUP_RUNNER_EXEC_RECOVERY_BUDGET: Duration = Duration::from_secs(5);
 const RECOVERY_KIND: &str = "runner_exec_recovery";
+const RECOVERY_OWNER_ID: &str = "runner-exec-recovery";
+const RECOVERY_CHILD_KIND: &str = "runner_exec_recovery_child";
+const RECOVERY_OWNER_LEASE: Duration = Duration::from_secs(30);
+const RECOVERY_LEASE_HEARTBEAT: Duration = Duration::from_secs(1);
+#[derive(Clone)]
+struct RecoveryWorker {
+    id: String,
+    token: String,
+    deadline: Instant,
+}
+
+impl RecoveryWorker {
+    fn renew(&self, store: &ObservationStore) -> Result<()> {
+        if !store.renew_running_run_lease(
+            &self.id,
+            &self.token,
+            chrono::Utc::now().timestamp_millis() + RECOVERY_OWNER_LEASE.as_millis() as i64,
+        )? {
+            let mut error = Error::validation_invalid_argument(
+                "recovery_owner",
+                "runner-exec recovery ownership was taken over",
+                Some(self.id.clone()),
+                None,
+            );
+            error.details["ownership_lost"] = json!(true);
+            return Err(error);
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RunnerExecRecoverySchedule {
     pub owner_id: String,
+    pub owner_token: String,
     pub deferred_count: usize,
     pub budget_ms: u64,
     pub inspection_action: String,
     pub is_new_owner: bool,
 }
 
+/// A child has one stable durable identity per source run. Reclaiming that
+/// identity after a terminal error records a new attempt without ever allowing
+/// two active workers for the same source record.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RunnerExecRecoveryChildSchedule {
+    pub child_id: String,
+    pub child_token: String,
+    pub source_run_id: String,
+    pub inspection_action: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunnerExecRecoveryOwnerWork {
+    pub children: Vec<RunnerExecRecoveryChildSchedule>,
+    pub deferred_count: usize,
+}
+
 /// Reserve a durable, independently inspectable owner before a background
 /// recovery worker is spawned. Scheduling only reads local evidence; remote
 /// reconciliation belongs to the owner, never to the mutating caller.
 pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecoverySchedule>> {
-    let store = ObservationStore::open_initialized()?;
-    if let Some(existing) = store
-        .list_runs(RunListFilter {
-            kind: Some(RECOVERY_KIND.to_string()),
-            status: Some(RunStatus::Running.as_str().to_string()),
-            limit: Some(1),
-            ..RunListFilter::default()
-        })?
-        .into_iter()
-        .next()
-    {
-        let deferred_count = existing
-            .metadata_json
-            .get("deferred_count")
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as usize;
-        return Ok(Some(recovery_schedule(&existing.id, deferred_count, false)));
-    }
-    let candidates = recovery_candidates(&store)?;
+    let reader = ObservationStore::open_scheduler_reader()?;
+    let candidates = recovery_candidates(&reader)?;
+    drop(reader);
     if candidates.is_empty() {
         return Ok(None);
     }
-    let owner_id = format!("runner-exec-recovery-{}", Uuid::new_v4());
-    let new_owner = store.start_run_with_id(
+    let store = ObservationStore::open_scheduler_writer()?;
+    // The store's expiring claim is keyed by run ID. A stable ID is therefore
+    // the singleton identity; a fresh UUID here would only make each scheduler
+    // claim itself and permit overlapping recovery workers.
+    let owner_id = RECOVERY_OWNER_ID.to_string();
+    let owner_token = Uuid::new_v4().to_string();
+    let lease_expires_at_ms =
+        chrono::Utc::now().timestamp_millis() + RECOVERY_OWNER_LEASE.as_millis() as i64;
+    let owner = store.claim_expiring_singleton_run(
         NewRunRecord::builder(RECOVERY_KIND)
             .metadata(json!({
                 "phase": "accepted",
@@ -54,38 +100,44 @@ pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecov
                 "inspection_action": format!("homeboy runs show {owner_id}"),
             }))
             .build(),
-        owner_id.clone(),
+        owner_id,
+        &owner_token,
+        lease_expires_at_ms,
     );
-    if new_owner.is_err() {
-        let existing = store
-            .list_runs(RunListFilter {
-                kind: Some(RECOVERY_KIND.to_string()),
-                status: Some(RunStatus::Running.as_str().to_string()),
-                limit: Some(1),
-                ..RunListFilter::default()
-            })?
-            .into_iter()
-            .next();
+    let Some(owner) = owner? else {
+        let existing = store.get_run(RECOVERY_OWNER_ID)?;
         if let Some(existing) = existing {
             let deferred_count = existing
                 .metadata_json
                 .get("deferred_count")
                 .and_then(Value::as_u64)
                 .unwrap_or(0) as usize;
-            return Ok(Some(recovery_schedule(&existing.id, deferred_count, false)));
+            return Ok(Some(recovery_schedule(
+                &existing.id,
+                deferred_count,
+                String::new(),
+                false,
+            )));
         }
-        new_owner?;
-    }
-    Ok(Some(recovery_schedule(&owner_id, candidates.len(), true)))
+        return Ok(None);
+    };
+    Ok(Some(recovery_schedule(
+        &owner.id,
+        candidates.len(),
+        owner_token,
+        true,
+    )))
 }
 
 fn recovery_schedule(
     owner_id: &str,
     deferred_count: usize,
+    owner_token: String,
     is_new_owner: bool,
 ) -> RunnerExecRecoverySchedule {
     RunnerExecRecoverySchedule {
         owner_id: owner_id.to_string(),
+        owner_token,
         deferred_count,
         budget_ms: STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64,
         inspection_action: format!("homeboy runs show {owner_id}"),
@@ -93,26 +145,21 @@ fn recovery_schedule(
     }
 }
 
-/// Scan durable generic runner-exec runs, query their exact accepted runner-job
-/// binding, then retain declared evidence before terminal projection. This runs
-/// before command dispatch so a new daemon operation cannot evict a completed
-/// job while its controller checkpoint is still pending.
-pub fn reconcile_terminal_runner_exec_runs() -> Result<usize> {
-    reconcile_terminal_runner_exec_runs_with_budget(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET)
-        .map(|(reconciled, _)| reconciled)
-}
-
-/// Reconcile under one owner-wide wall-clock budget. A failed endpoint is not
-/// retried for each historical job: all later records on that runner are
-/// deferred with their evidence intact for a later owner.
-pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Result<(usize, usize)> {
+fn reconcile_terminal_runner_exec_runs_with_owner(
+    worker: &RecoveryWorker,
+    source_run_id: &str,
+) -> Result<(usize, usize)> {
     let store = ObservationStore::open_initialized()?;
     let mut reconciled = 0;
     let mut deferred = 0;
-    let mut unavailable_runners = BTreeSet::new();
-    let deadline = Instant::now() + budget;
+    let mut unavailable_endpoints = BTreeSet::new();
+    let deadline = worker.deadline;
+    let mut sessions = BTreeMap::new();
     let candidates = recovery_candidates(&store)?;
     for (index, run) in candidates.iter().enumerate() {
+        if source_run_id != run.id {
+            continue;
+        }
         if Instant::now() >= deadline {
             deferred += candidates.len() - index;
             break;
@@ -126,36 +173,64 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
         ) else {
             continue;
         };
-        if unavailable_runners.contains(runner_id) {
+        if worker.deadline <= Instant::now() {
+            deferred += candidates.len() - index;
+            break;
+        }
+        // Resolve a persisted session under the owner deadline, then cache by
+        // its daemon identity. Runner aliases can name the same endpoint.
+        let session = {
+            if Instant::now() >= deadline {
+                Err(Error::validation_invalid_argument(
+                    "recovery_budget",
+                    "runner-exec recovery owner deadline expired before session resolution",
+                    None,
+                    None,
+                ))
+            } else {
+                crate::persisted_status_until(runner_id, deadline).and_then(|status| {
+                    status.session.ok_or_else(|| {
+                        Error::validation_invalid_argument(
+                            "runner",
+                            "runner has no persisted daemon session for recovery",
+                            Some(runner_id.to_string()),
+                            None,
+                        )
+                    })
+                })
+            }
+        };
+        let endpoint = session
+            .as_ref()
+            .map(endpoint_identity)
+            .unwrap_or_else(|_| runner_id.to_string());
+        if unavailable_endpoints.contains(&endpoint) {
             deferred += 1;
             continue;
         }
-        let snapshot = match crate::evidence::runner_job_log_snapshot(runner_id, job_id) {
+        // Cache both healthy sessions and their failures by resolved endpoint,
+        // never by an arbitrary runner alias.
+        let session = sessions.entry(endpoint.clone()).or_insert(session);
+        let snapshot = match session.as_ref().map_err(Clone::clone).and_then(|session| {
+            crate::evidence::runner_job_log_snapshot_for_session_until(session, job_id, deadline)
+        }) {
             Ok(snapshot) => snapshot,
             Err(error) => {
-                record_evicted_evidence_loss(&store, &run, &error)?;
+                worker.renew(&store)?;
+                record_evicted_evidence_loss(&store, &run, &error, &worker.token, job_id)?;
                 // A 404 is a durable per-job result. Other failures describe the
                 // endpoint, so avoid amplifying one unavailable daemon into N probes.
                 if error.details.get("http_status").and_then(Value::as_u64) != Some(404) {
-                    unavailable_runners.insert(runner_id.to_string());
-                    deferred += candidates
-                        .iter()
-                        .skip(index + 1)
-                        .filter(|candidate| {
-                            candidate
-                                .metadata_json
-                                .get("runner_id")
-                                .and_then(Value::as_str)
-                                == Some(runner_id)
-                        })
-                        .count();
+                    unavailable_endpoints.insert(endpoint);
                 }
+                deferred += 1;
                 continue;
             }
         };
         if !snapshot.job.status.is_terminal() {
             continue;
         }
+        worker.renew(&store)?;
         homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
             &run.id, &snapshot,
         )?;
@@ -187,6 +262,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
             ) {
                 continue;
             }
+            worker.renew(&store)?;
             let promoted = promote_runner_exec_artifacts(
                 &run.id,
                 &output,
@@ -209,6 +285,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
             ) {
                 continue;
             }
+            worker.renew(&store)?;
             let promoted = promote_runner_exec_artifact_dirs(
                 &run.id,
                 &output,
@@ -231,6 +308,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
             ) {
                 continue;
             }
+            worker.renew(&store)?;
             let promoted = promote_runner_exec_summaries(
                 &run.id,
                 &output,
@@ -250,41 +328,393 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
             .chain(summaries.iter())
             .cloned()
             .collect::<Vec<_>>();
+        worker.renew(&store)?;
         homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(&run.id, &retained)?;
+        worker.renew(&store)?;
         homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(&run.id, &snapshot)?;
         reconciled += 1;
     }
     Ok((reconciled, deferred))
 }
 
-/// Complete one accepted recovery owner and leave deferred source records
-/// running, preserving their remote-evidence recovery opportunity.
-pub fn run_scheduled_terminal_runner_exec_recovery(owner_id: &str) -> Result<()> {
-    let store = ObservationStore::open_initialized()?;
+fn endpoint_identity(session: &crate::RunnerSession) -> String {
+    session
+        .remote_daemon_address
+        .clone()
+        .or_else(|| session.broker_url.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "{:?}:{}",
+                session.mode,
+                session
+                    .remote_daemon_lease_id
+                    .as_deref()
+                    .unwrap_or_default()
+            )
+        })
+}
+
+/// The five-second owner only admits children. It never contacts a runner or
+/// mutates source evidence: each source record gets an independently leased
+/// worker that can safely outlive this startup budget.
+pub fn run_scheduled_terminal_runner_exec_recovery(
+    owner_id: &str,
+    owner_token: &str,
+) -> Result<Option<RunnerExecRecoveryOwnerWork>> {
+    let store = ObservationStore::open_scheduler_writer()?;
+    let Some(owner) = store.get_run(owner_id)? else {
+        return Ok(None);
+    };
+    if owner.kind != RECOVERY_KIND || owner.status != RunStatus::Running.as_str() {
+        return Ok(None);
+    }
+    if owner.metadata_json["owner_token"].as_str() != Some(owner_token) {
+        return Ok(None);
+    }
+    if !store.renew_running_run_lease(
+        owner_id,
+        owner_token,
+        chrono::Utc::now().timestamp_millis() + RECOVERY_OWNER_LEASE.as_millis() as i64,
+    )? {
+        return Ok(None);
+    }
+    let owner_context = RecoveryWorker {
+        id: owner_id.to_string(),
+        token: owner_token.to_string(),
+        deadline: Instant::now() + STARTUP_RUNNER_EXEC_RECOVERY_BUDGET,
+    };
+    let stop_heartbeat = Arc::new(AtomicBool::new(false));
+    let heartbeat_stop = Arc::clone(&stop_heartbeat);
+    let heartbeat_owner = owner_context.clone();
+    let (heartbeat_done, heartbeat_stop_signal) = mpsc::channel();
+    let heartbeat = thread::spawn(move || {
+        while !heartbeat_stop.load(Ordering::Acquire) {
+            if heartbeat_stop_signal
+                .recv_timeout(RECOVERY_LEASE_HEARTBEAT)
+                .is_ok()
+            {
+                break;
+            }
+            if heartbeat_stop.load(Ordering::Acquire) {
+                break;
+            }
+            let Ok(store) = ObservationStore::open_scheduler_writer() else {
+                break;
+            };
+            let Ok(owned) = store.renew_running_run_lease(
+                &heartbeat_owner.id,
+                &heartbeat_owner.token,
+                chrono::Utc::now().timestamp_millis() + RECOVERY_OWNER_LEASE.as_millis() as i64,
+            ) else {
+                break;
+            };
+            if !owned {
+                break;
+            }
+        }
+    });
+    let result = schedule_recovery_children(&store, &owner_context);
+    stop_heartbeat.store(true, Ordering::Release);
+    let _ = heartbeat_done.send(());
+    let _ = heartbeat.join();
+    let (children, deferred_count) = match result {
+        Ok(result) => result,
+        Err(error) => {
+            if error.details["ownership_lost"].as_bool() == Some(true) {
+                return Ok(None);
+            }
+            let Some(owner) = store.get_run(owner_id)? else {
+                return Ok(None);
+            };
+            let mut metadata = owner.metadata_json;
+            metadata["phase"] = json!("failed");
+            metadata["failure"] = json!({
+                "schema": "homeboy/runner-exec-recovery-failure/v1",
+                "code": format!("{:?}", error.code),
+                "message": error.message,
+                "details": error.details,
+                "retryable": true,
+                "next_actions": [format!("homeboy runs show {owner_id}"), "retry the original mutation to schedule a new recovery owner"],
+            });
+            store.finish_running_run_with_owner_token(
+                owner_id,
+                owner_token,
+                RunStatus::Error,
+                metadata,
+            )?;
+            return Ok(None);
+        }
+    };
+    Ok(Some(RunnerExecRecoveryOwnerWork {
+        children,
+        deferred_count,
+    }))
+}
+
+/// Complete the owner only after the CLI has accounted for every child spawn.
+pub fn finish_scheduled_terminal_runner_exec_recovery(
+    owner_id: &str,
+    owner_token: &str,
+    scheduled_count: usize,
+    spawn_failed_count: usize,
+    deferred_count: usize,
+) -> Result<()> {
+    let store = ObservationStore::open_scheduler_writer()?;
     let Some(owner) = store.get_run(owner_id)? else {
         return Ok(());
     };
-    if owner.kind != RECOVERY_KIND || owner.status != RunStatus::Running.as_str() {
-        return Ok(());
-    }
-    let (reconciled, deferred_count) =
-        reconcile_terminal_runner_exec_runs_with_budget(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET)?;
     let mut metadata = owner.metadata_json;
-    metadata["phase"] = json!(if deferred_count == 0 {
+    metadata["phase"] = json!(if deferred_count + spawn_failed_count == 0 {
         "completed"
     } else {
         "deferred"
     });
-    metadata["reconciled_count"] = json!(reconciled);
+    metadata["scheduled_count"] = json!(scheduled_count);
+    metadata["spawn_failed_count"] = json!(spawn_failed_count);
     metadata["deferred_count"] = json!(deferred_count);
     metadata["budget_ms"] = json!(STARTUP_RUNNER_EXEC_RECOVERY_BUDGET.as_millis() as u64);
     metadata["inspection_action"] = json!(format!("homeboy runs show {owner_id}"));
-    store.finish_running_run(owner_id, RunStatus::Pass, Some(metadata))?;
+    store.finish_running_run_with_owner_token(owner_id, owner_token, RunStatus::Pass, metadata)?;
     Ok(())
+}
+
+pub fn record_scheduled_terminal_runner_exec_recovery_child_spawn_failure(
+    child: &RunnerExecRecoveryChildSchedule,
+    error: &std::io::Error,
+) -> Result<()> {
+    let store = ObservationStore::open_scheduler_writer()?;
+    let Some(record) = store.get_run(&child.child_id)? else {
+        return Ok(());
+    };
+    let mut metadata = record.metadata_json;
+    metadata["phase"] = json!("spawn_failed");
+    metadata["failure"] = json!({
+        "schema": "homeboy/runner-exec-recovery-child-spawn-failure/v1",
+        "message": error.to_string(),
+        "retryable": true,
+        "action": child.inspection_action,
+    });
+    store.finish_running_run_with_owner_token(
+        &child.child_id,
+        &child.child_token,
+        RunStatus::Error,
+        metadata,
+    )?;
+    Ok(())
+}
+
+fn schedule_recovery_children(
+    store: &ObservationStore,
+    owner: &RecoveryWorker,
+) -> Result<(Vec<RunnerExecRecoveryChildSchedule>, usize)> {
+    let candidates = recovery_candidates(store)?;
+    let mut children = Vec::new();
+    let mut deferred = 0;
+    for run in candidates {
+        if owner.deadline <= Instant::now() {
+            deferred += 1;
+            continue;
+        }
+        owner.renew(store)?;
+        let Some(runner_job_id) = run.metadata_json["runner_job_id"].as_str() else {
+            deferred += 1;
+            continue;
+        };
+        let child_id = format!(
+            "runner-exec-recovery-child:{}",
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, run.id.as_bytes())
+        );
+        let child_token = Uuid::new_v4().to_string();
+        let lease_expires_at_ms =
+            chrono::Utc::now().timestamp_millis() + RECOVERY_OWNER_LEASE.as_millis() as i64;
+        let claimed = store.claim_expiring_singleton_run(
+            NewRunRecord::builder(RECOVERY_CHILD_KIND)
+                .metadata(json!({
+                    "phase": "scheduled",
+                    "source_run_id": run.id,
+                    "parent_owner_id": owner.id,
+                    "retryable": true,
+                    "inspection_action": format!("homeboy runs show {child_id}"),
+                }))
+                .build(),
+            child_id.clone(),
+            &child_token,
+            lease_expires_at_ms,
+        )?;
+        if claimed.is_some() {
+            if !store.claim_running_runner_exec_recovery_source(
+                &run.id,
+                &child_id,
+                &child_token,
+                runner_job_id,
+            )? {
+                let child = store.get_run(&child_id)?.expect("claimed child exists");
+                let mut metadata = child.metadata_json;
+                metadata["phase"] = json!("deferred_source_claim_lost");
+                metadata["inspection_action"] = json!(format!("homeboy runs show {child_id}"));
+                store.finish_running_run_with_owner_token(
+                    &child_id,
+                    &child_token,
+                    RunStatus::Pass,
+                    metadata,
+                )?;
+                deferred += 1;
+                continue;
+            }
+            children.push(RunnerExecRecoveryChildSchedule {
+                child_id: child_id.clone(),
+                child_token,
+                source_run_id: run.id,
+                inspection_action: format!("homeboy runs show {child_id}"),
+            });
+        } else {
+            deferred += 1;
+        }
+    }
+    Ok((children, deferred))
+}
+
+/// Execute one durable child. The filesystem lock is deliberately held for the
+/// complete side-effecting phase: an expired SQLite lease permits a replacement
+/// to *try* takeover, but never to overlap a still-live local process.
+pub fn run_scheduled_terminal_runner_exec_recovery_child(
+    child_id: &str,
+    child_token: &str,
+) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(child) = store.get_run(child_id)? else {
+        return Ok(());
+    };
+    if child.kind != RECOVERY_CHILD_KIND
+        || child.status != RunStatus::Running.as_str()
+        || child.metadata_json["owner_token"].as_str() != Some(child_token)
+    {
+        return Ok(());
+    }
+    let source_run_id = match child.metadata_json["source_run_id"].as_str() {
+        Some(id) => id.to_string(),
+        None => {
+            return terminalize_child_error(
+                &store,
+                child_id,
+                child_token,
+                &child,
+                "missing source run identity",
+            )
+        }
+    };
+    let Some(_lock) = try_acquire_child_lock(child_id)? else {
+        let mut metadata = child.metadata_json;
+        metadata["phase"] = json!("deferred_live_worker");
+        metadata["inspection_action"] = json!(format!("homeboy runs show {child_id}"));
+        store.finish_running_run_with_owner_token(
+            child_id,
+            child_token,
+            RunStatus::Pass,
+            metadata,
+        )?;
+        return Ok(());
+    };
+    let worker = RecoveryWorker {
+        id: child_id.to_string(),
+        token: child_token.to_string(),
+        // Child work is not governed by the startup owner's five-second budget.
+        deadline: Instant::now() + Duration::from_secs(24 * 60 * 60),
+    };
+    worker.renew(&store)?;
+    let stop = Arc::new(AtomicBool::new(false));
+    let heartbeat_stop = Arc::clone(&stop);
+    let heartbeat_worker = worker.clone();
+    let heartbeat = thread::spawn(move || {
+        while !heartbeat_stop.load(Ordering::Acquire) {
+            thread::sleep(RECOVERY_LEASE_HEARTBEAT);
+            if heartbeat_stop.load(Ordering::Acquire) {
+                break;
+            }
+            let Ok(store) = ObservationStore::open_initialized() else {
+                break;
+            };
+            if heartbeat_worker.renew(&store).is_err() {
+                break;
+            }
+        }
+    });
+    let result = reconcile_terminal_runner_exec_runs_with_owner(&worker, &source_run_id);
+    stop.store(true, Ordering::Release);
+    let _ = heartbeat.join();
+    match result {
+        Ok((reconciled, deferred)) => {
+            let Some(child) = store.get_run(child_id)? else {
+                return Ok(());
+            };
+            let mut metadata = child.metadata_json;
+            metadata["phase"] = json!(if deferred == 0 {
+                "completed"
+            } else {
+                "deferred"
+            });
+            metadata["reconciled_count"] = json!(reconciled);
+            metadata["deferred_count"] = json!(deferred);
+            metadata["inspection_action"] = json!(format!("homeboy runs show {child_id}"));
+            store.finish_running_run_with_owner_token(
+                child_id,
+                child_token,
+                RunStatus::Pass,
+                metadata,
+            )?;
+            Ok(())
+        }
+        Err(error) => {
+            terminalize_child_error(&store, child_id, child_token, &child, &error.message)
+        }
+    }
+}
+
+fn terminalize_child_error(
+    store: &ObservationStore,
+    child_id: &str,
+    child_token: &str,
+    child: &homeboy_core::observation::RunRecord,
+    message: &str,
+) -> Result<()> {
+    let mut metadata = child.metadata_json.clone();
+    metadata["phase"] = json!("error");
+    metadata["failure"] = json!({ "message": message, "retryable": true });
+    metadata["inspection_action"] = json!(format!("homeboy runs show {child_id}"));
+    store.finish_running_run_with_owner_token(child_id, child_token, RunStatus::Error, metadata)?;
+    Ok(())
+}
+
+fn try_acquire_child_lock(child_id: &str) -> Result<Option<std::fs::File>> {
+    let root = homeboy_core::paths::homeboy()?.join("runner-exec-recovery");
+    fs::create_dir_all(&root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("create {}", root.display())),
+        )
+    })?;
+    let path = root.join(format!("{child_id}.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("open {}", path.display())))
+        })?;
+    match file.try_lock_exclusive() {
+        Ok(true) => Ok(Some(file)),
+        Ok(false) => Ok(None),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("lock {}", path.display())),
+        )),
+    }
 }
 
 pub fn record_scheduled_terminal_runner_exec_recovery_spawn_failure(
     owner_id: &str,
+    owner_token: &str,
     error: &std::io::Error,
 ) -> Result<()> {
     let store = ObservationStore::open_initialized()?;
@@ -295,7 +725,7 @@ pub fn record_scheduled_terminal_runner_exec_recovery_spawn_failure(
     metadata["phase"] = json!("spawn_failed");
     metadata["spawn_error"] = json!(error.to_string());
     metadata["inspection_action"] = json!(format!("homeboy runs show {owner_id}"));
-    store.finish_running_run(owner_id, RunStatus::Error, Some(metadata))?;
+    store.finish_running_run_with_owner_token(owner_id, owner_token, RunStatus::Error, metadata)?;
     Ok(())
 }
 
@@ -323,6 +753,13 @@ fn recovery_candidates(
                     .and_then(Value::as_str)
                     .is_some()
                 && run.cwd.is_some()
+                && run
+                    .metadata_json
+                    .pointer("/runner_exec_source_lease/expires_at_ms")
+                    .and_then(Value::as_i64)
+                    .is_none_or(|expires_at_ms| {
+                        expires_at_ms < chrono::Utc::now().timestamp_millis()
+                    })
         })
         .collect())
 }
@@ -382,6 +819,8 @@ fn record_evicted_evidence_loss(
     store: &ObservationStore,
     run: &homeboy_core::observation::RunRecord,
     error: &Error,
+    child_token: &str,
+    runner_job_id: &str,
 ) -> Result<()> {
     let checkpointed = run
         .metadata_json
@@ -410,7 +849,12 @@ fn record_evicted_evidence_loss(
         "runner_id": run.metadata_json["runner_id"],
         "runner_job_id": run.metadata_json["runner_job_id"],
     });
-    store.finish_run(&run.id, RunStatus::Fail, Some(metadata))?;
+    store.fail_running_runner_exec_recovery_source(
+        &run.id,
+        child_token,
+        runner_job_id,
+        metadata,
+    )?;
     Ok(())
 }
 
@@ -419,6 +863,7 @@ mod tests {
     use super::*;
     use homeboy_core::test_support::with_isolated_home;
     use homeboy_core::{Error, ErrorCode};
+    use std::sync::{Arc, Barrier};
 
     #[test]
     fn startup_recovery_does_not_materialize_unrelated_active_payloads() {
@@ -442,10 +887,8 @@ mod tests {
                 .expect("corrupt unrelated payload");
             drop(connection);
 
-            assert_eq!(
-                reconcile_terminal_runner_exec_runs().expect("bounded recovery"),
-                0
-            );
+            let reader = ObservationStore::open_scheduler_reader().expect("reader");
+            assert!(recovery_candidates(&reader).expect("candidates").is_empty());
         });
     }
 
@@ -478,9 +921,10 @@ mod tests {
                 .expect("insert outside-budget candidate");
             drop(connection);
 
-            assert_eq!(
-                reconcile_terminal_runner_exec_runs().expect("bounded recovery"),
-                0
+            let reader = ObservationStore::open_scheduler_reader().expect("reader");
+            assert!(
+                recovery_candidates(&reader).expect("candidates").len()
+                    <= STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize
             );
         });
     }
@@ -515,14 +959,6 @@ mod tests {
                 format!("homeboy runs show {}", schedule.owner_id)
             );
 
-            // A zero owner budget is a deterministic interruption boundary: no
-            // daemon endpoint is contacted and every source record remains
-            // recoverable for the next owner.
-            assert_eq!(
-                reconcile_terminal_runner_exec_runs_with_budget(Duration::ZERO)
-                    .expect("bounded recovery"),
-                (0, STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize)
-            );
             let store = ObservationStore::open_initialized().expect("store");
             assert!(store
                 .get_run("stale-0")
@@ -530,6 +966,230 @@ mod tests {
                 .expect("historical record")
                 .status
                 .eq("running"));
+        });
+    }
+
+    #[test]
+    fn active_source_lease_skips_recovery_and_expired_lease_allows_takeover() {
+        with_isolated_home(|_| {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                "foreground",
+                "runner",
+                "job",
+                "/workspace",
+                &[],
+            )
+            .expect("source");
+            let store = ObservationStore::open_initialized().expect("store");
+            assert!(store
+                .claim_running_runner_exec_recovery_source(
+                    "foreground",
+                    "foreground-runner-exec",
+                    "foreground-token",
+                    "job",
+                )
+                .expect("foreground lease"));
+            let reader = ObservationStore::open_scheduler_reader().expect("reader");
+            assert!(recovery_candidates(&reader).expect("candidates").is_empty());
+            drop(reader);
+            let mut source = store.get_run("foreground").expect("read").expect("source");
+            source.metadata_json["runner_exec_source_lease"]["expires_at_ms"] = json!(0);
+            store
+                .update_run_metadata("foreground", source.metadata_json)
+                .expect("expire foreground lease");
+            let reader = ObservationStore::open_scheduler_reader().expect("reader");
+            assert_eq!(recovery_candidates(&reader).expect("candidates").len(), 1);
+            drop(reader);
+            assert!(store
+                .claim_running_runner_exec_recovery_source(
+                    "foreground",
+                    "recovery-child",
+                    "recovery-token",
+                    "job",
+                )
+                .expect("expired takeover"));
+        });
+    }
+
+    #[test]
+    fn owner_schedules_one_durable_child_per_source_within_its_budget() {
+        with_isolated_home(|_| {
+            for index in 0..STARTUP_RUNNER_EXEC_RECOVERY_LIMIT {
+                homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                    &format!("source-{index}"),
+                    "unavailable-runner",
+                    &format!("job-{index}"),
+                    "/workspace",
+                    &[],
+                )
+                .expect("source");
+            }
+            let owner = schedule_terminal_runner_exec_recovery()
+                .expect("schedule")
+                .expect("owner");
+            let started = Instant::now();
+            let work =
+                run_scheduled_terminal_runner_exec_recovery(&owner.owner_id, &owner.owner_token)
+                    .expect("owner schedules children")
+                    .expect("owner work");
+            let children = work.children;
+            assert!(started.elapsed() <= STARTUP_RUNNER_EXEC_RECOVERY_BUDGET);
+            assert_eq!(children.len(), STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize);
+            assert_eq!(
+                children
+                    .iter()
+                    .map(|child| &child.child_id)
+                    .collect::<BTreeSet<_>>()
+                    .len(),
+                STARTUP_RUNNER_EXEC_RECOVERY_LIMIT as usize
+            );
+            let store = ObservationStore::open_initialized().expect("store");
+            for child in children {
+                let child = store
+                    .get_run(&child.child_id)
+                    .expect("read")
+                    .expect("child");
+                assert_eq!(child.status, RunStatus::Running.as_str());
+                assert!(child.metadata_json["source_run_id"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with("source-")));
+            }
+        });
+    }
+
+    #[test]
+    fn concurrent_schedulers_grant_one_owner_and_one_spawn_entitlement() {
+        with_isolated_home(|_| {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                "stale",
+                "unavailable-runner",
+                "job",
+                "/workspace",
+                &[],
+            )
+            .expect("historical runner job");
+            let barrier = Arc::new(Barrier::new(3));
+            let mut workers = Vec::new();
+            for _ in 0..2 {
+                let barrier = Arc::clone(&barrier);
+                workers.push(std::thread::spawn(move || {
+                    barrier.wait();
+                    schedule_terminal_runner_exec_recovery().expect("schedule")
+                }));
+            }
+            barrier.wait();
+            let schedules = workers
+                .into_iter()
+                .map(|worker| worker.join().expect("scheduler thread").expect("owner"))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                schedules
+                    .iter()
+                    .filter(|schedule| schedule.is_new_owner)
+                    .count(),
+                1
+            );
+            assert_eq!(
+                schedules
+                    .iter()
+                    .map(|schedule| &schedule.owner_id)
+                    .collect::<BTreeSet<_>>()
+                    .len(),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn child_failure_is_terminal_and_retains_retryable_evidence() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let child_id = "runner-exec-recovery-child:broken";
+            let token = "child-token";
+            store
+                .claim_expiring_singleton_run(
+                    NewRunRecord::builder(RECOVERY_CHILD_KIND)
+                        .metadata(json!({ "phase": "scheduled" }))
+                        .build(),
+                    child_id.to_string(),
+                    token,
+                    chrono::Utc::now().timestamp_millis() + 60_000,
+                )
+                .expect("claim child")
+                .expect("new child");
+            run_scheduled_terminal_runner_exec_recovery_child(child_id, token)
+                .expect("terminalize malformed child");
+            let child = store.get_run(child_id).expect("read").expect("child");
+            assert_eq!(child.status, RunStatus::Error.as_str());
+            assert_eq!(child.metadata_json["failure"]["retryable"], true);
+        });
+    }
+
+    #[test]
+    fn child_spawn_failure_is_durable_and_excluded_from_successful_schedule() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let child = RunnerExecRecoveryChildSchedule {
+                child_id: "runner-exec-recovery-child:spawn-failure".to_string(),
+                child_token: "child-token".to_string(),
+                source_run_id: "source".to_string(),
+                inspection_action: "homeboy runs show runner-exec-recovery-child:spawn-failure"
+                    .to_string(),
+            };
+            store
+                .claim_expiring_singleton_run(
+                    NewRunRecord::builder(RECOVERY_CHILD_KIND)
+                        .metadata(json!({ "source_run_id": child.source_run_id }))
+                        .build(),
+                    child.child_id.clone(),
+                    &child.child_token,
+                    chrono::Utc::now().timestamp_millis() + 60_000,
+                )
+                .expect("claim child");
+            record_scheduled_terminal_runner_exec_recovery_child_spawn_failure(
+                &child,
+                &std::io::Error::new(std::io::ErrorKind::NotFound, "fixture executable missing"),
+            )
+            .expect("record spawn failure");
+            let child = store
+                .get_run(&child.child_id)
+                .expect("read")
+                .expect("child");
+            assert_eq!(child.status, RunStatus::Error.as_str());
+            assert_eq!(child.metadata_json["phase"], "spawn_failed");
+            assert_eq!(child.metadata_json["failure"]["retryable"], true);
+        });
+    }
+
+    #[test]
+    fn expired_owner_is_taken_over_with_a_new_token() {
+        with_isolated_home(|_| {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                "stale",
+                "unavailable-runner",
+                "job",
+                "/workspace",
+                &[],
+            )
+            .expect("historical runner job");
+            let first = schedule_terminal_runner_exec_recovery()
+                .expect("schedule")
+                .expect("owner");
+            let store = ObservationStore::open_initialized().expect("store");
+            let mut owner = store
+                .get_run(&first.owner_id)
+                .expect("read")
+                .expect("owner");
+            owner.metadata_json["lease_expires_at_ms"] = json!(0);
+            store
+                .update_run_metadata(&owner.id, owner.metadata_json)
+                .expect("expire lease");
+            let second = schedule_terminal_runner_exec_recovery()
+                .expect("schedule")
+                .expect("replacement owner");
+            assert!(second.is_new_owner);
+            assert_eq!(second.owner_id, first.owner_id);
+            assert_ne!(second.owner_token, first.owner_token);
         });
     }
 
@@ -554,6 +1214,9 @@ mod tests {
             .expect("declarations");
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.get_run(run_id).expect("read").expect("run");
+            store
+                .claim_running_runner_exec_recovery_source(run_id, "child", "token", "job")
+                .expect("source claim");
             let error = Error {
                 code: ErrorCode::ValidationInvalidArgument,
                 message: "daemon job evicted".to_string(),
@@ -562,12 +1225,50 @@ mod tests {
                 retryable: None,
                 source: None,
             };
-            record_evicted_evidence_loss(&store, &run, &error).expect("eviction recorded");
+            record_evicted_evidence_loss(&store, &run, &error, "token", "job")
+                .expect("eviction recorded");
             let terminal = store.get_run(run_id).expect("read").expect("terminal run");
             assert_eq!(terminal.status, "fail");
             assert_eq!(
                 terminal.metadata_json["runner_terminal_projection"]["classification"],
                 "daemon_evicted_before_terminal_projection"
+            );
+        });
+    }
+
+    #[test]
+    fn evicted_evidence_cannot_overwrite_a_concurrently_settled_source() {
+        with_isolated_home(|_| {
+            let run_id = "evicted-concurrent-source";
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                run_id,
+                "runner",
+                "job",
+                "/workspace",
+                &[],
+            )
+            .expect("run");
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(run_id).expect("read").expect("run");
+            store
+                .claim_running_runner_exec_recovery_source(run_id, "child", "token", "job")
+                .expect("source claim");
+            store
+                .finish_run(run_id, RunStatus::Pass, Some(run.metadata_json.clone()))
+                .expect("concurrent terminal result");
+            let error = Error {
+                code: ErrorCode::ValidationInvalidArgument,
+                message: "daemon job evicted".to_string(),
+                details: json!({ "http_status": 404 }),
+                hints: Vec::new(),
+                retryable: None,
+                source: None,
+            };
+            record_evicted_evidence_loss(&store, &run, &error, "token", "job")
+                .expect("stale child does not overwrite source");
+            assert_eq!(
+                store.get_run(run_id).expect("read").expect("source").status,
+                RunStatus::Pass.as_str()
             );
         });
     }

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -213,10 +213,10 @@ pub(crate) use connection::daemon_endpoint_identity;
 pub use connection::{
     close_reconnected_job_log_owner, connect, connect_reverse, connect_with_live_lease_adoption,
     connect_with_orphan_adoption, diagnostic_status, disconnect, disconnect_local_recovery,
-    persisted_status, persisted_statuses, reconcile_status, reconcile_terminal_jobs,
-    reconnect_job_log_owner, reverse_broker_artifact, reverse_broker_artifact_content,
-    reverse_broker_reconcile, runner_artifact_content, status, statuses, statuses_indexed,
-    submit_reverse_broker_job,
+    persisted_status, persisted_status_until, persisted_statuses, reconcile_status,
+    reconcile_terminal_jobs, reconnect_job_log_owner, reverse_broker_artifact,
+    reverse_broker_artifact_content, reverse_broker_reconcile, runner_artifact_content, status,
+    statuses, statuses_indexed, submit_reverse_broker_job,
 };
 pub(crate) use connection::{
     configured_runner_homeboy_build_identity, local_live_session, status_for_admission,
@@ -241,14 +241,16 @@ pub use evidence::{
 };
 pub(crate) use execution::exec_with_status_snapshot;
 pub use execution::{
-    daemon_api_get, daemon_api_post, exec, promote_runner_exec_artifact_dirs,
-    promote_runner_exec_artifacts, promote_runner_exec_summaries, promoted_output,
-    reconcile_runner_generation_after_evidence, reconcile_terminal_runner_exec_runs,
+    daemon_api_get, daemon_api_post, exec, finish_scheduled_terminal_runner_exec_recovery,
+    promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts,
+    promote_runner_exec_summaries, promoted_output, reconcile_runner_generation_after_evidence,
+    record_scheduled_terminal_runner_exec_recovery_child_spawn_failure,
     record_scheduled_terminal_runner_exec_recovery_spawn_failure,
-    run_scheduled_terminal_runner_exec_recovery, runner_exec_failure_error,
-    runner_exec_structured_summary, runner_job_cancel, runner_job_cancel_for_session,
-    runner_job_cancel_projection, schedule_terminal_runner_exec_recovery, RunnerExecDiagnostics,
-    RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerExecPromotedOutput,
+    run_scheduled_terminal_runner_exec_recovery, run_scheduled_terminal_runner_exec_recovery_child,
+    runner_exec_failure_error, runner_exec_structured_summary, runner_job_cancel,
+    runner_job_cancel_for_session, runner_job_cancel_projection,
+    schedule_terminal_runner_exec_recovery, RunnerExecDiagnostics, RunnerExecMode,
+    RunnerExecOptions, RunnerExecOutput, RunnerExecPromotedOutput, RunnerExecRecoveryChildSchedule,
     RunnerExecStructuredSummary,
 };
 pub use execution::{RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV};

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
 use std::process::Output;
+use std::time::{Duration, Instant};
 
+use homeboy_core::observation::{NewRunRecord, ObservationStore, RunListFilter, RunStatus};
 use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary};
 
 /// Run the fixture binary through the shared hermetic harness.
@@ -231,6 +234,109 @@ fn cook_detaches_local_placement_instead_of_rejecting_it() {
     #[cfg(unix)]
     unsafe {
         libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+/// Historical runner recovery is a distinct owner, never an admission gate for
+/// an accepted Cook. This invokes the actual detached Cook command path rather
+/// than a scheduler helper so its output and durable handoff remain observable.
+#[test]
+fn detached_cook_admission_is_bounded_with_a_hundred_unavailable_recovery_records() {
+    let context = HermeticTestContext::new();
+    let database = context.data_dir().join("homeboy.sqlite");
+    let store = ObservationStore::open_initialized_at(&database).expect("open fixture store");
+    for index in 0..100 {
+        store
+            .start_run_with_id(
+                NewRunRecord::builder("runner_execution")
+                    .cwd_path(Path::new("/workspace"))
+                    .metadata(serde_json::json!({
+                        "kind": "runner_exec",
+                        "runner_id": "unavailable-runner",
+                        "runner_job_id": format!("stale-job-{index}"),
+                    }))
+                    .build(),
+                format!("stale-runner-exec-{index}"),
+            )
+            .expect("seed stale runner execution");
+    }
+    drop(store);
+
+    let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    command
+        .env("HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS", "5000")
+        .args([
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "admit despite stale runner records",
+            "--to-worktree",
+            "missing@worktree",
+            "--verify",
+            "true",
+        ]);
+    let started = Instant::now();
+    let output = bounded_output(command);
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "Cook admission must not wait for stale daemon recovery"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "{stdout}");
+    let handoff_start = stdout
+        .find('{')
+        .unwrap_or_else(|| panic!("Cook handoff is durable output\n{stdout}"));
+    let handoff: serde_json::Value = serde_json::from_str(stdout[handoff_start..].trim())
+        .unwrap_or_else(|error| panic!("Cook handoff is JSON: {error}\n{stdout}"));
+    assert_eq!(handoff["detached"], true, "{stdout}");
+    assert!(handoff["cook_id"].as_str().is_some_and(|id| !id.is_empty()));
+
+    let observation_deadline = Instant::now() + Duration::from_secs(5);
+    let (owners, children) = loop {
+        let store = ObservationStore::open_initialized_at(&database).expect("reopen fixture store");
+        let owners = store
+            .list_runs(RunListFilter {
+                kind: Some("runner_exec_recovery".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("list recovery owners");
+        let children = store
+            .list_runs(RunListFilter {
+                kind: Some("runner_exec_recovery_child".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("list recovery children");
+        if owners.len() == 1
+            && owners[0].status != RunStatus::Running.as_str()
+            && children.len() == 100
+            && children
+                .iter()
+                .all(|child| child.status != RunStatus::Running.as_str())
+        {
+            break (owners, children);
+        }
+        assert!(
+            Instant::now() < observation_deadline,
+            "recovery state did not settle"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(owners.len(), 1, "recovery has its own durable owner");
+    assert_eq!(owners[0].status, RunStatus::Pass.as_str());
+    assert_eq!(owners[0].metadata_json["scheduled_count"], 100);
+    assert_eq!(children.len(), 100, "each source has a durable child");
+    assert!(children
+        .iter()
+        .all(|child| child.status == RunStatus::Pass.as_str()));
+
+    #[cfg(unix)]
+    if let Some(pid) = handoff["pid"].as_u64() {
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
     }
 }
 


### PR DESCRIPTION
Replaces #11576

Follow-up to #11572

Refs #11156

## Scope
Squashes the reviewed bounded startup-recovery net diff from `fbeed2cd4` onto current `origin/main` (`15ab7893`) as one commit. The recovery owner admits durable per-source children within its five-second budget; children hold fenced source leases and perform side effects independently.

## Diff equivalence
- Compared the replacement against #11576 at `fbeed2cd4`.
- All reviewed recovery files match; the only retained current-main overlap is the later `evaluate_lab_runner_capabilities_for_inventory` re-export in `crates/homeboy-lab-runner/src/lib.rs` from `537580eec`.
- The three reviewed SSH fixture updates were already present on current main.
- No Cook fast-path, endpoint-alias, deadline, or artifact-experiment branch changes are included.

## Evidence
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace --no-run`
- `cargo test -p homeboy-lab-runner execution::recovery --lib` (11 passed)
- `cargo test -p homeboy-agents runner_exec --lib` (15 passed)
- `cargo test --test cook_lab_handoff_test detached_cook_admission_is_bounded_with_a_hundred_unavailable_recovery_records` (1 passed)

AI assistance: OpenAI GPT-5.6 Sol via OpenCode applied the reviewed bounded recovery net diff to current main, verified semantic equivalence to #11576, and ran the listed verification. Chris Huber is responsible for every line.