### PR TITLE
fix(extension): resolve Rust 1.95 idioms

### DIFF
--- a/crates/homeboy-extension/src/bench/artifact_persistence.rs
+++ b/crates/homeboy-extension/src/bench/artifact_persistence.rs
@@ -422,15 +422,12 @@ fn resolve_bench_artifact_file_pointer(
     }
 
     let filename = url.and_then(artifact_filename_from_url)?;
-    for candidate in [
+    [
         run_dir.path().join("artifacts").join(&filename),
         run_dir.path().join(&filename),
-    ] {
-        if candidate.is_file() || candidate.is_dir() {
-            return Some(candidate);
-        }
-    }
-    None
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file() || candidate.is_dir())
 }
 
 fn artifact_filename_from_url(url: &str) -> Option<String> {

--- a/crates/homeboy-extension/src/bench/parsing/mod.rs
+++ b/crates/homeboy-extension/src/bench/parsing/mod.rs
@@ -281,8 +281,8 @@ fn scenario_ids_with_single_preferred_workspace_source(
 ) -> BTreeSet<String> {
     let duplicates = duplicate_scenario_sources(scenarios, Some(workspace));
     duplicates
-        .into_iter()
-        .filter_map(|(id, _)| {
+        .into_keys()
+        .filter_map(|id| {
             let preferred_paths = scenarios
                 .iter()
                 .filter(|scenario| {

--- a/crates/homeboy-extension/src/lifecycle/source_metadata.rs
+++ b/crates/homeboy-extension/src/lifecycle/source_metadata.rs
@@ -27,7 +27,7 @@ pub fn resolve_source_url_read_only(extension_id: &str) -> Result<String> {
             is_extension_linked(extension_id)
                 .then(|| git::remote_origin_url(&extension_dir))
                 .flatten()
-                .and_then(|url| normalize_source_url(url))
+                .and_then(normalize_source_url)
         })
         .ok_or_else(|| missing_source_url_error(extension_id, extension.extension_path.as_deref()))
 }

--- a/crates/homeboy-extension/src/lifecycle/update.rs
+++ b/crates/homeboy-extension/src/lifecycle/update.rs
@@ -351,9 +351,6 @@ fn linked_extension_git_root(extension_id: &str, source_dir: &Path) -> Result<Pa
     )))
 }
 
-/// Read the source revision for an installed extension.
-/// Checks (in order): .git directory (git rev-parse), then .source-revision file.
-
 fn source_metadata_file(extension_dir: &std::path::Path, kind: &str) -> String {
     if extension_dir.is_symlink() {
         if let Some(name) = extension_dir.file_name().and_then(|name| name.to_str()) {

--- a/crates/homeboy-extension/src/test/analyze.rs
+++ b/crates/homeboy-extension/src/test/analyze.rs
@@ -76,7 +76,7 @@ pub fn analyze(component: &str, input: &TestAnalysisInput) -> TestAnalysis {
         .collect();
 
     // Step 3: Sort by count descending
-    clusters.sort_by(|a, b| b.count.cmp(&a.count));
+    clusters.sort_by_key(|cluster| std::cmp::Reverse(cluster.count));
 
     // Step 4: Generate hints
     let hints = generate_hints(&clusters, failures.len());

--- a/crates/homeboy-extension/src/test/drift.rs
+++ b/crates/homeboy-extension/src/test/drift.rs
@@ -519,7 +519,7 @@ pub fn declares_test_function(contents: &str) -> bool {
         };
         let head = attr
             .trim_start()
-            .split(|c| c == '(' || c == ']' || c == ',')
+            .split(['(', ']', ','])
             .next()
             .unwrap_or("")
             .trim();
@@ -585,7 +585,7 @@ fn is_docs_or_config_path(path: &str) -> bool {
     DOC_CONFIG_SUFFIXES
         .iter()
         .any(|suffix| file_name.ends_with(suffix))
-        || DOC_CONFIG_NAMES.iter().any(|name| file_name == *name)
+        || DOC_CONFIG_NAMES.contains(&file_name)
         || lower.starts_with("docs/")
         || lower.contains("/docs/")
         || lower.starts_with(".github/")
@@ -1460,7 +1460,7 @@ mod workspace_layout_tests {
     /// those files as source; otherwise a change to any member crate is
     /// invisible to drift detection AND to the `#8340` fail-closed guard, so the
     /// gate reports green without running that crate's tests.
-
+    ///
     /// The regression that motivated this: `76c8c99a8` changed
     /// `crates/homeboy-lab-runner/src/lab/offload/hydration.rs` and broke two
     /// `#[cfg(test)] mod tests` cases inside that very crate. Drift only maps a

--- a/crates/homeboy-extension/src/test/report.rs
+++ b/crates/homeboy-extension/src/test/report.rs
@@ -262,15 +262,14 @@ fn test_phase_failure(
         };
     }
 
-    let category = if has_findings {
-        PhaseFailureCategory::Findings
-    } else if exit_code != 0 && counts.map(|counts| counts.total == 0).unwrap_or(false) {
-        PhaseFailureCategory::Findings
-    } else if exit_code != 0 && counts.map(|counts| counts.failed == 0).unwrap_or(false) {
-        PhaseFailureCategory::Infrastructure
-    } else {
-        phase_failure_category_from_exit_code(exit_code)
-    };
+    let category =
+        if has_findings || (exit_code != 0 && counts.is_some_and(|counts| counts.total == 0)) {
+            PhaseFailureCategory::Findings
+        } else if exit_code != 0 && counts.map(|counts| counts.failed == 0).unwrap_or(false) {
+            PhaseFailureCategory::Infrastructure
+        } else {
+            phase_failure_category_from_exit_code(exit_code)
+        };
     PhaseFailure {
         phase: VerificationPhase::Test,
         summary: match category {

--- a/crates/homeboy-extension/src/validation.rs
+++ b/crates/homeboy-extension/src/validation.rs
@@ -25,7 +25,7 @@ pub fn validate_required_extensions(component: &homeboy_core::component::Compone
         return Ok(());
     }
 
-    missing.sort_by(|(left, _), (right, _)| left.cmp(right));
+    missing.sort_by_key(|(id, _)| *id);
 
     let missing_ids: Vec<String> = missing.iter().map(|(id, _)| (*id).clone()).collect();
     let extension_list = missing_ids.join(", ");


### PR DESCRIPTION
Refs #11580

Resolves the remaining Rust 1.95 mechanical Clippy diagnostics in the extension lifecycle, benchmark artifact/parser, test, and validation code.

Validation:
- cargo fmt --check
- cargo check -p homeboy-extension
- focused parser, analysis, drift, report, and validation tests
- cargo clippy -p homeboy-extension --all-targets

Known test issue: `lifecycle::tests::linked_install_fails_and_rolls_back_when_declared_provider_is_not_discoverable` reproducibly fails because the fixture installation succeeds rather than rejecting its declared provider. This is outside this change set; update and source-metadata lifecycle tests pass.

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode used to identify and apply the mechanical Rust 1.95 idiom migrations; Chris remains responsible for the changes.