### PR TITLE
fix(refactor): resolve Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-refactor/src/collapse.rs
+++ b/crates/homeboy-refactor/src/collapse.rs
@@ -290,7 +290,7 @@ fn apply_collapse_edits(root: &Path, edits: &[CollapseEdit]) -> Result<(), Error
         let mut lines: Vec<String> = content.split('\n').map(|s| s.to_string()).collect();
 
         // Bottom-up so splices don't shift not-yet-applied ranges.
-        file_edits.sort_by(|a, b| b.start_line.cmp(&a.start_line));
+        file_edits.sort_by_key(|edit| std::cmp::Reverse(edit.start_line));
 
         for edit in file_edits {
             // 1-indexed inclusive → 0-indexed slice range.

--- a/crates/homeboy-refactor/src/move_items.rs
+++ b/crates/homeboy-refactor/src/move_items.rs
@@ -449,7 +449,7 @@ pub fn move_items_with_options(
     // Remove moved items (descending order to not shift indices)
     let mut items_to_remove: Vec<&ParsedItem> = found_items.clone();
     items_to_remove.extend(related_tests.iter());
-    items_to_remove.sort_by(|a, b| b.start_line.cmp(&a.start_line));
+    items_to_remove.sort_by_key(|item| std::cmp::Reverse(item.start_line));
 
     for item in &items_to_remove {
         let mut start = item.start_line.saturating_sub(1); // 0-indexed

--- a/crates/homeboy-refactor/src/move_items/whole_file_move.rs
+++ b/crates/homeboy-refactor/src/move_items/whole_file_move.rs
@@ -210,7 +210,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
                 let mut lines: Vec<&str> = content.split('\n').collect();
                 // Apply rewrites in reverse line order to preserve line numbers
                 let mut sorted_rewrites = rewrites.clone();
-                sorted_rewrites.sort_by(|a, b| b.line.cmp(&a.line));
+                sorted_rewrites.sort_by_key(|rewrite| std::cmp::Reverse(rewrite.line));
                 for rewrite in &sorted_rewrites {
                     let idx = rewrite.line.saturating_sub(1);
                     if idx < lines.len() {

--- a/crates/homeboy-refactor/src/plan/generate/comment_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/comment_fixes.rs
@@ -284,8 +284,8 @@ fn classify_and_bound(lines: &[&str], comment_idx: usize) -> (BlockKind, usize, 
 
 /// Find the next non-blank, non-comment line starting from `start_idx`.
 fn find_next_code_line(lines: &[&str], start_idx: usize) -> Option<usize> {
-    for i in start_idx..lines.len() {
-        let trimmed = lines[i].trim();
+    for (i, line) in lines.iter().enumerate().skip(start_idx) {
+        let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
@@ -383,8 +383,8 @@ fn find_enclosing_else_end(lines: &[&str], comment_idx: usize) -> Option<usize> 
     if trimmed.starts_with("} else") || trimmed.starts_with("}else") {
         // The else block opened on this line — find its close starting from the next line.
         let mut depth = 1i32; // the `{` from `} else {`
-        for i in (else_start + 1)..lines.len() {
-            for ch in lines[i].chars() {
+        for (i, line) in lines.iter().enumerate().skip(else_start + 1) {
+            for ch in line.chars() {
                 match ch {
                     '{' => depth += 1,
                     '}' => {
@@ -410,8 +410,8 @@ fn find_brace_block_end(lines: &[&str], start_idx: usize) -> Option<usize> {
     let mut depth = 0i32;
     let mut found_opening = false;
 
-    for i in start_idx..lines.len() {
-        for ch in lines[i].chars() {
+    for (i, line) in lines.iter().enumerate().skip(start_idx) {
+        for ch in line.chars() {
             match ch {
                 '{' => {
                     depth += 1;
@@ -496,8 +496,8 @@ fn find_match_arm_end(lines: &[&str], arm_idx: usize) -> Option<usize> {
     let arm_indent = leading_indent(lines[arm_idx]);
     let mut end = arm_idx;
 
-    for i in (arm_idx + 1)..lines.len() {
-        let trimmed = lines[i].trim();
+    for (i, line) in lines.iter().enumerate().skip(arm_idx + 1) {
+        let trimmed = line.trim();
 
         // Next arm or end of match.
         if trimmed.contains("=>") || trimmed == "}" {
@@ -510,7 +510,7 @@ fn find_match_arm_end(lines: &[&str], arm_idx: usize) -> Option<usize> {
         }
 
         // Lines at same or lower indent are outside this arm.
-        if leading_indent(lines[i]) <= arm_indent && !trimmed.is_empty() {
+        if leading_indent(line) <= arm_indent && !trimmed.is_empty() {
             break;
         }
 
@@ -526,15 +526,15 @@ fn find_code_section_end(lines: &[&str], comment_idx: usize) -> usize {
     let base_indent = leading_indent(lines[comment_idx]);
     let mut end = comment_idx;
 
-    for i in (comment_idx + 1)..lines.len() {
-        let trimmed = lines[i].trim();
+    for (i, line) in lines.iter().enumerate().skip(comment_idx + 1) {
+        let trimmed = line.trim();
 
         // Blank line ends the section.
         if trimmed.is_empty() {
             break;
         }
 
-        let indent = leading_indent(lines[i]);
+        let indent = leading_indent(line);
 
         // De-indent means we've left the section.
         if indent < base_indent {

--- a/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
@@ -220,9 +220,7 @@ fn find_test_function_range(content: &str, fn_name: &str) -> Option<(usize, usiz
     let mut found_open = false;
     let mut raw_string_close: Option<String> = None;
 
-    for i in decl_idx..lines.len() {
-        let line = lines[i];
-
+    for (i, line) in lines.iter().copied().enumerate().skip(decl_idx) {
         // If we're inside a raw string, skip until we find the close pattern.
         if let Some(ref close_pattern) = raw_string_close {
             if line.contains(close_pattern.as_str()) {

--- a/crates/homeboy-refactor/src/plan/generate/signatures.rs
+++ b/crates/homeboy-refactor/src/plan/generate/signatures.rs
@@ -113,7 +113,7 @@ pub(crate) fn generate_fallback_signature(
     MethodSignature {
         name: method_name.to_string(),
         signature,
-        language: language.clone(),
+        language: *language,
         body: None,
     }
 }

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -712,9 +712,12 @@ pub(super) fn run_test_stage(
     })
 }
 
+type StringSettings = Vec<(String, String)>;
+type JsonSettings = Vec<(String, serde_json::Value)>;
+
 fn split_refactor_settings(
     settings: &[(String, serde_json::Value)],
-) -> (Vec<(String, String)>, Vec<(String, serde_json::Value)>) {
+) -> (StringSettings, JsonSettings) {
     settings
         .iter()
         .cloned()

--- a/crates/homeboy-refactor/src/transform.rs
+++ b/crates/homeboy-refactor/src/transform.rs
@@ -743,23 +743,23 @@ fn apply_hoist_static_context(
         };
 
         // Rename all references within the function scope (skip the declaration line itself)
-        for i in start..end {
+        for (i, line) in new_lines.iter_mut().enumerate().take(end).skip(start) {
             if i == *match_line {
                 continue; // Already replaced
             }
-            if var_re.is_match(&new_lines[i]) {
-                let renamed = var_re.replace_all(&new_lines[i], new_var.as_str());
-                if renamed != new_lines[i] {
+            if var_re.is_match(line) {
+                let renamed = var_re.replace_all(line, new_var.as_str());
+                if renamed != *line {
                     record_match(
                         &mut replacement_count,
                         &mut matches,
                         detail_limit,
                         relative_path,
                         i + 1,
-                        &new_lines[i],
+                        line,
                         renamed.as_ref(),
                     );
-                    new_lines[i] = renamed.to_string();
+                    *line = renamed.to_string();
                 }
             }
         }
@@ -808,8 +808,8 @@ fn find_enclosing_fn_start(lines: &[String], from: usize) -> Option<usize> {
 fn find_enclosing_fn_end(lines: &[String], fn_line: usize) -> Option<usize> {
     let mut depth: i32 = 0;
     let mut found_open = false;
-    for i in fn_line..lines.len() {
-        for ch in lines[i].chars() {
+    for (i, line) in lines.iter().enumerate().skip(fn_line) {
+        for ch in line.chars() {
             if ch == '{' {
                 depth += 1;
                 found_open = true;


### PR DESCRIPTION
## Summary
- resolve all 13 Rust 1.95 Clippy diagnostics in `homeboy-refactor` without changing refactor planning, audit, serialization, or execution contracts

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo check --locked -p homeboy-refactor`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo clippy --locked -p homeboy-refactor --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test --locked -p homeboy-refactor`

Refs #11580

AI assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode identified and applied idiomatic Rust 1.95 lint fixes; Chris Huber remains responsible for every line.