### PR TITLE
fix(lab): resolve Rust 1.95 staging/controller diagnostics

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
+++ b/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
@@ -315,7 +315,7 @@ fn handoff_envelope_from_typed_handoff(handoff: &AgentTaskLabHandoff) -> Value {
     }
     if let Some(aggregate) = handoff.aggregate.as_ref() {
         if let Ok(value) = serde_json::to_value(
-            &homeboy_agents::agent_task_artifacts::reviewer_facing_aggregate(aggregate),
+            homeboy_agents::agent_task_artifacts::reviewer_facing_aggregate(aggregate),
         ) {
             envelope.insert("aggregate".to_string(), value);
         }

--- a/crates/homeboy-lab-runner/src/lab/args_util.rs
+++ b/crates/homeboy-lab-runner/src/lab/args_util.rs
@@ -53,10 +53,8 @@ impl ArgEditor {
         index: usize,
         values: impl IntoIterator<Item = String>,
     ) -> Self {
-        let mut insertion_index = index + 1;
-        for value in values {
+        for (insertion_index, value) in (index + 1..).zip(values) {
             self.args.insert(insertion_index, value);
-            insertion_index += 1;
         }
         self
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/errors.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/errors.rs
@@ -298,6 +298,10 @@ pub(crate) fn automatic_capability_fallback(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The fallback boundary accepts independently-derived routing, capability, and lifecycle evidence; grouping it would weaken their ownership contract."
+)]
 pub(crate) fn automatic_capability_fallback_or_error(
     request: &LabOffloadRequest<'_>,
     plan: HomeboyPlan,

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -756,7 +756,7 @@ pub(crate) fn exec_lab_context(
                                 )],
                             ))
                         } else {
-                            record_local_outcome(&request)?;
+                            record_local_outcome(request)?;
                             Ok(LabOffloadOutcome::RunLocal {
                                 metadata: Some(lab_offload_metadata_with_workspace_mapping(
                                     &context.plan,
@@ -1178,11 +1178,11 @@ pub(crate) fn run_lab_offload_inner(
     // Detached commands without an agent-task argv shape receive their durable
     // plan and identity from routing. Admit the controller job before capacity
     // checks or remote preparation so caller loss cannot orphan staging.
-    if request.detach_after_handoff
-        && request.durable_agent_task_plan.is_some()
-        && request.durable_run_id.is_some()
-    {
-        let run_id = request.durable_run_id.expect("checked durable run id");
+    if let (true, Some(durable_plan), Some(run_id)) = (
+        request.detach_after_handoff,
+        request.durable_agent_task_plan,
+        request.durable_run_id,
+    ) {
         emit_durable_run_id_before_execution(
             run_id,
             runner_id,
@@ -1198,14 +1198,12 @@ pub(crate) fn run_lab_offload_inner(
             Ok(controller_job_id) => controller_job_id,
             Err(error) => {
                 if error.retryable != Some(true) {
-                    if let Some(durable_plan) = request.durable_agent_task_plan {
-                        let _ = agent_task_lifecycle::record_pre_execution_failure(
-                            run_id,
-                            durable_plan,
-                            "lab_staging_submission",
-                            &error,
-                        );
-                    }
+                    let _ = agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        durable_plan,
+                        "lab_staging_submission",
+                        &error,
+                    );
                 }
                 return Err(with_agent_task_retry_hint(
                     error,
@@ -1815,10 +1813,11 @@ pub(crate) fn run_lab_offload_inner(
     // The safe default deletes every known terminal result. The explicit debug
     // profile keeps failures only through the registered runner TTL lifecycle.
     // Detached and uncertain in-flight work explicitly relinquishes ownership.
-    let cleanup_policy = request
-        .preserve_workspace_on_failure
-        .then_some(WorkspaceCleanupPolicy::PreserveOnFailure)
-        .unwrap_or(WorkspaceCleanupPolicy::DeleteAlways);
+    let cleanup_policy = if request.preserve_workspace_on_failure {
+        WorkspaceCleanupPolicy::PreserveOnFailure
+    } else {
+        WorkspaceCleanupPolicy::DeleteAlways
+    };
     let mut workspace_resource_lifecycle = synced.resource_lifecycle.clone();
     if request.preserve_workspace_on_failure {
         workspace_resource_lifecycle.cleanup_policy =
@@ -2024,7 +2023,7 @@ pub(crate) fn run_lab_offload_inner(
     lab_metadata["runtime_evidence"] =
         serde_json::to_value(&runtime_evidence).unwrap_or(serde_json::json!(null));
     let secret_env_handoff = build_lab_secret_env_handoff_plan(
-        &contract.secret_env_sources,
+        contract.secret_env_sources,
         &changed_since_preflight.args,
         env_delta,
     )?;

--- a/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/path_materialization.rs
@@ -5,7 +5,6 @@
 //! inputs after individual argument transforms.
 
 use super::*;
-use homeboy_rig;
 
 pub(crate) struct PathMaterializationPlanner {
     pub(crate) args: Vec<String>,

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -87,7 +87,7 @@ pub(crate) fn run_runner_resident_lab_offload(
     plan = with_step(
         plan,
         PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
-            .inputs(PlanValues::new().json("argv", &redact_argv(&command)))
+            .inputs(PlanValues::new().json("argv", redact_argv(&command)))
             .build(),
     );
 
@@ -121,7 +121,7 @@ pub(crate) fn run_runner_resident_lab_offload(
         serde_json::to_value(&path_materialization_plan).unwrap_or(serde_json::json!(null));
     lab_metadata["job_scoped_overrides"] = job_scoped_overrides_metadata(&request.job_overrides);
     let secret_env_handoff = build_lab_secret_env_handoff_plan(
-        &contract.secret_env_sources,
+        contract.secret_env_sources,
         &remapped_args,
         Default::default(),
     )?;

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -11,7 +11,6 @@ use homeboy_core::runner_execution_envelope::{
     PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
     PATH_MATERIALIZATION_OWNER_LAB_PROVIDER_CONFIG, PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
-use homeboy_rig;
 
 /// Owned command facts consumed while materializing a workspace. This keeps the
 /// durable controller path bounded by the request lifetime rather than forcing
@@ -642,7 +641,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     plan = with_step(
         plan,
         PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
-            .inputs(PlanValues::new().json("argv", &redact_argv(&command)))
+            .inputs(PlanValues::new().json("argv", redact_argv(&command)))
             .build(),
     );
     Ok(LabOffloadWorkspaceStage {

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -76,16 +76,16 @@ pub(super) fn preflight_agent_task_provider_on_runner(
             remote_cwd,
         )?;
     }
-    let probe = probe_agent_task_providers_on_runner(
+    let probe = probe_agent_task_providers_on_runner(ProviderProbeRequest {
         runner_id,
         remote_cwd,
-        &command,
-        env.clone(),
-        source_snapshot.clone(),
-        required_extensions.clone(),
-        capability_preflight.clone(),
-        runner_status.clone(),
-    )?;
+        command: &command,
+        env: env.clone(),
+        source_snapshot: source_snapshot.clone(),
+        required_extensions: required_extensions.clone(),
+        capability_preflight: capability_preflight.clone(),
+        status_snapshot: runner_status.clone(),
+    })?;
 
     let local_providers = ExtensionProviderAgentTaskExecutor::discover()
         .providers()
@@ -157,16 +157,16 @@ pub(super) fn preflight_agent_task_provider_on_runner(
             .cloned();
         refresh_result = Some(refresh.map(|_| ()));
         if let Some(replacement_status) = replacement_status {
-            let probe = probe_agent_task_providers_on_runner(
+            let probe = probe_agent_task_providers_on_runner(ProviderProbeRequest {
                 runner_id,
                 remote_cwd,
-                &command,
+                command: &command,
                 env,
                 source_snapshot,
                 required_extensions,
                 capability_preflight,
-                replacement_status,
-            )?;
+                status_snapshot: replacement_status,
+            })?;
             if probe.exit_code == 0 {
                 if let Ok(providers) = parse_agent_task_providers_output(&probe.stdout) {
                     runner_unavailable_reason = selection
@@ -317,25 +317,30 @@ struct AgentTaskProviderProbeOutput {
     exit_code: i32,
 }
 
-fn probe_agent_task_providers_on_runner(
-    runner_id: &str,
-    remote_cwd: &str,
-    command: &[String],
+struct ProviderProbeRequest<'a> {
+    runner_id: &'a str,
+    remote_cwd: &'a str,
+    command: &'a [String],
     env: std::collections::HashMap<String, String>,
     source_snapshot: Option<SourceSnapshot>,
     required_extensions: Vec<String>,
     capability_preflight: Option<RunnerCapabilityPreflight>,
     status_snapshot: RunnerStatusReport,
+}
+
+fn probe_agent_task_providers_on_runner(
+    request: ProviderProbeRequest<'_>,
 ) -> Result<AgentTaskProviderProbeOutput> {
     let options = provider_probe_options(
-        command,
-        remote_cwd,
-        env,
-        source_snapshot,
-        required_extensions,
-        capability_preflight,
+        request.command,
+        request.remote_cwd,
+        request.env,
+        request.source_snapshot,
+        request.required_extensions,
+        request.capability_preflight,
     );
-    let (output, exit_code) = exec_with_status_snapshot(runner_id, options, Some(status_snapshot))?;
+    let (output, exit_code) =
+        exec_with_status_snapshot(request.runner_id, options, Some(request.status_snapshot))?;
 
     Ok(AgentTaskProviderProbeOutput {
         stdout: output.stdout,

--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -165,7 +165,7 @@ pub(crate) fn materialize_inline_agent_task_json_specs_in_args<T>(
         "agent-task-tasks.json",
         "agent_task_tasks_remapped",
         "lab.sync_remapped_agent_task_tasks",
-        |spec| sync_inline_json(spec),
+        &mut sync_inline_json,
     )?;
     let (args, plan_entry) = materialize_inline_json_option(
         &args,
@@ -174,7 +174,7 @@ pub(crate) fn materialize_inline_agent_task_json_specs_in_args<T>(
         "agent-task-plan.json",
         "agent_task_plan_remapped",
         "lab.sync_remapped_agent_task_plan",
-        |spec| sync_inline_json(spec),
+        &mut sync_inline_json,
     )?;
     let (args, attempt_plan_entry) = materialize_inline_json_option(
         &args,
@@ -183,7 +183,7 @@ pub(crate) fn materialize_inline_agent_task_json_specs_in_args<T>(
         "agent-task-attempt-plan.json",
         "agent_task_attempt_plan_remapped",
         "lab.sync_remapped_agent_task_attempt_plan",
-        |spec| sync_inline_json(spec),
+        sync_inline_json,
     )?;
 
     let workspace_entries = task_entry

--- a/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/path_remap.rs
@@ -301,7 +301,7 @@ fn paths_match(path: &str, prefix: &str) -> bool {
     }
 }
 
-fn path_suffix<'a>(path: &'a str, prefix: &str) -> Option<String> {
+fn path_suffix(path: &str, prefix: &str) -> Option<String> {
     let path = normalize_path_separators(path);
     let prefix = normalize_path_separators(prefix)
         .trim_end_matches('/')

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -314,20 +314,15 @@ struct LabHandoffHomeboyIdentity {
 
 /// Compatibility is declared by the durable handoff protocol, rather than
 /// inferred from a product name or a particular runner implementation.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum RuntimeSetCompatibility {
     /// A record persisted before runtime-set compatibility was declared.
+    #[default]
     UnknownLegacy,
     Exact,
     CompatiblePatchDrift,
     WireOrLifecycleIncompatible,
-}
-
-impl Default for RuntimeSetCompatibility {
-    fn default() -> Self {
-        Self::UnknownLegacy
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -3719,25 +3714,22 @@ impl LabStagingDispatchDriver {
         } else {
             adapter.execute(&request, checkpoint, token, job.clone())
         };
-        let checkpoint = result.map_err(|error| {
-            if !job.is_cancelled() {
-                if homeboy_agents::agent_task_lifecycle::record_pre_execution_failure(
+        let checkpoint = result.inspect_err(|error| {
+            if !job.is_cancelled()
+                && homeboy_agents::agent_task_lifecycle::record_pre_execution_failure(
                     &request.recipe.run_id,
                     &request.durable_agent_task_plan,
                     "lab_staging_controller",
-                    &error,
+                    error,
                 )
                 .is_ok()
-                {
-                    let _ =
-                        homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_failure(
-                            &request.recipe.run_id,
-                            &format!("{:?}", expected_identity.phase),
-                            &job.job_id(),
-                        );
-                }
+            {
+                let _ = homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_failure(
+                    &request.recipe.run_id,
+                    &format!("{:?}", expected_identity.phase),
+                    &job.job_id(),
+                );
             }
-            error
         })?;
         checkpoint.validate()?;
         let checkpoint =
@@ -3748,12 +3740,12 @@ impl LabStagingDispatchDriver {
                 Some("serialize Lab staging checkpoint".to_string()),
             )
         })?)?;
-        Ok(serde_json::to_value(checkpoint).map_err(|error| {
+        serde_json::to_value(checkpoint).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
                 Some("serialize Lab staging result".to_string()),
             )
-        })?)
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- resolve the 21 Rust 1.95 diagnostics in Lab runner staging, controller, offload, and argument-remapping code
- retain legacy runtime compatibility, lifecycle failure recording, secret handling, fallback decisions, argument order, and staging semantics
- introduce ProviderProbeRequest for provider readiness probes and document the intentional capability-fallback boundary

Refs #11580

## Validation
- cargo fmt --all -- --check using the shared target
- cargo check -p homeboy-lab-runner using the shared target
- cargo test -p homeboy-lab-runner --lib lab: 609 passed; 3 pre-existing failures in lab::preparation_tests direct-session/daemon readiness expectations
- cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings: assigned modules clean; blocked by 88 non-owned library and 121 non-owned test diagnostics

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode implemented and validated the Rust diagnostic fixes. Chris Huber reviewed and remains responsible for every line.