### PR TITLE
fix(lab): resolve workspace Rust 1.95 diagnostics

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
@@ -94,10 +94,8 @@ pub(super) fn collect_provider_config_candidate_paths(
     paths: &mut Vec<String>,
 ) {
     match value {
-        serde_json::Value::String(text) => {
-            if is_controller_path_like(text) {
-                paths.push(text.to_string());
-            }
+        serde_json::Value::String(text) if is_controller_path_like(text) => {
+            paths.push(text.to_string());
         }
         serde_json::Value::Array(items) => {
             for item in items {
@@ -464,7 +462,7 @@ pub(super) fn bootstrap_source_cli_dependencies(
     preflight_remote_argv_path_translation(
         "Lab source-CLI dependency bootstrap",
         runner_id,
-        &command,
+        command,
         Path::new(local_path),
         remote_path,
     )?;

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use homeboy_core::materialization_currency::{self, Currency};
 use homeboy_core::source_snapshot::SourceSnapshot;
 use homeboy_core::{Error, Result};
-use homeboy_rig;
 
 use super::{
     dependency_cache_save_request, exec, load, materialize_git_dependency,
@@ -332,11 +331,11 @@ pub(super) fn sync_lab_offload_rigs(
                         .git_branch
                         .clone()
                         .or_else(|| metadata.source_ref.clone()),
-                    source_dirty: source_snapshot
-                        .git_sha
-                        .is_some()
-                        .then_some(source_snapshot.dirty)
-                        .unwrap_or(metadata.source_dirty),
+                    source_dirty: if source_snapshot.git_sha.is_some() {
+                        source_snapshot.dirty
+                    } else {
+                        metadata.source_dirty
+                    },
                     linked: metadata.linked,
                     materialized: metadata.materialized,
                     freshness_verified: false,

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -94,24 +94,28 @@ fn ensure_clean_git_working_tree(
     Ok(())
 }
 
+pub(super) struct GitMaterializationRequest<'a> {
+    pub remote_path: &'a str,
+    pub remote_url: &'a str,
+    pub head: &'a str,
+    pub branch: Option<&'a str>,
+    pub changed_since_base: Option<&'a str>,
+    pub git_fetch_refs: &'a [String],
+    pub allow_dirty_lab_workspace: bool,
+}
+
 pub(super) fn materialize_git(
     runner: &Runner,
-    remote_path: &str,
-    remote_url: &str,
-    head: &str,
-    branch: Option<&str>,
-    changed_since_base: Option<&str>,
-    git_fetch_refs: &[String],
-    allow_dirty_lab_workspace: bool,
+    request: GitMaterializationRequest<'_>,
 ) -> Result<()> {
     let command = materialize_git_command(
-        remote_path,
-        remote_url,
-        head,
-        branch,
-        changed_since_base,
-        git_fetch_refs,
-        allow_dirty_lab_workspace,
+        request.remote_path,
+        request.remote_url,
+        request.head,
+        request.branch,
+        request.changed_since_base,
+        request.git_fetch_refs,
+        request.allow_dirty_lab_workspace,
     );
     match runner.kind {
         RunnerKind::Local => run_shell_command(&command, "materialize local git workspace"),
@@ -124,7 +128,7 @@ pub(super) fn materialize_git(
                 Err(Error::validation_invalid_argument(
                     "changed_since",
                     "runner dispatch could not make the requested --changed-since base reachable in the runner workspace before dispatch",
-                    changed_since_base.map(str::to_string),
+                    request.changed_since_base.map(str::to_string),
                     Some(vec![
                         "Verify the branch and base commit are pushed to origin.".to_string(),
                         "Run with --placement local to execute the changed-since command locally."
@@ -137,18 +141,22 @@ pub(super) fn materialize_git(
     }
 }
 
+pub(super) struct ControllerGitBundleMaterializationRequest<'a> {
+    pub local_path: &'a Path,
+    pub remote_path: &'a str,
+    pub head: &'a str,
+    pub branch: Option<&'a str>,
+    pub remote_url: &'a str,
+    pub changed_since_base: Option<&'a str>,
+    pub git_fetch_refs: &'a [String],
+    pub allow_dirty_lab_workspace: bool,
+}
+
 pub(super) fn materialize_git_from_controller_bundle(
     runner: &Runner,
-    local_path: &Path,
-    remote_path: &str,
-    head: &str,
-    branch: Option<&str>,
-    remote_url: &str,
-    changed_since_base: Option<&str>,
-    git_fetch_refs: &[String],
-    allow_dirty_lab_workspace: bool,
+    request: ControllerGitBundleMaterializationRequest<'_>,
 ) -> Result<ControllerGitBundleProvenance> {
-    validate_controller_git_bundle_source(local_path)?;
+    validate_controller_git_bundle_source(request.local_path)?;
 
     let bundle_dir = tempfile::tempdir().map_err(|err| {
         Error::internal_io(
@@ -160,15 +168,15 @@ pub(super) fn materialize_git_from_controller_bundle(
 
     // `HEAD` preserves the complete selected ancestry in a bundle. The exact
     // resolved SHA is recorded separately in provenance and verified on Lab.
-    let refs = controller_bundle_refs("HEAD", changed_since_base, git_fetch_refs);
-    hydrate_controller_bundle_objects(local_path, &refs)?;
+    let refs = controller_bundle_refs("HEAD", request.changed_since_base, request.git_fetch_refs);
+    hydrate_controller_bundle_objects(request.local_path, &refs)?;
 
     let output = Command::new("git")
         .arg("bundle")
         .arg("create")
         .arg(&bundle_path)
         .args(&refs)
-        .current_dir(local_path)
+        .current_dir(request.local_path)
         .output()
         .map_err(|err| {
             Error::internal_io(err.to_string(), Some("create git bundle".to_string()))
@@ -182,13 +190,13 @@ pub(super) fn materialize_git_from_controller_bundle(
     let sha256 = sha256_file(&bundle_path)?;
 
     let install_command = git_bundle_install_command(
-        remote_path,
-        head,
-        branch,
-        remote_url,
-        changed_since_base,
+        request.remote_path,
+        request.head,
+        request.branch,
+        request.remote_url,
+        request.changed_since_base,
         &sha256,
-        allow_dirty_lab_workspace,
+        request.allow_dirty_lab_workspace,
     );
     let result = match runner.kind {
         RunnerKind::Local => materialize_git_bundle_piped(
@@ -224,7 +232,7 @@ pub(super) fn materialize_git_from_controller_bundle(
     result?;
     Ok(ControllerGitBundleProvenance {
         provenance: "controller_git_bundle",
-        source_sha: head.to_string(),
+        source_sha: request.head.to_string(),
         source_refs: refs,
         sha256,
         cleanup_owner: "controller",
@@ -252,14 +260,16 @@ pub(super) fn materialize_git_snapshot_from_controller_bundle(
         .unwrap_or_else(|| "homeboy-controller-bundle".to_string());
     let provenance = materialize_git_from_controller_bundle(
         runner,
-        local_path,
-        remote_path,
-        &head,
-        branch.as_deref(),
-        &remote_url,
-        None,
-        &[],
-        false,
+        ControllerGitBundleMaterializationRequest {
+            local_path,
+            remote_path,
+            head: &head,
+            branch: branch.as_deref(),
+            remote_url: &remote_url,
+            changed_since_base: None,
+            git_fetch_refs: &[],
+            allow_dirty_lab_workspace: false,
+        },
     )?;
     materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
     Ok(Some(provenance))

--- a/crates/homeboy-lab-runner/src/workspace/materialized.rs
+++ b/crates/homeboy-lab-runner/src/workspace/materialized.rs
@@ -22,10 +22,11 @@ use super::sync::{reap_run_workspace, record_workspace_terminal_evidence};
 use super::types::{RunnerWorkspaceReconciliation, RunnerWorkspaceTerminalEvidence};
 
 /// Teardown policy for a run-owned materialized workspace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum WorkspaceCleanupPolicy {
     /// Reap every terminal outcome. Use this for job-private runtime state that
     /// must never survive a completed or cancelled offload.
+    #[default]
     DeleteAlways,
     /// Reap the workspace when the run succeeds; preserve it on failure so
     /// post-mortem evidence survives on the lab through its registered TTL.
@@ -63,12 +64,6 @@ impl WorkspaceTerminalOutcome {
             Self::Panic => "panic",
             Self::UncertainHandoff => "uncertain_handoff",
         }
-    }
-}
-
-impl Default for WorkspaceCleanupPolicy {
-    fn default() -> Self {
-        Self::DeleteAlways
     }
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -38,9 +38,7 @@ const RESERVED_RUNNER_WORKSPACE_PATHS: &[&str] =
 /// runner-owned materialization artifact that must never contribute to a
 /// workspace content identity.
 fn is_reserved_runner_workspace_path(relative: &str) -> bool {
-    RESERVED_RUNNER_WORKSPACE_PATHS
-        .iter()
-        .any(|reserved| relative == *reserved)
+    RESERVED_RUNNER_WORKSPACE_PATHS.contains(&relative)
 }
 
 // The workspace-content *identity spec* (permission-policy names, the default
@@ -175,16 +173,14 @@ pub(crate) fn workspace_content_hash_for_policy(
     hasher.update(algorithm.as_bytes());
     hasher.update(b"\0");
     let root = content_hash_root(path)?;
-    collect_content_hash_entries_v2(
-        &root,
-        &root,
-        Path::new(""),
+    ContentHashTraversal {
+        root: &root,
         excludes,
-        &mut vec![root.clone()],
-        &mut hasher,
+        hasher: &mut hasher,
         executable_capability,
-        None,
-    )?;
+        manifest: None,
+    }
+    .collect(&root, Path::new(""), &mut vec![root.clone()])?;
     Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
@@ -215,16 +211,14 @@ pub(crate) fn workspace_content_manifest_for_policy(
     // Use the authoritative v2 traversal so diagnostics and the content hash
     // have identical symlink, exclusion, and metadata behavior.
     let mut hasher = Sha256::new();
-    collect_content_hash_entries_v2(
-        &root,
-        &root,
-        Path::new(""),
+    ContentHashTraversal {
+        root: &root,
         excludes,
-        &mut vec![root.clone()],
-        &mut hasher,
+        hasher: &mut hasher,
         executable_capability,
-        Some(&mut manifest),
-    )?;
+        manifest: Some(&mut manifest),
+    }
+    .collect(&root, Path::new(""), &mut vec![root.clone()])?;
     Ok(manifest)
 }
 
@@ -260,143 +254,145 @@ fn content_hash_root(path: &Path) -> Result<std::path::PathBuf> {
     })
 }
 
-fn collect_content_hash_entries_v2(
-    root: &Path,
-    path: &Path,
-    logical: &Path,
-    excludes: &[String],
-    ancestors: &mut Vec<std::path::PathBuf>,
-    hasher: &mut Sha256,
+struct ContentHashTraversal<'a> {
+    root: &'a Path,
+    excludes: &'a [String],
+    hasher: &'a mut Sha256,
     executable_capability: ExecutableCapability,
-    mut manifest: Option<&mut WorkspaceContentManifest>,
-) -> Result<()> {
-    let mut children = fs::read_dir(path)
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some("read sync directory entry".to_string()),
-            )
-        })?;
-    children.sort_by_key(|entry| entry.path());
-    for entry in children {
-        let entry_path = entry.path();
-        let relative_path = logical.join(entry.file_name());
-        let relative = relative_path.to_string_lossy().replace('\\', "/");
-        let is_runner_metadata_directory = relative == ".homeboy";
-        if relative == ".git"
-            || is_excluded(root, &root.join(&relative_path), excludes, &[])
-            || is_reserved_runner_workspace_path(&relative)
-        {
-            continue;
-        }
-        let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-        })?;
-        // A symlink whose target resolves is dereferenced so its target content
-        // stays provenance-bound (target drift changes the hash). A symlink whose
-        // target is intentionally unavailable on the controller (e.g. a tracked
-        // `blogs.dir -> /nfs`) is a valid Git workspace shape: bind its target
-        // text deterministically instead of refusing the whole hash. (#8374)
-        let resolved = if link_metadata.file_type().is_symlink() {
-            match entry_path.canonicalize() {
-                Ok(resolved) => resolved,
-                Err(_) => {
-                    let target = fs::read_link(&entry_path).map_err(|err| {
-                        Error::internal_io(
-                            err.to_string(),
-                            Some("read sync symlink target".to_string()),
-                        )
-                    })?;
-                    let target = target.to_string_lossy().replace('\\', "/");
-                    hasher.update(relative.as_bytes());
-                    hasher.update(b"\0symlink\0");
-                    hasher.update((target.len() as u64).to_le_bytes());
-                    hasher.update(target.as_bytes());
+    manifest: Option<&'a mut WorkspaceContentManifest>,
+}
+
+impl ContentHashTraversal<'_> {
+    fn collect(
+        &mut self,
+        path: &Path,
+        logical: &Path,
+        ancestors: &mut Vec<std::path::PathBuf>,
+    ) -> Result<()> {
+        let mut children = fs::read_dir(path)
+            .map_err(|err| {
+                Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some("read sync directory entry".to_string()),
+                )
+            })?;
+        children.sort_by_key(|entry| entry.path());
+        for entry in children {
+            let entry_path = entry.path();
+            let relative_path = logical.join(entry.file_name());
+            let relative = relative_path.to_string_lossy().replace('\\', "/");
+            let is_runner_metadata_directory = relative == ".homeboy";
+            if relative == ".git"
+                || is_excluded(
+                    self.root,
+                    &self.root.join(&relative_path),
+                    self.excludes,
+                    &[],
+                )
+                || is_reserved_runner_workspace_path(&relative)
+            {
+                continue;
+            }
+            let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
+                Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+            })?;
+            // A symlink whose target resolves is dereferenced so its target content
+            // stays provenance-bound (target drift changes the hash). A symlink whose
+            // target is intentionally unavailable on the controller (e.g. a tracked
+            // `blogs.dir -> /nfs`) is a valid Git workspace shape: bind its target
+            // text deterministically instead of refusing the whole hash. (#8374)
+            let resolved = if link_metadata.file_type().is_symlink() {
+                match entry_path.canonicalize() {
+                    Ok(resolved) => resolved,
+                    Err(_) => {
+                        let target = fs::read_link(&entry_path).map_err(|err| {
+                            Error::internal_io(
+                                err.to_string(),
+                                Some("read sync symlink target".to_string()),
+                            )
+                        })?;
+                        let target = target.to_string_lossy().replace('\\', "/");
+                        self.hasher.update(relative.as_bytes());
+                        self.hasher.update(b"\0symlink\0");
+                        self.hasher.update((target.len() as u64).to_le_bytes());
+                        self.hasher.update(target.as_bytes());
+                        record_workspace_content_manifest_entry(
+                            &mut self.manifest,
+                            relative,
+                            "symlink",
+                            Some(format!(
+                                "sha256:{}",
+                                content_hash::sha256_hex(target.as_bytes())
+                            )),
+                            Some(target.len() as u64),
+                            None,
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                entry_path.clone()
+            };
+            let metadata = fs::metadata(&resolved).map_err(|err| {
+                Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
+            })?;
+            if metadata.is_dir() {
+                let canonical = resolved
+                    .canonicalize()
+                    .map_err(|err| Error::internal_io(err.to_string(), None))?;
+                if ancestors.contains(&canonical) {
+                    return Err(Error::validation_invalid_argument(
+                        "workspace",
+                        "workspace content hash refused a symlink cycle",
+                        Some(entry_path.display().to_string()),
+                        None,
+                    ));
+                }
+                // The runner adds `.homeboy/runner-workspace.json` after transport.
+                // Recurse through the directory so user-owned children remain bound,
+                // but omit the transport-owned container entry and record itself.
+                if !is_runner_metadata_directory {
+                    self.hasher.update(relative.as_bytes());
+                    self.hasher.update(b"\0dir\0");
                     record_workspace_content_manifest_entry(
-                        &mut manifest,
-                        relative,
-                        "symlink",
-                        Some(format!(
-                            "sha256:{}",
-                            content_hash::sha256_hex(target.as_bytes())
-                        )),
-                        Some(target.len() as u64),
+                        &mut self.manifest,
+                        relative.clone(),
+                        "directory",
+                        None,
+                        None,
                         None,
                     );
-                    continue;
                 }
-            }
-        } else {
-            entry_path.clone()
-        };
-        let metadata = fs::metadata(&resolved).map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-        })?;
-        if metadata.is_dir() {
-            let canonical = resolved
-                .canonicalize()
-                .map_err(|err| Error::internal_io(err.to_string(), None))?;
-            if ancestors.contains(&canonical) {
-                return Err(Error::validation_invalid_argument(
-                    "workspace",
-                    "workspace content hash refused a symlink cycle",
-                    Some(entry_path.display().to_string()),
-                    None,
-                ));
-            }
-            // The runner adds `.homeboy/runner-workspace.json` after transport.
-            // Recurse through the directory so user-owned children remain bound,
-            // but omit the transport-owned container entry and record itself.
-            if !is_runner_metadata_directory {
-                hasher.update(relative.as_bytes());
-                hasher.update(b"\0dir\0");
+                ancestors.push(canonical);
+                self.collect(&resolved, &relative_path, ancestors)?;
+                ancestors.pop();
+            } else if metadata.is_file() {
+                let contents = fs::read(&resolved).map_err(|err| {
+                    Error::internal_io(err.to_string(), Some("read sync file".to_string()))
+                })?;
+                self.hasher.update(relative.as_bytes());
+                self.hasher.update(b"\0file\0");
+                if let Some(executable) = self.executable_capability.value(&metadata) {
+                    self.hasher.update([executable as u8]);
+                }
+                self.hasher.update((contents.len() as u64).to_le_bytes());
+                self.hasher.update(&contents);
                 record_workspace_content_manifest_entry(
-                    &mut manifest,
-                    relative.clone(),
-                    "directory",
-                    None,
-                    None,
-                    None,
+                    &mut self.manifest,
+                    relative,
+                    "file",
+                    Some(format!("sha256:{}", content_hash::sha256_hex(&contents))),
+                    Some(contents.len() as u64),
+                    self.executable_capability.owner_value(&metadata),
                 );
             }
-            ancestors.push(canonical);
-            collect_content_hash_entries_v2(
-                root,
-                &resolved,
-                &relative_path,
-                excludes,
-                ancestors,
-                hasher,
-                executable_capability,
-                manifest.as_deref_mut(),
-            )?;
-            ancestors.pop();
-        } else if metadata.is_file() {
-            let contents = fs::read(&resolved).map_err(|err| {
-                Error::internal_io(err.to_string(), Some("read sync file".to_string()))
-            })?;
-            hasher.update(relative.as_bytes());
-            hasher.update(b"\0file\0");
-            if let Some(executable) = executable_capability.value(&metadata) {
-                hasher.update([executable as u8]);
-            }
-            hasher.update((contents.len() as u64).to_le_bytes());
-            hasher.update(&contents);
-            record_workspace_content_manifest_entry(
-                &mut manifest,
-                relative,
-                "file",
-                Some(format!("sha256:{}", content_hash::sha256_hex(&contents))),
-                Some(contents.len() as u64),
-                executable_capability.owner_value(&metadata),
-            );
         }
+        Ok(())
     }
-    Ok(())
 }
 
 fn record_workspace_content_manifest_entry(
@@ -850,7 +846,8 @@ pub(crate) fn snapshot_manifest_delta(
     let seed_entries = index(seed)?;
     let changed_paths = controller_entries
         .iter()
-        .filter_map(|(path, entry)| (seed_entries.get(path) != Some(entry)).then(|| path.clone()))
+        .filter(|(path, entry)| seed_entries.get(*path) != Some(*entry))
+        .map(|(path, _)| path.clone())
         .collect::<Vec<_>>();
     let replaced_paths = changed_paths
         .iter()
@@ -958,8 +955,8 @@ pub(crate) fn materialize_snapshot_incremental(
         materialize_snapshot(runner, local_path, remote_path, excludes)?;
         return Ok(SnapshotTransferStats {
             reused: ByteFileCounts::default(),
-            transferred: delta.transfer.final_size.clone(),
-            final_size: delta.transfer.final_size.clone(),
+            transferred: delta.transfer.final_size,
+            final_size: delta.transfer.final_size,
         });
     }
     let prepare = incremental_prepare_command(remote_path, &temporary, seed_path, delta);
@@ -967,8 +964,8 @@ pub(crate) fn materialize_snapshot_incremental(
         materialize_snapshot(runner, local_path, remote_path, excludes)?;
         return Ok(SnapshotTransferStats {
             reused: ByteFileCounts::default(),
-            transferred: delta.transfer.final_size.clone(),
-            final_size: delta.transfer.final_size.clone(),
+            transferred: delta.transfer.final_size,
+            final_size: delta.transfer.final_size,
         });
     }
     let finalize = incremental_finalize_command(remote_path, &temporary);
@@ -1374,7 +1371,7 @@ fn incremental_prepare_command(
         "{owner_capture} ; mkdir -p {parent} && rm -rf {temporary} && mkdir -p {temporary} && {seed} && {cleanup} {removals}",
         owner_capture = owner_capture_shell(&parent),
         parent = shell::quote_arg(&parent),
-        temporary = shell::quote_arg(&temporary),
+        temporary = shell::quote_arg(temporary),
         seed = seed_snapshot_command(seed_path, temporary),
         cleanup = cleanup,
         removals = if removals.is_empty() { String::new() } else { format!(" && {removals}") },

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -26,7 +26,8 @@ use super::super::{
 };
 use super::git::{
     git_snapshot, materialize_git, materialize_git_from_controller_bundle,
-    materialize_git_snapshot_from_controller_bundle,
+    materialize_git_snapshot_from_controller_bundle, ControllerGitBundleMaterializationRequest,
+    GitMaterializationRequest,
 };
 use super::snapshot::{
     effective_snapshot_excludes, ensure_no_runner_workspace_metadata_collision,
@@ -226,8 +227,8 @@ pub fn sync_workspace(
                         }
                         super::types::SnapshotTransferStats {
                             reused: ByteFileCounts::default(),
-                            transferred: stats.clone(),
-                            final_size: stats.clone(),
+                            transferred: stats,
+                            final_size: stats,
                         }
                     }
                 });
@@ -243,19 +244,21 @@ pub fn sync_workspace(
                     Some(RunnerWorkspaceSyncMode::SnapshotGit.label().to_string());
             }
             materialization_plan.fallback_reason = fallback_reason;
-            let metadata = workspace_metadata(
-                &runner.id,
-                &local_path,
-                &remote_path,
-                options.mode,
-                materialization_plan.actual_materialization_mode.as_deref(),
-                materialization_plan.fallback_reason.as_deref(),
-                &snapshot,
-                &excludes,
-                Some(content_manifest),
-                options.run_isolation_token.as_deref(),
-                ResourceCleanupPolicy::DeleteOnSuccess,
-            );
+            let metadata = workspace_metadata(WorkspaceMetadataRequest {
+                runner_id: &runner.id,
+                local_path: &local_path,
+                remote_path: &remote_path,
+                sync_mode: options.mode,
+                actual_materialization_mode: materialization_plan
+                    .actual_materialization_mode
+                    .as_deref(),
+                fallback_reason: materialization_plan.fallback_reason.as_deref(),
+                snapshot_identity: &snapshot,
+                snapshot_excludes: &excludes,
+                content_manifest: Some(content_manifest),
+                run_id: options.run_isolation_token.as_deref(),
+                cleanup_policy: ResourceCleanupPolicy::DeleteOnSuccess,
+            });
             let resource_lifecycle = metadata.resource_lifecycle.clone().unwrap_or_else(|| {
                 workspace_resource_lifecycle(
                     &runner.id,
@@ -373,14 +376,16 @@ pub fn sync_workspace(
             {
                 materialize_git_from_controller_bundle(
                     &runner,
-                    &local_path,
-                    &remote_path,
-                    &git.head,
-                    git.branch.as_deref(),
-                    &git.remote_url,
-                    git.changed_since_base.as_deref(),
-                    &git.git_fetch_refs,
-                    options.allow_dirty_lab_workspace,
+                    ControllerGitBundleMaterializationRequest {
+                        local_path: &local_path,
+                        remote_path: &remote_path,
+                        head: &git.head,
+                        branch: git.branch.as_deref(),
+                        remote_url: &git.remote_url,
+                        changed_since_base: git.changed_since_base.as_deref(),
+                        git_fetch_refs: &git.git_fetch_refs,
+                        allow_dirty_lab_workspace: options.allow_dirty_lab_workspace,
+                    },
                 )
                 .map(Some)
             } else {
@@ -392,13 +397,15 @@ pub fn sync_workspace(
                 }
                 match materialize_git(
                     &runner,
-                    &remote_path,
-                    &git.remote_url,
-                    &git.head,
-                    git.branch.as_deref(),
-                    git.changed_since_base.as_deref(),
-                    &git.git_fetch_refs,
-                    options.allow_dirty_lab_workspace,
+                    GitMaterializationRequest {
+                        remote_path: &remote_path,
+                        remote_url: &git.remote_url,
+                        head: &git.head,
+                        branch: git.branch.as_deref(),
+                        changed_since_base: git.changed_since_base.as_deref(),
+                        git_fetch_refs: &git.git_fetch_refs,
+                        allow_dirty_lab_workspace: options.allow_dirty_lab_workspace,
+                    },
                 ) {
                     Ok(()) => Ok(None),
                     Err(error) => {
@@ -407,14 +414,16 @@ pub fn sync_workspace(
                         } else {
                             materialize_git_from_controller_bundle(
                                 &runner,
-                                &local_path,
-                                &remote_path,
-                                &git.head,
-                                git.branch.as_deref(),
-                                &git.remote_url,
-                                git.changed_since_base.as_deref(),
-                                &git.git_fetch_refs,
-                                options.allow_dirty_lab_workspace,
+                                ControllerGitBundleMaterializationRequest {
+                                    local_path: &local_path,
+                                    remote_path: &remote_path,
+                                    head: &git.head,
+                                    branch: git.branch.as_deref(),
+                                    remote_url: &git.remote_url,
+                                    changed_since_base: git.changed_since_base.as_deref(),
+                                    git_fetch_refs: &git.git_fetch_refs,
+                                    allow_dirty_lab_workspace: options.allow_dirty_lab_workspace,
+                                },
                             )
                             .map(Some)
                         }
@@ -436,19 +445,21 @@ pub fn sync_workspace(
                 }
                 Err(error) => return Err(error),
             }
-            let metadata = workspace_metadata(
-                &runner.id,
-                &local_path,
-                &remote_path,
-                RunnerWorkspaceSyncMode::Git,
-                materialization_plan.actual_materialization_mode.as_deref(),
-                materialization_plan.fallback_reason.as_deref(),
-                &git.head,
-                &excludes,
-                None,
-                options.run_isolation_token.as_deref(),
-                ResourceCleanupPolicy::DeleteOnSuccess,
-            );
+            let metadata = workspace_metadata(WorkspaceMetadataRequest {
+                runner_id: &runner.id,
+                local_path: &local_path,
+                remote_path: &remote_path,
+                sync_mode: RunnerWorkspaceSyncMode::Git,
+                actual_materialization_mode: materialization_plan
+                    .actual_materialization_mode
+                    .as_deref(),
+                fallback_reason: materialization_plan.fallback_reason.as_deref(),
+                snapshot_identity: &git.head,
+                snapshot_excludes: &excludes,
+                content_manifest: None,
+                run_id: options.run_isolation_token.as_deref(),
+                cleanup_policy: ResourceCleanupPolicy::DeleteOnSuccess,
+            });
             let resource_lifecycle = metadata.resource_lifecycle.clone().unwrap_or_else(|| {
                 workspace_resource_lifecycle(
                     &runner.id,
@@ -647,22 +658,22 @@ fn materialize_git_fallback_filesystem_snapshot(
         Some("controller_git_object_closure_unavailable".to_string());
     materialization_plan.snapshot_transfer = Some(super::types::SnapshotTransferStats {
         reused: ByteFileCounts::default(),
-        transferred: stats.clone(),
-        final_size: stats.clone(),
+        transferred: stats,
+        final_size: stats,
     });
-    let metadata = workspace_metadata(
-        &runner.id,
+    let metadata = workspace_metadata(WorkspaceMetadataRequest {
+        runner_id: &runner.id,
         local_path,
-        &remote_path,
-        options.mode,
-        materialization_plan.actual_materialization_mode.as_deref(),
-        materialization_plan.fallback_reason.as_deref(),
-        &snapshot,
-        excludes,
-        Some(content_manifest),
-        options.run_isolation_token.as_deref(),
-        ResourceCleanupPolicy::DeleteOnSuccess,
-    );
+        remote_path: &remote_path,
+        sync_mode: options.mode,
+        actual_materialization_mode: materialization_plan.actual_materialization_mode.as_deref(),
+        fallback_reason: materialization_plan.fallback_reason.as_deref(),
+        snapshot_identity: &snapshot,
+        snapshot_excludes: excludes,
+        content_manifest: Some(content_manifest),
+        run_id: options.run_isolation_token.as_deref(),
+        cleanup_policy: ResourceCleanupPolicy::DeleteOnSuccess,
+    });
     let resource_lifecycle = metadata.resource_lifecycle.clone().unwrap_or_else(|| {
         workspace_resource_lifecycle(
             &runner.id,
@@ -808,19 +819,19 @@ pub fn update_workspace(
         .unwrap_or_else(|| snapshot.snapshot_identity.clone());
     let mut update_lineage = snapshot.update_lineage.clone();
     update_lineage.push(resulting_snapshot_identity.clone());
-    let metadata = workspace_metadata(
-        &runner.id,
-        &local_path,
-        &snapshot.remote_path,
-        RunnerWorkspaceSyncMode::Snapshot,
-        Some("prepared_workspace_delta"),
-        None,
-        &resulting_snapshot_identity,
-        &excludes,
-        Some(manifest),
-        snapshot.run_id.as_deref(),
-        ResourceCleanupPolicy::DeleteOnSuccess,
-    );
+    let metadata = workspace_metadata(WorkspaceMetadataRequest {
+        runner_id: &runner.id,
+        local_path: &local_path,
+        remote_path: &snapshot.remote_path,
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        actual_materialization_mode: Some("prepared_workspace_delta"),
+        fallback_reason: None,
+        snapshot_identity: &resulting_snapshot_identity,
+        snapshot_excludes: &excludes,
+        content_manifest: Some(manifest),
+        run_id: snapshot.run_id.as_deref(),
+        cleanup_policy: ResourceCleanupPolicy::DeleteOnSuccess,
+    });
     let mut metadata = metadata;
     metadata.workspace_lease = Some(new_workspace_lease());
     metadata.workspace_generation = snapshot.workspace_generation.saturating_add(1);
@@ -1195,8 +1206,8 @@ fn write_prune_convergence_receipt(
     })
 }
 
-fn record_prune_convergence_page(
-    convergence: Option<&mut RunnerWorkspacePruneConvergence>,
+struct PruneConvergencePage<'a> {
+    convergence: Option<&'a mut RunnerWorkspacePruneConvergence>,
     pass: usize,
     cursor_before: Option<String>,
     cursor_after: Option<String>,
@@ -1206,30 +1217,32 @@ fn record_prune_convergence_page(
     skipped_count: usize,
     reclaimed_bytes: u64,
     scan_complete: bool,
-) {
-    let Some(convergence) = convergence else {
+}
+
+fn record_prune_convergence_page(page: PruneConvergencePage<'_>) {
+    let Some(convergence) = page.convergence else {
         return;
     };
     convergence.pass_count += 1;
-    convergence.cursor_history.push(cursor_before.clone());
-    convergence.cursor_history.push(cursor_after.clone());
-    convergence.inspected_count += scanned_workspace_count;
-    convergence.candidate_count += candidate_count;
-    convergence.applied_count += applied_count;
-    convergence.skipped_count += skipped_count;
-    convergence.verified_reclaimed_bytes += reclaimed_bytes;
+    convergence.cursor_history.push(page.cursor_before.clone());
+    convergence.cursor_history.push(page.cursor_after.clone());
+    convergence.inspected_count += page.scanned_workspace_count;
+    convergence.candidate_count += page.candidate_count;
+    convergence.applied_count += page.applied_count;
+    convergence.skipped_count += page.skipped_count;
+    convergence.verified_reclaimed_bytes += page.reclaimed_bytes;
     convergence
         .page_receipts
         .push(RunnerWorkspacePrunePageReceipt {
-            pass,
-            cursor_before,
-            cursor_after,
-            scanned_workspace_count,
-            candidate_count,
-            applied_count,
-            skipped_count,
-            reclaimed_bytes,
-            scan_complete,
+            pass: page.pass,
+            cursor_before: page.cursor_before,
+            cursor_after: page.cursor_after,
+            scanned_workspace_count: page.scanned_workspace_count,
+            candidate_count: page.candidate_count,
+            applied_count: page.applied_count,
+            skipped_count: page.skipped_count,
+            reclaimed_bytes: page.reclaimed_bytes,
+            scan_complete: page.scan_complete,
         });
 }
 
@@ -1409,18 +1422,18 @@ pub fn prune_workspaces(
             total_candidate_bytes = candidates.iter().map(|entry| entry.bytes).sum();
         }
         if candidates.is_empty() {
-            record_prune_convergence_page(
-                convergence.as_mut(),
-                pass + 1,
+            record_prune_convergence_page(PruneConvergencePage {
+                convergence: convergence.as_mut(),
+                pass: pass + 1,
                 cursor_before,
-                continuation_cursor.clone(),
-                page_scanned,
-                0,
-                0,
-                skipped.len() - skipped_before,
-                0,
+                cursor_after: continuation_cursor.clone(),
+                scanned_workspace_count: page_scanned,
+                candidate_count: 0,
+                applied_count: 0,
+                skipped_count: skipped.len() - skipped_before,
+                reclaimed_bytes: 0,
                 scan_complete,
-            );
+            });
             if options.apply {
                 persist_prune_convergence(
                     receipt_path.as_deref(),
@@ -1505,38 +1518,38 @@ pub fn prune_workspaces(
             }
         }
         if !options.apply || scan_complete {
-            record_prune_convergence_page(
-                convergence.as_mut(),
-                pass + 1,
+            record_prune_convergence_page(PruneConvergencePage {
+                convergence: convergence.as_mut(),
+                pass: pass + 1,
                 cursor_before,
-                continuation_cursor.clone(),
-                page_scanned,
+                cursor_after: continuation_cursor.clone(),
+                scanned_workspace_count: page_scanned,
                 candidate_count,
-                removed.len() - removed_before,
-                skipped.len() - skipped_before,
-                removed[removed_before..]
+                applied_count: removed.len() - removed_before,
+                skipped_count: skipped.len() - skipped_before,
+                reclaimed_bytes: removed[removed_before..]
                     .iter()
                     .map(|entry| entry.bytes)
                     .sum(),
                 scan_complete,
-            );
+            });
             break;
         }
-        record_prune_convergence_page(
-            convergence.as_mut(),
-            pass + 1,
+        record_prune_convergence_page(PruneConvergencePage {
+            convergence: convergence.as_mut(),
+            pass: pass + 1,
             cursor_before,
-            continuation_cursor.clone(),
-            page_scanned,
+            cursor_after: continuation_cursor.clone(),
+            scanned_workspace_count: page_scanned,
             candidate_count,
-            removed.len() - removed_before,
-            skipped.len() - skipped_before,
-            removed[removed_before..]
+            applied_count: removed.len() - removed_before,
+            skipped_count: skipped.len() - skipped_before,
+            reclaimed_bytes: removed[removed_before..]
                 .iter()
                 .map(|entry| entry.bytes)
                 .sum(),
             scan_complete,
-        );
+        });
         if options.apply {
             persist_prune_convergence(
                 receipt_path.as_deref(),
@@ -1555,7 +1568,7 @@ pub fn prune_workspaces(
     let has_more = !scan_complete || remaining_candidate_count > 0 || !skipped.is_empty();
     let runner_arg = shell_arg(&runner.id);
     let cursor_arg = (!scan_complete)
-        .then(|| continuation_cursor.as_deref())
+        .then_some(continuation_cursor.as_deref())
         .flatten()
         .map(|cursor| format!(" --cursor {}", shell_arg(cursor)))
         .unwrap_or_default();
@@ -1763,11 +1776,9 @@ pub fn reap_run_workspace(
             remote_path,
         )?;
     }
-    if let Err(error) = remove_workspace(&runner, &lab_workspaces_root, remote_path) {
-        // The remote side may have completed deletion before transport failed.
-        // Retain pending authority so either outcome remains safe and resumable.
-        return Err(error);
-    }
+    // The remote side may have completed deletion before transport failed.
+    // Retain pending authority so either outcome remains safe and resumable.
+    remove_workspace(&runner, &lab_workspaces_root, remote_path)?;
     // The sibling Homeboy artifact directory (`<checkout>-homeboy-artifacts`)
     // also lives under `_lab_workspaces`, so it passes the same containment
     // guard. It only exists when the run requested `--output`, so a
@@ -1817,44 +1828,52 @@ fn workspace_metadata_run_id(
         .map(str::to_string))
 }
 
-fn workspace_metadata(
-    runner_id: &str,
-    local_path: &Path,
-    remote_path: &str,
+struct WorkspaceMetadataRequest<'a> {
+    runner_id: &'a str,
+    local_path: &'a Path,
+    remote_path: &'a str,
     sync_mode: RunnerWorkspaceSyncMode,
-    actual_materialization_mode: Option<&str>,
-    fallback_reason: Option<&str>,
-    snapshot_identity: &str,
-    snapshot_excludes: &[String],
+    actual_materialization_mode: Option<&'a str>,
+    fallback_reason: Option<&'a str>,
+    snapshot_identity: &'a str,
+    snapshot_excludes: &'a [String],
     content_manifest: Option<super::snapshot::WorkspaceContentManifest>,
-    run_id: Option<&str>,
+    run_id: Option<&'a str>,
     cleanup_policy: ResourceCleanupPolicy,
-) -> RunnerWorkspaceMetadata {
-    let git_state = local_git_state(local_path);
-    let resource_lifecycle =
-        workspace_resource_lifecycle(runner_id, remote_path, run_id, cleanup_policy);
+}
+
+fn workspace_metadata(request: WorkspaceMetadataRequest<'_>) -> RunnerWorkspaceMetadata {
+    let git_state = local_git_state(request.local_path);
+    let resource_lifecycle = workspace_resource_lifecycle(
+        request.runner_id,
+        request.remote_path,
+        request.run_id,
+        request.cleanup_policy,
+    );
     RunnerWorkspaceMetadata {
         schema: "homeboy/runner-workspace/v1".to_string(),
-        runner_id: runner_id.to_string(),
-        repo: Some(workspace_repo_from_path(&local_path.display().to_string())),
-        local_path: local_path.display().to_string(),
-        remote_path: remote_path.to_string(),
-        sync_mode: sync_mode.label().to_string(),
-        actual_materialization_mode: actual_materialization_mode.map(str::to_string),
-        fallback_reason: fallback_reason.map(str::to_string),
-        snapshot_identity: snapshot_identity.to_string(),
+        runner_id: request.runner_id.to_string(),
+        repo: Some(workspace_repo_from_path(
+            &request.local_path.display().to_string(),
+        )),
+        local_path: request.local_path.display().to_string(),
+        remote_path: request.remote_path.to_string(),
+        sync_mode: request.sync_mode.label().to_string(),
+        actual_materialization_mode: request.actual_materialization_mode.map(str::to_string),
+        fallback_reason: request.fallback_reason.map(str::to_string),
+        snapshot_identity: request.snapshot_identity.to_string(),
         workspace_lease: Some(new_workspace_lease()),
         workspace_generation: 0,
-        original_prepared_snapshot_identity: Some(snapshot_identity.to_string()),
+        original_prepared_snapshot_identity: Some(request.snapshot_identity.to_string()),
         update_lineage: Vec::new(),
-        snapshot_excludes: snapshot_excludes.to_vec(),
-        content_manifest,
+        snapshot_excludes: request.snapshot_excludes.to_vec(),
+        content_manifest: request.content_manifest,
         synced_at: chrono::Utc::now().to_rfc3339(),
         source_ref: git_state.ref_name,
         source_commit: git_state.commit,
         source_remote_url: git_state.remote_url,
         source_dirty: git_state.dirty,
-        run_id: run_id.map(str::to_string),
+        run_id: request.run_id.map(str::to_string),
         job_id: None,
         resource_lifecycle: Some(resource_lifecycle),
         terminal_evidence: None,
@@ -2685,6 +2704,7 @@ fn snapshot_reservation_lock(path: &Path) -> Result<std::fs::File> {
         .create(true)
         .read(true)
         .write(true)
+        .truncate(false)
         .open(lock)
         .map_err(|error| {
             Error::internal_io(
@@ -2960,7 +2980,7 @@ fn prune_candidates_local(
         }
     }
     let continuation_cursor = (!scan_complete)
-        .then(|| last_inspected.as_ref())
+        .then_some(last_inspected.as_ref())
         .flatten()
         .map(|path| encode_prune_cursor(path));
     candidates.sort_by(|a, b| {
@@ -4385,14 +4405,14 @@ mod tests {
             let filesystem = probe("tmpfs-concurrent", 150, 150);
             let first = SnapshotFilesystemAdmission::acquire(
                 tempfile::tempdir().expect("scratch").keep(),
-                &[filesystem.clone()],
+                std::slice::from_ref(&filesystem),
                 requirement,
                 &runner,
             )
             .expect("first reservation");
             let error = SnapshotFilesystemAdmission::acquire(
                 tempfile::tempdir().expect("scratch").keep(),
-                &[filesystem.clone()],
+                std::slice::from_ref(&filesystem),
                 requirement,
                 &runner,
             )


### PR DESCRIPTION
## Summary
- Resolve Rust 1.95 diagnostics in Lab workspace and materialization code.
- Use transient request structs for Git materialization, workspace metadata, and prune-page recording.
- Retain the homeboy/runner-workspace/v1 schema and cleanup, receipt, containment, and hash behavior.

Refs #11580

## Verification
- cargo fmt --all
- cargo check -p homeboy-lab-runner
- cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings remains blocked by 115 diagnostics outside the six owned files; it reports no diagnostics in those files.
- cargo test -p homeboy-lab-runner workspace --lib -- --test-threads=1 ran 322 tests: 317 pass; five existing snapshot archive-command tests fail because unchanged snapshot_archive_command reads their non-existent fixture root.

## AI assistance
OpenAI openai/gpt-5.6-terra via OpenCode inspected the assigned Lab workspace modules, implemented the Rust 1.95 warning fixes, and ran the listed verification. Chris Huber retains responsibility for every line.