### PR TITLE
fix(cli): migrate runner clippy diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -78,16 +78,16 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             fingerprints,
         } => map_registry(policy::update(
             &runner_id,
-            policy::RunnerPolicyPatch::trust(
-                peers,
-                fingerprints,
-                projects,
-                commands,
+            policy::RunnerPolicyPatch {
+                accepted_peer_ids: peers,
+                accepted_peer_fingerprints: fingerprints,
+                allowed_projects: projects,
+                allowed_commands: commands,
                 allow_raw_exec,
                 allow_homeboy_convergence,
                 workspace_roots,
                 artifact_policy,
-            ),
+            },
             "runner.trust",
         )),
         RunnerCommand::Pair {
@@ -131,7 +131,7 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             },
         )),
         RunnerCommand::Preflight { request } => Ok((
-            RunnerCommandOutput::Preflight(runner::placement_readiness(
+            RunnerCommandOutput::Preflight(Box::new(runner::placement_readiness(
                 &serde_json::from_str(&request).map_err(|error| {
                     homeboy::core::Error::validation_invalid_argument(
                         "request",
@@ -140,7 +140,7 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
                         None,
                     )
                 })?,
-            )?),
+            )?)),
             0,
         )),
         RunnerCommand::Connect {
@@ -296,8 +296,9 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             run_id,
             status,
             exit_code,
-        } => lifecycle::lifecycle(runner_id, workspace, job_id, run_id, status, exit_code)
-            .map(|(output, exit_code)| (RunnerCommandOutput::Lifecycle(output), exit_code)),
+        } => lifecycle::lifecycle(runner_id, workspace, job_id, run_id, status, exit_code).map(
+            |(output, exit_code)| (RunnerCommandOutput::Lifecycle(Box::new(output)), exit_code),
+        ),
         RunnerCommand::Job { command } => map_job(jobs::job(command)),
         RunnerCommand::Work {
             runner_id,
@@ -329,12 +330,15 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
                 broker_retry_limit,
             }))
         }
-        RunnerCommand::Workspace { command } => workspace::run(command)
-            .map(|(output, exit_code)| (RunnerCommandOutput::Workspace(output), exit_code)),
+        RunnerCommand::Workspace { command } => {
+            workspace::run(command).map(|(output, exit_code)| {
+                (RunnerCommandOutput::Workspace(Box::new(output)), exit_code)
+            })
+        }
         RunnerCommand::RefreshPlan(args) => refresh_plan::refresh_plan(args)
-            .map(|output| (RunnerCommandOutput::RefreshPlan(output), 0)),
+            .map(|output| (RunnerCommandOutput::RefreshPlan(Box::new(output)), 0)),
         RunnerCommand::Broker { command } => {
-            run_broker(command).map(|output| (RunnerCommandOutput::Broker(output), 0))
+            run_broker(command).map(|output| (RunnerCommandOutput::Broker(Box::new(output)), 0))
         }
     }
 }
@@ -537,7 +541,7 @@ fn run_json_exec(
         )
         .map(|(output, exit_code)| {
             (
-                RunnerCommandOutput::Execution(runner_exec_command_output(output)),
+                RunnerCommandOutput::Execution(Box::new(runner_exec_command_output(output))),
                 exit_code,
             )
         }),
@@ -719,7 +723,7 @@ pub(super) fn run_compact_exec(
 pub(super) fn compact_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> CommandRun {
     let compact_stdout = render_compact_exec_output(&output);
     let (output_file_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
-        RunnerCommandOutput::Execution(runner_exec_command_output(output)),
+        RunnerCommandOutput::Execution(Box::new(runner_exec_command_output(output))),
         exit_code,
     )));
 
@@ -789,7 +793,7 @@ pub(super) fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> 
     let presentation_stdout = output.stdout.clone();
     let presentation_stderr = output.stderr.clone();
     let (stdout_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
-        RunnerCommandOutput::Execution(runner_exec_command_output(output)),
+        RunnerCommandOutput::Execution(Box::new(runner_exec_command_output(output))),
         exit_code,
     )));
 
