### PR TITLE
fix(cli): bundle remaining command parameters

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -1720,11 +1720,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     WORKTREE_PROVIDERS_METADATA,
                     apply,
-                    0,
-                    0,
-                    output.failure_count,
-                    0,
-                    0,
+                    CleanupCategoryMetrics {
+                        candidate_count: 0,
+                        applied_count: 0,
+                        skipped_count: output.failure_count,
+                        estimated_bytes: 0,
+                        reclaimed_bytes: 0,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -1754,11 +1756,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     TERMINAL_RUNS_METADATA,
                     apply,
-                    output.candidate_run_ids.len(),
-                    output.removed_run_count,
-                    output.skipped_run_ids.len(),
-                    lifecycle_bytes,
-                    if apply { lifecycle_bytes } else { 0 },
+                    CleanupCategoryMetrics {
+                        candidate_count: output.candidate_run_ids.len(),
+                        applied_count: output.removed_run_count,
+                        skipped_count: output.skipped_run_ids.len(),
+                        estimated_bytes: lifecycle_bytes,
+                        reclaimed_bytes: if apply { lifecycle_bytes } else { 0 },
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -1829,11 +1833,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     ORPHANED_ARTIFACT_BYTES_METADATA,
                     apply,
-                    output.planned_count,
-                    output.removed_count,
-                    output.skipped_count,
-                    output.planned_size_bytes,
-                    output.removed_size_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.planned_count,
+                        applied_count: output.removed_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.planned_size_bytes,
+                        reclaimed_bytes: output.removed_size_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -1870,11 +1876,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     RUNNER_DOWNLOADS_METADATA,
                     apply,
-                    output.planned_count,
-                    output.removed_count,
-                    output.skipped_count,
-                    output.planned_size_bytes,
-                    output.removed_size_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.planned_count,
+                        applied_count: output.removed_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.planned_size_bytes,
+                        reclaimed_bytes: output.removed_size_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -1942,11 +1950,13 @@ fn cleanup_inventory_with_deadline(
                 let mut category = category_from_output(
                     RUNTIME_TMP_METADATA,
                     apply,
-                    output.planned_count,
-                    output.removed_count,
-                    output.skipped_count,
-                    output.totals.planned_size_bytes,
-                    output.totals.removed_size_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.planned_count,
+                        applied_count: output.removed_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.totals.planned_size_bytes,
+                        reclaimed_bytes: output.totals.removed_size_bytes,
+                    },
                     output,
                 )?;
                 if let Some((canonical, specialist)) = commands {
@@ -1985,11 +1995,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     LEAKED_TEST_HOMES_METADATA,
                     apply,
-                    output.planned_count,
-                    output.removed_count,
-                    output.skipped_count,
-                    output.planned_size_bytes,
-                    output.removed_size_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.planned_count,
+                        applied_count: output.removed_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.planned_size_bytes,
+                        reclaimed_bytes: output.removed_size_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -2024,11 +2036,13 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     CONTROLLER_SCRATCH_METADATA,
                     apply,
-                    output.candidate_count,
-                    output.applied_count,
-                    output.skipped_count,
-                    output.estimated_bytes,
-                    output.reclaimed_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.candidate_count,
+                        applied_count: output.applied_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.estimated_bytes,
+                        reclaimed_bytes: output.reclaimed_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -2062,15 +2076,17 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     CONTROLLER_RUNTIMES_METADATA,
                     apply,
-                    output
-                        .snapshots
-                        .iter()
-                        .filter(|snapshot| snapshot.eligible)
-                        .count(),
-                    output.removed_identities.len(),
-                    output.retained.len(),
-                    estimated_bytes,
-                    output.reclaimed_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output
+                            .snapshots
+                            .iter()
+                            .filter(|snapshot| snapshot.eligible)
+                            .count(),
+                        applied_count: output.removed_identities.len(),
+                        skipped_count: output.retained.len(),
+                        estimated_bytes,
+                        reclaimed_bytes: output.reclaimed_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -2101,11 +2117,17 @@ fn cleanup_inventory_with_deadline(
                 category_from_output(
                     SHARED_CARGO_TARGETS_METADATA,
                     apply,
-                    output.candidate_count,
-                    output.applied_count,
-                    output.skipped_count,
-                    output.candidates.iter().map(|store| store.size_bytes).sum(),
-                    output.reclaimed_bytes,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.candidate_count,
+                        applied_count: output.applied_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output
+                            .candidates
+                            .iter()
+                            .map(|store| store.size_bytes)
+                            .sum(),
+                        reclaimed_bytes: output.reclaimed_bytes,
+                    },
                     output,
                 )
                 .map(|category| vec![category])
@@ -2590,55 +2612,60 @@ fn applied_category_count(categories: &[CleanupInventoryCategory]) -> usize {
         .count()
 }
 
-fn category_from_output<T: Serialize>(
-    metadata: CleanupInventoryCategoryMetadata,
-    apply: bool,
+struct CleanupCategoryMetrics {
     candidate_count: usize,
     applied_count: usize,
     skipped_count: usize,
     estimated_bytes: u64,
     reclaimed_bytes: u64,
+}
+
+struct CleanupCategoryCommands {
+    category: &'static str,
+    canonical_cleanup_command: String,
+    specialist_command: String,
+}
+
+fn category_from_output<T: Serialize>(
+    metadata: CleanupInventoryCategoryMetadata,
+    apply: bool,
+    metrics: CleanupCategoryMetrics,
     output: T,
 ) -> homeboy::core::Result<CleanupInventoryCategory> {
     category_from_command(
-        metadata.category,
-        metadata.canonical_cleanup_command(apply),
-        metadata.specialist_command(apply).to_string(),
-        candidate_count,
-        applied_count,
-        skipped_count,
-        estimated_bytes,
-        reclaimed_bytes,
+        CleanupCategoryCommands {
+            category: metadata.category,
+            canonical_cleanup_command: metadata.canonical_cleanup_command(apply),
+            specialist_command: metadata.specialist_command(apply).to_string(),
+        },
+        metrics,
         output,
     )
 }
 
 fn category_from_command<T: Serialize>(
-    category: &'static str,
-    canonical_cleanup_command: String,
-    specialist_command: String,
-    candidate_count: usize,
-    applied_count: usize,
-    skipped_count: usize,
-    estimated_bytes: u64,
-    reclaimed_bytes: u64,
+    commands: CleanupCategoryCommands,
+    metrics: CleanupCategoryMetrics,
     output: T,
 ) -> homeboy::core::Result<CleanupInventoryCategory> {
     Ok(CleanupInventoryCategory {
-        category,
-        canonical_cleanup_command,
-        specialist_command,
+        category: commands.category,
+        canonical_cleanup_command: commands.canonical_cleanup_command,
+        specialist_command: commands.specialist_command,
         included: true,
         skipped: false,
         skip_reason: None,
         failure: None,
-        candidate_count,
-        applied_count,
-        skipped_count,
-        estimated_bytes,
-        reclaimed_bytes,
+        candidate_count: metrics.candidate_count,
+        applied_count: metrics.applied_count,
+        skipped_count: metrics.skipped_count,
+        estimated_bytes: metrics.estimated_bytes,
+        reclaimed_bytes: metrics.reclaimed_bytes,
         output: serde_json::to_value(output).map_err(|err| {
-            homeboy::core::Error::internal_json(err.to_string(), Some(category.to_string()))
+            homeboy::core::Error::internal_json(
+                err.to_string(),
+                Some(commands.category.to_string()),
+            )
         })?,
     })
 }
@@ -2650,11 +2677,13 @@ fn task_worktrees_category(
     category_from_output(
         TASK_WORKTREES_METADATA,
         apply,
-        output.counts.candidates,
-        output.counts.removed + output.counts.branches_deleted,
-        output.counts.skipped,
-        0,
-        0,
+        CleanupCategoryMetrics {
+            candidate_count: output.counts.candidates,
+            applied_count: output.counts.removed + output.counts.branches_deleted,
+            skipped_count: output.counts.skipped,
+            estimated_bytes: 0,
+            reclaimed_bytes: 0,
+        },
         output,
     )
 }
@@ -2765,14 +2794,19 @@ fn remote_workspace_category(
 ) -> homeboy::core::Result<CleanupInventoryCategory> {
     let command = runner_workspace_specialist_command(&output.runner_id, apply);
     category_from_command(
-        "remote_lab_workspaces",
-        REMOTE_LAB_WORKSPACES_METADATA.canonical_cleanup_command(apply),
-        command,
-        output.total_candidate_count,
-        output.removed.len(),
-        output.skipped.len(),
-        output.total_candidate_bytes,
-        output.total_removed_bytes,
+        CleanupCategoryCommands {
+            category: "remote_lab_workspaces",
+            canonical_cleanup_command: REMOTE_LAB_WORKSPACES_METADATA
+                .canonical_cleanup_command(apply),
+            specialist_command: command,
+        },
+        CleanupCategoryMetrics {
+            candidate_count: output.total_candidate_count,
+            applied_count: output.removed.len(),
+            skipped_count: output.skipped.len(),
+            estimated_bytes: output.total_candidate_bytes,
+            reclaimed_bytes: output.total_removed_bytes,
+        },
         output,
     )
 }
@@ -2835,14 +2869,19 @@ fn runner_binary_cache_output_category(
     specialist_command: String,
 ) -> homeboy::core::Result<CleanupInventoryCategory> {
     category_from_command(
-        RUNNER_BINARY_CACHES_METADATA.category,
-        RUNNER_BINARY_CACHES_METADATA.canonical_cleanup_command(apply),
-        specialist_command,
-        output.eligible.len(),
-        output.removed.len(),
-        output.skipped.len(),
-        output.eligible_bytes,
-        output.removed_bytes,
+        CleanupCategoryCommands {
+            category: RUNNER_BINARY_CACHES_METADATA.category,
+            canonical_cleanup_command: RUNNER_BINARY_CACHES_METADATA
+                .canonical_cleanup_command(apply),
+            specialist_command,
+        },
+        CleanupCategoryMetrics {
+            candidate_count: output.eligible.len(),
+            applied_count: output.removed.len(),
+            skipped_count: output.skipped.len(),
+            estimated_bytes: output.eligible_bytes,
+            reclaimed_bytes: output.removed_bytes,
+        },
         output,
     )
 }
@@ -3194,14 +3233,18 @@ mod count_unit_tests {
 
     fn category(name: &'static str, candidates: usize, applied: usize) -> CleanupInventoryCategory {
         category_from_command(
-            name,
-            format!("homeboy cleanup --include {name} --apply"),
-            format!("homeboy {name} --apply"),
-            candidates,
-            applied,
-            0,
-            0,
-            0,
+            CleanupCategoryCommands {
+                category: name,
+                canonical_cleanup_command: format!("homeboy cleanup --include {name} --apply"),
+                specialist_command: format!("homeboy {name} --apply"),
+            },
+            CleanupCategoryMetrics {
+                candidate_count: candidates,
+                applied_count: applied,
+                skipped_count: 0,
+                estimated_bytes: 0,
+                reclaimed_bytes: 0,
+            },
             serde_json::json!({}),
         )
         .expect("category fixture")
@@ -3991,11 +4034,13 @@ mod tests {
                 category_from_output(
                     CONTROLLER_SCRATCH_METADATA,
                     true,
-                    1,
-                    1,
-                    0,
-                    128,
-                    128,
+                    CleanupCategoryMetrics {
+                        candidate_count: 1,
+                        applied_count: 1,
+                        skipped_count: 0,
+                        estimated_bytes: 128,
+                        reclaimed_bytes: 128,
+                    },
                     serde_json::json!({ "reclaimed": "scratch" }),
                 )
                 .map(|category| vec![category])
@@ -4012,11 +4057,13 @@ mod tests {
                 category_from_output(
                     CONTROLLER_RUNTIMES_METADATA,
                     true,
-                    1,
-                    1,
-                    0,
-                    256,
-                    256,
+                    CleanupCategoryMetrics {
+                        candidate_count: 1,
+                        applied_count: 1,
+                        skipped_count: 0,
+                        estimated_bytes: 256,
+                        reclaimed_bytes: 256,
+                    },
                     serde_json::json!({ "reclaimed": "runtimes" }),
                 )
                 .map(|category| vec![category])

--- a/crates/homeboy-cli/src/commands/refactor.rs
+++ b/crates/homeboy-cli/src/commands/refactor.rs
@@ -436,15 +436,15 @@ pub fn run(args: RefactorArgs) -> CmdResult<RefactorOutput> {
             full_match_details,
             target,
             write_mode,
-        }) => transform_command::run_transform(
-            &find,
-            &replace,
-            &files,
-            &context,
+        }) => transform_command::run_transform(transform_command::TransformRequest {
+            find: &find,
+            replace: &replace,
+            files: &files,
+            context: &context,
             full_match_details,
-            &target,
-            write_mode.write,
-        ),
+            target: &target,
+            write: write_mode.write,
+        }),
 
         Some(RefactorCommand::Decompose {
             file,

--- a/crates/homeboy-cli/src/commands/refactor/transform_command.rs
+++ b/crates/homeboy-cli/src/commands/refactor/transform_command.rs
@@ -5,43 +5,36 @@ use homeboy::refactor::{self, RuleResult, TransformResult};
 use super::{run_across_targets, RefactorOutput, RefactorTargetArgs};
 use crate::commands::CmdResult;
 
-pub(super) fn run_transform(
-    find: &str,
-    replace: &str,
-    files: &str,
-    context: &str,
-    full_match_details: bool,
-    target: &RefactorTargetArgs,
-    write: bool,
-) -> CmdResult<RefactorOutput> {
-    let targets = target.resolve_targets()?;
+pub(super) struct TransformRequest<'a> {
+    pub(super) find: &'a str,
+    pub(super) replace: &'a str,
+    pub(super) files: &'a str,
+    pub(super) context: &'a str,
+    pub(super) full_match_details: bool,
+    pub(super) target: &'a RefactorTargetArgs,
+    pub(super) write: bool,
+}
+
+pub(super) fn run_transform(request: TransformRequest<'_>) -> CmdResult<RefactorOutput> {
+    let targets = request.target.resolve_targets()?;
     run_across_targets("transform", targets, |component_id, path| {
-        run_transform_single(
-            find,
-            replace,
-            files,
-            context,
-            full_match_details,
-            component_id,
-            path,
-            write,
-        )
+        run_transform_single(&request, component_id, path)
     })
 }
 
 fn run_transform_single(
-    find: &str,
-    replace: &str,
-    files: &str,
-    context: &str,
-    full_match_details: bool,
+    request: &TransformRequest<'_>,
     component_id: Option<&str>,
     path: Option<&str>,
-    write: bool,
 ) -> CmdResult<RefactorOutput> {
     let root = refactor::move_items::resolve_root(component_id, path)?;
     let set_name = "ad-hoc";
-    let set = refactor::ad_hoc_transform(find, replace, files, context);
+    let set = refactor::ad_hoc_transform(
+        request.find,
+        request.replace,
+        request.files,
+        request.context,
+    );
 
     homeboy::log_status!(
         "transform",
@@ -55,7 +48,7 @@ fn run_transform_single(
         homeboy::log_status!("info", "{}", set.description);
     }
 
-    if write {
+    if request.write {
         if let Ok(preview) = refactor::apply_transforms(
             &root,
             set_name,
@@ -77,9 +70,9 @@ fn run_transform_single(
         &root,
         set_name,
         &set,
-        write,
+        request.write,
         None,
-        if full_match_details {
+        if request.full_match_details {
             None
         } else {
             Some(refactor::DEFAULT_MATCH_DETAIL_LIMIT)
@@ -87,7 +80,7 @@ fn run_transform_single(
     )?;
 
     log_transform_rules(&result);
-    log_transform_summary(&result, write);
+    log_transform_summary(&result, request.write);
 
     let exit_code = 0;
     Ok((RefactorOutput::Transform { result }, exit_code))
@@ -175,15 +168,20 @@ mod tests {
         fs::create_dir_all(&src).expect("src dir");
         fs::write(src.join("sample.txt"), "hello world\n").expect("fixture file");
 
+        let target = RefactorTargetArgs::default();
+        let request = TransformRequest {
+            find: "NO_MATCH_TOKEN",
+            replace: "NEW",
+            files: "src/**/*.txt",
+            context: "line",
+            full_match_details: false,
+            target: &target,
+            write: false,
+        };
         let (output, exit_code) = run_transform_single(
-            "NO_MATCH_TOKEN",
-            "NEW",
-            "src/**/*.txt",
-            "line",
-            false,
+            &request,
             None,
             Some(dir.path().to_str().expect("utf8 path")),
-            false,
         )
         .expect("transform should return structured output");
 

--- a/crates/homeboy-cli/src/commands/report/performance_digest.rs
+++ b/crates/homeboy-cli/src/commands/report/performance_digest.rs
@@ -161,6 +161,19 @@ pub struct HostPressureDigest {
     pub host: BTreeMap<String, Value>,
 }
 
+struct PerformanceDigestMarkdownContext<'a> {
+    resource_summary: Option<&'a ResourceSummaryDigest>,
+    budget_findings: &'a [BudgetFindingDigest],
+    benchmark_memory: &'a [BenchmarkMemoryDigest],
+    baseline_health: &'a [BaselineHealthDiagnostic],
+    host_pressure: Option<&'a HostPressureDigest>,
+    lab_offload: &'a BTreeMap<String, String>,
+    preview: &'a BTreeMap<String, String>,
+    preview_origin_evidence: &'a [BrowserOriginEvidenceDigest],
+    gaps: &'a [String],
+    run_url: &'a str,
+}
+
 use helpers::*;
 
 pub fn render_performance_digest_from_args(
@@ -218,18 +231,18 @@ pub fn performance_digest_from_args(
 
     let budget_findings = collect_budget_findings(&bench_data);
     let benchmark_memory = collect_benchmark_memory(&bench_data);
-    let markdown = render_markdown(
-        resource_summary.as_ref(),
-        &budget_findings,
-        &benchmark_memory,
-        &baseline_health,
-        host_pressure.as_ref(),
-        &lab_offload,
-        &preview,
-        &preview_origin_evidence,
-        &gaps,
-        args.run_url.as_deref().unwrap_or_default(),
-    );
+    let markdown = render_markdown(PerformanceDigestMarkdownContext {
+        resource_summary: resource_summary.as_ref(),
+        budget_findings: &budget_findings,
+        benchmark_memory: &benchmark_memory,
+        baseline_health: &baseline_health,
+        host_pressure: host_pressure.as_ref(),
+        lab_offload: &lab_offload,
+        preview: &preview,
+        preview_origin_evidence: &preview_origin_evidence,
+        gaps: &gaps,
+        run_url: args.run_url.as_deref().unwrap_or_default(),
+    });
 
     Ok(PerformanceDigestReport {
         markdown,
@@ -601,31 +614,20 @@ mod helpers {
         })
     }
 
-    pub(super) fn render_markdown(
-        resource_summary: Option<&ResourceSummaryDigest>,
-        budget_findings: &[BudgetFindingDigest],
-        benchmark_memory: &[BenchmarkMemoryDigest],
-        baseline_health: &[BaselineHealthDiagnostic],
-        host_pressure: Option<&HostPressureDigest>,
-        lab_offload: &BTreeMap<String, String>,
-        preview: &BTreeMap<String, String>,
-        preview_origin_evidence: &[BrowserOriginEvidenceDigest],
-        gaps: &[String],
-        run_url: &str,
-    ) -> String {
+    pub(super) fn render_markdown(context: PerformanceDigestMarkdownContext<'_>) -> String {
         let mut out = String::new();
         out.push_str("## Performance Digest\n\n");
-        render_resource_summary(&mut out, resource_summary);
-        render_budget_findings(&mut out, budget_findings);
-        render_benchmark_memory(&mut out, benchmark_memory);
-        render_baseline_health(&mut out, baseline_health);
-        render_host_pressure(&mut out, host_pressure);
-        render_lab_offload(&mut out, lab_offload);
-        render_preview(&mut out, preview);
-        render_preview_origin_evidence(&mut out, preview_origin_evidence);
-        render_gaps(&mut out, gaps);
-        if !run_url.is_empty() {
-            let _ = writeln!(out, "### Full run\n- {}\n", run_url);
+        render_resource_summary(&mut out, context.resource_summary);
+        render_budget_findings(&mut out, context.budget_findings);
+        render_benchmark_memory(&mut out, context.benchmark_memory);
+        render_baseline_health(&mut out, context.baseline_health);
+        render_host_pressure(&mut out, context.host_pressure);
+        render_lab_offload(&mut out, context.lab_offload);
+        render_preview(&mut out, context.preview);
+        render_preview_origin_evidence(&mut out, context.preview_origin_evidence);
+        render_gaps(&mut out, context.gaps);
+        if !context.run_url.is_empty() {
+            let _ = writeln!(out, "### Full run\n- {}\n", context.run_url);
         }
         out
     }

--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -93,16 +93,16 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
     let candidate_path = output_dir.join("candidate.aggregate.json");
     let summary_path = output_dir.join("summary.md");
 
-    let mut compare = compare_trace_aggregates_with_focus(
-        &baseline_path,
-        aggregate_to_compare_input(&baseline_aggregate),
-        &candidate_path,
-        aggregate_to_compare_input(&candidate_aggregate),
-        &args.focus_spans,
-        args.regression_threshold,
-        args.regression_min_delta_ms,
-        &args.metric_guardrails,
-    );
+    let mut compare = compare_trace_aggregates_with_focus(super::output::TraceCompareRequest {
+        before_path: &baseline_path,
+        before: aggregate_to_compare_input(&baseline_aggregate),
+        after_path: &candidate_path,
+        after: aggregate_to_compare_input(&candidate_aggregate),
+        focus_span_ids: &args.focus_spans,
+        regression_threshold_percent: args.regression_threshold,
+        regression_min_delta_ms: args.regression_min_delta_ms,
+        metric_guardrail_specs: &args.metric_guardrails,
+    });
     compare.before_target = Some(baseline_target.input.clone());
     compare.after_target = Some(candidate_target.input.clone());
     compare.before_git_sha = baseline_target.git_sha;

--- a/crates/homeboy-cli/src/commands/trace/compare_variant.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_variant.rs
@@ -85,16 +85,16 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     compare_artifacts::write_compare_variant_json(&variant_path, &variant)?;
     compare_artifacts::write_compare_variant_json(&run_order_path, &run_order)?;
 
-    let compare = compare_trace_aggregates_with_focus(
-        &baseline_path,
-        aggregate_to_compare_input(&baseline),
-        &variant_path,
-        aggregate_to_compare_input(&variant),
-        &focus_spans,
-        regression_threshold,
+    let compare = compare_trace_aggregates_with_focus(super::output::TraceCompareRequest {
+        before_path: &baseline_path,
+        before: aggregate_to_compare_input(&baseline),
+        after_path: &variant_path,
+        after: aggregate_to_compare_input(&variant),
+        focus_span_ids: &focus_spans,
+        regression_threshold_percent: regression_threshold,
         regression_min_delta_ms,
-        &metric_guardrails,
-    );
+        metric_guardrail_specs: &metric_guardrails,
+    });
     compare_artifacts::write_compare_variant_json(&compare_path, &compare)?;
     write_trace_compare_variant_summary(
         &summary_path,

--- a/crates/homeboy-cli/src/commands/trace/matrix.rs
+++ b/crates/homeboy-cli/src/commands/trace/matrix.rs
@@ -347,16 +347,16 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
         let aggregate_path = output_dir.join(format!("{}.aggregate.json", slug));
         let compare_path = output_dir.join(format!("{}.compare.json", slug));
         write_json_artifact(&aggregate_path, &aggregate)?;
-        let compare = compare_trace_aggregates_with_focus(
-            &baseline_path,
-            aggregate_to_compare_input(&baseline),
-            &aggregate_path,
-            aggregate_to_compare_input(&aggregate),
-            &args.focus_spans,
-            args.regression_threshold,
-            args.regression_min_delta_ms,
-            &args.metric_guardrails,
-        );
+        let compare = compare_trace_aggregates_with_focus(super::output::TraceCompareRequest {
+            before_path: &baseline_path,
+            before: aggregate_to_compare_input(&baseline),
+            after_path: &aggregate_path,
+            after: aggregate_to_compare_input(&aggregate),
+            focus_span_ids: &args.focus_spans,
+            regression_threshold_percent: args.regression_threshold,
+            regression_min_delta_ms: args.regression_min_delta_ms,
+            metric_guardrail_specs: &args.metric_guardrails,
+        });
         write_json_artifact(&compare_path, &compare)?;
         if !aggregate.passed
             || compare.focus_status.as_deref() == Some("fail")

--- a/crates/homeboy-cli/src/commands/trace/observations.rs
+++ b/crates/homeboy-cli/src/commands/trace/observations.rs
@@ -149,36 +149,36 @@ fn record_declared_artifact(
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             result.missing_declared_artifacts += 1;
-            record_declared_artifact_finding(
+            record_declared_artifact_finding(DeclaredArtifactFinding {
                 store,
                 run_id,
-                "trace.artifact.missing",
-                "error",
-                format!(
+                rule: "trace.artifact.missing",
+                severity: "error",
+                message: format!(
                     "trace result declared artifact '{}' at '{}', but the path does not exist",
                     artifact.label, artifact.path
                 ),
                 artifact,
                 run_root,
                 resolved,
-            );
+            });
             return;
         }
         Err(error) => {
             result.invalid_declared_artifacts += 1;
-            record_declared_artifact_finding(
+            record_declared_artifact_finding(DeclaredArtifactFinding {
                 store,
                 run_id,
-                "trace.artifact.metadata_error",
-                "error",
-                format!(
+                rule: "trace.artifact.metadata_error",
+                severity: "error",
+                message: format!(
                     "trace result declared artifact '{}' at '{}' could not be inspected: {error}",
                     artifact.label, artifact.path
                 ),
                 artifact,
                 run_root,
                 resolved,
-            );
+            });
             return;
         }
     };
@@ -189,19 +189,19 @@ fn record_declared_artifact(
         store.record_directory_artifact(run_id, "trace-artifact", resolved)
     } else {
         result.invalid_declared_artifacts += 1;
-        record_declared_artifact_finding(
+        record_declared_artifact_finding(DeclaredArtifactFinding {
             store,
             run_id,
-            "trace.artifact.unsupported_type",
-            "error",
-            format!(
+            rule: "trace.artifact.unsupported_type",
+            severity: "error",
+            message: format!(
                 "trace result declared artifact '{}' at '{}' is neither a file nor a directory",
                 artifact.label, artifact.path
             ),
             artifact,
             run_root,
             resolved,
-        );
+        });
         return;
     };
 
@@ -214,19 +214,19 @@ fn record_declared_artifact(
         Err(error) => {
             result.invalid_declared_artifacts += 1;
             result.persistence_failures += 1;
-            record_declared_artifact_finding(
+            record_declared_artifact_finding(DeclaredArtifactFinding {
                 store,
                 run_id,
-                "trace.artifact.record_failed",
-                "error",
-                format!(
+                rule: "trace.artifact.record_failed",
+                severity: "error",
+                message: format!(
                     "trace result declared artifact '{}' at '{}' could not be persisted: {}",
                     artifact.label, artifact.path, error.message
                 ),
                 artifact,
                 run_root,
                 resolved,
-            );
+            });
         }
     }
 }
@@ -244,19 +244,19 @@ fn record_unresolved_declared_artifact(
         .any(|component| matches!(component, std::path::Component::ParentDir))
     {
         result.invalid_declared_artifacts += 1;
-        record_declared_artifact_finding(
+        record_declared_artifact_finding(DeclaredArtifactFinding {
             store,
             run_id,
-            "trace.artifact.invalid_path",
-            "error",
-            format!(
+            rule: "trace.artifact.invalid_path",
+            severity: "error",
+            message: format!(
                 "trace result declared artifact '{}' at '{}' is outside the trace run directory",
                 artifact.label, artifact.path
             ),
             artifact,
             run_root,
-            declared_path,
-        );
+            resolved: declared_path,
+        });
         return;
     }
 
@@ -266,52 +266,54 @@ fn record_unresolved_declared_artifact(
     } else {
         run_root.join(declared_path)
     };
-    record_declared_artifact_finding(
+    record_declared_artifact_finding(DeclaredArtifactFinding {
         store,
         run_id,
-        "trace.artifact.missing",
-        "error",
-        format!(
+        rule: "trace.artifact.missing",
+        severity: "error",
+        message: format!(
             "trace result declared artifact '{}' at '{}', but the path does not exist",
             artifact.label, artifact.path
         ),
         artifact,
         run_root,
-        &resolved,
-    );
+        resolved: &resolved,
+    });
 }
 
-fn record_declared_artifact_finding(
-    store: &ObservationStore,
-    run_id: &str,
-    rule: &str,
-    severity: &str,
-    message: String,
-    artifact: &extension_trace::TraceArtifact,
-    run_root: &Path,
-    resolved: &Path,
-) {
-    let _ = store.record_finding(&NewFindingRecord {
-        run_id: run_id.to_string(),
+fn record_declared_artifact_finding(request: DeclaredArtifactFinding<'_>) {
+    let _ = request.store.record_finding(&NewFindingRecord {
+        run_id: request.run_id.to_string(),
         tool: "trace".to_string(),
-        rule: Some(rule.to_string()),
+        rule: Some(request.rule.to_string()),
         file: None,
         line: None,
-        severity: Some(severity.to_string()),
-        fingerprint: Some(format!("{rule}:{}", artifact.path)),
-        message,
+        severity: Some(request.severity.to_string()),
+        fingerprint: Some(format!("{}:{}", request.rule, request.artifact.path)),
+        message: request.message,
         fixable: Some(false),
         metadata_json: serde_json::json!({
             "declared_artifact": {
-                "label": artifact.label,
-                "path": artifact.path,
-                "resolved_path": resolved.to_string_lossy(),
-                "relative_to_run_dir": resolved.strip_prefix(run_root)
+                "label": request.artifact.label,
+                "path": request.artifact.path,
+                "resolved_path": request.resolved.to_string_lossy(),
+                "relative_to_run_dir": request.resolved.strip_prefix(request.run_root)
                     .ok()
                     .map(|path| path.to_string_lossy().to_string()),
             }
         }),
     });
+}
+
+struct DeclaredArtifactFinding<'a> {
+    store: &'a ObservationStore,
+    run_id: &'a str,
+    rule: &'a str,
+    severity: &'a str,
+    message: String,
+    artifact: &'a extension_trace::TraceArtifact,
+    run_root: &'a Path,
+    resolved: &'a Path,
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/trace/output.rs
+++ b/crates/homeboy-cli/src/commands/trace/output.rs
@@ -113,6 +113,17 @@ pub enum TraceMetricGuardrailPolicy {
     PercentDelta { max_percent: f64 },
 }
 
+pub(super) struct TraceCompareRequest<'a> {
+    pub(super) before_path: &'a Path,
+    pub(super) before: TraceAggregateInput,
+    pub(super) after_path: &'a Path,
+    pub(super) after: TraceAggregateInput,
+    pub(super) focus_span_ids: &'a [String],
+    pub(super) regression_threshold_percent: f64,
+    pub(super) regression_min_delta_ms: u64,
+    pub(super) metric_guardrail_specs: &'a [TraceMetricGuardrailSpec],
+}
+
 #[derive(Deserialize)]
 pub(super) struct TraceOverlayInput {
     pub(super) path: String,
@@ -141,16 +152,16 @@ pub(super) fn run_compare(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let after_json = read_trace_aggregate_json(&after_path)?;
     let before = parse_trace_aggregate_for_path(&before_json, &before_path)?;
     let after = parse_trace_aggregate_for_path(&after_json, &after_path)?;
-    let output = compare_trace_aggregates_with_focus(
-        &before_path,
+    let output = compare_trace_aggregates_with_focus(TraceCompareRequest {
+        before_path: &before_path,
         before,
-        &after_path,
+        after_path: &after_path,
         after,
-        &args.focus_spans,
-        args.regression_threshold,
-        args.regression_min_delta_ms,
-        &args.metric_guardrails,
-    );
+        focus_span_ids: &args.focus_spans,
+        regression_threshold_percent: args.regression_threshold,
+        regression_min_delta_ms: args.regression_min_delta_ms,
+        metric_guardrail_specs: &args.metric_guardrails,
+    });
     let exit_code = if output.focus_status.as_deref() == Some("fail")
         || output.guardrail_status.as_deref() == Some("fail")
         || output.metric_guardrail_status.as_deref() == Some("fail")
@@ -228,28 +239,32 @@ pub(super) fn compare_trace_aggregates(
     after_path: &Path,
     after: TraceAggregateInput,
 ) -> extension_trace::TraceCompareOutput {
-    compare_trace_aggregates_with_focus(
+    compare_trace_aggregates_with_focus(TraceCompareRequest {
         before_path,
         before,
         after_path,
         after,
-        &[],
-        extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-        &[],
-    )
+        focus_span_ids: &[],
+        regression_threshold_percent:
+            extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        metric_guardrail_specs: &[],
+    })
 }
 
 pub(super) fn compare_trace_aggregates_with_focus(
-    before_path: &Path,
-    before: TraceAggregateInput,
-    after_path: &Path,
-    after: TraceAggregateInput,
-    focus_span_ids: &[String],
-    regression_threshold_percent: f64,
-    regression_min_delta_ms: u64,
-    metric_guardrail_specs: &[TraceMetricGuardrailSpec],
+    request: TraceCompareRequest<'_>,
 ) -> extension_trace::TraceCompareOutput {
+    let TraceCompareRequest {
+        before_path,
+        before,
+        after_path,
+        after,
+        focus_span_ids,
+        regression_threshold_percent,
+        regression_min_delta_ms,
+        metric_guardrail_specs,
+    } = request;
     let before_spans = before
         .spans
         .into_iter()

--- a/crates/homeboy-cli/src/commands/trace/output_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/output_tests.rs
@@ -9,7 +9,7 @@ use super::output::{
     render_compare_markdown, render_trace_aggregate_evidence_markdown,
     render_trace_compare_evidence_markdown, render_trace_run_evidence_markdown, run_compare,
     TraceAggregateIdentity, TraceAggregateInput, TraceAggregateMetricInput,
-    TraceAggregateSpanInput,
+    TraceAggregateSpanInput, TraceCompareRequest,
 };
 use super::*;
 
@@ -130,16 +130,16 @@ fn trace_compare_focus_spans_report_independent_regression_status() {
         guardrail_failure_count: 0,
     };
 
-    let compare = compare_trace_aggregates_with_focus(
-        Path::new("before.json"),
+    let compare = compare_trace_aggregates_with_focus(TraceCompareRequest {
+        before_path: Path::new("before.json"),
         before,
-        Path::new("after.json"),
+        after_path: Path::new("after.json"),
         after,
-        &["focused".to_string()],
-        20.0,
-        10,
-        &[],
-    );
+        focus_span_ids: &["focused".to_string()],
+        regression_threshold_percent: 20.0,
+        regression_min_delta_ms: 10,
+        metric_guardrail_specs: &[],
+    });
 
     assert_eq!(compare.span_count, 2);
     assert_eq!(compare.spans.len(), 2);
@@ -299,20 +299,20 @@ fn trace_compare_reports_scalar_metric_deltas_and_passing_guardrails() {
         guardrail_failure_count: 0,
     };
 
-    let compare = compare_trace_aggregates_with_focus(
-        Path::new("before.json"),
+    let compare = compare_trace_aggregates_with_focus(TraceCompareRequest {
+        before_path: Path::new("before.json"),
         before,
-        Path::new("after.json"),
+        after_path: Path::new("after.json"),
         after,
-        &[],
-        20.0,
-        10,
-        &[
+        focus_span_ids: &[],
+        regression_threshold_percent: 20.0,
+        regression_min_delta_ms: 10,
+        metric_guardrail_specs: &[
             super::output::parse_metric_guardrail("request_count:required").unwrap(),
             super::output::parse_metric_guardrail("request_count:equal").unwrap(),
             super::output::parse_metric_guardrail("request_count.max:lte").unwrap(),
         ],
-    );
+    });
 
     assert_eq!(compare.metrics.len(), 1);
     assert_eq!(compare.metrics[0].id, "request_count");
@@ -357,20 +357,20 @@ fn trace_compare_fails_scalar_metric_guardrails() {
         guardrail_failure_count: 0,
     };
 
-    let compare = compare_trace_aggregates_with_focus(
-        Path::new("before.json"),
+    let compare = compare_trace_aggregates_with_focus(TraceCompareRequest {
+        before_path: Path::new("before.json"),
         before,
-        Path::new("after.json"),
+        after_path: Path::new("after.json"),
         after,
-        &[],
-        20.0,
-        10,
-        &[
+        focus_span_ids: &[],
+        regression_threshold_percent: 20.0,
+        regression_min_delta_ms: 10,
+        metric_guardrail_specs: &[
             super::output::parse_metric_guardrail("page_errors:lte").unwrap(),
             super::output::parse_metric_guardrail("page_errors:delta:0.5").unwrap(),
             super::output::parse_metric_guardrail("missing_metric:required").unwrap(),
         ],
-    );
+    });
 
     assert_eq!(compare.metric_guardrail_status.as_deref(), Some("fail"));
     assert_eq!(compare.metric_guardrail_failure_count, 3);


### PR DESCRIPTION
Refs #11580

## Summary
- Bundle cleanup category metrics and command metadata.
- Bundle transform, performance digest, trace comparison, and trace artifact-finding inputs.
- Preserve CLI arguments, serialized output, and existing sequencing.

## Validation
- `cargo fmt --all`
- `cargo check -p homeboy-cli`
- Focused homeboy-cli command tests
- `cargo clippy -p homeboy-cli --lib --no-deps -- -D clippy::too_many_arguments`

## AI assistance
Used OpenAI `openai/gpt-5.6-terra` via OpenCode to implement the internal Rust parameter-bundle refactors, update direct callers/tests, and run validation. Chris remains responsible for every line.