### PR TITLE
Fix Rust 1.95 diagnostics in homeboy-agents

### DIFF
--- a/crates/homeboy-agents/src/agent_task/capabilities.rs
+++ b/crates/homeboy-agents/src/agent_task/capabilities.rs
@@ -71,9 +71,8 @@ pub(crate) fn ready_attached_tools_from_metadata(metadata: &Value) -> BTreeSet<S
         .and_then(Value::as_object)
         .into_iter()
         .flat_map(|entries| entries.iter())
-        .filter_map(|(id, readiness)| {
-            (readiness.get("state").and_then(Value::as_str) == Some("ready")).then(|| id.clone())
-        })
+        .filter(|&(_id, readiness)| readiness.get("state").and_then(Value::as_str) == Some("ready"))
+        .map(|(id, _readiness)| id.clone())
         .collect()
 }
 

--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -829,7 +829,7 @@ where
             let run_result = agent_task_service::run_next(executor)?;
             let value = match run_result.value {
                 Some(aggregate) => serde_json::to_value(
-                    &crate::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
+                    crate::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
                 )
                 .map_err(|error| Error::internal_json(error.to_string(), None))?,
                 None => serde_json::json!({ "claimed": false }),
@@ -907,6 +907,10 @@ fn request_with_controller_dispatch_identity(
     request
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "controller action keeps lifecycle state, dispatch identity, and provider contract explicit"
+)]
 pub(super) fn execute_fan_out_action<E, D>(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,

--- a/crates/homeboy-agents/src/agent_task_controller_service/spec_source.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/spec_source.rs
@@ -98,31 +98,6 @@ pub fn load_materialize_spec_source(source: &str) -> Result<MaterializeSpecSourc
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn invalid_manifest_shape_preserves_primary_and_fallback_serde_causes() {
-        let error = match load_materialize_spec_source("{}") {
-            Ok(_) => panic!("expected schema mismatch error"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error.code.as_str(), "validation.invalid_argument");
-        assert!(error.message.contains("agent task repo loop spec"));
-        assert!(error.message.contains("fallback cause"));
-        assert!(error.details["cause"]
-            .as_str()
-            .expect("primary cause")
-            .contains("missing field"));
-        assert!(error.details["fallback_cause"]
-            .as_str()
-            .expect("fallback cause")
-            .contains("missing field"));
-    }
-}
-
 fn load_generated_materialize_spec(
     source: &str,
     manifest: ControllerSpecGeneratorManifest,
@@ -455,4 +430,29 @@ fn attach_generator_failure_diagnostics(
             "max_stderr_bytes": bounds.max_stderr_bytes,
         }
     }]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_manifest_shape_preserves_primary_and_fallback_serde_causes() {
+        let error = match load_materialize_spec_source("{}") {
+            Ok(_) => panic!("expected schema mismatch error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("agent task repo loop spec"));
+        assert!(error.message.contains("fallback cause"));
+        assert!(error.details["cause"]
+            .as_str()
+            .expect("primary cause")
+            .contains("missing field"));
+        assert!(error.details["fallback_cause"]
+            .as_str()
+            .expect("fallback cause")
+            .contains("missing field"));
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_dependency_actions.rs
+++ b/crates/homeboy-agents/src/agent_task_dependency_actions.rs
@@ -327,7 +327,8 @@ mod tests {
             target_base: "main".into(),
         };
         let mut first = Fake::default();
-        execute_resolved_dependency_actions(&id, &[resolution.clone()], &mut first).unwrap();
+        execute_resolved_dependency_actions(&id, std::slice::from_ref(&resolution), &mut first)
+            .unwrap();
         assert_eq!(first.calls, ["fetch", "rebase", "push"]);
         let mut resumed = Fake::default();
         execute_resolved_dependency_actions(&id, &[resolution], &mut resumed).unwrap();

--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -831,6 +831,10 @@ fn publication_proof(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "finalization report preserves independently persisted publication proof fields"
+)]
 fn report(
     options: &AgentTaskPrFinalizationOptions,
     mut publication_intent: AgentTaskPublicationIntent,
@@ -1050,6 +1054,10 @@ fn durable_model(lifecycle: &RunLifecycleRecord) -> Result<String> {
     Ok(model)
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "outcome fields mirror the durable finalization schema"
+)]
 fn finalization_outcome(
     intent: &AgentTaskPublicationIntent,
     publication_proof: &AgentTaskPublicationProof,

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -85,7 +85,7 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         if !output.status.success() {
             return Err(Error::validation_invalid_argument(
                 "base",
-                &format!(
+                format!(
                     "could not fetch requested base `refs/heads/{base}` from origin; verify remote access and that the branch exists, then retry: {}",
                     String::from_utf8_lossy(&output.stderr).trim()
                 ),
@@ -620,6 +620,102 @@ fn is_git_object_id(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+pub(super) fn validate_real_candidate_fingerprint(
+    options: &AgentTaskPrFinalizationOptions,
+) -> Result<()> {
+    let record = crate::agent_task_lifecycle::status(&options.run_id)?;
+    let promotion: AgentTaskPromotionReport = deserialize_persisted_value(
+        record.metadata.get("latest_promotion").cloned(),
+        "normal finalization requires persisted latest_promotion",
+        "persisted latest_promotion is invalid",
+    )?;
+    let expected: AgentTaskPromotionCandidate = deserialize_persisted_value(
+        promotion.provenance.get("candidate").cloned(),
+        "applied promotion is missing a candidate capability; rerun promotion before normal finalization or use --manual-finalization to record the explicit bypass",
+        "persisted candidate capability is invalid",
+    )?;
+    if !matches!(expected, AgentTaskPromotionCandidate::Git { .. }) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "normal GitHub PR finalization requires an exact Git candidate fingerprint; the applied promotion target was not a Git worktree. Rerun promotion into a Git worktree or use --manual-finalization to record the explicit provenance bypass",
+            None,
+            None,
+        ));
+    }
+    if super::normalize_changed_files(&options.changed_files)
+        != super::normalize_changed_files(&promotion.changed_files)
+    {
+        return Err(super::changed_files_mismatch_error(
+            &options.run_id,
+            &options.changed_files,
+            &promotion.changed_files,
+        ));
+    }
+    validate_candidate_fingerprint(options, &expected)
+}
+
+pub(super) fn validate_candidate_fingerprint(
+    options: &AgentTaskPrFinalizationOptions,
+    expected: &AgentTaskPromotionCandidate,
+) -> Result<()> {
+    let AgentTaskPromotionCandidate::Git {
+        fingerprint: expected_fingerprint,
+    } = expected
+    else {
+        unreachable!("caller validates Git promotion candidate")
+    };
+    let actual = crate::agent_task_promotion::candidate_fingerprint(&options.path)?;
+    let AgentTaskPromotionCandidate::Git {
+        fingerprint: actual_fingerprint,
+    } = &actual
+    else {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "finalization path is not a Git worktree; normal GitHub PR finalization requires the promoted Git candidate",
+            Some(options.path.clone()),
+            None,
+        ));
+    };
+    if actual == *expected {
+        return Ok(());
+    }
+    if !actual_fingerprint.changed_files.is_empty()
+        || expected_fingerprint.tree.is_empty()
+        || !committed_candidate_matches(options, expected_fingerprint)?
+    {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "candidate changed after promotion; durable finalization accepts a recovery commit only when its parent and tree exactly match the recorded promoted candidate. Rerun promotion gates before finalization.",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn committed_candidate_matches(
+    options: &AgentTaskPrFinalizationOptions,
+    fingerprint: &crate::agent_task_promotion::AgentTaskCandidateFingerprint,
+) -> Result<bool> {
+    let parent = git_output(&options.path, &["rev-parse", "HEAD^"])?;
+    if parent.trim() != fingerprint.head {
+        return Ok(false);
+    }
+    let tree = git_output(&options.path, &["rev-parse", "HEAD^{tree}"])?;
+    Ok(tree.trim() == fingerprint.tree)
+}
+
+fn deserialize_persisted_value<T: DeserializeOwned>(
+    value: Option<serde_json::Value>,
+    missing_message: &str,
+    invalid_message: &str,
+) -> Result<T> {
+    let value = value
+        .ok_or_else(|| Error::validation_invalid_argument("run_id", missing_message, None, None))?;
+    serde_json::from_value(value)
+        .map_err(|_| Error::validation_invalid_argument("run_id", invalid_message, None, None))
+}
+
 #[cfg(test)]
 mod remote_base_tests {
     use super::*;
@@ -1124,100 +1220,4 @@ mod remote_base_tests {
             .expect("newer snapshot compares candidate");
         assert!(matches!(stale, AgentTaskPrCandidateState::Invalid { .. }));
     }
-}
-
-pub(super) fn validate_real_candidate_fingerprint(
-    options: &AgentTaskPrFinalizationOptions,
-) -> Result<()> {
-    let record = crate::agent_task_lifecycle::status(&options.run_id)?;
-    let promotion: AgentTaskPromotionReport = deserialize_persisted_value(
-        record.metadata.get("latest_promotion").cloned(),
-        "normal finalization requires persisted latest_promotion",
-        "persisted latest_promotion is invalid",
-    )?;
-    let expected: AgentTaskPromotionCandidate = deserialize_persisted_value(
-        promotion.provenance.get("candidate").cloned(),
-        "applied promotion is missing a candidate capability; rerun promotion before normal finalization or use --manual-finalization to record the explicit bypass",
-        "persisted candidate capability is invalid",
-    )?;
-    if !matches!(expected, AgentTaskPromotionCandidate::Git { .. }) {
-        return Err(Error::validation_invalid_argument(
-            "run_id",
-            "normal GitHub PR finalization requires an exact Git candidate fingerprint; the applied promotion target was not a Git worktree. Rerun promotion into a Git worktree or use --manual-finalization to record the explicit provenance bypass",
-            None,
-            None,
-        ));
-    }
-    if super::normalize_changed_files(&options.changed_files)
-        != super::normalize_changed_files(&promotion.changed_files)
-    {
-        return Err(super::changed_files_mismatch_error(
-            &options.run_id,
-            &options.changed_files,
-            &promotion.changed_files,
-        ));
-    }
-    validate_candidate_fingerprint(options, &expected)
-}
-
-pub(super) fn validate_candidate_fingerprint(
-    options: &AgentTaskPrFinalizationOptions,
-    expected: &AgentTaskPromotionCandidate,
-) -> Result<()> {
-    let AgentTaskPromotionCandidate::Git {
-        fingerprint: expected_fingerprint,
-    } = expected
-    else {
-        unreachable!("caller validates Git promotion candidate")
-    };
-    let actual = crate::agent_task_promotion::candidate_fingerprint(&options.path)?;
-    let AgentTaskPromotionCandidate::Git {
-        fingerprint: actual_fingerprint,
-    } = &actual
-    else {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "finalization path is not a Git worktree; normal GitHub PR finalization requires the promoted Git candidate",
-            Some(options.path.clone()),
-            None,
-        ));
-    };
-    if actual == *expected {
-        return Ok(());
-    }
-    if !actual_fingerprint.changed_files.is_empty()
-        || expected_fingerprint.tree.is_empty()
-        || !committed_candidate_matches(options, expected_fingerprint)?
-    {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "candidate changed after promotion; durable finalization accepts a recovery commit only when its parent and tree exactly match the recorded promoted candidate. Rerun promotion gates before finalization.",
-            None,
-            None,
-        ));
-    }
-    Ok(())
-}
-
-fn committed_candidate_matches(
-    options: &AgentTaskPrFinalizationOptions,
-    fingerprint: &crate::agent_task_promotion::AgentTaskCandidateFingerprint,
-) -> Result<bool> {
-    let parent = git_output(&options.path, &["rev-parse", "HEAD^"])?;
-    if parent.trim() != fingerprint.head {
-        return Ok(false);
-    }
-    let tree = git_output(&options.path, &["rev-parse", "HEAD^{tree}"])?;
-    Ok(tree.trim() == fingerprint.tree)
-}
-
-fn deserialize_persisted_value<T: DeserializeOwned>(
-    value: Option<serde_json::Value>,
-    missing_message: &str,
-    invalid_message: &str,
-) -> Result<T> {
-    let value = value
-        .ok_or_else(|| Error::validation_invalid_argument("run_id", missing_message, None, None))?;
-    serde_json::from_value(value)
-        .map_err(|_| Error::validation_invalid_argument("run_id", invalid_message, None, None))
 }

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -34,13 +34,15 @@ const GATE_TOOLCHAIN_CAPTURE_LIMIT_BYTES: usize = 64 * 1024;
 
 pub type AgentTaskGateVisibility = HomeboyGateVisibility;
 pub type AgentTaskGateRevealPolicy = HomeboyGateRevealPolicy;
+type GateSpawnCallback = Arc<dyn Fn(u32, &str) -> Result<()> + Send + Sync>;
+type GateHeartbeatCallback = Arc<dyn Fn(&AgentTaskGateLiveStatus) -> Result<()> + Send + Sync>;
 
 pub(crate) struct GateSupervision {
     pub timeout: Duration,
     pub no_progress_timeout: Duration,
     pub heartbeat_interval: Duration,
-    pub on_spawn: Arc<dyn Fn(u32, &str) -> Result<()> + Send + Sync>,
-    pub on_heartbeat: Arc<dyn Fn(&AgentTaskGateLiveStatus) -> Result<()> + Send + Sync>,
+    pub on_spawn: GateSpawnCallback,
+    pub on_heartbeat: GateHeartbeatCallback,
     pub is_cancelled: Arc<dyn Fn() -> bool + Send + Sync>,
 }
 
@@ -887,6 +889,10 @@ fn gate_diagnostic_record_schema() -> String {
 }
 
 impl AgentTaskGateReport {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "constructor mirrors persisted gate result fields"
+    )]
     pub fn new(
         id: impl Into<String>,
         command: Vec<String>,
@@ -1064,8 +1070,7 @@ pub(crate) fn failure_fingerprint(
 }
 
 fn normalize_failure_record(line: &str) -> String {
-    line.trim()
-        .split_whitespace()
+    line.split_whitespace()
         .map(|token| {
             if token.contains('T')
                 && token.contains(':')
@@ -1229,6 +1234,10 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "gate execution inputs remain explicit across lifecycle and provider boundaries"
+)]
 pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
     cwd: &Path,
     index: usize,
@@ -1252,6 +1261,10 @@ pub(crate) fn run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "supervision callbacks and durable gate inputs remain independently auditable"
+)]
 pub(crate) fn run_gate_command_with_supervision(
     cwd: &Path,
     index: usize,
@@ -1407,6 +1420,10 @@ pub(crate) fn run_gate_command_with_supervision(
 /// Run a comparison gate with a hard wall-clock limit. The bounded path keeps
 /// candidate adoption inspectable instead of allowing a known-red baseline to
 /// consume an unbounded second broad-suite run.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "legacy gate provider entrypoint preserves mixed-version callers"
+)]
 pub(crate) fn run_gate_command_with_timeout(
     cwd: &Path,
     index: usize,
@@ -2753,7 +2770,12 @@ mod tests {
                 schema: "example/producer-output/v1".to_string(),
             },
         };
