### PR TITLE
fix(command): stop counting zombies as a live process group

### DIFF
--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -625,7 +625,7 @@ pub fn wait_with_bounded_output_supervised_with_progress(
 /// tree with the same semantics instead of reimplementing them.
 #[cfg(unix)]
 pub fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
-    if !process_group_is_running(root_pid) {
+    if !process_group_has_live_member(root_pid) {
         return Ok(());
     }
     signal_process_group(root_pid, libc::SIGTERM)?;
@@ -831,6 +831,81 @@ fn process_group_is_running(root_pid: u32) -> bool {
     unsafe { libc::kill(-(root_pid as libc::pid_t), 0) == 0 }
 }
 
+/// Whether `root_pid`'s process group still holds a process that can run.
+///
+/// `process_group_is_running` asks `kill(-pgid, 0)`, which succeeds for a
+/// **zombie**. `reap_exited_process_group_children` clears the zombies we are
+/// the parent of, but not every zombie in the group is ours: a shell background
+/// job whose parent exits first is reparented to PID 1, and where PID 1 does not
+/// reap — the usual case inside a container — it stays a zombie until the
+/// container ends. `waitpid` cannot touch a process we did not spawn, so the
+/// group reads as alive forever.
+///
+/// The visible cost is not just a wrong error. Termination burns both the
+/// SIGTERM and SIGKILL grace windows (4s combined) waiting for processes that
+/// already exited, then reports "remained alive after SIGKILL" for a tree that
+/// is dead in every sense that matters.
+///
+/// A zombie holds no descriptors, runs no code, and cannot be killed again. For
+/// the question these wait loops ask — may this tree still act? — it is gone.
+#[cfg(unix)]
+fn process_group_has_live_member(root_pid: u32) -> bool {
+    if !process_group_is_running(root_pid) {
+        return false;
+    }
+    // Absent a way to inspect process state, keep the historical answer: the
+    // group exists, so treat it as alive.
+    process_group_live_member_count(root_pid).is_none_or(|live| live > 0)
+}
+
+/// Count non-zombie members of `root_pid`'s process group, or `None` where
+/// process state cannot be read.
+#[cfg(all(unix, target_os = "linux"))]
+fn process_group_live_member_count(root_pid: u32) -> Option<usize> {
+    let mut live = 0usize;
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name.parse::<u32>().is_err() {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            // A process that exits mid-scan is not a live member.
+            continue;
+        };
+        // `comm` (field 2) is parenthesised and may itself contain spaces and
+        // ')', so the fields after the final ')' are the only stable ones:
+        // state, ppid, pgrp.
+        let Some((_, rest)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let mut fields = rest.split_whitespace();
+        let Some(state) = fields.next() else {
+            continue;
+        };
+        let Some(_ppid) = fields.next() else {
+            continue;
+        };
+        let Some(pgrp) = fields.next().and_then(|field| field.parse::<u32>().ok()) else {
+            continue;
+        };
+        if pgrp != root_pid {
+            continue;
+        }
+        if state != "Z" {
+            live += 1;
+        }
+    }
+    Some(live)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_group_live_member_count(_root_pid: u32) -> Option<usize> {
+    None
+}
+
 /// Reap any of our own already-exited children that belong to `root_pid`'s
 /// process group.
 ///
@@ -870,12 +945,12 @@ fn wait_for_process_group_exit(
     status: &mut Option<ExitStatus>,
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
-    while process_group_is_running(root_pid) {
+    while process_group_has_live_member(root_pid) {
         if status.is_none() {
             *status = child.try_wait()?;
         }
         reap_exited_process_group_children(root_pid);
-        if !process_group_is_running(root_pid) {
+        if !process_group_has_live_member(root_pid) {
             break;
         }
         if std::time::Instant::now() >= deadline {
@@ -889,9 +964,9 @@ fn wait_for_process_group_exit(
 #[cfg(unix)]
 fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> bool {
     let deadline = std::time::Instant::now() + grace;
-    while process_group_is_running(root_pid) {
+    while process_group_has_live_member(root_pid) {
         reap_exited_process_group_children(root_pid);
-        if !process_group_is_running(root_pid) {
+        if !process_group_has_live_member(root_pid) {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -900,6 +975,74 @@ fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> 
         thread::sleep(PROCESS_TREE_POLL_INTERVAL);
     }
     true
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod process_group_liveness_tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    /// A process group whose only remaining member is a zombie is not alive.
+    ///
+    /// `kill(-pgid, 0)` succeeds for a zombie, so the group reads as running
+    /// long after it can do anything. Where the zombie is not our own child we
+    /// cannot reap it away, so the wait loops have to recognise the state
+    /// rather than wait it out.
+    #[test]
+    fn a_process_group_of_only_zombies_is_not_live() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        isolate_process_tree(&mut command);
+        let child = command.spawn().expect("spawn child");
+        let pid = child.id();
+        // Deliberately leak the handle: dropping `Child` without waiting is what
+        // leaves the exited process as an unreaped zombie.
+        std::mem::forget(child);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let live = process_group_live_member_count(pid).expect("read process state");
+            if live == 0 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child never exited; group still reports {live} live member(s)"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            process_group_is_running(pid),
+            "precondition: kill(-pgid, 0) still succeeds for the zombie, which is \
+             exactly why the naive probe is wrong"
+        );
+        assert!(
+            !process_group_has_live_member(pid),
+            "a group holding only a zombie must not be reported as alive"
+        );
+
+        reap_exited_process_group_children(pid);
+    }
+
+    /// The zombie allowance must not blind the probe to a group that is running.
+    #[test]
+    fn a_process_group_with_a_running_member_is_live() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 5"]);
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        isolate_process_tree(&mut command);
+        let mut child = command.spawn().expect("spawn child");
+        let pid = child.id();
+
+        assert!(
+            process_group_has_live_member(pid),
+            "a group running `sleep 5` must be reported as alive"
+        );
+
+        let _ = terminate_process_tree_and_reap(&mut child);
+    }
 }
 
 #[cfg(all(test, unix))]


### PR DESCRIPTION
Eight tests fail on main's Test job and pass on every developer machine. They
are the largest block of red on main.

```
agent_task_gate::baseline_tests::bounded_baseline_gate_is_cancelled
agent_task_gate::baseline_tests::bounded_baseline_gate_reaps_background_descendants_before_reader_join
agent_task_gate::tests::silent_gate_stall_is_not_a_semantic_command_failure
agent_task_gate::tests::timeout_is_distinct_from_no_progress
agent_task_gate::tests::toolchain_preflight_honors_a_100ms_limit
agent_task_gate::tests::toolchain_preflight_times_out_and_reaps_descendants
agent_task_process_containment::tests::reaping_after_leader_exit_kills_a_surviving_descendant
agent_task_process_containment::tests::terminating_a_live_leader_kills_its_descendants
```

## The claim is impossible on its face

```
process group 27923 remained alive after SIGKILL
```

Nothing survives `SIGKILL`. A zombie does not need to — it is already dead, and
`process_group_is_running` asks `kill(-pgid, 0)`, which **succeeds for a
zombie**. A group containing nothing but exited processes reads as running.

## Why the existing guard is not enough

#10356 found exactly this and added `reap_exited_process_group_children`. But
`waitpid` only reaps processes we are the parent of, and not every zombie in the
group is ours. The failing gate command backgrounds a job inside `sh`:

```sh
sh -c 'trap "" TERM; while :; do sleep 1; done' & echo $! > .../descendant.pid; wait
```

When the group is killed the outer `sh` exits first, so the background job is
reparented to PID 1. Under an init that reaps, it disappears and the tests pass
— which is every developer machine, and why this has never reproduced locally.
Under a container PID 1 that does not reap, it stays a zombie we have no
standing to reap, and the group reads as alive until the container ends.

## It also explains the two failures that are not about SIGKILL

`toolchain_preflight_honors_a_100ms_limit` and
`toolchain_preflight_times_out_and_reaps_descendants` fail on

```
assertion failed: started.elapsed() < Duration::from_secs(3)
```

Waiting out a group that can never be observed to exit costs the full
`PROCESS_TREE_TERM_GRACE` + `PROCESS_TREE_KILL_GRACE` — 2s + 2s. Same cause,
different symptom. Two clusters, one bug.

## Fix

`process_group_has_live_member` keeps `kill(-pgid, 0)` as the fast path, and
only when that reports the group present does it check whether any member is in
a state other than `Z`. A zombie holds no descriptors, runs no code, and cannot
be killed again; for the question these wait loops ask — *may this tree still
act?* — it is gone.

The check is used inside the poll loops rather than only at the deadline, so a
group that is already dead is recognised immediately instead of after both grace
windows. That is what brings `toolchain_preflight` back under its 3s bound.

Where process state cannot be read the function returns the previous answer, so
non-Linux behaviour is unchanged.

## Verification

Two tests pin the mechanism directly — one leaks a `Child` so its exited process
stays an unreaped zombie and asserts the group is not live *while*
`kill(-pgid, 0)` still succeeds, and one asserts a group running `sleep 5` is
still reported alive, so the allowance cannot blind the probe.

```
homeboy-engine-primitives --lib     248 passed
agent_task_gate                      54 passed, 0 failed
agent_task_process_containment        4 passed, 0 failed
cargo check --workspace --tests                      clean
cargo check --target x86_64-pc-windows-msvc          clean
cargo fmt --all --check                              clean
```

`homeboy-engine-primitives` also reports 3 `measurement_registry_test` failures.
Those are already red on main — stale `VERDICT_SITES` entries pointing at
`homeboy-extension/src/{lint,test}/report.rs` — and are identical with this
patch reverted from the same tree. Unrelated to this change; worth its own fix.