### PR TITLE
fix(cli): box adapter fallback command

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/adapter.rs
+++ b/crates/homeboy-cli/src/commands/infra/adapter.rs
@@ -11,6 +11,7 @@ use crate::commands::{contract, fleet, observe};
 pub(crate) type JsonHandlerResult = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args) -> JsonHandlerResult;
 pub(crate) type LabContractResolver<Args> = fn(&Args) -> Option<LabCommandContract>;
+type CommandAdapterResult = Result<BoundCommandAdapter, Box<Commands>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CommandLabRunnerPolicy {
@@ -108,7 +109,7 @@ impl<Args> TypedCommandAdapter<Args> {
 pub(crate) fn command_adapter(
     command: Commands,
     output_file_mode: CommandOutputFileMode,
-) -> Result<BoundCommandAdapter, Commands> {
+) -> CommandAdapterResult {
     match command {
         Commands::Fleet(args) => {
             let executor = fleet::adapter(output_file_mode)
@@ -128,7 +129,7 @@ pub(crate) fn command_adapter(
                 .expect("contract adapter supports JSON execution");
             Ok(BoundCommandAdapter::bind(args, executor))
         }
-        command => Err(command),
+        command => Err(Box::new(command)),
     }
 }
 
@@ -206,6 +207,35 @@ mod tests {
             CommandOutputFileMode::None,
         )
         .is_ok());
+    }
+
+    #[test]
+    fn command_adapter_executes_migrated_command_with_unchanged_json_result() {
+        let Ok(adapter) = command_adapter(
+            parsed_command(&["homeboy", "contract", "manifest"]),
+            CommandOutputFileMode::None,
+        ) else {
+            panic!("contract manifest is adapter-backed");
+        };
+
+        let (result, exit_code) = adapter.run();
+
+        assert_eq!(exit_code, 0);
+        let json = result.expect("contract manifest JSON result");
+        assert_eq!(json["command"], "contract.manifest");
+        assert!(json["commands"].is_array());
+    }
+
+    #[test]
+    fn command_adapter_preserves_unhandled_command_for_existing_dispatch_diagnostics() {
+        let Err(command) = command_adapter(
+            parsed_command(&["homeboy", "status"]),
+            CommandOutputFileMode::None,
+        ) else {
+            panic!("status remains owned by the existing workspace dispatcher");
+        };
+
+        assert!(matches!(*command, Commands::Status(_)));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -298,7 +298,7 @@ fn dispatch(command: Commands, spec: &CommandSpec) -> (homeboy::core::Result<Val
         crate::command_contract::CommandOutputFileMode::None,
     ) {
         Ok(adapter) => return adapter.run(),
-        Err(command) => command,
+        Err(command) => *command,
     };
 
     match spec.json_family {


### PR DESCRIPTION
## Summary
Boxes only the adapter fallback Commands error to resolve the Rust 1.95 clippy::result_large_err diagnostic. JSON dispatch immediately unboxes it, preserving parsed command routing and its downstream diagnostics.

## Verification
- CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo check -p homeboy-cli
- CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-cli commands::infra::adapter::tests
- CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo clippy -p homeboy-cli --lib --no-deps -- -D clippy::result_large_err

The strict crate-wide Clippy gate remains blocked by pre-existing unrelated diagnostics in homeboy-cli; broad all-targets Clippy additionally reaches unrelated workspace crate diagnostics.

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode implemented the fix, analyzed callers and compatibility, and ran verification. Chris Huber remains responsible for every line.