-        ingest_gate_diagnostic_sidecars(temp.path(), &[mapping.clone()], &mut report, "evidence");
+        ingest_gate_diagnostic_sidecars(
+            temp.path(),
+            std::slice::from_ref(&mapping),
+            &mut report,
+            "evidence",
+        );
         fs::write(temp.path().join("diagnostics.json"), "not json")
             .expect("write malformed sidecar");
         ingest_gate_diagnostic_sidecars(temp.path(), &[mapping], &mut report, "evidence");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -157,7 +157,7 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
             is_failure(state)
                 && load_controller_plan(&record.run_id)
                     .as_ref()
-                    .is_ok_and(|plan| plan_has_retry_materialization_identity(plan)),
+                    .is_ok_and(plan_has_retry_materialization_identity),
         ),
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/artifact_materialization.rs
@@ -1,6 +1,6 @@
 use homeboy_engine_primitives::content_hash;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::json;
 
@@ -263,7 +263,7 @@ fn unavailable(artifact: &AgentTaskArtifact, reason: &str) -> Error {
     )
 }
 
-fn io_error(path: &PathBuf) -> impl FnOnce(std::io::Error) -> Error + '_ {
+fn io_error(path: &Path) -> impl FnOnce(std::io::Error) -> Error + '_ {
     move |error| {
         Error::internal_io(
             error.to_string(),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -219,7 +219,7 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
             reconcile_runner_job_snapshot(
                 &mut record,
                 &homeboy_core::api_jobs::RunnerJobLogSnapshot {
-                    job: job.clone(),
+                    job: *job.clone(),
                     events: events.clone(),
                 },
             )?;
@@ -424,7 +424,7 @@ pub(super) fn reconcile_controller_job_cancellation(
 enum LiveCancellationOutcome {
     Terminated(homeboy_core::process::ProcessTreeTermination),
     RunnerJobCancelled {
-        job: homeboy_core::api_jobs::Job,
+        job: Box<homeboy_core::api_jobs::Job>,
         events: Vec<homeboy_core::api_jobs::JobEvent>,
     },
     Unsupported(UnsupportedLiveCancellation),
@@ -458,7 +458,10 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
         {
             match cancel_runner_job(runner_id, runner_job_id, &record.run_id) {
                 Ok((job, events)) => {
-                    return Ok(LiveCancellationOutcome::RunnerJobCancelled { job, events });
+                    return Ok(LiveCancellationOutcome::RunnerJobCancelled {
+                        job: Box::new(job),
+                        events,
+                    });
                 }
                 // An accepted Lab handoff has an authoritative remote owner.
                 // Leaving it active while only cancelling this projection loses
@@ -542,57 +545,6 @@ fn cancel_runner_job(
     })
 }
 
-#[cfg(test)]
-pub(super) mod test_cancel_hook {
-    use super::*;
-    use std::cell::RefCell;
-
-    type CancelHook = Box<
-        dyn FnMut(
-            &str,
-            &str,
-            &str,
-        ) -> Result<(
-            homeboy_core::api_jobs::Job,
-            Vec<homeboy_core::api_jobs::JobEvent>,
-        )>,
-    >;
-
-    thread_local! {
-        static HOOK: RefCell<Option<CancelHook>> = const { RefCell::new(None) };
-    }
-
-    pub(in super::super) struct Guard;
-
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            HOOK.with(|cell| *cell.borrow_mut() = None);
-        }
-    }
-
-    pub(in super::super) fn install(hook: CancelHook) -> Guard {
-        HOOK.with(|cell| *cell.borrow_mut() = Some(hook));
-        Guard
-    }
-
-    pub(super) fn take(
-        runner_id: &str,
-        runner_job_id: &str,
-        durable_run_id: &str,
-    ) -> Option<
-        Result<(
-            homeboy_core::api_jobs::Job,
-            Vec<homeboy_core::api_jobs::JobEvent>,
-        )>,
-    > {
-        HOOK.with(|cell| {
-            cell.borrow_mut()
-                .as_mut()
-                .map(|hook| hook(runner_id, runner_job_id, durable_run_id))
-        })
-    }
-}
-
 pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     if matches!(
@@ -657,5 +609,56 @@ fn terminalize_running_provider_executions(
             execution["state"] = json!("cancelled");
             execution["finished_at"] = json!(finished_at);
         }
+    }
+}
+
+#[cfg(test)]
+pub(super) mod test_cancel_hook {
+    use super::*;
+    use std::cell::RefCell;
+
+    type CancelHook = Box<
+        dyn FnMut(
+            &str,
+            &str,
+            &str,
+        ) -> Result<(
+            homeboy_core::api_jobs::Job,
+            Vec<homeboy_core::api_jobs::JobEvent>,
+        )>,
+    >;
+
+    thread_local! {
+        static HOOK: RefCell<Option<CancelHook>> = const { RefCell::new(None) };
+    }
+
+    pub(in super::super) struct Guard;
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            HOOK.with(|cell| *cell.borrow_mut() = None);
+        }
+    }
+
+    pub(in super::super) fn install(hook: CancelHook) -> Guard {
+        HOOK.with(|cell| *cell.borrow_mut() = Some(hook));
+        Guard
+    }
+
+    pub(super) fn take(
+        runner_id: &str,
+        runner_job_id: &str,
+        durable_run_id: &str,
+    ) -> Option<
+        Result<(
+            homeboy_core::api_jobs::Job,
+            Vec<homeboy_core::api_jobs::JobEvent>,
+        )>,
+    > {
+        HOOK.with(|cell| {
+            cell.borrow_mut()
+                .as_mut()
+                .map(|hook| hook(runner_id, runner_job_id, durable_run_id))
+        })
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1017,144 +1017,6 @@ pub fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<Str
     ))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn artifact(id: &str, kind: &str, runner_id: Option<&str>) -> AgentTaskArtifact {
-        AgentTaskArtifact {
-            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: id.to_string(),
-            kind: kind.to_string(),
-            name: None,
-            label: None,
-            role: None,
-            semantic_key: None,
-            path: Some("/runner/patch.diff".to_string()),
-            url: None,
-            mime: None,
-            size_bytes: Some(1),
-            sha256: Some("a".repeat(64)),
-            metadata: runner_id.map_or_else(
-                || json!({}),
-                |runner_id| json!({ "source_provenance": { "runner_id": runner_id } }),
-            ),
-        }
-    }
-
-    #[test]
-    fn legacy_runner_provenance_uses_only_actionable_patch_artifacts() {
-        let mut aggregate = AgentTaskAggregate {
-            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
-            plan_id: "plan".to_string(),
-            status: AgentTaskAggregateStatus::Succeeded,
-            totals: AgentTaskAggregateTotals::default(),
-            outcomes: Vec::new(),
-            events: Vec::new(),
-            artifact_lineage: Vec::new(),
-            child_runs: Vec::new(),
-            artifact_bindings: Vec::new(),
-            queue: AgentTaskQueueStatus::default(),
-        };
-        aggregate.outcomes.push(AgentTaskOutcome {
-            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-            task_id: "task".to_string(),
-            status: AgentTaskOutcomeStatus::Succeeded,
-            summary: None,
-            failure_classification: None,
-            artifacts: vec![
-                artifact("patch", "patch", Some("runner-a")),
-                artifact("transcript", "transcript", None),
-                artifact("result", "result", None),
-                artifact("runtime-log", "runtime-log", None),
-            ],
-            typed_artifacts: Vec::new(),
-            evidence_refs: Vec::new(),
-            diagnostics: Vec::new(),
-            outputs: Value::Null,
-            workflow: None,
-            follow_up: None,
-            metadata: Value::Null,
-        });
-
-        assert_eq!(
-            runner_id_from_artifact_provenance(&aggregate).expect("consistent provenance"),
-            "runner-a"
-        );
-        aggregate.outcomes[0]
-            .artifacts
-            .push(artifact("second-patch", "patch", Some("runner-b")));
-        assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
-    }
-
-    #[test]
-    fn artifact_runner_provenance_must_match_the_lifecycle_binding() {
-        let artifact = artifact("patch", "patch", Some("runner-a"));
-
-        validate_artifact_runner_binding(&artifact, "runner-a").expect("matching runner binding");
-        let error = validate_artifact_runner_binding(&artifact, "runner-b")
-            .expect_err("conflicting runner identity must fail closed");
-
-        assert!(error
-            .message
-            .contains("conflicts with lifecycle runner binding"));
-    }
-
-    #[test]
-    fn reusable_artifact_rejects_conflicting_persisted_logical_identity() {
-        homeboy_core::test_support::with_isolated_home(|home| {
-            let store = homeboy_core::observation::ObservationStore::open_initialized()
-                .expect("observation store");
-            let run = store
-                .start_run(
-                    homeboy_core::observation::NewRunRecord::builder("agent-task")
-                        .cwd_path(home.path())
-                        .build(),
-                )
-                .expect("run");
-            let path = home.path().join("patch.diff");
-            let bytes = b"patch";
-            std::fs::write(&path, bytes).expect("patch bytes");
-            let mut artifact = artifact("patch", "patch", None);
-            artifact.size_bytes = Some(bytes.len() as u64);
-            artifact.sha256 = Some(format!("{:x}", sha2::Sha256::digest(bytes)));
-            store
-                .record_artifact_with_id(
-                    &run.id,
-                    "patch",
-                    &path,
-                    "stable-patch",
-                    json!({
-                        "agent_task": {
-                            "task_id": "other-task",
-                            "logical_artifact_id": "patch",
-                        }
-                    }),
-                )
-                .expect("imported artifact");
-
-            let error = reusable_terminal_artifact(
-                &store,
-                &run.id,
-                "task",
-                &artifact,
-                "stable-patch",
-                &json!({
-                    "agent_task": {
-                        "task_id": "task",
-                        "logical_artifact_id": "patch",
-                    }
-                }),
-            )
-            .expect_err("conflicting logical identity must fail closed");
-
-            assert!(error
-                .message
-                .contains("conflicts with terminal artifact projection"));
-        });
-    }
-}
-
 /// Project finalized executor artifacts into the standard observation registry.
 /// The lifecycle aggregate remains the source of task semantics; the registry
 /// supplies the canonical retrievable-byte index used by `runs artifact get`.
