### PR TITLE
fix(agent-task): do not supervise a plan that declares no services

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -390,6 +390,20 @@ impl ManagedServices {
 
     #[cfg(not(test))]
     pub(super) fn start(specs: &[AgentTaskManagedService], run_id: &str) -> Result<Self, String> {
+        // A plan that declares no services has nothing to supervise. Spawning a
+        // durable worker anyway costs a process and then blocks the scheduler
+        // for up to six seconds waiting for a readiness state that describes an
+        // empty set -- on every run, and most runs declare no services.
+        //
+        // It also fails outright in any host whose `current_exe()` is not the
+        // Homeboy CLI. An integration test binary spawned as
+        // `self service-supervisor-worker --request <path>` reads those as
+        // libtest filters, runs no tests, exits, and never writes a state file,
+        // so the poll runs to exhaustion and the plan fails before reaching its
+        // first step.
+        if specs.is_empty() {
+            return AgentTaskServiceSupervisor::start(specs, run_id).map(Self::Local);
+        }
         let request = AgentTaskServiceWorkerRequest {
             schema: AgentTaskServiceWorkerRequest::SCHEMA.to_string(),
             operation: "start".to_string(),

--- a/tests/postprocess_worker_startup.rs
+++ b/tests/postprocess_worker_startup.rs
@@ -98,7 +98,9 @@ fn postprocess_plan() -> AgentTaskPlan {
 
 #[test]
 fn scheduler_recovers_a_worker_killed_before_claim_creation() {
-    let _lock = POSTPROCESS_TEST_LOCK.lock().expect("test lock");
+    let _lock = POSTPROCESS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("home");
     let artifact_root = home.path().join("artifacts");
     homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
@@ -179,7 +181,9 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
 
 #[test]
 fn scheduler_restart_adopts_a_live_worker_without_reinvoking_helper() {
-    let _lock = POSTPROCESS_TEST_LOCK.lock().expect("test lock");
+    let _lock = POSTPROCESS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let home = tempfile::tempdir().expect("home");
     let artifact_root = home.path().join("artifacts");
     homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));


### PR DESCRIPTION
Fresh red on `main`. Bisected to #11537 — both tests pass at `df602ba57^` and
fail at `df602ba57`.

```
tests/postprocess_worker_startup.rs
  scheduler_recovers_a_worker_killed_before_claim_creation
  scheduler_restart_adopts_a_live_worker_without_reinvoking_helper
```

## Cause

`ManagedServices::start` now spawns a durable supervisor worker and polls for
its readiness. It does that **unconditionally**, including when the plan
declares no services:

```rust
let request = AgentTaskServiceWorkerRequest { /* services: [] */ };
Command::new(worker).args(["self", "service-supervisor-worker", "--request"])…
for _ in 0..600 {
    …
    thread::sleep(Duration::from_millis(10));
}
Err("managed service worker did not become ready")
```

Two costs.

**Every service-less run pays for it.** That is most runs: a spawned process
plus up to six seconds of blocked scheduler, waiting for a readiness state that
would describe an empty set.

**The worker path is only right when the CLI is the running binary.** With
`HOMEBOY_SERVICE_SUPERVISOR_WORKER` unset it resolves through
`std::env::current_exe()`. In an integration test that is the *test binary*, so
it gets spawned as `self service-supervisor-worker --request <path>` — libtest
reads those as filters, matches no tests, exits, and never writes a state file.
The poll then runs to exhaustion.

The symptom was misleading: the plan failed before reaching its first step, so
the postprocess root was never created and the tests timed out waiting for
`worker.json`. Nothing pointed at managed services. I confirmed it by dumping
the artifact tree at failure — the `artifacts/` directory did not exist at all,
which ruled out the postprocess path entirely.

## Fix

An empty service set needs no supervisor. It now takes the same handle the
hermetic fixtures use, which owns no payload process — `records()` is empty and
`cleanup()` a no-op, exactly as it already was for a supervisor that started
nothing.

## Also: one failure was becoming two

Both tests take `POSTPROCESS_TEST_LOCK` with `.expect("test lock")`. The first
panic poisoned the mutex, so the second test died on `PoisonError` instead of
running:

```
panicked at tests/postprocess_worker_startup.rs:182:46: test lock: PoisonError { .. }
```

That hides whether the second test would have passed and points a reader at the
wrong test. They now recover the guard with
`unwrap_or_else(|poisoned| poisoned.into_inner())`, the idiom `test_support`
already uses. With it applied, the second test failed on its own assertion —
which is how I knew both were genuinely broken rather than one being collateral.

## Verification

```
tests/postprocess_worker_startup           2 failed -> 2 passed (3.54s)
homeboy-agents agent_task_scheduler        124 passed, 0 failed
cargo check --workspace --tests            clean
cargo fmt --all --check                    clean
```