### PR TITLE
fix(extension): resolve design diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -201,7 +201,7 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
         }),
     );
     Ok((
-        TraceCommandOutput::Compare(compare),
+        TraceCommandOutput::Compare(Box::new(compare)),
         if failed { 1 } else { 0 },
     ))
 }

--- a/crates/homeboy-cli/src/commands/trace/compare_variant.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_variant.rs
@@ -115,7 +115,7 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     } else {
         1
     };
-    Ok((TraceCommandOutput::Compare(compare), exit_code))
+    Ok((TraceCommandOutput::Compare(Box::new(compare)), exit_code))
 }
 
 fn run_compare_variant_pair(
@@ -336,7 +336,7 @@ fn run_repeat_output(
 ) -> homeboy::core::Result<extension_trace::TraceAggregateOutput> {
     let (output, _exit_code) = run_repeat(args)?;
     match output {
-        TraceCommandOutput::Aggregate(aggregate) => Ok(aggregate),
+        TraceCommandOutput::Aggregate(aggregate) => Ok(*aggregate),
         _ => Err(homeboy::core::Error::internal_unexpected(
             "trace compare-variant expected aggregate output",
         )),

--- a/crates/homeboy-cli/src/commands/trace/matrix.rs
+++ b/crates/homeboy-cli/src/commands/trace/matrix.rs
@@ -416,7 +416,7 @@ fn run_variant_aggregate(
     run_args.variants = Vec::new();
     run_args.output_dir = None;
     match run_repeat(run_args)?.0 {
-        TraceCommandOutput::Aggregate(output) => Ok(output),
+        TraceCommandOutput::Aggregate(output) => Ok(*output),
         _ => unreachable!("run_repeat returns aggregate output"),
     }
 }

--- a/crates/homeboy-cli/src/commands/trace/output.rs
+++ b/crates/homeboy-cli/src/commands/trace/output.rs
@@ -175,7 +175,7 @@ pub(super) fn run_compare(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             compare: &output,
         })?;
     }
-    Ok((TraceCommandOutput::Compare(output), exit_code))
+    Ok((TraceCommandOutput::Compare(Box::new(output)), exit_code))
 }
 
 fn required_compare_path_arg<T>(value: Option<T>, field: &'static str) -> homeboy::core::Result<T> {

--- a/crates/homeboy-cli/src/commands/trace/repeat.rs
+++ b/crates/homeboy-cli/src/commands/trace/repeat.rs
@@ -205,7 +205,7 @@ pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         profile: resolved_profile_output_for_args(&args),
     };
 
