### PR TITLE
fix(cli): resolve remaining Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -380,6 +380,59 @@ fn child_args(record: &deferred_workload::DeferredWorkload, runner_id: &str) -> 
     args
 }
 
+pub(crate) fn redacted_record(record: &deferred_workload::DeferredWorkload) -> serde_json::Value {
+    let mut value = serde_json::to_value(record).expect("deferred workload serializes");
+    let secret_names = record
+        .job_overrides
+        .secret_env_names
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    if let Some(env) = value
+        .pointer_mut("/job_overrides/env")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        for name in secret_names {
+            if env.contains_key(name) {
+                env.insert(
+                    name.to_string(),
+                    serde_json::Value::String("[REDACTED]".to_string()),
+                );
+            }
+        }
+    }
+    if let Some(args) = value
+        .get_mut("args")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        redact_settings_args(args);
+    }
+    value
+}
+
+fn redact_settings_args(args: &mut [serde_json::Value]) {
+    let mut redact_next = false;
+    for arg in args {
+        let Some(value) = arg.as_str() else { continue };
+        if redact_next {
+            *arg = serde_json::Value::String("[REDACTED]".to_string());
+            redact_next = false;
+        } else if matches!(
+            value,
+            "--setting" | "--setting-json" | "--settings-json-file" | "--settings-profile"
+        ) {
+            redact_next = true;
+        } else if value.starts_with("--setting=")
+            || value.starts_with("--setting-json=")
+            || value.starts_with("--settings-json-file=")
+            || value.starts_with("--settings-profile=")
+        {
+            *arg = serde_json::Value::String(
+                value.split_once('=').expect("checked").0.to_string() + "=[REDACTED]",
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -662,58 +715,5 @@ mod tests {
             .expect("restart dead worker");
             assert_eq!(spawned.get(), 1);
         });
-    }
-}
-
-pub(crate) fn redacted_record(record: &deferred_workload::DeferredWorkload) -> serde_json::Value {
-    let mut value = serde_json::to_value(record).expect("deferred workload serializes");
-    let secret_names = record
-        .job_overrides
-        .secret_env_names
-        .iter()
-        .collect::<std::collections::BTreeSet<_>>();
-    if let Some(env) = value
-        .pointer_mut("/job_overrides/env")
-        .and_then(serde_json::Value::as_object_mut)
-    {
-        for name in secret_names {
-            if env.contains_key(name) {
-                env.insert(
-                    name.to_string(),
-                    serde_json::Value::String("[REDACTED]".to_string()),
-                );
-            }
-        }
-    }
-    if let Some(args) = value
-        .get_mut("args")
-        .and_then(serde_json::Value::as_array_mut)
-    {
-        redact_settings_args(args);
-    }
-    value
-}
-
-fn redact_settings_args(args: &mut [serde_json::Value]) {
-    let mut redact_next = false;
-    for arg in args {
-        let Some(value) = arg.as_str() else { continue };
-        if redact_next {
-            *arg = serde_json::Value::String("[REDACTED]".to_string());
-            redact_next = false;
-        } else if matches!(
-            value,
-            "--setting" | "--setting-json" | "--settings-json-file" | "--settings-profile"
-        ) {
-            redact_next = true;
-        } else if value.starts_with("--setting=")
-            || value.starts_with("--setting-json=")
-            || value.starts_with("--settings-json-file=")
-            || value.starts_with("--settings-profile=")
-        {
-            *arg = serde_json::Value::String(
-                value.split_once('=').expect("checked").0.to_string() + "=[REDACTED]",
-            );
-        }
     }
 }

--- a/crates/homeboy-cli/src/commands/project.rs
+++ b/crates/homeboy-cli/src/commands/project.rs
@@ -609,6 +609,38 @@ fn pin_update(
     ))
 }
 
+fn pin_rename(
+    project_id: &str,
+    old_path: &str,
+    new_path: &str,
+    pin_type: ProjectPinType,
+) -> CmdResult<ProjectOutput> {
+    let pin = project::rename_pin(project_id, map_pin_type(pin_type), old_path, new_path)?;
+
+    Ok((
+        project::build_pin_output("project.pin.rename", project_id, pin),
+        0,
+    ))
+}
+
+fn map_pin_type(pin_type: ProjectPinType) -> project::PinType {
+    match pin_type {
+        ProjectPinType::File => project::PinType::File,
+        ProjectPinType::Log => project::PinType::Log,
+    }
+}
+
+fn status(project_id: &str, health_only: bool) -> CmdResult<ProjectOutput> {
+    homeboy::log_status!("project", "Checking '{}'...", project_id);
+
+    let report = project::status_report(project_id, health_only)?;
+    let exit_code = report
+        .health
+        .as_ref()
+        .is_some_and(|health| !health.state.is_healthy()) as i32;
+    Ok((project::build_status_output(project_id, report), exit_code))
+}
+
 #[cfg(test)]
 mod tests {
     use super::status;
@@ -687,36 +719,4 @@ mod tests {
             );
         });
     }
