### PR TITLE
fix(runner): document Rust 1.95 execution diagnostics

### DIFF
--- a/crates/homeboy-lab-runner/src/dev_run.rs
+++ b/crates/homeboy-lab-runner/src/dev_run.rs
@@ -160,8 +160,8 @@ pub fn run_extension_dev_run(
         runner_id,
         source,
         command,
-        |runner_id, options| crate::runners::sync_workspace(runner_id, options),
-        |runner_id, options| crate::runners::exec(runner_id, options),
+        crate::runners::sync_workspace,
+        crate::runners::exec,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1078,6 +1078,10 @@ fn spawn_admission_renewer(
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "Production daemon helpers remain below focused admission tests after the staged source split."
+)]
 mod admission_tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1434,6 +1438,10 @@ pub(super) fn validate_daemon_job_identity(requested_job_id: &str, job: &Job) ->
     ))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Detached handoff retains durable job, source, materialization, and mirror identities independently."
+)]
 pub(super) fn detached_handoff_output(
     runner: &Runner,
     mode: RunnerExecMode,

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -382,6 +382,10 @@ pub struct RunnerExecOutput {
     pub diagnostics: Option<RunnerExecDiagnostics>,
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "RunnerExecutionRecord preserves separately typed compatibility fields from every transport."
+)]
 fn runner_execution_record_for_output(
     runner: &Runner,
     transport: &str,

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -45,6 +45,10 @@ pub(super) fn exec_local(plan: PreparedRunnerProcess) -> Result<(RunnerExecOutpu
     ))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Diagnostic SSH keeps secret, path, timeout, and run-identity boundaries explicit."
