### PR TITLE
fix(rig): resolve Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -98,7 +98,7 @@ impl DependencyMaterializationCache {
             .iter()
             .map(|input| {
                 let path =
-                    contained_path(&workspace, &expand_vars_with_settings(rig, input, settings))?;
+                    contained_path(&workspace, expand_vars_with_settings(rig, input, settings))?;
                 let relative = path.strip_prefix(&workspace).unwrap().display().to_string();
                 Ok(Input {
                     path: relative,
@@ -344,6 +344,7 @@ impl DependencyMaterializationCache {
             .map_err(|error| io_error("create dependency cache root", error))?;
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(self.root.join(format!(".{}.lock", self.key)))
@@ -584,8 +585,7 @@ fn clear_path(path: &Path) -> Result<()> {
 
 fn contained_path(root: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {
     let path =
-        homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")
-            .map_err(Error::from)?;
+        homeboy_paths::resolve_contained_local_path(root, path, "dependency_materialization")?;
     let root =
         fs::canonicalize(root).map_err(|error| io_error("resolve dependency workspace", error))?;
     let mut ancestor = path.as_path();
@@ -655,7 +655,7 @@ fn hash_path(path: &Path) -> Result<String> {
 }
 fn hash_directory(root: &Path) -> Result<String> {
     let mut files = Vec::new();
-    collect_files(root, root, &mut files)?;
+    collect_files(root, &mut files)?;
     files.sort();
     let mut hasher = Sha256::new();
     for file in files {
@@ -669,7 +669,7 @@ fn hash_directory(root: &Path) -> Result<String> {
     }
     Ok(format!("{:x}", hasher.finalize()))
 }
-fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+fn collect_files(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
     for entry in fs::read_dir(directory)
         .map_err(|error| io_error("read dependency cache directory", error))?
     {
@@ -687,7 +687,7 @@ fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Res
             ));
         }
         if metadata.is_dir() {
-            collect_files(root, &path, files)?;
+            collect_files(&path, files)?;
         } else if metadata.is_file() {
             files.push(path);
         }
@@ -701,7 +701,7 @@ fn path_bytes(path: &Path) -> Result<u64> {
             .len());
     }
     let mut files = Vec::new();
-    collect_files(path, path, &mut files)?;
+    collect_files(path, &mut files)?;
     files.into_iter().try_fold(0, |total, file| {
         Ok(total
             + fs::metadata(file)

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -334,7 +334,7 @@ pub(crate) fn write_rig_config_from_source(
 /// The conventional `rigs/<id>/rig.json` layout inherits templates from its
 /// package root. Other layouts are bounded by the rig directory.
 pub fn default_materialize_source_root(path: &Path) -> PathBuf {
-    if path.file_name().map_or(true, |name| name != "rig.json") {
+    if path.file_name().is_none_or(|name| name != "rig.json") {
         return path.parent().unwrap_or(path).to_path_buf();
     }
     let Some(rig_directory) = path.parent() else {

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -352,7 +352,7 @@ pub enum ReleaseLeaseOutcome {
     Released {
         rig_id: String,
         /// The released lease.
-        lease: RigRunLease,
+        lease: Box<RigRunLease>,
         /// Wall-clock age of the released lease in seconds, when derivable.
         age_seconds: Option<i64>,
         /// Whether the holder was already dead/stale (safe release) vs. a live
@@ -406,7 +406,7 @@ pub fn release_active_run_lease(rig_id: &str, force: bool) -> Result<ReleaseLeas
 
     Ok(ReleaseLeaseOutcome::Released {
         rig_id: rig_id.to_string(),
-        lease,
+        lease: Box::new(lease),
         age_seconds,
         was_reclaimable,
         forced: force && !was_reclaimable,

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -43,6 +43,10 @@ pub mod toolchain;
 pub mod trace_experiment;
 pub mod workloads;
 
+#[cfg(test)]
+#[path = "../../../tests/core/rig/support.rs"]
+mod rig_test_support;
+
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use artifact_index::{
     for_run as artifact_index_for_run,

--- a/crates/homeboy-rig/src/spec/dependencies.rs
+++ b/crates/homeboy-rig/src/spec/dependencies.rs
@@ -190,13 +190,11 @@ pub fn validate_dependency_materialization_steps(rig: &RigSpec) -> Vec<String> {
             (None, None) => errors.push(format!(
                 "{context} must declare exactly one of command or provider"
             )),
-            (Some(command), None) => {
-                if command_starts_with_env_assignment(command) {
-                    errors.push(format!(
-                        "{context} command must not start with shell-style environment assignments; declare environment values in env instead"
-                    ));
-                }
-            }
+            (Some(command), None) if command_starts_with_env_assignment(command) => errors.push(
+                format!(
+                    "{context} command must not start with shell-style environment assignments; declare environment values in env instead"
+                ),
+            ),
             _ => {}
         }
 

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -11,10 +11,7 @@ use homeboy_core::ErrorCode;
 use std::fs;
 use std::path::Path;
 
-#[path = "support.rs"]
-mod support;
-
-use support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
+use crate::rig_test_support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
 
 fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     fs::create_dir_all(dir).expect("single rig dir");

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -513,7 +513,9 @@ mod log_rotation {
 
     #[test]
     fn the_shipped_bounds_are_finite() {
-        assert!(RIG_LOG_MAX_BYTES > 0);
-        assert!(RIG_LOG_MAX_GENERATIONS > 0);
+        const {
+            assert!(RIG_LOG_MAX_BYTES > 0);
+            assert!(RIG_LOG_MAX_GENERATIONS > 0);
+        }
     }
 }

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -8,10 +8,9 @@ use homeboy_core::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
 
-#[path = "support.rs"]
-mod support;
-
-use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack, GitFixture};
+use crate::rig_test_support::{
+    bare_source_path, minimal_rig, minimal_stack, run_git, write_rig, write_stack, GitFixture,
+};
 
 /// Source-update-only fixture helpers. These live here rather than in the
 /// shared `support.rs` because only the source-update tests attach to an
@@ -396,9 +395,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     let before = crate::read_source_metadata("alpha")
@@ -438,9 +435,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     let installed_metadata =
@@ -481,9 +476,7 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     let mut metadata = crate::read_source_metadata("alpha").expect("metadata");
@@ -526,9 +519,7 @@ fn update_all_reports_broken_sources_and_continues() {
     let broken_package = tempfile::tempdir().expect("broken package");
     write_rig(broken_package.path(), "broken", &minimal_rig("broken"));
     let broken_bare = create_bare_source(broken_package.path());
-    let broken_source = support::bare_source_path(&broken_bare)
-        .to_string_lossy()
-        .to_string();
+    let broken_source = bare_source_path(&broken_bare).to_string_lossy().to_string();
     install(&broken_source, None, false).expect("install broken source");
     let broken_metadata = crate::read_source_metadata("broken").expect("broken metadata");
     fs::remove_dir_all(&broken_metadata.package_path).expect("remove installed package clone");
@@ -536,9 +527,7 @@ fn update_all_reports_broken_sources_and_continues() {
     let good_package = tempfile::tempdir().expect("good package");
     let good_rig = write_rig(good_package.path(), "good", &minimal_rig("good"));
     let good_bare = create_bare_source(good_package.path());
-    let good_source = support::bare_source_path(&good_bare)
-        .to_string_lossy()
-        .to_string();
+    let good_source = bare_source_path(&good_bare).to_string_lossy().to_string();
     install(&good_source, None, false).expect("install good source");
     fs::write(
         &good_rig,
@@ -566,9 +555,7 @@ fn refresh_source_selector_updates_recorded_package() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     let before = crate::read_source_metadata("alpha")
@@ -612,9 +599,7 @@ fn refresh_without_selector_updates_all_sources() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     fs::write(
@@ -640,9 +625,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
     let bare = create_bare_source(package.path());
-    let source = support::bare_source_path(&bare)
-        .to_string_lossy()
-        .to_string();
+    let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&source, None, false).expect("install");
     let config = homeboy_core::paths::stack_config("alpha-combined").expect("stack config");

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -222,7 +222,7 @@ fn set_effective_component_path_ignores_unknown_component() {
     let component = snapshot.components.get("studio").expect("component");
     assert_eq!(component.path, "/Users/user/Developer/studio");
     assert!(component.declared_path.is_none());
-    assert!(snapshot.components.get("missing").is_none());
+    assert!(!snapshot.components.contains_key("missing"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Resolve the seven Rust 1.95 diagnostics in `homeboy-rig` while preserving rig source, materialization, provenance, and command behavior.
- Share rig test support once to satisfy the duplicate-module diagnostic without changing fixture behavior.

Refs #11580

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/.cargo-target cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/.cargo-target cargo check -p homeboy-rig`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/.cargo-target cargo clippy -p homeboy-rig --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/.cargo-target cargo test -p homeboy-rig -- --test-threads=1` reports 484 passing tests and two pre-existing failures in `runner_observation_test` where expected retained observation records are absent.

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode was used to update the Rust 1.95 diagnostics, adjust affected test module structure, and run verification. Chris remains responsible for every line.