-    Ok((TraceCommandOutput::Aggregate(output), exit_code))
+    Ok((TraceCommandOutput::Aggregate(Box::new(output)), exit_code))
 }
 
 pub(super) fn focus_aggregate_spans(

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -211,7 +211,7 @@ struct ProviderChangedScopeResponse {
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum BuildResult {
-    Single(BuildOutput),
+    Single(Box<BuildOutput>),
     Bulk(BulkResult<BuildOutput>),
 }
 
@@ -315,7 +315,7 @@ fn run_single_changed_since(
     changed_since: Option<&str>,
 ) -> Result<(BuildResult, i32)> {
     let (output, exit_code) = execute_build(component_id, None, changed_since)?;
-    Ok((BuildResult::Single(output), exit_code))
+    Ok((BuildResult::Single(Box::new(output)), exit_code))
 }
 
 /// Build a single component with an overridden local_path.
@@ -332,7 +332,7 @@ pub fn run_with_path_changed_since(
     changed_since: Option<&str>,
 ) -> Result<(BuildResult, i32)> {
     let (output, exit_code) = execute_build(component_id, Some(path), changed_since)?;
-    Ok((BuildResult::Single(output), exit_code))
+    Ok((BuildResult::Single(Box::new(output)), exit_code))
 }
 
 fn run_bulk_changed_since(
@@ -374,7 +374,7 @@ pub fn run_component_with_changed_since(
     changed_since: Option<&str>,
 ) -> Result<(BuildResult, i32)> {
     let (output, exit_code) = execute_build_component(component, changed_since)?;
-    Ok((BuildResult::Single(output), exit_code))
+    Ok((BuildResult::Single(Box::new(output)), exit_code))
 }
 
 /// Build multiple pre-resolved components.
@@ -517,13 +517,15 @@ fn execute_build_component(
     let runner_output = if let ResolvedBuildCommand::ComponentScript { .. } = &resolved {
         crate::component_script::run_component_scripts_with_run_dir_and_timeout(
             comp,
-            extension::ExtensionCapability::Build,
-            &validated_path,
-            &run_dir,
-            true,
-            &build_env(changed_since, changed_scope.as_ref()),
-            &[],
-            Some(build_timeout),
+            crate::component_script::ComponentScriptRunRequest {
+                capability: extension::ExtensionCapability::Build,
+                source_path: &validated_path,
+                run_dir: &run_dir,
+                passthrough: true,
+                extra_env: &build_env(changed_since, changed_scope.as_ref()),
+                script_args: &[],
+                timeout: Some(build_timeout),
+            },
         )?
         .into()
     } else if let Some(context) = build_context {
@@ -976,6 +978,27 @@ mod tests {
             "HOMEBOY_BUILD_SCOPE_OUTCOME".to_string(),
             "full".to_string()
         )));
+    }
+
+    #[test]
+    fn build_result_single_serializes_with_the_existing_output_shape() {
+        let result = BuildResult::Single(Box::new(BuildOutput {
+            command: "build.run".to_string(),
+            component_id: "example".to_string(),
+            build_command: "make build".to_string(),
+            active_env_keys: Vec::new(),
+            output: CapturedOutput::new(String::new(), String::new()),
+            artifact_inputs: Vec::new(),
+            extension_phase_timings: Vec::new(),
+            changed_scope: None,
+            success: true,
+        }));
+
+        let value = serde_json::to_value(result).expect("build result serializes");
+
+        assert_eq!(value["command"], "build.run");
+        assert_eq!(value["component_id"], "example");
+        assert!(value.get("Single").is_none());
     }
 }
 

--- a/crates/homeboy-extension/src/component_script.rs
+++ b/crates/homeboy-extension/src/component_script.rs
@@ -168,40 +168,47 @@ pub fn run_component_scripts_with_run_dir(
 ) -> Result<ComponentScriptOutput> {
     run_component_scripts_with_run_dir_and_timeout(
         component,
-        capability,
-        source_path,
-        run_dir,
-        passthrough,
-        extra_env,
-        script_args,
-        None,
+        ComponentScriptRunRequest {
+            capability,
+            source_path,
+            run_dir,
+            passthrough,
+            extra_env,
+            script_args,
+            timeout: None,
+        },
     )
+}
+
+pub(crate) struct ComponentScriptRunRequest<'a> {
+    pub capability: ExtensionCapability,
+    pub source_path: &'a Path,
+    pub run_dir: &'a RunDir,
+    pub passthrough: bool,
+    pub extra_env: &'a [(String, String)],
+    pub script_args: &'a [String],
+    pub timeout: Option<Duration>,
 }
 
 pub(crate) fn run_component_scripts_with_run_dir_and_timeout(
     component: &Component,
-    capability: ExtensionCapability,
-    source_path: &Path,
-    run_dir: &RunDir,
-    passthrough: bool,
-    extra_env: &[(String, String)],
-    script_args: &[String],
-    timeout: Option<Duration>,
+    request: ComponentScriptRunRequest<'_>,
 ) -> Result<ComponentScriptOutput> {
-    let mut env = run_dir.legacy_env_vars();
-    let invocation = InvocationGuard::acquire(run_dir, &InvocationRequirements::default())?;
+    let mut env = request.run_dir.legacy_env_vars();
+    let invocation = InvocationGuard::acquire(request.run_dir, &InvocationRequirements::default())?;
     env.extend(invocation.env_vars());
-    env.extend(extra_env.iter().cloned());
+    env.extend(request.extra_env.iter().cloned());
     let mut output = run_component_scripts_with_env_and_timeout(
         component,
-        capability,
-        source_path,
-        passthrough,
+        request.capability,
+        request.source_path,
+        request.passthrough,
         &env,
-        script_args,
-        timeout,
+        request.script_args,
+        request.timeout,
     )?;
-    output.extension_phase_timings = super::runner::read_extension_phase_timings(run_dir.path())?;
+    output.extension_phase_timings =
+        super::runner::read_extension_phase_timings(request.run_dir.path())?;
     Ok(output)
 }
 