+)]
 pub(super) fn exec_diagnostic_ssh(
     runner: &Runner,
     cwd: String,
@@ -471,6 +475,10 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::items_after_test_module,
+    reason = "Production process helpers remain below focused tests after the staged source split."
+)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Barrier};
@@ -1141,6 +1149,10 @@ pub(super) fn command_output(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Cancellation, progress, child identity, redaction, and resource guard inputs are independently security-relevant."
+)]
 pub(super) fn command_output_until_cancelled_with_progress(
     command: &mut std::process::Command,
     is_cancelled: impl FnMut() -> bool,

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -133,7 +133,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
         let snapshot = match crate::evidence::runner_job_log_snapshot(runner_id, job_id) {
             Ok(snapshot) => snapshot,
             Err(error) => {
-                record_evicted_evidence_loss(&store, &run, &error)?;
+                record_evicted_evidence_loss(&store, run, &error)?;
                 // A 404 is a durable per-job result. Other failures describe the
                 // endpoint, so avoid amplifying one unavailable daemon into N probes.
                 if error.details.get("http_status").and_then(Value::as_u64) != Some(404) {
@@ -177,11 +177,11 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
                 })
                 .unwrap_or_default()
         };
-        let output = recovered_output(&run, &snapshot, cwd);
+        let output = recovered_output(run, &snapshot, cwd);
         let mut artifacts = Vec::new();
         for declaration in strings("artifacts") {
             if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
-                &run,
+                run,
                 "artifact",
                 &declaration,
             ) {
@@ -203,7 +203,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
         let mut directories = Vec::new();
         for declaration in strings("artifact_dirs") {
             if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
-                &run,
+                run,
                 "artifact_dir",
                 &declaration,
             ) {
@@ -225,7 +225,7 @@ pub fn reconcile_terminal_runner_exec_runs_with_budget(budget: Duration) -> Resu
         let mut summaries = Vec::new();
         for declaration in strings("summaries") {
             if homeboy_agents::agent_task_lifecycle::runner_exec_declaration_is_promoted(
-                &run,
+                run,
                 "summary",
                 &declaration,
             ) {

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -25,14 +25,19 @@ const PREFERRED_HOST_HEADROOM_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 #[cfg(any(target_os = "linux", test))]
 const HOST_HEADROOM_DIVISOR: u64 = 10;
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const DEFAULT_PROCESS_COUNT_LIMIT: u64 = 128;
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const RSS_LIMIT_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_RSS_BYTES";
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const PROCESS_COUNT_LIMIT_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_PROCESS_COUNT";
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const DEFAULT_PROCESS_COUNT_LIMIT_CEILING: u64 = 256;
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const PROCESS_COUNT_LIMIT_CEILING_ENV: &str = "HOMEBOY_RUNNER_RESOURCE_GUARD_MAX_PROCESS_COUNT";
 
 fn require_process_tree_isolation() -> Result<()> {
@@ -110,6 +115,10 @@ pub(crate) fn measured_command_output(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The execution boundary keeps cancellation, progress, identity acknowledgement, and resource-limit inputs explicit."
+)]
 pub(crate) fn measured_command_output_until_cancelled_with_progress(
     command: &mut Command,
     mut is_cancelled: impl FnMut() -> bool,
@@ -713,6 +722,7 @@ struct ResolvedProcessCountLimit {
 }
 
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn resolved_process_count_limit(
     resource_guard_env: &HashMap<String, String>,
 ) -> ResolvedProcessCountLimit {
@@ -786,6 +796,7 @@ fn classify_resource_guard_violation(
 }
 
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn resource_guard_limit(env_name: &str, default_value: u64) -> u64 {
     std::env::var(env_name)
         .ok()

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -63,6 +63,10 @@ pub fn reconnect_runner_daemon(runner_id: &str) -> Result<(String, Option<String
     )))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Recovery diagnostics retain independent source, binary, version, and identity observations for compatible remediation output."
+)]
 pub fn runner_recovery_commands(
     runner_id: &str,
     homeboy_path: &str,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/failure.rs
@@ -53,7 +53,14 @@ pub fn runner_upgrade_failure_entry(
 /// continue (either no realignment was needed, or the retry succeeded). Returns
 /// `Err(entry)` with a fully-populated failure entry (minus `previous_version`,
 /// which the caller assigns) when recovery or the retry definitively fails.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The retry boundary preserves the complete failed-upgrade diagnostic contract."
+)]
+#[expect(
+    clippy::result_large_err,
+    reason = "RunnerUpgradeEntry is a stable result payload consumed by existing upgrade reporting."
+)]
 pub fn recover_and_retry_failed_upgrade(
     runner: &Runner,
     force: bool,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -180,6 +180,10 @@ pub fn upgrade_runners_with_executor(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Compatibility entry point exposes separately injectable upgrade operations for focused tests."
+)]
 pub fn upgrade_runners_with_executor_and_source_materializer(
     runners: &[Runner],
     force: bool,
@@ -203,6 +207,10 @@ pub fn upgrade_runners_with_executor_and_source_materializer(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The internal operation keeps expected controller identity explicit through source materialization."
+)]
 fn upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
     runners: &[Runner],
     force: bool,
@@ -228,6 +236,10 @@ fn upgrade_runners_with_executor_and_source_materializer_with_expected_controlle
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Compatibility entry point preserves injectable execution, materialization, and path update operations."
+)]
 pub fn upgrade_runners_with_executor_source_materializer_and_path_updater(
     runners: &[Runner],
     force: bool,
@@ -253,6 +265,10 @@ pub fn upgrade_runners_with_executor_source_materializer_and_path_updater(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The internal upgrade operation retains explicit controller identity and path mutation boundaries."
+)]
 fn upgrade_runners_with_executor_source_materializer_and_path_updater_with_expected_controller_identity(
     runners: &[Runner],
     force: bool,
@@ -280,6 +296,10 @@ fn upgrade_runners_with_executor_source_materializer_and_path_updater_with_expec
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Compatibility entry point preserves independently injectable reconnect and path operations."
+)]
 pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector(
     runners: &[Runner],
     force: bool,
@@ -307,7 +327,10 @@ pub fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconn
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The orchestration boundary keeps every mutating operation explicit for deterministic runner upgrade recovery."
+)]
 fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnector_with_expected_controller_identity(
     runners: &[Runner],
     force: bool,
@@ -355,6 +378,10 @@ fn upgrade_runners_with_executor_source_materializer_path_updater_and_reconnecto
     (updated, skipped)
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "A single runner upgrade retains explicit diagnostic inputs and operations to preserve callback order."
+)]
 pub fn upgrade_runner_with_executor(
     runner: &Runner,
     force: bool,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/path_alignment.rs
@@ -79,6 +79,10 @@ pub struct SourceUpgradeHomeboyPathRealignment {
     pub detail: String,
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Source realignment compares independent configured, candidate, version, and identity observations."
+)]
 pub fn source_upgrade_homeboy_path_realignment(
     runner: &Runner,
     original_homeboy_path: &str,

--- a/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
@@ -37,6 +37,10 @@ pub fn runner_stale_daemon(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Upgrade reporting preserves independent drift and extension result fields for compatible detail output."
+)]
 pub fn runner_upgrade_final_detail(
     runner_id: &str,
     detail: String,

--- a/crates/homeboy-lab-runner/src/worker/broker.rs
+++ b/crates/homeboy-lab-runner/src/worker/broker.rs
@@ -46,6 +46,10 @@ pub(super) fn claim_job(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Progress must carry the exact claim and workspace lease bindings that authorize the event."
+)]
 pub(super) fn append_progress_data(
     client: &Client,
     broker_url: &str,
@@ -75,6 +79,10 @@ pub(super) fn append_progress_data(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Terminal result submission preserves independently verified claim and workspace lease bindings."
+)]
 pub(super) fn finish_job(
     client: &Client,
     broker_url: &str,
@@ -109,6 +117,10 @@ pub(super) fn finish_job(
     Ok(job)
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Receipt consumption must keep its context, claim, and workspace lease evidence distinct."
+)]
 pub(super) fn consume_execution(
     client: &Client,
     broker_url: &str,
@@ -177,6 +189,10 @@ pub(super) fn validate_workspace_owner(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Lease renewal carries every current authorization binding to prevent stale-owner renewal."
+)]
 fn renew_claim(
     client: &Client,
     broker_url: &str,


### PR DESCRIPTION
Summary: resolve assigned Rust 1.95 diagnostics in lab-runner execution, recovery, resource guard, broker, and upgrade diagnostic paths; preserve execution, cancellation, lease, redaction, and upgrade compatibility boundaries; simplify recovery borrows and dev-run operation forwarding.\n\nRefs #11580\n\nVerification: cargo fmt --check; cargo check -p homeboy-lab-runner; cargo test -p homeboy-lab-runner --lib upgrade_runners:: -- --test-threads=1 (43 passed). Package-wide strict Clippy remains blocked by 83 diagnostics in unassigned lab-runner modules; none remain in this PR's assigned files. The execution suite has 171 passing and 8 pre-existing failures in runner fixture/state and reverse-broker artifact projection tests.\n\nAI Assistance: OpenAI openai/gpt-5.6-terra via OpenCode was used to inspect diagnostics, make the focused Rust edits, and run verification. Chris Huber remains responsible for every line.