### PR TITLE
fix(upgrade): resolve Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -60,6 +60,19 @@ pub(crate) struct ActiveBinaryInfo {
     pub build_identity: Option<String>,
 }
 
+type UpgradeExecutionResult = Result<(bool, Option<String>, Option<String>, Option<String>)>;
+
+struct SourceSwapVerification<'a> {
+    method: InstallMethod,
+    success: bool,
+    new_version: Option<&'a str>,
+    new_build_identity: Option<&'a str>,
+    source_workspace: Option<&'a Path>,
+    built_binary: Option<&'a Path>,
+    replacement_target: Option<&'a Path>,
+    built_binary_identity: Option<&'a str>,
+}
+
 /// Bound a captured stream to a retained-byte cap, keeping the trailing bytes
 /// (the most relevant tail for a failure message) and returning the retained
 /// text plus truncation metadata. Mirrors the `bound_captured_stream` pattern
@@ -101,7 +114,7 @@ pub(crate) fn execute_upgrade(
     force: bool,
     previous_build_identity: Option<&str>,
     selected_binary_version: Option<&str>,
-) -> Result<(bool, Option<String>, Option<String>, Option<String>)> {
+) -> UpgradeExecutionResult {
     let defaults = defaults::load_defaults();
     // The binary installer replaces `command -v homeboy`. Capture that path
     // before its shell runs so verification proves the intended PATH target was
@@ -287,7 +300,7 @@ fn complete_source_upgrade(
     force: bool,
     previous_build_identity: Option<&str>,
     source_revision: Option<String>,
-) -> Result<(bool, Option<String>, Option<String>, Option<String>)> {
+) -> UpgradeExecutionResult {
     let replacement_target = replacement_target.ok_or_else(|| {
         Error::internal_unexpected("active binary path unavailable for source upgrade install")
     })?;
@@ -314,16 +327,16 @@ fn complete_source_upgrade(
         std::thread::sleep,
     );
 
-    if let Some(error) = source_swap_failure(
+    if let Some(error) = source_swap_failure(SourceSwapVerification {
         method,
         success,
-        new_version.as_deref(),
-        new_build_identity.as_deref(),
-        Some(&workspace_root),
-        Some(&built_binary),
-        Some(replacement_target),
-        previous_build_identity,
-    ) {
+        new_version: new_version.as_deref(),
+        new_build_identity: new_build_identity.as_deref(),
+        source_workspace: Some(&workspace_root),
+        built_binary: Some(&built_binary),
+        replacement_target: Some(replacement_target),
+        built_binary_identity: previous_build_identity,
+    }) {
         return Err(error);
     }
 
@@ -403,30 +416,22 @@ fn terminate_upgrade_child(child: &mut std::process::Child) {
 ///
 /// Returns `None` for every other case (verified swap, or a non-source method
 /// where a soft unverified result is reported by the caller).
-fn source_swap_failure(
-    method: InstallMethod,
-    success: bool,
-    new_version: Option<&str>,
-    new_build_identity: Option<&str>,
-    source_workspace: Option<&Path>,
-    built_binary: Option<&Path>,
-    replacement_target: Option<&Path>,
-    built_binary_identity: Option<&str>,
-) -> Option<Error> {
-    if method != InstallMethod::Source || success {
+fn source_swap_failure(verification: SourceSwapVerification<'_>) -> Option<Error> {
+    if verification.method != InstallMethod::Source || verification.success {
         return None;
     }
 
-    let observed = new_build_identity
-        .or(new_version)
+    let observed = verification
+        .new_build_identity
+        .or(verification.new_version)
         .unwrap_or("an unverifiable version");
 
     let diagnostics = source_swap_failure_diagnostics(
-        source_workspace,
-        built_binary,
-        replacement_target,
-        built_binary_identity,
-        new_build_identity,
+        verification.source_workspace,
+        verification.built_binary,
+        verification.replacement_target,
+        verification.built_binary_identity,
+        verification.new_build_identity,
     );
     let mut error = Error::internal_unexpected(format!(
         "source upgrade command exited successfully but the active binary was not replaced (still {observed})"
@@ -803,7 +808,7 @@ where
 
     for attempt in 0..attempts {
         let active_binary = read_active();
-        if active_binary.as_ref().is_some_and(|info| verified(info)) {
+        if active_binary.as_ref().is_some_and(&mut verified) {
             return (true, active_binary);
         }
 

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_b.rs
@@ -130,16 +130,16 @@ fn source_swap_failure_errors_when_active_binary_unchanged() {
     // Issue #5772: the source upgrade command exited 0 but the read-back
     // proves the active binary was not replaced — fail loudly instead of a
     // soft `upgraded: false` "completed".
-    let err = source_swap_failure(
-        InstallMethod::Source,
-        false,
-        Some("0.247.5"),
-        Some("homeboy 0.247.5+old"),
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        Some(Path::new("/active/homeboy")),
-        Some("homeboy 0.247.5+new"),
-    )
+    let err = source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Source,
+        success: false,
+        new_version: Some("0.247.5"),
+        new_build_identity: Some("homeboy 0.247.5+old"),
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: Some(Path::new("/active/homeboy")),
+        built_binary_identity: Some("homeboy 0.247.5+new"),
+    })
     .expect("unverified source swap must surface an error");
 
     assert!(err.message.contains("active binary was not replaced"));
@@ -174,16 +174,16 @@ fn source_swap_failure_errors_when_active_binary_unchanged() {
 
 #[test]
 fn source_swap_failure_reports_version_when_no_build_identity() {
-    let err = source_swap_failure(
-        InstallMethod::Source,
-        false,
-        Some("0.247.5"),
-        None,
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        None,
-        None,
-    )
+    let err = source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Source,
+        success: false,
+        new_version: Some("0.247.5"),
+        new_build_identity: None,
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: None,
+        built_binary_identity: None,
+    })
     .expect("unverified source swap must surface an error");
 
     assert!(err.message.contains("0.247.5"));
@@ -191,16 +191,16 @@ fn source_swap_failure_reports_version_when_no_build_identity() {
 
 #[test]
 fn source_swap_failure_reports_placeholder_when_version_unverifiable() {
-    let err = source_swap_failure(
-        InstallMethod::Source,
-        false,
-        None,
-        None,
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        None,
-        None,
-    )
+    let err = source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Source,
+        success: false,
+        new_version: None,
+        new_build_identity: None,
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: None,
+        built_binary_identity: None,
+    })
     .expect("unverified source swap must surface an error");
 
     assert!(err.message.contains("an unverifiable version"));
@@ -209,16 +209,16 @@ fn source_swap_failure_reports_placeholder_when_version_unverifiable() {
 #[test]
 fn source_swap_failure_silent_on_verified_swap() {
     assert!(
-        source_swap_failure(
-            InstallMethod::Source,
-            true,
-            Some("0.249.0"),
-            None,
-            Some(Path::new("/src/homeboy")),
-            Some(Path::new("/src/homeboy/target/release/homeboy")),
-            None,
-            None,
-        )
+        source_swap_failure(SourceSwapVerification {
+            method: InstallMethod::Source,
+            success: true,
+            new_version: Some("0.249.0"),
+            new_build_identity: None,
+            source_workspace: Some(Path::new("/src/homeboy")),
+            built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+            replacement_target: None,
+            built_binary_identity: None,
+        })
         .is_none(),
         "a verified source swap is not a failure"
     );
@@ -228,27 +228,27 @@ fn source_swap_failure_silent_on_verified_swap() {
 fn source_swap_failure_ignores_non_source_methods() {
     // Non-source methods keep their soft unverified reporting; only source
     // (where the swap is part of the command's contract) fails loudly here.
-    assert!(source_swap_failure(
-        InstallMethod::Binary,
-        false,
-        Some("0.247.5"),
-        None,
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        None,
-        None,
-    )
+    assert!(source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Binary,
+        success: false,
+        new_version: Some("0.247.5"),
+        new_build_identity: None,
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: None,
+        built_binary_identity: None,
+    })
     .is_none());
-    assert!(source_swap_failure(
-        InstallMethod::Secondary,
-        false,
-        Some("0.247.5"),
-        None,
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        None,
-        None,
-    )
+    assert!(source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Secondary,
+        success: false,
+        new_version: Some("0.247.5"),
+        new_build_identity: None,
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: None,
+        built_binary_identity: None,
+    })
     .is_none());
 }
 
@@ -260,16 +260,16 @@ fn source_swap_failure_diagnostics_use_replacement_target_path() {
     std::fs::create_dir_all(source.join("target/release")).expect("source dirs");
     std::fs::write(&target, "old").expect("target");
 
-    let err = source_swap_failure(
-        InstallMethod::Source,
-        false,
-        Some("0.255.8"),
-        Some("homeboy 0.255.8+old"),
-        Some(&source),
-        Some(&source.join("target/release/homeboy")),
-        Some(&target),
-        Some("homeboy 0.255.8+new"),
-    )
+    let err = source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Source,
+        success: false,
+        new_version: Some("0.255.8"),
+        new_build_identity: Some("homeboy 0.255.8+old"),
+        source_workspace: Some(&source),
+        built_binary: Some(&source.join("target/release/homeboy")),
+        replacement_target: Some(&target),
+        built_binary_identity: Some("homeboy 0.255.8+new"),
+    })
     .expect("unverified source swap must surface an error");
 
     assert!(err.hints.iter().any(|hint| hint
@@ -905,16 +905,16 @@ fn verify_upgrade_with_retry_terminates_on_identity_mismatch() {
 
 #[test]
 fn source_swap_failure_includes_identity_comparison() {
-    let err = source_swap_failure(
-        InstallMethod::Source,
-        false,
-        Some("0.300.0"),
-        Some("homeboy 0.300.0+old"),
-        Some(Path::new("/src/homeboy")),
-        Some(Path::new("/src/homeboy/target/release/homeboy")),
-        Some(Path::new("/active/homeboy")),
-        Some("homeboy 0.300.0+new"),
-    )
+    let err = source_swap_failure(SourceSwapVerification {
+        method: InstallMethod::Source,
+        success: false,
+        new_version: Some("0.300.0"),
+        new_build_identity: Some("homeboy 0.300.0+old"),
+        source_workspace: Some(Path::new("/src/homeboy")),
+        built_binary: Some(Path::new("/src/homeboy/target/release/homeboy")),
+        replacement_target: Some(Path::new("/active/homeboy")),
+        built_binary_identity: Some("homeboy 0.300.0+new"),
+    })
     .expect("unverified source swap must surface an error");
 
     assert!(err

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -2140,12 +2140,16 @@ mod convergence_tests {
         let runner = runner("0.301.2", "0.301.2", false);
 
         assert!(runner_convergence_failed(
-            &[runner.clone()],
+            std::slice::from_ref(&runner),
             &[],
             Some("0.304.0")
         ));
-        let disposition =
-            runner_convergence_disposition(false, &[runner.clone()], &[], Some("0.304.0"));
+        let disposition = runner_convergence_disposition(
+            false,
+            std::slice::from_ref(&runner),
+            &[],
+            Some("0.304.0"),
+        );
         assert_eq!(disposition, RunnerConvergenceDisposition::Partial);
         assert!(
             upgrade_message(true, Some("0.304.0"), None, disposition, &[runner], &[])
@@ -2177,8 +2181,12 @@ mod convergence_tests {
     #[test]
     fn converged_runners_still_report_convergence() {
         let runner = runner("0.301.2", "0.310.0", true);
-        let disposition =
-            runner_convergence_disposition(false, &[runner.clone()], &[], Some("0.310.0"));
+        let disposition = runner_convergence_disposition(
+            false,
+            std::slice::from_ref(&runner),
+            &[],
+            Some("0.310.0"),
+        );
         assert_eq!(disposition, RunnerConvergenceDisposition::Converged);
         let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[runner], &[]);
         assert!(


### PR DESCRIPTION
## Summary
- factors private upgrade execution results and source-swap validation inputs to satisfy Rust 1.95 Clippy diagnostics
- removes redundant retry predicate closure and test-only cloned single-item slices
- preserves upgrade result layout, source identity verification, rollback behavior, and serialized output

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo check -p homeboy-upgrade`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-upgrade` (150 passed)
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo clippy -p homeboy-upgrade --all-targets -- -D warnings`

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode refactored private upgrade lint surfaces and ran the scoped Rust verification suite. Chris remains responsible for every line.