@@ -805,7 +809,7 @@ pub(super) fn map_registry(result: CmdResult<RunnerOutput>) -> CmdResult<RunnerC
     result.map(|(mut output, exit_code)| {
         registry::redact_runner_output_env(&mut output);
         output.extra.variant = runner_variant_from_command(&output.command);
-        (RunnerCommandOutput::Registry(output), exit_code)
+        (RunnerCommandOutput::Registry(Box::new(output)), exit_code)
     })
 }
 
@@ -827,13 +831,13 @@ fn runner_variant_from_command(command: &str) -> &'static str {
 }
 
 fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::Doctor(output), exit_code))
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Doctor(Box::new(output)), exit_code))
 }
 
 fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {
     result.map(|(output, exit_code)| {
         (
-            RunnerCommandOutput::Execution(runner_exec_command_output(output)),
+            RunnerCommandOutput::Execution(Box::new(runner_exec_command_output(output))),
             exit_code,
         )
     })
@@ -924,10 +928,9 @@ fn map_refresh_homeboy(
             metadata
         });
         (
-            RunnerCommandOutput::RefreshHomeboy(super::types::RunnerRefreshHomeboyCommandOutput {
-                output,
-                actionable,
-            }),
+            RunnerCommandOutput::RefreshHomeboy(Box::new(
+                super::types::RunnerRefreshHomeboyCommandOutput { output, actionable },
+            )),
             exit_code,
         )
     })
@@ -936,17 +939,30 @@ fn map_refresh_homeboy(
 fn map_dev_sync(
     result: homeboy::core::Result<(runner::RunnerDevSyncOutput, i32)>,
 ) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::DevSync(output), exit_code))
+    result.map(|(output, exit_code)| (RunnerCommandOutput::DevSync(Box::new(output)), exit_code))
 }
 
 fn map_cache_prune(
     result: homeboy::core::Result<(runner::RunnerBinaryCachePruneOutput, i32)>,
 ) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::CachePrune(output), exit_code))
+    result.map(|(output, exit_code)| (RunnerCommandOutput::CachePrune(Box::new(output)), exit_code))
 }
 
 fn map_env(result: CmdResult<RunnerEnvOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::Env(output), exit_code))
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Env(Box::new(output)), exit_code))
+}
+
+fn map_job(result: CmdResult<RunnerJobCommandOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| match output {
+        RunnerJobCommandOutput::Daemon(output) => (RunnerCommandOutput::Job(output), exit_code),
+        RunnerJobCommandOutput::Broker(output) => {
+            (RunnerCommandOutput::BrokerJob(Box::new(output)), exit_code)
+        }
+    })
+}
+
+fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Worker(Box::new(output)), exit_code))
 }
 
 #[cfg(test)]
@@ -1018,17 +1034,4 @@ mod tests {
             .iter()
             .any(|action| action["command"] == "homeboy retry"));
     }
-}
-
-fn map_job(result: CmdResult<RunnerJobCommandOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| match output {
-        RunnerJobCommandOutput::Daemon(output) => (RunnerCommandOutput::Job(output), exit_code),
-        RunnerJobCommandOutput::Broker(output) => {
-            (RunnerCommandOutput::BrokerJob(output), exit_code)
-        }
-    })
-}
-
-fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::Worker(output), exit_code))
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -858,13 +858,10 @@ pub(super) fn managed_runner_source_state_check(
         ));
     }
 
