### PR TITLE
fix(lab-runner): resolve transport protocol diagnostics

### DIFF
--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -199,18 +199,18 @@ pub(crate) fn validate_runner_capability_preflight(
         preflight
             .required_toolchain_probes
             .iter()
-            .filter_map(|probe| {
+            .filter(|probe| {
                 failed_toolchain_probes
                     .iter()
                     .any(|failed| failed.starts_with(&format!("{}:", probe.id)))
-                    .then(|| {
-                        probe.repair_command.clone().unwrap_or_else(|| {
-                            format!(
-                                "Repair extension `{}` toolchain probe `{}` and retry.",
-                                probe.extension_id, probe.id
-                            )
-                        })
-                    })
+            })
+            .map(|probe| {
+                probe.repair_command.clone().unwrap_or_else(|| {
+                    format!(
+                        "Repair extension `{}` toolchain probe `{}` and retry.",
+                        probe.extension_id, probe.id
+                    )
+                })
             }),
     );
     remediation.extend(missing_env.iter().map(|name| {
@@ -274,10 +274,11 @@ pub fn runner_capability_inventory(runner_id: &str) -> Result<RunnerCapabilityIn
         .chain(snapshot.components.iter().cloned())
         .collect::<BTreeSet<_>>();
     capabilities.extend(snapshot.tool_capabilities);
-    let runtime_ids = capabilities
-        .contains("homeboy")
-        .then(|| BTreeSet::from(["homeboy".to_string()]))
-        .unwrap_or_default();
+    let runtime_ids = if capabilities.contains("homeboy") {
+        BTreeSet::from(["homeboy".to_string()])
+    } else {
+        BTreeSet::new()
+    };
     Ok(RunnerCapabilityInventory {
         runtime_ids,
         capabilities,

--- a/crates/homeboy-lab-runner/src/command_path.rs
+++ b/crates/homeboy-lab-runner/src/command_path.rs
@@ -165,6 +165,13 @@ struct PathSurfaceFailure {
     exists_locally: bool,
 }
 
+struct PathFailureContext<'a> {
+    source_path: &'a Path,
+    remote_cwd: &'a str,
+    mappings: &'a [LabPathRemap],
+    failures: &'a mut Vec<PathSurfaceFailure>,
+}
+
 fn collect_path_setting_failures(
     command: &[String],
     source_path: &Path,
@@ -172,6 +179,12 @@ fn collect_path_setting_failures(
     mappings: &[LabPathRemap],
     failures: &mut Vec<PathSurfaceFailure>,
 ) {
+    let mut context = PathFailureContext {
+        source_path,
+        remote_cwd,
+        mappings,
+        failures,
+    };
     let mut iter = command.iter().peekable();
     let mut passthrough = false;
     while let Some(arg) = iter.next() {
@@ -181,15 +194,7 @@ fn collect_path_setting_failures(
         }
         if arg == "--setting" {
             if let Some(raw) = iter.next() {
-                collect_setting_pair_failures(
-                    "--setting",
-                    raw,
-                    source_path,
-                    remote_cwd,
-                    mappings,
-                    !passthrough,
-                    failures,
-                );
+                collect_setting_pair_failures("--setting", raw, !passthrough, &mut context);
             }
             continue;
         }
@@ -198,60 +203,23 @@ fn collect_path_setting_failures(
                 collect_json_setting_pair_failures(
                     "--setting-json",
                     raw,
-                    source_path,
-                    remote_cwd,
-                    mappings,
                     !passthrough,
-                    failures,
+                    &mut context,
                 );
             }
             continue;
         }
         if let Some(raw) = arg.strip_prefix("--setting=") {
-            collect_setting_pair_failures(
-                "--setting",
-                raw,
-                source_path,
-                remote_cwd,
-                mappings,
-                !passthrough,
-                failures,
-            );
+            collect_setting_pair_failures("--setting", raw, !passthrough, &mut context);
         } else if let Some(raw) = arg.strip_prefix("--setting-json=") {
-            collect_json_setting_pair_failures(
-                "--setting-json",
-                raw,
-                source_path,
-                remote_cwd,
-                mappings,
-                !passthrough,
-                failures,
-            );
+            collect_json_setting_pair_failures("--setting-json", raw, !passthrough, &mut context);
         } else if let Some((flag, value)) = arg.split_once('=') {
             if is_path_bearing_flag(flag) {
-                collect_value_path_failures(
-                    "arg",
-                    flag,
-                    value,
-                    source_path,
-                    remote_cwd,
-                    mappings,
-                    !passthrough,
-                    failures,
-                );
+                collect_value_path_failures("arg", flag, value, !passthrough, &mut context);
             }
         } else if is_path_bearing_flag(arg) {
             if let Some(value) = iter.peek() {
-                collect_value_path_failures(
-                    "arg",
-                    arg,
-                    value,
-                    source_path,
-                    remote_cwd,
-                    mappings,
-                    !passthrough,
-                    failures,
-                );
+                collect_value_path_failures("arg", arg, value, !passthrough, &mut context);
             }
         }
     }
@@ -260,11 +228,8 @@ fn collect_path_setting_failures(
 fn collect_setting_pair_failures(
     flag: &str,
     raw: &str,
-    source_path: &Path,
-    remote_cwd: &str,
-    mappings: &[LabPathRemap],
     include_existing_local: bool,
-    failures: &mut Vec<PathSurfaceFailure>,
+    context: &mut PathFailureContext<'_>,
 ) {
     let Some((key, value)) = raw.split_once('=') else {
         return;
@@ -276,22 +241,16 @@ fn collect_setting_pair_failures(
         "setting",
         &format!("{flag} {key}"),
         value,
-        source_path,
-        remote_cwd,
-        mappings,
         include_existing_local,
-        failures,
+        context,
     );
 }
 
 fn collect_json_setting_pair_failures(
     flag: &str,
     raw: &str,
-    source_path: &Path,
-    remote_cwd: &str,
-    mappings: &[LabPathRemap],
     include_existing_local: bool,
-    failures: &mut Vec<PathSurfaceFailure>,
+    context: &mut PathFailureContext<'_>,
 ) {
     let Some((key, value)) = raw.split_once('=') else {
         return;
@@ -304,21 +263,15 @@ fn collect_json_setting_pair_failures(
             "setting-json",
             &format!("{flag} {key}"),
             &json,
-            source_path,
-            remote_cwd,
-            mappings,
             include_existing_local,
-            failures,
+            context,
         ),
         Err(_) => collect_value_path_failures(
             "setting-json",
             &format!("{flag} {key}"),
             value,
-            source_path,
-            remote_cwd,
-            mappings,
             include_existing_local,
-            failures,
+            context,
         ),
     }
 }
@@ -327,34 +280,21 @@ fn collect_json_value_path_failures(
     kind: &'static str,
     surface: &str,
     value: &serde_json::Value,
-    source_path: &Path,
-    remote_cwd: &str,
-    mappings: &[LabPathRemap],
     include_existing_local: bool,
-    failures: &mut Vec<PathSurfaceFailure>,
+    context: &mut PathFailureContext<'_>,
 ) {
     match value {
-        serde_json::Value::String(text) => collect_value_path_failures(
-            kind,
-            surface,
-            text,
-            source_path,
-            remote_cwd,
-            mappings,
-            include_existing_local,
-            failures,
-        ),
+        serde_json::Value::String(text) => {
+            collect_value_path_failures(kind, surface, text, include_existing_local, context)
+        }
         serde_json::Value::Array(items) => {
             for item in items {
                 collect_json_value_path_failures(
                     kind,
                     surface,
                     item,
-                    source_path,
-                    remote_cwd,
-                    mappings,
                     include_existing_local,
-                    failures,
+                    context,
                 );
             }
         }
@@ -364,11 +304,8 @@ fn collect_json_value_path_failures(
                     kind,
                     surface,
                     item,
-                    source_path,
-                    remote_cwd,
-                    mappings,
                     include_existing_local,
-                    failures,
+                    context,
                 );
             }
         }
@@ -383,20 +320,17 @@ fn collect_path_env_failures(
     mappings: &[LabPathRemap],
     failures: &mut Vec<PathSurfaceFailure>,
 ) {
+    let mut context = PathFailureContext {
+        source_path,
+        remote_cwd,
+        mappings,
+        failures,
+    };
     for (key, value) in env {
         if !is_path_bearing_env_key(key) {
             continue;
         }
-        collect_value_path_failures(
-            "env",
-            key,
-            value,
-            source_path,
-            remote_cwd,
-            mappings,
-            true,
-            failures,
-        );
+        collect_value_path_failures("env", key, value, true, &mut context);
     }
 }
 
@@ -404,23 +338,20 @@ fn collect_value_path_failures(
     kind: &'static str,
     surface: &str,
     value: &str,
-    source_path: &Path,
-    remote_cwd: &str,
-    mappings: &[LabPathRemap],
     include_existing_local: bool,
-    failures: &mut Vec<PathSurfaceFailure>,
+    context: &mut PathFailureContext<'_>,
 ) {
     for path in path_candidates(value) {
         if !is_unmapped_controller_path(
             &path,
-            source_path,
-            remote_cwd,
-            mappings,
+            context.source_path,
+            context.remote_cwd,
+            context.mappings,
             include_existing_local,
         ) {
             continue;
         }
-        failures.push(PathSurfaceFailure {
+        context.failures.push(PathSurfaceFailure {
             kind,
             surface: surface.to_string(),
             exists_locally: expanded_path(&path).exists(),

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -65,8 +65,29 @@ struct CliEnvelope {
     error: Option<Value>,
 }
 
+struct RemoteDaemonConnectOptions<'a> {
+    orphan_lease_id: Option<&'a str>,
+    confirmed_no_pid_job_ids: &'a [uuid::Uuid],
+    reconcile_leaseless_orphans: bool,
+    missing_lease_id: Option<&'a str>,
+    recorded_pid: Option<u32>,
+    recorded_endpoint: Option<&'a str>,
+    live_lease_expectation: Option<(&'a str, u32)>,
+}
+
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
-    connect_with_orphan_adoption(runner_id, None, &[], false, None, None, None)
+    connect_with_orphan_adoption_and_live_lease(
+        runner_id,
+        RemoteDaemonConnectOptions {
+            orphan_lease_id: None,
+            confirmed_no_pid_job_ids: &[],
+            reconcile_leaseless_orphans: false,
+            missing_lease_id: None,
+            recorded_pid: None,
+            recorded_endpoint: None,
+            live_lease_expectation: None,
+        },
+    )
 }
 
 /// Start and validate a second daemon without touching the recorded admission
@@ -109,8 +130,7 @@ pub(crate) fn rotate_daemon_generation(
     let state_dir =
         format!("$HOME/.config/homeboy/daemon-generations/{runner_segment}/{generation}");
     let command = format!(
-        "HOMEBOY_DAEMON_STATE_DIR={} {} daemon ensure-running --addr 127.0.0.1:0",
-        format!("\"{state_dir}\""),
+        "HOMEBOY_DAEMON_STATE_DIR=\"{state_dir}\" {} daemon ensure-running --addr 127.0.0.1:0",
         shell::quote_arg(candidate_homeboy),
     );
     let output = client.execute_with_timeout(&command, REMOTE_RUNNER_CONNECT_TIMEOUT);
@@ -158,40 +178,42 @@ pub(crate) fn rotate_daemon_generation(
         inspected_freshness: None,
     };
     let session_path = session_path(runner_id)?;
-    let (local_port, tunnel_pid, local_url, daemon) = match connect_remote_daemon(
-        &server,
-        &client,
-        candidate_homeboy,
-        daemon.clone(),
-        "",
-        candidate_identity,
-        runner_id,
-        &session_path,
-    ) {
-        Ok(connection) => connection,
-        Err((report, _)) => {
-            // Startup may have created the candidate lease even though tunnel
-            // or identity validation failed. Stop that exact lease and erase a
-            // pre-existing candidate ledger entry before returning to A.
-            if let Some(lease_id) = daemon.lease_id.as_deref() {
-                let command = format!(
-                    "{} daemon stop --force --lease-id {}",
-                    shell::quote_arg(candidate_homeboy),
-                    shell::quote_arg(lease_id),
-                );
-                let _ = client.execute(&command);
+    let (local_port, tunnel_pid, local_url, daemon) =
+        match connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
+            server: &server,
+            homeboy: candidate_homeboy,
+            daemon: daemon.clone(),
+            expected_version: "",
+            expected_identity: candidate_identity,
+            runner_id,
+            session_path: &session_path,
+        }) {
+            Ok(connection) => connection,
+            Err(report) => {
+                let (report, _) = *report;
+                // Startup may have created the candidate lease even though tunnel
+                // or identity validation failed. Stop that exact lease and erase a
+                // pre-existing candidate ledger entry before returning to A.
+                if let Some(lease_id) = daemon.lease_id.as_deref() {
+                    let command = format!(
+                        "{} daemon stop --force --lease-id {}",
+                        shell::quote_arg(candidate_homeboy),
+                        shell::quote_arg(lease_id),
+                    );
+                    let _ = client.execute(&command);
+                }
+                let _ =
+                    super::generation_store::rollback_candidate(runner_id, &current, &generation);
+                return Err(Error::validation_invalid_argument(
+                    "reconnect",
+                    report
+                        .failure_message
+                        .unwrap_or_else(|| "candidate daemon tunnel validation failed".to_string()),
+                    Some(runner_id.to_string()),
+                    None,
+                ));
             }
-            let _ = super::generation_store::rollback_candidate(runner_id, &current, &generation);
-            return Err(Error::validation_invalid_argument(
-                "reconnect",
-                report
-                    .failure_message
-                    .unwrap_or_else(|| "candidate daemon tunnel validation failed".to_string()),
-                Some(runner_id.to_string()),
-                None,
-            ));
-        }
-    };
+        };
     let candidate = RunnerSession {
         runner_id: runner_id.to_string(),
         mode: RunnerTunnelMode::DirectSsh,
@@ -306,13 +328,15 @@ pub fn connect_with_orphan_adoption(
 ) -> Result<(RunnerConnectReport, i32)> {
     connect_with_orphan_adoption_and_live_lease(
         runner_id,
-        orphan_lease_id,
-        confirmed_no_pid_job_ids,
-        reconcile_leaseless_orphans,
-        missing_lease_id,
-        recorded_pid,
-        recorded_endpoint,
-        None,
+        RemoteDaemonConnectOptions {
+            orphan_lease_id,
+            confirmed_no_pid_job_ids,
+            reconcile_leaseless_orphans,
+            missing_lease_id,
+            recorded_pid,
+            recorded_endpoint,
+            live_lease_expectation: None,
+        },
     )
 }
 
@@ -326,26 +350,31 @@ pub fn connect_with_live_lease_adoption(
 ) -> Result<(RunnerConnectReport, i32)> {
     connect_with_orphan_adoption_and_live_lease(
         runner_id,
-        None,
-        &[],
-        false,
-        None,
-        None,
-        None,
-        Some((lease_id, pid)),
+        RemoteDaemonConnectOptions {
+            orphan_lease_id: None,
+            confirmed_no_pid_job_ids: &[],
+            reconcile_leaseless_orphans: false,
+            missing_lease_id: None,
+            recorded_pid: None,
+            recorded_endpoint: None,
+            live_lease_expectation: Some((lease_id, pid)),
+        },
     )
 }
 
 fn connect_with_orphan_adoption_and_live_lease(
     runner_id: &str,
-    orphan_lease_id: Option<&str>,
-    confirmed_no_pid_job_ids: &[uuid::Uuid],
-    reconcile_leaseless_orphans: bool,
-    missing_lease_id: Option<&str>,
-    recorded_pid: Option<u32>,
-    recorded_endpoint: Option<&str>,
-    live_lease_expectation: Option<(&str, u32)>,
+    options: RemoteDaemonConnectOptions<'_>,
 ) -> Result<(RunnerConnectReport, i32)> {
+    let RemoteDaemonConnectOptions {
+        orphan_lease_id,
+        confirmed_no_pid_job_ids,
+        reconcile_leaseless_orphans,
+        missing_lease_id,
+        recorded_pid,
+        recorded_endpoint,
+        live_lease_expectation,
+    } = options;
     // Reconnect replaces daemon runtime state. It shares the promotion lease
     // with binary selection so a second session cannot reconnect against a
     // different configured executable halfway through the transaction.
@@ -778,19 +807,19 @@ fn connect_with_orphan_adoption_and_live_lease(
             previous_session.as_ref(),
             "ensure_remote_daemon",
             |admission_fence| {
-                ensure_remote_daemon(
-                    &client,
+                ensure_remote_daemon(remote_daemon::RemoteDaemonEnsureRequest {
+                    client: &client,
                     homeboy,
                     runner_id,
-                    previous_session.as_ref(),
-                    &configured_build_identity,
+                    previous_session: previous_session.as_ref(),
+                    configured_identity: &configured_build_identity,
                     orphan_lease_id,
                     confirmed_no_pid_job_ids,
                     live_lease_expectation,
-                    Some(&replacement_operation_id),
+                    replacement_operation_id: Some(&replacement_operation_id),
                     admission_fence,
-                    false,
-                )
+                    registry_lock_held: false,
+                })
                 .map_err(Error::internal_unexpected)
             },
         )
@@ -834,19 +863,19 @@ fn connect_with_orphan_adoption_and_live_lease(
         .build_identity
         .clone()
         .unwrap_or(configured_build_identity.clone());
-    let connection = connect_remote_daemon(
-        &server,
-        &client,
+    let connection = connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
+        server: &server,
         homeboy,
         daemon,
-        &expected_version,
-        &expected_identity,
+        expected_version: &expected_version,
+        expected_identity: &expected_identity,
         runner_id,
-        &session_path,
-    );
+        session_path: &session_path,
+    });
     let (local_port, tunnel_pid, local_url, daemon) = match connection {
         Ok(connection) => connection,
-        Err((mut report, exit_code)) => {
+        Err(report) => {
+            let (mut report, exit_code) = *report;
             attach_state_loss_recovery(&mut report, state_loss_recovery);
             attach_leaseless_recovery(&mut report, leaseless_recovery, recovery_evidence);
             return Ok((report, exit_code));
@@ -1717,7 +1746,7 @@ fn reconnect_job_owner(runner_id: &str, job_id: &str) -> Result<RunnerSession> {
             None,
         ));
     }
-    let Some((_server_id, server, client)) = resolve_ssh_runner(&runner)? else {
+    let Some((_server_id, server, _client)) = resolve_ssh_runner(&runner)? else {
         return Err(Error::validation_invalid_argument(
             "runner",
             "job log recovery requires an SSH-backed runner",
@@ -1736,26 +1765,27 @@ fn reconnect_job_owner(runner_id: &str, job_id: &str) -> Result<RunnerSession> {
         inspected_freshness: None,
     };
     let session_path = session_path(runner_id)?;
-    let (local_port, tunnel_pid, local_url, daemon) = connect_remote_daemon(
-        &server,
-        &client,
-        "",
-        daemon,
-        &owner.homeboy_version,
-        owner.homeboy_build_identity.as_deref().unwrap_or(""),
-        runner_id,
-        &session_path,
-    )
-    .map_err(|(report, _)| {
-        Error::validation_invalid_argument(
-            "runner",
-            report.failure_message.unwrap_or_else(|| {
-                "unable to reattach the job-owning daemon generation".to_string()
-            }),
-            Some(runner_id.to_string()),
-            None,
-        )
-    })?;
+    let (local_port, tunnel_pid, local_url, daemon) =
+        connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
+            server: &server,
+            homeboy: "",
+            daemon,
+            expected_version: &owner.homeboy_version,
+            expected_identity: owner.homeboy_build_identity.as_deref().unwrap_or(""),
+            runner_id,
+            session_path: &session_path,
+        })
+        .map_err(|report| {
+            let (report, _) = *report;
+            Error::validation_invalid_argument(
+                "runner",
+                report.failure_message.unwrap_or_else(|| {
+                    "unable to reattach the job-owning daemon generation".to_string()
+                }),
+                Some(runner_id.to_string()),
+                None,
+            )
+        })?;
     let tunnel_process_start_identity = match capture_tunnel_process_start_identity(tunnel_pid) {
         Ok(identity) => identity,
         Err(error) => {
@@ -2271,7 +2301,7 @@ fn runner_jobs(
             } else {
                 crate::readonly_probe::REASON_PROBE_UNAVAILABLE
             },
-            timeout_seconds: timed_out.then_some(timeout.as_secs()).unwrap_or(0),
+            timeout_seconds: if timed_out { timeout.as_secs() } else { 0 },
             detail: format!(
                 "read-only typed-job probe for runner `{runner_id}` did not complete; active-job state is partial: {}",
                 error.message

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -210,9 +210,11 @@ pub(super) fn compare_identities(left: Option<&str>, right: Option<&str>) -> Ide
         (Some(left), Some(right))
             if immutable_build_identity(left) && immutable_build_identity(right) =>
         {
-            (left.trim() == right.trim())
-                .then_some(IdentityComparison::Match)
-                .unwrap_or(IdentityComparison::Mismatch)
+            if left.trim() == right.trim() {
+                IdentityComparison::Match
+            } else {
+                IdentityComparison::Mismatch
+            }
         }
         _ => IdentityComparison::Unverifiable,
     }
@@ -602,19 +604,36 @@ pub(super) enum RemoteDaemonConnectAction {
     ReplaceUnhealthyExactOwner,
 }
 
+pub(super) struct RemoteDaemonEnsureRequest<'a> {
+    pub(super) client: &'a SshClient,
+    pub(super) homeboy: &'a str,
+    pub(super) runner_id: &'a str,
+    pub(super) previous_session: Option<&'a RunnerSession>,
+    pub(super) configured_identity: &'a str,
+    pub(super) orphan_lease_id: Option<&'a str>,
+    pub(super) confirmed_no_pid_job_ids: &'a [uuid::Uuid],
+    pub(super) live_lease_expectation: Option<(&'a str, u32)>,
+    pub(super) replacement_operation_id: Option<&'a str>,
+    pub(super) admission_fence: Option<&'a crate::generation_store::AdmissionFence>,
+    pub(super) registry_lock_held: bool,
+}
+
 pub(super) fn ensure_remote_daemon(
-    client: &SshClient,
-    homeboy: &str,
-    runner_id: &str,
-    previous_session: Option<&RunnerSession>,
-    configured_identity: &str,
-    orphan_lease_id: Option<&str>,
-    confirmed_no_pid_job_ids: &[uuid::Uuid],
-    live_lease_expectation: Option<(&str, u32)>,
-    replacement_operation_id: Option<&str>,
-    admission_fence: Option<&crate::generation_store::AdmissionFence>,
-    registry_lock_held: bool,
+    request: RemoteDaemonEnsureRequest<'_>,
 ) -> std::result::Result<RemoteDaemon, String> {
+    let RemoteDaemonEnsureRequest {
+        client,
+        homeboy,
+        runner_id,
+        previous_session,
+        configured_identity,
+        orphan_lease_id,
+        confirmed_no_pid_job_ids,
+        live_lease_expectation,
+        replacement_operation_id,
+        admission_fence,
+        registry_lock_held,
+    } = request;
     let mut status = remote_daemon_status(client, homeboy)?;
     probe_remote_daemon_endpoint(client, &mut status, Some(runner_id));
     if let Some(lease_id) = orphan_lease_id {
@@ -658,7 +677,7 @@ pub(super) fn ensure_remote_daemon(
                 "remote daemon reattach selected without a daemon lease".to_string()
             })?;
             daemon.inspected_freshness = Some(inspected_freshness);
-            return Ok(daemon);
+            Ok(daemon)
         }
         RemoteDaemonConnectAction::Start => {
             negotiate_ensure_running_operation_id(client, homeboy, replacement_operation_id)?;
@@ -668,7 +687,7 @@ pub(super) fn ensure_remote_daemon(
                 replacement_operation_id,
                 registry_lock_held,
             )?;
-            return remote_daemon_ensure_running(client, homeboy, replacement_operation_id);
+            remote_daemon_ensure_running(client, homeboy, replacement_operation_id)
         }
         RemoteDaemonConnectAction::ReplaceIdleStale
         | RemoteDaemonConnectAction::ReplaceUnhealthyExactOwner => {
@@ -691,12 +710,7 @@ pub(super) fn ensure_remote_daemon(
             remote_daemon_force_stop(client, homeboy, lease_id)?;
             let replacement =
                 remote_daemon_ensure_running(client, homeboy, replacement_operation_id)?;
-            return verify_remote_daemon_replacement(
-                client,
-                homeboy,
-                &replacement,
-                configured_identity,
-            );
+            verify_remote_daemon_replacement(client, homeboy, &replacement, configured_identity)
         }
     }
 }
@@ -1069,11 +1083,13 @@ fn lease_reconciliation_failure(
 }
 
 fn active_job_recovery_guidance(active_jobs: usize) -> String {
-    (active_jobs > 0)
-        .then(|| format!(
+    if active_jobs > 0 {
+        format!(
             "; {active_jobs} active job(s) were not replaced. Inspect `homeboy daemon status` and use explicit active-job recovery guidance before retrying"
-        ))
-        .unwrap_or_default()
+        )
+    } else {
+        String::new()
+    }
 }
 
 pub(super) fn remote_daemon_status(

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::session::RunnerConnectFailureEvidence;
+use std::path::Path;
 
 pub(super) fn session_is_live(session: &RunnerSession) -> bool {
     session_is_live_with_timeout(session, Duration::from_secs(2))
@@ -191,7 +192,7 @@ pub(super) fn read_session_for_status(runner_id: &str) -> Result<Option<RunnerSe
     }
     let directory = paths::runner_sessions_dir()?.join(runner_id);
     match status_peer_session_in(&directory, &controller_id)? {
-        StatusPeerSession::One(peer) => Ok(Some(peer)),
+        StatusPeerSession::One(peer) => Ok(Some(*peer)),
         StatusPeerSession::None => Ok(session),
         StatusPeerSession::Ambiguous => {
             crate::readonly_probe::record_degradation(
@@ -212,7 +213,7 @@ pub(super) fn read_session_for_status(runner_id: &str) -> Result<Option<RunnerSe
 
 enum StatusPeerSession {
     None,
-    One(RunnerSession),
+    One(Box<RunnerSession>),
     Ambiguous,
 }
 
@@ -222,14 +223,14 @@ enum StatusPeerSession {
 const STATUS_PEER_SESSION_LIMIT: usize = 8;
 const STATUS_PEER_SESSION_TIMEOUT: Duration = Duration::from_secs(1);
 
-fn status_peer_session_in(directory: &PathBuf, controller_id: &str) -> Result<StatusPeerSession> {
+fn status_peer_session_in(directory: &Path, controller_id: &str) -> Result<StatusPeerSession> {
     status_peer_session_in_with(directory, controller_id, |session| {
         session_is_live_with_timeout(session, STATUS_PEER_SESSION_TIMEOUT)
     })
 }
 
 fn status_peer_session_in_with(
-    directory: &PathBuf,
+    directory: &Path,
     controller_id: &str,
     is_live: impl Fn(&RunnerSession) -> bool,
 ) -> Result<StatusPeerSession> {
@@ -278,7 +279,9 @@ fn status_peer_session_in_with(
         }
         peer = Some(candidate);
     }
-    Ok(peer.map_or(StatusPeerSession::None, StatusPeerSession::One))
+    Ok(peer.map_or(StatusPeerSession::None, |peer| {
+        StatusPeerSession::One(Box::new(peer))
+    }))
 }
 
 /// Keep the local tunnel observation inside the same explicit read-only budget
@@ -331,12 +334,12 @@ fn read_session_or_live_peer_for_controller(
 }
 
 fn resolve_session_or_live_peer_in(
-    directory: &PathBuf,
+    directory: &Path,
     controller_id: &str,
     session: Option<RunnerSession>,
     is_live: impl Fn(&RunnerSession) -> bool,
 ) -> Result<Option<RunnerSession>> {
-    if session.as_ref().is_some_and(|session| is_live(session)) {
+    if session.as_ref().is_some_and(&is_live) {
         return Ok(session);
     }
 
@@ -379,11 +382,11 @@ pub(super) fn read_ownership(runner_id: &str) -> Result<Option<RunnerSession>> {
     read_session_at(&ownership_path(runner_id)?)
 }
 
-fn read_session_at(path: &PathBuf) -> Result<Option<RunnerSession>> {
+fn read_session_at(path: &Path) -> Result<Option<RunnerSession>> {
     if !path.exists() {
         return Ok(None);
     }
-    let raw = std::fs::read_to_string(&path).map_err(|err| {
+    let raw = std::fs::read_to_string(path).map_err(|err| {
         Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
     })?;
     serde_json::from_str(&raw)
@@ -413,7 +416,7 @@ pub(super) fn claim_ownership_if_owner_not_live(session: &RunnerSession) -> Resu
         .is_some_and(session_is_live))
 }
 
-fn write_session_at(path: &PathBuf, session: &RunnerSession) -> Result<()> {
+fn write_session_at(path: &Path, session: &RunnerSession) -> Result<()> {
     homeboy_core::engine::local_files::write_json_file(path, session)
 }
 
@@ -506,7 +509,7 @@ fn has_live_peer_session_in(
 }
 
 fn live_peer_session_in(
-    directory: &PathBuf,
+    directory: &Path,
     controller_id: Option<&str>,
     is_live: impl Fn(&RunnerSession) -> bool,
 ) -> Result<Option<RunnerSession>> {
@@ -1145,7 +1148,7 @@ mod tests {
             status_peer_session_in_with(&root.path().to_path_buf(), "current-controller", |_| true)
                 .expect("project peer session");
 
-        assert!(matches!(projected, StatusPeerSession::One(session) if session == peer));
+        assert!(matches!(projected, StatusPeerSession::One(session) if *session == peer));
         assert!(root.path().join("peer-controller.json").exists());
         assert!(!root.path().join("current-controller.json").exists());
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -2093,19 +2093,19 @@ fn idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_ow
         "lease-new",
         "homeboy 0.289.0+configured",
         |client, homeboy, configured_identity, argv_path| {
-            let daemon = ensure_remote_daemon(
+            let daemon = ensure_remote_daemon(RemoteDaemonEnsureRequest {
                 client,
                 homeboy,
-                "homeboy-lab",
-                None,
+                runner_id: "homeboy-lab",
+                previous_session: None,
                 configured_identity,
-                None,
-                &[],
-                None,
-                None,
-                None,
-                false,
-            )
+                orphan_lease_id: None,
+                confirmed_no_pid_job_ids: &[],
+                live_lease_expectation: None,
+                replacement_operation_id: None,
+                admission_fence: None,
+                registry_lock_held: false,
+            })
             .expect("replacement succeeds");
             assert_eq!(daemon.lease_id.as_deref(), Some("lease-new"));
             assert_eq!(daemon.pid, Some(222));
@@ -2125,19 +2125,19 @@ fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
         "lease-raced",
         "homeboy 0.288.13+stale",
         |client, homeboy, configured_identity, _| {
-            let error = ensure_remote_daemon(
+            let error = ensure_remote_daemon(RemoteDaemonEnsureRequest {
                 client,
                 homeboy,
-                "homeboy-lab",
-                None,
+                runner_id: "homeboy-lab",
+                previous_session: None,
                 configured_identity,
-                None,
-                &[],
-                None,
-                None,
-                None,
-                false,
-            )
+                orphan_lease_id: None,
+                confirmed_no_pid_job_ids: &[],
+                live_lease_expectation: None,
+                replacement_operation_id: None,
+                admission_fence: None,
+                registry_lock_held: false,
+            })
             .expect_err("concurrent stale daemon is refused");
             assert!(error.contains("ownership changed"));
         },
@@ -2151,19 +2151,19 @@ fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
         "lease-new",
         "homeboy 0.288.13+stale",
         |client, homeboy, configured_identity, _| {
-            let error = ensure_remote_daemon(
+            let error = ensure_remote_daemon(RemoteDaemonEnsureRequest {
                 client,
                 homeboy,
-                "homeboy-lab",
-                None,
+                runner_id: "homeboy-lab",
+                previous_session: None,
                 configured_identity,
-                None,
-                &[],
-                None,
-                None,
-                None,
-                false,
-            )
+                orphan_lease_id: None,
+                confirmed_no_pid_job_ids: &[],
+                live_lease_expectation: None,
+                replacement_operation_id: None,
+                admission_fence: None,
+                registry_lock_held: false,
+            })
             .expect_err("stale replacement identity is refused");
             assert!(error.contains("does not match configured runner binary"));
         },

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
 use homeboy_core::engine::shell;
-use homeboy_core::server::{Server, SshClient};
+use homeboy_core::server::Server;
 
 use super::super::session::RunnerStaleRuntimePath;
 use super::{
@@ -32,16 +32,33 @@ struct DaemonHealthReport {
     pid: Option<u32>,
 }
 
+pub(super) struct RemoteDaemonConnectRequest<'a> {
+    pub(super) server: &'a Server,
+    pub(super) homeboy: &'a str,
+    pub(super) daemon: RemoteDaemon,
+    pub(super) expected_version: &'a str,
+    pub(super) expected_identity: &'a str,
+    pub(super) runner_id: &'a str,
+    pub(super) session_path: &'a Path,
+}
+
+type RemoteDaemonConnectResult =
+    std::result::Result<(u16, Option<u32>, String, RemoteDaemon), Box<(RunnerConnectReport, i32)>>;
+type TunnelOpenResult =
+    std::result::Result<(u16, Option<u32>, String), Box<(RunnerConnectReport, i32)>>;
+
 pub(super) fn connect_remote_daemon(
-    server: &Server,
-    _client: &SshClient,
-    homeboy: &str,
-    daemon: RemoteDaemon,
-    expected_version: &str,
-    expected_identity: &str,
-    runner_id: &str,
-    session_path: &Path,
-) -> std::result::Result<(u16, Option<u32>, String, RemoteDaemon), (RunnerConnectReport, i32)> {
+    request: RemoteDaemonConnectRequest<'_>,
+) -> RemoteDaemonConnectResult {
+    let RemoteDaemonConnectRequest {
+        server,
+        homeboy,
+        daemon,
+        expected_version,
+        expected_identity,
+        runner_id,
+        session_path,
+    } = request;
     let failed_after_tunnel = |tunnel_pid: Option<u32>,
                                message: String,
                                health_attempts: Vec<String>,
@@ -70,7 +87,7 @@ pub(super) fn connect_remote_daemon(
             health_attempt_count: health_attempts.len(),
             health_attempts,
         });
-        (report, exit_code)
+        Box::new((report, exit_code))
     };
     let (local_port, tunnel_pid, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
@@ -190,14 +207,14 @@ fn open_daemon_tunnel(
     daemon: &RemoteDaemon,
     runner_id: &str,
     session_path: &Path,
-) -> std::result::Result<(u16, Option<u32>, String), (RunnerConnectReport, i32)> {
+) -> TunnelOpenResult {
     let Ok(remote_addr) = parse_loopback_daemon_addr(&daemon.address) else {
-        return Err(failed_connect(
+        return Err(Box::new(failed_connect(
             runner_id,
             session_path.to_path_buf(),
             RunnerFailureKind::DaemonStartupFailure,
             "remote daemon did not report a loopback address".to_string(),
-        ));
+        )));
     };
 
     // A loopback runner already shares the controller network namespace, so
@@ -207,12 +224,12 @@ fn open_daemon_tunnel(
         remote_addr.port()
     } else {
         reserve_loopback_port().map_err(|err| {
-            failed_connect(
+            Box::new(failed_connect(
                 runner_id,
                 session_path.to_path_buf(),
                 RunnerFailureKind::TunnelFailure,
                 err.to_string(),
-            )
+            ))
         })?
     };
     let tunnel = open_loopback_tunnel(
@@ -222,19 +239,19 @@ fn open_daemon_tunnel(
         remote_addr.port(),
     );
     if !tunnel.success {
-        return Err(failed_connect(
+        return Err(Box::new(failed_connect(
             runner_id,
             session_path.to_path_buf(),
             RunnerFailureKind::TunnelFailure,
             format!("SSH tunnel setup failed: {}", tunnel.stderr.trim()),
-        ));
+        )));
     }
 
     if !wait_for_tcp(local_port, Duration::from_secs(5)) {
         if let Some(pid) = tunnel.pid {
             terminate_pid(pid);
         }
-        return Err(failed_connect(
+        return Err(Box::new(failed_connect(
             runner_id,
             session_path.to_path_buf(),
             RunnerFailureKind::TunnelFailure,
@@ -242,7 +259,7 @@ fn open_daemon_tunnel(
                 "local tunnel 127.0.0.1:{} did not become reachable",
                 local_port
             ),
-        ));
+        )));
     }
     Ok((
         local_port,

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -340,7 +340,7 @@ fn should_stop_remote_daemon(
     ownership: Option<&RunnerSession>,
     has_live_peer: bool,
 ) -> bool {
-    let owns_daemon = ownership.map_or(true, |owner| {
+    let owns_daemon = ownership.is_none_or(|owner| {
         same_remote_daemon_ownership(&session.runner_id, session, owner)
             && owner.controller_id == session.controller_id
     });
@@ -517,7 +517,7 @@ where
     Probe: FnOnce() -> std::result::Result<remote_daemon::RemoteDaemonStatus, String>,
 {
     match confirm_remote_daemon_stopped_after_transport_error(session, initial_status) {
-        Ok(()) => return Ok(()),
+        Ok(()) => Ok(()),
         Err(_initial_error) if exact_live_remote_daemon_owner(session, initial_status) => {
             let stop_error = stop().err();
             let final_status = probe().map_err(|error| {
@@ -712,7 +712,7 @@ pub(super) fn remote_lease_bound_daemon_stop_command(
     format!(
         "{} daemon stop{} --lease-id {}",
         shell::quote_arg(homeboy),
-        force.then_some(" --force").unwrap_or_default(),
+        if force { " --force" } else { "" },
         shell::quote_arg(lease_id)
     )
 }

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -171,10 +171,9 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             )
         })?;
 
-        let mut is_cancelled = is_cancelled;
         let output = execute_runner_process_until_cancelled_with_progress(
             &plan,
-            || is_cancelled(),
+            is_cancelled,
             progress_sink,
             require_child_identity_acknowledgement,
             child_started,

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -1524,15 +1524,15 @@ impl RunnerStaleDaemonWarning {
         } else {
             "daemon_configured_identity == equal"
         };
-        let recovery_actions = (!version_matches || !identity_matches)
-            .then(|| {
-                recovery_action(
-                    runner_id,
-                    current_homeboy_build_identity.as_deref(),
-                    &homeboy_product_identity::build_identity(),
-                )
-            })
-            .unwrap_or_default();
+        let recovery_actions = if !version_matches || !identity_matches {
+            recovery_action(
+                runner_id,
+                current_homeboy_build_identity.as_deref(),
+                &homeboy_product_identity::build_identity(),
+            )
+        } else {
+            Vec::new()
+        };
         let recovery_commands = rendered_commands(&recovery_actions);
         let message = if !version_matches {
             format!(


### PR DESCRIPTION
## Summary
- resolve the 26 Rust 1.95 diagnostics in the Lab runner transport/protocol surface
- use request structs for daemon connect and ensure operations while preserving identity, lease, tunnel, and recovery contracts
- retain compatibility coverage for session schema, replacement, stop recovery, and protocol timing

Refs #11580

## Verification
- 
- 
- 
running 205 tests
test connection::connection_daemon::tests::tunnel_health_rejects_pid_mismatch ... ok
test connection::session_store::tests::controller_sessions_have_distinct_paths_and_share_a_lease_record ... ok
test connection::connection_daemon::tests::tunnel_health_rejects_lease_mismatch ... ok
test connection::connection_daemon::tests::tunnel_health_accepts_legacy_response_without_pid ... ok
test connection::session_store::tests::direct_session_liveness_caps_failed_probes_at_three_attempts ... ok
test connection::session_store::tests::direct_session_liveness_retries_a_transient_probe_failure ... ok
test connection::session_store::tests::controller_scope_ignores_runtime_path_and_cwd_churn ... ok
test connection::connection_daemon::tests::health_pid_is_read_from_the_daemon_health_body ... ok
test connection::connection_daemon::tests::controller_frame_preserves_dead_lease_adoption_eligibility ... ok
test connection::session_store::tests::cook_handoff_adopts_a_live_peer_direct_ssh_session_without_claiming_it ... ok
test connection::session_store::tests::sequential_daemon_phases_keep_the_os_scoped_live_session_across_runtime_churn ... ok
test connection::session_store::tests::stale_owner_can_be_replaced_without_reusing_its_tunnel ... ok
test connection::session_store::tests::peer_scans_fail_closed_for_malformed_controller_sessions ... ok
test connection::session_store::tests::compare_and_delete_retains_a_changed_controller_session ... ok
test connection::session_store::tests::fresh_peer_session_survives_repeated_cook_preflight_and_handoff_reads ... ok
test connection::session_store::tests::concurrent_status_observers_do_not_mutate_a_borrowed_session ... ok
test connection::status_read_purity_tests::status_has_no_lifecycle_mutation_path ... ok
test connection::session_store::tests::promoted_controller_scope_resolves_status_and_cancel_to_the_same_live_session ... ok
test connection::session_store::tests::repeated_peer_handoffs_reject_ambiguous_daemon_ownership_without_mutation ... ok
test connection::session_store::tests::peer_scans_ignore_reserved_sidecars ... ok
test connection::session_store::tests::status_projects_one_live_peer_without_creating_a_local_session ... ok
test connection::stop_transport_recovery::tests::failed_stop_recovery_uses_the_final_authoritative_lease_not_the_persisted_lease ... ok
test connection::session_store::tests::stale_runtime_controller_alias_borrows_the_same_authoritative_session ... ok
test connection::session_store::tests::stale_controller_scope_resolves_the_live_peer_for_refresh_and_availability ... ok
test connection::stop_transport_recovery::tests::lease_bound_ssh_stop_uses_the_exact_stale_owner_primitive ... ok
test connection::stop_transport_recovery::tests::lease_bound_ssh_stop_rejects_timeout_and_malformed_output ... ok
test connection::session_store::tests::status_peer_projection_refuses_ambiguous_live_daemons_without_mutation ... ok
test connection::stop_transport_recovery::tests::lease_bound_ssh_stop_rejects_successful_stopped_false_response ... ok
test connection::stop_transport_recovery::tests::lease_bound_ssh_stop_accepts_proven_already_absent_response ... ok
test connection::stop_transport_recovery::tests::transport_drop_accepts_already_dead_exact_owner_without_active_jobs ... ok
test connection::stop_transport_recovery::tests::transport_drop_after_successful_stop_accepts_matching_clean_stop_evidence ... ok
test connection::stop_transport_recovery::tests::transport_drop_reconciles_missing_lease_after_idempotent_stop ... ok
test connection::stop_transport_recovery::tests::transport_drop_refuses_daemon_still_live_after_ssh_stop ... ok
test connection::stop_transport_recovery::tests::transport_drop_refuses_live_or_mismatched_daemon_evidence ... ok
test connection::stop_transport_recovery::tests::transport_drop_refuses_mismatch_or_active_jobs_without_ssh_stop ... ok
test connection::tests::artifact_content_transport_routes_reverse_sessions_to_the_broker ... ok
test connection::stop_transport_recovery::tests::transport_drop_uses_bounded_ssh_stop_for_exact_live_owner ... ok
test connection::tests::artifact_content_transport_routes_direct_sessions_to_the_daemon ... ok
test connection::tests::generation_data_root_preserves_home_scoped_config_and_auth ... ok
test connection::tests::artifact_content_transport_rejects_sessions_without_a_managed_endpoint ... ok
test connection::tests::recovery::authoritative_dead_lease_allows_stale_generation_tombstoning ... ok
test connection::session_store::tests::transient_current_probe_does_not_yield_to_same_daemon_aliases ... ok
test connection::tests::recovery::converged_idle_generations_rebind_the_normal_disconnect_owner ... ok
test connection::connection_daemon::tests::loopback_liveness_preserves_legacy_pid_only_sessions ... ok
test connection::connection_daemon::tests::loopback_liveness_requires_the_recorded_daemon_identity ... ok
test connection::tests::failed_generation_cleanup_kills_the_exact_daemon_and_tunnel ... ok
test connection::connection_daemon::tests::health_probe_does_not_retry_an_identity_mismatch ... ok
test connection::tests::recovery::dead_recorded_daemon_without_active_jobs_routes_to_idempotent_ensure_start ... ok
test connection::tests::recovery::dead_listener_with_active_jobs_or_ambiguous_coordinates_fails_closed ... ok
test connection::tests::recovery::fresh_idle_remote_daemon_is_recoverable_by_reconnect ... ok
test connection::tests::recovery::failed_connect_without_recovery_omits_recovery_evidence ... ok
test connection::tests::recovery::hanging_ssh_connect_is_classified_as_a_timeout ... ok
test connection::tests::recovery::idle_stale_replacement_fails_closed_for_active_or_inconsistent_typed_jobs ... ok
test connection::tests::recovery::ensure_or_tunnel_failure_report_retains_completed_state_loss_recovery ... ok
test connection::tests::recovery::idle_stale_replacement_refuses_unreachable_daemon_evidence ... ok
test connection::session_store::tests::session_health_rejects_a_mismatched_pid ... ok
test connection::tests::recovery::leaseless_recovery_does_not_mutate_before_successful_negotiation ... ok
test connection::tests::recovery::leaseless_recovery_evidence_records_selected_contract_and_command_identity ... ok
test connection::tests::recovery::leaseless_recovery_parses_only_exact_option_declarations ... ok
test connection::tests::recovery::leaseless_recovery_refuses_failed_or_timed_out_probe ... ok
test connection::tests::recovery::leaseless_recovery_refuses_unsupported_or_ambiguous_help ... ok
test connection::tests::recovery::leaseless_recovery_rejects_control_plane_lost_contract ... ok
test connection::tests::recovery::leaseless_recovery_rejects_legacy_two_flag_contract ... ok
test connection::tests::recovery::leaseless_recovery_uses_confirm_no_daemon_owner_contract ... ok
test connection::tests::recovery::live_exact_owner_with_dead_listener_selects_bounded_replacement ... ok
test connection::tests::recovery::lost_local_session_refuses_unreachable_daemon_with_active_jobs ... ok
test connection::tests::recovery::missing_or_uninspectable_tunnel_identity_never_signals ... ok
test connection::session_store::tests::session_health_rejects_a_closed_tunnel ... ok
test connection::tests::recovery::orphan_adoption_command_carries_exact_lease_and_dead_pid_confirmation ... ok
test connection::tests::recovery::parses_daemon_status_envelope ... ok
test connection::tests::recovery::persisted_recovery_evidence_without_result_deserializes ... ok
test connection::tests::recovery::persisted_session_without_leaseless_recovery_evidence_deserializes ... ok
test connection::tests::recovery::persisted_tunnel_identity_roundtrips_and_old_sessions_default_to_none ... ok
test connection::tests::recovery::pid_reuse_never_signals_a_temporary_tunnel ... ok
test connection::tests::recovery::reads_remote_active_job_count_from_daemon_freshness ... ok
test connection::tests::recovery::reattaches_active_daemon_without_changing_lease_or_pid ... ok
test connection::tests::recovery::reconciles_multiple_stale_generation_leases_to_one_authoritative_idle_lease ... ok
test connection::tests::recovery::reconnect_converges_to_configured_identity_and_repeated_recovery_reattaches ... ok
test connection::tests::recovery::recorded_dead_daemon_with_active_jobs_refuses_implicit_replacement ... ok
test connection::tests::recovery::recovery_reconnect_uses_the_published_replacement_generation ... ok
test connection::tests::recovery::recovery_replacement_does_not_reuse_the_interrupted_session_generation ... ok
test connection::session_store::tests::session_health_rejects_a_mismatched_lease ... ok
test connection::tests::recovery::refuses_to_replace_proven_dead_daemon_with_active_jobs_when_lease_mismatches ... ok
test connection::tests::recovery::rejects_non_loopback_remote_daemon_address ... ok
test connection::tests::recovery::remote_conflicted_dead_lease_preserves_no_adoption_command ... ok
test connection::tests::recovery::remote_daemon_status_probe_has_a_bounded_deadline ... ok
test connection::tests::recovery::remote_dead_lease_recovery_exposes_exact_adoption_command ... ok
test connection::tests::recovery::remote_leaseless_recovery_decodes_and_propagates_report ... ok
test connection::tests::recovery::remote_leaseless_recovery_timeout_is_actionable ... ok
test connection::tests::recovery::remote_missing_or_corrupt_lease_with_active_jobs_exposes_bounded_reconciliation ... ok
test connection::tests::recovery::remote_recovery_repair_plan_carries_the_lease_specific_action ... ok
test connection::tests::recovery::remote_recovery_without_evidence_emits_no_repair_plan ... ok
test connection::tests::recovery::remote_status_without_reason_is_evidence_unavailable_and_non_adoptable ... ok
test connection::tests::recovery::repeated_tunnel_flaps_continue_to_select_the_same_active_daemon ... ok
test connection::tests::recovery::replaces_idle_stale_daemon_when_typed_jobs_are_zero_without_lease_recovery_evidence ... ok
test connection::session_store::tests::session_health_accepts_a_healthy_endpoint_after_one_hundred_milliseconds ... ok
test connection::tests::recovery::stale_active_daemon_without_a_matching_session_fails_closed_without_replacing_it ... ok
test connection::tests::recovery::stale_daemon_without_a_matching_session_fails_closed_without_replacement ... ok
test connection::tests::recovery::stale_generation_reconciliation_refuses_a_lease_change_after_stop ... ok
test connection::tests::recovery::stale_generation_reconciliation_refuses_active_jobs_changed_lease_or_unproven_owner ... ok
test connection::tests::recovery::stale_generation_reconciliation_requires_every_ledger_entry_to_be_direct_and_leased ... ok
test connection::connection_daemon::tests::health_probe_retries_through_a_transient_startup_failure ... ok
test connection::tests::recovery::state_loss_recovery_delegation_decodes_and_serializes_auditable_evidence ... ok
test connection::tests::recovery::state_loss_recovery_delegation_uses_the_canonical_exact_contract ... ok
test connection::tests::recovery::tunnel_only_failure_reattaches_the_persisted_daemon ... ok
test connection::tests::recovery::unavailable_remote_recovery_is_fail_closed ... ok
test connection::tests::session::active_runner_job_source_maps_direct_and_reverse_endpoints ... ok
test connection::tests::session::admission_does_not_reconnect_a_known_reverse_session ... ok
test connection::tests::session::admission_reconnects_a_lost_tunnel_to_the_same_proven_daemon ... ok
test connection::tests::session::admission_reconnects_when_concurrent_rotation_removes_the_session ... ok
test connection::tests::session::admission_refuses_a_lease_mismatch_without_retrying_status ... ok
test connection::tests::session::aligned_runner_identity_protocol_with_shell_preamble_accepts_jobs ... ok
test connection::stop_transport_recovery::tests::endpoint_reuse_after_identity_probe_never_receives_stop ... ok
test connection::tests::session::changed_runtime_paths_reports_runner_config_changes_since_daemon_start ... ok
test connection::tests::session::child_run_matching_accepts_durable_run_id_or_command_reference ... ok
test connection::tests::session::clean_controller_still_requires_an_exact_commit_match ... ok
test connection::tests::session::compares_cli_and_daemon_version_shapes ... ok
test connection::stop_transport_recovery::tests::foreign_loopback_html_is_identity_mismatch_and_never_receives_stop ... ok
test connection::tests::session::controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions ... ok
test connection::tests::session::differing_versions_are_stale_and_name_both_versions ... ok
test connection::tests::session::direct_daemon_fresh_live_job_suppresses_false_orphan_inference ... ok
test connection::tests::session::direct_ssh_tunnel_process_isolated_from_cook_command_cleanup ... ok
test connection::tests::session::dirty_controller_does_not_mark_a_converged_runner_stale ... ok
test connection::tests::session::dirty_controller_preserves_a_runner_side_daemon_recovery ... ok
test connection::tests::session::dirty_controller_still_catches_a_version_skewed_runner ... ok
test connection::remote_daemon::tests::bounded_status_records_a_timed_out_remote_daemon_probe ... ok
test connection::tests::session::equal_version_build_identity_and_runtime_paths_are_current ... ok
test connection::tests::session::equal_versions_with_different_build_identities_are_stale_and_name_both_builds ... ok
test connection::tests::session::explicit_live_lease_adoption_accepts_an_exact_reachable_stale_daemon ... ok
test connection::tests::session::explicit_live_lease_adoption_requires_the_exact_current_lease_and_pid ... ok
test connection::tests::session::explicit_live_lease_adoption_with_endpoint_timeout_reports_the_probe_blocker ... ok
test connection::tests::session::explicit_live_lease_adoption_with_unavailable_identity_reports_the_identity_blocker ... ok
test connection::tests::session::extracts_current_daemon_version_shape ... ok
test connection::tests::session::failed_identity_probe_reports_the_error_instead_of_the_session_version ... ok
test connection::tests::session::first_connect_routes_to_idempotent_ensure_start_when_no_daemon_exists ... ok
test connection::stop_transport_recovery::tests::fixture_two_controller_session_ownership_lifecycle ... ok
test connection::tests::session::healthy_sessionless_daemon_requires_verified_runner_identity ... ok
test connection::tests::session::identical_rendered_runtime_identities_are_current_without_refresh ... ok
test connection::tests::session::identity_comparison_distinguishes_match_unverifiable_and_mismatch ... ok
test connection::tests::session::legacy_session_adopts_consistent_live_daemon_identity ... ok
test connection::tests::session::legacy_session_refuses_pid_reuse_with_different_daemon_identity ... ok
test connection::tests::session::missing_daemon_state_with_active_jobs_refuses_ensure_running ... ok
test connection::tests::session::observed_matching_daemon_identity_reconciles_stale_session_metadata ... ok
test connection::tests::session::orphaned_child_run_job_reports_stale_retryable_runner_state ... ok
test connection::tests::session::parses_daemon_envelope_after_noisy_stdout_preamble ... ok
test connection::tests::session::parses_daemon_runtime_stale_paths_from_version_body ... ok
test connection::tests::session::parses_remote_daemon_status_lease_as_single_source_of_truth ... ok
test connection::tests::session::parses_self_identity_json_envelope ... ok
test connection::tests::session::persisted_session_version_drift_rejects_admission_with_bounded_recovery ... ok
test connection::stop_transport_recovery::tests::local_recovery_removes_only_the_controller_session_without_remote_access ... ok
test connection::tests::recovery::connect_fences_two_active_jobs_before_starting_a_new_daemon_generation ... ok
test connection::tests::recovery::failed_recovery_persistence_closes_only_the_new_tunnel ... ok
test connection::tests::recovery::generation_recovery_allows_different_generations_to_progress ... ok
test connection::tests::session::release_only_self_identity_remains_unverifiable ... ok
test connection::tests::session::resolves_immutable_identity_from_commit_when_display_is_release_only ... ok
test connection::tests::session::reverse_controller_session_requires_fresh_heartbeat ... ok
test connection::tests::session::reverse_session_is_checked_and_reports_an_unverified_verdict ... ok
test connection::tests::recovery::generation_recovery_deduplicates_two_jobs_to_one_physical_tunnel ... ok
test connection::tests::session::routine_disconnect_refuses_an_unbound_session_without_executing_a_configured_binary ... ok
test connection::tests::recovery::generation_recovery_serializes_same_job_contention ... ok
test connection::tests::session::runtime_path_diagnostics_redact_sensitive_values_without_hiding_path_drift ... ok
test connection::tests::session::runtime_path_drift_is_stale_and_names_the_changed_generation ... ok
test connection::tests::session::same_version_different_controller_build_is_incompatible_and_truthful ... ok
test connection::tests::session::sessionless_active_daemon_fails_closed_when_endpoint_identity_is_ambiguous ... ok
test connection::tests::session::sessionless_active_daemon_prescribes_matching_pinned_controller_on_identity_mismatch ... ok
test connection::tests::session::sessionless_active_daemon_requires_explicit_adoption_even_with_matching_identity ... ok
test connection::tests::session::stale_active_mismatched_daemon_never_reattaches_or_adopts ... ok
test connection::tests::session::stale_daemon_warning_includes_explicit_refresh_recovery_command ... ok
test connection::tests::session::stale_persisted_lease_refuses_an_unverified_live_daemon_with_recovery_guidance ... ok
test connection::tests::session::stale_persisted_lease_requires_explicit_live_lease_adoption ... ok
test connection::tests::session::runtime_path_warning_uses_rebuild_specific_message ... ok
test connection::tests::session::routine_disconnect_probes_the_exact_live_daemon_tunnel_before_authoritative_stop ... ok
test connection::tests::session::synthetic_active_job_run_summaries_are_not_child_runs ... ok
test connection::tests::session::terminal_phantom_reconciliation_ignores_non_success_responses ... ok
test connection::tests::session::terminal_phantom_reconciliation_is_fail_soft_for_an_unreachable_stale_session ... ok
test connection::tests::session::terminal_phantom_reconciliation_refreshes_counts_and_exposes_bounded_evidence ... ok
test connection::tests::session::terminal_phantom_reconciliation_rejects_mismatched_count_and_ids ... ok
test connection::tests::session::terminal_reconciliation_routes_direct_sessions_to_the_daemon ... ok
test connection::tests::session::terminal_reconciliation_routes_reverse_sessions_to_the_broker ... ok
test connection::tests::session::test_open_loopback_tunnel_noops_for_local_runner ... ok
test connection::tests::session::unknown_controller_dirty_state_keeps_the_exact_commit_gate ... ok
test connection::tests::session::unresolved_generation_fence_allows_reattach_but_rejects_new_admission ... ok
test connection::tests::session::unverifiable_identity_warning_is_actionable_without_claiming_a_mismatch ... ok
test connection::tests::session::unverified_reports_fence_nothing_while_compared_mismatches_still_do ... ok
test lab::preparation_tests::successful_connect_session_converges_after_transient_disconnection ... ok
test runner_probe_gate::tests::a_repeated_probe_inside_the_ttl_opens_no_connection ... ok
test runner_probe_gate::tests::concurrent_callers_asking_the_same_question_open_one_connection ... ok
test workspace::tests::snapshot::snapshot_ssh_connection_exit_is_a_retryable_transport_failure ... ok
test connection::tests::recovery::idle_stale_replacement_refuses_a_post_stop_identity_change ... ok
test connection::tests::recovery::idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change ... ok
test connection::tests::recovery::idle_stale_replacement_uses_actual_endpoint_envelopes_and_reprobes_the_new_owner ... ok
test connection::tests::recovery::normal_start_response_loss_replays_b_without_creating_c ... ok
test connection::tests::recovery::recovery_retry_reattaches_journaled_b_after_two_lost_health_requests ... ok
test connection::tests::recovery::runner_connect_persists_recovery_evidence_after_daemon_failure ... ok
test connection::tests::recovery::stale_replacement_force_stop_rejects_a_success_envelope_without_stop_action ... ok
test connection::tests::session::authenticated_promotion_provenance_allows_ordinary_reconnect_after_session_drift ... ok
test connection::tests::session::connect_reports_local_runner_as_unsupported ... ok
test connection::tests::session::disconnect_removes_existing_session_file ... ok
test connection::tests::session::full_status_projection_leaves_large_legacy_shared_state_and_observation_db_unchanged ... ok
test connection::tests::session::records_reverse_runner_session_without_marking_transport_live ... ok
test connection::tests::session::refresh_disconnect_refuses_remote_address_or_pid_drift ... ok
test connection::tests::session::refresh_disconnect_refuses_remote_lease_drift_after_promotion_started ... ok
test connection::tests::session::refresh_disconnect_retains_a_rotated_tunnel_without_ssh_authority ... ok
test connection::tests::session::status_lists_reverse_session_records ... ok
test connection::tests::session::status_marks_connected_reverse_active_jobs_unavailable_without_broker_url ... ok

test result: ok. 205 passed; 0 failed; 0 ignored; 0 measured; 1467 filtered out; finished in 30.90s (205 passed)
-  (targeted transport/protocol diagnostics resolved; 83 pre-existing warnings remain in unrelated Lab runner modules)

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented the scoped Rust diagnostic remediation and ran the listed verification. Chris remains responsible for every line.