### PR TITLE
fix(cli): migrate runs clippy diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -35,7 +35,7 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
             disk_budget,
         });
 
-    Ok((RunsOutput::Evidence(report), 0))
+    Ok((RunsOutput::Evidence(Box::new(report)), 0))
 }
 
 #[cfg(test)]
@@ -213,6 +213,9 @@ mod tests {
                 .expect("record url");
 
             let (output, _) = evidence(&run.id).expect("evidence");
+            let serialized = serde_json::to_value(&output).expect("serialize evidence output");
+            assert_eq!(serialized["variant"], "evidence");
+            assert_eq!(serialized["payload"]["command"], "runs.evidence");
             let RunsOutput::Evidence(output) = output else {
                 panic!("expected evidence output");
             };

--- a/crates/homeboy-cli/src/commands/runs/fuzz_compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/fuzz_compare.rs
@@ -161,7 +161,7 @@ fn read_related_fuzz_artifact_json(artifact: &ArtifactRecord) -> Option<Value> {
     let path = Path::new(&artifact.path);
     let file = File::open(path).ok()?;
     let json = serde_json::from_reader::<_, Value>(file).ok()?;
-    is_related_fuzz_json(&json).then(|| json)
+    is_related_fuzz_json(&json).then_some(json)
 }
 
 fn is_related_fuzz_json(value: &Value) -> bool {

--- a/crates/homeboy-cli/src/commands/runs/gh_actions.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions.rs
@@ -613,8 +613,8 @@ fn list_run_artifacts(gh: &GhClient, gh_run_id: u64) -> homeboy::core::Result<Ve
         "repos/{}/actions/runs/{gh_run_id}/artifacts?per_page=100",
         gh.repo_path()?
     );
-    let args = vec!["api".to_string(), "--paginate".into(), api_path.clone()];
-    let output = gh.output(&args.iter().map(String::as_str).collect::<Vec<_>>())?;
+    let args = ["api", "--paginate", api_path.as_str()];
+    let output = gh.output(&args)?;
     if !output.status.success() {
         return Err(Error::internal_io(
             format!(

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -90,10 +90,11 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
     let limit = args.limit.max(0) as usize;
     let run_records = run_records.into_iter().take(limit).collect::<Vec<_>>();
 
-    let active_runner_jobs = args
-        .include_active_runner_jobs
-        .then(|| active_runner_job_summaries(status_filter.as_deref()))
-        .unwrap_or_default();
+    let active_runner_jobs = if args.include_active_runner_jobs {
+        active_runner_job_summaries(status_filter.as_deref())
+    } else {
+        ActiveRunnerJobEnrichment::default()
+    };
     let stale_runs = stale_run_summary(
         &run_records,
         &active_runner_jobs.durable_run_ids,
@@ -1294,7 +1295,8 @@ mod pull_tests {
                 .record_artifact(&run.id, "finding-packets", &source)
                 .expect("artifact");
 
-            let summary = pull_artifacts_to_local(&[artifact.clone()], None).expect("pull summary");
+            let summary = pull_artifacts_to_local(std::slice::from_ref(&artifact), None)
+                .expect("pull summary");
 
             assert_eq!(summary.already_local_count, 1);
             assert_eq!(summary.pulled_count, 0);

--- a/crates/homeboy-cli/src/commands/runs/types.rs
+++ b/crates/homeboy-cli/src/commands/runs/types.rs
@@ -242,7 +242,7 @@ pub enum RunsOutput {
     FieldSelection(RunsFieldSelectionOutput),
     Dossier(RunsDossierOutput),
     ResumePlan(RunsResumePlanOutput),
-    Evidence(RunsEvidenceOutput),
+    Evidence(Box<RunsEvidenceOutput>),
     Env(RunsEnvOutput),
     Artifacts(RunsArtifactsOutput),
     ArtifactAttach(RunsArtifactAttachOutput),
@@ -923,10 +923,11 @@ pub(super) fn actionable_for_run_detail(run: &RunDetail) -> CommandActionableMet
             semantic_key: Some(artifact.artifact_type.clone()),
         })
         .collect();
-    metadata
-        .next_actions
-        .extend(run.artifacts.iter().filter_map(|artifact| {
-            (artifact.artifact_type == "file").then(|| {
+    metadata.next_actions.extend(
+        run.artifacts
+            .iter()
+            .filter(|artifact| artifact.artifact_type == "file")
+            .map(|artifact| {
                 CommandNextAction::new(
                     format!("get artifact {}", artifact.id),
                     format!(
@@ -935,8 +936,8 @@ pub(super) fn actionable_for_run_detail(run: &RunDetail) -> CommandActionableMet
                     ),
                 )
                 .with_kind(CommandNextActionKind::Artifacts)
-            })
-        }));
+            }),
+    );
     metadata
 }
 

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -285,7 +285,7 @@ mod tests {
             poller,
             "run-1",
             cfg,
-            |d| advance(d),
+            advance,
             || clock.get(),
             |_run, _poll| {},
         )


### PR DESCRIPTION
## Summary
- resolve the seven Rust 1.95 Clippy diagnostics in `commands/runs/**`
- preserve evidence JSON output while boxing the large evidence payload
- retain runner enrichment, artifact action, fuzz artifact lookup, and watch behavior

Refs #11580

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli --lib commands::runs::evidence::tests::`
- scoped Clippy: no remaining diagnostics in `commands/runs/**`; package remains blocked by 72 diagnostics outside this owned scope

## Known Test State
- `cargo test -p homeboy-cli --lib runs::` ran 200 tests: 197 passed, 3 unrelated runner/reconciliation fixture failures remain in `reconcile`, `remote`, and `resources`.

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode implemented and verified the Rust 1.95 runs diagnostics migration. Chris Huber remains responsible for every line.