-}
-
-fn pin_rename(
-    project_id: &str,
-    old_path: &str,
-    new_path: &str,
-    pin_type: ProjectPinType,
-) -> CmdResult<ProjectOutput> {
-    let pin = project::rename_pin(project_id, map_pin_type(pin_type), old_path, new_path)?;
-
-    Ok((
-        project::build_pin_output("project.pin.rename", project_id, pin),
-        0,
-    ))
-}
-
-fn map_pin_type(pin_type: ProjectPinType) -> project::PinType {
-    match pin_type {
-        ProjectPinType::File => project::PinType::File,
-        ProjectPinType::Log => project::PinType::Log,
-    }
-}
-
-fn status(project_id: &str, health_only: bool) -> CmdResult<ProjectOutput> {
-    homeboy::log_status!("project", "Checking '{}'...", project_id);
-
-    let report = project::status_report(project_id, health_only)?;
-    let exit_code = report
-        .health
-        .as_ref()
-        .is_some_and(|health| !health.state.is_healthy()) as i32;
-    Ok((project::build_status_output(project_id, report), exit_code))
 }

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -367,52 +367,6 @@ impl ReleaseExecuteArgs {
     }
 }
 
-#[cfg(test)]
-impl ReleaseExecuteArgs {
-    /// Construct ReleaseExecuteArgs programmatically for tests and internal callers.
-    fn from_parts(
-        components: Vec<String>,
-        project: Option<String>,
-        outdated: bool,
-        path: Option<String>,
-        dry_run: bool,
-        deploy: bool,
-        recover: bool,
-        head: bool,
-        from_artifacts: Option<String>,
-        skip_checks: bool,
-        skip_publish: bool,
-        bump: Option<String>,
-    ) -> Self {
-        Self {
-            components,
-            project,
-            outdated,
-            path,
-            dry_run_args: DryRunArgs { dry_run },
-            apply: false,
-            deploy,
-            recover,
-            owner_run_ref: None,
-            retag: false,
-            head,
-            from_artifacts,
-            package_only: false,
-            tag: None,
-            skip_checks: if skip_checks { Some(Vec::new()) } else { None },
-            skip_build_validation: false,
-            bump,
-            force_lower_bump: false,
-            skip_publish,
-            no_github_release: false,
-            i_know_ci_creates_the_github_release: false,
-            i_know_this_is_a_manual_tag_only_release: false,
-            git_identity: None,
-            cascade: false,
-        }
-    }
-}
-
 pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
     match args.command {
         Some(ReleaseSubcommand::Changes(args)) => {
@@ -1007,20 +961,32 @@ mod tests {
     use super::*;
 
     fn args(components: &[&str]) -> ReleaseExecuteArgs {
-        ReleaseExecuteArgs::from_parts(
-            components.iter().map(|value| value.to_string()).collect(),
-            None,
-            false,
-            None,
-            true,
-            false,
-            false,
-            false,
-            None,
-            false,
-            false,
-            None,
-        )
+        ReleaseExecuteArgs {
+            components: components.iter().map(|value| value.to_string()).collect(),
+            project: None,
+            outdated: false,
+            path: None,
+            dry_run_args: DryRunArgs { dry_run: true },
+            apply: false,
+            deploy: false,
+            recover: false,
+            owner_run_ref: None,
+            retag: false,
+            head: false,
+            from_artifacts: None,
+            package_only: false,
+            tag: None,
+            skip_checks: None,
+            skip_build_validation: false,
+            bump: None,
+            force_lower_bump: false,
+            skip_publish: false,
+            no_github_release: false,
+            i_know_ci_creates_the_github_release: false,
+            i_know_this_is_a_manual_tag_only_release: false,
+            git_identity: None,
+            cascade: false,
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move deferred workload and project production helpers before their test modules
- replace the oversized release test fixture constructor with a direct fixture

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-target cargo check --workspace`
- focused `homeboy-cli` deferred-workload, project, and release tests
- `CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-target cargo clippy -p homeboy-cli --all-targets --no-deps -- -D warnings`

Refs #11580

AI assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode identified the Rust 1.95 Clippy diagnostics, applied the minimal code reordering/test-fixture refactor, and ran verification. Chris remains responsible for every line.