### PR TITLE
fix(cli): migrate surface contract clippy diagnostics

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1557,10 +1557,7 @@ fn resource_policy_runner_hint<'a>(
     cli.runner.as_deref().or(default_runner)
 }
 
-fn explicit_runner_placement<'a>(
-    cli: &'a Cli,
-    hot_command: resource_policy::HotCommand,
-) -> Option<&'a str> {
+fn explicit_runner_placement(cli: &Cli, hot_command: resource_policy::HotCommand) -> Option<&str> {
     cli.runner.as_deref().filter(|_| {
         hot_command.lab_offload_supported
             && !matches!(cli.placement, crate::cli_surface::Placement::Local)

--- a/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
+++ b/crates/homeboy-cli/src/cli_surface/argument_provenance.rs
@@ -293,7 +293,7 @@ mod tests {
     fn captures_environment_and_allows_non_parser_resolution_sources() {
         let previous = std::env::var_os("HOMEBOY_PROVENANCE_TEST_ENV");
         std::env::set_var("HOMEBOY_PROVENANCE_TEST_ENV", "configured");
-        let result = (|| {
+        {
             let matches = TestCli::command()
                 .try_get_matches_from(["homeboy", "cook"])
                 .expect("parse environment default");
@@ -315,13 +315,12 @@ mod tests {
                     &[ArgumentSource::Configuration, ArgumentSource::Policy],
                 )
                 .expect("allowed source group");
-        })();
+        }
         if let Some(previous) = previous {
             std::env::set_var("HOMEBOY_PROVENANCE_TEST_ENV", previous);
         } else {
             std::env::remove_var("HOMEBOY_PROVENANCE_TEST_ENV");
         }
-        result
     }
 
     #[test]

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -167,6 +167,9 @@ impl Cli {
 }
 
 #[derive(Subcommand)]
+// Clap derives this public transport enum directly. Boxing variants would
+// cascade through typed command dispatch without improving the CLI boundary.
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Unified view of active and recently finished Homeboy work
     Activity(activity::ActivityArgs),

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -89,7 +89,7 @@ pub fn live_generated_reference_docs() -> BTreeMap<String, String> {
     for command in documented_subcommands(&root) {
         let name = command.get_name().to_string();
         node_count += count_nodes(command);
-        commands_without_description(&[name.clone()], command, &mut undocumented);
+        commands_without_description(std::slice::from_ref(&name), command, &mut undocumented);
         summaries.push((
             name.clone(),
             styled(command.get_about())
@@ -206,7 +206,7 @@ fn render_node(out: &mut String, path: &[String], command: &Command) {
     let subcommands = documented_subcommands(command);
     if !subcommands.is_empty() {
         out.push_str("| Subcommand | Summary |\n| --- | --- |\n");
-        for subcommand in subcommands.iter().copied() {
+        for &subcommand in &subcommands {
             let name = subcommand.get_name();
             let summary = styled(subcommand.get_about())
                 .map(|about| cell(&about))

--- a/crates/homeboy-cli/src/command_contract/constants.rs
+++ b/crates/homeboy-cli/src/command_contract/constants.rs
@@ -58,6 +58,9 @@ pub struct ContractConstantsOutput {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
+// This is a serialized contract union. Boxing would not change its wire shape
+// but would add allocation to every constants response.
+#[allow(clippy::large_enum_variant)]
 pub enum ContractConstants {
     All(AllContractConstants),
     ArtifactManifest(ArtifactManifestConstants),
@@ -505,4 +508,19 @@ fn represented_artifact_schema_ids() -> Vec<String> {
         GENERIC_MATRIX_SUMMARY_SCHEMA.to_string(),
         MATRIX_ARTIFACT_SUMMARY_SCHEMA.to_string(),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_constants_keep_the_untagged_contract_shape() {
+        let output = contract_constants("all").expect("all constants are registered");
+        let value = serde_json::to_value(output).expect("constants serialize");
+
+        assert_eq!(value["schema"], CONTRACT_CONSTANTS_SCHEMA);
+        assert!(value["constants"].get("artifact_manifest").is_some());
+        assert!(value["constants"].get("All").is_none());
+    }
 }

--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -31,26 +31,26 @@
 macro_rules! ops_command_descriptors {
     ($consumer:ident) => {
         $consumer! {
-            (ssh, Ssh, crate::commands::ssh::run),
-            (server, Server, crate::commands::server::run),
-            (db, Db, crate::commands::db::run),
-            (file, File, crate::commands::file::run),
-            (logs, Logs, crate::commands::logs::run),
-            (triage, Triage, crate::commands::triage::run),
-            (deploy, Deploy, crate::commands::deploy::run),
-            (harvest, Harvest, crate::commands::harvest::run),
-            (daemon, Daemon, crate::commands::daemon::run),
+            (ssh, Ssh, $crate::commands::ssh::run),
+            (server, Server, $crate::commands::server::run),
+            (db, Db, $crate::commands::db::run),
+            (file, File, $crate::commands::file::run),
+            (logs, Logs, $crate::commands::logs::run),
+            (triage, Triage, $crate::commands::triage::run),
+            (deploy, Deploy, $crate::commands::deploy::run),
+            (harvest, Harvest, $crate::commands::harvest::run),
+            (daemon, Daemon, $crate::commands::daemon::run),
             (
                 deferred_workload,
                 DeferredWorkload,
-                crate::commands::deferred_workload::run
+                $crate::commands::deferred_workload::run
             ),
-            (schedule, Schedule, crate::commands::schedule::run),
-            (status, Status, crate::commands::status::run),
-            (git, Git, crate::commands::git::run),
-            (self_cmd, SelfCmd, crate::commands::self_cmd::run),
-            (api, Api, crate::commands::api::run),
-            (upgrade, Upgrade, crate::commands::upgrade::run),
+            (schedule, Schedule, $crate::commands::schedule::run),
+            (status, Status, $crate::commands::status::run),
+            (git, Git, $crate::commands::git::run),
+            (self_cmd, SelfCmd, $crate::commands::self_cmd::run),
+            (api, Api, $crate::commands::api::run),
+            (upgrade, Upgrade, $crate::commands::upgrade::run),
         }
     };
 }


### PR DESCRIPTION
Refs #11580

## Summary
- resolves the Rust 1.95 CLI surface/contract diagnostic group without changing CLI parsing, command schemas, safety manifests, or help output
- retains the two public transport enums as unboxed types with documented narrow Clippy exemptions
- adds an untagged contract serialization regression test

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-cli`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-cli command_contract::constants::tests::all_constants_keep_the_untagged_contract_shape`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-cli cli_surface::argument_provenance::tests::captures_environment_and_allows_non_parser_resolution_sources`

Scoped Clippy identified no remaining diagnostics in the owned paths. A category-wide `homeboy-cli` Clippy gate remains blocked by pre-existing Rust 1.95 diagnostics in `crates/homeboy-cli/src/commands/**` outside this PR scope.

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode was used to implement the scoped Rust 1.95 Clippy fixes and run verification. Chris remains responsible for every line.