### PR TITLE
fix(tunnel): resolve Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-fuzz/src/proof.rs
+++ b/crates/homeboy-fuzz/src/proof.rs
@@ -303,7 +303,7 @@ pub fn derive_fuzz_proof(run: &RunRecord) -> Option<FuzzProof> {
     let overall = metadata
         .get("success")
         .and_then(Value::as_bool)
-        .unwrap_or_else(|| matches!(run.status.as_str(), "pass" | "passed"));
+        .unwrap_or(matches!(run.status.as_str(), "pass" | "passed"));
 
     let failed_case_ids: Vec<String> = cases
         .as_ref()

--- a/crates/homeboy-tunnel/src/preview_client/mod.rs
+++ b/crates/homeboy-tunnel/src/preview_client/mod.rs
@@ -359,6 +359,8 @@ fn forward_to_local_origin_result(
 /// request when the upstream fails with a transient connection-level error.
 const LOCAL_ORIGIN_MAX_ATTEMPTS: u32 = 4;
 
+type LocalOriginResponse = (u16, Vec<(String, String)>, reqwest::blocking::Response);
+
 /// Build the HTTP client used to forward requests to the local preview origin.
 ///
 /// Keep-alive connection pooling is disabled (`pool_max_idle_per_host(0)`): under
@@ -395,10 +397,7 @@ fn open_local_origin_response(
     client: &Client,
     local_origin: &str,
     request: &PreviewIngressRequest,
-) -> std::result::Result<
-    (u16, Vec<(String, String)>, reqwest::blocking::Response),
-    PreviewClientForwardError,
-> {
+) -> std::result::Result<LocalOriginResponse, PreviewClientForwardError> {
     let method: reqwest::Method =
         request
             .method

--- a/crates/homeboy-tunnel/src/preview_consumer.rs
+++ b/crates/homeboy-tunnel/src/preview_consumer.rs
@@ -19,19 +19,14 @@ use serde_json::Value;
 use crate::status as tunnel_status;
 
 /// Execution mode for a preview consumer run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PreviewConsumerRunMode {
     /// Run the command to completion and record output after it exits.
+    #[default]
     Blocking,
     /// Start the command under supervision and return as soon as the preview is
     /// ready (or the readiness wait elapses), leaving the command running.
     NonBlocking,
-}
-
-impl Default for PreviewConsumerRunMode {
-    fn default() -> Self {
-        Self::Blocking
-    }
 }
 
 /// Lifecycle status reported by a preview consumer run.


### PR DESCRIPTION
## Summary
- factor the local-origin response tuple into a named type
- derive the preview consumer blocking default
- use eager fallback evaluation for the fuzz verdict

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo check -p homeboy-tunnel -p homeboy-fuzz`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-tunnel --lib preview_client`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-tunnel --lib preview_consumer`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-fuzz --lib proof`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo clippy -p homeboy-tunnel -p homeboy-fuzz --all-targets -- -D warnings`

Refs #11580

AI assistance: OpenAI `openai/gpt-5.6-sol` via OpenCode identified and applied Rust 1.95 Clippy diagnostic fixes; Chris remains responsible for every line.