### PR TITLE
test(postprocess): stop the helper fixture swallowing the failure it hit

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
@@ -1283,7 +1283,7 @@ mod tests {
         let helper = home.path().join("postprocess-helper");
         std::fs::write(
             &helper,
-            "#!/bin/sh\ncase \"$1\" in\n  copy) cp \"$HOMEBOY_ARTIFACT_POSTPROCESS_INPUT\" \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\"; printf x >> \"$HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT/count\" ;;\n  report) printf x >> \"$HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT/count\"; printf report > \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\" ;;\n  fail) exit 3 ;;\nesac\n",
+            "#!/bin/sh\nset -e\ncase \"$1\" in\n  copy) cp \"$HOMEBOY_ARTIFACT_POSTPROCESS_INPUT\" \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\"; printf x >> \"$HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT/count\" ;;\n  report) printf x >> \"$HOMEBOY_ARTIFACT_POSTPROCESS_ARTIFACT_ROOT/count\"; printf report > \"$HOMEBOY_ARTIFACT_POSTPROCESS_OUTPUT\" ;;\n  fail) exit 3 ;;\nesac\n",
         )
         .expect("helper");
         #[cfg(unix)]
@@ -1370,9 +1370,17 @@ mod tests {
                 &AgentTaskCancellationToken::default(),
             );
             let result = outcomes.last().expect("postprocess outcome");
-            assert_eq!(result.status, AgentTaskOutcomeStatus::Succeeded);
             assert_eq!(
-                std::fs::read(result.artifacts[0].path.as_deref().expect("path")).expect("output"),
+                result.status,
+                AgentTaskOutcomeStatus::Succeeded,
+                "postprocess step did not succeed; outcome: {result:#?}"
+            );
+            let output_path = result.artifacts[0].path.as_deref().expect("path");
+            assert_eq!(
+                std::fs::read(output_path).unwrap_or_else(|error| panic!(
+                    "helper reported success but wrote no output at {output_path}: {error}; \
+                     outcome: {result:#?}"
+                )),
                 [0, 255, 17, 42]
             );
             assert_eq!(
@@ -1514,7 +1522,13 @@ mod tests {
                 &mut events,
                 &AgentTaskCancellationToken::default(),
             );
-            assert_eq!(std::fs::read_to_string(count).expect("count"), "x");
+            assert_eq!(
+                std::fs::read_to_string(&count).unwrap_or_else(|error| panic!(
+                    "helper wrote no count file at {}: {error}; resumed outcomes: {resumed:#?}",
+                    count.display()
+                )),
+                "x"
+            );
             assert_eq!(
                 resumed.last().expect("resumed outcome").artifacts[0]
                     .path


### PR DESCRIPTION
Two tests fail on main's Test job and pass locally:

```
agent_task_scheduler::postprocess::tests::materializes_binary_dependency_and_records_postprocessed_artifact
  postprocess.rs:1375:83   output: Os { code: 2, kind: NotFound, message: "No such file or directory" }

agent_task_scheduler::postprocess::tests::checkpoint_reuses_completed_step_after_interruption
  postprocess.rs:1517:55   count: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Neither message names anything that failed. The fixture helper is why:

```sh
copy) cp "$..._INPUT" "$..._OUTPUT"; printf x >> "$..._ARTIFACT_ROOT/count" ;;
```

The branch's exit status is `printf`'s, not `cp`'s. **A failed `cp` still exits
0**, so the step is recorded `Succeeded` and the test walks on to read an output
file that was never written.

That is exactly the observed signature — `materializes_binary_dependency`
asserts `Succeeded` and *passes* that assertion, then fails on the read
immediately below it. A step cannot both succeed and produce nothing; the
fixture made it look like it could.

## What this does not claim

The product code is not the suspect. `run_artifact_postprocess_step` creates
both the artifact root (`artifact_postprocess.rs:263`) and the output's parent
(`:320`) before spawning the helper, so the usual explanation for ENOENT does
not apply. The likely candidate is the dependency materialisation these tests
exist to check — `${run.input}/capture/capture.bin` — which would make `cp` fail
on a missing *input*. I cannot confirm that from a machine where both tests
pass, and I would rather not guess at a fix for a failure I cannot see.

So this is a **diagnostic change, not a repair**. It does not claim to turn
these two green.

## What it does

- `set -e` in the helper, so it exits on the first failing command instead of
  reporting the last one.
- Both assertions now print the step outcome, which already carries the helper's
  exit code and stderr, instead of an ENOENT with no subject.

The next CI run then names the cause rather than the symptom, which is the part
that cannot be done from here.

## Verification

```
agent_task_scheduler::postprocess   9 passed, 0 failed
cargo check --workspace --tests     clean
cargo fmt --all --check             clean
```

`set -e` was checked against all nine tests sharing this helper, including the
`fail) exit 3` path that depends on a non-zero exit.