### PR TITLE
fix(cli): migrate command idiom diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -622,9 +622,8 @@ fn rendered_plan(plan: &daemon::recovery_actions::DaemonRecoveryPlan) -> String 
 fn legacy_child_recovery_migration_error() -> Error {
     Error::validation_invalid_argument(
         "recover_missing_child_identity",
-        format!(
-            "--recover-missing-child-identity is migration-only. Recover each job with exact persisted evidence instead"
-        ),
+        "--recover-missing-child-identity is migration-only. Recover each job with exact persisted evidence instead"
+            .to_string(),
         None,
         Some(vec![
             "Use `homeboy daemon recover-missing-child-identity --lease-id <expected-lease> --recorded-daemon-pid <recorded-daemon-pid> --recorded-daemon-endpoint <recorded-daemon-endpoint> --job-id <job-id> --child-pid <child-pid> --child-starttime-ticks <child-starttime-ticks>`.".to_string(),

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -142,7 +142,7 @@ pub fn ensure_worker() -> homeboy::core::Result<()> {
 }
 
 pub fn restart_worker_if_pending() -> homeboy::core::Result<()> {
-    restart_worker_if_pending_with(deferred_workload::worker_is_live, || ensure_worker())
+    restart_worker_if_pending_with(deferred_workload::worker_is_live, ensure_worker)
 }
 
 fn ensure_worker_with(
@@ -285,7 +285,7 @@ pub(crate) fn run_worker_with(
             format!("{} via {runner_id}", record.id),
         )?;
         deferred_workload::append_worker_log(format!("claimed {} via {runner_id}", record.id))?;
-        let success = match dispatch(&record, &runner_id, owner) {
+        let success = match dispatch(&record, runner_id, owner) {
             Ok(success) => success,
             Err(error) if error.message == CAPABILITY_MISMATCH_ERROR => {
                 deferred_workload::defer_claim(&record.id, owner)?;

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -664,7 +664,7 @@ fn runner_diff_installed(
         RunnerKind::Local => {
             let output = Command::new(homeboy_path)
                 .args(["extension", "diff-installed"])
-                .args(extension_id.into_iter())
+                .args(extension_id)
                 .output()
                 .map_err(|err| {
                     homeboy::core::Error::internal_io(

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -335,7 +335,7 @@ pub fn route_after_parse_with_provenance(
         lab_route_source_path_args(&cli.command, normalized_args, capture_mutation_patch);
     let routed_args = rewritten_args.as_deref().unwrap_or(normalized_args);
     let generic_detached_source_path = needs_generic_detached_handoff
-        .then(|| source_path_for_generic_detached_lab_handoff(&normalized_args))
+        .then(|| source_path_for_generic_detached_lab_handoff(normalized_args))
         .transpose()?;
     // Resolve this once on the controller. The decision records the same source
     // worktree that will be snapshotted, never an ambient identity inferred by a
@@ -1128,7 +1128,7 @@ pub(crate) fn reconstruct_cook_attempt_dispatcher(
             recipe
                 .get("detach_after_handoff")
                 .cloned()
-                .unwrap_or_else(|| serde_json::json!(false)),
+                .unwrap_or(serde_json::json!(false)),
         )?,
         source_path: decode_cook_dispatch_field("source_path", value("source_path")?)?,
         job_overrides: runners::LabJobOverrides {
@@ -3025,7 +3025,7 @@ fn agent_task_fanout_cook_batch_dispatch_id(
             .issues
             .first()
             .and_then(|issue| issue.split_once("/issues/").map(|(_, number)| number))
-            .and_then(|number| number.split(|c| matches!(c, '/' | '?' | '#')).next())
+            .and_then(|number| number.split(['/', '?', '#']).next())
             .filter(|value| !value.is_empty())
             .unwrap_or("batch");
         format!(

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -388,7 +388,7 @@ mod tests {
 
         let error =
             homeboy::core::Error::validation_invalid_argument("test", "invalid", None, None);
-        let expected_code = error.code.clone();
+        let expected_code = error.code;
         let run = command_run_with_summary((Err(error.clone()), 2), |_, _| {
             panic!("renderer must not run for errors")
         });

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -537,7 +537,7 @@ fn open_test_artifact_no_follow(
 
     #[cfg(unix)]
     {
-        return open_test_artifact_no_follow_unix(files_root, relative_path);
+        open_test_artifact_no_follow_unix(files_root, relative_path)
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -183,9 +183,7 @@ fn top_level_runner_exec_index(args: &[String]) -> Option<usize> {
         let flag = flags.iter().find(|flag| {
             arg == &flag.flag || (flag.takes_value && arg.strip_prefix(&flag.flag) == Some("="))
         });
-        let Some(flag) = flag else {
-            return None;
-        };
+        let flag = flag?;
         index += usize::from(flag.takes_value && arg == &flag.flag) + 1;
     }
 

--- a/crates/homeboy-cli/src/deferred_workload.rs
+++ b/crates/homeboy-cli/src/deferred_workload.rs
@@ -349,6 +349,8 @@ pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
     let path = root.join("deferred-workload-worker-start.lock");
     let file = OpenOptions::new()
         .create(true)
+        // This is an advisory lock file; retain its contents for concurrent holders.
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&path)
@@ -499,6 +501,8 @@ fn update<T>(mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>) -> Re
     }
     let lock = OpenOptions::new()
         .create(true)
+        // This is an advisory lock file, not the workload store being replaced below.
+        .truncate(false)
         .read(true)
         .write(true)
         .open(path.with_extension("lock"))


### PR DESCRIPTION
## Summary

- clear the Rust 1.95 command-idiom diagnostics in daemon, deferred workload, extension, test, routing, JSON output, and argument utilities
- preserve command behavior, response schemas, side-effect ordering, and diagnostics
- keep enum layout changes isolated to the sibling output-enum stack

Refs #11580

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib commands::deferred_workload::tests --no-fail-fast` (7 passed)
- scoped no-dependency Clippy reduced CLI failures from 77 to 66; remaining diagnostics belong to sibling stacked shards

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode identified and migrated the assigned Rust 1.95 command idioms, preserved the owning command contracts, and ran focused verification. Chris Huber remains responsible for every line.