### PR TITLE
fix(deploy): resolve Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-deploy/src/binding.rs
+++ b/crates/homeboy-deploy/src/binding.rs
@@ -114,16 +114,13 @@ pub(crate) fn bind_project_payloads(
                     None,
                 ));
             }
-            match component.deploy_strategy() {
-                Some("git" | "file") => {
-                    return Err(Error::validation_invalid_argument(
-                        "deploy_strategy",
-                        "Prepared artifacts require an artifact deploy strategy",
-                        None,
-                        None,
-                    ));
-                }
-                _ => {}
+            if let Some("git" | "file") = component.deploy_strategy() {
+                return Err(Error::validation_invalid_argument(
+                    "deploy_strategy",
+                    "Prepared artifacts require an artifact deploy strategy",
+                    None,
+                    None,
+                ));
             }
             let install_dir = resolve_effective_remote_path(project, component, base_path)?;
             validate_deploy_target(

--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -90,10 +90,7 @@ mod tests {
         assert!(text.ends_with("Version: 9.9.9"));
     }
 
-    #[test]
-    fn bound_captured_read_default_cap_is_nonzero() {
-        assert!(ARTIFACT_VERSION_READ_LIMIT_BYTES > 0);
-    }
+    const _: () = assert!(ARTIFACT_VERSION_READ_LIMIT_BYTES > 0);
 
     #[test]
     fn test_execute_component_deploy_failure_helper_preserves_build_exit_code() {

--- a/crates/homeboy-deploy/src/execution/prepare.rs
+++ b/crates/homeboy-deploy/src/execution/prepare.rs
@@ -16,7 +16,9 @@ use super::super::types::{
 use super::super::version_overrides::is_self_deploy;
 use super::preflight::{resolve_preflight_artifact_path, validate_preflight_file_artifact};
 use super::release_plan::{release_artifact_plan, ReleaseArtifactPlan};
-use super::strategies::{execute_artifact_deploy, execute_file_deploy, execute_git_deploy};
+use super::strategies::{
+    execute_artifact_deploy, execute_file_deploy, execute_git_deploy, GitDeployInput,
+};
 use homeboy_core::git::release_download::ReleaseArtifactLease;
 
 pub(crate) struct PreparedComponentDeploy {
@@ -332,16 +334,16 @@ pub(crate) fn execute_preflighted_component_deploy(
     let strategy = component.deploy_strategy.as_deref().unwrap_or("rsync");
 
     if strategy == "git" {
-        return execute_git_deploy(
+        return execute_git_deploy(GitDeployInput {
             component,
-            &prepared.config,
+            config: &prepared.config,
             ctx,
             base_path,
-            &prepared.install_dir,
-            prepared.local_version.clone(),
-            prepared.remote_version.clone(),
+            install_dir: &prepared.install_dir,
+            local_version: prepared.local_version.clone(),
+            remote_version: prepared.remote_version.clone(),
             observation,
-        );
+        });
     }
 
     if strategy == "file" {

--- a/crates/homeboy-deploy/src/execution/strategies.rs
+++ b/crates/homeboy-deploy/src/execution/strategies.rs
@@ -19,23 +19,35 @@ use super::super::version_overrides::{
 use super::prepare::PreparedComponentDeploy;
 
 /// Deploy a component via git push strategy.
-pub(super) fn execute_git_deploy(
-    component: &Component,
-    config: &DeployConfig,
-    ctx: &RemoteProjectContext,
-    base_path: &str,
-    install_dir: &str,
-    local_version: Option<String>,
-    remote_version: Option<String>,
-    mut observation: Option<&mut DeployObservation>,
-) -> ComponentDeployResult {
+pub(super) struct GitDeployInput<'a> {
+    pub(super) component: &'a Component,
+    pub(super) config: &'a DeployConfig,
+    pub(super) ctx: &'a RemoteProjectContext,
+    pub(super) base_path: &'a str,
+    pub(super) install_dir: &'a str,
+    pub(super) local_version: Option<String>,
+    pub(super) remote_version: Option<String>,
+    pub(super) observation: Option<&'a mut DeployObservation>,
+}
+
+pub(super) fn execute_git_deploy(input: GitDeployInput<'_>) -> ComponentDeployResult {
+    let GitDeployInput {
+        component,
+        config,
+        ctx,
+        base_path,
+        install_dir,
+        local_version,
+        remote_version,
+        observation,
+    } = input;
     let git_config = component.git_deploy.clone().unwrap_or_default();
     let deploy_result = deploy_via_git(
         &ctx.client,
         install_dir,
         &git_config,
         local_version.as_deref(),
-        observation.as_deref_mut(),
+        observation,
     );
 
     match deploy_result {
@@ -92,7 +104,7 @@ pub(super) fn execute_file_deploy(
     install_dir: &str,
     local_version: Option<String>,
     remote_version: Option<String>,
-    mut observation: Option<&mut DeployObservation>,
+    observation: Option<&mut DeployObservation>,
 ) -> ComponentDeployResult {
     let local_path = Path::new(&component.local_path);
 
@@ -131,7 +143,7 @@ pub(super) fn execute_file_deploy(
         "mkdir -p {}",
         homeboy_core::engine::shell::quote_path(remote_parent)
     );
-    if let Some(observation) = observation.as_deref_mut() {
+    if let Some(observation) = observation {
         if let Err(error) = observation.phase("transfer", true) {
             return ComponentDeployResult::failed(
                 component,

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -30,7 +30,7 @@ mod preflight;
 mod prepared_payloads;
 mod smoke_check;
 
-use modes::{extension_skipped_results, run_check_mode, run_dry_run_mode};
+use modes::{extension_skipped_results, run_check_mode, run_dry_run_mode, CheckModeInput};
 use preflight::{
     check_uncommitted_changes, check_unreleased_commits, guard_head_matches_invocation_checkout,
     guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
@@ -235,18 +235,18 @@ pub(super) fn deploy_components(
 
     // Check and dry-run modes return early without building or deploying
     if config.check {
-        let mut result = run_check_mode(
-            &components,
-            &local_versions,
-            &remote_versions,
-            &loaded.extension_skipped,
-            &project,
+        let mut result = run_check_mode(CheckModeInput {
+            components: &components,
+            local_versions: &local_versions,
+            remote_versions: &remote_versions,
+            extension_skipped: &loaded.extension_skipped,
+            project: &project,
             base_path,
             config,
-            &ctx.client,
-            &resolved_release_artifacts,
-            &unavailable_canonical_packages,
-        );
+            client: &ctx.client,
+            canonical_packages: &resolved_release_artifacts,
+            unavailable_canonical_packages: &unavailable_canonical_packages,
+        });
         attach_version_sources(&mut result, &components);
         return Ok(result);
     }
@@ -347,10 +347,7 @@ pub(super) fn deploy_components(
             checkout.hydrate_dependencies(config.skip_deps_hydration)?;
         }
 
-        tag_checkouts = match checkout_resolved_deploy_tags(in_place) {
-            Ok(checkouts) => checkouts,
-            Err(err) => return Err(err),
-        };
+        tag_checkouts = checkout_resolved_deploy_tags(in_place)?;
 
         // Repoint every materialized component at its isolated worktree so
         // version reads, packaging, and provenance all observe the tagged tree.
@@ -540,10 +537,11 @@ pub(super) fn deploy_components(
                 &["rev-parse", "--abbrev-ref", "HEAD"],
             )
             .map(|branch| format!("{} (HEAD)", branch))
-        } else if let Some(prepared_artifact) = config.prepared_artifact.as_ref() {
-            Some(prepared_artifact.tag.clone())
         } else {
-            None
+            config
+                .prepared_artifact
+                .as_ref()
+                .map(|prepared_artifact| prepared_artifact.tag.clone())
         };
 
         if let Some(ref git_ref) = deployed_ref {
@@ -588,16 +586,16 @@ pub(super) fn deploy_components(
             ) {
                 let exclusions = resolve_component_scope(component, ScopeCommand::Deploy).exclude;
                 let version = prepared.local_version.as_deref().unwrap_or_default();
-                if let Err(error) = super::receipt::write(
-                    &project,
-                    &component.id,
-                    &prepared.install_dir,
+                if let Err(error) = super::receipt::write(super::receipt::ReceiptWrite {
+                    project: &project,
+                    component_id: &component.id,
+                    target: &prepared.install_dir,
                     version,
                     manifest,
                     payload_sha256,
                     build_provenance,
                     exclusions,
-                ) {
+                }) {
                     result.status = "failed".to_string();
                     result.error = Some(format!(
                         "deployment completed but authoritative deployed-package receipt could not be persisted: {}",
@@ -625,7 +623,7 @@ pub(super) fn deploy_components(
     // to fresh visitors should fail the deploy here so it gets rolled back
     // instead of sitting live. Catches runtime errors that a syntax-only
     // preflight structurally cannot. See homeboy#5471.
-    if let Some(observation) = observation.as_deref_mut() {
+    if let Some(observation) = observation {
         observation.phase("verify", true)?;
     }
     if succeeded > 0 {
@@ -675,7 +673,7 @@ fn attach_version_sources(result: &mut DeployOrchestrationResult, components: &[
         let artifact = row
             .artifact_path
             .as_ref()
-            .and_then(|_| row.local_version.as_ref())
+            .and(row.local_version.as_ref())
             .and_then(|_| crate::types::artifact_version_source(component));
         let remote = row.remote_version.as_ref().and_then(|_| {
             crate::types::local_version_source(component).map(|source| VersionSource {
@@ -1246,7 +1244,7 @@ mod tests {
             check_config.expected_version = Some("9.9.9".to_string());
             let mut store = ReleaseArtifactStore::default();
             let (resolved, unavailable) = resolve_release_artifacts_for_deploy(
-                &[component.clone()],
+                std::slice::from_ref(&component),
                 &check_config,
                 &mut store,
             )
@@ -1261,7 +1259,7 @@ mod tests {
             dry_run_config.dry_run = true;
             dry_run_config.expected_version = Some("9.9.9".to_string());
             let (resolved, unavailable) = resolve_release_artifacts_for_deploy(
-                &[component.clone()],
+                std::slice::from_ref(&component),
                 &dry_run_config,
                 &mut store,
             )
@@ -2269,7 +2267,7 @@ mod tests {
             config.requested_ref = Some("requested".to_string());
             config.force = true;
             let prepared = prepare_component_deployments(
-                &[checkout.component.clone()],
+                std::slice::from_ref(&checkout.component),
                 &config,
                 &Project::default(),
                 "/srv/site",
@@ -2425,7 +2423,7 @@ mod tests {
         config.force = true;
         let local_versions = HashMap::from([("fixture".to_string(), "1.2.3".to_string())]);
         let prepared = prepare_component_deployments(
-            &[checkout.component.clone()],
+            std::slice::from_ref(&checkout.component),
             &config,
             &project,
             "/srv/site",
@@ -2554,7 +2552,7 @@ mod tests {
         config.requested_ref = Some("target".to_string());
         config.force = true;
         let prepared = prepare_component_deployments(
-            &[checkout.component.clone()],
+            std::slice::from_ref(&checkout.component),
             &config,
             &Project::default(),
             "/srv/site",

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -19,18 +19,32 @@ use super::super::types::{
 };
 
 /// Check mode: return component status without building or deploying.
-pub(super) fn run_check_mode(
-    components: &[Component],
-    local_versions: &HashMap<String, String>,
-    remote_versions: &HashMap<String, String>,
-    extension_skipped: &[ExtensionSkippedComponent],
-    project: &Project,
-    base_path: &str,
-    config: &DeployConfig,
-    client: &SshClient,
-    canonical_packages: &HashMap<String, ReleaseArtifactLease>,
-    unavailable_canonical_packages: &HashMap<String, String>,
-) -> DeployOrchestrationResult {
+pub(super) struct CheckModeInput<'a> {
+    pub(super) components: &'a [Component],
+    pub(super) local_versions: &'a HashMap<String, String>,
+    pub(super) remote_versions: &'a HashMap<String, String>,
+    pub(super) extension_skipped: &'a [ExtensionSkippedComponent],
+    pub(super) project: &'a Project,
+    pub(super) base_path: &'a str,
+    pub(super) config: &'a DeployConfig,
+    pub(super) client: &'a SshClient,
+    pub(super) canonical_packages: &'a HashMap<String, ReleaseArtifactLease>,
+    pub(super) unavailable_canonical_packages: &'a HashMap<String, String>,
+}
+
+pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationResult {
+    let CheckModeInput {
+        components,
+        local_versions,
+        remote_versions,
+        extension_skipped,
+        project,
+        base_path,
+        config,
+        client,
+        canonical_packages,
+        unavailable_canonical_packages,
+    } = input;
     let mut git_probe_cache = GitProbeCache::default();
     let mut results: Vec<ComponentDeployResult> = components
         .iter()
@@ -683,18 +697,18 @@ mod tests {
             resume_run_id: None,
         };
 
-        let checked = run_check_mode(
-            std::slice::from_ref(&component),
-            &local_versions,
-            &remote_versions,
-            &[],
-            &Project::default(),
-            "/srv/site",
-            &config,
-            &local_client(),
-            &HashMap::new(),
-            &HashMap::new(),
-        );
+        let checked = run_check_mode(CheckModeInput {
+            components: std::slice::from_ref(&component),
+            local_versions: &local_versions,
+            remote_versions: &remote_versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: "/srv/site",
+            config: &config,
+            client: &local_client(),
+            canonical_packages: &HashMap::new(),
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         assert_eq!(checked.results[0].status, "checked");
         assert_eq!(checked.results[0].local_version.as_deref(), Some("1.2.3"));
         assert_eq!(checked.results[0].remote_version.as_deref(), Some("1.3.0"));
@@ -762,18 +776,18 @@ mod tests {
         let config = DeployConfig::check_all_no_pull_head();
         let packages = HashMap::from([("plugin".to_string(), package)]);
 
-        let clean = run_check_mode(
-            std::slice::from_ref(&component),
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &config,
-            &local_client(),
-            &packages,
-            &HashMap::new(),
-        );
+        let clean = run_check_mode(CheckModeInput {
+            components: std::slice::from_ref(&component),
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &config,
+            client: &local_client(),
+            canonical_packages: &packages,
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         assert_eq!(
             clean.results[0].component_status,
             Some(ComponentStatus::UpToDate)
@@ -792,36 +806,36 @@ mod tests {
         );
 
         std::fs::write(remote.join("plugin.php"), "modified").expect("drift");
-        let drift = run_check_mode(
-            std::slice::from_ref(&component),
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &config,
-            &local_client(),
-            &packages,
-            &HashMap::new(),
-        );
+        let drift = run_check_mode(CheckModeInput {
+            components: std::slice::from_ref(&component),
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &config,
+            client: &local_client(),
+            canonical_packages: &packages,
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         assert_eq!(
             drift.results[0].component_status,
             Some(ComponentStatus::RemoteModified)
         );
 
         std::fs::write(&packages["plugin"].path, "mutated after lease").expect("mutate package");
-        let mutated = run_check_mode(
-            std::slice::from_ref(&component),
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &config,
-            &local_client(),
-            &packages,
-            &HashMap::new(),
-        );
+        let mutated = run_check_mode(CheckModeInput {
+            components: std::slice::from_ref(&component),
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &config,
+            client: &local_client(),
+            canonical_packages: &packages,
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         let manifest = mutated.results[0]
             .content_manifest
             .as_ref()
@@ -889,18 +903,18 @@ mod tests {
             tag: "v1.0.0".to_string(),
             source_commit: "prepared-commit".to_string(),
         });
-        let result = run_check_mode(
-            &[component],
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &config,
-            &local_client(),
-            &HashMap::from([("plugin".to_string(), release)]),
-            &HashMap::new(),
-        );
+        let result = run_check_mode(CheckModeInput {
+            components: &[component],
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &config,
+            client: &local_client(),
+            canonical_packages: &HashMap::from([("plugin".to_string(), release)]),
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         let manifest = result.results[0]
             .content_manifest
             .as_ref()
@@ -947,18 +961,18 @@ mod tests {
         };
         let local_versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let remote_versions = HashMap::from([("plugin".to_string(), "2.0.0".to_string())]);
-        let result = run_check_mode(
-            &[component],
-            &local_versions,
-            &remote_versions,
-            &[],
-            &Project::default(),
-            ".",
-            &DeployConfig::check_all_no_pull_head(),
-            &local_client(),
-            &HashMap::from([("plugin".to_string(), lease)]),
-            &HashMap::new(),
-        );
+        let result = run_check_mode(CheckModeInput {
+            components: &[component],
+            local_versions: &local_versions,
+            remote_versions: &remote_versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &DeployConfig::check_all_no_pull_head(),
+            client: &local_client(),
+            canonical_packages: &HashMap::from([("plugin".to_string(), lease)]),
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         assert_eq!(
             result.results[0].component_status,
             Some(ComponentStatus::MixedDrift)
@@ -982,21 +996,21 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
-        let result = run_check_mode(
-            &[component],
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &DeployConfig::check_all_no_pull_head(),
-            &local_client(),
-            &HashMap::new(),
-            &HashMap::from([(
+        let result = run_check_mode(CheckModeInput {
+            components: &[component],
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &DeployConfig::check_all_no_pull_head(),
+            client: &local_client(),
+            canonical_packages: &HashMap::new(),
+            unavailable_canonical_packages: &HashMap::from([(
                 "plugin".to_string(),
                 "release asset download failed".to_string(),
             )]),
-        );
+        });
         let manifest = result.results[0]
             .content_manifest
             .as_ref()
@@ -1042,18 +1056,18 @@ mod tests {
             },
         ] {
             config.check = true;
-            let result = run_check_mode(
-                std::slice::from_ref(&component),
-                &versions,
-                &versions,
-                &[],
-                &Project::default(),
-                ".",
-                &config,
-                &local_client(),
-                &HashMap::new(),
-                &HashMap::new(),
-            );
+            let result = run_check_mode(CheckModeInput {
+                components: std::slice::from_ref(&component),
+                local_versions: &versions,
+                remote_versions: &versions,
+                extension_skipped: &[],
+                project: &Project::default(),
+                base_path: ".",
+                config: &config,
+                client: &local_client(),
+                canonical_packages: &HashMap::new(),
+                unavailable_canonical_packages: &HashMap::new(),
+            });
             let manifest = result.results[0]
                 .content_manifest
                 .as_ref()
@@ -1079,18 +1093,18 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
-        let result = run_check_mode(
-            &[component],
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &DeployConfig::check_all_no_pull_head(),
-            &local_client(),
-            &HashMap::new(),
-            &HashMap::new(),
-        );
+        let result = run_check_mode(CheckModeInput {
+            components: &[component],
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &DeployConfig::check_all_no_pull_head(),
+            client: &local_client(),
+            canonical_packages: &HashMap::new(),
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         assert_eq!(
             result.results[0]
                 .content_manifest
@@ -1110,18 +1124,18 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
-        let result = run_check_mode(
-            &[component],
-            &versions,
-            &versions,
-            &[],
-            &Project::default(),
-            ".",
-            &DeployConfig::check_all_no_pull_head(),
-            &local_client(),
-            &HashMap::new(),
-            &HashMap::new(),
-        );
+        let result = run_check_mode(CheckModeInput {
+            components: &[component],
+            local_versions: &versions,
+            remote_versions: &versions,
+            extension_skipped: &[],
+            project: &Project::default(),
+            base_path: ".",
+            config: &DeployConfig::check_all_no_pull_head(),
+            client: &local_client(),
+            canonical_packages: &HashMap::new(),
+            unavailable_canonical_packages: &HashMap::new(),
+        });
         let manifest = result.results[0]
             .content_manifest
             .as_ref()

--- a/crates/homeboy-deploy/src/orchestration/preflight.rs
+++ b/crates/homeboy-deploy/src/orchestration/preflight.rs
@@ -589,443 +589,6 @@ fn dirty_worktree_path_summary(dirty: &[DirtyComponent]) -> String {
         .join("; ")
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::path::Path;
-    use std::process::Command;
-
-    use super::{
-        guard_deployment_provenance, guard_head_matches_invocation_checkout,
-        guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
-        warn_non_default_branch,
-    };
-    use crate::DeployConfig;
-    use homeboy_core::component::Component;
-    use homeboy_core::project::{
-        DeploymentForgeEvidence, DeploymentProvenanceMode, DeploymentProvenancePolicy, Project,
-    };
-
-    fn config() -> DeployConfig {
-        DeployConfig {
-            component_ids: vec![],
-            all: false,
-            outdated: false,
-            behind_upstream: false,
-            dry_run: false,
-            check: false,
-            force: false,
-            skip_build: false,
-            keep_deps: false,
-            skip_deps_hydration: false,
-            expected_version: None,
-            no_pull: true,
-            allow_stale_source: false,
-            allow_downgrade: false,
-            head: false,
-            requested_ref: None,
-            requested_refs: Default::default(),
-            resolved_refs: Default::default(),
-            preflighted_source_paths: Default::default(),
-            preflighted_component_identities: Default::default(),
-            prepared_projection: None,
-            tagged: false,
-            prepared_artifact: None,
-            resume_run_id: None,
-        }
-    }
-
-    fn component(path: &Path) -> Component {
-        Component {
-            id: "example".to_string(),
-            local_path: path.to_string_lossy().to_string(),
-            ..Component::default()
-        }
-    }
-
-    fn accepted_ref_project() -> Project {
-        Project {
-            id: "production".to_string(),
-            deployment_provenance: Some(DeploymentProvenancePolicy {
-                mode: DeploymentProvenanceMode::AcceptedRef,
-                forge_evidence: vec![],
-            }),
-            ..Project::default()
-        }
-    }
-
-    #[test]
-    fn deployment_provenance_policy_fails_before_mutable_selectors_can_run() {
-        let component = component(Path::new("/unread-source"));
-        let project = accepted_ref_project();
-        let mut config = config();
-        config.head = true;
-        let error = guard_deployment_provenance(&project, &[component], &mut config)
-            .expect_err("HEAD must fail before source work");
-        assert_eq!(error.details["field"], "deployment_provenance");
-    }
-
-    #[test]
-    fn accepted_ref_policy_accepts_validated_release_set_and_refuses_force() {
-        let component = component(Path::new("/unread-source"));
-        let project = accepted_ref_project();
-        let mut config = config();
-        config
-            .requested_refs
-            .insert("example".to_string(), "v1.2.3".to_string());
-        config
-            .resolved_refs
-            .insert("example".to_string(), "a".repeat(40));
-        config
-            .preflighted_source_paths
-            .insert("example".to_string(), "/unread-source".to_string());
-        config
-            .preflighted_component_identities
-            .insert("example".to_string(), "identity".to_string());
-        let evidence = guard_deployment_provenance(&project, &[component.clone()], &mut config)
-            .expect("validated release set is accepted evidence");
-        assert_eq!(evidence["example"].kind, "release_set");
-
-        config.force = true;
-        let error = guard_deployment_provenance(&project, &[component], &mut config)
-            .expect_err("force must not bypass active policy");
-        assert_eq!(error.details["field"], "force");
-    }
-
-    #[test]
-    fn accepted_ref_policy_accepts_release_tag_and_sha_bound_forge_evidence() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        init_repo_with_commit(temp.path());
-        git(temp.path(), &["tag", "v1.2.3"]);
-        let component = component(temp.path());
-        let project = accepted_ref_project();
-
-        let mut tagged = config();
-        let evidence = guard_deployment_provenance(&project, &[component.clone()], &mut tagged)
-            .expect("latest release tag is accepted");
-        assert_eq!(evidence["example"].kind, "release_tag");
-
-        let sha = homeboy_core::git::run_git(temp.path(), &["rev-parse", "HEAD"], "read SHA")
-            .expect("SHA")
-            .trim()
-            .to_string();
-        let mut project = accepted_ref_project();
-        project
-            .deployment_provenance
-            .as_mut()
-            .expect("policy")
-            .forge_evidence = vec![DeploymentForgeEvidence {
-            sha: sha.clone(),
-            forge: "github".to_string(),
-            reference: "https://github.com/acme/example/pull/42".to_string(),
-        }];
-        let mut direct = config();
-        direct.requested_ref = Some(sha);
-        let evidence = guard_deployment_provenance(&project, &[component], &mut direct)
-            .expect("forge evidence for exact SHA is accepted");
-        assert_eq!(evidence["example"].kind, "forge");
-        assert_eq!(evidence["example"].forge.as_deref(), Some("github"));
-    }
-
-    #[test]
-    fn accepted_ref_policy_refuses_unverifiable_ref() {
-        let component = component(Path::new("/unread-source"));
-        let mut config = config();
-        config.requested_ref = Some("unverifiable".to_string());
-        assert!(
-            guard_deployment_provenance(&accepted_ref_project(), &[component], &mut config)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn omitted_deployment_provenance_policy_preserves_force_compatibility() {
-        let component = component(Path::new("/unread-source"));
-        let mut config = config();
-        config.head = true;
-        config.force = true;
-        guard_deployment_provenance(&Project::default(), &[component], &mut config)
-            .expect("projects without a policy retain legacy force semantics");
-    }
-
-    fn git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    #[test]
-    fn stale_local_source_refuses_until_explicitly_allowed() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let remote = temp.path().join("remote.git");
-        let source = temp.path().join("source");
-        let updater = temp.path().join("updater");
-        std::fs::create_dir(&source).expect("source dir");
-        git(
-            temp.path(),
-            &["init", "--bare", remote.to_str().expect("remote path")],
-        );
-        git(&source, &["init"]);
-        git(&source, &["config", "user.email", "test@example.com"]);
-        git(&source, &["config", "user.name", "Test"]);
-        std::fs::write(source.join("version.txt"), "1.0.0").expect("version");
-        git(&source, &["add", "."]);
-        git(&source, &["commit", "-m", "initial"]);
-        git(&source, &["branch", "-M", "main"]);
-        git(
-            &source,
-            &[
-                "remote",
-                "add",
-                "origin",
-                remote.to_str().expect("remote path"),
-            ],
-        );
-        git(&source, &["push", "-u", "origin", "main"]);
-        git(
-            temp.path(),
-            &[
-                "clone",
-                "-b",
-                "main",
-                remote.to_str().expect("remote path"),
-                updater.to_str().expect("updater path"),
-            ],
-        );
-        git(&updater, &["config", "user.email", "test@example.com"]);
-        git(&updater, &["config", "user.name", "Test"]);
-        std::fs::write(updater.join("version.txt"), "1.1.0").expect("updated version");
-        git(&updater, &["add", "."]);
-        git(&updater, &["commit", "-m", "update"]);
-        git(&updater, &["push"]);
-
-        let component = component(&source);
-        let error = guard_local_build_source_freshness(&[component.clone()], &config())
-            .expect_err("stale source must refuse");
-        assert!(error.message.contains("1 commit(s) behind upstream"));
-        assert!(error.details.to_string().contains("--allow-stale-source"));
-
-        let mut allowed = config();
-        allowed.allow_stale_source = true;
-        guard_local_build_source_freshness(&[component], &allowed)
-            .expect("explicit stale-source override must proceed");
-    }
-
-    #[test]
-    fn semantic_downgrade_refuses_until_explicitly_allowed() {
-        let component = component(Path::new("."));
-        let local = HashMap::from([("example".to_string(), "1.2.3".to_string())]);
-        let remote = HashMap::from([("example".to_string(), "1.3.0".to_string())]);
-        let error = guard_local_build_downgrades(&[component.clone()], &local, &remote, &config())
-            .expect_err("remote-newer version must refuse");
-        assert!(error.message.contains("remote 1.3.0 > local 1.2.3"));
-        assert!(error.details.to_string().contains("--allow-downgrade"));
-
-        let mut allowed = config();
-        allowed.allow_downgrade = true;
-        guard_local_build_downgrades(&[component], &local, &remote, &allowed)
-            .expect("explicit downgrade override must proceed");
-    }
-
-    #[test]
-    fn equal_or_newer_local_semantic_versions_are_allowed() {
-        let component = component(Path::new("."));
-        for (local_version, remote_version) in [("1.3.0", "1.3.0"), ("1.4.0", "1.3.0")] {
-            let local = HashMap::from([("example".to_string(), local_version.to_string())]);
-            let remote = HashMap::from([("example".to_string(), remote_version.to_string())]);
-            guard_local_build_downgrades(&[component.clone()], &local, &remote, &config())
-                .expect("equal or newer local version must proceed");
-        }
-    }
-
-    #[test]
-    fn unavailable_or_invalid_versions_do_not_create_false_downgrade_refusals() {
-        let component = component(Path::new("."));
-        for (local, remote) in [
-            (
-                HashMap::new(),
-                HashMap::from([("example".to_string(), "1.3.0".to_string())]),
-            ),
-            (
-                HashMap::from([("example".to_string(), "dev".to_string())]),
-                HashMap::from([("example".to_string(), "1.3.0".to_string())]),
-            ),
-        ] {
-            guard_local_build_downgrades(&[component.clone()], &local, &remote, &config())
-                .expect("unavailable or invalid versions are not proven downgrades");
-        }
-    }
-
-    #[test]
-    fn immutable_release_asset_bypasses_local_source_guards() {
-        let component = Component {
-            id: "example".to_string(),
-            local_path: "/not/a/checkout".to_string(),
-            remote_url: Some("https://github.com/example/example".to_string()),
-            build_artifact: Some("example.zip".to_string()),
-            ..Component::default()
-        };
-        let mut config = config();
-        config.expected_version = Some("1.2.3".to_string());
-
-        assert!(local_build_components(&[component], &config).is_empty());
-    }
-
-    #[test]
-    fn non_default_head_requires_force_for_dry_run_and_apply() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        init_repo_with_commit(temp.path());
-        git(temp.path(), &["checkout", "-b", "feature"]);
-        let component = component(temp.path());
-
-        for dry_run in [true, false] {
-            let mut config = config();
-            config.head = true;
-            config.dry_run = dry_run;
-            let error = warn_non_default_branch(&[component.clone()], &config)
-                .expect_err("non-default --head requires --force");
-            assert_eq!(error.details["field"], "head");
-            assert!(error.message.contains("branch 'feature', not 'main'"));
-            assert!(error.details.to_string().contains("Use --force"));
-
-            config.force = true;
-            warn_non_default_branch(&[component.clone()], &config)
-                .expect("--force approves non-default --head for dry-run and apply");
-        }
-    }
-
-    // Serialize the #7599 tests: they mutate the process CWD, which is global.
-    fn cwd_lock() -> &'static std::sync::Mutex<()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-    }
-
-    fn with_cwd<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
-        let _guard = cwd_lock().lock().unwrap_or_else(|p| p.into_inner());
-        let previous = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(dir).expect("set cwd");
-        let result = f();
-        std::env::set_current_dir(previous).expect("restore cwd");
-        result
-    }
-
-    fn init_repo_with_commit(path: &Path) {
-        std::fs::create_dir_all(path).expect("repo dir");
-        git(path, &["init"]);
-        git(path, &["config", "user.email", "test@example.com"]);
-        git(path, &["config", "user.name", "Test"]);
-        std::fs::write(path.join("file.txt"), "a").expect("seed file");
-        git(path, &["add", "."]);
-        git(path, &["commit", "-m", "initial"]);
-        git(path, &["branch", "-M", "main"]);
-    }
-
-    #[test]
-    fn head_deploy_fails_closed_when_invocation_worktree_advanced_past_registered_checkout() {
-        // #7599: registered checkout (primary) is behind the worktree the
-        // operator is standing in. --head would build/report the primary's SHA,
-        // so refuse with an actionable message rather than ship the wrong commit.
-        let temp = tempfile::tempdir().expect("temp dir");
-        let primary = temp.path().join("primary");
-        init_repo_with_commit(&primary);
-        let worktree = temp.path().join("component@feature");
-        git(
-            &primary,
-            &["worktree", "add", worktree.to_str().expect("worktree path")],
-        );
-        // Advance the worktree past the primary.
-        std::fs::write(worktree.join("file.txt"), "b").expect("edit");
-        git(&worktree, &["add", "."]);
-        git(&worktree, &["commit", "-m", "advance worktree"]);
-
-        let mut cfg = config();
-        cfg.head = true;
-
-        let error = with_cwd(&worktree, || {
-            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
-                .expect_err("advanced invocation worktree must fail closed")
-        });
-        assert_eq!(error.details["field"], "head");
-        assert!(error.to_string().contains("different checkout"));
-    }
-
-    #[test]
-    fn head_deploy_passes_when_invocation_checkout_matches_registered_head() {
-        // Same repo, same HEAD (e.g. invoked from the registered checkout, or a
-        // worktree that has not advanced): nothing to reconcile.
-        let temp = tempfile::tempdir().expect("temp dir");
-        let primary = temp.path().join("primary");
-        init_repo_with_commit(&primary);
-        let worktree = temp.path().join("component@even");
-        git(
-            &primary,
-            &["worktree", "add", worktree.to_str().expect("worktree path")],
-        );
-
-        let mut cfg = config();
-        cfg.head = true;
-
-        with_cwd(&worktree, || {
-            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
-                .expect("matching HEAD passes the guard")
-        });
-    }
-
-    #[test]
-    fn head_deploy_ignores_unrelated_invocation_checkout() {
-        // The operator is standing in a *different* repository (different
-        // git-common-dir). The registered checkout is authoritative; do not
-        // false-positive on an unrelated advanced repo.
-        let temp = tempfile::tempdir().expect("temp dir");
-        let primary = temp.path().join("primary");
-        init_repo_with_commit(&primary);
-        let unrelated = temp.path().join("unrelated");
-        init_repo_with_commit(&unrelated);
-        std::fs::write(unrelated.join("file.txt"), "z").expect("edit");
-        git(&unrelated, &["add", "."]);
-        git(&unrelated, &["commit", "-m", "unrelated advance"]);
-
-        let mut cfg = config();
-        cfg.head = true;
-
-        with_cwd(&unrelated, || {
-            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
-                .expect("an unrelated repo must not trip the same-repo guard")
-        });
-    }
-
-    #[test]
-    fn head_deploy_force_bypasses_the_invocation_checkout_guard() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let primary = temp.path().join("primary");
-        init_repo_with_commit(&primary);
-        let worktree = temp.path().join("component@forced");
-        git(
-            &primary,
-            &["worktree", "add", worktree.to_str().expect("worktree path")],
-        );
-        std::fs::write(worktree.join("file.txt"), "b").expect("edit");
-        git(&worktree, &["add", "."]);
-        git(&worktree, &["commit", "-m", "advance worktree"]);
-
-        let mut cfg = config();
-        cfg.head = true;
-        cfg.force = true;
-
-        with_cwd(&worktree, || {
-            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
-                .expect("--force bypasses the guard")
-        });
-    }
-}
-
 /// Fetch and pull latest changes for each component before deploying.
 ///
 /// Prevents deploying stale code when the local clone is behind remote.
@@ -1192,4 +755,458 @@ pub(super) fn verify_expected_version(components: &[Component], expected: &str) 
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::process::Command;
+
+    use super::{
+        guard_deployment_provenance, guard_head_matches_invocation_checkout,
+        guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
+        warn_non_default_branch,
+    };
+    use crate::DeployConfig;
+    use homeboy_core::component::Component;
+    use homeboy_core::project::{
+        DeploymentForgeEvidence, DeploymentProvenanceMode, DeploymentProvenancePolicy, Project,
+    };
+
+    fn config() -> DeployConfig {
+        DeployConfig {
+            component_ids: vec![],
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            skip_deps_hydration: false,
+            expected_version: None,
+            no_pull: true,
+            allow_stale_source: false,
+            allow_downgrade: false,
+            head: false,
+            requested_ref: None,
+            requested_refs: Default::default(),
+            resolved_refs: Default::default(),
+            preflighted_source_paths: Default::default(),
+            preflighted_component_identities: Default::default(),
+            prepared_projection: None,
+            tagged: false,
+            prepared_artifact: None,
+            resume_run_id: None,
+        }
+    }
+
+    fn component(path: &Path) -> Component {
+        Component {
+            id: "example".to_string(),
+            local_path: path.to_string_lossy().to_string(),
+            ..Component::default()
+        }
+    }
+
+    fn accepted_ref_project() -> Project {
+        Project {
+            id: "production".to_string(),
+            deployment_provenance: Some(DeploymentProvenancePolicy {
+                mode: DeploymentProvenanceMode::AcceptedRef,
+                forge_evidence: vec![],
+            }),
+            ..Project::default()
+        }
+    }
+
+    #[test]
+    fn deployment_provenance_policy_fails_before_mutable_selectors_can_run() {
+        let component = component(Path::new("/unread-source"));
+        let project = accepted_ref_project();
+        let mut config = config();
+        config.head = true;
+        let error = guard_deployment_provenance(&project, &[component], &mut config)
+            .expect_err("HEAD must fail before source work");
+        assert_eq!(error.details["field"], "deployment_provenance");
+    }
+
+    #[test]
+    fn accepted_ref_policy_accepts_validated_release_set_and_refuses_force() {
+        let component = component(Path::new("/unread-source"));
+        let project = accepted_ref_project();
+        let mut config = config();
+        config
+            .requested_refs
+            .insert("example".to_string(), "v1.2.3".to_string());
+        config
+            .resolved_refs
+            .insert("example".to_string(), "a".repeat(40));
+        config
+            .preflighted_source_paths
+            .insert("example".to_string(), "/unread-source".to_string());
+        config
+            .preflighted_component_identities
+            .insert("example".to_string(), "identity".to_string());
+        let evidence =
+            guard_deployment_provenance(&project, std::slice::from_ref(&component), &mut config)
+                .expect("validated release set is accepted evidence");
+        assert_eq!(evidence["example"].kind, "release_set");
+
+        config.force = true;
+        let error = guard_deployment_provenance(&project, &[component], &mut config)
+            .expect_err("force must not bypass active policy");
+        assert_eq!(error.details["field"], "force");
+    }
+
+    #[test]
+    fn accepted_ref_policy_accepts_release_tag_and_sha_bound_forge_evidence() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        init_repo_with_commit(temp.path());
+        git(temp.path(), &["tag", "v1.2.3"]);
+        let component = component(temp.path());
+        let project = accepted_ref_project();
+
+        let mut tagged = config();
+        let evidence =
+            guard_deployment_provenance(&project, std::slice::from_ref(&component), &mut tagged)
+                .expect("latest release tag is accepted");
+        assert_eq!(evidence["example"].kind, "release_tag");
+
+        let sha = homeboy_core::git::run_git(temp.path(), &["rev-parse", "HEAD"], "read SHA")
+            .expect("SHA")
+            .trim()
+            .to_string();
+        let mut project = accepted_ref_project();
+        project
+            .deployment_provenance
+            .as_mut()
+            .expect("policy")
+            .forge_evidence = vec![DeploymentForgeEvidence {
+            sha: sha.clone(),
+            forge: "github".to_string(),
+            reference: "https://github.com/acme/example/pull/42".to_string(),
+        }];
+        let mut direct = config();
+        direct.requested_ref = Some(sha);
+        let evidence = guard_deployment_provenance(&project, &[component], &mut direct)
+            .expect("forge evidence for exact SHA is accepted");
+        assert_eq!(evidence["example"].kind, "forge");
+        assert_eq!(evidence["example"].forge.as_deref(), Some("github"));
+    }
+
+    #[test]
+    fn accepted_ref_policy_refuses_unverifiable_ref() {
+        let component = component(Path::new("/unread-source"));
+        let mut config = config();
+        config.requested_ref = Some("unverifiable".to_string());
+        assert!(
+            guard_deployment_provenance(&accepted_ref_project(), &[component], &mut config)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn omitted_deployment_provenance_policy_preserves_force_compatibility() {
+        let component = component(Path::new("/unread-source"));
+        let mut config = config();
+        config.head = true;
+        config.force = true;
+        guard_deployment_provenance(&Project::default(), &[component], &mut config)
+            .expect("projects without a policy retain legacy force semantics");
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn stale_local_source_refuses_until_explicitly_allowed() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let remote = temp.path().join("remote.git");
+        let source = temp.path().join("source");
+        let updater = temp.path().join("updater");
+        std::fs::create_dir(&source).expect("source dir");
+        git(
+            temp.path(),
+            &["init", "--bare", remote.to_str().expect("remote path")],
+        );
+        git(&source, &["init"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Test"]);
+        std::fs::write(source.join("version.txt"), "1.0.0").expect("version");
+        git(&source, &["add", "."]);
+        git(&source, &["commit", "-m", "initial"]);
+        git(&source, &["branch", "-M", "main"]);
+        git(
+            &source,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("remote path"),
+            ],
+        );
+        git(&source, &["push", "-u", "origin", "main"]);
+        git(
+            temp.path(),
+            &[
+                "clone",
+                "-b",
+                "main",
+                remote.to_str().expect("remote path"),
+                updater.to_str().expect("updater path"),
+            ],
+        );
+        git(&updater, &["config", "user.email", "test@example.com"]);
+        git(&updater, &["config", "user.name", "Test"]);
+        std::fs::write(updater.join("version.txt"), "1.1.0").expect("updated version");
+        git(&updater, &["add", "."]);
+        git(&updater, &["commit", "-m", "update"]);
+        git(&updater, &["push"]);
+
+        let component = component(&source);
+        let error = guard_local_build_source_freshness(std::slice::from_ref(&component), &config())
+            .expect_err("stale source must refuse");
+        assert!(error.message.contains("1 commit(s) behind upstream"));
+        assert!(error.details.to_string().contains("--allow-stale-source"));
+
+        let mut allowed = config();
+        allowed.allow_stale_source = true;
+        guard_local_build_source_freshness(&[component], &allowed)
+            .expect("explicit stale-source override must proceed");
+    }
+
+    #[test]
+    fn semantic_downgrade_refuses_until_explicitly_allowed() {
+        let component = component(Path::new("."));
+        let local = HashMap::from([("example".to_string(), "1.2.3".to_string())]);
+        let remote = HashMap::from([("example".to_string(), "1.3.0".to_string())]);
+        let error = guard_local_build_downgrades(
+            std::slice::from_ref(&component),
+            &local,
+            &remote,
+            &config(),
+        )
+        .expect_err("remote-newer version must refuse");
+        assert!(error.message.contains("remote 1.3.0 > local 1.2.3"));
+        assert!(error.details.to_string().contains("--allow-downgrade"));
+
+        let mut allowed = config();
+        allowed.allow_downgrade = true;
+        guard_local_build_downgrades(&[component], &local, &remote, &allowed)
+            .expect("explicit downgrade override must proceed");
+    }
+
+    #[test]
+    fn equal_or_newer_local_semantic_versions_are_allowed() {
+        let component = component(Path::new("."));
+        for (local_version, remote_version) in [("1.3.0", "1.3.0"), ("1.4.0", "1.3.0")] {
+            let local = HashMap::from([("example".to_string(), local_version.to_string())]);
+            let remote = HashMap::from([("example".to_string(), remote_version.to_string())]);
+            guard_local_build_downgrades(
+                std::slice::from_ref(&component),
+                &local,
+                &remote,
+                &config(),
+            )
+            .expect("equal or newer local version must proceed");
+        }
+    }
+
+    #[test]
+    fn unavailable_or_invalid_versions_do_not_create_false_downgrade_refusals() {
+        let component = component(Path::new("."));
+        for (local, remote) in [
+            (
+                HashMap::new(),
+                HashMap::from([("example".to_string(), "1.3.0".to_string())]),
+            ),
+            (
+                HashMap::from([("example".to_string(), "dev".to_string())]),
+                HashMap::from([("example".to_string(), "1.3.0".to_string())]),
+            ),
+        ] {
+            guard_local_build_downgrades(
+                std::slice::from_ref(&component),
+                &local,
+                &remote,
+                &config(),
+            )
+            .expect("unavailable or invalid versions are not proven downgrades");
+        }
+    }
+
+    #[test]
+    fn immutable_release_asset_bypasses_local_source_guards() {
+        let component = Component {
+            id: "example".to_string(),
+            local_path: "/not/a/checkout".to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("example.zip".to_string()),
+            ..Component::default()
+        };
+        let mut config = config();
+        config.expected_version = Some("1.2.3".to_string());
+
+        assert!(local_build_components(&[component], &config).is_empty());
+    }
+
+    #[test]
+    fn non_default_head_requires_force_for_dry_run_and_apply() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        init_repo_with_commit(temp.path());
+        git(temp.path(), &["checkout", "-b", "feature"]);
+        let component = component(temp.path());
+
+        for dry_run in [true, false] {
+            let mut config = config();
+            config.head = true;
+            config.dry_run = dry_run;
+            let error = warn_non_default_branch(std::slice::from_ref(&component), &config)
+                .expect_err("non-default --head requires --force");
+            assert_eq!(error.details["field"], "head");
+            assert!(error.message.contains("branch 'feature', not 'main'"));
+            assert!(error.details.to_string().contains("Use --force"));
+
+            config.force = true;
+            warn_non_default_branch(std::slice::from_ref(&component), &config)
+                .expect("--force approves non-default --head for dry-run and apply");
+        }
+    }
+
+    // Serialize the #7599 tests: they mutate the process CWD, which is global.
+    fn cwd_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    fn with_cwd<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = cwd_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir).expect("set cwd");
+        let result = f();
+        std::env::set_current_dir(previous).expect("restore cwd");
+        result
+    }
+
+    fn init_repo_with_commit(path: &Path) {
+        std::fs::create_dir_all(path).expect("repo dir");
+        git(path, &["init"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Test"]);
+        std::fs::write(path.join("file.txt"), "a").expect("seed file");
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "initial"]);
+        git(path, &["branch", "-M", "main"]);
+    }
+
+    #[test]
+    fn head_deploy_fails_closed_when_invocation_worktree_advanced_past_registered_checkout() {
+        // #7599: registered checkout (primary) is behind the worktree the
+        // operator is standing in. --head would build/report the primary's SHA,
+        // so refuse with an actionable message rather than ship the wrong commit.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let primary = temp.path().join("primary");
+        init_repo_with_commit(&primary);
+        let worktree = temp.path().join("component@feature");
+        git(
+            &primary,
+            &["worktree", "add", worktree.to_str().expect("worktree path")],
+        );
+        // Advance the worktree past the primary.
+        std::fs::write(worktree.join("file.txt"), "b").expect("edit");
+        git(&worktree, &["add", "."]);
+        git(&worktree, &["commit", "-m", "advance worktree"]);
+
+        let mut cfg = config();
+        cfg.head = true;
+
+        let error = with_cwd(&worktree, || {
+            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
+                .expect_err("advanced invocation worktree must fail closed")
+        });
+        assert_eq!(error.details["field"], "head");
+        assert!(error.to_string().contains("different checkout"));
+    }
+
+    #[test]
+    fn head_deploy_passes_when_invocation_checkout_matches_registered_head() {
+        // Same repo, same HEAD (e.g. invoked from the registered checkout, or a
+        // worktree that has not advanced): nothing to reconcile.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let primary = temp.path().join("primary");
+        init_repo_with_commit(&primary);
+        let worktree = temp.path().join("component@even");
+        git(
+            &primary,
+            &["worktree", "add", worktree.to_str().expect("worktree path")],
+        );
+
+        let mut cfg = config();
+        cfg.head = true;
+
+        with_cwd(&worktree, || {
+            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
+                .expect("matching HEAD passes the guard")
+        });
+    }
+
+    #[test]
+    fn head_deploy_ignores_unrelated_invocation_checkout() {
+        // The operator is standing in a *different* repository (different
+        // git-common-dir). The registered checkout is authoritative; do not
+        // false-positive on an unrelated advanced repo.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let primary = temp.path().join("primary");
+        init_repo_with_commit(&primary);
+        let unrelated = temp.path().join("unrelated");
+        init_repo_with_commit(&unrelated);
+        std::fs::write(unrelated.join("file.txt"), "z").expect("edit");
+        git(&unrelated, &["add", "."]);
+        git(&unrelated, &["commit", "-m", "unrelated advance"]);
+
+        let mut cfg = config();
+        cfg.head = true;
+
+        with_cwd(&unrelated, || {
+            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
+                .expect("an unrelated repo must not trip the same-repo guard")
+        });
+    }
+
+    #[test]
+    fn head_deploy_force_bypasses_the_invocation_checkout_guard() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let primary = temp.path().join("primary");
+        init_repo_with_commit(&primary);
+        let worktree = temp.path().join("component@forced");
+        git(
+            &primary,
+            &["worktree", "add", worktree.to_str().expect("worktree path")],
+        );
+        std::fs::write(worktree.join("file.txt"), "b").expect("edit");
+        git(&worktree, &["add", "."]);
+        git(&worktree, &["commit", "-m", "advance worktree"]);
+
+        let mut cfg = config();
+        cfg.head = true;
+        cfg.force = true;
+
+        with_cwd(&worktree, || {
+            guard_head_matches_invocation_checkout(&[component(&primary)], &cfg)
+                .expect("--force bypasses the guard")
+        });
+    }
 }

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -203,7 +203,7 @@ fn run_component(
         )
     }?;
     if !dry_run {
-        if let Some(observation) = observation.as_deref_mut() {
+        if let Some(observation) = observation {
             observation.phase("verify", true)?;
         }
     }
@@ -211,13 +211,11 @@ fn run_component(
     let output = format!("{}{}", evidence.stdout, evidence.stderr);
     // Layered input can contain target secrets. Provider output is therefore not
     // promoted into deploy evidence or errors on that path.
-    let provider_result = if is_layered && layered_result_schema.is_some() {
-        layered_provider_evidence(&evidence.stdout, layered_result_schema.expect("checked"))
-    } else if is_layered {
-        serde_json::json!({ "status": "opaque" })
-    } else {
-        serde_json::from_str::<serde_json::Value>(&evidence.stdout)
-            .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output }))
+    let provider_result = match (is_layered, layered_result_schema) {
+        (true, Some(schema)) => layered_provider_evidence(&evidence.stdout, schema),
+        (true, None) => serde_json::json!({ "status": "opaque" }),
+        (false, _) => serde_json::from_str::<serde_json::Value>(&evidence.stdout)
+            .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output })),
     };
     let status = if run.exit_code == 0 {
         if config.dry_run || config.check {

--- a/crates/homeboy-deploy/src/receipt.rs
+++ b/crates/homeboy-deploy/src/receipt.rs
@@ -77,16 +77,28 @@ pub(super) fn load(
     Ok(Some(receipt))
 }
 
-pub(super) fn write(
-    project: &Project,
-    component_id: &str,
-    target: &str,
-    version: &str,
-    manifest: Manifest,
-    payload_sha256: String,
-    build_provenance: BuildProvenance,
-    exclusions: Vec<String>,
-) -> Result<(), Error> {
+pub(super) struct ReceiptWrite<'a> {
+    pub(super) project: &'a Project,
+    pub(super) component_id: &'a str,
+    pub(super) target: &'a str,
+    pub(super) version: &'a str,
+    pub(super) manifest: Manifest,
+    pub(super) payload_sha256: String,
+    pub(super) build_provenance: BuildProvenance,
+    pub(super) exclusions: Vec<String>,
+}
+
+pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
+    let ReceiptWrite {
+        project,
+        component_id,
+        target,
+        version,
+        manifest,
+        payload_sha256,
+        build_provenance,
+        exclusions,
+    } = input;
     let path = path(project, component_id, target, version)?;
     let parent = path.parent().expect("receipt path has a parent");
     fs::create_dir_all(parent)

--- a/crates/homeboy-deploy/src/safety_and_artifact.rs
+++ b/crates/homeboy-deploy/src/safety_and_artifact.rs
@@ -23,7 +23,7 @@ pub(super) fn deploy_via_git(
     remote_path: &str,
     git_config: &component::GitDeployConfig,
     component_version: Option<&str>,
-    mut observation: Option<&mut DeployObservation>,
+    observation: Option<&mut DeployObservation>,
 ) -> Result<DeployResult> {
     // Determine what to checkout
     let checkout_target = if let Some(ref pattern) = git_config.tag_pattern {
@@ -38,7 +38,7 @@ pub(super) fn deploy_via_git(
 
     // Step 1: Fetch latest. `git fetch` writes remote-tracking refs and
     // FETCH_HEAD, so record the mutation boundary before issuing it.
-    if let Some(observation) = observation.as_deref_mut() {
+    if let Some(observation) = observation {
         observation.phase("transfer", true)?;
     }
     homeboy_core::log_status!(
@@ -309,7 +309,7 @@ pub(super) fn deploy_artifact(
 
     // Step 3: Run verification if configured
     if verification.is_some() {
-        if let Some(observation) = observation.as_deref_mut() {
+        if let Some(observation) = observation {
             observation.phase("verify", true)?;
         }
     }

--- a/crates/homeboy-deploy/src/transfer.rs
+++ b/crates/homeboy-deploy/src/transfer.rs
@@ -64,7 +64,7 @@ fn rsync_directory(
 
     let mut ssh_cmd_parts = vec!["ssh".to_string()];
     ssh_cmd_parts.extend(homeboy_core::server::ssh_args::client_option_args(
-        &ssh_client,
+        ssh_client,
         homeboy_core::server::ssh_args::SshArgOptions {
             batch_mode: true,
             connect_timeout: true,

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -323,6 +323,7 @@ pub enum BuildSource {
 /// makes both facts visible without treating the transfer as a skipped build.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum BuildPhase {
     /// The deploy phase built the payload directly.
     Deploy,
@@ -331,13 +332,8 @@ pub enum BuildPhase {
     /// No build ran in this deploy lifecycle.
     NotRun,
     /// The phase was not recorded by an older persisted result.
+    #[default]
     Unknown,
-}
-
-impl Default for BuildPhase {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 /// Content identity of a deployed artifact file, so stale artifacts are detectable.

--- a/crates/homeboy-deploy/src/version_overrides.rs
+++ b/crates/homeboy-deploy/src/version_overrides.rs
@@ -575,7 +575,7 @@ pub(super) fn deploy_with_override(
     // until after this step so extension verifiers can compare installed files
     // against the exact uploaded payload.
     if let Some(v) = verification {
-        if let Some(observation) = observation.as_deref_mut() {
+        if let Some(observation) = observation {
             observation.phase("verify", true)?;
         }
         if let Some(ref verify_cmd_template) = v.verify_command {


### PR DESCRIPTION
## Summary
- replace wide deploy execution, check-mode, and receipt interfaces with typed inputs
- adopt Rust 1.95 Clippy idioms while preserving deploy ordering and lifecycle boundaries
- retain source-selector, schema, and resumability coverage

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo clippy -p homeboy-deploy --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-deploy exact_ref_preparation_preserves_duplicate_source_version_target_artifact_paths -- --test-threads=1`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy-target cargo test -p homeboy-cli deploy -- --test-threads=1`

Refs #11580

AI assistance: OpenAI openai/gpt-5.6-sol via OpenCode implemented the diagnostic refactor and ran the listed verification. Chris Huber remains responsible for every line.