@@ -1295,7 +1157,7 @@ pub(crate) fn project_terminal_artifacts(
                     None => {
                         let remote_ref = homeboy_core::execution_contract::EXECUTION_CONTRACT
                             .artifacts
-                            .runner_artifact_ref(runner_id, &record.run_id, &logical_id);
+                            .runner_artifact_ref(runner_id, &record.run_id, logical_id);
                         let mirror_result = if requires_durable_lab_projection(artifact) {
                             (|| -> Result<()> {
                                 let mirror = tempfile::NamedTempFile::new().map_err(|error| {
@@ -1800,5 +1662,143 @@ fn persist_provider_handle_models(
             .as_object_mut()
             .expect("provider handle metadata object")
             .insert("model".to_string(), json!(model));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(id: &str, kind: &str, runner_id: Option<&str>) -> AgentTaskArtifact {
+        AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: id.to_string(),
+            kind: kind.to_string(),
+            name: None,
+            label: None,
+            role: None,
+            semantic_key: None,
+            path: Some("/runner/patch.diff".to_string()),
+            url: None,
+            mime: None,
+            size_bytes: Some(1),
+            sha256: Some("a".repeat(64)),
+            metadata: runner_id.map_or_else(
+                || json!({}),
+                |runner_id| json!({ "source_provenance": { "runner_id": runner_id } }),
+            ),
+        }
+    }
+
+    #[test]
+    fn legacy_runner_provenance_uses_only_actionable_patch_artifacts() {
+        let mut aggregate = AgentTaskAggregate {
+            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: "plan".to_string(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals::default(),
+            outcomes: Vec::new(),
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: AgentTaskQueueStatus::default(),
+        };
+        aggregate.outcomes.push(AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![
+                artifact("patch", "patch", Some("runner-a")),
+                artifact("transcript", "transcript", None),
+                artifact("result", "result", None),
+                artifact("runtime-log", "runtime-log", None),
+            ],
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(
+            runner_id_from_artifact_provenance(&aggregate).expect("consistent provenance"),
+            "runner-a"
+        );
+        aggregate.outcomes[0]
+            .artifacts
+            .push(artifact("second-patch", "patch", Some("runner-b")));
+        assert!(runner_id_from_artifact_provenance(&aggregate).is_err());
+    }
+
+    #[test]
+    fn artifact_runner_provenance_must_match_the_lifecycle_binding() {
+        let artifact = artifact("patch", "patch", Some("runner-a"));
+
+        validate_artifact_runner_binding(&artifact, "runner-a").expect("matching runner binding");
+        let error = validate_artifact_runner_binding(&artifact, "runner-b")
+            .expect_err("conflicting runner identity must fail closed");
+
+        assert!(error
+            .message
+            .contains("conflicts with lifecycle runner binding"));
+    }
+
+    #[test]
+    fn reusable_artifact_rejects_conflicting_persisted_logical_identity() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let store = homeboy_core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            let run = store
+                .start_run(
+                    homeboy_core::observation::NewRunRecord::builder("agent-task")
+                        .cwd_path(home.path())
+                        .build(),
+                )
+                .expect("run");
+            let path = home.path().join("patch.diff");
+            let bytes = b"patch";
+            std::fs::write(&path, bytes).expect("patch bytes");
+            let mut artifact = artifact("patch", "patch", None);
+            artifact.size_bytes = Some(bytes.len() as u64);
+            artifact.sha256 = Some(format!("{:x}", sha2::Sha256::digest(bytes)));
+            store
+                .record_artifact_with_id(
+                    &run.id,
+                    "patch",
+                    &path,
+                    "stable-patch",
+                    json!({
+                        "agent_task": {
+                            "task_id": "other-task",
+                            "logical_artifact_id": "patch",
+                        }
+                    }),
+                )
+                .expect("imported artifact");
+
+            let error = reusable_terminal_artifact(
+                &store,
+                &run.id,
+                "task",
+                &artifact,
+                "stable-patch",
+                &json!({
+                    "agent_task": {
+                        "task_id": "task",
+                        "logical_artifact_id": "patch",
+                    }
+                }),
+            )
+            .expect_err("conflicting logical identity must fail closed");
+
+            assert!(error
+                .message
+                .contains("conflicts with terminal artifact projection"));
+        });
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -91,10 +91,10 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
             continue;
         }
         report.considered += 1;
-        let reconstructable = !run
+        let reconstructable = run
             .metadata_json
             .pointer("/agent_task_run/lab_handoff")
-            .is_some()
+            .is_none()
             && matches!(
                 item.reason,
                 AgentTaskRecordHealthReason::MissingMetadata

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -56,7 +56,7 @@ pub struct LabOffloadProxyPlan<'a> {
 /// identity and is reconciled from that child once it is accepted.
 pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<AgentTaskRunRecord> {
     record_lab_offload_proxy(
-        &input.run_id,
+        input.run_id,
         input.runner_id,
         input.remote_workspace,
         input.remote_command,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -40,7 +40,7 @@ pub(crate) fn project_cook_alias_adoption(
             adoption,
         );
         let replace = selected.as_ref().is_none_or(|current| {
-            candidate.0 > current.0
+            candidate.0 & !current.0
                 // Among equally active or inactive attempts, the newest
                 // adoption timestamp wins; index order breaks timestamp ties.
                 || (candidate.0 == current.0

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -34,6 +34,7 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
     }
     let file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&lock_path)
@@ -216,6 +217,7 @@ impl LabHandoffLock {
         }
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_path)
@@ -1903,7 +1905,6 @@ pub fn persisted_status(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// a read model (such as activity) projects lifecycle state. A controller wait
 /// expiry is not terminal after a runner job is recorded: the runner daemon
 /// remains the authority until it reports a terminal job result.
-
 pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
     let record = status(run_id)?;
     let aggregate = store::read_aggregate(&record.run_id).ok();
@@ -1979,11 +1980,10 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
 pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
     let mut records = Vec::new();
     for record in store::read_records()? {
-        match status(&record.run_id) {
-            Ok(record) => records.push(record),
+        if let Ok(record) = status(&record.run_id) {
+            records.push(record);
             // Discovery health owns malformed-record reporting. A transient
             // status refresh failure must not reintroduce stderr-only state.
-            Err(_) => (),
         }
     }
     records.sort_by(|left, right| {
@@ -2343,6 +2343,7 @@ impl RetryLineageLock {
         }
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&path)
@@ -2450,7 +2451,6 @@ pub fn find_unbound_cook_retry_successor(
 /// Rebuild a gate-failed Cook candidate from its controller-owned promotion
 /// before retrying. A persisted follow-up plan names a temporary checkout, not
 /// authority to reuse whatever happens to exist at that path.
-
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     let snapshot = durable_local_read(run_id)?;
     let record = snapshot.record;
@@ -2988,9 +2988,7 @@ fn substantive_candidate_in_aggregate(
             .then(|| aggregate.outcomes.first())
             .flatten()
     });
-    let Some(outcome) = outcome else {
-        return None;
-    };
+    let outcome = outcome?;
     // Metadata alone (and typed artifact envelopes) cannot authorize recovery.
     // Selection requires controller-readable bytes that pass the same integrity
     // and canonical patch normalization used by promotion.
@@ -2998,15 +2996,13 @@ fn substantive_candidate_in_aggregate(
         if !crate::agent_task_timeout_artifacts::is_actionable_patch_artifact(artifact) {
             return None;
         }
-        let Some(path) = crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
+        let path = crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
             run_id,
             &outcome.task_id,
             artifact,
         )
         .ok()
-        .flatten() else {
-            return None;
-        };
+        .flatten()?;
         std::fs::canonicalize(path)
             .ok()
             .and_then(|path| std::fs::read_to_string(path).ok())

--- a/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
@@ -44,7 +44,11 @@ pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog>
         schema: schemas::RUN_LOG.to_string(),
         run_id,
         events,
-        raw_events: include_raw.then_some(raw_events).unwrap_or_default(),
+        raw_events: if include_raw {
+            raw_events
+        } else {
+            Default::default()
+        },
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -24,7 +24,7 @@ use homeboy_core::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
 /// confirms the job is absent. Transport failures remain deliberately
 /// unconfirmed so a transient daemon error cannot discard runner-owned work.
 pub enum RunnerJobReconciliation {
-    Snapshot(RunnerJobLogSnapshot),
+    Snapshot(Box<RunnerJobLogSnapshot>),
     ConfirmedAbsent { checked_generations: usize },
     UnconfirmedAbsence,
 }
@@ -110,7 +110,7 @@ pub trait RunnerContinuationProvider: Send + Sync {
     /// ownership support retain the conservative snapshot-only behavior.
     fn reconcile_runner_job(&self, runner_id: &str, job_id: &str) -> RunnerJobReconciliation {
         match self.runner_job_log_snapshot(runner_id, job_id) {
-            Ok(snapshot) => RunnerJobReconciliation::Snapshot(snapshot),
+            Ok(snapshot) => RunnerJobReconciliation::Snapshot(Box::new(snapshot)),
             Err(_) => RunnerJobReconciliation::UnconfirmedAbsence,
         }
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -46,13 +46,11 @@ pub fn accepted_lab_runner_job_identity(
 pub(crate) fn accepted_lab_runner_job_identity_from_record(
     record: &AgentTaskRunRecord,
 ) -> Option<homeboy_core::lab_contract::RunnerJobIdentity> {
-    let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {
+    let handoff = record.lab_handoff.as_ref().filter(|handoff| {
         handoff.validation_error().is_none()
             && handoff.state == AgentTaskLabHandoffState::Accepted
             && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
-    }) else {
-        return None;
-    };
+    })?;
     let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
         &record.run_id,
         &handoff.runner_id,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 enum TestRunnerReconciliation {
-    Snapshot(homeboy_core::api_jobs::RunnerJobLogSnapshot),
+    Snapshot(Box<homeboy_core::api_jobs::RunnerJobLogSnapshot>),
     ConfirmedAbsent(usize),
     Unconfirmed,
 }
@@ -927,7 +927,7 @@ fn accepted_handoff_adopts_a_job_found_on_another_known_generation() {
         let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
             // This represents a 404 on the current generation followed by a
             // matching snapshot on another generation in the durable ledger.
-            result: Mutex::new(Some(TestRunnerReconciliation::Snapshot(snapshot))),
+            result: Mutex::new(Some(TestRunnerReconciliation::Snapshot(Box::new(snapshot)))),
         }));
 
         let reconciled = status(run_id).expect("adopted generation snapshot");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -34,7 +34,7 @@ fn commit_budget_ms(now_ms: u64, claims: impl Iterator<Item = u64>) -> u64 {
 /// to present durable evidence without treating an uncertain probe as terminal.
 #[derive(Debug, Clone)]
 pub enum TerminalWorkspaceAuthorityResolution {
-    Proven(TerminalWorkspaceAuthorityProof),
+    Proven(Box<TerminalWorkspaceAuthorityProof>),
     Refused {
         reason: String,
         observations: Vec<TerminalWorkspaceAuthorityObservation>,
@@ -62,7 +62,9 @@ pub fn resolve_terminal_workspace_authority(
             && proof.authority_set == authority_set
             && proof.authority_set_fingerprint == authority_set_fingerprint(&authority_set)
         {
-            return Ok(TerminalWorkspaceAuthorityResolution::Proven(proof.clone()));
+            return Ok(TerminalWorkspaceAuthorityResolution::Proven(Box::new(
+                proof.clone(),
+            )));
         }
         return Ok(TerminalWorkspaceAuthorityResolution::Refused {
             reason:
@@ -203,7 +205,7 @@ pub fn resolve_terminal_workspace_authority(
             observations,
         });
     }
-    Ok(TerminalWorkspaceAuthorityResolution::Proven(
+    Ok(TerminalWorkspaceAuthorityResolution::Proven(Box::new(
         TerminalWorkspaceAuthorityProof {
             schema: TERMINAL_WORKSPACE_AUTHORITY_SCHEMA.into(),
             capability: TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY.into(),
@@ -221,7 +223,7 @@ pub fn resolve_terminal_workspace_authority(
             observations,
             issued_evidence: vec![format!("controller-run:{run_id}")],
         },
-    ))
+    )))
 }
 
 fn configured_terminal_authorities() -> std::result::Result<Vec<String>, String> {
@@ -489,7 +491,7 @@ impl CompositeWorkspaceClaimAcquisitionGuard {
         }
         CompositeWorkspaceClaimAcquisitionFailure {
             primary,
-            cleanup: (!rollback_failures.is_empty()).then(|| CompositeWorkspaceClaim {
+            cleanup: (!rollback_failures.is_empty()).then_some(CompositeWorkspaceClaim {
                 workspace: self.workspace,
                 generation: self.generation,
                 commit_deadline: self.acquired_at,
@@ -502,6 +504,10 @@ impl CompositeWorkspaceClaimAcquisitionGuard {
     }
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "failure retains all acquired authority receipts for deterministic rollback"
+)]
 pub fn acquire_composite_workspace_claim(
     workspace: WorkspaceIdentity,
     generation: u64,
@@ -585,6 +591,10 @@ pub fn acquire_composite_workspace_claim(
     }
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "failure retains all acquired authority receipts for deterministic rollback"
+)]
 fn acquire_composite_workspace_claim_unrecovered(
     workspace: WorkspaceIdentity,
     generation: u64,
@@ -1165,7 +1175,7 @@ fn composite_error(message: &str, failures: Vec<String>) -> Error {
         "workspace_claim_composite",
         message,
         None,
-        (!failures.is_empty()).then(|| failures),
+        (!failures.is_empty()).then_some(failures),
     )
 }
 

--- a/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
+++ b/crates/homeboy-agents/src/agent_task_loop_controller/service.rs
@@ -288,15 +288,9 @@ fn controller_next_commands(
                     shell_arg(&action.action_id)
                 ));
             }
-            commands.push(format!(
-                "homeboy agent-task controller from-spec <spec> --resume --fork  # start fresh with a new backend/spec without changing this state"
-            ));
-            commands.push(format!(
-                "homeboy agent-task controller from-spec <spec> --resume --replace  # discard this persisted controller state"
-            ));
-            commands.push(format!(
-                "homeboy agent-task controller from-spec <spec> --resume-existing  # intentionally continue this persisted state"
-            ));
+            commands.push("homeboy agent-task controller from-spec <spec> --resume --fork  # start fresh with a new backend/spec without changing this state".to_string());
+            commands.push("homeboy agent-task controller from-spec <spec> --resume --replace  # discard this persisted controller state".to_string());
+            commands.push("homeboy agent-task controller from-spec <spec> --resume-existing  # intentionally continue this persisted state".to_string());
             commands
         }
         "running_pending_work" => vec![format!("homeboy agent-task controller resume {loop_id}")],

--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -361,6 +361,10 @@ pub(crate) trait AgentTaskPromotionWorkspaceProvider {
         reveal_policy: AgentTaskGateRevealPolicy,
     ) -> Result<AgentTaskGateReport>;
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "trait adapter preserves the stable gate verifier provider contract"
+    )]
     fn verify_with_runtime_tmpdir(
         &mut self,
         cwd: &Path,

--- a/crates/homeboy-agents/src/agent_task_promotion/fingerprint.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/fingerprint.rs
@@ -181,7 +181,7 @@ fn reject_gitlinks(git: &impl Fn(&[&str]) -> Result<Vec<u8>>) -> Result<()> {
         ["diff", "--raw", "-z", "--cached"].as_slice(),
         ["diff", "--raw", "-z"].as_slice(),
     ] {
-        if text(git(&args)?)
+        if text(git(args)?)
             .split('\0')
             .any(|entry| entry.starts_with(":160000 ") || entry.get(8..15) == Some("160000 "))
         {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -219,10 +219,10 @@ fn validate_resume_provenance(
     previous: &Value,
 ) -> Result<()> {
     let previous_status = previous.get("status").and_then(Value::as_str);
-    if !matches!(
+    if !(matches!(
         previous_status,
         Some("gate_failed" | "verification_pending")
-    ) && !(options.gates.rerun_completed_gates && previous_status == Some("applied"))
+    ) || options.gates.rerun_completed_gates && previous_status == Some("applied"))
     {
         return Err(Error::validation_invalid_argument(
             "promotion",
@@ -2116,6 +2116,10 @@ fn promotion_notification_with_gate_summary(
     notification
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "report construction keeps durable promotion evidence explicit"
+)]
 fn post_apply_report(
     options: &AgentTaskPromotionOptions,
     source_kind: &str,

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -106,10 +106,11 @@ impl ExecutorArtifactRootIdentity {
             ));
         }
         #[cfg(unix)]
-        if {
+        let res = {
             use std::os::unix::fs::MetadataExt;
             current.dev() != self.device || current.ino() != self.inode
-        } {
+        };
+        if res {
             return Err(Error::validation_invalid_argument(
                 "artifacts_path",
                 "Homeboy executor artifact root changed during provider execution",

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -220,175 +220,6 @@ fn provider_catalog_version(
     format!("resolved:{}", content_hash::sha256_hex(&content))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn catalog_version_is_deterministic_and_detects_stale_content() {
-        let empty = provider_catalog_version(&[], &[]);
-        assert_eq!(empty, provider_catalog_version(&[], &[]));
-
-        let changed = provider_catalog_version(
-            &[],
-            &[AgentRuntimeDiscoveryDiagnostic {
-                class: "agent_runtime_catalog.conflict".to_string(),
-                message: "runtime collision".to_string(),
-                runtime_id: Some("example".to_string()),
-                extension_id: None,
-                path: None,
-            }],
-        );
-
-        assert_ne!(empty, changed);
-        assert!(empty.starts_with("resolved:"));
-    }
-
-    fn disclosure_provider() -> AgentTaskExecutorProvider {
-        // Deserialize from JSON so schema-string and other required defaults are
-        // populated the same way discovery populates them.
-        serde_json::from_value(serde_json::json!({
-            "id": "test.opencode",
-            "backend": "opencode",
-            "cli": {
-                "default_ai_disclosure": "OpenCode (GPT-5.5)",
-                "profiles": [
-                    {
-                        "name": "terra",
-                        "model": "openai/gpt-5.6-terra",
-                        "ai_disclosure": "OpenCode (GPT-5.6 Terra)"
-                    },
-                    {
-                        "name": "sol",
-                        "model": "openai/gpt-5.6-sol",
-                        "ai_disclosure": "OpenCode (GPT-5.6 Sol)"
-                    }
-                ]
-            }
-        }))
-        .expect("valid provider fixture")
-    }
-
-    fn disclosure_catalog() -> AgentTaskProviderCatalog {
-        AgentTaskProviderCatalog {
-            providers: vec![disclosure_provider()],
-            ..Default::default()
-        }
-    }
-
-    fn provider_with_backend(id: &str, backend: &str) -> AgentTaskExecutorProvider {
-        serde_json::from_value(serde_json::json!({
-            "id": id,
-            "backend": backend,
-        }))
-        .expect("valid provider fixture")
-    }
-
-    #[test]
-    fn backends_are_sorted_deduped_and_skip_blanks() {
-        let catalog = AgentTaskProviderCatalog {
-            providers: vec![
-                provider_with_backend("b.opencode", "opencode"),
-                provider_with_backend("a.pi", "pi"),
-                // Two providers for one backend must not double-list it.
-                provider_with_backend("c.opencode", "opencode"),
-                provider_with_backend("d.claude", "claude-code"),
-                provider_with_backend("e.blank", "   "),
-            ],
-            ..Default::default()
-        };
-
-        assert_eq!(
-            catalog.backends(),
-            vec![
-                "claude-code".to_string(),
-                "opencode".to_string(),
-                "pi".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn backends_of_an_empty_catalog_is_empty() {
-        assert!(AgentTaskProviderCatalog::default().backends().is_empty());
-    }
-
-    #[test]
-    fn ai_disclosure_for_uses_the_model_matching_profile() {
-        let catalog = disclosure_catalog();
-        assert_eq!(
-            catalog
-                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-terra"))
-                .as_deref(),
-            Some("OpenCode (GPT-5.6 Terra)"),
-            "a model override must derive its matching profile disclosure"
-        );
-        assert_eq!(
-            catalog
-                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-sol"))
-                .as_deref(),
-            Some("OpenCode (GPT-5.6 Sol)")
-        );
-    }
-
-    #[test]
-    fn ai_disclosure_for_falls_back_to_provider_default() {
-        let catalog = disclosure_catalog();
-        // No model and an unknown model both fall back to the provider default.
-        assert_eq!(
-            catalog.ai_disclosure_for("opencode", None, None).as_deref(),
-            Some("OpenCode (GPT-5.5)")
-        );
-        assert_eq!(
-            catalog
-                .ai_disclosure_for("opencode", None, Some("openai/unknown-model"))
-                .as_deref(),
-            Some("OpenCode (GPT-5.5)")
-        );
-    }
-
-    #[test]
-    fn ai_disclosure_for_unknown_backend_is_none() {
-        let catalog = disclosure_catalog();
-        assert_eq!(
-            catalog.ai_disclosure_for("no-such-backend", None, Some("m")),
-            None
-        );
-    }
-
-    #[test]
-    fn declared_provider_rejects_unsupported_explicit_model_with_diagnostics() {
-        let catalog = disclosure_catalog();
-        let mut plan = AgentTaskPlan::new("model-preflight", Vec::new());
-        plan.tasks.push(
-            serde_json::from_value(serde_json::json!({
-                "schema": crate::agent_task::AGENT_TASK_REQUEST_SCHEMA,
-                "task_id": "task",
-                "executor": { "backend": "opencode" },
-                "instructions": "Cook",
-                "workspace": { "mode": "existing" },
-                "metadata": {
-                    "model_selection": {
-                        "requested": "openai/gpt-5.6-unknown",
-                        "selected": "openai/gpt-5.6-unknown",
-                        "reason": "explicit-request"
-                    }
-                }
-            }))
-            .expect("task"),
-        );
-
-        let error = catalog
-            .validate_explicit_models(&plan)
-            .expect_err("unsupported model");
-        assert!(error.message.contains("does not support requested model"));
-        assert_eq!(
-            error.details["tried"][0].as_str(),
-            Some("supported models: openai/gpt-5.6-sol, openai/gpt-5.6-terra")
-        );
-    }
-}
-
 impl ExtensionProviderAgentTaskExecutor {
     pub fn discover() -> Self {
         Self::from_catalog(AgentTaskProviderCatalog::discover())
@@ -796,4 +627,173 @@ pub(super) fn component_default_backend(component: &component::Component) -> Opt
                 .filter(|backend| !backend.trim().is_empty())
                 .map(String::from)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_version_is_deterministic_and_detects_stale_content() {
+        let empty = provider_catalog_version(&[], &[]);
+        assert_eq!(empty, provider_catalog_version(&[], &[]));
+
+        let changed = provider_catalog_version(
+            &[],
+            &[AgentRuntimeDiscoveryDiagnostic {
+                class: "agent_runtime_catalog.conflict".to_string(),
+                message: "runtime collision".to_string(),
+                runtime_id: Some("example".to_string()),
+                extension_id: None,
+                path: None,
+            }],
+        );
+
+        assert_ne!(empty, changed);
+        assert!(empty.starts_with("resolved:"));
+    }
+
+    fn disclosure_provider() -> AgentTaskExecutorProvider {
+        // Deserialize from JSON so schema-string and other required defaults are
+        // populated the same way discovery populates them.
+        serde_json::from_value(serde_json::json!({
+            "id": "test.opencode",
+            "backend": "opencode",
+            "cli": {
+                "default_ai_disclosure": "OpenCode (GPT-5.5)",
+                "profiles": [
+                    {
+                        "name": "terra",
+                        "model": "openai/gpt-5.6-terra",
+                        "ai_disclosure": "OpenCode (GPT-5.6 Terra)"
+                    },
+                    {
+                        "name": "sol",
+                        "model": "openai/gpt-5.6-sol",
+                        "ai_disclosure": "OpenCode (GPT-5.6 Sol)"
+                    }
+                ]
+            }
+        }))
+        .expect("valid provider fixture")
+    }
+
+    fn disclosure_catalog() -> AgentTaskProviderCatalog {
+        AgentTaskProviderCatalog {
+            providers: vec![disclosure_provider()],
+            ..Default::default()
+        }
+    }
+
+    fn provider_with_backend(id: &str, backend: &str) -> AgentTaskExecutorProvider {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "backend": backend,
+        }))
+        .expect("valid provider fixture")
+    }
+
+    #[test]
+    fn backends_are_sorted_deduped_and_skip_blanks() {
+        let catalog = AgentTaskProviderCatalog {
+            providers: vec![
+                provider_with_backend("b.opencode", "opencode"),
+                provider_with_backend("a.pi", "pi"),
+                // Two providers for one backend must not double-list it.
+                provider_with_backend("c.opencode", "opencode"),
+                provider_with_backend("d.claude", "claude-code"),
+                provider_with_backend("e.blank", "   "),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            catalog.backends(),
+            vec![
+                "claude-code".to_string(),
+                "opencode".to_string(),
+                "pi".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn backends_of_an_empty_catalog_is_empty() {
+        assert!(AgentTaskProviderCatalog::default().backends().is_empty());
+    }
+
+    #[test]
+    fn ai_disclosure_for_uses_the_model_matching_profile() {
+        let catalog = disclosure_catalog();
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-terra"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.6 Terra)"),
+            "a model override must derive its matching profile disclosure"
+        );
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/gpt-5.6-sol"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.6 Sol)")
+        );
+    }
+
+    #[test]
+    fn ai_disclosure_for_falls_back_to_provider_default() {
+        let catalog = disclosure_catalog();
+        // No model and an unknown model both fall back to the provider default.
+        assert_eq!(
+            catalog.ai_disclosure_for("opencode", None, None).as_deref(),
+            Some("OpenCode (GPT-5.5)")
+        );
+        assert_eq!(
+            catalog
+                .ai_disclosure_for("opencode", None, Some("openai/unknown-model"))
+                .as_deref(),
+            Some("OpenCode (GPT-5.5)")
+        );
+    }
+
+    #[test]
+    fn ai_disclosure_for_unknown_backend_is_none() {
+        let catalog = disclosure_catalog();
+        assert_eq!(
+            catalog.ai_disclosure_for("no-such-backend", None, Some("m")),
+            None
+        );
+    }
+
+    #[test]
+    fn declared_provider_rejects_unsupported_explicit_model_with_diagnostics() {
+        let catalog = disclosure_catalog();
+        let mut plan = AgentTaskPlan::new("model-preflight", Vec::new());
+        plan.tasks.push(
+            serde_json::from_value(serde_json::json!({
+                "schema": crate::agent_task::AGENT_TASK_REQUEST_SCHEMA,
+                "task_id": "task",
+                "executor": { "backend": "opencode" },
+                "instructions": "Cook",
+                "workspace": { "mode": "existing" },
+                "metadata": {
+                    "model_selection": {
+                        "requested": "openai/gpt-5.6-unknown",
+                        "selected": "openai/gpt-5.6-unknown",
+                        "reason": "explicit-request"
+                    }
+                }
+            }))
+            .expect("task"),
+        );
+
+        let error = catalog
+            .validate_explicit_models(&plan)
+            .expect_err("unsupported model");
+        assert!(error.message.contains("does not support requested model"));
+        assert_eq!(
+            error.details["tried"][0].as_str(),
+            Some("supported models: openai/gpt-5.6-sol, openai/gpt-5.6-terra")
+        );
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1109,10 +1109,7 @@ where
 {
     std::thread::spawn(move || {
         let mut chunk = [0; 4096];
-        loop {
-            let Ok(read) = reader.read(&mut chunk) else {
-                break;
-            };
+        while let Ok(read) = reader.read(&mut chunk) {
             if read == 0 {
                 break;
             }

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -240,6 +240,10 @@ fn resolved_provider_from_request(
     Ok(Some(provider))
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "caller must retain the original request and artifact path to record a durable failure"
+)]
 fn materialize_executor_request(
     request: AgentTaskRequest,
     context: &AgentTaskExecutionContext,
@@ -257,6 +261,10 @@ fn materialize_executor_request(
     materialize_executor_request_at_root(request, context, root)
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "caller must retain the original request and artifact path to record a durable failure"
+)]
 fn materialize_executor_request_at_root(
     request: AgentTaskRequest,
     context: &AgentTaskExecutionContext,
@@ -301,62 +309,6 @@ fn materialize_executor_request_at_root(
         resolved_runtime_tools: Vec::new(),
         artifacts_root_identity,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::agent_task::{
-        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
-    };
-
-    #[test]
-    fn materialization_fails_before_execution_when_runner_root_is_not_a_directory() {
-        let blocked_root = tempfile::NamedTempFile::new().expect("blocked artifact root");
-        let request = AgentTaskRequest {
-            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
-            task_id: "blocked-artifacts".to_string(),
-            group_key: None,
-            parent_plan_id: None,
-            executor: AgentTaskExecutor {
-                backend: "test".to_string(),
-                selector: None,
-                runtime_selection: None,
-                required_capabilities: Vec::new(),
-                secret_env: Vec::new(),
-                model: None,
-                config: Value::Null,
-            },
-            instructions: "run".to_string(),
-            inputs: Value::Null,
-            source_refs: Vec::new(),
-            workspace: AgentTaskWorkspace::default(),
-            component_contracts: Vec::new(),
-            policy: AgentTaskPolicy::default(),
-            limits: AgentTaskLimits::default(),
-            expected_artifacts: Vec::new(),
-            artifact_declarations: Vec::new(),
-            output_declarations: Vec::new(),
-            runtime_tools: Vec::new(),
-            metadata: Value::Null,
-        };
-        let context = AgentTaskExecutionContext {
-            plan_id: "blocked-plan".to_string(),
-            run_id: Some("blocked-run".to_string()),
-            attempt: 1,
-            cancellation: Default::default(),
-        };
-
-        let (_, path, error) = materialize_executor_request_at_root(
-            request,
-            &context,
-            blocked_root.path().to_path_buf(),
-        )
-        .expect_err("file root must fail");
-
-        assert!(path.starts_with(blocked_root.path()));
-        assert!(!error.to_string().is_empty());
-    }
 }
 
 fn ensure_writable_directory(path: &Path) -> std::io::Result<()> {
@@ -441,5 +393,61 @@ fn selector_mismatch_message(backend: &str, selector: Option<&str>) -> String {
     match selector_runtime_provider_hint(backend, selector) {
         Some(hint) => format!("{base}; {hint}"),
         None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+    };
+
+    #[test]
+    fn materialization_fails_before_execution_when_runner_root_is_not_a_directory() {
+        let blocked_root = tempfile::NamedTempFile::new().expect("blocked artifact root");
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "blocked-artifacts".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                runtime_selection: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "run".to_string(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            component_contracts: Vec::new(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            artifact_declarations: Vec::new(),
+            output_declarations: Vec::new(),
+            runtime_tools: Vec::new(),
+            metadata: Value::Null,
+        };
+        let context = AgentTaskExecutionContext {
+            plan_id: "blocked-plan".to_string(),
+            run_id: Some("blocked-run".to_string()),
+            attempt: 1,
+            cancellation: Default::default(),
+        };
+
+        let (_, path, error) = materialize_executor_request_at_root(
+            request,
+            &context,
+            blocked_root.path().to_path_buf(),
+        )
+        .expect_err("file root must fail");
+
+        assert!(path.starts_with(blocked_root.path()));
+        assert!(!error.to_string().is_empty());
     }
 }

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -1922,10 +1922,8 @@ mod tests {
         value
             .validate(&default_profile())
             .expect("complete evidence");
-        assert!(
-            render_review_dossier(&value, &default_profile()).contains("unavailable_manual_review")
-                == false
-        );
+        assert!(!render_review_dossier(&value, &default_profile())
+            .contains("unavailable_manual_review"));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/candidate_adoption.rs
@@ -79,6 +79,10 @@ pub(super) fn select_candidate_adoption(
     })
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "scheduler returns the complete outcome for durable lifecycle recording"
+)]
 pub(super) fn validate_and_apply_candidate_adoption(
     request: &AgentTaskRequest,
     adoption: &AgentTaskCandidateAdoption,

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -705,12 +705,12 @@ where
                                 executor.execute(request, context)
                             }))
                             .unwrap_or_else(|_| provider_worker_panic(task_id.clone()));
-                        let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
+                        let _ = tx.send(SchedulerEvent::TaskResult(Box::new(TaskResult {
                             task_id,
                             attempt,
                             outcome,
                             scratch,
-                        }));
+                        })));
                     })
                 });
                 running
@@ -1055,6 +1055,10 @@ where
                             continue;
                         }
                     }
+                    #[expect(
+                        clippy::redundant_locals,
+                        reason = "the branch deliberately shadows its pre-retry outcome before terminal mutation"
+                    )]
                     let mut outcome = outcome;
                     cleanup_attempt_workspace(&mut outcome, &running_task);
                     append_unique_artifacts(
@@ -1578,7 +1582,7 @@ fn reset_attempt_request(
 }
 
 enum SchedulerEvent {
-    TaskResult(TaskResult),
+    TaskResult(Box<TaskResult>),
     Cancellation,
 }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
@@ -187,7 +187,7 @@ fn start_or_reconcile_worker_with_retry(
     write_json_atomically(&request_path, &request).map_err(|error| error.message)?;
     #[cfg(test)]
     {
-        return run_postprocess_worker(&request_path)
+        run_postprocess_worker(&request_path)
             .map_err(|error| error.message)
             .and_then(|_| {
                 read_checkpoint(
@@ -197,7 +197,7 @@ fn start_or_reconcile_worker_with_retry(
                     fingerprint,
                 )
                 .ok_or_else(|| "artifact postprocess worker did not write checkpoint".to_string())
-            });
+            })
     }
     #[cfg(not(test))]
     let worker = std::env::var_os("HOMEBOY_POSTPROCESS_WORKER")
@@ -1766,13 +1766,17 @@ mod tests {
                 ..AgentTaskPlan::new("recover", Vec::new())
             };
             let checkpoint = postprocess_checkpoint_path(Some("recover-run"), &step.id);
-            let identity =
-                checkpoint_identity(&plan, Some("recover-run"), &step, &[producer.clone()]);
+            let identity = checkpoint_identity(
+                &plan,
+                Some("recover-run"),
+                &step,
+                std::slice::from_ref(&producer),
+            );
             write_checkpoint(
                 &checkpoint,
                 Some("recover-run"),
                 &identity,
-                &[producer.clone()],
+                std::slice::from_ref(&producer),
                 &step,
                 &postprocess_outcome(&step, AgentTaskOutcomeStatus::Succeeded, "done", None),
             )
@@ -1886,8 +1890,12 @@ mod tests {
                 ..Default::default()
             };
             let checkpoint = postprocess_checkpoint_path(Some("restart-run"), &step.id);
-            let identity =
-                checkpoint_identity(&plan, Some("restart-run"), &step, &[producer.clone()]);
+            let identity = checkpoint_identity(
+                &plan,
+                Some("restart-run"),
+                &step,
+                std::slice::from_ref(&producer),
+            );
             write_checkpoint(
                 &checkpoint,
                 Some("restart-run"),

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -46,6 +46,10 @@ fn deferred_timeout_outcome(task_id: &str, timeout_ms: u64, source: &str) -> Age
 }
 
 impl AgentTaskScheduleSupport {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "scheduler inputs are independently bounded resource and lifecycle state"
+    )]
     pub(super) fn next_dispatchable_index(
         queued: &VecDeque<ScheduledTask>,
         running: &[RunningTask],
@@ -201,6 +205,10 @@ impl AgentTaskScheduleSupport {
         task_ids
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "scheduler returns the complete outcome for durable lifecycle recording"
+    )]
     pub(super) fn render_output_dependencies(
         request: &mut AgentTaskRequest,
         completed_by_task: &HashMap<String, AgentTaskOutcome>,
@@ -1414,7 +1422,7 @@ impl AgentTaskScheduleSupport {
         // consumed at all. A limit of zero was never available to exhaust, so
         // blaming it explains nothing about why this attempt failed.
         let exhausted = terminal_is_failure
-            .then(|| {
+            .then_some({
                 if executions_used >= budget.max_provider_executions {
                     Some("total_executions")
                 } else if rotations_used > 0
@@ -1466,6 +1474,10 @@ impl AgentTaskScheduleSupport {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "retry policy preserves separately persisted counters and classifications"
+    )]
     pub(super) fn should_retry(
         outcome: &AgentTaskOutcome,
         attempt: u32,
@@ -1525,6 +1537,10 @@ impl AgentTaskScheduleSupport {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "queue status projects independently observable scheduler dimensions"
+    )]
     pub(super) fn queue_status(
         max_concurrency: usize,
         max_tasks: Option<usize>,

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/fixtures.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/fixtures.rs
@@ -182,7 +182,7 @@ impl AgentTaskExecutorAdapter for RuntimeBundleOutcomeExecutor {
                     .patch_path
                     .parent()
                     .and_then(|path| path.parent())
-                    .unwrap_or_else(|| self.patch_path.as_path())
+                    .unwrap_or(self.patch_path.as_path())
                     .display()
                     .to_string(),
                 label: Some("Sample runtime artifact bundle".to_string()),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -988,7 +988,7 @@ pub fn compile_cook_attempt(
         &dispatch.tasks,
         dispatch.core.tasks_json.as_deref(),
     )?;
-    let request = agent_task_dispatch_service::resolve_dispatch_request(dispatch.into())?;
+    let request = agent_task_dispatch_service::resolve_dispatch_request(dispatch)?;
     options.initial_plan = build_dispatch_plan(&request)?;
     crate::agent_task_provider::AgentTaskProviderCatalog::discover()
         .validate_explicit_models(&options.initial_plan)?;
@@ -1544,6 +1544,10 @@ fn review_budget_authority(
 /// Append and dispatch one remediation attempt from an authenticated promoted
 /// candidate. Both ordinary Cook feedback and external candidate adoption use
 /// this boundary so their budget, provenance, and baseline authority match.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Cook follow-up retains explicit durable recipe and dispatch identity fields"
+)]
 pub(crate) fn dispatch_cook_follow_up<E>(
     options: &AgentTaskCookServiceOptions,
     executor: E,
@@ -2388,11 +2392,12 @@ where
         &options.ai_tool,
     );
     let required_toolchains = options.gates.required_toolchains();
-    let preflight = (required_toolchains.is_empty()
+    let preflight = if required_toolchains.is_empty()
         && options.gates.gate_package_artifacts.is_empty()
-        && options.gates.gate_environment.extension_inputs.is_empty())
-    .then_some(Ok(()))
-    .unwrap_or_else(|| {
+        && options.gates.gate_environment.extension_inputs.is_empty()
+    {
+        Ok(())
+    } else {
         let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "workspace",
@@ -2409,7 +2414,7 @@ where
             None,
             options.gates.gate_timeout(),
         )
-    });
+    };
     if let Err(error) = preflight {
         let error = with_pre_execution_phase(error, "gate_toolchain_preflight");
         record_pre_execution_failure(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -813,44 +813,6 @@ fn project_execution_placement(finalization: &mut Value, metadata: &Value) {
     }
 }
 
-#[cfg(test)]
-mod projection_tests {
-    use super::*;
-
-    #[test]
-    fn finalization_projects_the_exact_durable_placement_decision_and_outcome_ids() {
-        let decision = serde_json::json!({
-            "decision_id": "epd-durable-decision",
-            "runner": { "runner_id": "fixture-lab", "source": "policy" }
-        });
-        let outcome = serde_json::json!({
-            "decision_id": "epd-durable-decision",
-            "effective": "lab",
-            "runner_id": "fixture-lab"
-        });
-        let metadata = serde_json::json!({
-            "execution_placement_decision": decision,
-            "execution_placement_outcome": outcome
-        });
-        let mut finalization = serde_json::json!({ "status": "review_ready" });
-
-        project_execution_placement(&mut finalization, &metadata);
-
-        assert_eq!(
-            finalization["execution_placement_decision"],
-            metadata["execution_placement_decision"]
-        );
-        assert_eq!(
-            finalization["execution_placement_outcome"],
-            metadata["execution_placement_outcome"]
-        );
-        assert_eq!(
-            finalization["execution_placement_decision"]["decision_id"],
-            finalization["execution_placement_outcome"]["decision_id"]
-        );
-    }
-}
-
 fn reusable_applied_adoption_promotion(
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     candidate_sha: &str,
@@ -1256,5 +1218,43 @@ fn compact_text(value: &str) -> String {
         format!("{prefix}...")
     } else {
         prefix
+    }
+}
+
+#[cfg(test)]
+mod projection_tests {
+    use super::*;
+
+    #[test]
+    fn finalization_projects_the_exact_durable_placement_decision_and_outcome_ids() {
+        let decision = serde_json::json!({
+            "decision_id": "epd-durable-decision",
+            "runner": { "runner_id": "fixture-lab", "source": "policy" }
+        });
+        let outcome = serde_json::json!({
+            "decision_id": "epd-durable-decision",
+            "effective": "lab",
+            "runner_id": "fixture-lab"
+        });
+        let metadata = serde_json::json!({
+            "execution_placement_decision": decision,
+            "execution_placement_outcome": outcome
+        });
+        let mut finalization = serde_json::json!({ "status": "review_ready" });
+
+        project_execution_placement(&mut finalization, &metadata);
+
+        assert_eq!(
+            finalization["execution_placement_decision"],
+            metadata["execution_placement_decision"]
+        );
+        assert_eq!(
+            finalization["execution_placement_outcome"],
+            metadata["execution_placement_outcome"]
+        );
+        assert_eq!(
+            finalization["execution_placement_decision"]["decision_id"],
+            finalization["execution_placement_outcome"]["decision_id"]
+        );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -716,6 +716,38 @@ fn parent_snapshot_from_transport(raw: &str) -> Result<Value> {
     })
 }
 
+pub(crate) fn git_output(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
+    git_output_with_env(cwd, args, &[])
+}
+
+pub(crate) fn git_output_with_env(
+    cwd: &std::path::Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .envs(env.iter().copied())
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("git {}", args.join(" "))))
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "promotion",
+            format!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            None,
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -832,44 +864,8 @@ mod tests {
             );
             assert_eq!(
                 promotion.status,
-                if accepted {
-                    crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
-                } else {
-                    crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
-                }
+                crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
             );
         }
     }
-}
-
-pub(crate) fn git_output(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
-    git_output_with_env(cwd, args, &[])
-}
-
-pub(crate) fn git_output_with_env(
-    cwd: &std::path::Path,
-    args: &[&str],
-    env: &[(&str, &str)],
-) -> Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .envs(env.iter().copied())
-        .current_dir(cwd)
-        .output()
-        .map_err(|error| {
-            Error::internal_io(error.to_string(), Some(format!("git {}", args.join(" "))))
-        })?;
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "promotion",
-            format!(
-                "git {} failed: {}",
-                args.join(" "),
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-            None,
-            None,
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1615,9 +1615,7 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     Ok(value)
 }
 
-fn manual_finalization_run_ids<'a>(
-    recipe: &'a super::cook_recipe::AgentTaskCookRecipe,
-) -> Vec<&'a str> {
+fn manual_finalization_run_ids(recipe: &super::cook_recipe::AgentTaskCookRecipe) -> Vec<&str> {
     recipe
         .attempts
         .iter()

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -319,7 +319,7 @@ fn matches_discovery_options(
     if options
         .state
         .as_deref()
-        .is_some_and(|state| format!("{:?}", record.state).eq_ignore_ascii_case(state) == false)
+        .is_some_and(|state| !format!("{:?}", record.state).eq_ignore_ascii_case(state))
         || submitted_after.is_some_and(|after| {
             chrono::DateTime::parse_from_rfc3339(&record.submitted_at)
                 .map(|submitted| submitted.with_timezone(&chrono::Utc) <= *after)
@@ -327,10 +327,10 @@ fn matches_discovery_options(
         })
         || options.placement.as_deref().is_some_and(|placement| {
             let source = run_source(record);
-            !matches!(
+            !(matches!(
                 (placement, source.as_str()),
                 ("local", "local") | ("remote", "remote")
-            ) && !(placement == "runner" && source.starts_with("runner:"))
+            ) || placement == "runner" && source.starts_with("runner:"))
         })
     {
         return false;

--- a/crates/homeboy-agents/src/agent_task_service/status_support.rs
+++ b/crates/homeboy-agents/src/agent_task_service/status_support.rs
@@ -674,6 +674,17 @@ fn first_diagnostics(value: &Value) -> Value {
     }
 }
 
+fn excerpt(text: &str) -> String {
+    const LIMIT: usize = 600;
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= LIMIT {
+        trimmed.to_string()
+    } else {
+        let prefix: String = trimmed.chars().take(LIMIT).collect();
+        format!("{prefix}...")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -840,16 +851,5 @@ mod tests {
             hydrated.content["diagnostic_class"],
             "agent_task.provider_executable_missing"
         );
-    }
-}
-
-fn excerpt(text: &str) -> String {
-    const LIMIT: usize = 600;
-    let trimmed = text.trim();
-    if trimmed.chars().count() <= LIMIT {
-        trimmed.to_string()
-    } else {
-        let prefix: String = trimmed.chars().take(LIMIT).collect();
-        format!("{prefix}...")
     }
 }

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -926,7 +926,7 @@ fn cleanup_unlocked(
         .collect::<Vec<_>>();
     for candidate in &mutation_candidates {
         if options.apply {
-            match remove_candidate(&candidate, now, options.retention_override_seconds)? {
+            match remove_candidate(candidate, now, options.retention_override_seconds)? {
                 ScratchRemoval::Removed(bytes) => {
                     applied_count += 1;
                     reclaimed_bytes += bytes;
@@ -1821,6 +1821,7 @@ fn with_index_lock<T>(index_path: &Path, operation: impl FnOnce() -> Result<T>) 
     }
     let file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&lock_path)
@@ -1877,7 +1878,7 @@ fn read_index_unlocked() -> Result<ControllerScratchIndex> {
 }
 
 fn read_index_at_unlocked(path: &Path) -> Result<ControllerScratchIndex> {
-    match fs::read_to_string(&path) {
+    match fs::read_to_string(path) {
         Ok(raw) => serde_json::from_str(&raw).map_err(|error| {
             Error::internal_json(error.to_string(), Some(path.display().to_string()))
         }),


### PR DESCRIPTION
Refs #11580\n\nResolves the Rust 1.95 Clippy diagnostics scoped to homeboy-agents while retaining durable lifecycle, provider, retry/timing, schema, observability, and mixed-version boundaries.\n\nValidation:\n- cargo fmt --all\n- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo check -p homeboy-agents\n- CARGO_TARGET_DIR=/Users/chubes/Developer/.cargo-targets/homeboy-11580-core cargo clippy -p homeboy-agents --all-targets -- -D warnings\n- lifecycle focused suite: 258 passed\n- scheduler focused suite: 114 passed; 3 filesystem-contention failures passed individually on rerun\n\nAI assistance: OpenAI openai/gpt-5.6-terra via OpenCode was used to categorize Rust 1.95 diagnostics, implement scoped fixes, and run verification. Chris remains responsible for every line.