### PR TITLE
fix(cli): resolve final idiom diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -853,7 +853,7 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
         args.setting_args.setting_json.clone(),
     );
     resolve_options.extension_overrides =
-        effective_extension_overrides(&args.extension_override.extensions, rig_spec.as_deref());
+        effective_extension_overrides(&args.extension_override.extensions, rig_spec);
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
     warn_unknown_setting_keys(

--- a/crates/homeboy-cli/src/commands/ci/failure_log_triage.rs
+++ b/crates/homeboy-cli/src/commands/ci/failure_log_triage.rs
@@ -406,11 +406,11 @@ mod engine {
             if is_relevant_log_line(line, failed_steps) {
                 let start = idx.saturating_sub(context_lines);
                 let end = (idx + context_lines + 1).min(lines.len());
-                for snippet_idx in start..end {
+                for (snippet_idx, line) in lines.iter().enumerate().take(end).skip(start) {
                     if hits.len() >= max_snippets {
                         return hits;
                     }
-                    let text = normalize_log_line(lines[snippet_idx]);
+                    let text = normalize_log_line(line);
                     if text.is_empty()
                         || hits
                             .iter()


### PR DESCRIPTION
## Summary
- resolve the remaining owned CLI idiom diagnostics without changing command schemas

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode identified and mechanically applied the Clippy fixes; Chris Huber remains responsible for the change.