--- a/crates/homeboy-extension/src/lint/mod.rs
+++ b/crates/homeboy-extension/src/lint/mod.rs
@@ -15,6 +15,25 @@ pub use run::{
 
 use homeboy_core::engine::run_dir::RunDir;
 
+pub type LintStringSettings = Vec<(String, String)>;
+pub type LintJsonSettings = Vec<(String, serde_json::Value)>;
+
+pub struct LintRunnerRequest<'a> {
+    pub component: &'a Component,
+    pub path_override: Option<String>,
+    pub settings: &'a [(String, serde_json::Value)],
+    pub summary: bool,
+    pub file: Option<&'a str>,
+    pub glob: Option<&'a str>,
+    pub errors_only: bool,
+    pub sniffs: Option<&'a str>,
+    pub exclude_sniffs: Option<&'a str>,
+    pub category: Option<&'a str>,
+    pub step: Option<&'a str>,
+    pub changed_files: Option<&'a [String]>,
+    pub run_dir: &'a RunDir,
+}
+
 pub fn resolve_lint_command(
     component: &Component,
 ) -> homeboy_core::error::Result<ExtensionExecutionContext> {
@@ -54,24 +73,9 @@ pub fn declares_lint_findings_sidecar(component: &Component) -> bool {
         .any(|declaration| declaration.name == LINT_FINDINGS_SIDECAR)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn build_lint_runner(
-    component: &Component,
-    path_override: Option<String>,
-    settings: &[(String, serde_json::Value)],
-    summary: bool,
-    file: Option<&str>,
-    glob: Option<&str>,
-    errors_only: bool,
-    sniffs: Option<&str>,
-    exclude_sniffs: Option<&str>,
-    category: Option<&str>,
-    step: Option<&str>,
-    changed_files: Option<&[String]>,
-    run_dir: &RunDir,
-) -> homeboy_core::Result<ExtensionRunner> {
-    let resolved = resolve_lint_command(component)?;
-    let (string_settings, json_settings) = split_lint_settings(settings);
+pub fn build_lint_runner(request: LintRunnerRequest<'_>) -> homeboy_core::Result<ExtensionRunner> {
+    let resolved = resolve_lint_command(request.component)?;
+    let (string_settings, json_settings) = split_lint_settings(request.settings);
 
     // Additive: hand the runner core's authoritative changed-file list, resolved
     // via the three-dot merge-base diff in `get_files_changed_since`. Downstream
@@ -79,29 +83,29 @@ pub fn build_lint_runner(
     // re-deriving a weaker two-dot diff. Leaves the var unset for full/glob runs,
     // so existing `HOMEBOY_LINT_GLOB`/`HOMEBOY_LINT_FILE`/`HOMEBOY_CHANGED_SINCE`
     // semantics are untouched.
-    let changed_files_file = write_changed_files_manifest(run_dir, changed_files)?;
+    let changed_files_file = write_changed_files_manifest(request.run_dir, request.changed_files)?;
 
     Ok(ExtensionRunner::for_context(resolved)
-        .component(component.clone())
-        .path_override(path_override)
+        .component(request.component.clone())
+        .path_override(request.path_override)
         .settings(&string_settings)
         .settings_json(&json_settings)
-        .with_run_dir(run_dir)
+        .with_run_dir(request.run_dir)
         // Summary mode captures the lint/clippy stream into evidence rather than
         // tee-ing the full warning output to the terminal, so `--summary` renders
         // only the compact findings envelope on large repositories (#9845).
-        .passthrough(!summary)
-        .env_if(summary, "HOMEBOY_SUMMARY_MODE", "1")
-        .env_opt("HOMEBOY_LINT_FILE", &file.map(str::to_string))
-        .env_opt("HOMEBOY_LINT_GLOB", &glob.map(str::to_string))
-        .env_if(errors_only, "HOMEBOY_ERRORS_ONLY", "1")
-        .env_opt("HOMEBOY_SNIFFS", &sniffs.map(str::to_string))
-        .env_opt("HOMEBOY_STEP", &step.map(str::to_string))
+        .passthrough(!request.summary)
+        .env_if(request.summary, "HOMEBOY_SUMMARY_MODE", "1")
+        .env_opt("HOMEBOY_LINT_FILE", &request.file.map(str::to_string))
+        .env_opt("HOMEBOY_LINT_GLOB", &request.glob.map(str::to_string))
+        .env_if(request.errors_only, "HOMEBOY_ERRORS_ONLY", "1")
+        .env_opt("HOMEBOY_SNIFFS", &request.sniffs.map(str::to_string))
+        .env_opt("HOMEBOY_STEP", &request.step.map(str::to_string))
         .env_opt(
             "HOMEBOY_EXCLUDE_SNIFFS",
-            &exclude_sniffs.map(str::to_string),
+            &request.exclude_sniffs.map(str::to_string),
         )
-        .env_opt("HOMEBOY_CATEGORY", &category.map(str::to_string))
+        .env_opt("HOMEBOY_CATEGORY", &request.category.map(str::to_string))
         .env_opt("HOMEBOY_LINT_CHANGED_FILES_FILE", &changed_files_file))
 }
 
@@ -135,7 +139,7 @@ fn write_changed_files_manifest(
 
 fn split_lint_settings(
     settings: &[(String, serde_json::Value)],
-) -> (Vec<(String, String)>, Vec<(String, serde_json::Value)>) {
+) -> (LintStringSettings, LintJsonSettings) {
     settings
         .iter()
         .cloned()

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -163,21 +163,21 @@ pub fn run_main_lint_workflow(
             None,
             vec![("lint runner".to_string(), args.component_label.clone())],
         )?;
-        let runner = build_lint_runner(
+        let runner = build_lint_runner(crate::lint::LintRunnerRequest {
             component,
-            args.path_override.clone(),
-            &args.settings,
-            args.summary || args.json_summary,
-            args.file.as_deref(),
-            args.glob.as_deref(),
-            args.sniff_filters.errors_only,
-            args.sniff_filters.sniffs.as_deref(),
-            args.sniff_filters.exclude_sniffs.as_deref(),
-            args.category.as_deref(),
-            None,
-            None,
+            path_override: args.path_override.clone(),
+            settings: &args.settings,
+            summary: args.summary || args.json_summary,
+            file: args.file.as_deref(),
+            glob: args.glob.as_deref(),
+            errors_only: args.sniff_filters.errors_only,
+            sniffs: args.sniff_filters.sniffs.as_deref(),
+            exclude_sniffs: args.sniff_filters.exclude_sniffs.as_deref(),
+            category: args.category.as_deref(),
+            step: None,
+            changed_files: None,
             run_dir,
-        )?;
+        })?;
         let runner = args
             .ci_env
             .iter()
@@ -398,21 +398,21 @@ fn run_full_candidate_baseline(
     args: &LintRunWorkflowArgs,
 ) -> homeboy_core::Result<FullCandidateBaseline> {
     let full_run_dir = RunDir::create()?;
-    let runner = build_lint_runner(
+    let runner = build_lint_runner(crate::lint::LintRunnerRequest {
         component,
-        args.path_override.clone(),
-        &args.settings,
-        true,
-        None,
-        None,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        &full_run_dir,
-    )?;
+        path_override: args.path_override.clone(),
+        settings: &args.settings,
+        summary: true,
+        file: None,
+        glob: None,
+        errors_only: false,
+        sniffs: None,
+        exclude_sniffs: None,
+        category: None,
+        step: None,
+        changed_files: None,
+        run_dir: &full_run_dir,
+    })?;
     let runner = args
         .ci_env
         .iter()
@@ -477,21 +477,21 @@ fn run_scoped_lint_runs(
         let scoped_run_dir = (index > 0).then(RunDir::create).transpose()?;
         let active_run_dir = scoped_run_dir.as_ref().unwrap_or(run_dir);
 
-        let runner = build_lint_runner(
+        let runner = build_lint_runner(crate::lint::LintRunnerRequest {
             component,
-            args.path_override.clone(),
-            &args.settings,
-            args.summary || args.json_summary,
-            args.file.as_deref(),
-            Some(run.glob.as_str()),
-            args.sniff_filters.errors_only,
-            args.sniff_filters.sniffs.as_deref(),
-            args.sniff_filters.exclude_sniffs.as_deref(),
-            args.category.as_deref(),
-            run.step.as_deref(),
-            Some(run.changed_files.as_slice()),
-            active_run_dir,
-        )?;
+            path_override: args.path_override.clone(),
+            settings: &args.settings,
+            summary: args.summary || args.json_summary,
+            file: args.file.as_deref(),
+            glob: Some(run.glob.as_str()),
+            errors_only: args.sniff_filters.errors_only,
+            sniffs: args.sniff_filters.sniffs.as_deref(),
+            exclude_sniffs: args.sniff_filters.exclude_sniffs.as_deref(),
+            category: args.category.as_deref(),
+            step: run.step.as_deref(),
+            changed_files: Some(run.changed_files.as_slice()),
+            run_dir: active_run_dir,
+        })?;
         let runner = args
             .ci_env
             .iter()

--- a/crates/homeboy-extension/src/trace/assertions.rs
+++ b/crates/homeboy-extension/src/trace/assertions.rs
@@ -85,16 +85,16 @@ fn evaluate_temporal_assertion(
             p95_ms,
             p99_ms,
             message,
-        } => evaluate_latency_bound(
+        } => evaluate_latency_bound(LatencyBoundAssertionRequest {
             id,
             from,
             to,
-            *p50_ms,
-            *p95_ms,
-            *p99_ms,
-            message.as_deref(),
+            p50_ms: *p50_ms,
+            p95_ms: *p95_ms,
+            p99_ms: *p99_ms,
+            message: message.as_deref(),
             timeline,
-        ),
+        }),
         TraceTemporalAssertionDefinition::RequiredSequence {
             id,
             sequence,
@@ -361,17 +361,19 @@ fn evaluate_ordering(
     }
 }
 
-fn evaluate_latency_bound(
-    id: &str,
-    from: &str,
-    to: &str,
+struct LatencyBoundAssertionRequest<'a> {
+    id: &'a str,
+    from: &'a str,
+    to: &'a str,
     p50_ms: Option<u64>,
     p95_ms: Option<u64>,
     p99_ms: Option<u64>,
-    message: Option<&str>,
-    timeline: &[super::parsing::TraceEvent],
-) -> TraceAssertion {
-    let durations = paired_durations(timeline, from, to);
+    message: Option<&'a str>,
+    timeline: &'a [super::parsing::TraceEvent],
+}
+
+fn evaluate_latency_bound(request: LatencyBoundAssertionRequest<'_>) -> TraceAssertion {
+    let durations = paired_durations(request.timeline, request.from, request.to);
     let samples = durations
         .iter()
         .map(|duration| *duration as f64)
@@ -380,29 +382,33 @@ fn evaluate_latency_bound(
     let actual_p95 = (!samples.is_empty()).then(|| percentile(&samples, 95.0));
     let actual_p99 = (!samples.is_empty()).then(|| percentile(&samples, 99.0));
     let passed = !samples.is_empty()
-        && p50_ms.is_none_or(|limit| actual_p50.is_some_and(|actual| actual <= limit as f64))
-        && p95_ms.is_none_or(|limit| actual_p95.is_some_and(|actual| actual <= limit as f64))
-        && p99_ms.is_none_or(|limit| actual_p99.is_some_and(|actual| actual <= limit as f64));
+        && request
+            .p50_ms
+            .is_none_or(|limit| actual_p50.is_some_and(|actual| actual <= limit as f64))
+        && request
+            .p95_ms
+            .is_none_or(|limit| actual_p95.is_some_and(|actual| actual <= limit as f64))
+        && request
+            .p99_ms
+            .is_none_or(|limit| actual_p99.is_some_and(|actual| actual <= limit as f64));
 
     TraceAssertion {
-        id: id.to_string(),
+        id: request.id.to_string(),
         status: if passed {
             TraceAssertionStatus::Pass
         } else {
             TraceAssertionStatus::Fail
         },
-        message: Some(
-            message
-                .map(str::to_string)
-                .unwrap_or_else(|| latency_bound_message(from, to, durations.len(), passed)),
-        ),
+        message: Some(request.message.map(str::to_string).unwrap_or_else(|| {
+            latency_bound_message(request.from, request.to, durations.len(), passed)
+        })),
         details: Some(json!({
             "kind": "latency-bound",
-            "from": from,
-            "to": to,
-            "p50_ms": p50_ms,
-            "p95_ms": p95_ms,
-            "p99_ms": p99_ms,
+            "from": request.from,
+            "to": request.to,
+            "p50_ms": request.p50_ms,
+            "p95_ms": request.p95_ms,
+            "p99_ms": request.p99_ms,
             "actual_p50_ms": actual_p50,
             "actual_p95_ms": actual_p95,
             "actual_p99_ms": actual_p99,

--- a/crates/homeboy-extension/src/trace/canonicality.rs
+++ b/crates/homeboy-extension/src/trace/canonicality.rs
@@ -368,14 +368,16 @@ fn check_git_checkout(
     };
 
     push_git_reasons(
-        target,
-        path,
-        dirty,
-        branch.as_deref(),
-        upstream.as_deref(),
-        ahead,
-        behind,
-        trusted_exact_sha,
+        GitCheckoutState {
+            target,
+            path,
+            dirty,
+            branch: branch.as_deref(),
+            upstream: upstream.as_deref(),
+            ahead,
+            behind,
+            trusted_exact_sha,
+        },
         reasons,
     );
 
@@ -515,32 +517,37 @@ fn empty_check(target: &str, path: &Path, status: &str) -> TraceCanonicalCheck {
     }
 }
 
-fn push_git_reasons(
-    target: &str,
-    path: &Path,
+struct GitCheckoutState<'a> {
+    target: &'a str,
+    path: &'a Path,
     dirty: bool,
-    branch: Option<&str>,
-    upstream: Option<&str>,
+    branch: Option<&'a str>,
+    upstream: Option<&'a str>,
     ahead: Option<u32>,
     behind: Option<u32>,
     trusted_exact_sha: bool,
-    reasons: &mut Vec<String>,
-) {
-    if dirty {
-        reasons.push(format!("{} checkout is dirty: {}", target, path.display()));
-    }
-    if branch == Some("HEAD") && !trusted_exact_sha {
+}
+
+fn push_git_reasons(checkout: GitCheckoutState<'_>, reasons: &mut Vec<String>) {
+    if checkout.dirty {
         reasons.push(format!(
-            "{} checkout is detached: {}",
-            target,
-            path.display()
+            "{} checkout is dirty: {}",
+            checkout.target,
+            checkout.path.display()
         ));
     }
-    if upstream.is_none() && !trusted_exact_sha {
+    if checkout.branch == Some("HEAD") && !checkout.trusted_exact_sha {
+        reasons.push(format!(
+            "{} checkout is detached: {}",
+            checkout.target,
+            checkout.path.display()
+        ));
+    }
+    if checkout.upstream.is_none() && !checkout.trusted_exact_sha {
         reasons.push(format!(
             "{} checkout has no upstream branch: {}",
-            target,
-            path.display()
+            checkout.target,
+            checkout.path.display()
         ));
     }
     let mut push_divergence = |count: Option<u32>, direction: &str, qualifier: &str| {
@@ -548,16 +555,16 @@ fn push_git_reasons(
         if count > 0 {
             reasons.push(format!(
                 "{} checkout is {} upstream by {} {}commit(s): {}",
-                target,
+                checkout.target,
                 direction,
                 count,
                 qualifier,
-                path.display()
+                checkout.path.display()
             ));
         }
     };
-    push_divergence(behind, "behind", "");
-    push_divergence(ahead, "ahead of", "unmerged ");
+    push_divergence(checkout.behind, "behind", "");
+    push_divergence(checkout.ahead, "ahead of", "unmerged ");
 }
 
 fn checkout_status(

--- a/crates/homeboy-extension/src/trace/report.rs
+++ b/crates/homeboy-extension/src/trace/report.rs
@@ -33,9 +33,9 @@ mod envelope_types {
     #[serde(untagged)]
     pub enum TraceCommandOutput {
         Run(Box<TraceRunOutput>),
-        Summary(TraceRunSummaryOutput),
-        Aggregate(TraceAggregateOutput),
-        Compare(TraceCompareOutput),
+        Summary(Box<TraceRunSummaryOutput>),
+        Aggregate(Box<TraceAggregateOutput>),
+        Compare(Box<TraceCompareOutput>),
         Matrix(TraceVariantMatrixOutput),
         ScenarioMatrix(TraceScenarioMatrixOutput),
         List(TraceListOutput),
@@ -632,7 +632,7 @@ mod builders {
                 profile: None,
             };
             return (
-                TraceCommandOutput::Summary(output),
+                TraceCommandOutput::Summary(Box::new(output)),
                 Some(full_output),
                 exit_code,
             );
@@ -1068,6 +1068,42 @@ mod tests {
             "submit_to_cli"
         );
         assert_eq!(artifact_value["results"]["timeline"][0]["event"], "submit");
+    }
+
+    #[test]
+    fn boxed_trace_output_variants_preserve_untagged_serialization() {
+        let aggregate = TraceCommandOutput::Aggregate(Box::new(TraceAggregateOutput {
+            command: "trace.repeat",
+            passed: true,
+            status: "pass".to_string(),
+            component: "Studio".to_string(),
+            scenario_id: "create-site".to_string(),
+            phase_preset: None,
+            repeat: 1,
+            run_count: 1,
+            failure_count: 0,
+            exit_code: 0,
+            schedule: None,
+            run_order: Vec::new(),
+            rig_state: None,
+            overlays: Vec::new(),
+            runs: Vec::new(),
+            spans: Vec::new(),
+            metrics: Vec::new(),
+            guardrails: Vec::new(),
+            guardrail_failure_count: 0,
+            focus_span_ids: Vec::new(),
+            focus_spans: Vec::new(),
+            classification_summaries: Vec::new(),
+            unmatched_span_metadata_ids: Vec::new(),
+            profile: None,
+        }));
+
+        let value = serde_json::to_value(aggregate).expect("aggregate output serializes");
+
+        assert_eq!(value["command"], "trace.repeat");
+        assert_eq!(value["component"], "Studio");
+        assert!(value.get("Aggregate").is_none());
     }
 
     #[test]

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -313,21 +313,21 @@ pub(super) fn run_lint_stage(
     // Helper: build the lint runner with the current stage options.
     // Used by both the diagnostic pass and the fix-only pass.
     let build_lint_runner = |effective_glob: Option<&str>, step: Option<&str>| {
-        extension::lint::build_lint_runner(
+        extension::lint::build_lint_runner(extension::lint::LintRunnerRequest {
             component,
-            None,
+            path_override: None,
             settings,
-            false,
-            options.file.as_deref(),
-            effective_glob,
-            options.sniff_filters.errors_only,
-            options.sniff_filters.sniffs.as_deref(),
-            options.sniff_filters.exclude_sniffs.as_deref(),
-            options.category.as_deref(),
+            summary: false,
+            file: options.file.as_deref(),
+            glob: effective_glob,
+            errors_only: options.sniff_filters.errors_only,
+            sniffs: options.sniff_filters.sniffs.as_deref(),
+            exclude_sniffs: options.sniff_filters.exclude_sniffs.as_deref(),
+            category: options.category.as_deref(),
             step,
-            None,
+            changed_files: None,
             run_dir,
-        )
+        })
     };
 
     // ── Phase 1: Diagnose ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace high-arity extension internals with cohesive request/state structs and name lint settings split types.
- Box build and trace command output payloads to reduce enum sizes without changing untagged JSON envelopes.
- Add serialization compatibility coverage for boxed build and trace output.

## Verification
- `cargo fmt --check`
- `cargo check --workspace`
- Focused homeboy-extension serialization and behavior tests
- Scoped Clippy run; remaining failures are unrelated pending idiom/layout diagnostics in homeboy-extension.

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode implemented the refactor, updated direct callers, and ran the listed verification. Chris Huber remains responsible for every line.