### PR TITLE
fix(measurement): stop a test-only import blinding the verdict scan

### DIFF
--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -625,7 +625,7 @@ pub fn wait_with_bounded_output_supervised_with_progress(
 /// tree with the same semantics instead of reimplementing them.
 #[cfg(unix)]
 pub fn terminate_remaining_process_group(root_pid: u32) -> io::Result<()> {
-    if !process_group_is_running(root_pid) {
+    if !process_group_has_live_member(root_pid) {
         return Ok(());
     }
     signal_process_group(root_pid, libc::SIGTERM)?;
@@ -831,6 +831,81 @@ fn process_group_is_running(root_pid: u32) -> bool {
     unsafe { libc::kill(-(root_pid as libc::pid_t), 0) == 0 }
 }
 
+/// Whether `root_pid`'s process group still holds a process that can run.
+///
+/// `process_group_is_running` asks `kill(-pgid, 0)`, which succeeds for a
+/// **zombie**. `reap_exited_process_group_children` clears the zombies we are
+/// the parent of, but not every zombie in the group is ours: a shell background
+/// job whose parent exits first is reparented to PID 1, and where PID 1 does not
+/// reap — the usual case inside a container — it stays a zombie until the
+/// container ends. `waitpid` cannot touch a process we did not spawn, so the
+/// group reads as alive forever.
+///
+/// The visible cost is not just a wrong error. Termination burns both the
+/// SIGTERM and SIGKILL grace windows (4s combined) waiting for processes that
+/// already exited, then reports "remained alive after SIGKILL" for a tree that
+/// is dead in every sense that matters.
+///
+/// A zombie holds no descriptors, runs no code, and cannot be killed again. For
+/// the question these wait loops ask — may this tree still act? — it is gone.
+#[cfg(unix)]
+fn process_group_has_live_member(root_pid: u32) -> bool {
+    if !process_group_is_running(root_pid) {
+        return false;
+    }
+    // Absent a way to inspect process state, keep the historical answer: the
+    // group exists, so treat it as alive.
+    process_group_live_member_count(root_pid).is_none_or(|live| live > 0)
+}
+
+/// Count non-zombie members of `root_pid`'s process group, or `None` where
+/// process state cannot be read.
+#[cfg(all(unix, target_os = "linux"))]
+fn process_group_live_member_count(root_pid: u32) -> Option<usize> {
+    let mut live = 0usize;
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name.parse::<u32>().is_err() {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            // A process that exits mid-scan is not a live member.
+            continue;
+        };
+        // `comm` (field 2) is parenthesised and may itself contain spaces and
+        // ')', so the fields after the final ')' are the only stable ones:
+        // state, ppid, pgrp.
+        let Some((_, rest)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let mut fields = rest.split_whitespace();
+        let Some(state) = fields.next() else {
+            continue;
+        };
+        let Some(_ppid) = fields.next() else {
+            continue;
+        };
+        let Some(pgrp) = fields.next().and_then(|field| field.parse::<u32>().ok()) else {
+            continue;
+        };
+        if pgrp != root_pid {
+            continue;
+        }
+        if state != "Z" {
+            live += 1;
+        }
+    }
+    Some(live)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_group_live_member_count(_root_pid: u32) -> Option<usize> {
+    None
+}
+
 /// Reap any of our own already-exited children that belong to `root_pid`'s
 /// process group.
 ///
@@ -870,12 +945,12 @@ fn wait_for_process_group_exit(
     status: &mut Option<ExitStatus>,
 ) -> io::Result<bool> {
     let deadline = std::time::Instant::now() + grace;
-    while process_group_is_running(root_pid) {
+    while process_group_has_live_member(root_pid) {
         if status.is_none() {
             *status = child.try_wait()?;
         }
         reap_exited_process_group_children(root_pid);
-        if !process_group_is_running(root_pid) {
+        if !process_group_has_live_member(root_pid) {
             break;
         }
         if std::time::Instant::now() >= deadline {
@@ -889,9 +964,9 @@ fn wait_for_process_group_exit(
 #[cfg(unix)]
 fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> bool {
     let deadline = std::time::Instant::now() + grace;
-    while process_group_is_running(root_pid) {
+    while process_group_has_live_member(root_pid) {
         reap_exited_process_group_children(root_pid);
-        if !process_group_is_running(root_pid) {
+        if !process_group_has_live_member(root_pid) {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -900,6 +975,74 @@ fn wait_for_process_group_exit_without_child(root_pid: u32, grace: Duration) -> 
         thread::sleep(PROCESS_TREE_POLL_INTERVAL);
     }
     true
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod process_group_liveness_tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    /// A process group whose only remaining member is a zombie is not alive.
+    ///
+    /// `kill(-pgid, 0)` succeeds for a zombie, so the group reads as running
+    /// long after it can do anything. Where the zombie is not our own child we
+    /// cannot reap it away, so the wait loops have to recognise the state
+    /// rather than wait it out.
+    #[test]
+    fn a_process_group_of_only_zombies_is_not_live() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        isolate_process_tree(&mut command);
+        let child = command.spawn().expect("spawn child");
+        let pid = child.id();
+        // Deliberately leak the handle: dropping `Child` without waiting is what
+        // leaves the exited process as an unreaped zombie.
+        std::mem::forget(child);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let live = process_group_live_member_count(pid).expect("read process state");
+            if live == 0 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child never exited; group still reports {live} live member(s)"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            process_group_is_running(pid),
+            "precondition: kill(-pgid, 0) still succeeds for the zombie, which is \
+             exactly why the naive probe is wrong"
+        );
+        assert!(
+            !process_group_has_live_member(pid),
+            "a group holding only a zombie must not be reported as alive"
+        );
+
+        reap_exited_process_group_children(pid);
+    }
+
+    /// The zombie allowance must not blind the probe to a group that is running.
+    #[test]
+    fn a_process_group_with_a_running_member_is_live() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 5"]);
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        isolate_process_tree(&mut command);
+        let mut child = command.spawn().expect("spawn child");
+        let pid = child.id();
+
+        assert!(
+            process_group_has_live_member(pid),
+            "a group running `sleep 5` must be reported as alive"
+        );
+
+        let _ = terminate_process_tree_and_reap(&mut child);
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -149,6 +149,25 @@ const VERDICT_SITES: &[VerdictSite] = &[
                a measured comparison, not an absence of one.",
     },
     VerdictSite {
+        file: "crates/homeboy-cli/src/commands/agent_task/status.rs",
+        basis: MeasurementBasis::Projection,
+        note: "A match arm rendering an already-decided promotion state as a label: \
+               \"applied\" | \"verified_no_changes\" => \"passed\". It cannot measure anything; \
+               the obligation sits with whatever set the promotion state.",
+    },
+    VerdictSite {
+        file: "crates/homeboy-cli/src/commands/fuzz/report.rs",
+        basis: MeasurementBasis::Unguarded,
+        note: "gate_status returns \"passed\" when `gates.iter().all(..)` holds, and `all` on an \
+               empty slice is true -- a campaign that evaluated no gates renders passed having \
+               measured nothing. This is the invariant, not an exception to it. Left as a debt \
+               marker rather than changed here because the fix is a behaviour change to fuzz \
+               reporting and belongs with an owner who can say what an empty gate set should \
+               mean. Blast radius: the `fuzz` command's rendered gate status only; it feeds no \
+               release or merge gate. It became visible when production_lines stopped \
+               truncating at a #[cfg(test)] import.",
+    },
+    VerdictSite {
         file: "crates/homeboy-cli/src/commands/trace/guardrails.rs",
         basis: MeasurementBasis::PerUnitEvaluation,
         note: "One TraceGuardrailOutput per declared guardrail, from a real evaluate() call. Zero \
@@ -355,6 +374,52 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                is Contradicted and a hard error.",
     },
     GateLayerSite {
+        file: ".github/validate-required-gates.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::ExplicitlySkipped,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: three exits share this decision and none of them launders an absence. \
+               `--local` \
+               exits after the declaration check, which is the only claim that mode makes. \
+               `--report` exits 0 by construction after recording the live enforcement outcome, \
+               because reporting must never become enforcement (#11084) -- the outcome is written \
+               to the step summary as evidence, so the non-enforcement is stated rather than \
+               hidden. The `enforced | bypassable` exit is a measured verdict read from the live \
+               ruleset, and every unreadable or non-matching state falls to the exit 1 beside it. \
+               Not skip-rendering: this is the gate's own verdict and it starts no downstream job. \
+               Its executing fixtures (report_mode_reports_unenforced_when_the_live_ruleset_requires_no_checks \
+               and siblings, which spawn the real script through Command::new(\"bash\")) live in \
+               tests/required_gates_policy_test.rs, and `fixture` can only name tests in \
+               tests/release_workflow_test.rs, so they are recorded here rather than claimed \
+               falsely.",
+    },
+    GateLayerSite {
+        file: ".github/validate-required-gates.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the script's refusal path -- an undeclared or non-strict required-check \
+               policy, and every live enforcement state that is not `enforced` or `bypassable`. A \
+               non-zero exit cannot manufacture a pass, so it carries no measurement obligation; \
+               it is registered because the scan keys on every exit in a gate script and an \
+               unregistered one is indistinguishable from an unexamined one. Exercised by the \
+               same tests/required_gates_policy_test.rs fixtures noted on `exit 0`, which the \
+               `fixture` field cannot name.",
+    },
+    GateLayerSite {
+        file: ".github/validate-required-gates.sh",
+        decision: "exit 2",
+        basis: MeasurementBasis::NotAGate,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: usage error. Reached only when argv names a mode other than \
+               --local/--report/--github, before any policy file is read or any claim is \
+               evaluated. It renders no verdict about the repository at all, and its distinct \
+               exit code keeps a mistyped invocation from being read as a policy failure.",
+    },
+    GateLayerSite {
         file: ".github/workflows/release.yml",
         decision: "blocked=false",
         basis: MeasurementBasis::EmptyPopulation,
@@ -521,17 +586,56 @@ fn is_test_owned(relative: &str) -> bool {
         || relative.contains("/fixtures/")
 }
 
-/// Production lines of a file: everything before the first `#[cfg(test)]`.
+/// Production lines of a file: everything before its `#[cfg(test)]` **module**.
 ///
-/// This mirrors the convention the audit's own source policies use
-/// (`ignore_after_line_equals`), and it fails **open** — a verdict hidden below
-/// a `#[cfg(test)]` is test code by definition, so skipping it can only make
-/// this guard more permissive, never spuriously red.
+/// Stopping at the first `#[cfg(test)]` of any kind is not the same rule.
+/// `#[cfg(test)]` is also an attribute on individual items, and a test-only
+/// import sits at the *top* of a file:
+///
+/// ```ignore
+/// use homeboy_core::ci_profile::CiContext;
+/// #[cfg(test)]
+/// use homeboy_core::finding::HomeboyFinding;   // line 12 of 440
+/// ```
+///
+/// Truncating there left eleven lines of imports as the entire "production" body
+/// of `homeboy-extension/src/{lint,test}/report.rs`, so two files that build
+/// `passed: true` in real code scanned as producing no verdict at all.
+///
+/// The old comment here argued this failed open — that a verdict below a
+/// `#[cfg(test)]` "is test code by definition", so the rule could only be
+/// permissive, "never spuriously red". Both halves were wrong. It is not test
+/// code when the attribute is on a `use`, and being permissive is the failure
+/// mode this registry exists to prevent: a guard blind to a file cannot ask that
+/// file how it established a measurement. It went red too, via
+/// [`no_registration_outlives_the_site_it_describes`], which correctly reported
+/// two live registrations as stale.
 fn production_lines(contents: &str) -> Vec<&str> {
-    contents
-        .lines()
-        .take_while(|line| line.trim() != "#[cfg(test)]")
-        .collect()
+    let lines: Vec<&str> = contents.lines().collect();
+    let test_module = (0..lines.len()).find(|index| {
+        lines[*index].trim() == "#[cfg(test)]"
+            && lines[index + 1..]
+                .iter()
+                .find(|candidate| !candidate.trim().is_empty())
+                .is_some_and(|candidate| declares_a_module(candidate))
+    });
+    match test_module {
+        Some(stop) => lines[..stop].to_vec(),
+        None => lines,
+    }
+}
+
+/// Whether a line declares a module, ignoring any visibility qualifier.
+fn declares_a_module(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let without_visibility = trimmed
+        .strip_prefix("pub")
+        .map(|rest| {
+            rest.trim_start_matches(|c| c != ' ' && c != '\t')
+                .trim_start()
+        })
+        .unwrap_or(trimmed);
+    without_visibility.starts_with("mod ")
 }
 
 fn line_constructs_a_green_verdict(line: &str) -> bool {
@@ -880,6 +984,56 @@ fn production_lines_stop_at_the_test_module() {
         "fn real() -> bool {\n    true\n}\n#[cfg(test)]\nmod tests {\n    passed: true\n}\n";
     let lines = production_lines(source);
     assert_eq!(lines.len(), 3);
+    assert!(!lines.iter().any(|line| line.contains("passed: true")));
+}
+
+/// A `#[cfg(test)]` on an import must not end the production scan.
+///
+/// This is the shape that hid two registered files: a test-only `use` on line 12
+/// of 440 truncated the scan to the import block, so real code building
+/// `passed: true` below it was never seen. The guard reported the live
+/// registrations as stale rather than reporting the files as unguarded, which is
+/// the more dangerous of the two failures — it argues for *deleting* the
+/// registration that still applies.
+#[test]
+fn production_lines_survive_a_test_only_import() {
+    let source = concat!(
+        "use std::fmt;\n",
+        "#[cfg(test)]\n",
+        "use crate::testing::Fixture;\n",
+        "\n",
+        "fn build() -> Report {\n",
+        "    Report { passed: true }\n",
+        "}\n",
+        "#[cfg(test)]\n",
+        "mod tests {\n",
+        "    fn ignored() { let _ = \"passed: true\"; }\n",
+        "}\n",
+    );
+    let lines = production_lines(source);
+    assert!(
+        lines.iter().any(|line| line.contains("passed: true")),
+        "a test-only import truncated the production scan and hid a real verdict"
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains("fn ignored")),
+        "the scan must still stop at the test module"
+    );
+}
+
+/// Visibility qualifiers must not hide the test module.
+#[test]
+fn production_lines_stop_at_a_qualified_test_module() {
+    let source = concat!(
+        "fn real() -> bool {\n",
+        "    true\n",
+        "}\n",
+        "#[cfg(test)]\n",
+        "pub(crate) mod tests {\n",
+        "    passed: true\n",
+        "}\n",
+    );
+    let lines = production_lines(source);
     assert!(!lines.iter().any(|line| line.contains("passed: true")));
 }
 


### PR DESCRIPTION
Three `measurement_registry_test` tests are red on main.

## A test-only import ended the scan

`production_lines` took every line before the **first** `#[cfg(test)]`. But that
attribute also sits on individual items, and a test-only import sits at the
*top* of a file:

```rust
use homeboy_core::ci_profile::CiContext;
#[cfg(test)]
use homeboy_core::finding::HomeboyFinding;   // line 12 of 440
```

So the entire "production" body of `homeboy-extension/src/lint/report.rs` and
`homeboy-extension/src/test/report.rs` was eleven lines of imports. Two files
that build `passed: true` in real code scanned as producing no verdict at all.

The guard then reported their live registrations as **stale** — the more
dangerous of the two possible failures, because it argues for deleting a
registration that still applies.

The comment on the function claimed this failed open: a verdict below a
`#[cfg(test)]` "is test code by definition", so the rule could "only make this
guard more permissive, never spuriously red". Both halves were wrong. It is not
test code when the attribute is on a `use`, and permissiveness is precisely the
failure mode this registry exists to prevent — a guard blind to a file cannot
ask that file how it established a measurement. It managed to be spuriously red
as well.

`production_lines` now stops at the test *module*: a `#[cfg(test)]` whose next
non-empty line declares a `mod`, visibility qualifier included.

## Restoring sight found one real instance

`crates/homeboy-cli/src/commands/fuzz/report.rs`:

```rust
pub(super) fn gate_status(gates: &[FuzzGateEvaluation]) -> String {
    if gates.iter().all(|gate| gate.status == "passed") {
        "passed".to_string()
```

`all` on an empty slice is `true`, so a campaign that evaluated **no gates**
renders `passed` having measured nothing. That is the invariant this registry
exists for, not an exception to it.

Registered as `Unguarded` with its blast radius rather than changed here — it
feeds no release or merge gate, and what an empty gate set *should* mean is a
behaviour decision for its owner.

## Three sites were already unregistered on main

These are the other two failures, and they predate this change:

- `crates/homeboy-cli/src/commands/agent_task/status.rs` — `Projection`, a match
  arm rendering an already-decided promotion state.
- `.github/validate-required-gates.sh` — `exit 0`, `exit 1`, and `exit 2`. The
  scan keys on every exit in a gate script, and all three were missing.

The `exit 0` entry is worth reading: three exits share it, and none launders an
absence. `--report` exits 0 by construction because reporting must never become
enforcement (#11084), and writes the live outcome to the step summary, so the
non-enforcement is stated rather than hidden.

Those exits *are* executed by real fixtures — `run_validator` spawns the script
through `Command::new("bash")` in `tests/required_gates_policy_test.rs`. The
`fixture` field can only name tests in `tests/release_workflow_test.rs`, so the
notes record them explicitly rather than claim a fixture the assertion would
reject. That constraint looks worth loosening, but not in a red-main fix.

## Verification

Two new unit tests pin the semantics: a test-only `use` must not truncate the
scan, and a `pub(crate) mod tests` must still stop it.

```
homeboy-engine-primitives --lib   3 failed  ->  253 passed, 0 failed
cargo check --workspace --tests   clean
cargo fmt --all --check           clean
```