### PR TITLE
fix(cli): box large output enum variants

### DIFF
--- a/crates/homeboy-cli/src/command_contract/constants.rs
+++ b/crates/homeboy-cli/src/command_contract/constants.rs
@@ -59,7 +59,7 @@ pub struct ContractConstantsOutput {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ContractConstants {
-    All(AllContractConstants),
+    All(Box<AllContractConstants>),
     ArtifactManifest(ArtifactManifestConstants),
     ArtifactPaths(ArtifactPathsConstants),
     ArtifactPostprocess(ArtifactPostprocessConstants),
@@ -73,7 +73,7 @@ pub enum ContractConstants {
     PathMaterializationPlan(PathMaterializationPlanConstants),
     RunOutcomeEnvelope(RunOutcomeEnvelopeConstants),
     RunArtifactFiles(RunArtifactFilesConstants),
-    RuntimeArtifacts(RuntimeArtifactConstants),
+    RuntimeArtifacts(Box<RuntimeArtifactConstants>),
     RunnerArtifactManifestRef(RunnerArtifactManifestRefConstants),
     ReviewerFacingRef(ReviewerFacingRefConstants),
 }
@@ -234,7 +234,7 @@ pub struct ReviewerFacingRefConstants {
 pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> {
     let normalized = contract_id.trim();
     let constants = match normalized {
-        "all" => ContractConstants::All(AllContractConstants {
+        "all" => ContractConstants::All(Box::new(AllContractConstants {
             artifact_manifest: artifact_manifest_constants(),
             artifact_paths: artifact_paths_constants(),
             artifact_postprocess: artifact_postprocess_constants(),
@@ -251,7 +251,7 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
             runtime_artifacts: runtime_artifact_constants(),
             runner_artifact_manifest_ref: runner_artifact_manifest_ref_constants(),
             reviewer_facing_ref: reviewer_facing_ref_constants(),
-        }),
+        })),
         "artifact-manifest" => ContractConstants::ArtifactManifest(artifact_manifest_constants()),
         "artifact-paths" => ContractConstants::ArtifactPaths(artifact_paths_constants()),
         "artifact-postprocess" => {
@@ -280,7 +280,7 @@ pub fn contract_constants(contract_id: &str) -> Option<ContractConstantsOutput> 
         }
         "run-artifact-files" => ContractConstants::RunArtifactFiles(run_artifact_files_constants()),
         "runtime-artifacts" | "runtime-agent-artifacts" => {
-            ContractConstants::RuntimeArtifacts(runtime_artifact_constants())
+            ContractConstants::RuntimeArtifacts(Box::new(runtime_artifact_constants()))
         }
         "runner-artifact-manifest-ref" => {
             ContractConstants::RunnerArtifactManifestRef(runner_artifact_manifest_ref_constants())

--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -64,8 +64,8 @@ pub struct ActivityWatchArgs {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum ActivityOutput {
-    Report(ActivityReportOutput),
-    Watch(ActivityWatchOutput),
+    Report(Box<ActivityReportOutput>),
+    Watch(Box<ActivityWatchOutput>),
 }
 
 #[derive(Serialize)]
@@ -192,7 +192,7 @@ fn list(args: ActivityListArgs) -> CmdResult<ActivityOutput> {
     let report = activity::activity_report(scope, args.limit)?;
     let actionable = actionable_for_activity_report(&report);
     Ok((
-        ActivityOutput::Report(ActivityReportOutput { report, actionable }),
+        ActivityOutput::Report(Box::new(ActivityReportOutput { report, actionable })),
         0,
     ))
 }
@@ -201,7 +201,7 @@ fn show(id: &str) -> CmdResult<ActivityOutput> {
     let report = activity::show_activity(id)?;
     let actionable = actionable_for_activity_report(&report);
     Ok((
-        ActivityOutput::Report(ActivityReportOutput { report, actionable }),
+        ActivityOutput::Report(Box::new(ActivityReportOutput { report, actionable })),
         0,
     ))
 }
@@ -276,7 +276,7 @@ fn watch_output(
         .collect();
     let actionable = actionable_for_activity_item(&item);
     (
-        ActivityOutput::Watch(ActivityWatchOutput {
+        ActivityOutput::Watch(Box::new(ActivityWatchOutput {
             schema: activity::ACTIVITY_REPORT_SCHEMA,
             command: "activity.watch",
             id: args.id,
@@ -289,7 +289,7 @@ fn watch_output(
             next_actions,
             actionable,
             notify,
-        }),
+        })),
         exit_code,
     )
 }

--- a/crates/homeboy-cli/src/commands/api/auth.rs
+++ b/crates/homeboy-cli/src/commands/api/auth.rs
@@ -137,7 +137,7 @@ pub(crate) enum ProfileCommand {
 pub enum AuthOutput {
     Login(LoginResult),
     Set(SetResult),
-    Get(GetResult),
+    Get(Box<GetResult>),
     Remove(RemoveResult),
     Logout(LogoutResult),
     Status(AuthStatus),
@@ -248,7 +248,7 @@ fn run_set(project_id: &str, variable: &str, value: Option<String>) -> CmdResult
 
 fn run_get(project_id: &str, variable: &str, redacted: bool) -> CmdResult<AuthOutput> {
     let result = auth::get(project_id, variable, redacted)?;
-    Ok((AuthOutput::Get(result), 0))
+    Ok((AuthOutput::Get(Box::new(result)), 0))
 }
 
 fn run_remove(project_id: &str, variable: &str) -> CmdResult<AuthOutput> {

--- a/crates/homeboy-cli/src/commands/api/mod.rs
+++ b/crates/homeboy-cli/src/commands/api/mod.rs
@@ -94,13 +94,15 @@ pub(crate) enum ApiCommand {
 #[serde(untagged)]
 pub enum ApiCommandOutput {
     Project(api::ApiOutput),
-    Auth(auth::AuthOutput),
+    Auth(Box<auth::AuthOutput>),
     Http(homeboy::core::http_request::HttpRequestOutput),
 }
 
 pub fn run(args: ApiArgs) -> CmdResult<ApiCommandOutput> {
     match args.command {
-        ApiCommand::Auth(args) => map_nested(auth::run(args), ApiCommandOutput::Auth),
+        ApiCommand::Auth(args) => map_nested(auth::run(args), |output| {
+            ApiCommandOutput::Auth(Box::new(output))
+        }),
         ApiCommand::Http(args) => map_nested(http::run(args), ApiCommandOutput::Http),
         command => run_project(ApiArgs { command })
             .map(|(output, code)| (ApiCommandOutput::Project(output), code)),

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -586,10 +586,10 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 #[derive(Serialize)]
 #[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum BenchOutput {
-    Single(BenchCommandOutput),
+    Single(Box<BenchCommandOutput>),
     Comparison(BenchComparisonOutput),
     ComparisonSummary(BenchComparisonSummaryOutput),
-    MatrixFanout(fanout::BenchMatrixFanoutOutput),
+    MatrixFanout(Box<fanout::BenchMatrixFanoutOutput>),
     SettingsMatrix(settings_matrix::BenchSettingsMatrixOutput),
     List(BenchListWorkflowResult),
 }
@@ -613,7 +613,7 @@ pub fn run(mut args: BenchArgs) -> CmdResult<BenchOutput> {
     if !args.run.matrix.is_empty() {
         let output = fanout::run_matrix_fanout(&args.run)?;
         let exit = if output.matrix.passed { 0 } else { 1 };
-        return Ok((BenchOutput::MatrixFanout(output), exit));
+        return Ok((BenchOutput::MatrixFanout(Box::new(output)), exit));
     }
 
     // No --rig: single component run. No rig pinning, no rig
@@ -622,7 +622,7 @@ pub fn run(mut args: BenchArgs) -> CmdResult<BenchOutput> {
         validate_report_selection_for_single_run(&args.run)?;
         let passthrough_args = filter_homeboy_flags(&args.run.args);
         let (output, exit) = matrix::run_single(&args.run, &passthrough_args, None)?;
-        let mut output = BenchOutput::Single(output);
+        let mut output = BenchOutput::Single(Box::new(output));
         attach_bench_actionable(&mut output);
         return Ok((output, exit));
     }
@@ -652,7 +652,7 @@ pub fn run(mut args: BenchArgs) -> CmdResult<BenchOutput> {
         validate_report_selection_for_single_run(run_args)?;
         let rig_id = run_args.rig[0].clone();
         let (output, exit) = matrix::run_single_rig(run_args, &passthrough_args, rig_id)?;
-        let mut output = BenchOutput::Single(output);
+        let mut output = BenchOutput::Single(Box::new(output));
         attach_bench_actionable(&mut output);
         return Ok((output, exit));
     }

--- a/crates/homeboy-cli/src/commands/bench/tests/output_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/output_tests.rs
@@ -22,7 +22,7 @@ fn bench_output_single_serializes_with_tagged_payload() {
         persisted_run: None,
         actionable: None,
     };
-    let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
+    let value = serde_json::to_value(BenchOutput::Single(Box::new(single))).unwrap();
     assert_eq!(
         value.get("variant"),
         Some(&serde_json::Value::String("single".to_string()))

--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -110,7 +110,7 @@ pub struct ContractShowArgs {
 #[serde(untagged)]
 pub enum ContractOutput {
     Export(ContractExportOutput),
-    Constants(ContractConstantsOutput),
+    Constants(Box<ContractConstantsOutput>),
     List(ContractListOutput),
     Show(ContractShowOutput),
     Validate(ContractValidateOutput),
@@ -227,7 +227,7 @@ pub enum ContractNormalizeOutput {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ContractMaterializeOutput {
     SecretEnvHandoff(SecretEnvMaterializedHandoff),
-    SecretEnvPlan(SecretEnvPlanMaterialization),
+    SecretEnvPlan(Box<SecretEnvPlanMaterialization>),
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -484,7 +484,7 @@ fn constants(contract_id: &str) -> CmdResult<ContractOutput> {
         )
     })?;
 
-    Ok((ContractOutput::Constants(output), 0))
+    Ok((ContractOutput::Constants(Box::new(output)), 0))
 }
 
 fn normalize(args: ContractNormalizeArgs) -> Result<ContractNormalizeOutput> {
@@ -516,9 +516,9 @@ fn materialize(args: ContractMaterializeArgs) -> Result<ContractMaterializeOutpu
         ContractMaterializeKind::SecretEnvHandoff => {
             materialize_secret_env_handoff(value).map(ContractMaterializeOutput::SecretEnvHandoff)
         }
-        ContractMaterializeKind::SecretEnvPlan => {
-            materialize_secret_env_plan(value).map(ContractMaterializeOutput::SecretEnvPlan)
-        }
+        ContractMaterializeKind::SecretEnvPlan => materialize_secret_env_plan(value)
+            .map(Box::new)
+            .map(ContractMaterializeOutput::SecretEnvPlan),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/issues.rs
+++ b/crates/homeboy-cli/src/commands/issues.rs
@@ -163,7 +163,7 @@ pub(crate) enum IssuesCommand {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum IssuesCommandOutput {
-    Reconcile(ReconcileOutput),
+    Reconcile(Box<ReconcileOutput>),
     ReconcileRun(ReconcileRunOutput),
     BuildFindings(ReconcileFindingsInput),
 }
@@ -278,7 +278,7 @@ pub fn run(args: IssuesArgs) -> CmdResult<IssuesCommandOutput> {
                 apply: mutation.is_apply(),
                 path,
             })?;
-            Ok((IssuesCommandOutput::Reconcile(output), exit))
+            Ok((IssuesCommandOutput::Reconcile(Box::new(output)), exit))
         }
         IssuesCommand::ReconcileRun {
             component_id,

--- a/crates/homeboy-cli/src/commands/raw_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/raw_output/mod.rs
@@ -13,7 +13,7 @@ pub enum RawExecution {
 pub enum CommandRunPreparation {
     Handled(i32),
     Json(Box<Commands>),
-    Raw(CommandRun),
+    Raw(Box<CommandRun>),
 }
 
 pub fn prepare_command_run(command: Commands, mode: CommandResponseMode) -> CommandRunPreparation {
@@ -28,7 +28,7 @@ pub fn prepare_command_run(command: Commands, mode: CommandResponseMode) -> Comm
         CommandResponseMode::Raw(raw_mode) => {
             let raw_run = run(command, raw_mode)
                 .expect("markdown and plain-text modes should return raw output");
-            CommandRunPreparation::Raw(raw_run)
+            CommandRunPreparation::Raw(Box::new(raw_run))
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/refactor.rs
+++ b/crates/homeboy-cli/src/commands/refactor.rs
@@ -588,7 +588,7 @@ pub enum RefactorOutput {
 
     #[serde(rename = "refactor.decompose")]
     Decompose {
-        plan: homeboy::refactor::DecomposePlan,
+        plan: Box<homeboy::refactor::DecomposePlan>,
         move_results: Vec<homeboy::refactor::MoveResult>,
         dry_run: bool,
         applied: bool,

--- a/crates/homeboy-cli/src/commands/refactor/operations_command.rs
+++ b/crates/homeboy-cli/src/commands/refactor/operations_command.rs
@@ -514,7 +514,7 @@ fn run_decompose_single(
 
     Ok((
         RefactorOutput::Decompose {
-            plan,
+            plan: Box::new(plan),
             move_results,
             dry_run: !write,
             applied: write,

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -263,9 +263,9 @@ pub struct ArtifactSourceAuthorityOutput {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum ReleaseCommandOutput {
-    Single(ReleaseOutput),
+    Single(Box<ReleaseOutput>),
     Batch(BatchReleaseOutput),
-    Package(ReleasePackageOutput),
+    Package(Box<ReleasePackageOutput>),
     ArtifactSourceAuthority(ArtifactSourceAuthorityOutput),
     Changes(changes::ChangesCommandOutput),
     Changelog(changelog::ChangelogOutput),
@@ -489,13 +489,13 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         let cascade = run_cascade_if_requested(&args, component_id, &result, &input)?;
 
         return Ok((
-            ReleaseCommandOutput::Single(ReleaseOutput {
+            ReleaseCommandOutput::Single(Box::new(ReleaseOutput {
                 variant: "single",
                 actionable: recovery_actionable_metadata(&result),
                 result,
                 workspace: workspace_result.workspace,
                 cascade,
-            }),
+            })),
             exit_code,
         ));
     }
@@ -701,10 +701,10 @@ fn run_package_only(
     )?;
 
     Ok((
-        ReleaseCommandOutput::Package(ReleasePackageOutput {
+        ReleaseCommandOutput::Package(Box::new(ReleasePackageOutput {
             variant: "package",
             result,
-        }),
+        })),
         0,
     ))
 }

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -610,11 +610,11 @@ fn show(rig_id: &str) -> CmdResult<RigCommandOutput> {
     let rig = rig::load(rig_id)?;
     let resources = rig::expand::expand_resources(&rig);
     Ok((
-        RigCommandOutput::Show(RigShowOutput {
+        RigCommandOutput::Show(Box::new(RigShowOutput {
             command: "rig.show",
             rig,
             resources,
-        }),
+        })),
         0,
     ))
 }
@@ -977,7 +977,7 @@ fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
 
     if !sync_report.success {
         return Ok((
-            RigCommandOutput::Run(RigRunOutput {
+            RigCommandOutput::Run(Box::new(RigRunOutput {
                 command: "rig.run",
                 rig_id: rig.id,
                 profile,
@@ -985,14 +985,14 @@ fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
                 sync: sync_report,
                 bench_invocation,
                 bench: None,
-            }),
+            })),
             1,
         ));
     }
 
     let (bench, bench_exit_code) = super::bench::run_rig_profile(bench_options)?;
     Ok((
-        RigCommandOutput::Run(RigRunOutput {
+        RigCommandOutput::Run(Box::new(RigRunOutput {
             command: "rig.run",
             rig_id: rig.id,
             profile,
@@ -1000,7 +1000,7 @@ fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
             sync: sync_report,
             bench_invocation,
             bench: Some(bench),
-        }),
+        })),
         bench_exit_code,
     ))
 }

--- a/crates/homeboy-cli/src/commands/rig/output.rs
+++ b/crates/homeboy-cli/src/commands/rig/output.rs
@@ -14,7 +14,7 @@ use homeboy::rig::{self, RigResourcesSpec, RigSpec};
 #[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RigCommandOutput {
     List(RigListOutput),
-    Show(RigShowOutput),
+    Show(Box<RigShowOutput>),
     Materialize(RigMaterializeOutput),
     Up(RigUpOutput),
     UpPlan(RigUpPlanOutput),
@@ -29,7 +29,7 @@ pub enum RigCommandOutput {
     App(RigAppOutput),
     ArtifactRegister(RigArtifactRegisterOutput),
     ReleaseLock(RigReleaseLockOutput),
-    Run(RigRunOutput),
+    Run(Box<RigRunOutput>),
 }
 
 #[derive(Serialize)]
@@ -169,7 +169,7 @@ pub type RigSourcesOutput = CommandReport<RigSourcesReport>;
 #[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RigSourcesReport {
     List(rig::RigSourceListResult),
-    Remove(rig::RigSourceRemoveResult),
+    Remove(Box<rig::RigSourceRemoveResult>),
     Refresh(rig::RigSourceUpdateResult),
 }
 

--- a/crates/homeboy-cli/src/commands/rig/sources.rs
+++ b/crates/homeboy-cli/src/commands/rig/sources.rs
@@ -44,7 +44,7 @@ fn remove(source: &str) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Sources(RigSourcesOutput {
             command: "rig.sources.remove",
-            report: RigSourcesReport::Remove(rig::remove_source(source)?),
+            report: RigSourcesReport::Remove(Box::new(rig::remove_source(source)?)),
         }),
         0,
     ))

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -81,7 +81,7 @@ pub fn run(args: StatusArgs) -> CmdResult<StatusResult> {
     if args.full {
         let mut report = context::build_report(args.all, "status")?;
         report.command = "status".to_string();
-        return Ok((StatusResult::Full(report), 0));
+        return Ok((StatusResult::Full(Box::new(report)), 0));
     }
 
     let mut timer = StatusTimer::new(args.timings);
@@ -281,7 +281,7 @@ fn run_path_status(args: &StatusArgs, controller: ControllerStaleness) -> CmdRes
     if args.full {
         let mut report = context::build_report_for_component(args.all, "status", component, path)?;
         report.command = "status".to_string();
-        return Ok((StatusResult::Full(report), 0));
+        return Ok((StatusResult::Full(Box::new(report)), 0));
     }
 
     summarize_components(vec![component], args, timer, controller)

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -377,7 +377,7 @@ fn is_zero(value: &usize) -> bool {
 pub enum StatusResult {
     Summary(StatusOutput),
     UnregisteredContext(UnregisteredContextStatusOutput),
-    Full(homeboy::core::context::report::ContextReport),
+    Full(Box<homeboy::core::context::report::ContextReport>),
     Dashboard(ProjectDashboardOutput),
 }
 

--- a/crates/homeboy-cli/src/commands/tunnel.rs
+++ b/crates/homeboy-cli/src/commands/tunnel.rs
@@ -57,7 +57,7 @@ pub enum ServiceTunnelActionOutput {
         service_id: String,
         local_url: String,
     },
-    Status(ServiceTunnelStatus),
+    Status(Box<ServiceTunnelStatus>),
 }
 
 #[derive(Debug, Serialize)]
@@ -71,8 +71,8 @@ pub struct PreviewClientActionOutput {
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum PreviewIngressActionOutput {
-    Install(PreviewIngressInstallPlan),
-    InstallStatus(PreviewIngressInstallStatusPlan),
+    Install(Box<PreviewIngressInstallPlan>),
+    InstallStatus(Box<PreviewIngressInstallStatusPlan>),
     Route(PreviewIngressRoute),
     Routes { routes: Vec<PreviewIngressRoute> },
     Status(PreviewIngressStatus),
@@ -729,7 +729,7 @@ fn run_preview_ingress(command: TunnelPreviewIngressCommand) -> CmdResult<Tunnel
                     command: "tunnel.preview_ingress.install".to_string(),
                     id: Some(server_id),
                     extra: TunnelExtra {
-                        preview_ingress: Some(PreviewIngressActionOutput::Install(plan)),
+                        preview_ingress: Some(PreviewIngressActionOutput::Install(Box::new(plan))),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -745,7 +745,9 @@ fn run_preview_ingress(command: TunnelPreviewIngressCommand) -> CmdResult<Tunnel
                     command: "tunnel.preview_ingress.install_status".to_string(),
                     id: Some(server_id),
                     extra: TunnelExtra {
-                        preview_ingress: Some(PreviewIngressActionOutput::InstallStatus(status)),
+                        preview_ingress: Some(PreviewIngressActionOutput::InstallStatus(Box::new(
+                            status,
+                        ))),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/crates/homeboy-cli/src/commands/tunnel/service.rs
+++ b/crates/homeboy-cli/src/commands/tunnel/service.rs
@@ -528,7 +528,7 @@ fn status_service(id: &str) -> CmdResult<TunnelOutput> {
             command: "tunnel.service.status".to_string(),
             id: Some(id.to_string()),
             extra: TunnelExtra {
-                service: Some(ServiceTunnelActionOutput::Status(report)),
+                service: Some(ServiceTunnelActionOutput::Status(Box::new(report))),
                 ..Default::default()
             },
             ..Default::default()
@@ -545,7 +545,7 @@ fn start_service(spec: StartServiceTunnelSpec) -> CmdResult<TunnelOutput> {
             command: "tunnel.service.start".to_string(),
             id: Some(id),
             extra: TunnelExtra {
-                service: Some(ServiceTunnelActionOutput::Status(report)),
+                service: Some(ServiceTunnelActionOutput::Status(Box::new(report))),
                 ..Default::default()
             },
             ..Default::default()
@@ -561,7 +561,7 @@ fn stop_service(id: &str) -> CmdResult<TunnelOutput> {
             command: "tunnel.service.stop".to_string(),
             id: Some(id.to_string()),
             extra: TunnelExtra {
-                service: Some(ServiceTunnelActionOutput::Status(report)),
+                service: Some(ServiceTunnelActionOutput::Status(Box::new(report))),
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
## Summary
- box oversized CLI output enum payloads and update their direct constructors
- preserve existing Serde JSON tags, discriminators, and payload shapes
- update the tagged bench output serialization assertion for boxed construction

## Verification
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-cli
- focused output serialization tests for bench, activity, issues, and rig
- scoped large-enum Clippy confirms this branch output findings are clear; remaining diagnostics belong to sibling command-surface, agent-task, fuzz, runner, and runs branches

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode was used to identify and apply the Rust 1.95 Clippy-compatible indirection changes and run verification. Chris remains responsible for every line.