-    let Some(git_ref) = contract
+    let git_ref = contract
         .git_ref
         .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    else {
-        return None;
-    };
+        .filter(|value| !value.trim().is_empty())?;
     let branch = branch.unwrap_or("").trim();
     if branch != git_ref {
         return Some(checks::warning_with_details(

--- a/crates/homeboy-cli/src/commands/runner/doctor/target.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/target.rs
@@ -8,7 +8,7 @@ pub enum RunnerTarget {
     Ssh {
         id: String,
         runner: Runner,
-        server: Server,
+        server: Box<Server>,
         client: SshClient,
     },
 }
@@ -45,7 +45,7 @@ fn from_registry(runner_id: &str, runner: Runner) -> homeboy::core::Result<Runne
             Ok(RunnerTarget::Ssh {
                 id: runner_id.to_string(),
                 runner,
-                server,
+                server: Box::new(server),
                 client,
             })
         }

--- a/crates/homeboy-cli/src/commands/runner/jobs.rs
+++ b/crates/homeboy-cli/src/commands/runner/jobs.rs
@@ -12,7 +12,7 @@ use super::cli::RunnerJobCommand;
 use super::types::{RunnerBrokerJobOutput, RunnerJobOutput};
 
 pub(super) enum RunnerJobCommandOutput {
-    Daemon(RunnerJobOutput),
+    Daemon(Box<RunnerJobOutput>),
     Broker(RunnerBrokerJobOutput),
 }
 
@@ -42,7 +42,7 @@ pub(super) fn job(command: RunnerJobCommand) -> CmdResult<RunnerJobCommandOutput
 }
 
 fn map_daemon_job(result: CmdResult<RunnerJobOutput>) -> CmdResult<RunnerJobCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerJobCommandOutput::Daemon(output), exit_code))
