### PR TITLE
fix(cli): resolve agent-task Clippy diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -47,6 +47,12 @@ pub use args::{
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
+pub(crate) type CookProgressCallback<'a> = dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
+    + Send
+    + Sync
+    + 'a;
+pub(crate) type CookProgress<'a> = Option<&'a CookProgressCallback<'a>>;
+
 pub fn run(args: AgentTaskArgs) -> CmdResult<Value> {
     // Announce durable identity exactly once, on the first progress event that
     // carries a run id, and do it outside the TTY gate. Phase chatter stays
@@ -201,22 +207,14 @@ fn next_machine_progress_message(
 
 pub(crate) fn run_with_cook_progress(
     args: AgentTaskArgs,
-    progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
-              + Send
-              + Sync),
-    >,
+    progress: CookProgress<'_>,
 ) -> CmdResult<Value> {
     run_with_cook_progress_and_provenance(args, progress, None)
 }
 
 pub(crate) fn run_with_cook_progress_and_provenance(
     args: AgentTaskArgs,
-    progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
-              + Send
-              + Sync),
-    >,
+    progress: CookProgress<'_>,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value> {
     match args.command {
@@ -227,14 +225,14 @@ pub(crate) fn run_with_cook_progress_and_provenance(
             run::validate_cook_request_with_provenance(&cook_args, provenance)?;
             if progress.is_some() {
                 run::run_cook_with_executor_and_dispatcher_with_progress(
-                    cook_args,
+                    *cook_args,
                     homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
                     None,
                     progress,
                     provenance,
                 )
             } else {
-                run::run_cook(cook_args)
+                run::run_cook(*cook_args)
             }
         }
         AgentTaskCommand::CookContinue(args) if args.preflight => {
@@ -279,12 +277,14 @@ pub(crate) fn run_with_cook_progress_and_provenance(
         AgentTaskCommand::Retry(retry_args) => run::retry(retry_args),
         AgentTaskCommand::Fanout(fanout_args) => fanout::fanout(fanout_args),
         AgentTaskCommand::Review(review_args) => review::review(review_args),
-        AgentTaskCommand::Promote(promote_args) => review::promote_artifact(promote_args),
+        AgentTaskCommand::Promote(promote_args) => review::promote_artifact(*promote_args),
         AgentTaskCommand::Adopt(adopt_args) => review::adopt_candidate(adopt_args),
         AgentTaskCommand::PromotionProvider(provider_args) => {
             run::promotion_provider(provider_args)
         }
-        AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
+        AgentTaskCommand::FinalizePr(finalize_args) => {
+            review::finalize_pull_request(*finalize_args)
+        }
         AgentTaskCommand::RecordReplacementGateProof(args) => {
             review::record_replacement_gate_proof(args)
         }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -75,7 +75,7 @@ pub enum AgentTaskCommand {
     /// client that needs one predictable contract should pass the flag rather than
     /// rely on the default, and read the terminal outcome from
     /// `agent-task status <run-id>` in either case.
-    Cook(AgentTaskCookArgs),
+    Cook(Box<AgentTaskCookArgs>),
     /// Continue a detached Cook from its durable Cook ID or provider attempt ID.
     /// The persisted recipe supplies the original prompt, transport, gates,
     /// worktree, and disclosure policy.
@@ -155,7 +155,7 @@ pub enum AgentTaskCommand {
     /// and promotion hints.
     Review(ReviewArgs),
     /// Promote a completed generic patch artifact into a managed worktree.
-    Promote(PromoteArgs),
+    Promote(Box<PromoteArgs>),
     /// Adopt an immutable commit candidate through a tracked cook's normal gates and finalization.
     Adopt(AdoptArgs),
     #[command(hide = true)]
@@ -163,7 +163,7 @@ pub enum AgentTaskCommand {
     /// Finalize a green run, or recover publication from a durable Cook record.
     ///
     /// This is the core-owned publication boundary for external runtimes.
-    FinalizePr(FinalizePrArgs),
+    FinalizePr(Box<FinalizePrArgs>),
     /// Attach authorized candidate-bound replacement gate proof after an infrastructure gate failure.
     RecordReplacementGateProof(RecordReplacementGateProofArgs),
     /// Record an independent, durable acceptance verdict for a candidate.

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -15,7 +15,7 @@ pub enum AgentTaskFanoutCommand {
     /// Requires at least one deterministic gate: pass `--verify` or
     /// `--private-verify`. The gate is not optional — a child cook that cannot
     /// verify its work cannot promote it (#9838).
-    CookBatch(AgentTaskFanoutCookBatchArgs),
+    CookBatch(Box<AgentTaskFanoutCookBatchArgs>),
     /// Normalize and inspect a batch-cook plan without submitting or running it.
     Plan(AgentTaskFanoutPlanArgs),
     /// Submit a batch of independent cooks and print the exact per-cook commands

--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum CandidateState {
     Finalized,
     Promoted,
@@ -13,13 +13,8 @@ pub(crate) enum CandidateState {
     Unreadable,
     Conflicting,
     RetainedOnly,
+    #[default]
     Unknown,
-}
-
-impl Default for CandidateState {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 impl CandidateState {
@@ -170,10 +165,12 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
         by_identity.entry(identity).or_default().push(artifact);
     }
 
-    let mut counts = CandidateResult::default();
-    counts.attempts_omitted = attempts_omitted;
-    counts.outcomes_omitted = outcomes_omitted;
-    counts.artifacts_omitted = artifacts_omitted;
+    let mut counts = CandidateResult {
+        attempts_omitted,
+        outcomes_omitted,
+        artifacts_omitted,
+        ..Default::default()
+    };
     for artifacts in by_identity.into_values() {
         let artifact = artifacts[0];
         let size = artifact.get("size_bytes").and_then(Value::as_u64);
@@ -296,7 +293,6 @@ fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
         outcomes_omitted: omitted("outcomes_omitted"),
         artifacts_omitted: omitted("artifacts_omitted"),
         no_changes_produced: state == CandidateState::NoChangesProduced,
-        ..Default::default()
     })
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -45,7 +45,7 @@ use super::command_json_value;
 
 pub(super) fn fanout(args: AgentTaskFanoutArgs) -> CmdResult<Value> {
     match args.command {
-        AgentTaskFanoutCommand::CookBatch(cook_batch_args) => cook_batch(cook_batch_args),
+        AgentTaskFanoutCommand::CookBatch(cook_batch_args) => cook_batch(*cook_batch_args),
         AgentTaskFanoutCommand::Plan(plan_args) => {
             let plan = load_batch_cook_fanout_plan(&plan_args.input)?;
             Ok((command_json_value(plan)?, 0))
@@ -2271,7 +2271,7 @@ impl IssueRef {
             ));
         };
         let number = number_part
-            .split(|c| matches!(c, '/' | '?' | '#'))
+            .split(['/', '?', '#'])
             .next()
             .unwrap_or_default();
         if number.is_empty() || !number.chars().all(|c| c.is_ascii_digit()) {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -232,14 +232,16 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             aggregate
                 .map(|aggregate| {
                     promotion_candidates(
-                        &record.run_id,
-                        Some(&record.run_id),
-                        record.aggregate_path.as_deref(),
-                        args.to_worktree.as_deref(),
-                        cook_base.as_deref(),
-                        args.provider_command.as_deref(),
-                        &args.provider_argv,
-                        record.metadata.get("latest_promotion"),
+                        PromotionCandidateContext {
+                            source: &record.run_id,
+                            source_run_id: Some(&record.run_id),
+                            aggregate_path: record.aggregate_path.as_deref(),
+                            to_worktree: args.to_worktree.as_deref(),
+                            cook_base: cook_base.as_deref(),
+                            provider_command: args.provider_command.as_deref(),
+                            provider_argv: &args.provider_argv,
+                            latest_promotion: record.metadata.get("latest_promotion"),
+                        },
                         aggregate,
                         review,
                     )
@@ -1046,8 +1048,6 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
         diagnostics
             .iter()
             .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|diagnostic| serde_json::to_value(diagnostic).unwrap_or(Value::Null))
             .collect::<Vec<_>>()
     } else {
@@ -1318,15 +1318,20 @@ pub(crate) fn default_protected_branches() -> Vec<String> {
     ]
 }
 
+#[derive(Clone, Copy)]
+struct PromotionCandidateContext<'a> {
+    source: &'a str,
+    source_run_id: Option<&'a str>,
+    aggregate_path: Option<&'a str>,
+    to_worktree: Option<&'a str>,
+    cook_base: Option<&'a str>,
+    provider_command: Option<&'a str>,
+    provider_argv: &'a [String],
+    latest_promotion: Option<&'a Value>,
+}
+
 fn promotion_candidates(
-    source: &str,
-    source_run_id: Option<&str>,
-    aggregate_path: Option<&str>,
-    to_worktree: Option<&str>,
-    cook_base: Option<&str>,
-    provider_command: Option<&str>,
-    provider_argv: &[String],
-    latest_promotion: Option<&Value>,
+    context: PromotionCandidateContext<'_>,
     aggregate: &AgentTaskAggregate,
     review: &AgentTaskAggregateReport,
 ) -> Vec<Value> {
@@ -1357,13 +1362,13 @@ fn promotion_candidates(
                         outcome,
                         &AgentTaskPromotionOptions {
                             source: "{}".to_string(),
-                            source_run_id: source_run_id.map(str::to_string),
-                            source_path: aggregate_path.map(std::path::PathBuf::from),
+                            source_run_id: context.source_run_id.map(str::to_string),
+                            source_path: context.aggregate_path.map(std::path::PathBuf::from),
                             source_worktree_path: None,
                             base_ref: None,
                             task_base_sha: None,
                             candidate_ref: None,
-                            to_worktree: to_worktree.unwrap_or("<managed-worktree>").to_string(),
+                            to_worktree: context.to_worktree.unwrap_or("<managed-worktree>").to_string(),
                             task_id: Some(candidate.task_id.clone()),
                             artifact_id: None,
                             dry_run: true,
@@ -1382,13 +1387,13 @@ fn promotion_candidates(
                     "homeboy".to_string(),
                     "agent-task".to_string(),
                     "promote".to_string(),
-                    source.to_string(),
+                    context.source.to_string(),
                     "--task-id".to_string(),
                     candidate.task_id.clone(),
                     "--artifact-id".to_string(),
                     artifact_id.clone(),
                 ];
-                let continuation = latest_promotion.filter(|promotion| {
+                let continuation = context.latest_promotion.filter(|promotion| {
                     promotion_is_resumable(promotion, false)
                         && promotion.pointer("/source/task_id").and_then(Value::as_str)
                             == Some(candidate.task_id.as_str())
@@ -1398,7 +1403,7 @@ fn promotion_candidates(
                 if let Some(to_worktree) = continuation
                     .and_then(|promotion| promotion.pointer("/target/worktree"))
                     .and_then(Value::as_str)
-                    .or(to_worktree)
+                    .or(context.to_worktree)
                 {
                     command.push("--to-worktree".to_string());
                     command.push(to_worktree.to_string());
@@ -1407,15 +1412,15 @@ fn promotion_candidates(
                     .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
                 {
                     append_resume_contract(&mut command, contract);
-                } else if let Some(base) = cook_base {
+                } else if let Some(base) = context.cook_base {
                     command.extend(["--base".to_string(), base.to_string()]);
                 }
-                if let Some(provider_command) = provider_command {
+                if let Some(provider_command) = context.provider_command {
                     command.push("--provider-command".to_string());
                     command.push(provider_command.to_string());
                 }
                 command.extend(
-                    provider_argv
+                    context.provider_argv
                         .iter()
                         .map(|argument| format!("--provider-argv={argument}")),
                 );
@@ -1425,7 +1430,7 @@ fn promotion_candidates(
                     "artifact_id": artifact_id,
                     "reason": candidate.reason,
                     "command": command,
-                    "ready": to_worktree.is_some(),
+                    "ready": context.to_worktree.is_some(),
                     "selection_required": selection_required,
                 })
             })
@@ -1716,8 +1721,7 @@ mod tests {
             "capabilities": vec!["capability-".to_string() + &"x".repeat(10_000); 100],
         }))
         .expect("provider fixture");
-        let providers = std::iter::repeat(provider)
-            .take(DEFAULT_PROVIDER_LIMIT + 100)
+        let providers = std::iter::repeat_n(provider, DEFAULT_PROVIDER_LIMIT + 100)
             .map(|provider| compact_provider(&provider))
             .take(DEFAULT_PROVIDER_LIMIT)
             .collect::<Vec<_>>();
@@ -1919,20 +1923,23 @@ mod tests {
         }))
         .expect("aggregate");
 
+        let provider_argv = [
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "promotion-provider".to_string(),
+            "--workspace=/tmp/target".to_string(),
+        ];
         let candidates = promotion_candidates(
-            "aggregate.json",
-            None,
-            None,
-            Some("fixture@target"),
-            None,
-            None,
-            &[
-                "homeboy".to_string(),
-                "agent-task".to_string(),
-                "promotion-provider".to_string(),
-                "--workspace=/tmp/target".to_string(),
-            ],
-            None,
+            PromotionCandidateContext {
+                source: "aggregate.json",
+                source_run_id: None,
+                aggregate_path: None,
+                to_worktree: Some("fixture@target"),
+                cook_base: None,
+                provider_command: None,
+                provider_argv: &provider_argv,
+                latest_promotion: None,
+            },
             &aggregate,
             &review,
         );
@@ -1985,14 +1992,16 @@ mod tests {
         .expect("aggregate");
 
         let candidates = promotion_candidates(
-            "cook-attempt-9400",
-            Some("cook-attempt-9400"),
-            None,
-            Some("fixture@target"),
-            Some("trunk"),
-            None,
-            &[],
-            None,
+            PromotionCandidateContext {
+                source: "cook-attempt-9400",
+                source_run_id: Some("cook-attempt-9400"),
+                aggregate_path: None,
+                to_worktree: Some("fixture@target"),
+                cook_base: Some("trunk"),
+                provider_command: None,
+                provider_argv: &[],
+                latest_promotion: None,
+            },
             &aggregate,
             &review,
         );
@@ -2083,14 +2092,16 @@ mod tests {
         assert_eq!(equivalent_review.apply_candidates.len(), 0);
         assert_eq!(equivalent_review.review_candidates.len(), 1);
         let equivalent = promotion_candidates(
-            "review-run",
-            None,
-            None,
-            Some("fixture@target"),
-            None,
-            None,
-            &[],
-            None,
+            PromotionCandidateContext {
+                source: "review-run",
+                source_run_id: None,
+                aggregate_path: None,
+                to_worktree: Some("fixture@target"),
+                cook_base: None,
+                provider_command: None,
+                provider_argv: &[],
+                latest_promotion: None,
+            },
             &equivalent_aggregate,
             &equivalent_review,
         );
@@ -2102,14 +2113,16 @@ mod tests {
         let distinct_aggregate = recoverable_review_aggregate(&temp, &[1, 2]);
         let distinct_review = AgentTaskAggregateReport::from(distinct_aggregate.outcomes.clone());
         let distinct = promotion_candidates(
-            "review-run",
-            None,
-            None,
-            Some("fixture@target"),
-            None,
-            None,
-            &[],
-            None,
+            PromotionCandidateContext {
+                source: "review-run",
+                source_run_id: None,
+                aggregate_path: None,
+                to_worktree: Some("fixture@target"),
+                cook_base: None,
+                provider_command: None,
+                provider_argv: &[],
+                latest_promotion: None,
+            },
             &distinct_aggregate,
             &distinct_review,
         );

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -638,7 +638,7 @@ pub(crate) fn resolve_cook_destination(
 fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
     let issue = task_url
         .trim()
-        .split(|character| matches!(character, '?' | '#'))
+        .split(['?', '#'])
         .next()
         .unwrap_or_default()
         .trim_end_matches('/');
@@ -865,11 +865,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
     attempt_dispatcher: Option<
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
     >,
-    progress: Option<
-        &(dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> homeboy::core::Result<()>
-              + Send
-              + Sync),
-    >,
+    progress: super::CookProgress<'_>,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value>
 where

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2283,7 +2283,7 @@ fn failed_task_statuses(
                     | AgentTaskOutcomeStatus::UnableToRemediate
             )
         })
-        .map(|outcome| (outcome.task_id.clone(), outcome.status.clone()))
+        .map(|outcome| (outcome.task_id.clone(), outcome.status))
         .collect()
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -37,7 +37,7 @@ fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
     let AgentTaskCommand::Cook(cook) = agent_task.command else {
         panic!("cook command");
     };
-    cook
+    *cook
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
         };
 
         let error = super::super::run::run_cook_with_executor(
-            cook,
+            *cook,
             ExtensionProviderAgentTaskExecutor::default(),
         )
         .expect_err("queue-only cook must fail before resolving its worktree");
@@ -236,7 +236,7 @@ fn cook_goal_frames_explicit_task_without_creating_another_provider_cell() {
         };
 
         let _ = run_cook_with_executor_and_dispatcher(
-            cook,
+            *cook,
             CapturingExecutor::default(),
             Some(Arc::new(RecipeOnlyDispatcher)),
         );
@@ -287,7 +287,7 @@ fn cook_goal_without_explicit_work_remains_one_provider_cell() {
         };
 
         let _ = run_cook_with_executor_and_dispatcher(
-            cook,
+            *cook,
             CapturingExecutor::default(),
             Some(Arc::new(RecipeOnlyDispatcher)),
         );
@@ -426,7 +426,7 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
             let AgentTaskCommand::Cook(cook) = agent_task.command else {
                 panic!("cook command")
             };
-            run_cook_with_executor(cook, ExtensionProviderAgentTaskExecutor::default())
+            run_cook_with_executor(*cook, ExtensionProviderAgentTaskExecutor::default())
                 .expect_err("invalid Cook input is rejected before provider ensure");
         }
         assert!(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -83,7 +83,7 @@ fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
     let AgentTaskCommand::Cook(cook) = agent_task.command else {
         panic!("cook command");
     };
-    cook
+    *cook
 }
 
 #[test]
@@ -282,7 +282,7 @@ fn recoverable_runner_cook_args(
     let AgentTaskCommand::Cook(cook) = agent_task.command else {
         panic!("cook command");
     };
-    cook
+    *cook
 }
 
 #[test]
@@ -2283,7 +2283,7 @@ fn gate_requirement_cook_args(
     let AgentTaskCommand::Cook(cook) = agent_task.command else {
         panic!("cook command");
     };
-    cook
+    *cook
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/agent_task_summary/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/controller.rs
@@ -60,7 +60,7 @@ pub(super) fn render_controller_summary(payload: &Value) -> Option<String> {
     Some(finish(lines))
 }
 
-fn controller_payload<'a>(payload: &'a Value) -> Option<&'a Value> {
+fn controller_payload(payload: &Value) -> Option<&Value> {
     value_at(payload, &["controller"])
         .or_else(|| value_at(payload, &["resume", "controller"]))
         .or_else(|| value_at(payload, &["from_spec", "controller"]))
@@ -192,7 +192,7 @@ fn controller_last_failure<'a>(payload: &'a Value, controller: &'a Value) -> Opt
         })
 }
 
-fn best_failure_diagnostic<'a>(candidates: [Option<&'a str>; 2]) -> Option<&'a str> {
+fn best_failure_diagnostic(candidates: [Option<&str>; 2]) -> Option<&str> {
     candidates
         .into_iter()
         .flatten()

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -123,22 +123,16 @@ impl Commands {
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command:
-                            agent_task::AgentTaskFanoutCommand::CookBatch(
-                                agent_task::AgentTaskFanoutCookBatchArgs { dry_run: true, .. },
-                            ),
+                        command: agent_task::AgentTaskFanoutCommand::CookBatch(args),
                     }),
-            }) => agent_task_fanout_local_only_contract(
+            }) if args.dry_run => agent_task_fanout_local_only_contract(
                 AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
                 AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON,
             ),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                        command:
-                            agent_task::AgentTaskFanoutCommand::CookBatch(
-                                agent_task::AgentTaskFanoutCookBatchArgs { dry_run: false, .. },
-                            ),
+                        command: agent_task::AgentTaskFanoutCommand::CookBatch(_),
                     }),
             }) => agent_task_fanout_local_only_contract(
                 AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
@@ -292,11 +286,8 @@ impl Commands {
         if matches!(
             self,
             Commands::AgentTask(agent_task::AgentTaskArgs {
-                command: agent_task::AgentTaskCommand::Promote(agent_task::PromoteArgs {
-                    dry_run: true,
-                    ..
-                }),
-            })
+                command: agent_task::AgentTaskCommand::Promote(args),
+            }) if args.dry_run
         ) {
             return false;
         }
@@ -371,10 +362,10 @@ pub(crate) fn agent_task_provider_requires_cwd_git_checkout_with(
     provider_requires_cwd_git_checkout: impl Fn(&str, Option<&str>) -> bool,
 ) -> bool {
     match command {
-        agent_task::AgentTaskCommand::Cook(agent_task::AgentTaskCookArgs { dispatch, .. }) => {
+        agent_task::AgentTaskCommand::Cook(cook) => {
             provider_requires_cwd_git_checkout_for_dispatch(
-                dispatch.backend.as_deref(),
-                dispatch.selector.as_deref(),
+                cook.dispatch.backend.as_deref(),
+                cook.dispatch.selector.as_deref(),
                 default_backend,
                 provider_requires_cwd_git_checkout,
             )

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -822,7 +822,7 @@ fn run_split_placement_fanout(
                 ),
         }) if args.run_plan => {
             crate::commands::agent_task::fanout::cook_batch_with_attempt_dispatcher(
-                args.clone(),
+                *args.clone(),
                 &attempt_dispatcher,
             )?
         }
@@ -1033,7 +1033,7 @@ fn run_split_placement_cook(
     };
     let (value, exit_code) =
         crate::commands::agent_task::run::run_cook_with_executor_and_dispatcher_with_progress(
-            controller,
+            *controller,
             homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
             Some(dispatcher),
             Some(&progress),
@@ -1718,7 +1718,7 @@ fn materialize_agent_task_cook_plan(
     else {
         return Ok(None);
     };
-    let cook = crate::commands::agent_task::run::resolve_cook_destination(cook.clone())?;
+    let cook = crate::commands::agent_task::run::resolve_cook_destination(*cook.clone())?;
     crate::commands::agent_task::run::validate_cook_request_with_provenance(&cook, provenance)?;
     let provision = crate::commands::agent_task::run::provision_cook_destination(&cook)?;
     let mut plan = crate::commands::agent_task::run::compile_cook_plan(&cook, provision)?;

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -234,11 +234,9 @@ pub(super) fn is_plan_only_command(command: &Commands) -> bool {
         command,
         Commands::AgentTask(agent_task::AgentTaskArgs {
             command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
-                command: agent_task::AgentTaskFanoutCommand::CookBatch(
-                    agent_task::AgentTaskFanoutCookBatchArgs { dry_run: true, .. },
-                ),
+                command: agent_task::AgentTaskFanoutCommand::CookBatch(args),
             }),
-        })
+        }) if args.dry_run
     )
 }
 


### PR DESCRIPTION
## Summary
- resolve Rust 1.95 Clippy diagnostics in the agent-task CLI group
- preserve durable cook, promotion, fanout, and controller summary contracts
- maintain direct routing behavior for boxed command payloads

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-cli`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-cli commands::agent_task::review::tests::promotion_candidates --lib`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-cli commands::agent_task_summary --lib`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo clippy -p homeboy-cli --all-targets --no-deps -- -D warnings`

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode was used to implement, test, and review this change. Chris remains responsible for every line.