+    result.map(|(output, exit_code)| (RunnerJobCommandOutput::Daemon(Box::new(output)), exit_code))
 }
 
 fn job_reconcile(runner_id: &str) -> CmdResult<RunnerJobCommandOutput> {

--- a/crates/homeboy-cli/src/commands/runner/policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/policy/mod.rs
@@ -16,28 +16,6 @@ pub(super) struct RunnerPolicyPatch {
 }
 
 impl RunnerPolicyPatch {
-    pub(super) fn trust(
-        peers: Vec<String>,
-        fingerprints: Vec<String>,
-        projects: Vec<String>,
-        commands: Vec<String>,
-        allow_raw_exec: Option<bool>,
-        allow_homeboy_convergence: Option<bool>,
-        workspace_roots: Vec<String>,
-        artifact_policy: Option<String>,
-    ) -> Self {
-        Self {
-            accepted_peer_ids: peers,
-            accepted_peer_fingerprints: fingerprints,
-            allowed_projects: projects,
-            allowed_commands: commands,
-            allow_raw_exec,
-            allow_homeboy_convergence,
-            workspace_roots,
-            artifact_policy,
-        }
-    }
-
     pub(super) fn pair(
         peers: Vec<String>,
         fingerprints: Vec<String>,

--- a/crates/homeboy-cli/src/commands/runner/registry.rs
+++ b/crates/homeboy-cli/src/commands/runner/registry.rs
@@ -439,7 +439,7 @@ pub(super) fn connect(id: &str, input: RunnerConnectInput) -> CmdResult<RunnerOu
             command: "runner.connect".to_string(),
             id: Some(report.runner_id.clone()),
             extra: RunnerExtra {
-                connection: Some(RunnerConnectionOutput::Connect(report)),
+                connection: Some(RunnerConnectionOutput::Connect(Box::new(report))),
                 ..Default::default()
             },
             ..Default::default()
@@ -454,11 +454,13 @@ pub(super) fn disconnect(id: &str, local_recovery: bool) -> CmdResult<RunnerOutp
             command: "runner.disconnect".to_string(),
             id: Some(id.to_string()),
             extra: RunnerExtra {
-                connection: Some(RunnerConnectionOutput::Disconnect(if local_recovery {
-                    runner::disconnect_local_recovery(id)?
-                } else {
-                    runner::disconnect(id)?
-                })),
+                connection: Some(RunnerConnectionOutput::Disconnect(Box::new(
+                    if local_recovery {
+                        runner::disconnect_local_recovery(id)?
+                    } else {
+                        runner::disconnect(id)?
+                    },
+                ))),
                 ..Default::default()
             },
             ..Default::default()
@@ -474,6 +476,17 @@ pub(super) fn redact_runner_output_env(output: &mut RunnerOutput) {
 
     for runner in &mut output.entities {
         redact_runner_env(runner);
+    }
+}
+
+fn redact_runner_env(runner: &mut Runner) {
+    let policy = RedactionPolicy::default();
+    for (key, value) in runner.env.iter_mut() {
+        if policy.is_sensitive_key(key) {
+            *value = REDACTED_ENV_VALUE.to_string();
+        } else {
+            *value = policy.redact_string(value);
+        }
     }
 }
 
@@ -713,17 +726,6 @@ mod tests {
             let error = validate_connect_input(&input)
                 .expect_err("multiple recovery modes must fail before SSH");
             assert!(error.message.contains("mutually exclusive"));
-        }
-    }
-}
-
-fn redact_runner_env(runner: &mut Runner) {
-    let policy = RedactionPolicy::default();
-    for (key, value) in runner.env.iter_mut() {
-        if policy.is_sensitive_key(key) {
-            *value = REDACTED_ENV_VALUE.to_string();
-        } else {
-            *value = policy.redact_string(value);
         }
     }
 }

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -99,7 +99,7 @@ pub(super) fn status(
                 id: Some(id.to_string()),
                 extra: RunnerExtra {
                     admission_summary,
-                    connection: Some(RunnerConnectionOutput::Status(report)),
+                    connection: Some(RunnerConnectionOutput::Status(Box::new(report))),
                     generation_inventory,
                     preferred_lab_runner,
                     selected_lab_runner,
@@ -200,7 +200,7 @@ pub(super) fn reconcile(id: &str) -> CmdResult<RunnerOutput> {
                     &generation_inventory,
                     generation_inventory.len(),
                 )),
-                connection: Some(RunnerConnectionOutput::Status(report.clone())),
+                connection: Some(RunnerConnectionOutput::Status(Box::new(report.clone()))),
                 generation_inventory,
                 operator_hints: runner_status_operator_hints(&report),
                 operator_commands: runner_status_operator_commands(&report),
@@ -552,13 +552,15 @@ pub(crate) fn declared_runtime_diagnostics(
     );
     let packages = declared_runtime_packages(
         declaration,
-        runner_id,
-        env,
-        &install_dir,
-        &install_dir_source,
-        &managed_cache_source,
-        &default_install_dir,
-        &default_managed_cache_source,
+        RuntimePackageContext {
+            runner_id,
+            env,
+            install_dir: &install_dir,
+            install_dir_source: &install_dir_source,
+            managed_cache_source: &managed_cache_source,
+            default_install_dir: &default_install_dir,
+            default_managed_cache_source: &default_managed_cache_source,
+        },
     );
     let mut diagnostics = declared_runtime_source_diagnostics(
         &declaration.source_consistency,
@@ -738,15 +740,19 @@ fn render_path_message(template: &str, path: &str, root: &str) -> String {
     template.replace("${path}", path).replace("${root}", root)
 }
 
+struct RuntimePackageContext<'a> {
+    runner_id: Option<&'a str>,
+    env: &'a BTreeMap<String, String>,
+    install_dir: &'a str,
+    install_dir_source: &'a str,
+    managed_cache_source: &'a str,
+    default_install_dir: &'a str,
+    default_managed_cache_source: &'a str,
+}
+
 fn declared_runtime_packages(
     declaration: &AgentRuntimeRuntimeDiagnosticDeclaration,
-    runner_id: Option<&str>,
-    env: &BTreeMap<String, String>,
-    install_dir: &str,
-    install_dir_source: &str,
-    managed_cache_source: &str,
-    default_install_dir: &str,
-    default_managed_cache_source: &str,
+    context: RuntimePackageContext<'_>,
 ) -> Vec<RunnerRuntimePackageDiagnostics> {
     declaration
         .packages
@@ -754,22 +760,26 @@ fn declared_runtime_packages(
         .map(|package| {
             let effective_path = render_diagnostic_template(
                 &package.expected_path,
-                install_dir,
-                managed_cache_source,
+                context.install_dir,
+                context.managed_cache_source,
             );
             let default_path = render_diagnostic_template(
                 &package.expected_path,
-                default_install_dir,
-                default_managed_cache_source,
+                context.default_install_dir,
+                context.default_managed_cache_source,
             );
             let override_value = package
                 .env_override
                 .as_deref()
-                .and_then(|key| env.get(key).map(|value| (key, value.clone())));
+                .and_then(|key| context.env.get(key).map(|value| (key, value.clone())));
             let (expected_path, selection_source, env_override, remediation_command) =
                 if let Some((key, value)) = override_value {
                     let remediation_command = if value != default_path {
-                        Some(runner_env_update_command(runner_id, key, &default_path))
+                        Some(runner_env_update_command(
+                            context.runner_id,
+                            key,
+                            &default_path,
+                        ))
                     } else {
                         None
                     };
@@ -780,7 +790,12 @@ fn declared_runtime_packages(
                         remediation_command,
                     )
                 } else {
-                    (effective_path, install_dir_source.to_string(), None, None)
+                    (
+                        effective_path,
+                        context.install_dir_source.to_string(),
+                        None,
+                        None,
+                    )
                 };
             RunnerRuntimePackageDiagnostics {
                 field: package.field.clone(),
@@ -1422,34 +1437,31 @@ pub(super) fn runner_status_operator_commands(
         }
     }
 
-    if session.mode == RunnerTunnelMode::Reverse {
-        if session.broker_url.is_some() {
+    if session.mode == RunnerTunnelMode::Reverse && session.broker_url.is_some() {
+        commands.push(RunnerOperatorCommand {
+            scope: "broker_reconcile",
+            runner_id: report.runner_id.clone(),
+            job_id: None,
+            command: format!(
+                "homeboy runner job reconcile {}",
+                shell_arg(&report.runner_id)
+            ),
+            description:
+                "Fail expired reverse-runner claims through the broker-owned lifecycle path."
+                    .to_string(),
+        });
+        for job in &report.active_runner_jobs {
             commands.push(RunnerOperatorCommand {
-                scope: "broker_reconcile",
+                scope: "broker_artifact_lookup",
                 runner_id: report.runner_id.clone(),
-                job_id: None,
+                job_id: Some(job.job_id.clone()),
                 command: format!(
-                    "homeboy runner job reconcile {}",
-                    shell_arg(&report.runner_id)
+                    "homeboy runner job artifacts {} {} <artifact-id>",
+                    shell_arg(&report.runner_id),
+                    shell_arg(&job.job_id)
                 ),
-                description:
-                    "Fail expired reverse-runner claims through the broker-owned lifecycle path."
-                        .to_string(),
+                description: "Inspect broker-held reverse-runner artifact metadata.".to_string(),
             });
-            for job in &report.active_runner_jobs {
-                commands.push(RunnerOperatorCommand {
-                    scope: "broker_artifact_lookup",
-                    runner_id: report.runner_id.clone(),
-                    job_id: Some(job.job_id.clone()),
-                    command: format!(
-                        "homeboy runner job artifacts {} {} <artifact-id>",
-                        shell_arg(&report.runner_id),
-                        shell_arg(&job.job_id)
-                    ),
-                    description: "Inspect broker-held reverse-runner artifact metadata."
-                        .to_string(),
-                });
-            }
         }
     }
 

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -21,6 +21,7 @@ use super::super::status::{
     runner_followups, runner_followups_with_admission, runner_status_operator_commands,
     selected_admission_summary,
 };
+use super::super::types::RunnerConnectionOutput;
 use crate::cli_surface::Cli;
 
 #[test]
@@ -144,6 +145,12 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
     assert!(serialized.contains("homeboy runner job reconcile homeboy-lab"));
     assert!(serialized.contains("homeboy runner job artifacts homeboy-lab job-123 <artifact-id>"));
     assert!(!serialized.contains("curl -fsS"));
+
+    let serialized_connection =
+        serde_json::to_value(RunnerConnectionOutput::Status(Box::new(report.clone())))
+            .expect("serialize boxed status connection");
+    assert_eq!(serialized_connection["action"], "status");
+    assert_eq!(serialized_connection["runner_id"], "homeboy-lab");
 
     let mut orphan = report.active_runner_jobs[0].clone();
     orphan.job_id = "orphaned-child-run-run-123".to_string();

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -334,9 +334,9 @@ pub struct RunnerOperatorCommand {
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RunnerConnectionOutput {
-    Connect(RunnerConnectReport),
-    Status(RunnerStatusReport),
-    Disconnect(RunnerDisconnectReport),
+    Connect(Box<RunnerConnectReport>),
+    Status(Box<RunnerStatusReport>),
+    Disconnect(Box<RunnerDisconnectReport>),
 }
 
 pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
@@ -346,21 +346,21 @@ pub(super) const REDACTED_ENV_VALUE: &str = "[redacted]";
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum RunnerCommandOutput {
-    Registry(RunnerOutput),
-    Doctor(doctor::RunnerDoctorOutput),
-    Preflight(homeboy::runner::runners::PlacementReadiness),
-    Execution(RunnerExecutionCommandOutput),
-    Env(RunnerEnvOutput),
-    Lifecycle(lifecycle::RunnerLifecycleOutput),
-    Job(RunnerJobOutput),
-    BrokerJob(RunnerBrokerJobOutput),
-    RefreshHomeboy(RunnerRefreshHomeboyCommandOutput),
-    DevSync(homeboy::runner::runners::RunnerDevSyncOutput),
-    CachePrune(homeboy::runner::runners::RunnerBinaryCachePruneOutput),
-    Worker(ReverseRunnerWorkerOutput),
-    Workspace(workspace::RunnerWorkspaceOutput),
-    RefreshPlan(refresh_plan::LabRefreshPlanOutput),
-    Broker(RunnerBrokerOutput),
+    Registry(Box<RunnerOutput>),
+    Doctor(Box<doctor::RunnerDoctorOutput>),
+    Preflight(Box<homeboy::runner::runners::PlacementReadiness>),
+    Execution(Box<RunnerExecutionCommandOutput>),
+    Env(Box<RunnerEnvOutput>),
+    Lifecycle(Box<lifecycle::RunnerLifecycleOutput>),
+    Job(Box<RunnerJobOutput>),
+    BrokerJob(Box<RunnerBrokerJobOutput>),
+    RefreshHomeboy(Box<RunnerRefreshHomeboyCommandOutput>),
+    DevSync(Box<homeboy::runner::runners::RunnerDevSyncOutput>),
+    CachePrune(Box<homeboy::runner::runners::RunnerBinaryCachePruneOutput>),
+    Worker(Box<ReverseRunnerWorkerOutput>),
+    Workspace(Box<workspace::RunnerWorkspaceOutput>),
+    RefreshPlan(Box<refresh_plan::LabRefreshPlanOutput>),
+    Broker(Box<RunnerBrokerOutput>),
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/workspace/mod.rs
@@ -15,13 +15,13 @@ use super::CmdResult;
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RunnerWorkspaceOutput {
-    List(RunnerWorkspaceListOutput),
-    Snapshots(RunnerWorkspaceSnapshotsOutput),
-    Sync(RunnerWorkspaceSyncOutput),
-    Update(RunnerWorkspaceUpdateOutput),
-    Pull(RunnerWorkspacePullOutput),
-    Apply(RunnerWorkspaceApplyOutput),
-    Prune(RunnerWorkspacePruneOutput),
+    List(Box<RunnerWorkspaceListOutput>),
+    Snapshots(Box<RunnerWorkspaceSnapshotsOutput>),
+    Sync(Box<RunnerWorkspaceSyncOutput>),
+    Update(Box<RunnerWorkspaceUpdateOutput>),
+    Pull(Box<RunnerWorkspacePullOutput>),
+    Apply(Box<RunnerWorkspaceApplyOutput>),
+    Prune(Box<RunnerWorkspacePruneOutput>),
 }
 
 #[derive(Subcommand)]
@@ -175,8 +175,9 @@ pub(super) enum RunnerWorkspaceSyncModeArg {
 pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceOutput> {
     match command {
         RunnerWorkspaceCommand::List { runner_id, limit } => {
-            runner::list_workspaces(&runner_id, limit)
-                .map(|(output, exit_code)| (RunnerWorkspaceOutput::List(output), exit_code))
+            runner::list_workspaces(&runner_id, limit).map(|(output, exit_code)| {
+                (RunnerWorkspaceOutput::List(Box::new(output)), exit_code)
+            })
         }
         RunnerWorkspaceCommand::Snapshots {
             runner_id,
@@ -195,20 +196,27 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
                 limit,
             },
         )
-        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Snapshots(output), exit_code)),
+        .map(|(output, exit_code)| {
+            (
+                RunnerWorkspaceOutput::Snapshots(Box::new(output)),
+                exit_code,
+            )
+        }),
         RunnerWorkspaceCommand::Sync {
             runner_id,
             path,
             mode,
             allow_dirty_lab_workspace,
         } => sync(&runner_id, path, mode, allow_dirty_lab_workspace)
-            .map(|(output, exit_code)| (RunnerWorkspaceOutput::Sync(output), exit_code)),
+            .map(|(output, exit_code)| (RunnerWorkspaceOutput::Sync(Box::new(output)), exit_code)),
         RunnerWorkspaceCommand::Update {
             runner_id,
             path,
             lease,
         } => runner::update_workspace(&runner_id, RunnerWorkspaceUpdateOptions { path, lease })
-            .map(|(output, exit_code)| (RunnerWorkspaceOutput::Update(output), exit_code)),
+            .map(|(output, exit_code)| {
+                (RunnerWorkspaceOutput::Update(Box::new(output)), exit_code)
+            }),
         RunnerWorkspaceCommand::Pull {
             runner_id,
             remote_path,
@@ -224,11 +232,11 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
                 dry_run,
             },
         )
-        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Pull(output), exit_code)),
-        RunnerWorkspaceCommand::Apply { input, force } => {
-            runner::apply_workspace_patch(runner::RunnerWorkspaceApplyOptions { input, force })
-                .map(|(output, exit_code)| (RunnerWorkspaceOutput::Apply(output), exit_code))
-        }
+        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Pull(Box::new(output)), exit_code)),
+        RunnerWorkspaceCommand::Apply { input, force } => runner::apply_workspace_patch(
+            runner::RunnerWorkspaceApplyOptions { input, force },
+        )
+        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Apply(Box::new(output)), exit_code)),
         RunnerWorkspaceCommand::Prune {
             runner_id,
             mutation,
@@ -255,7 +263,7 @@ pub(super) fn run(command: RunnerWorkspaceCommand) -> CmdResult<RunnerWorkspaceO
                 max_wall_time_seconds,
             },
         )
-        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Prune(output), exit_code)),
+        .map(|(output, exit_code)| (RunnerWorkspaceOutput::Prune(Box::new(output)), exit_code)),
     }
 }
 


### PR DESCRIPTION
## Summary
- migrate the Rust 1.95 runner diagnostic group while preserving runner identity, admission, timeout, and serialized output behavior
- box internal runner transport payloads so serialized JSON remains unchanged while enum stack size stays bounded
- add a focused status-output serialization assertion

## Verification
- cargo fmt --check
- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-cli
- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo clippy --no-deps -p homeboy-cli --all-targets -- -D warnings: no commands/runner diagnostics; remaining diagnostics belong to parallel CLI groups
- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo test -p homeboy-cli commands::runner --lib -- --test-threads=1: 157 passed; two pre-existing failures: dropped_transport_reconnects_to_authoritative_generation_without_replaying_events and stale_daemon_status_hint_labels_control_plane_and_job_binary

Refs #11580

## AI assistance
OpenAI openai/gpt-5.6-sol via OpenCode implemented and verified the scoped runner diagnostic migration; Chris Huber remains responsible for every line.