### PR TITLE
feat(runner): persist sealed staging handoffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "fs4",
  "glob",
  "glob-match",
  "homeboy-agents",

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -25,6 +25,7 @@ use homeboy_upgrade::upgrade;
 
 const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
 const RUNNER_EXEC_RECOVERY_OWNER_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER";
+const CONTROLLER_FALLBACK_RECONCILIATION_ENV: &str = "HOMEBOY_CONTROLLER_FALLBACK_RECONCILIATION";
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
@@ -358,6 +359,15 @@ impl CliRuntime {
         }
 
         register_startup_providers_before_reconcile();
+        if std::env::var_os(CONTROLLER_FALLBACK_RECONCILIATION_ENV).is_some() {
+            let config = crate::core::defaults::load_config();
+            if register_startup_providers_after_reconcile(&config.agent_task).is_err() {
+                return std::process::ExitCode::from(2);
+            }
+            let _ =
+                crate::runner::controller_fallback_projection::reconcile_on_controller_startup();
+            return std::process::ExitCode::SUCCESS;
+        }
         if let Some(owner_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_OWNER_ENV) {
             let _ = crate::runner::run_scheduled_terminal_runner_exec_recovery(
                 &owner_id.to_string_lossy(),
@@ -369,14 +379,9 @@ impl CliRuntime {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
-        // Runner-owned fallback staging may outlive the controller process. Its
-        // receipt ledger is replay-safe and finalizes staging exactly once.
-        if let Err(error) =
-            crate::runner::controller_fallback_projection::reconcile_on_controller_startup()
-        {
-            eprintln!("error: {error}");
-            return std::process::ExitCode::from(2);
-        }
+        // Runner-owned fallback staging may outlive the controller process. A
+        // detached bounded pass keeps command startup independent of remote I/O.
+        schedule_controller_fallback_reconciliation();
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
         if command_capability == CommandCapability::Mutation
@@ -720,6 +725,20 @@ fn schedule_runner_exec_recovery() {
             &error,
         );
     }
+}
+
+fn schedule_controller_fallback_reconciliation() {
+    let Ok(executable) = std::env::current_exe() else {
+        return;
+    };
+    let mut command = ProcessCommand::new(executable);
+    command
+        .env(CONTROLLER_FALLBACK_RECONCILIATION_ENV, "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    crate::core::process::detach_from_caller_session(&mut command);
+    let _ = command.spawn();
 }
 
 /// A cook has no durable run record until controller admission. Re-exec before

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -196,6 +196,7 @@ pub fn register_startup_providers_before_reconcile() {
     // the secret-env plan and validate workload dispatch for remote-runner
     // jobs without core depending on runner behavior.
     crate::runner::register_runner_job_preparation_provider();
+    crate::runner::register_runner_staging_provider();
     // Register the lab-workspace provenance provider so the agent-task
     // scheduler can verify lab-materialized workspaces without core depending
     // on runner behavior.

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -369,6 +369,14 @@ impl CliRuntime {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
+        // Runner-owned fallback staging may outlive the controller process. Its
+        // receipt ledger is replay-safe and finalizes staging exactly once.
+        if let Err(error) =
+            crate::runner::controller_fallback_projection::reconcile_on_controller_startup()
+        {
+            eprintln!("error: {error}");
+            return std::process::ExitCode::from(2);
+        }
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
         if command_capability == CommandCapability::Mutation

--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -985,6 +985,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deferred_staging_follow_up_commands_are_registered_cli_commands() {
+        for args in [
+            ["homeboy", "agent-task", "status", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "logs", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "cancel", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "evidence", "run-1", "--full"].as_slice(),
+        ] {
+            assert!(
+                Cli::try_parse_from(args).is_ok(),
+                "deferred staging emitted an invalid command: {args:?}"
+            );
+        }
+    }
+
     /// Dry run is the default. Recovery mutates the daemon that owns the
     /// caller's durable jobs, so it may not happen because someone ran the
     /// obvious command to find out what it would do.

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -37,6 +37,7 @@ pub mod recovery_actions;
 mod remote_runner;
 pub mod runner_exec_driver;
 mod runner_files;
+pub mod runner_staging;
 mod stop;
 pub(crate) use stop::stop_unlocked;
 use stop::{active_daemon_job_ids, active_jobs_block_daemon_stop_error, stop_with_force_for_lease};
@@ -1652,6 +1653,9 @@ where
         | ("POST", "/runner/workspace-owners/validate")
         | ("POST", "/runner/workspace-owners/renew")
         | ("POST", "/runner/workspace-owners/release") => {
+            remote_runner::route(method, path, body, job_store, &broker_auth)
+        }
+        ("POST", "/runner/staging") | ("POST", "/runner/staging/capabilities") => {
             remote_runner::route(method, path, body, job_store, &broker_auth)
         }
         ("GET", "/runner/sessions")

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -5616,6 +5616,16 @@ where
     Ok(())
 }
 
+/// Test-support network entry point for the production reverse-broker routes.
+/// Authentication and route handling remain identical to a daemon connection.
+#[cfg(any(test, feature = "test-support"))]
+pub fn handle_reverse_broker_test_connection(
+    stream: TcpStream,
+    job_store: &JobStore,
+) -> std::io::Result<()> {
+    handle_connection(stream, job_store, UnsupportedAnalysisJobRunner, false)
+}
+
 fn read_http_request(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
     let mut request = Vec::new();
     let mut buffer = [0; 8 * 1024];

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -157,7 +157,7 @@ pub(in crate::daemon) fn route(
             Ok(body) => daemon_endpoint_response("runner.staging.capabilities", body),
             Err(err) => auth_or_bad_request(err),
         },
-        ("POST", "/runner/staging") => match stage(body, auth) {
+        ("POST", "/runner/staging") => match stage(body, job_store, auth) {
             Ok(body) => daemon_endpoint_response("runner.staging.submit", body),
             Err(err) => auth_or_bad_request(err),
         },
@@ -276,11 +276,11 @@ fn staging_capabilities(body: Option<Value>, auth: &BrokerAuthContext) -> Result
     }))
 }
 
-fn stage(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+fn stage(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
     let runner_id = staging_runner_id(&body)?;
     auth.authorize(BrokerScope::Submit, Some(&runner_id))?;
     crate::daemon::runner_staging::with_provider(|provider| {
-        provider.stage(body.unwrap_or(Value::Null))
+        provider.stage(body.unwrap_or(Value::Null), job_store)
     })
 }
 

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -153,6 +153,14 @@ pub(in crate::daemon) fn route(
     auth: &BrokerAuthContext,
 ) -> HttpResponse {
     match (method, path) {
+        ("POST", "/runner/staging/capabilities") => match staging_capabilities(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.staging.capabilities", body),
+            Err(err) => auth_or_bad_request(err),
+        },
+        ("POST", "/runner/staging") => match stage(body, auth) {
+            Ok(body) => daemon_endpoint_response("runner.staging.submit", body),
+            Err(err) => auth_or_bad_request(err),
+        },
         ("GET", "/runner/workspace-claims/capabilities") => {
             match workspace_claim_capabilities(auth) {
                 Ok(body) => daemon_endpoint_response("runner.workspace_claims.capabilities", body),
@@ -229,6 +237,51 @@ pub(in crate::daemon) fn route(
             ),
         ),
     }
+}
+
+fn staging_runner_id(body: &Option<Value>) -> Result<String> {
+    body.as_ref()
+        .and_then(|body| body.pointer("/envelope/handoff/runner_id"))
+        .and_then(Value::as_str)
+        .filter(|runner_id| !runner_id.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_id",
+                "sealed staging request requires envelope.handoff.runner_id",
+                None,
+                None,
+            )
+        })
+}
+
+fn staging_capabilities(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    let runner_id = body
+        .as_ref()
+        .and_then(|body| body.get("runner_id"))
+        .and_then(Value::as_str)
+        .filter(|runner_id| !runner_id.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_id",
+                "sealed staging capability lookup requires runner_id",
+                None,
+                None,
+            )
+        })?;
+    auth.authorize(BrokerScope::Submit, Some(runner_id))?;
+    Ok(json!({
+        "runner_id": runner_id,
+        "capabilities": crate::daemon::runner_staging::with_provider(|provider| provider.capabilities(runner_id))?,
+    }))
+}
+
+fn stage(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Value> {
+    let runner_id = staging_runner_id(&body)?;
+    auth.authorize(BrokerScope::Submit, Some(&runner_id))?;
+    crate::daemon::runner_staging::with_provider(|provider| {
+        provider.stage(body.unwrap_or(Value::Null))
+    })
 }
 
 fn lookup(path: &str, job_store: &JobStore, auth: &BrokerAuthContext) -> HttpResponse {

--- a/crates/homeboy-core/src/daemon/runner_staging.rs
+++ b/crates/homeboy-core/src/daemon/runner_staging.rs
@@ -2,11 +2,14 @@
 
 use serde_json::Value;
 
+use crate::api_jobs::JobStore;
 use crate::error::Result;
 
 pub trait RunnerStagingProvider: Send + Sync {
     fn capabilities(&self, runner_id: &str) -> Result<Vec<String>>;
-    fn stage(&self, request: Value) -> Result<Value>;
+    /// The daemon-owned queue is passed through this narrow boundary so staging
+    /// admits the real execution job instead of inventing a second executor.
+    fn stage(&self, request: Value, jobs: &JobStore) -> Result<Value>;
 }
 
 struct NoopProvider;
@@ -16,7 +19,7 @@ impl RunnerStagingProvider for NoopProvider {
         Ok(Vec::new())
     }
 
-    fn stage(&self, _request: Value) -> Result<Value> {
+    fn stage(&self, _request: Value, _jobs: &JobStore) -> Result<Value> {
         Err(crate::Error::validation_invalid_argument(
             "runner_capabilities",
             "runner does not support sealed staging",

--- a/crates/homeboy-core/src/daemon/runner_staging.rs
+++ b/crates/homeboy-core/src/daemon/runner_staging.rs
@@ -1,0 +1,34 @@
+//! Runner-owned sealed staging hook for authenticated daemon/broker routes.
+
+use serde_json::Value;
+
+use crate::error::Result;
+
+pub trait RunnerStagingProvider: Send + Sync {
+    fn capabilities(&self, runner_id: &str) -> Result<Vec<String>>;
+    fn stage(&self, request: Value) -> Result<Value>;
+}
+
+struct NoopProvider;
+
+impl RunnerStagingProvider for NoopProvider {
+    fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
+    fn stage(&self, _request: Value) -> Result<Value> {
+        Err(crate::Error::validation_invalid_argument(
+            "runner_capabilities",
+            "runner does not support sealed staging",
+            None,
+            None,
+        ))
+    }
+}
+
+homeboy_engine_primitives::provider_registry! {
+    provider: dyn RunnerStagingProvider,
+    noop: NoopProvider,
+    register: pub fn register_runner_staging_provider,
+    with: pub(crate) fn with_provider,
+}

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -753,6 +753,7 @@ fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
         auth: Some(ManagedSshSession {
             control_path: "/tmp/homeboy-%h-%p-%r".to_string(),
             persist: "4h".to_string(),
+            persist_source: super::super::ManagedSshSessionPersistSource::Configured,
         }),
         is_local: false,
         env: HashMap::new(),

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -208,6 +208,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: control_path.to_string_lossy().to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -568,6 +568,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: "/tmp/homeboy-control".to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeSet,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use tempfile::TempDir;
 
@@ -1287,6 +1291,105 @@ pub struct ReverseBrokerFixture {
     broker_url: String,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
+}
+
+/// An authenticated reverse broker backed by the daemon's production HTTP
+/// routes and durable job store. The Lab runner registers its staging provider
+/// before using this fixture.
+pub struct AuthenticatedReverseBrokerFixture {
+    pub store: JobStore,
+    runner_id: String,
+    broker_url: String,
+    token: String,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AuthenticatedReverseBrokerFixture {
+    pub fn start(runner_id: impl Into<String>) -> Self {
+        let runner_id = runner_id.into();
+        let mut auth = crate::broker_auth::BrokerAuthStore::default();
+        let credential = auth
+            .pair(
+                format!("test-{runner_id}"),
+                &runner_id,
+                [
+                    crate::broker_auth::BrokerScope::Submit,
+                    crate::broker_auth::BrokerScope::Work,
+                ]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            )
+            .expect("pair authenticated reverse broker fixture");
+        auth.save()
+            .expect("persist authenticated reverse broker fixture auth");
+        let token = credential.token;
+        let store = JobStore::default();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind authenticated reverse broker fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("make authenticated reverse broker fixture nonblocking");
+        let broker_url = format!("http://{}", listener.local_addr().expect("broker address"));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_store = store.clone();
+        let handle = std::thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make authenticated reverse broker fixture stream blocking");
+                        crate::daemon::handle_reverse_broker_test_connection(stream, &thread_store)
+                            .expect("serve authenticated reverse broker fixture request");
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => {
+                        panic!("accept authenticated reverse broker fixture request: {error}")
+                    }
+                }
+            }
+        });
+        Self {
+            store,
+            runner_id,
+            broker_url,
+            token,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.broker_url
+    }
+
+    pub fn runner_id(&self) -> &str {
+        &self.runner_id
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn jobs(&self) -> Vec<Job> {
+        self.store.list()
+    }
+}
+
+impl Drop for AuthenticatedReverseBrokerFixture {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.broker_url.trim_start_matches("http://"));
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .expect("authenticated reverse broker fixture joins");
+        }
+    }
 }
 
 impl ReverseBrokerFixture {

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -26,6 +26,7 @@ homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "string"] }
+fs4 = "0.13"
 glob = "0.3"
 glob-match = "0.2"
 libc = "0.2"

--- a/crates/homeboy-lab-runner/src/broker_http.rs
+++ b/crates/homeboy-lab-runner/src/broker_http.rs
@@ -1,6 +1,6 @@
 use reqwest::blocking::{Client, RequestBuilder};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use homeboy_core::broker_auth::BROKER_TOKEN_HEADER;
 use homeboy_core::error::{Error, Result};
@@ -45,10 +45,14 @@ pub(crate) fn post_json(
         Error::internal_json(err.to_string(), Some("parse broker response".to_string()))
     })?;
     if status_code >= 400 || !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "broker request failed: {}",
-            envelope.error.unwrap_or(Value::Null)
-        )));
+        return Err(Error::new(
+            homeboy_core::ErrorCode::InternalUnexpected,
+            format!(
+                "broker request failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            json!({ "http_status": status_code, "path": path }),
+        ));
     }
     let data = envelope
         .data

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1425,7 +1425,9 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
-    let response = client
+    let broker_token =
+        homeboy_core::broker_auth::broker_submit_token_for_runner(&session.runner_id)?;
+    let request = client
         .post(format!(
             "{}/runner/sessions",
             broker_url.trim_end_matches('/')
@@ -1439,11 +1441,15 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
             "worker_identity": session.worker_identity,
             "worker_pid": session.worker_pid,
             "last_seen_at": session.last_seen_at,
-        }))
-        .send()
-        .map_err(|err| {
-            Error::internal_unexpected(format!("register reverse runner session: {err}"))
-        })?;
+        }));
+    let request = if let Some(token) = broker_token.as_deref() {
+        request.header(homeboy_core::broker_auth::BROKER_TOKEN_HEADER, token)
+    } else {
+        request
+    };
+    let response = request.send().map_err(|err| {
+        Error::internal_unexpected(format!("register reverse runner session: {err}"))
+    })?;
     let status_code = response.status().as_u16();
     let envelope: CliEnvelope = response.json().map_err(|err| {
         Error::internal_json(

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -66,7 +66,7 @@ pub struct RunnerTerminalEvidence {
 pub struct ControllerMissionProjection {
     pub mission_id: String,
     pub runner_id: String,
-    pub runner_job_id: String,
+    pub runner_staging_id: String,
     pub terminal_outcome: String,
     pub artifacts: RunnerStagingArtifacts,
     pub finalization_owner: String,
@@ -147,9 +147,30 @@ impl ControllerFallbackProjectionStore {
         Ok(receipt)
     }
 
-    /// Repeated controller startup projects exactly one mission and fails closed
-    /// if later runner evidence differs from the first terminal evidence.
-    pub fn reconcile_after_controller_restart(
+    /// Repeated controller startup projects each accepted runner staging receipt
+    /// exactly once. The receipt is terminal evidence for staging only; it does
+    /// not claim that the eventual provider workload has completed.
+    pub fn reconcile_after_controller_restart(&self) -> Result<Vec<ControllerMissionProjection>> {
+        let state = self.load()?;
+        state
+            .receipts
+            .iter()
+            .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
+            .map(|(mission_id, receipt)| {
+                self.project_terminal_evidence(
+                    mission_id,
+                    RunnerTerminalEvidence {
+                        outcome: "staged".to_string(),
+                        artifacts: receipt.runner_receipt.artifacts.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Projects explicit runner terminal evidence and fails closed if later
+    /// evidence differs from the first finalized projection.
+    pub fn project_terminal_evidence(
         &self,
         mission_id: &str,
         evidence: RunnerTerminalEvidence,
@@ -178,7 +199,7 @@ impl ControllerFallbackProjectionStore {
         let projection = ControllerMissionProjection {
             mission_id: mission_id.to_string(),
             runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
-            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            runner_staging_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
             terminal_outcome: evidence.outcome,
             artifacts: evidence.artifacts,
             finalization_owner: "controller".to_string(),
@@ -250,6 +271,14 @@ impl ControllerFallbackProjectionStore {
     }
 }
 
+/// Production startup reconciliation for deferred runner staging. An empty
+/// ledger is a no-op, preserving healthy controller startup behavior.
+pub fn reconcile_on_controller_startup() -> Result<usize> {
+    Ok(ControllerFallbackProjectionStore::open_default()?
+        .reconcile_after_controller_restart()?
+        .len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,27 +319,48 @@ mod tests {
     }
 
     #[test]
-    fn restart_projects_one_controller_mission_and_preserves_runner_artifacts() {
+    fn controller_restart_projects_each_staged_mission_once() {
         let store = store();
         let envelope = envelope();
         let mut runner = Transport::compatible();
         let receipt = store
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
-        let evidence = RunnerTerminalEvidence {
-            outcome: "succeeded".to_string(),
-            artifacts: receipt.runner_receipt.artifacts.clone(),
-        };
-        let projected = store
-            .reconcile_after_controller_restart(&receipt.mission_id, evidence.clone())
-            .expect("project");
-        assert_eq!(projected.artifacts, evidence.artifacts);
+        let projected = store.reconcile_after_controller_restart().expect("project");
+        assert_eq!(projected.len(), 1);
+        let projected = &projected[0];
+        assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
+        assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");
         assert_eq!(
             store
-                .reconcile_after_controller_restart(&receipt.mission_id, evidence)
-                .expect("idempotent projection"),
-            projected
+                .reconcile_after_controller_restart()
+                .expect("idempotent projection")
+                .len(),
+            0
         );
+    }
+
+    #[test]
+    fn explicit_terminal_evidence_cannot_replace_startup_projection() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit");
+        store
+            .reconcile_after_controller_restart()
+            .expect("startup projection");
+
+        assert!(store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts,
+                },
+            )
+            .is_err());
     }
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -97,6 +97,12 @@ pub struct ControllerFallbackProjectionStore {
 }
 
 impl ControllerFallbackProjectionStore {
+    /// Shared controller ledger survives daemon restarts independently of the
+    /// runner-owned staging store.
+    pub fn open_default() -> Result<Self> {
+        Self::open(homeboy_core::paths::homeboy_data()?.join("controller-fallback-projection.json"))
+    }
+
     pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
         let store = Self { path: path.into() };
         if store.load()?.schema != STORE_SCHEMA {

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -4,6 +4,9 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
 
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
@@ -17,6 +20,8 @@ use crate::runner_staging_operation::{
 };
 
 const STORE_SCHEMA: &str = "homeboy/controller-fallback-projection/v1";
+const STARTUP_RECONCILIATION_BATCH_SIZE: usize = 8;
+const REMOTE_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Controller-visible durable receipt for a runner-owned admission.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,6 +87,8 @@ struct State {
     schema: String,
     receipts: BTreeMap<String, DeferredControllerReceipt>,
     projections: BTreeMap<String, ControllerMissionProjection>,
+    #[serde(default)]
+    reconciliation: BTreeMap<String, ReconciliationObservation>,
 }
 
 impl Default for State {
@@ -90,8 +97,17 @@ impl Default for State {
             schema: STORE_SCHEMA.to_string(),
             receipts: BTreeMap::new(),
             projections: BTreeMap::new(),
+            reconciliation: BTreeMap::new(),
         }
     }
+}
+
+/// Durable status for work intentionally left for a later bounded pass.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReconciliationObservation {
+    pub state: String,
+    pub detail: String,
 }
 
 /// File-backed controller receipt/projection ledger. Runner admission is
@@ -158,42 +174,106 @@ impl ControllerFallbackProjectionStore {
     pub fn reconcile_after_controller_restart_with<Snapshot, Finalize>(
         &self,
         limit: usize,
-        mut snapshot: Snapshot,
-        mut finalize: Finalize,
+        snapshot: Snapshot,
+        finalize: Finalize,
     ) -> Result<Vec<ControllerMissionProjection>>
     where
-        Snapshot: FnMut(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>,
-        Finalize: FnMut(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+        Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+            + Send
+            + Sync
+            + 'static,
+        Finalize: Fn(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+    {
+        self.reconcile_after_controller_restart_with_timeout(
+            limit,
+            REMOTE_STATUS_TIMEOUT,
+            snapshot,
+            finalize,
+        )
+    }
+
+    fn reconcile_after_controller_restart_with_timeout<Snapshot, Finalize>(
+        &self,
+        limit: usize,
+        timeout: Duration,
+        snapshot: Snapshot,
+        finalize: Finalize,
+    ) -> Result<Vec<ControllerMissionProjection>>
+    where
+        Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+            + Send
+            + Sync
+            + 'static,
+        Finalize: Fn(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
     {
         let state = self.load()?;
-        state
+        let receipts = state
             .receipts
             .iter()
             .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
             .take(limit)
-            .filter_map(|(mission_id, receipt)| {
-                let snapshot = snapshot(
-                    &receipt.runner_receipt.handoff.runner_id,
-                    &receipt.runner_receipt.handoff.runner_job_id,
-                )
-                .ok()?;
-                snapshot
-                    .job
-                    .status
-                    .is_terminal()
-                    .then_some((mission_id, receipt, snapshot))
-            })
-            .map(|(mission_id, receipt, snapshot)| {
-                finalize(mission_id, &snapshot)?;
-                self.project_terminal_evidence(
-                    mission_id,
-                    RunnerTerminalEvidence {
-                        outcome: snapshot.job.status.daemon_status_label().to_string(),
-                        artifacts: receipt.runner_receipt.artifacts.clone(),
+            .map(|(mission_id, receipt)| (mission_id.clone(), receipt.clone()))
+            .collect::<Vec<_>>();
+        let snapshot = Arc::new(snapshot);
+        let mut projections = Vec::new();
+
+        for (mission_id, receipt) in receipts {
+            let result = remote_snapshot_with_timeout(
+                Arc::clone(&snapshot),
+                receipt.runner_receipt.handoff.runner_id.clone(),
+                receipt.runner_receipt.handoff.runner_job_id.clone(),
+                timeout,
+            );
+            let snapshot = match result {
+                Ok(snapshot) if snapshot.job.status.is_terminal() => snapshot,
+                Ok(snapshot) => {
+                    self.record_observation(
+                        &mission_id,
+                        "pending",
+                        format!(
+                            "runner job remains {}",
+                            snapshot.job.status.daemon_status_label()
+                        ),
+                    )?;
+                    continue;
+                }
+                Err(error) => {
+                    self.record_observation(&mission_id, "retryable", error.message)?;
+                    continue;
+                }
+            };
+
+            // The ledger lock serializes contenders before they enter lifecycle CAS.
+            // A restart or concurrent controller can then replay the same evidence safely.
+            let _lock = self.lock()?;
+            let mut state = self.load()?;
+            if state.projections.contains_key(&mission_id) {
+                continue;
+            }
+            if let Err(error) = finalize(&mission_id, &snapshot) {
+                state.reconciliation.insert(
+                    mission_id.clone(),
+                    ReconciliationObservation {
+                        state: "retryable".to_string(),
+                        detail: error.message,
                     },
-                )
-            })
-            .collect()
+                );
+                self.persist(&state)?;
+                continue;
+            }
+            let projection = self.project_terminal_evidence_in_state(
+                &mut state,
+                &mission_id,
+                RunnerTerminalEvidence {
+                    outcome: snapshot.job.status.daemon_status_label().to_string(),
+                    artifacts: receipt.runner_receipt.artifacts,
+                },
+            )?;
+            state.reconciliation.remove(&mission_id);
+            self.persist(&state)?;
+            projections.push(projection);
+        }
+        Ok(projections)
     }
 
     /// Projects explicit runner terminal evidence and fails closed if later
@@ -217,6 +297,18 @@ impl ControllerFallbackProjectionStore {
         }
         let _lock = self.lock()?;
         let mut state = self.load()?;
+        let projection =
+            self.project_terminal_evidence_in_state(&mut state, mission_id, evidence)?;
+        self.persist(&state)?;
+        Ok(projection)
+    }
+
+    fn project_terminal_evidence_in_state(
+        &self,
+        state: &mut State,
+        mission_id: &str,
+        evidence: RunnerTerminalEvidence,
+    ) -> Result<ControllerMissionProjection> {
         let receipt = state.receipts.get(mission_id).ok_or_else(|| {
             Error::validation_invalid_argument(
                 "mission_id",
@@ -247,8 +339,28 @@ impl ControllerFallbackProjectionStore {
         state
             .projections
             .insert(mission_id.to_string(), projection.clone());
-        self.persist(&state)?;
         Ok(projection)
+    }
+
+    fn record_observation(&self, mission_id: &str, state: &str, detail: String) -> Result<()> {
+        let _lock = self.lock()?;
+        let mut ledger = self.load()?;
+        if !ledger.projections.contains_key(mission_id) {
+            ledger.reconciliation.insert(
+                mission_id.to_string(),
+                ReconciliationObservation {
+                    state: state.to_string(),
+                    detail,
+                },
+            );
+            self.persist(&ledger)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn observation(&self, mission_id: &str) -> Result<Option<ReconciliationObservation>> {
+        Ok(self.load()?.reconciliation.get(mission_id).cloned())
     }
 
     fn load(&self) -> Result<State> {
@@ -353,24 +465,81 @@ impl ControllerFallbackProjectionStore {
 pub fn reconcile_on_controller_startup() -> Result<usize> {
     Ok(ControllerFallbackProjectionStore::open_default()?
         .reconcile_after_controller_restart_with(
-            8,
+            STARTUP_RECONCILIATION_BATCH_SIZE,
             crate::runner_job_log_snapshot,
             homeboy_agents::agent_task_lifecycle::project_terminal_runner_result,
         )?
         .len())
 }
 
+fn remote_snapshot_with_timeout<Snapshot>(
+    snapshot: Arc<Snapshot>,
+    runner_id: String,
+    job_id: String,
+    timeout: Duration,
+) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+where
+    Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+        + Send
+        + Sync
+        + 'static,
+{
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = sender.send(snapshot(&runner_id, &job_id));
+    });
+    receiver.recv_timeout(timeout).map_err(|error| {
+        Error::internal_unexpected(format!(
+            "runner status query timed out after {}ms: {error}",
+            timeout.as_millis()
+        ))
+    })?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::runner_staging_operation::tests_support::{envelope, Transport};
+    use homeboy_core::api_jobs::{Job, JobStatus, RunnerJobLogSnapshot};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
+    use std::time::Instant;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     fn store() -> ControllerFallbackProjectionStore {
         ControllerFallbackProjectionStore::open(
             tempdir().expect("temp").keep().join("controller.json"),
         )
         .expect("store")
+    }
+
+    fn snapshot(status: JobStatus) -> RunnerJobLogSnapshot {
+        RunnerJobLogSnapshot {
+            job: Job {
+                id: Uuid::new_v4(),
+                operation: "staged-agent-task".to_string(),
+                status,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+                started_at_ms: None,
+                finished_at_ms: None,
+                event_count: 0,
+                source_snapshot: None,
+                path_materialization_plan: None,
+                stale_reason: None,
+                daemon_lease_id: None,
+                target_runner_id: None,
+                target_project_id: None,
+                claim_id: None,
+                claimed_by_runner_id: None,
+                claimed_at_ms: None,
+                claim_expires_at_ms: None,
+                artifacts: Vec::new(),
+                runner_job_projection: None,
+            },
+            events: Vec::new(),
+        }
     }
 
     #[test]
@@ -446,5 +615,142 @@ mod tests {
                 },
             )
             .is_err());
+    }
+
+    #[test]
+    fn startup_reconciliation_returns_before_a_blocked_remote_query() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit deferred receipt");
+        let started = Instant::now();
+
+        let projected = store
+            .reconcile_after_controller_restart_with_timeout(
+                8,
+                Duration::from_millis(20),
+                |_, _| {
+                    thread::sleep(Duration::from_secs(1));
+                    Ok(snapshot(JobStatus::Succeeded))
+                },
+                |_, _| Ok(true),
+            )
+            .expect("bounded reconciliation");
+
+        assert!(started.elapsed() < Duration::from_millis(250));
+        assert!(projected.is_empty());
+        assert_eq!(
+            store.observation(&receipt.mission_id).expect("observation"),
+            Some(ReconciliationObservation {
+                state: "retryable".to_string(),
+                detail: "runner status query timed out after 20ms: timed out waiting on channel"
+                    .to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn nonterminal_runner_status_stays_pending_for_the_next_bounded_pass() {
+        let store = store();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope())
+            .expect("admit deferred receipt");
+
+        let projected = store
+            .reconcile_after_controller_restart_with(
+                8,
+                |_, _| Ok(snapshot(JobStatus::Running)),
+                |_, _| panic!("nonterminal status must not enter lifecycle finalization"),
+            )
+            .expect("nonterminal reconciliation");
+
+        assert!(projected.is_empty());
+        assert_eq!(
+            store.observation(&receipt.mission_id).expect("observation"),
+            Some(ReconciliationObservation {
+                state: "pending".to_string(),
+                detail: "runner job remains running".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn terminal_success_and_failure_project_the_staged_artifacts() {
+        for (status, outcome) in [
+            (JobStatus::Succeeded, "succeeded"),
+            (JobStatus::Failed, "failed"),
+        ] {
+            let store = store();
+            let envelope = envelope();
+            let mut runner = Transport::compatible();
+            let receipt = store
+                .submit_detached(&mut runner, &envelope)
+                .expect("admit deferred receipt");
+            let projected = store
+                .reconcile_after_controller_restart_with(
+                    8,
+                    move |_, _| Ok(snapshot(status)),
+                    |_, _| Ok(true),
+                )
+                .expect("terminal reconciliation");
+
+            assert_eq!(projected.len(), 1);
+            assert_eq!(projected[0].terminal_outcome, outcome);
+            assert_eq!(projected[0].artifacts, receipt.runner_receipt.artifacts);
+        }
+    }
+
+    #[test]
+    fn concurrent_reconcilers_enter_lifecycle_finalization_once_and_replay_after_restart() {
+        let directory = tempdir().expect("temp directory");
+        let path = directory.path().join("controller.json");
+        let store = ControllerFallbackProjectionStore::open(&path).expect("store");
+        let mut runner = Transport::compatible();
+        store
+            .submit_detached(&mut runner, &envelope())
+            .expect("admit deferred receipt");
+        let barrier = Arc::new(Barrier::new(2));
+        let finalizations = Arc::new(AtomicUsize::new(0));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            let finalizations = Arc::clone(&finalizations);
+            workers.push(thread::spawn(move || {
+                ControllerFallbackProjectionStore::open(path)
+                    .expect("concurrent store")
+                    .reconcile_after_controller_restart_with(
+                        8,
+                        move |_, _| {
+                            barrier.wait();
+                            Ok(snapshot(JobStatus::Succeeded))
+                        },
+                        move |_, _| {
+                            finalizations.fetch_add(1, Ordering::SeqCst);
+                            Ok(true)
+                        },
+                    )
+            }));
+        }
+        for worker in workers {
+            worker
+                .join()
+                .expect("worker join")
+                .expect("worker reconcile");
+        }
+        assert_eq!(finalizations.load(Ordering::SeqCst), 1);
+
+        let replay = ControllerFallbackProjectionStore::open(path)
+            .expect("restarted store")
+            .reconcile_after_controller_restart_with(
+                8,
+                |_, _| Ok(snapshot(JobStatus::Succeeded)),
+                |_, _| panic!("terminal lifecycle CAS must not be re-entered after restart"),
+            )
+            .expect("restart replay");
+        assert!(replay.is_empty());
     }
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -148,20 +148,43 @@ impl ControllerFallbackProjectionStore {
         Ok(receipt)
     }
 
-    /// Repeated controller startup projects each accepted runner staging receipt
-    /// exactly once. The receipt is terminal evidence for staging only; it does
-    /// not claim that the eventual provider workload has completed.
-    pub fn reconcile_after_controller_restart(&self) -> Result<Vec<ControllerMissionProjection>> {
+    /// Reconcile a bounded receipt batch against authoritative runner jobs.
+    /// Nonterminal jobs remain deferred; only a terminal snapshot reaches the
+    /// agent-task lifecycle finalizer and this projection ledger.
+    pub fn reconcile_after_controller_restart_with<Snapshot, Finalize>(
+        &self,
+        limit: usize,
+        mut snapshot: Snapshot,
+        mut finalize: Finalize,
+    ) -> Result<Vec<ControllerMissionProjection>>
+    where
+        Snapshot: FnMut(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>,
+        Finalize: FnMut(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+    {
         let state = self.load()?;
         state
             .receipts
             .iter()
             .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
-            .map(|(mission_id, receipt)| {
+            .take(limit)
+            .filter_map(|(mission_id, receipt)| {
+                let snapshot = snapshot(
+                    &receipt.runner_receipt.handoff.runner_id,
+                    &receipt.runner_receipt.handoff.runner_job_id,
+                )
+                .ok()?;
+                snapshot
+                    .job
+                    .status
+                    .is_terminal()
+                    .then_some((mission_id, receipt, snapshot))
+            })
+            .map(|(mission_id, receipt, snapshot)| {
+                finalize(mission_id, &snapshot)?;
                 self.project_terminal_evidence(
                     mission_id,
                     RunnerTerminalEvidence {
-                        outcome: "staged".to_string(),
+                        outcome: snapshot.job.status.daemon_status_label().to_string(),
                         artifacts: receipt.runner_receipt.artifacts.clone(),
                     },
                 )
@@ -272,11 +295,15 @@ impl ControllerFallbackProjectionStore {
     }
 }
 
-/// Production startup reconciliation for deferred runner staging. An empty
-/// ledger is a no-op, preserving healthy controller startup behavior.
+/// Production startup reconciliation for deferred runner staging. It reads at
+/// most eight runner jobs so ordinary CLI startup remains bounded by work count.
 pub fn reconcile_on_controller_startup() -> Result<usize> {
     Ok(ControllerFallbackProjectionStore::open_default()?
-        .reconcile_after_controller_restart()?
+        .reconcile_after_controller_restart_with(
+            8,
+            crate::runner_job_log_snapshot,
+            homeboy_agents::agent_task_lifecycle::project_terminal_runner_result,
+        )?
         .len())
 }
 
@@ -320,45 +347,24 @@ mod tests {
     }
 
     #[test]
-    fn controller_restart_projects_each_staged_mission_once() {
+    fn terminal_runner_evidence_projects_once_after_restart() {
         let store = store();
         let envelope = envelope();
         let mut runner = Transport::compatible();
         let receipt = store
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
-        let projected = store.reconcile_after_controller_restart().expect("project");
-        assert_eq!(projected.len(), 1);
-        let projected = &projected[0];
+        let projected = store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts.clone(),
+                },
+            )
+            .expect("project");
+        assert_eq!(projected.terminal_outcome, "succeeded");
         assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
-        assert_eq!(
-            projected
-                .artifacts
-                .source_artifact
-                .as_ref()
-                .expect("source artifact descriptor")
-                .artifact_id,
-            "source-package-1"
-        );
-        assert_eq!(
-            projected
-                .artifacts
-                .source_artifact
-                .as_ref()
-                .expect("source artifact descriptor")
-                .package
-                .format,
-            "homeboy/source-package-json/v1"
-        );
-        assert_eq!(projected.terminal_outcome, "staged");
-        assert_eq!(projected.finalization_owner, "controller");
-        assert_eq!(
-            store
-                .reconcile_after_controller_restart()
-                .expect("idempotent projection")
-                .len(),
-            0
-        );
     }
 
     #[test]
@@ -370,14 +376,19 @@ mod tests {
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
         store
-            .reconcile_after_controller_restart()
-            .expect("startup projection");
-
-        assert!(store
             .project_terminal_evidence(
                 &receipt.mission_id,
                 RunnerTerminalEvidence {
                     outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts.clone(),
+                },
+            )
+            .expect("first terminal projection");
+        assert!(store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "failed".to_string(),
                     artifacts: receipt.runner_receipt.artifacts,
                 },
             )

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -66,7 +66,8 @@ pub struct RunnerTerminalEvidence {
 pub struct ControllerMissionProjection {
     pub mission_id: String,
     pub runner_id: String,
-    pub runner_staging_id: String,
+    #[serde(alias = "runner_staging_id")]
+    pub runner_job_id: String,
     pub terminal_outcome: String,
     pub artifacts: RunnerStagingArtifacts,
     pub finalization_owner: String,
@@ -199,7 +200,7 @@ impl ControllerFallbackProjectionStore {
         let projection = ControllerMissionProjection {
             mission_id: mission_id.to_string(),
             runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
-            runner_staging_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
             terminal_outcome: evidence.outcome,
             artifacts: evidence.artifacts,
             finalization_owner: "controller".to_string(),
@@ -338,6 +339,16 @@ mod tests {
                 .expect("source artifact descriptor")
                 .artifact_id,
             "source-package-1"
+        );
+        assert_eq!(
+            projected
+                .artifacts
+                .source_artifact
+                .as_ref()
+                .expect("source artifact descriptor")
+                .package
+                .format,
+            "homeboy/source-package-json/v1"
         );
         assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -1,0 +1,310 @@
+//! Durable controller fallback and later projection for sealed runner staging.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_core::{Error, Result};
+
+use crate::runner_staging_operation::{
+    submit_remote_runner_staging, RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt,
+    RemoteRunnerStagingTransport, RunnerStagingArtifacts,
+};
+
+const STORE_SCHEMA: &str = "homeboy/controller-fallback-projection/v1";
+
+/// Controller-visible durable receipt for a runner-owned admission.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DeferredControllerReceipt {
+    pub schema: String,
+    pub mission_id: String,
+    pub runner_receipt: RemoteRunnerStagingReceipt,
+    pub controller_projection: String,
+}
+
+impl DeferredControllerReceipt {
+    fn new(mission_id: impl Into<String>, runner_receipt: RemoteRunnerStagingReceipt) -> Self {
+        Self {
+            schema: STORE_SCHEMA.to_string(),
+            mission_id: mission_id.into(),
+            runner_receipt,
+            controller_projection: "deferred".to_string(),
+        }
+    }
+
+    fn validate_for(&self, envelope: &RemoteRunnerStagingEnvelope) -> Result<()> {
+        if self.schema != STORE_SCHEMA
+            || self.mission_id.trim().is_empty()
+            || self.controller_projection != "deferred"
+        {
+            return Err(Error::validation_invalid_argument(
+                "controller_fallback_receipt",
+                "deferred controller receipt is malformed",
+                Some(envelope.handoff.run_id.clone()),
+                None,
+            ));
+        }
+        self.runner_receipt.validate_for(envelope)
+    }
+}
+
+/// Terminal evidence from the runner-owned store. The controller copies these
+/// identities without replacing or re-materializing runner artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerTerminalEvidence {
+    pub outcome: String,
+    pub artifacts: RunnerStagingArtifacts,
+}
+
+/// The one controller-owned finalization projection for a deferred mission.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerMissionProjection {
+    pub mission_id: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    pub terminal_outcome: String,
+    pub artifacts: RunnerStagingArtifacts,
+    pub finalization_owner: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct State {
+    schema: String,
+    receipts: BTreeMap<String, DeferredControllerReceipt>,
+    projections: BTreeMap<String, ControllerMissionProjection>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            schema: STORE_SCHEMA.to_string(),
+            receipts: BTreeMap::new(),
+            projections: BTreeMap::new(),
+        }
+    }
+}
+
+/// File-backed controller receipt/projection ledger. Runner admission is
+/// atomic in its own store; this ledger only records accepted receipts.
+pub struct ControllerFallbackProjectionStore {
+    path: PathBuf,
+}
+
+impl ControllerFallbackProjectionStore {
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let store = Self { path: path.into() };
+        if store.load()?.schema != STORE_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "controller_fallback_store",
+                "unsupported controller fallback projection store schema",
+                Some(store.path.display().to_string()),
+                None,
+            ));
+        }
+        Ok(store)
+    }
+
+    /// Preflight happens inside `submit_remote_runner_staging` before the
+    /// transport mutation boundary, so refusals spend no provider budget.
+    pub fn submit_detached<T: RemoteRunnerStagingTransport>(
+        &self,
+        transport: &mut T,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<DeferredControllerReceipt> {
+        let receipt = DeferredControllerReceipt::new(
+            &envelope.handoff.run_id,
+            submit_remote_runner_staging(transport, envelope)?,
+        );
+        receipt.validate_for(envelope)?;
+        let mut state = self.load()?;
+        if let Some(existing) = state.receipts.get(&receipt.mission_id) {
+            if existing != &receipt {
+                return Err(Error::validation_invalid_argument(
+                    "idempotency_key",
+                    "controller fallback mission is already bound to a different runner receipt",
+                    Some(receipt.mission_id),
+                    None,
+                ));
+            }
+            return Ok(existing.clone());
+        }
+        state
+            .receipts
+            .insert(receipt.mission_id.clone(), receipt.clone());
+        self.persist(&state)?;
+        Ok(receipt)
+    }
+
+    /// Repeated controller startup projects exactly one mission and fails closed
+    /// if later runner evidence differs from the first terminal evidence.
+    pub fn reconcile_after_controller_restart(
+        &self,
+        mission_id: &str,
+        evidence: RunnerTerminalEvidence,
+    ) -> Result<ControllerMissionProjection> {
+        if evidence.outcome.trim().is_empty()
+            || evidence.artifacts.lifecycle_id.trim().is_empty()
+            || evidence.artifacts.source_artifact_id.trim().is_empty()
+            || evidence.artifacts.workspace_artifact_id.trim().is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner_terminal_evidence",
+                "runner terminal evidence requires an outcome and all staged artifacts",
+                Some(mission_id.to_string()),
+                None,
+            ));
+        }
+        let mut state = self.load()?;
+        let receipt = state.receipts.get(mission_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "mission_id",
+                "controller cannot project a mission without a deferred runner receipt",
+                Some(mission_id.to_string()),
+                None,
+            )
+        })?;
+        let projection = ControllerMissionProjection {
+            mission_id: mission_id.to_string(),
+            runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
+            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            terminal_outcome: evidence.outcome,
+            artifacts: evidence.artifacts,
+            finalization_owner: "controller".to_string(),
+        };
+        if let Some(existing) = state.projections.get(mission_id) {
+            if existing != &projection {
+                return Err(Error::validation_invalid_argument(
+                    "runner_terminal_evidence",
+                    "controller mission already has a different terminal projection",
+                    Some(mission_id.to_string()),
+                    None,
+                ));
+            }
+            return Ok(existing.clone());
+        }
+        state
+            .projections
+            .insert(mission_id.to_string(), projection.clone());
+        self.persist(&state)?;
+        Ok(projection)
+    }
+
+    fn load(&self) -> Result<State> {
+        if !self.path.exists() {
+            return Ok(State::default());
+        }
+        serde_json::from_slice(&fs::read(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", self.path.display())),
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse {}", self.path.display())),
+            )
+        })
+    }
+
+    fn persist(&self, state: &State) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("create {}", parent.display())),
+                )
+            })?;
+        }
+        let temporary = self.path.with_extension("tmp");
+        let bytes = serde_json::to_vec(state).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize controller fallback projection".to_string()),
+            )
+        })?;
+        fs::write(&temporary, bytes).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
+        fs::rename(&temporary, &self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("publish {}", self.path.display())),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner_staging_operation::tests_support::{envelope, Transport};
+    use tempfile::tempdir;
+
+    fn store() -> ControllerFallbackProjectionStore {
+        ControllerFallbackProjectionStore::open(
+            tempdir().expect("temp").keep().join("controller.json"),
+        )
+        .expect("store")
+    }
+
+    #[test]
+    fn failed_controller_daemon_uses_compatible_runner_once_and_returns_deferred_receipt() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let first = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("fallback admission");
+        let repeated = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("replay");
+        assert_eq!(first, repeated);
+        assert_eq!(first.controller_projection, "deferred");
+        assert_eq!(runner.provider_budget(), 0);
+    }
+
+    #[test]
+    fn disconnected_or_incompatible_runner_refuses_before_provider_budget() {
+        let envelope = envelope();
+        for mut runner in [Transport::incompatible(), Transport::disconnected()] {
+            assert!(store().submit_detached(&mut runner, &envelope).is_err());
+            assert_eq!(runner.calls(), 0);
+            assert_eq!(runner.provider_budget(), 0);
+        }
+    }
+
+    #[test]
+    fn restart_projects_one_controller_mission_and_preserves_runner_artifacts() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit");
+        let evidence = RunnerTerminalEvidence {
+            outcome: "succeeded".to_string(),
+            artifacts: receipt.runner_receipt.artifacts.clone(),
+        };
+        let projected = store
+            .reconcile_after_controller_restart(&receipt.mission_id, evidence.clone())
+            .expect("project");
+        assert_eq!(projected.artifacts, evidence.artifacts);
+        assert_eq!(projected.finalization_owner, "controller");
+        assert_eq!(
+            store
+                .reconcile_after_controller_restart(&receipt.mission_id, evidence)
+                .expect("idempotent projection"),
+            projected
+        );
+    }
+}

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -330,6 +330,15 @@ mod tests {
         assert_eq!(projected.len(), 1);
         let projected = &projected[0];
         assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
+        assert_eq!(
+            projected
+                .artifacts
+                .source_artifact
+                .as_ref()
+                .expect("source artifact descriptor")
+                .artifact_id,
+            "source-package-1"
+        );
         assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");
         assert_eq!(

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -1,10 +1,13 @@
 //! Durable controller fallback and later projection for sealed runner staging.
 
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 use homeboy_core::{Error, Result};
 
@@ -129,6 +132,7 @@ impl ControllerFallbackProjectionStore {
             submit_remote_runner_staging(transport, envelope)?,
         );
         receipt.validate_for(envelope)?;
+        let _lock = self.lock()?;
         let mut state = self.load()?;
         if let Some(existing) = state.receipts.get(&receipt.mission_id) {
             if existing != &receipt {
@@ -211,6 +215,7 @@ impl ControllerFallbackProjectionStore {
                 None,
             ));
         }
+        let _lock = self.lock()?;
         let mut state = self.load()?;
         let receipt = state.receipts.get(mission_id).ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -273,25 +278,73 @@ impl ControllerFallbackProjectionStore {
                 )
             })?;
         }
-        let temporary = self.path.with_extension("tmp");
         let bytes = serde_json::to_vec(state).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
                 Some("serialize controller fallback projection".to_string()),
             )
         })?;
-        fs::write(&temporary, bytes).map_err(|error| {
+        let parent = self.path.parent().expect("ledger path has parent");
+        let mut temporary = NamedTempFile::new_in(parent).map_err(|error| {
             Error::internal_io(
                 error.to_string(),
-                Some(format!("write {}", temporary.display())),
+                Some(format!("create ledger temporary in {}", parent.display())),
             )
         })?;
-        fs::rename(&temporary, &self.path).map_err(|error| {
+        temporary.write_all(&bytes).map_err(|error| {
             Error::internal_io(
                 error.to_string(),
+                Some("write controller fallback projection".to_string()),
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("sync controller fallback projection".to_string()),
+            )
+        })?;
+        temporary.persist(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.error.to_string(),
                 Some(format!("publish {}", self.path.display())),
             )
-        })
+        })?;
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("sync {}", parent.display())),
+                )
+            })
+    }
+
+    fn lock(&self) -> Result<File> {
+        let parent = self.path.parent().expect("ledger path has parent");
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(self.path.with_extension("lock"))
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("open controller fallback lock".to_string()),
+                )
+            })?;
+        file.lock_exclusive().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("lock controller fallback ledger".to_string()),
+            )
+        })?;
+        Ok(file)
     }
 }
 

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -99,18 +99,11 @@ impl DirectLabHandoffReceipt {
             controller_identity: envelope.controller_identity.clone(),
             acceptance_state: "accepted".to_string(),
             controller_projection: "deferred".to_string(),
-            status_command: format!(
-                "homeboy runner jobs show {} {}",
-                envelope.runner_id, runner_job_id
-            ),
-            cancel_command: format!(
-                "homeboy runner jobs cancel {} {}",
-                envelope.runner_id, runner_job_id
-            ),
-            evidence_command: format!(
-                "homeboy runner jobs evidence {} {}",
-                envelope.runner_id, runner_job_id
-            ),
+            // Sealed staging has no runner daemon job yet. The durable run is
+            // the status, cancellation, and evidence authority.
+            status_command: format!("homeboy agent-task status {}", envelope.run_id),
+            cancel_command: format!("homeboy agent-task cancel {}", envelope.run_id),
+            evidence_command: format!("homeboy agent-task evidence {} --full", envelope.run_id),
         }
     }
 
@@ -248,7 +241,12 @@ mod tests {
         assert_eq!(first, repeated);
         assert_eq!(receiver.receipts.len(), 1);
         assert_eq!(first.controller_projection, "deferred");
-        assert!(first.status_command.contains("runner-job-1"));
+        assert_eq!(first.status_command, "homeboy agent-task status run-1");
+        assert_eq!(first.cancel_command, "homeboy agent-task cancel run-1");
+        assert_eq!(
+            first.evidence_command,
+            "homeboy agent-task evidence run-1 --full"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -64,7 +64,7 @@ impl DirectLabHandoffEnvelope {
                 None,
             ));
         }
-        self.recipe.validate()
+        self.recipe.validate_for_runner_staging()
     }
 }
 

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -126,6 +126,43 @@ pub(crate) fn daemon_api_post_for_session(session: &RunnerSession, path: &str) -
     daemon_post(&client, local_url, path)
 }
 
+pub(crate) fn daemon_api_post_json_for_session(
+    session: &RunnerSession,
+    path: &str,
+    payload: &Value,
+) -> Result<Value> {
+    let local_url = session.local_url.as_deref().ok_or_else(|| {
+        Error::internal_unexpected("known daemon generation has no direct local endpoint")
+    })?;
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    let response = daemon_post_json_text(
+        &client,
+        local_url,
+        path,
+        payload,
+        DaemonPostOptions::default(),
+    )?;
+    let envelope: DaemonEnvelope = parse_daemon_response_json(
+        &response.body,
+        response.status_code,
+        path,
+        "parse daemon response",
+    )?;
+    if !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
+}
+
 pub fn daemon_api_post(runner_id: &str, path: &str) -> Result<Value> {
     daemon_api_request(runner_id, path, "POST")
 }

--- a/crates/homeboy-lab-runner/src/execution/daemon_api.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon_api.rs
@@ -153,10 +153,14 @@ pub(crate) fn daemon_api_post_json_for_session(
         "parse daemon response",
     )?;
     if !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "daemon request failed: {}",
-            envelope.error.unwrap_or(Value::Null)
-        )));
+        return Err(Error::new(
+            ErrorCode::InternalUnexpected,
+            format!(
+                "daemon request failed: {}",
+                envelope.error.unwrap_or(Value::Null)
+            ),
+            json!({ "http_status": response.status_code, "path": path }),
+        ));
     }
     envelope
         .data

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -81,8 +81,8 @@ use policy::{preflight_remote_argv, remote_execution_preflight};
 // API. `use` re-exports are not counted as structural items.
 use broker::*;
 use daemon::*;
-pub(crate) use daemon_api::daemon_api_get_for_session;
 use daemon_api::*;
+pub(crate) use daemon_api::{daemon_api_get_for_session, daemon_api_post_json_for_session};
 use failure::*;
 use handoff::*;
 use paths::*;

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2296,7 +2296,7 @@ pub(crate) fn detached_staging_submission_output(
         }
         crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt) => {
             output["status"] = serde_json::json!("staged");
-            output["runner_staging_id"] =
+            output["runner_job_id"] =
                 serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
             output["controller_projection"] = serde_json::json!(receipt.controller_projection);
         }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1409,7 +1409,10 @@ pub(crate) fn run_lab_offload_inner(
         .session
         .as_ref()
         .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh)
-        && runner_status.stale_daemon.is_none()
+        // An unverified reverse session is an availability warning rather than
+        // a freshness fence. Only a typed blocking verdict can suppress this
+        // direct-SSH identity comparison.
+        && runner_status.admission_blocking_stale_daemon().is_none()
     {
         let session = runner_status
             .session

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2298,6 +2298,10 @@ pub(crate) fn detached_staging_submission_output(
             output["status"] = serde_json::json!("staged");
             output["runner_job_id"] =
                 serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
+            // Older clients consumed this name before staging admitted a real
+            // runner daemon job. Keep it additive while they migrate.
+            output["runner_staging_id"] =
+                serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
             output["controller_projection"] = serde_json::json!(receipt.controller_projection);
         }
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1189,13 +1189,13 @@ pub(crate) fn run_lab_offload_inner(
             request.local_output_file,
             &mut messages,
         );
-        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+        let submission = match crate::lab_staging_controller::submit_detached_staging(
             run_id,
             runner_id,
             selection.mode.clone(),
             &request,
         ) {
-            Ok(controller_job_id) => controller_job_id,
+            Ok(submission) => submission,
             Err(error) => {
                 if error.retryable != Some(true) {
                     if let Some(durable_plan) = request.durable_agent_task_plan {
@@ -1214,29 +1214,17 @@ pub(crate) fn run_lab_offload_inner(
                 ));
             }
         };
-        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
+        let submission = detached_staging_submission_output(submission, run_id);
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
-            "data": {
-                "status": "materializing",
-                "durable_run_id": run_id,
-                "controller_job_id": controller_job_id,
-                "retrieval_commands": {
-                    "status": format!("homeboy agent-task status {run_id}"),
-                    "controller_job": controller_job_commands.show,
-                    "controller_job_watch": controller_job_commands.watch,
-                },
-            }
+            "data": submission,
         }))
-        .unwrap_or_else(|_| {
-            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
-        });
+        .unwrap_or_else(|_| format!("Lab staging accepted for {run_id}"));
         return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: format!("{stdout}\n"),
             stderr: format!(
-                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
-                controller_job_commands.show, controller_job_commands.watch,
+                "Lab staging continues for durable run `{run_id}`.\nNext: homeboy agent-task status {run_id}\nNext: homeboy agent-task logs {run_id}\n",
             ),
             exit_code: 0,
             output_file_content: Some(format!("{stdout}\n")),
@@ -1686,13 +1674,13 @@ pub(crate) fn run_lab_offload_inner(
             request.local_output_file,
             &mut messages,
         );
-        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+        let submission = match crate::lab_staging_controller::submit_detached_staging(
             run_id,
             runner_id,
             selection.mode.clone(),
             &request,
         ) {
-            Ok(controller_job_id) => controller_job_id,
+            Ok(submission) => submission,
             Err(error) => {
                 // A retryable transport failure can follow durable acceptance.
                 // Keep the parent nonterminal so replay can reconcile the same
@@ -1714,33 +1702,17 @@ pub(crate) fn run_lab_offload_inner(
                 ));
             }
         };
-        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
+        let submission = detached_staging_submission_output(submission, run_id);
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
-            "data": {
-                "status": "materializing",
-                "durable_run_id": run_id,
-                "controller_job_id": controller_job_id,
-                "retrieval_commands": {
-                    "status": format!("homeboy agent-task status {run_id}"),
-                    "controller_job": controller_job_commands.show,
-                    "controller_job_watch": controller_job_commands.watch,
-                },
-                "next_actions": [
-                    format!("Show controller job: {}", controller_job_commands.show),
-                    format!("Watch controller job: {}", controller_job_commands.watch),
-                ],
-            }
+            "data": submission,
         }))
-        .unwrap_or_else(|_| {
-            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
-        });
+        .unwrap_or_else(|_| format!("Lab staging accepted for {run_id}"));
         return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: format!("{stdout}\n"),
             stderr: format!(
-                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
-                controller_job_commands.show, controller_job_commands.watch,
+                "Lab staging continues for durable run `{run_id}`.\nNext: homeboy agent-task status {run_id}\nNext: homeboy agent-task logs {run_id}\n",
             ),
             exit_code: 0,
             output_file_content: Some(format!("{stdout}\n")),
@@ -2300,6 +2272,36 @@ pub(crate) fn controller_job_retrieval_commands(job_id: &str) -> ControllerJobRe
         show: format!("homeboy activity show {job_id}"),
         watch: format!("homeboy activity watch {job_id}"),
     }
+}
+
+pub(crate) fn detached_staging_submission_output(
+    submission: crate::lab_staging_controller::DetachedStagingSubmission,
+    run_id: &str,
+) -> serde_json::Value {
+    let mut output = serde_json::json!({
+        "durable_run_id": run_id,
+        "retrieval_commands": {
+            "status": format!("homeboy agent-task status {run_id}"),
+            "logs": format!("homeboy agent-task logs {run_id}"),
+        },
+    });
+    match submission {
+        crate::lab_staging_controller::DetachedStagingSubmission::Controller { job_id } => {
+            let commands = controller_job_retrieval_commands(&job_id);
+            output["status"] = serde_json::json!("materializing");
+            output["controller_job_id"] = serde_json::json!(job_id);
+            output["retrieval_commands"]["controller_job"] = serde_json::json!(commands.show);
+            output["retrieval_commands"]["controller_job_watch"] =
+                serde_json::json!(commands.watch);
+        }
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt) => {
+            output["status"] = serde_json::json!("staged");
+            output["runner_staging_id"] =
+                serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
+            output["controller_projection"] = serde_json::json!(receipt.controller_projection);
+        }
+    }
+    output
 }
 
 /// Keep the generated direct command and the reverse-transport command in

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -124,6 +124,8 @@ use crate::runtime_materializer::{
 
 #[cfg(test)]
 pub(super) use inner::accepted_runner_job_id_with;
+#[cfg(test)]
+pub(super) use inner::detached_staging_submission_output;
 
 use super::super::workload::{
     build_lab_runner_workload_for_dispatched_command, lab_runner_workload_agent_task_from_command,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -19,7 +19,7 @@ fn deferred_staging_emits_only_durable_run_commands() {
                 schema: "homeboy/direct-lab-handoff-receipt/v1".to_string(),
                 run_id: "run-1".to_string(),
                 runner_id: "runner-1".to_string(),
-                runner_job_id: "staging-run-1".to_string(),
+                runner_job_id: "00000000-0000-0000-0000-000000000001".to_string(),
                 idempotency_key: "run-1".to_string(),
                 controller_identity: "controller-1".to_string(),
                 acceptance_state: "accepted".to_string(),
@@ -44,12 +44,16 @@ fn deferred_staging_emits_only_durable_run_commands() {
         controller_projection: "deferred".to_string(),
     };
     let output = detached_staging_submission_output(
-        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt),
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt.clone()),
         "run-1",
     );
 
     assert_eq!(output["status"], "staged");
-    assert_eq!(output["runner_staging_id"], "staging-run-1");
+    assert_eq!(
+        output["runner_job_id"],
+        "00000000-0000-0000-0000-000000000001"
+    );
+    assert!(output.get("runner_staging_id").is_none());
     assert!(output.get("controller_job_id").is_none());
     assert!(output["retrieval_commands"].get("controller_job").is_none());
     assert_eq!(
@@ -60,6 +64,13 @@ fn deferred_staging_emits_only_durable_run_commands() {
         output["retrieval_commands"]["logs"],
         "homeboy agent-task logs run-1"
     );
+    let source = receipt
+        .runner_receipt
+        .artifacts
+        .source_artifact
+        .expect("source artifact descriptor");
+    assert_eq!(source.package.extraction_root, "workspace");
+    assert_eq!(source.package.entries[0].path, "source.bin");
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -9,6 +9,53 @@ fn detached_staging_controller_job_commands_use_activity_surface() {
 }
 
 #[test]
+fn deferred_staging_emits_only_durable_run_commands() {
+    let receipt = crate::controller_fallback_projection::DeferredControllerReceipt {
+        schema: "homeboy/controller-fallback-projection/v1".to_string(),
+        mission_id: "run-1".to_string(),
+        runner_receipt: crate::runner_staging_operation::RemoteRunnerStagingReceipt {
+            schema: "homeboy/remote-runner-staging-receipt/v1".to_string(),
+            handoff: crate::direct_lab_handoff::DirectLabHandoffReceipt {
+                schema: "homeboy/direct-lab-handoff-receipt/v1".to_string(),
+                run_id: "run-1".to_string(),
+                runner_id: "runner-1".to_string(),
+                runner_job_id: "staging-run-1".to_string(),
+                idempotency_key: "run-1".to_string(),
+                controller_identity: "controller-1".to_string(),
+                acceptance_state: "accepted".to_string(),
+                controller_projection: "deferred".to_string(),
+                status_command: "homeboy agent-task status run-1".to_string(),
+                cancel_command: "homeboy agent-task cancel run-1".to_string(),
+                evidence_command: "homeboy agent-task evidence run-1 --full".to_string(),
+            },
+            artifacts: crate::runner_staging_operation::RunnerStagingArtifacts {
+                lifecycle_id: "staging-run-1".to_string(),
+                source_artifact_id: "source-1".to_string(),
+                workspace_artifact_id: "workspace-1".to_string(),
+            },
+        },
+        controller_projection: "deferred".to_string(),
+    };
+    let output = detached_staging_submission_output(
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt),
+        "run-1",
+    );
+
+    assert_eq!(output["status"], "staged");
+    assert_eq!(output["runner_staging_id"], "staging-run-1");
+    assert!(output.get("controller_job_id").is_none());
+    assert!(output["retrieval_commands"].get("controller_job").is_none());
+    assert_eq!(
+        output["retrieval_commands"]["status"],
+        "homeboy agent-task status run-1"
+    );
+    assert_eq!(
+        output["retrieval_commands"]["logs"],
+        "homeboy agent-task logs run-1"
+    );
+}
+
+#[test]
 fn emit_durable_run_id_writes_json_to_output_before_execution() {
     let dir = tempfile::tempdir().expect("temp dir");
     let output_path = dir.path().join("cook-output.json");

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -53,7 +53,10 @@ fn deferred_staging_emits_only_durable_run_commands() {
         output["runner_job_id"],
         "00000000-0000-0000-0000-000000000001"
     );
-    assert!(output.get("runner_staging_id").is_none());
+    assert_eq!(
+        output["runner_staging_id"],
+        "00000000-0000-0000-0000-000000000001"
+    );
     assert!(output.get("controller_job_id").is_none());
     assert!(output["retrieval_commands"].get("controller_job").is_none());
     assert_eq!(

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -32,6 +32,13 @@ fn deferred_staging_emits_only_durable_run_commands() {
                 lifecycle_id: "staging-run-1".to_string(),
                 source_artifact_id: "source-1".to_string(),
                 workspace_artifact_id: "workspace-1".to_string(),
+                source_artifact: Some(
+                    crate::runner_staging_operation::SourceArtifactTransfer::from_bytes(
+                        "source-run-1",
+                        b"sealed source package",
+                    )
+                    .descriptor(),
+                ),
             },
         },
         controller_projection: "deferred".to_string(),

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -971,6 +971,25 @@ pub(crate) fn submit_detached_staging(
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
 ) -> Result<DetachedStagingSubmission> {
+    submit_detached_staging_with_daemon_ensure(
+        run_id,
+        runner_id,
+        tunnel_mode,
+        request,
+        ensure_current_controller_daemon,
+    )
+}
+
+fn submit_detached_staging_with_daemon_ensure<Ensure>(
+    run_id: &str,
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    request: &LabOffloadRequest<'_>,
+    ensure_daemon: Ensure,
+) -> Result<DetachedStagingSubmission>
+where
+    Ensure: FnOnce() -> Result<homeboy_core::daemon::DaemonStartResult>,
+{
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -979,7 +998,7 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let daemon = match ensure_current_controller_daemon() {
+    let daemon = match ensure_daemon() {
         Ok(daemon) => daemon,
         Err(daemon_error) => {
             return submit_deferred_runner_staging(
@@ -4062,6 +4081,189 @@ mod tests {
             Some(run_id),
         )
         .expect("submit durable attempt");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detached_staging_falls_back_through_authenticated_reverse_broker_and_projects_terminal_result_once(
+    ) {
+        use homeboy_core::api_jobs::{JobEventKind, JobStatus};
+        use homeboy_core::server::RunnerPolicy;
+        use homeboy_core::test_support::{with_isolated_home, AuthenticatedReverseBrokerFixture};
+
+        with_isolated_home(|home| {
+            let _adapter_guard = global_state_lock().lock().expect("adapter lock");
+            std::env::set_var("HOMEBOY_CONTROLLER_ID", "fixture-controller");
+            clear_installed_adapter();
+            register();
+            enable_production_routing();
+            crate::register_runner_staging_provider();
+            crate::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create Lab runner");
+            crate::merge(
+                Some("lab"),
+                &serde_json::json!({
+                    "policy": RunnerPolicy {
+                        allow_raw_exec: Some(true),
+                        workspace_roots: vec!["/tmp".to_string()],
+                        allowed_commands: vec!["sh".to_string()],
+                        ..Default::default()
+                    }
+                })
+                .to_string(),
+                &[],
+            )
+            .expect("allow deterministic fixture command");
+            let broker = AuthenticatedReverseBrokerFixture::start("lab");
+            let (connected, code) = crate::connect_reverse(crate::ReverseRunnerConnectOptions {
+                controller_id: "fixture-controller".to_string(),
+                runner_id: "lab".to_string(),
+                broker_url: Some(broker.url().to_string()),
+            })
+            .expect("register authenticated reverse session");
+            assert_eq!(code, 0);
+            assert!(connected.connected);
+            // `connect_reverse` is the runner-side registration protocol. The
+            // controller observes that runner through its controller-role
+            // session record, just as the two production processes do.
+            let controller_session = crate::RunnerSession {
+                runner_id: "lab".to_string(),
+                mode: crate::RunnerTunnelMode::Reverse,
+                role: crate::RunnerSessionRole::Controller,
+                server_id: None,
+                controller_id: Some("fixture-controller".to_string()),
+                broker_url: Some(broker.url().to_string()),
+                remote_daemon_address: None,
+                local_port: None,
+                local_url: None,
+                tunnel_pid: None,
+                tunnel_process_start_identity: None,
+                remote_daemon_pid: None,
+                remote_daemon_lease_id: None,
+                homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
+                homeboy_build_identity: Some(homeboy_product_identity::build_identity().display),
+                connected_at: chrono::Utc::now().to_rfc3339(),
+                worker_identity: Some("fixture-worker".to_string()),
+                worker_pid: Some(std::process::id()),
+                last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
+                leaseless_recovery_evidence: None,
+            };
+            let controller_session_path =
+                homeboy_core::paths::runner_controller_session_file("lab", "fixture-controller")
+                    .expect("controller session path");
+            std::fs::create_dir_all(controller_session_path.parent().expect("session parent"))
+                .expect("create controller session parent");
+            std::fs::write(
+                controller_session_path,
+                serde_json::to_vec(&controller_session).expect("serialize controller session"),
+            )
+            .expect("write controller session");
+
+            let source = home.path().join("source");
+            std::fs::create_dir_all(&source).expect("create source");
+            std::fs::write(source.join("input.txt"), "staged-source\n").expect("write source");
+            let output = home.path().join("worker-output.txt");
+            let args = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("printf staged-worker-ok > {}", output.display()),
+            ];
+            let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
+                "authenticated-reverse-staging",
+                Vec::new(),
+            );
+            let run_id = "authenticated-reverse-staging-run";
+            submit_recipe_run(run_id);
+            let mut request = recipe_request(Some(recipe_command()), &args, HashMap::new());
+            request.placement_decision =
+                homeboy_core::lab_routing::compatibility_placement_decision(
+                    homeboy_lab_runner_contract::Placement::Lab,
+                    Some("lab"),
+                    false,
+                );
+            request.source_path = Some(&source);
+            request.durable_agent_task_plan = Some(&plan);
+            let pre_provider = || {
+                Err(Error::internal_unexpected(
+                    "fixture typed pre-provider daemon admission failure",
+                ))
+            };
+            let receipt = submit_detached_staging_with_daemon_ensure(
+                run_id,
+                "lab",
+                crate::RunnerTunnelMode::Reverse,
+                &request,
+                pre_provider,
+            )
+            .expect("admit durable fallback staging");
+            let DetachedStagingSubmission::Deferred(receipt) = receipt else {
+                panic!("typed pre-provider failure must select deferred staging");
+            };
+            let job_id = receipt.runner_receipt.handoff.runner_job_id.clone();
+            assert!(!job_id.is_empty());
+            assert_eq!(broker.jobs().len(), 1, "staging owns queue admission");
+            assert_eq!(broker.jobs()[0].status, JobStatus::Queued);
+            let warning = crate::status("lab")
+                .expect("read reverse runner status")
+                .stale_daemon
+                .expect("reverse verification warning");
+            assert_eq!(
+                warning.compatibility_reason.as_deref(),
+                Some("reverse_unverified")
+            );
+
+            let (worker, worker_code) =
+                crate::run_reverse_worker(crate::ReverseRunnerWorkerOptions {
+                    runner_id: "lab".to_string(),
+                    broker_url: broker.url().to_string(),
+                    broker_token: Some(broker.token().to_string()),
+                    project_id: None,
+                    lease_ms: 30_000,
+                    concurrency_limit: Some(1),
+                    loop_mode: false,
+                    idle_backoff_ms: 1,
+                    max_idle_backoff_ms: 10,
+                    broker_failure_backoff_ms: 1,
+                    broker_retry_limit: 1,
+                })
+                .expect("execute staged reverse job");
+            assert_eq!(worker_code, 0, "worker={worker:#?}");
+            assert!(worker.claimed);
+            assert_eq!(
+                std::fs::read_to_string(&output).expect("worker side effect"),
+                "staged-worker-ok"
+            );
+            let job = broker
+                .store
+                .get(uuid::Uuid::parse_str(&job_id).expect("job id"))
+                .expect("broker job");
+            assert_eq!(job.status, JobStatus::Succeeded);
+            let results = broker.store.events(job.id).expect("terminal evidence");
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|event| event.kind == JobEventKind::Result)
+                    .count(),
+                1
+            );
+            assert!(results
+                .iter()
+                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("project terminal result"),
+                1
+            );
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("replay projection"),
+                0
+            );
+        });
     }
 
     fn envelope() -> LabStagingDispatchEnvelope {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1092,7 +1092,7 @@ fn submit_deferred_runner_staging(
         request,
         request.local_output_file.is_some(),
     )?;
-    let _source_path = recipe.source_path.take().ok_or_else(|| {
+    let source_path = recipe.source_path.take().ok_or_else(|| {
         Error::validation_invalid_argument(
             "source_path",
             "controller fallback requires a source path to seal before detached staging",
@@ -1116,7 +1116,7 @@ fn submit_deferred_runner_staging(
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
     let source_artifact =
-        SourceArtifactTransfer::from_bytes(format!("source-{run_id}"), &sealed_payload);
+        SourceArtifactTransfer::from_directory(format!("source-{run_id}"), &source_path)?;
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -969,7 +969,7 @@ pub(crate) fn submit_detached_staging(
     runner_id: &str,
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
-) -> Result<String> {
+) -> Result<DetachedStagingSubmission> {
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -988,7 +988,7 @@ pub(crate) fn submit_detached_staging(
                 request,
                 daemon_error,
             )
-            .map(|receipt| receipt.handoff.runner_job_id);
+            .map(DetachedStagingSubmission::Deferred);
         }
     };
     let recipe = persist_lab_staging_recipe_for_transport(
@@ -1056,7 +1056,14 @@ pub(crate) fn submit_detached_staging(
             started.id, job.id
         )));
     }
-    Ok(job_id)
+    Ok(DetachedStagingSubmission::Controller { job_id })
+}
+
+/// The initiating client must distinguish a controller job from runner-owned
+/// staging. They have separate status and reconciliation authorities.
+pub(crate) enum DetachedStagingSubmission {
+    Controller { job_id: String },
+    Deferred(crate::controller_fallback_projection::DeferredControllerReceipt),
 }
 
 /// Explicit detached fallback after local controller admission has failed. The
@@ -1068,7 +1075,7 @@ fn submit_deferred_runner_staging(
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
     daemon_error: Error,
-) -> Result<crate::runner_staging_operation::RemoteRunnerStagingReceipt> {
+) -> Result<crate::controller_fallback_projection::DeferredControllerReceipt> {
     let plan = request.durable_agent_task_plan.ok_or_else(|| {
         Error::validation_invalid_argument(
             "durable_agent_task_plan",
@@ -1136,25 +1143,24 @@ fn submit_deferred_runner_staging(
             });
             error
         })?;
-    let receipt =
+    let deferred_receipt =
         crate::controller_fallback_projection::ControllerFallbackProjectionStore::open_default()?
-            .submit_detached(&mut transport, &envelope)?
-            .runner_receipt;
+            .submit_detached(&mut transport, &envelope)?;
     homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
         run_id,
         DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND,
-        &receipt,
+        &deferred_receipt.runner_receipt,
     )?;
     homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
         homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
             run_id,
             runner_id,
-            runner_job_id: &receipt.handoff.runner_job_id,
+            runner_job_id: &deferred_receipt.runner_receipt.handoff.runner_job_id,
             remote_workspace: "runner-staging",
             remote_command: &[],
         },
     )?;
-    Ok(receipt)
+    Ok(deferred_receipt)
 }
 
 /// A response can be lost after the daemon accepted the request. Create uses

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -4169,7 +4169,7 @@ mod tests {
             let args = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("printf staged-worker-ok > {}", output.display()),
+                format!("cat input.txt | tee {}", output.display()),
             ];
             let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
                 "authenticated-reverse-staging",
@@ -4234,7 +4234,7 @@ mod tests {
             assert!(worker.claimed);
             assert_eq!(
                 std::fs::read_to_string(&output).expect("worker side effect"),
-                "staged-worker-ok"
+                "staged-source\n"
             );
             let job = broker
                 .store
@@ -4249,9 +4249,15 @@ mod tests {
                     .count(),
                 1
             );
-            assert!(results
+            let terminal_result = results
                 .iter()
-                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+                .find(|event| event.kind == JobEventKind::Result)
+                .and_then(|event| event.data.as_ref())
+                .expect("terminal result data");
+            assert_eq!(
+                terminal_result["stdout"],
+                serde_json::json!("staged-source\n")
+            );
 
             assert_eq!(
                 crate::controller_fallback_projection::reconcile_on_controller_startup()

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -24,6 +24,10 @@ use homeboy_core::lab_contract::{
 use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::{Error, Result};
 
+use crate::direct_lab_handoff::DirectLabHandoffEnvelope;
+use crate::runner_staging_operation::{
+    RemoteRunnerStagingEnvelope, RunnerMaterializationAuthority, SealedSourceAuthority,
+};
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
 pub const LAB_STAGING_DISPATCH_JOB_TYPE: &str = "lab.staging-dispatch";
@@ -37,6 +41,7 @@ const DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND: &str = "durable-lab-runtime-sta
 const DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND: &str = "durable-lab-hydration-stage";
 const DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-dispatch-receipt";
 const DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-terminal-receipt";
+const DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND: &str = "deferred-runner-staging-receipt";
 const CONTROLLER_SUBMISSION_ATTEMPTS: usize = 3;
 
 /// Serializable, owned counterpart to the static Lab command contract.
@@ -973,7 +978,19 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let daemon = ensure_current_controller_daemon()?;
+    let daemon = match ensure_current_controller_daemon() {
+        Ok(daemon) => daemon,
+        Err(daemon_error) => {
+            return submit_deferred_runner_staging(
+                run_id,
+                runner_id,
+                tunnel_mode,
+                request,
+                daemon_error,
+            )
+            .map(|receipt| receipt.handoff.runner_job_id);
+        }
+    };
     let recipe = persist_lab_staging_recipe_for_transport(
         run_id,
         runner_id,
@@ -1040,6 +1057,104 @@ pub(crate) fn submit_detached_staging(
         )));
     }
     Ok(job_id)
+}
+
+/// Explicit detached fallback after local controller admission has failed. The
+/// resolver performs connectivity/capability observation before the runner's
+/// durable staging mutation; no provider execution is available at this layer.
+fn submit_deferred_runner_staging(
+    run_id: &str,
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    request: &LabOffloadRequest<'_>,
+    daemon_error: Error,
+) -> Result<crate::runner_staging_operation::RemoteRunnerStagingReceipt> {
+    let plan = request.durable_agent_task_plan.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "durable_agent_task_plan",
+            "controller fallback requires an explicit detached durable plan",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let mut recipe = LabStagingRecipe::from_request_with_transport(
+        run_id,
+        runner_id,
+        tunnel_mode,
+        request,
+        request.local_output_file.is_some(),
+    )?;
+    let _source_path = recipe.source_path.take().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source_path",
+            "controller fallback requires a source path to seal before detached staging",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    // The portable recipe is the sealed staging authority. It deliberately
+    // excludes the controller-local source path before crossing the runner API.
+    let sealed_payload = canonical_json_bytes(&serde_json::to_value(&recipe).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize deferred staging recipe".to_string()),
+        )
+    })?)
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("canonicalize deferred staging recipe".to_string()),
+        )
+    })?;
+    let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
+    let handoff = DirectLabHandoffEnvelope::new(
+        homeboy_product_identity::build_identity().display,
+        recipe,
+        plan.clone(),
+    );
+    let envelope = RemoteRunnerStagingEnvelope::from_direct_handoff(
+        &handoff,
+        RunnerMaterializationAuthority {
+            authority_id: format!("staging-{run_id}"),
+            workspace_key: run_id.to_string(),
+            source: SealedSourceAuthority::new(
+                digest,
+                String::from_utf8(sealed_payload).map_err(|error| {
+                    Error::internal_unexpected(format!(
+                        "deferred staging payload is not UTF-8: {error}"
+                    ))
+                })?,
+            ),
+        },
+    )?;
+    let mut transport =
+        crate::resolve_runner_staging_transport(runner_id).map_err(|mut error| {
+            error.details["controller_daemon_fallback"] = json!({
+                "daemon_error": daemon_error.message,
+                "phase": "pre_provider",
+                "provider_budget_consumed": false,
+            });
+            error
+        })?;
+    let receipt =
+        crate::controller_fallback_projection::ControllerFallbackProjectionStore::open_default()?
+            .submit_detached(&mut transport, &envelope)?
+            .runner_receipt;
+    homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+        run_id,
+        DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND,
+        &receipt,
+    )?;
+    homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
+        homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+            run_id,
+            runner_id,
+            runner_job_id: &receipt.handoff.runner_job_id,
+            remote_workspace: "runner-staging",
+            remote_command: &[],
+        },
+    )?;
+    Ok(receipt)
 }
 
 /// A response can be lost after the daemon accepted the request. Create uses

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -27,6 +27,7 @@ use homeboy_core::{Error, Result};
 use crate::direct_lab_handoff::DirectLabHandoffEnvelope;
 use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RunnerMaterializationAuthority, SealedSourceAuthority,
+    SourceArtifactTransfer,
 };
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
@@ -1114,6 +1115,8 @@ fn submit_deferred_runner_staging(
         )
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
+    let source_artifact =
+        SourceArtifactTransfer::from_bytes(format!("source-{run_id}"), &sealed_payload);
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,
@@ -1132,6 +1135,7 @@ fn submit_deferred_runner_staging(
                     ))
                 })?,
             ),
+            source_artifact: Some(source_artifact),
         },
     )?;
     let mut transport =

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -41,6 +41,7 @@ mod command_path;
 )]
 mod connection;
 mod continuation_provider;
+pub mod controller_fallback_projection;
 mod daemon_exec_driver;
 mod daemon_health;
 mod daemon_http_get;

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -75,6 +75,7 @@ mod generation_store;
 )]
 pub mod lab_staging_controller;
 pub mod runner_staging_operation;
+pub mod runner_staging_store;
 pub fn runner_generation_inventory(runner_id: &str) -> Result<Vec<RunnerDaemonGenerationStatus>> {
     let report = connection::status(runner_id)?;
     runner_generation_inventory_for_session(runner_id, report.session.as_ref())

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -301,6 +301,9 @@ pub use resource_metrics::{
 pub use rolling_generation::{
     RollingDrainState, RollingGeneration, RollingGenerations, RollingStart,
 };
+pub use runner_staging_store::{
+    register_runner_staging_provider, resolve_runner_staging_transport,
+};
 pub use runtime_materialization_status::{RunnerBinarySource, RuntimeMaterializationStatus};
 pub use session::{
     LabRunnerHandoff, ReverseRunnerConnectOptions, RunnerActiveJobError, RunnerActiveJobSource,

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -9,6 +9,8 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
 
 use homeboy_core::{Error, Result};
 
@@ -56,6 +58,125 @@ pub struct SourceArtifactTransfer {
 }
 
 impl SourceArtifactTransfer {
+    /// Packages a controller-owned source tree into the versioned runner
+    /// manifest. Traversal is lexical and deterministic; links and non-files
+    /// are refused rather than crossing a controller filesystem boundary.
+    pub fn from_directory(artifact_id: impl Into<String>, root: &Path) -> Result<Self> {
+        fn collect(
+            root: &Path,
+            directory: &Path,
+            files: &mut BTreeMap<String, Vec<u8>>,
+        ) -> Result<()> {
+            let mut entries = fs::read_dir(directory)
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+                })?;
+            entries.sort_by_key(|entry| entry.file_name());
+            for entry in entries {
+                let path = entry.path();
+                let metadata = fs::symlink_metadata(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+                if metadata.file_type().is_symlink() || !(metadata.is_file() || metadata.is_dir()) {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package accepts only regular files and directories",
+                        Some(path.display().to_string()),
+                        None,
+                    ));
+                }
+                if metadata.is_dir() {
+                    collect(root, &path, files)?;
+                    continue;
+                }
+                if metadata.len() > MAX_SOURCE_PACKAGE_FILE_BYTES {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package file exceeds the configured size bound",
+                        Some(path.display().to_string()),
+                        None,
+                    ));
+                }
+                let relative = path.strip_prefix(root).expect("walk remains under root");
+                let relative = relative.to_string_lossy().replace('\\', "/");
+                let bytes = fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+                files.insert(relative, bytes);
+                if files.len() > MAX_SOURCE_PACKAGE_ENTRIES
+                    || files.values().map(|bytes| bytes.len() as u64).sum::<u64>()
+                        > MAX_SOURCE_ARTIFACT_BYTES
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package exceeds configured entry or total size bounds",
+                        Some(root.display().to_string()),
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+
+        if !root.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "source_path",
+                "source package root must be a readable directory",
+                Some(root.display().to_string()),
+                None,
+            ));
+        }
+        let mut files = BTreeMap::new();
+        collect(root, root, &mut files)?;
+        if files.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "source_path",
+                "source package root must contain at least one regular file",
+                Some(root.display().to_string()),
+                None,
+            ));
+        }
+        let entries = files
+            .iter()
+            .map(|(path, bytes)| SourcePackageEntry {
+                path: path.clone(),
+                sha256: format!("sha256:{:x}", Sha256::digest(bytes)),
+                size_bytes: bytes.len() as u64,
+            })
+            .collect::<Vec<_>>();
+        let package = serde_json::to_vec(
+            &files
+                .iter()
+                .map(|(path, bytes)| {
+                    (
+                        path,
+                        base64::engine::general_purpose::STANDARD.encode(bytes),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        )
+        .expect("source package serializes");
+        let transfer = Self {
+            schema: SOURCE_ARTIFACT_TRANSFER_SCHEMA.to_string(),
+            artifact_id: artifact_id.into(),
+            sha256: format!("sha256:{:x}", Sha256::digest(&package)),
+            size_bytes: package.len() as u64,
+            content_base64: base64::engine::general_purpose::STANDARD.encode(package),
+            package: SourcePackageManifest {
+                schema: "homeboy/source-package-manifest/v1".into(),
+                format: "homeboy/source-package-json/v1".into(),
+                extraction_root: "workspace".into(),
+                entries,
+            },
+        };
+        transfer.decode_verified()?;
+        Ok(transfer)
+    }
+
     pub fn from_bytes(artifact_id: impl Into<String>, bytes: &[u8]) -> Self {
         let package = serde_json::to_vec(&BTreeMap::from([(
             "source.bin",
@@ -679,5 +800,30 @@ pub(crate) mod tests_support {
         assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
         assert_eq!(incompatible.calls, 0);
         assert_eq!(incompatible.provider_budget, 0);
+    }
+
+    #[test]
+    fn source_tree_package_is_deterministic_and_preserves_manifest_entries() {
+        let source = tempfile::tempdir().expect("source");
+        std::fs::create_dir(source.path().join("nested")).expect("nested");
+        std::fs::write(source.path().join("z.txt"), b"z").expect("z");
+        std::fs::write(source.path().join("nested/a.txt"), b"a").expect("a");
+
+        let first =
+            SourceArtifactTransfer::from_directory("source-1", source.path()).expect("pack");
+        let second =
+            SourceArtifactTransfer::from_directory("source-1", source.path()).expect("repack");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .package
+                .entries
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["nested/a.txt", "z.txt"]
+        );
+        first.decode_verified().expect("verified package");
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -215,7 +215,7 @@ pub fn submit_remote_runner_staging(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests_support {
     use std::collections::HashMap;
 
     use super::*;
@@ -263,7 +263,7 @@ mod tests {
         }
     }
 
-    fn envelope() -> RemoteRunnerStagingEnvelope {
+    pub(crate) fn envelope() -> RemoteRunnerStagingEnvelope {
         let args = vec![
             "homeboy".to_string(),
             "agent-task".to_string(),

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -199,14 +199,11 @@ pub fn submit_remote_runner_staging(
         ));
     }
     if !transport.supports_capability(REMOTE_RUNNER_STAGING_CAPABILITY) {
-        return Err(Error::validation_invalid_argument(
-            "runner_capabilities",
-            format!(
-                "runner `{}` does not support {REMOTE_RUNNER_STAGING_CAPABILITY}",
-                envelope.handoff.runner_id
-            ),
-            Some(envelope.handoff.runner_id.clone()),
-            None,
+        return Err(Error::runner_capability_missing(
+            &envelope.handoff.runner_id,
+            "sealed runner staging",
+            vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+            Vec::new(),
         ));
     }
     let receipt = transport.stage_durable(envelope)?;
@@ -341,7 +338,8 @@ pub(crate) mod tests_support {
             compatible: false,
             ..transport()
         };
-        assert!(submit_remote_runner_staging(&mut incompatible, &envelope).is_err());
+        let error = submit_remote_runner_staging(&mut incompatible, &envelope).expect_err("refuse");
+        assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
         assert_eq!(incompatible.calls, 0);
         assert_eq!(incompatible.provider_budget, 0);
         let mut disconnected = Transport {

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -8,6 +8,7 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy_core::{Error, Result};
 
@@ -21,6 +22,25 @@ pub const SEALED_SOURCE_AUTHORITY_SCHEMA: &str = "homeboy/sealed-source-authorit
 pub const SOURCE_ARTIFACT_TRANSFER_SCHEMA: &str = "homeboy/runner-source-artifact-transfer/v1";
 pub const RUNNER_SOURCE_ARTIFACT_SCHEMA: &str = "homeboy/runner-source-artifact/v1";
 pub const MAX_SOURCE_ARTIFACT_BYTES: u64 = 4 * 1024 * 1024;
+pub const MAX_SOURCE_PACKAGE_ENTRIES: usize = 1024;
+pub const MAX_SOURCE_PACKAGE_FILE_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourcePackageEntry {
+    pub path: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourcePackageManifest {
+    pub schema: String,
+    pub format: String,
+    pub extraction_root: String,
+    pub entries: Vec<SourcePackageEntry>,
+}
 
 /// Bounded package bytes transferred exactly once during staging. The receipt
 /// carries only [`RunnerSourceArtifact`], never these potentially large bytes.
@@ -32,16 +52,32 @@ pub struct SourceArtifactTransfer {
     pub sha256: String,
     pub size_bytes: u64,
     pub content_base64: String,
+    pub package: SourcePackageManifest,
 }
 
 impl SourceArtifactTransfer {
     pub fn from_bytes(artifact_id: impl Into<String>, bytes: &[u8]) -> Self {
+        let package = serde_json::to_vec(&BTreeMap::from([(
+            "source.bin",
+            base64::engine::general_purpose::STANDARD.encode(bytes),
+        )]))
+        .expect("package");
         Self {
             schema: SOURCE_ARTIFACT_TRANSFER_SCHEMA.to_string(),
             artifact_id: artifact_id.into(),
-            sha256: format!("sha256:{:x}", Sha256::digest(bytes)),
-            size_bytes: bytes.len() as u64,
-            content_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+            sha256: format!("sha256:{:x}", Sha256::digest(&package)),
+            size_bytes: package.len() as u64,
+            content_base64: base64::engine::general_purpose::STANDARD.encode(package),
+            package: SourcePackageManifest {
+                schema: "homeboy/source-package-manifest/v1".into(),
+                format: "homeboy/source-package-json/v1".into(),
+                extraction_root: "workspace".into(),
+                entries: vec![SourcePackageEntry {
+                    path: "source.bin".into(),
+                    sha256: format!("sha256:{:x}", Sha256::digest(bytes)),
+                    size_bytes: bytes.len() as u64,
+                }],
+            },
         }
     }
 
@@ -80,6 +116,7 @@ impl SourceArtifactTransfer {
                 None,
             ));
         }
+        self.package.validate(&bytes)?;
         Ok(bytes)
     }
 
@@ -89,6 +126,7 @@ impl SourceArtifactTransfer {
             artifact_id: self.artifact_id.clone(),
             sha256: self.sha256.clone(),
             size_bytes: self.size_bytes,
+            package: self.package.clone(),
         }
     }
 }
@@ -101,6 +139,7 @@ pub struct RunnerSourceArtifact {
     pub artifact_id: String,
     pub sha256: String,
     pub size_bytes: u64,
+    pub package: SourcePackageManifest,
 }
 
 impl RunnerSourceArtifact {
@@ -118,6 +157,101 @@ impl RunnerSourceArtifact {
                 Some(self.artifact_id.clone()),
                 None,
             ));
+        }
+        self.package.validate_shape()
+    }
+}
+
+impl SourcePackageManifest {
+    fn validate_shape(&self) -> Result<()> {
+        if self.schema != "homeboy/source-package-manifest/v1"
+            || self.format != "homeboy/source-package-json/v1"
+            || self.extraction_root != "workspace"
+            || self.entries.is_empty()
+            || self.entries.len() > MAX_SOURCE_PACKAGE_ENTRIES
+        {
+            return Err(Error::validation_invalid_argument(
+                "source_package",
+                "invalid source package manifest",
+                None,
+                None,
+            ));
+        }
+        let mut paths = BTreeSet::new();
+        let mut total = 0u64;
+        for entry in &self.entries {
+            if entry.path.is_empty()
+                || entry.path.starts_with('/')
+                || entry.path.contains('\\')
+                || entry
+                    .path
+                    .split('/')
+                    .any(|part| part == "." || part == "..")
+                || !paths.insert(&entry.path)
+                || !entry.sha256.starts_with("sha256:")
+                || entry.size_bytes > MAX_SOURCE_PACKAGE_FILE_BYTES
+            {
+                return Err(Error::validation_invalid_argument(
+                    "source_package",
+                    "unsafe, duplicate, or oversized source package path",
+                    Some(entry.path.clone()),
+                    None,
+                ));
+            }
+            total = total.saturating_add(entry.size_bytes);
+        }
+        if total > MAX_SOURCE_ARTIFACT_BYTES {
+            return Err(Error::validation_invalid_argument(
+                "source_package",
+                "source package exceeds total size bound",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+    fn validate(&self, bytes: &[u8]) -> Result<()> {
+        self.validate_shape()?;
+        let files: BTreeMap<String, String> = serde_json::from_slice(bytes).map_err(|error| {
+            Error::validation_invalid_argument("source_package", error.to_string(), None, None)
+        })?;
+        if files.len() != self.entries.len() {
+            return Err(Error::validation_invalid_argument(
+                "source_package",
+                "source package entries do not match manifest",
+                None,
+                None,
+            ));
+        }
+        for entry in &self.entries {
+            let encoded = files.get(&entry.path).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "source_package",
+                    "source package entry is missing",
+                    Some(entry.path.clone()),
+                    None,
+                )
+            })?;
+            let content = base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "source_package",
+                        error.to_string(),
+                        Some(entry.path.clone()),
+                        None,
+                    )
+                })?;
+            if content.len() as u64 != entry.size_bytes
+                || format!("sha256:{:x}", Sha256::digest(&content)) != entry.sha256
+            {
+                return Err(Error::validation_invalid_argument(
+                    "source_package",
+                    "source package entry does not match manifest",
+                    Some(entry.path.clone()),
+                    None,
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -497,7 +497,7 @@ pub(crate) mod tests_support {
     use crate::lab_staging_controller::LabStagingRecipe;
     use homeboy_core::lab_contract::LabCommandContract;
 
-    struct Transport {
+    pub(crate) struct Transport {
         connected: bool,
         compatible: bool,
         source_artifact_compatible: bool,
@@ -540,8 +540,35 @@ pub(crate) mod tests_support {
             };
             self.receipts
                 .insert(envelope.handoff.idempotency_key.clone(), receipt.clone());
-            self.provider_budget += 1;
             Ok(receipt)
+        }
+    }
+
+    impl Transport {
+        pub(crate) fn compatible() -> Self {
+            transport()
+        }
+
+        pub(crate) fn incompatible() -> Self {
+            Self {
+                compatible: false,
+                ..transport()
+            }
+        }
+
+        pub(crate) fn disconnected() -> Self {
+            Self {
+                connected: false,
+                ..transport()
+            }
+        }
+
+        pub(crate) fn calls(&self) -> usize {
+            self.calls
+        }
+
+        pub(crate) fn provider_budget(&self) -> usize {
+            self.provider_budget
         }
     }
 
@@ -617,7 +644,7 @@ pub(crate) mod tests_support {
         let replay = submit_remote_runner_staging(&mut transport, &envelope).expect("replay");
         assert_eq!(first, replay);
         assert_eq!(transport.receipts.len(), 1);
-        assert_eq!(transport.provider_budget, 1);
+        assert_eq!(transport.provider_budget, 0);
         assert_eq!(first.artifacts.lifecycle_id, "runner-lifecycle-1");
     }
 

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -5,7 +5,9 @@
 //! instruction to resolve controller state; it durably owns materialization,
 //! staging artifacts, and the replayable receipt.
 
+use base64::Engine;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use homeboy_core::{Error, Result};
 
@@ -14,7 +16,112 @@ use crate::direct_lab_handoff::{DirectLabHandoffEnvelope, DirectLabHandoffReceip
 pub const REMOTE_RUNNER_STAGING_SCHEMA: &str = "homeboy/remote-runner-staging/v1";
 pub const REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA: &str = "homeboy/remote-runner-staging-receipt/v1";
 pub const REMOTE_RUNNER_STAGING_CAPABILITY: &str = "remote-runner-staging/v1";
+pub const REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY: &str = "remote-runner-source-artifact/v1";
 pub const SEALED_SOURCE_AUTHORITY_SCHEMA: &str = "homeboy/sealed-source-authority/v1";
+pub const SOURCE_ARTIFACT_TRANSFER_SCHEMA: &str = "homeboy/runner-source-artifact-transfer/v1";
+pub const RUNNER_SOURCE_ARTIFACT_SCHEMA: &str = "homeboy/runner-source-artifact/v1";
+pub const MAX_SOURCE_ARTIFACT_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Bounded package bytes transferred exactly once during staging. The receipt
+/// carries only [`RunnerSourceArtifact`], never these potentially large bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourceArtifactTransfer {
+    pub schema: String,
+    pub artifact_id: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub content_base64: String,
+}
+
+impl SourceArtifactTransfer {
+    pub fn from_bytes(artifact_id: impl Into<String>, bytes: &[u8]) -> Self {
+        Self {
+            schema: SOURCE_ARTIFACT_TRANSFER_SCHEMA.to_string(),
+            artifact_id: artifact_id.into(),
+            sha256: format!("sha256:{:x}", Sha256::digest(bytes)),
+            size_bytes: bytes.len() as u64,
+            content_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        }
+    }
+
+    pub fn decode_verified(&self) -> Result<Vec<u8>> {
+        if self.schema != SOURCE_ARTIFACT_TRANSFER_SCHEMA
+            || self.artifact_id.trim().is_empty()
+            || self.artifact_id.contains('/')
+            || self.artifact_id.contains('\\')
+            || !self.sha256.starts_with("sha256:")
+            || self.size_bytes > MAX_SOURCE_ARTIFACT_BYTES
+        {
+            return Err(Error::validation_invalid_argument(
+                "source_artifact",
+                "remote staging requires a bounded v1 source artifact transfer",
+                Some(self.artifact_id.clone()),
+                None,
+            ));
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&self.content_base64)
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "source_artifact.content_base64",
+                    error.to_string(),
+                    Some(self.artifact_id.clone()),
+                    None,
+                )
+            })?;
+        if bytes.len() as u64 != self.size_bytes
+            || format!("sha256:{:x}", Sha256::digest(&bytes)) != self.sha256
+        {
+            return Err(Error::validation_invalid_argument(
+                "source_artifact",
+                "source artifact bytes do not match their declared size and SHA-256 digest",
+                Some(self.artifact_id.clone()),
+                None,
+            ));
+        }
+        Ok(bytes)
+    }
+
+    pub fn descriptor(&self) -> RunnerSourceArtifact {
+        RunnerSourceArtifact {
+            schema: RUNNER_SOURCE_ARTIFACT_SCHEMA.to_string(),
+            artifact_id: self.artifact_id.clone(),
+            sha256: self.sha256.clone(),
+            size_bytes: self.size_bytes,
+        }
+    }
+}
+
+/// Immutable, retrievable source-package identity returned by staging.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerSourceArtifact {
+    pub schema: String,
+    pub artifact_id: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+impl RunnerSourceArtifact {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != RUNNER_SOURCE_ARTIFACT_SCHEMA
+            || self.artifact_id.trim().is_empty()
+            || self.artifact_id.contains('/')
+            || self.artifact_id.contains('\\')
+            || !self.sha256.starts_with("sha256:")
+            || self.size_bytes > MAX_SOURCE_ARTIFACT_BYTES
+        {
+            return Err(Error::validation_invalid_argument(
+                "source_artifact",
+                "invalid runner source artifact descriptor",
+                Some(self.artifact_id.clone()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
 
 /// Opaque, self-contained source authority. The producer seals the source
 /// payload before transport; its private filesystem location is never part of
@@ -61,6 +168,8 @@ pub struct RunnerMaterializationAuthority {
     pub authority_id: String,
     pub workspace_key: String,
     pub source: SealedSourceAuthority,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_artifact: Option<SourceArtifactTransfer>,
 }
 
 impl RunnerMaterializationAuthority {
@@ -77,7 +186,19 @@ impl RunnerMaterializationAuthority {
                 None,
             ));
         }
-        self.source.validate()
+        self.source.validate()?;
+        self.source_artifact
+            .as_ref()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "source_artifact",
+                    "remote staging requires a transferable source artifact before admission",
+                    Some(self.authority_id.clone()),
+                    None,
+                )
+            })?
+            .decode_verified()
+            .map(|_| ())
     }
 }
 
@@ -139,6 +260,8 @@ pub struct RunnerStagingArtifacts {
     pub lifecycle_id: String,
     pub source_artifact_id: String,
     pub workspace_artifact_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_artifact: Option<RunnerSourceArtifact>,
 }
 
 /// Durable runner receipt. Replays return this exact value for the same
@@ -165,6 +288,18 @@ impl RemoteRunnerStagingReceipt {
                 None,
             ));
         }
+        self.artifacts
+            .source_artifact
+            .as_ref()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "remote_runner_staging_receipt.source_artifact",
+                    "remote staging receipt is missing its immutable source artifact",
+                    Some(envelope.handoff.run_id.clone()),
+                    None,
+                )
+            })?
+            .validate()?;
         self.handoff.validate_for(&envelope.handoff)
     }
 }
@@ -206,6 +341,14 @@ pub fn submit_remote_runner_staging(
             Vec::new(),
         ));
     }
+    if !transport.supports_capability(REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY) {
+        return Err(Error::runner_capability_missing(
+            &envelope.handoff.runner_id,
+            "sealed runner source artifact transfer",
+            vec![REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string()],
+            Vec::new(),
+        ));
+    }
     let receipt = transport.stage_durable(envelope)?;
     receipt.validate_for(envelope)?;
     Ok(receipt)
@@ -223,6 +366,7 @@ pub(crate) mod tests_support {
     struct Transport {
         connected: bool,
         compatible: bool,
+        source_artifact_compatible: bool,
         calls: usize,
         provider_budget: usize,
         receipts: HashMap<String, RemoteRunnerStagingReceipt>,
@@ -233,7 +377,9 @@ pub(crate) mod tests_support {
             self.connected
         }
         fn supports_capability(&self, capability: &str) -> bool {
-            self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY
+            (self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY)
+                || (self.source_artifact_compatible
+                    && capability == REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY)
         }
         fn stage_durable(
             &mut self,
@@ -251,6 +397,11 @@ pub(crate) mod tests_support {
                     lifecycle_id: "runner-lifecycle-1".to_string(),
                     source_artifact_id: "runner-source-1".to_string(),
                     workspace_artifact_id: "runner-workspace-1".to_string(),
+                    source_artifact: envelope
+                        .materialization
+                        .source_artifact
+                        .as_ref()
+                        .map(SourceArtifactTransfer::descriptor),
                 },
             };
             self.receipts
@@ -300,6 +451,10 @@ pub(crate) mod tests_support {
                 authority_id: "authority-1".to_string(),
                 workspace_key: "run-1".to_string(),
                 source: SealedSourceAuthority::new("sha256:source-1", "sealed-source-payload"),
+                source_artifact: Some(SourceArtifactTransfer::from_bytes(
+                    "source-package-1",
+                    b"source package",
+                )),
             },
         )
         .expect("sealed envelope")
@@ -309,6 +464,7 @@ pub(crate) mod tests_support {
         Transport {
             connected: true,
             compatible: true,
+            source_artifact_compatible: true,
             calls: 0,
             provider_budget: 0,
             receipts: HashMap::new(),
@@ -349,5 +505,18 @@ pub(crate) mod tests_support {
         assert!(submit_remote_runner_staging(&mut disconnected, &envelope).is_err());
         assert_eq!(disconnected.calls, 0);
         assert_eq!(disconnected.provider_budget, 0);
+    }
+
+    #[test]
+    fn source_artifact_capability_is_negotiated_before_admission() {
+        let envelope = envelope();
+        let mut incompatible = Transport {
+            source_artifact_compatible: false,
+            ..transport()
+        };
+        let error = submit_remote_runner_staging(&mut incompatible, &envelope).expect_err("refuse");
+        assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
+        assert_eq!(incompatible.calls, 0);
+        assert_eq!(incompatible.provider_budget, 0);
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 
 use homeboy_core::{Error, Result};
@@ -19,11 +20,52 @@ use homeboy_core::{Error, Result};
 use crate::direct_lab_handoff::DirectLabHandoffReceipt;
 use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt, RemoteRunnerStagingTransport,
-    RunnerStagingArtifacts, REMOTE_RUNNER_STAGING_CAPABILITY, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
+    RunnerSourceArtifact, RunnerStagingArtifacts, SourceArtifactTransfer,
+    REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY, REMOTE_RUNNER_STAGING_CAPABILITY,
+    REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
 };
 use crate::{broker_submit_token_for_runner, RunnerSession, RunnerTunnelMode};
 
 const STORE_SCHEMA: &str = "homeboy/remote-runner-staging-store/v1";
+
+/// Read the verified source package named by a staging receipt. Execution code
+/// uses this before extracting its own workspace; it never receives controller
+/// paths or the transfer's inline content.
+pub fn read_staged_source_artifact(
+    store_path: impl AsRef<Path>,
+    artifact: &RunnerSourceArtifact,
+) -> Result<Vec<u8>> {
+    artifact.validate()?;
+    let path = store_path
+        .as_ref()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("source-artifacts")
+        .join(&artifact.artifact_id);
+    let bytes = fs::read(&path).map_err(|error| {
+        Error::validation_invalid_argument(
+            "source_artifact",
+            "staged source artifact is unavailable",
+            Some(artifact.artifact_id.clone()),
+            Some(vec![format!(
+                "restore or retransmit source artifact at {}",
+                path.display()
+            )]),
+        )
+        .with_source(error)
+    })?;
+    if bytes.len() as u64 != artifact.size_bytes
+        || format!("sha256:{:x}", Sha256::digest(&bytes)) != artifact.sha256
+    {
+        return Err(Error::validation_invalid_argument(
+            "source_artifact",
+            "staged source artifact no longer matches its immutable descriptor",
+            Some(artifact.artifact_id.clone()),
+            None,
+        ));
+    }
+    Ok(bytes)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -102,6 +144,13 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 None,
             ));
         }
+        let transfer = envelope
+            .materialization
+            .source_artifact
+            .as_ref()
+            .expect("envelope validation requires source artifact");
+        let bytes = transfer.decode_verified()?;
+        let source_artifact = transfer.descriptor();
         let _lock = self.admission_lock()?;
         let mut state = self.load()?;
         let key = &envelope.handoff.idempotency_key;
@@ -114,11 +163,13 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                     None,
                 ));
             }
+            self.verify_source_artifact(&source_artifact)?;
             return Ok(existing.receipt.clone());
         }
 
         // The lock covers materialization and receipt publication. Concurrent
         // requests therefore observe one durable admission, not two writes.
+        self.persist_source_artifact(&source_artifact, &bytes)?;
         let artifacts = self.materializer.materialize(envelope)?;
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
@@ -126,7 +177,10 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 &envelope.handoff,
                 format!("staging-{}", envelope.handoff.run_id),
             ),
-            artifacts,
+            artifacts: RunnerStagingArtifacts {
+                source_artifact: Some(source_artifact),
+                ..artifacts
+            },
         };
         receipt.validate_for(envelope)?;
         state.stages.insert(
@@ -200,6 +254,72 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
             Error::internal_io(
                 error.error.to_string(),
                 Some(format!("publish {}", self.path.display())),
+            )
+        })?;
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("sync {}", parent.display())),
+                )
+            })
+    }
+
+    /// Return verified, runner-owned package bytes for the later execution
+    /// layer. The receipt descriptor remains the only authority it needs.
+    pub fn read_source_artifact(&self, artifact: &RunnerSourceArtifact) -> Result<Vec<u8>> {
+        read_staged_source_artifact(&self.path, artifact)
+    }
+
+    fn source_artifact_path(&self, artifact: &RunnerSourceArtifact) -> Result<PathBuf> {
+        artifact.validate()?;
+        Ok(self
+            .path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("source-artifacts")
+            .join(&artifact.artifact_id))
+    }
+
+    fn verify_source_artifact(&self, artifact: &RunnerSourceArtifact) -> Result<()> {
+        read_staged_source_artifact(&self.path, artifact).map(|_| ())
+    }
+
+    fn persist_source_artifact(&self, artifact: &RunnerSourceArtifact, bytes: &[u8]) -> Result<()> {
+        let path = self.source_artifact_path(artifact)?;
+        if path.exists() {
+            return self.verify_source_artifact(artifact);
+        }
+        let parent = path.parent().expect("source artifact has parent");
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+        let mut temporary = NamedTempFile::new_in(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create source artifact in {}", parent.display())),
+            )
+        })?;
+        temporary.write_all(bytes).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write source artifact {}", artifact.artifact_id)),
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("sync source artifact {}", artifact.artifact_id)),
+            )
+        })?;
+        temporary.persist_noclobber(&path).map_err(|error| {
+            Error::internal_io(
+                error.error.to_string(),
+                Some(format!("publish source artifact {}", artifact.artifact_id)),
             )
         })?;
         File::open(parent)
@@ -303,7 +423,11 @@ impl<M: RunnerStagingMaterializer> RemoteRunnerStagingTransport for RunnerStagin
         self.connected
     }
     fn supports_capability(&self, capability: &str) -> bool {
-        self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY
+        self.compatible
+            && matches!(
+                capability,
+                REMOTE_RUNNER_STAGING_CAPABILITY | REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY
+            )
     }
     fn stage_durable(
         &mut self,
@@ -523,6 +647,7 @@ impl RunnerStagingMaterializer for SealedPayloadMaterializer {
                 envelope.materialization.source.content_digest
             ),
             workspace_artifact_id: format!("workspace:{}", envelope.materialization.workspace_key),
+            source_artifact: None,
         })
     }
 }
@@ -531,7 +656,10 @@ struct ProductionStagingProvider;
 
 impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionStagingProvider {
     fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
-        Ok(vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()])
+        Ok(vec![
+            REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+            REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
+        ])
     }
 
     fn stage(&self, request: serde_json::Value) -> Result<serde_json::Value> {
@@ -609,6 +737,7 @@ mod tests {
                     "workspace-{}",
                     envelope.materialization.workspace_key
                 ),
+                source_artifact: None,
             })
         }
     }
@@ -677,6 +806,7 @@ mod tests {
                 lifecycle_id: format!("lifecycle-{}", envelope.handoff.run_id),
                 source_artifact_id: "source-1".to_string(),
                 workspace_artifact_id: "workspace-1".to_string(),
+                source_artifact: None,
             })
         }
     }
@@ -706,6 +836,66 @@ mod tests {
         let second = workers.remove(0).join().expect("second worker");
         assert_eq!(first, second);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn staged_source_artifact_is_retrievable_and_tampering_is_refused() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("staging.json");
+        let request = envelope();
+        let mut initial = transport(&path);
+        let receipt = initial.stage_durable(&request).expect("stage");
+        let source = receipt.artifacts.source_artifact.expect("source artifact");
+        assert_eq!(
+            initial.store.read_source_artifact(&source).expect("source"),
+            b"source package"
+        );
+        fs::write(
+            initial.store.source_artifact_path(&source).expect("path"),
+            b"tampered",
+        )
+        .expect("tamper");
+        let mut restarted = transport(&path);
+        let error = restarted
+            .stage_durable(&request)
+            .expect_err("tampered source refusal");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::ValidationInvalidArgument
+        );
+        assert_eq!(restarted.store.materializer.calls, 0);
+    }
+
+    #[test]
+    fn missing_staged_source_is_refused_on_receipt_replay() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("staging.json");
+        let request = envelope();
+        let mut initial = transport(&path);
+        let receipt = initial.stage_durable(&request).expect("stage");
+        let source = receipt.artifacts.source_artifact.expect("source artifact");
+        fs::remove_file(initial.store.source_artifact_path(&source).expect("path"))
+            .expect("remove");
+        let mut restarted = transport(&path);
+        let error = restarted
+            .stage_durable(&request)
+            .expect_err("missing source refusal");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::ValidationInvalidArgument
+        );
+        assert_eq!(restarted.store.materializer.calls, 0);
+    }
+
+    #[test]
+    fn source_transfer_rejects_declared_size_above_bound() {
+        let mut source = SourceArtifactTransfer::from_bytes("source-package-1", b"source package");
+        source.size_bytes = crate::runner_staging_operation::MAX_SOURCE_ARTIFACT_BYTES + 1;
+        let error = source.decode_verified().expect_err("size bound");
+        assert_eq!(
+            error.code,
+            homeboy_core::ErrorCode::ValidationInvalidArgument
+        );
     }
 
     #[test]
@@ -739,6 +929,11 @@ mod tests {
                 lifecycle_id: "lifecycle-1".to_string(),
                 source_artifact_id: "source-1".to_string(),
                 workspace_artifact_id: "workspace-1".to_string(),
+                source_artifact: request
+                    .materialization
+                    .source_artifact
+                    .as_ref()
+                    .map(SourceArtifactTransfer::descriptor),
             },
         };
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -747,7 +942,10 @@ mod tests {
         let mut direct = ProductionRunnerStagingTransport {
             runner_id: "runner-1".to_string(),
             session: direct_session,
-            capabilities: vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+            capabilities: vec![
+                REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
+            ],
         };
         assert_eq!(
             submit_remote_runner_staging(&mut direct, &request).expect("direct"),
@@ -758,7 +956,10 @@ mod tests {
         let mut reverse = ProductionRunnerStagingTransport {
             runner_id: "runner-1".to_string(),
             session: reverse_session,
-            capabilities: vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+            capabilities: vec![
+                REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
+            ],
         };
         assert_eq!(
             submit_remote_runner_staging(&mut reverse, &request).expect("reverse"),

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -129,12 +129,23 @@ struct StoredStage {
     envelope: RemoteRunnerStagingEnvelope,
     receipt: RemoteRunnerStagingReceipt,
 }
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StagingIntent {
+    envelope: RemoteRunnerStagingEnvelope,
+    source_artifact: RunnerSourceArtifact,
+    state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    runner_job_id: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StagingStoreState {
     schema: String,
     stages: BTreeMap<String, StoredStage>,
+    #[serde(default)]
+    intents: BTreeMap<String, StagingIntent>,
 }
 
 impl Default for StagingStoreState {
@@ -142,6 +153,7 @@ impl Default for StagingStoreState {
         Self {
             schema: STORE_SCHEMA.to_string(),
             stages: BTreeMap::new(),
+            intents: BTreeMap::new(),
         }
     }
 }
@@ -200,6 +212,16 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
         runner_job_id: impl Into<String>,
     ) -> Result<RemoteRunnerStagingReceipt> {
         let runner_job_id = runner_job_id.into();
+        self.stage_durable_with_submit(envelope, |_| Ok(runner_job_id))
+    }
+
+    /// Lock-held admission state machine: intent -> source_ready -> job_submitted
+    /// -> receipt. `submit` must use the handoff idempotency key.
+    pub fn stage_durable_with_submit(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+        submit: impl FnOnce(&RemoteRunnerStagingEnvelope) -> Result<String>,
+    ) -> Result<RemoteRunnerStagingReceipt> {
         envelope.validate()?;
         if envelope.handoff.runner_id != self.runner_id {
             return Err(Error::validation_invalid_argument(
@@ -232,9 +254,38 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
             return Ok(existing.receipt.clone());
         }
 
+        state
+            .intents
+            .entry(key.clone())
+            .or_insert_with(|| StagingIntent {
+                envelope: envelope.clone(),
+                source_artifact: source_artifact.clone(),
+                state: "intent_created".to_string(),
+                runner_job_id: None,
+            });
+        self.persist(&state)?;
+
         // The lock covers materialization and receipt publication. Concurrent
         // requests therefore observe one durable admission, not two writes.
         self.persist_source_artifact(&source_artifact, &bytes)?;
+        // Source bytes are now durable before any queue entry can become claimable.
+        state.intents.get_mut(key).expect("intent").state = "source_ready".to_string();
+        self.persist(&state)?;
+        let runner_job_id = match state
+            .intents
+            .get(key)
+            .and_then(|intent| intent.runner_job_id.clone())
+        {
+            Some(job_id) => job_id,
+            None => {
+                let job_id = submit(envelope)?;
+                let intent = state.intents.get_mut(key).expect("intent");
+                intent.runner_job_id = Some(job_id.clone());
+                intent.state = "job_submitted".to_string();
+                self.persist(&state)?;
+                job_id
+            }
+        };
         let artifacts = self.materializer.materialize(envelope)?;
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
@@ -252,6 +303,7 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 receipt: receipt.clone(),
             },
         );
+        state.intents.remove(key);
         self.persist(&state)?;
         Ok(receipt)
     }
@@ -767,34 +819,37 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
             .as_ref()
             .expect("validated source artifact")
             .descriptor();
-        let job =
-            jobs.submit_remote_runner_job(homeboy_core::api_jobs::RemoteRunnerJobRequest {
-                runner_id: request.envelope.handoff.runner_id.clone(),
-                project_id: None,
-                operation: "runner_staged_execution".to_string(),
-                command: request.envelope.handoff.recipe.normalized_args.clone(),
-                cwd: None,
-                env: std::collections::HashMap::new(),
-                secret_env_names: Vec::new(),
-                secret_env_plan: Default::default(),
-                env_materialization: None,
-                capture_patch: request.envelope.handoff.recipe.capture_patch,
-                source_snapshot: None,
-                path_materialization_plan: None,
-                require_paths: Vec::new(),
-                extension_env_providers: Vec::new(),
-                lab_runner_workload: None,
-                lifecycle: None,
-                workspace_claim_binding: None,
-                workspace_owner_lease: None,
-                metadata: Some(serde_json::json!({
-                    "submission_key": request.envelope.handoff.idempotency_key,
-                    "staged_source_artifact": source_artifact,
-                })),
-            })?;
         let receipt = transport
             .store
-            .stage_durable_with_job_id(&request.envelope, job.id.to_string())?;
+            .stage_durable_with_submit(&request.envelope, |envelope| {
+                let job = jobs.submit_remote_runner_job(
+                    homeboy_core::api_jobs::RemoteRunnerJobRequest {
+                        runner_id: envelope.handoff.runner_id.clone(),
+                        project_id: None,
+                        operation: "runner_staged_execution".to_string(),
+                        command: envelope.handoff.recipe.normalized_args.clone(),
+                        cwd: None,
+                        env: std::collections::HashMap::new(),
+                        secret_env_names: Vec::new(),
+                        secret_env_plan: Default::default(),
+                        env_materialization: None,
+                        capture_patch: envelope.handoff.recipe.capture_patch,
+                        source_snapshot: None,
+                        path_materialization_plan: None,
+                        require_paths: Vec::new(),
+                        extension_env_providers: Vec::new(),
+                        lab_runner_workload: None,
+                        lifecycle: None,
+                        workspace_claim_binding: None,
+                        workspace_owner_lease: None,
+                        metadata: Some(serde_json::json!({
+                            "submission_key": envelope.handoff.idempotency_key,
+                            "staged_source_artifact": source_artifact,
+                        })),
+                    },
+                )?;
+                Ok(job.id.to_string())
+            })?;
         Ok(serde_json::json!({ "receipt": receipt }))
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -5,9 +5,14 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 use homeboy_core::{Error, Result};
 
@@ -97,6 +102,7 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 None,
             ));
         }
+        let _lock = self.admission_lock()?;
         let mut state = self.load()?;
         let key = &envelope.handoff.idempotency_key;
         if let Some(existing) = state.stages.get(key) {
@@ -111,8 +117,8 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
             return Ok(existing.receipt.clone());
         }
 
-        // Materialization happens before this receipt is acknowledged and only
-        // after the runner, schema, and source authority have all been checked.
+        // The lock covers materialization and receipt publication. Concurrent
+        // requests therefore observe one durable admission, not two writes.
         let artifacts = self.materializer.materialize(envelope)?;
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
@@ -153,7 +159,64 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
     }
 
     fn persist(&self, state: &StagingStoreState) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+        let bytes = serde_json::to_vec(state).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize remote runner staging store".to_string()),
+            )
+        })?;
+        let mut temporary = NamedTempFile::new_in(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create staging temporary in {}", parent.display())),
+            )
+        })?;
+        temporary.write_all(&bytes).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "write staging temporary for {}",
+                    self.path.display()
+                )),
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "sync staging temporary for {}",
+                    self.path.display()
+                )),
+            )
+        })?;
+        temporary.persist(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.error.to_string(),
+                Some(format!("publish {}", self.path.display())),
+            )
+        })?;
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("sync {}", parent.display())),
+                )
+            })
+    }
+
+    fn admission_lock(&self) -> Result<File> {
+        const LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+        const LOCK_RETRY: Duration = Duration::from_millis(25);
+        let lock_path = self.path.with_extension("lock");
+        if let Some(parent) = lock_path.parent() {
             fs::create_dir_all(parent).map_err(|error| {
                 Error::internal_io(
                     error.to_string(),
@@ -161,25 +224,49 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 )
             })?;
         }
-        let temporary = self.path.with_extension("staging.tmp");
-        let bytes = serde_json::to_vec(state).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("serialize remote runner staging store".to_string()),
-            )
-        })?;
-        fs::write(&temporary, bytes).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!("write {}", temporary.display())),
-            )
-        })?;
-        fs::rename(&temporary, &self.path).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!("publish {}", self.path.display())),
-            )
-        })
+        let lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("open {}", lock_path.display())),
+                )
+            })?;
+        let deadline = Instant::now() + LOCK_TIMEOUT;
+        loop {
+            match lock.try_lock_exclusive() {
+                Ok(true) => return Ok(lock),
+                Ok(false) => {}
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {}
+                Err(error) => {
+                    return Err(Error::internal_io(
+                        error.to_string(),
+                        Some(format!("lock {}", lock_path.display())),
+                    ));
+                }
+            }
+            if Instant::now() >= deadline {
+                let mut error = Error::internal_io(
+                    format!(
+                        "timed out after {}ms waiting for staging admission lock",
+                        LOCK_TIMEOUT.as_millis()
+                    ),
+                    Some(format!("lock {}", lock_path.display())),
+                );
+                error.details = serde_json::json!({
+                    "kind": "runner_staging_lock_timeout",
+                    "runner_id": self.runner_id,
+                    "timeout_ms": LOCK_TIMEOUT.as_millis(),
+                });
+                error.retryable = Some(true);
+                return Err(error);
+            }
+            std::thread::sleep(LOCK_RETRY);
+        }
     }
 }
 
@@ -341,7 +428,8 @@ fn production_capabilities(session: &RunnerSession) -> Result<Vec<String>> {
             session,
             "/runner/staging/capabilities",
             &serde_json::json!({ "runner_id": runner_id }),
-        )?,
+        )
+        .map_err(|error| staging_capability_error(runner_id, error))?,
         RunnerTunnelMode::Reverse => {
             let broker_url = session.broker_url.as_deref().ok_or_else(|| {
                 Error::validation_invalid_argument(
@@ -364,7 +452,8 @@ fn production_capabilities(session: &RunnerSession) -> Result<Vec<String>> {
                 serde_json::json!({ "runner_id": runner_id }),
                 "read sealed staging capabilities",
                 broker_submit_token_for_runner(runner_id)?.as_deref(),
-            )?
+            )
+            .map_err(|error| staging_capability_error(runner_id, error))?
         }
     };
     serde_json::from_value(response.get("capabilities").cloned().unwrap_or_default()).map_err(
@@ -375,6 +464,23 @@ fn production_capabilities(session: &RunnerSession) -> Result<Vec<String>> {
             )
         },
     )
+}
+
+fn staging_capability_error(runner_id: &str, error: Error) -> Error {
+    if error
+        .details
+        .get("http_status")
+        .and_then(serde_json::Value::as_u64)
+        == Some(404)
+    {
+        return Error::runner_capability_missing(
+            runner_id,
+            "sealed runner staging",
+            vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+            Vec::new(),
+        );
+    }
+    error
 }
 
 struct SealedPayloadMaterializer {
@@ -474,7 +580,10 @@ pub fn register_runner_staging_provider() {
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier, Mutex,
+    };
 
     use super::*;
     use crate::runner_staging_operation::submit_remote_runner_staging;
@@ -550,6 +659,74 @@ mod tests {
         disconnected.connected = false;
         assert!(submit_remote_runner_staging(&mut disconnected, &request).is_err());
         assert_eq!(disconnected.store.materializer.calls, 0);
+    }
+
+    #[derive(Clone)]
+    struct ConcurrentMaterializer {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl RunnerStagingMaterializer for ConcurrentMaterializer {
+        fn materialize(
+            &mut self,
+            envelope: &RemoteRunnerStagingEnvelope,
+        ) -> Result<RunnerStagingArtifacts> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            Ok(RunnerStagingArtifacts {
+                lifecycle_id: format!("lifecycle-{}", envelope.handoff.run_id),
+                source_artifact_id: "source-1".to_string(),
+                workspace_artifact_id: "workspace-1".to_string(),
+            })
+        }
+    }
+
+    #[test]
+    fn concurrent_admission_materializes_once_and_replays_one_receipt() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("staging.json");
+        let request = envelope();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let path = path.clone();
+            let request = request.clone();
+            let calls = calls.clone();
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                let mut store =
+                    RunnerStagingStore::open(path, "runner-1", ConcurrentMaterializer { calls })
+                        .expect("store");
+                barrier.wait();
+                store.stage_durable(&request).expect("stage")
+            }));
+        }
+        let first = workers.remove(0).join().expect("first worker");
+        let second = workers.remove(0).join().expect("second worker");
+        assert_eq!(first, second);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn old_runner_capability_endpoint_is_a_typed_pre_mutation_refusal() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0; 4096];
+            let _ = stream.read(&mut request).expect("read");
+            let body =
+                serde_json::json!({ "success": false, "error": "unknown route" }).to_string();
+            write!(stream, "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body).expect("response");
+        });
+        let session = production_session(RunnerTunnelMode::DirectSsh, &format!("http://{address}"));
+        let error = production_capabilities(&session).expect_err("old runner refusal");
+        assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
+        assert_eq!(
+            error.details["missing_capabilities"][0],
+            REMOTE_RUNNER_STAGING_CAPABILITY
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -16,6 +16,7 @@ use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt, RemoteRunnerStagingTransport,
     RunnerStagingArtifacts, REMOTE_RUNNER_STAGING_CAPABILITY, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
 };
+use crate::{broker_submit_token_for_runner, RunnerSession, RunnerTunnelMode};
 
 const STORE_SCHEMA: &str = "homeboy/remote-runner-staging-store/v1";
 
@@ -228,8 +229,253 @@ impl<M: RunnerStagingMaterializer> RemoteRunnerStagingTransport for RunnerStagin
 pub type DirectRunnerStagingTransport<M> = RunnerStagingTransport<M>;
 pub type ReverseRunnerStagingTransport<M> = RunnerStagingTransport<M>;
 
+/// Resolve the connected runner into the production HTTP transport. Capability
+/// discovery is read-only and happens before `submit_remote_runner_staging`
+/// reaches its mutation boundary.
+pub fn resolve_runner_staging_transport(
+    runner_id: &str,
+) -> Result<ProductionRunnerStagingTransport> {
+    let report = crate::status(runner_id)?;
+    let session = report.session.filter(|_| report.connected).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "runner_connection",
+            format!("runner `{runner_id}` is disconnected"),
+            Some(runner_id.to_string()),
+            None,
+        )
+    })?;
+    let capabilities = production_capabilities(&session)?;
+    Ok(ProductionRunnerStagingTransport {
+        runner_id: runner_id.to_string(),
+        session,
+        capabilities,
+    })
+}
+
+pub struct ProductionRunnerStagingTransport {
+    runner_id: String,
+    session: RunnerSession,
+    capabilities: Vec<String>,
+}
+
+impl RemoteRunnerStagingTransport for ProductionRunnerStagingTransport {
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    fn supports_capability(&self, capability: &str) -> bool {
+        self.capabilities
+            .iter()
+            .any(|candidate| candidate == capability)
+    }
+
+    fn stage_durable(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<RemoteRunnerStagingReceipt> {
+        if envelope.handoff.runner_id != self.runner_id {
+            return Err(Error::validation_invalid_argument(
+                "runner_authority",
+                "sealed staging envelope does not match the resolved runner",
+                Some(envelope.handoff.runner_id.clone()),
+                None,
+            ));
+        }
+        let body = serde_json::to_value(RemoteRunnerStagingRequest::new(envelope.clone()))
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize sealed staging request".to_string()),
+                )
+            })?;
+        let response = match self.session.mode {
+            RunnerTunnelMode::DirectSsh => {
+                let data = crate::execution::daemon_api_post_json_for_session(
+                    &self.session,
+                    "/runner/staging",
+                    &body,
+                )?;
+                crate::execution::canonical_daemon_body(&data, "sealed staging daemon response")
+                    .cloned()?
+            }
+            RunnerTunnelMode::Reverse => {
+                let broker_url = self.session.broker_url.as_deref().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "runner_connection",
+                        "reverse runner has no broker URL",
+                        Some(self.runner_id.clone()),
+                        None,
+                    )
+                })?;
+                let client = reqwest::blocking::Client::builder()
+                    .timeout(std::time::Duration::from_secs(10))
+                    .build()
+                    .map_err(|error| {
+                        Error::internal_unexpected(format!("build staging broker client: {error}"))
+                    })?;
+                crate::broker_http::post_json(
+                    &client,
+                    broker_url,
+                    "/runner/staging",
+                    body,
+                    "submit sealed runner staging",
+                    broker_submit_token_for_runner(&self.runner_id)?.as_deref(),
+                )?
+            }
+        };
+        serde_json::from_value(response.get("receipt").cloned().unwrap_or(response)).map_err(
+            |error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse sealed staging receipt".to_string()),
+                )
+            },
+        )
+    }
+}
+
+fn production_capabilities(session: &RunnerSession) -> Result<Vec<String>> {
+    let runner_id = &session.runner_id;
+    let response = match session.mode {
+        RunnerTunnelMode::DirectSsh => crate::execution::daemon_api_post_json_for_session(
+            session,
+            "/runner/staging/capabilities",
+            &serde_json::json!({ "runner_id": runner_id }),
+        )?,
+        RunnerTunnelMode::Reverse => {
+            let broker_url = session.broker_url.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runner_connection",
+                    "reverse runner has no broker URL",
+                    Some(runner_id.clone()),
+                    None,
+                )
+            })?;
+            let client = reqwest::blocking::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .map_err(|error| {
+                    Error::internal_unexpected(format!("build staging broker client: {error}"))
+                })?;
+            crate::broker_http::post_json(
+                &client,
+                broker_url,
+                "/runner/staging/capabilities",
+                serde_json::json!({ "runner_id": runner_id }),
+                "read sealed staging capabilities",
+                broker_submit_token_for_runner(runner_id)?.as_deref(),
+            )?
+        }
+    };
+    serde_json::from_value(response.get("capabilities").cloned().unwrap_or_default()).map_err(
+        |error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse sealed staging capabilities".to_string()),
+            )
+        },
+    )
+}
+
+struct SealedPayloadMaterializer {
+    root: PathBuf,
+}
+
+impl RunnerStagingMaterializer for SealedPayloadMaterializer {
+    fn materialize(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<RunnerStagingArtifacts> {
+        let stage_root = self.root.join(&envelope.materialization.authority_id);
+        fs::create_dir_all(&stage_root).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", stage_root.display())),
+            )
+        })?;
+        fs::write(
+            stage_root.join("source.sealed"),
+            &envelope.materialization.source.sealed_payload,
+        )
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("persist sealed runner source".to_string()),
+            )
+        })?;
+        let workspace = stage_root.join(&envelope.materialization.workspace_key);
+        fs::create_dir_all(&workspace).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", workspace.display())),
+            )
+        })?;
+        Ok(RunnerStagingArtifacts {
+            lifecycle_id: format!("staging:{}", envelope.handoff.run_id),
+            source_artifact_id: format!(
+                "sealed:{}",
+                envelope.materialization.source.content_digest
+            ),
+            workspace_artifact_id: format!("workspace:{}", envelope.materialization.workspace_key),
+        })
+    }
+}
+
+struct ProductionStagingProvider;
+
+impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionStagingProvider {
+    fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
+        Ok(vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()])
+    }
+
+    fn stage(&self, request: serde_json::Value) -> Result<serde_json::Value> {
+        let request: RemoteRunnerStagingRequest =
+            serde_json::from_value(request).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "remote_runner_staging",
+                    error.to_string(),
+                    None,
+                    None,
+                )
+            })?;
+        if request.schema != RemoteRunnerStagingRequest::SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "remote_runner_staging",
+                "unsupported sealed staging request schema",
+                Some(request.schema),
+                None,
+            ));
+        }
+        let session_path =
+            homeboy_core::paths::runner_session_file(&request.envelope.handoff.runner_id)?;
+        let root =
+            session_path.with_file_name(format!("{}-staging", request.envelope.handoff.runner_id));
+        let store = RunnerStagingStore::open(
+            root.join("store.json"),
+            request.envelope.handoff.runner_id.clone(),
+            SealedPayloadMaterializer { root },
+        )?;
+        let mut transport = RunnerStagingTransport {
+            connected: true,
+            compatible: true,
+            store,
+        };
+        let receipt = transport.stage_durable(&request.envelope)?;
+        Ok(serde_json::json!({ "receipt": receipt }))
+    }
+}
+
+pub fn register_runner_staging_provider() {
+    homeboy_core::daemon::runner_staging::register_runner_staging_provider(Box::new(
+        ProductionStagingProvider,
+    ));
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use crate::runner_staging_operation::submit_remote_runner_staging;
     use crate::runner_staging_operation::tests_support::envelope;
@@ -304,5 +550,122 @@ mod tests {
         disconnected.connected = false;
         assert!(submit_remote_runner_staging(&mut disconnected, &request).is_err());
         assert_eq!(disconnected.store.materializer.calls, 0);
+    }
+
+    #[test]
+    fn production_direct_and_reverse_transports_dispatch_the_versioned_endpoint() {
+        let request = envelope();
+        let receipt = RemoteRunnerStagingReceipt {
+            schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
+            handoff: DirectLabHandoffReceipt::accepted(&request.handoff, "runner-stage-1"),
+            artifacts: RunnerStagingArtifacts {
+                lifecycle_id: "lifecycle-1".to_string(),
+                source_artifact_id: "source-1".to_string(),
+                workspace_artifact_id: "workspace-1".to_string(),
+            },
+        };
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let endpoint = staging_endpoint(receipt.clone(), seen.clone(), 2);
+        let direct_session = production_session(RunnerTunnelMode::DirectSsh, &endpoint);
+        let mut direct = ProductionRunnerStagingTransport {
+            runner_id: "runner-1".to_string(),
+            session: direct_session,
+            capabilities: vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+        };
+        assert_eq!(
+            submit_remote_runner_staging(&mut direct, &request).expect("direct"),
+            receipt
+        );
+
+        let reverse_session = production_session(RunnerTunnelMode::Reverse, &endpoint);
+        let mut reverse = ProductionRunnerStagingTransport {
+            runner_id: "runner-1".to_string(),
+            session: reverse_session,
+            capabilities: vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+        };
+        assert_eq!(
+            submit_remote_runner_staging(&mut reverse, &request).expect("reverse"),
+            receipt
+        );
+        let paths = seen.lock().expect("paths");
+        assert_eq!(paths.as_slice(), ["/runner/staging", "/runner/staging"]);
+    }
+
+    fn production_session(mode: RunnerTunnelMode, endpoint: &str) -> RunnerSession {
+        RunnerSession {
+            runner_id: "runner-1".to_string(),
+            mode: mode.clone(),
+            role: crate::RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: Some("controller-1".to_string()),
+            broker_url: (mode == RunnerTunnelMode::Reverse).then(|| endpoint.to_string()),
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: (mode == RunnerTunnelMode::DirectSsh).then(|| endpoint.to_string()),
+            tunnel_pid: None,
+            tunnel_process_start_identity: None,
+            remote_daemon_pid: None,
+            remote_daemon_lease_id: None,
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "2026-08-05T00:00:00Z".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+            leaseless_recovery_evidence: None,
+        }
+    }
+
+    fn staging_endpoint(
+        receipt: RemoteRunnerStagingReceipt,
+        seen: Arc<Mutex<Vec<String>>>,
+        count: usize,
+    ) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        std::thread::spawn(move || {
+            for _ in 0..count {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let mut request = Vec::new();
+                let mut chunk = [0; 1024];
+                loop {
+                    let read = stream.read(&mut chunk).expect("read");
+                    request.extend_from_slice(&chunk[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let header_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .expect("headers")
+                    + 4;
+                let headers = std::str::from_utf8(&request[..header_end]).expect("headers");
+                let length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.split_once(':')
+                            .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                            .map(|(_, value)| value.trim())
+                    })
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(0);
+                while request.len() < header_end + length {
+                    let read = stream.read(&mut chunk).expect("read body");
+                    request.extend_from_slice(&chunk[..read]);
+                }
+                let first = std::str::from_utf8(&request)
+                    .expect("request")
+                    .lines()
+                    .next()
+                    .expect("line");
+                seen.lock()
+                    .expect("record")
+                    .push(first.split_whitespace().nth(1).expect("path").to_string());
+                let body = serde_json::json!({ "success": true, "data": { "body": { "receipt": receipt } } }).to_string();
+                write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body).expect("response");
+            }
+        });
+        format!("http://{address}")
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -1,0 +1,308 @@
+//! Durable runner-side storage and concrete transports for sealed staging.
+//!
+//! This is deliberately separate from remote process jobs: staging owns the
+//! sealed source and workspace authority before a provider-facing job exists.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_core::{Error, Result};
+
+use crate::direct_lab_handoff::DirectLabHandoffReceipt;
+use crate::runner_staging_operation::{
+    RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt, RemoteRunnerStagingTransport,
+    RunnerStagingArtifacts, REMOTE_RUNNER_STAGING_CAPABILITY, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
+};
+
+const STORE_SCHEMA: &str = "homeboy/remote-runner-staging-store/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredStage {
+    envelope: RemoteRunnerStagingEnvelope,
+    receipt: RemoteRunnerStagingReceipt,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StagingStoreState {
+    schema: String,
+    stages: BTreeMap<String, StoredStage>,
+}
+
+impl Default for StagingStoreState {
+    fn default() -> Self {
+        Self {
+            schema: STORE_SCHEMA.to_string(),
+            stages: BTreeMap::new(),
+        }
+    }
+}
+
+/// The only runner-side mutation used by sealed staging. It receives sealed
+/// content and opaque keys, never a controller filesystem path.
+pub trait RunnerStagingMaterializer {
+    fn materialize(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<RunnerStagingArtifacts>;
+}
+
+/// A file-backed, runner-owned staging ledger. One store belongs to one runner;
+/// binding the runner before any write prevents a controller from staging under
+/// another runner's authority.
+pub struct RunnerStagingStore<M> {
+    path: PathBuf,
+    runner_id: String,
+    materializer: M,
+}
+
+impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
+    pub fn open(
+        path: impl Into<PathBuf>,
+        runner_id: impl Into<String>,
+        materializer: M,
+    ) -> Result<Self> {
+        let store = Self {
+            path: path.into(),
+            runner_id: runner_id.into(),
+            materializer,
+        };
+        let state = store.load()?;
+        if state.schema != STORE_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "staging_store",
+                "unsupported remote runner staging store schema",
+                Some(store.path.display().to_string()),
+                None,
+            ));
+        }
+        Ok(store)
+    }
+
+    pub fn stage_durable(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<RemoteRunnerStagingReceipt> {
+        envelope.validate()?;
+        if envelope.handoff.runner_id != self.runner_id {
+            return Err(Error::validation_invalid_argument(
+                "runner_authority",
+                "sealed staging envelope is not authorized for this runner",
+                Some(envelope.handoff.runner_id.clone()),
+                None,
+            ));
+        }
+        let mut state = self.load()?;
+        let key = &envelope.handoff.idempotency_key;
+        if let Some(existing) = state.stages.get(key) {
+            if existing.envelope != *envelope {
+                return Err(Error::validation_invalid_argument(
+                    "idempotency_key",
+                    "sealed staging key is already bound to a different envelope",
+                    Some(key.clone()),
+                    None,
+                ));
+            }
+            return Ok(existing.receipt.clone());
+        }
+
+        // Materialization happens before this receipt is acknowledged and only
+        // after the runner, schema, and source authority have all been checked.
+        let artifacts = self.materializer.materialize(envelope)?;
+        let receipt = RemoteRunnerStagingReceipt {
+            schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
+            handoff: DirectLabHandoffReceipt::accepted(
+                &envelope.handoff,
+                format!("staging-{}", envelope.handoff.run_id),
+            ),
+            artifacts,
+        };
+        receipt.validate_for(envelope)?;
+        state.stages.insert(
+            key.clone(),
+            StoredStage {
+                envelope: envelope.clone(),
+                receipt: receipt.clone(),
+            },
+        );
+        self.persist(&state)?;
+        Ok(receipt)
+    }
+
+    fn load(&self) -> Result<StagingStoreState> {
+        if !self.path.exists() {
+            return Ok(StagingStoreState::default());
+        }
+        serde_json::from_slice(&fs::read(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", self.path.display())),
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse {}", self.path.display())),
+            )
+        })
+    }
+
+    fn persist(&self, state: &StagingStoreState) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("create {}", parent.display())),
+                )
+            })?;
+        }
+        let temporary = self.path.with_extension("staging.tmp");
+        let bytes = serde_json::to_vec(state).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize remote runner staging store".to_string()),
+            )
+        })?;
+        fs::write(&temporary, bytes).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
+        fs::rename(&temporary, &self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("publish {}", self.path.display())),
+            )
+        })
+    }
+}
+
+/// Versioned request carried by either direct daemon or reverse broker transport.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteRunnerStagingRequest {
+    pub schema: String,
+    pub envelope: RemoteRunnerStagingEnvelope,
+}
+
+impl RemoteRunnerStagingRequest {
+    pub const SCHEMA: &'static str = "homeboy/remote-runner-staging-request/v1";
+
+    pub fn new(envelope: RemoteRunnerStagingEnvelope) -> Self {
+        Self {
+            schema: Self::SCHEMA.to_string(),
+            envelope,
+        }
+    }
+}
+
+/// Direct and reverse routing share the same runner-owned store. The channel is
+/// intentionally not part of the persisted receipt, so either channel replays
+/// the exact accepted result after a reconnect.
+pub struct RunnerStagingTransport<M> {
+    pub connected: bool,
+    pub compatible: bool,
+    pub store: RunnerStagingStore<M>,
+}
+
+impl<M: RunnerStagingMaterializer> RemoteRunnerStagingTransport for RunnerStagingTransport<M> {
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+    fn supports_capability(&self, capability: &str) -> bool {
+        self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY
+    }
+    fn stage_durable(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<RemoteRunnerStagingReceipt> {
+        self.store.stage_durable(envelope)
+    }
+}
+
+pub type DirectRunnerStagingTransport<M> = RunnerStagingTransport<M>;
+pub type ReverseRunnerStagingTransport<M> = RunnerStagingTransport<M>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner_staging_operation::submit_remote_runner_staging;
+    use crate::runner_staging_operation::tests_support::envelope;
+
+    #[derive(Default)]
+    struct Materializer {
+        calls: usize,
+    }
+    impl RunnerStagingMaterializer for Materializer {
+        fn materialize(
+            &mut self,
+            envelope: &RemoteRunnerStagingEnvelope,
+        ) -> Result<RunnerStagingArtifacts> {
+            self.calls += 1;
+            Ok(RunnerStagingArtifacts {
+                lifecycle_id: format!("lifecycle-{}", envelope.handoff.run_id),
+                source_artifact_id: format!(
+                    "source-{}",
+                    envelope.materialization.source.content_digest
+                ),
+                workspace_artifact_id: format!(
+                    "workspace-{}",
+                    envelope.materialization.workspace_key
+                ),
+            })
+        }
+    }
+
+    fn transport(path: &Path) -> RunnerStagingTransport<Materializer> {
+        RunnerStagingTransport {
+            connected: true,
+            compatible: true,
+            store: RunnerStagingStore::open(path, "runner-1", Materializer::default())
+                .expect("store"),
+        }
+    }
+
+    #[test]
+    fn direct_and_reverse_transport_replay_one_runner_owned_receipt() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("staging.json");
+        let request = RemoteRunnerStagingRequest::new(envelope());
+        assert!(!serde_json::to_string(&request)
+            .expect("request")
+            .contains("/controller/private/source"));
+        let mut direct = transport(&path);
+        let first =
+            submit_remote_runner_staging(&mut direct, &request.envelope).expect("direct stage");
+        assert_eq!(direct.store.materializer.calls, 1);
+        let mut reverse: ReverseRunnerStagingTransport<_> = transport(&path);
+        let replay =
+            submit_remote_runner_staging(&mut reverse, &request.envelope).expect("reverse replay");
+        assert_eq!(first, replay);
+        assert_eq!(reverse.store.materializer.calls, 0);
+    }
+
+    #[test]
+    fn restart_replays_and_refusals_happen_before_materialization() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("staging.json");
+        let request = envelope();
+        let mut initial = transport(&path);
+        submit_remote_runner_staging(&mut initial, &request).expect("stage");
+        let mut restarted = transport(&path);
+        submit_remote_runner_staging(&mut restarted, &request).expect("restart replay");
+        assert_eq!(restarted.store.materializer.calls, 0);
+        let mut incompatible = transport(&temp.path().join("incompatible.json"));
+        incompatible.compatible = false;
+        assert!(submit_remote_runner_staging(&mut incompatible, &request).is_err());
+        assert_eq!(incompatible.store.materializer.calls, 0);
+        let mut disconnected = transport(&temp.path().join("disconnected.json"));
+        disconnected.connected = false;
+        assert!(submit_remote_runner_staging(&mut disconnected, &request).is_err());
+        assert_eq!(disconnected.store.materializer.calls, 0);
+    }
+}

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -10,6 +10,7 @@ use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use base64::Engine;
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -20,9 +21,8 @@ use homeboy_core::{Error, Result};
 use crate::direct_lab_handoff::DirectLabHandoffReceipt;
 use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt, RemoteRunnerStagingTransport,
-    RunnerSourceArtifact, RunnerStagingArtifacts, SourceArtifactTransfer,
-    REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY, REMOTE_RUNNER_STAGING_CAPABILITY,
-    REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
+    RunnerSourceArtifact, RunnerStagingArtifacts, REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY,
+    REMOTE_RUNNER_STAGING_CAPABILITY, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
 };
 use crate::{broker_submit_token_for_runner, RunnerSession, RunnerTunnelMode};
 
@@ -65,6 +65,62 @@ pub fn read_staged_source_artifact(
         ));
     }
     Ok(bytes)
+}
+
+/// Materialize a verified package beneath the manifest-declared `workspace`
+/// root. Validated relative entries are the only paths joined to `destination`.
+pub fn extract_staged_source_artifact(
+    store_path: impl AsRef<Path>,
+    artifact: &RunnerSourceArtifact,
+    destination: impl AsRef<Path>,
+) -> Result<PathBuf> {
+    let package = read_staged_source_artifact(store_path, artifact)?;
+    let files: BTreeMap<String, String> = serde_json::from_slice(&package).map_err(|error| {
+        Error::validation_invalid_argument("source_package", error.to_string(), None, None)
+    })?;
+    let root = destination.as_ref().join(&artifact.package.extraction_root);
+    fs::create_dir_all(&root)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
+    for entry in &artifact.package.entries {
+        let encoded = files.get(&entry.path).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "source_package",
+                "source package entry is missing",
+                Some(entry.path.clone()),
+                None,
+            )
+        })?;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "source_package",
+                    error.to_string(),
+                    Some(entry.path.clone()),
+                    None,
+                )
+            })?;
+        if bytes.len() as u64 != entry.size_bytes
+            || format!("sha256:{:x}", Sha256::digest(&bytes)) != entry.sha256
+        {
+            return Err(Error::validation_invalid_argument(
+                "source_package",
+                "source package entry does not match manifest",
+                Some(entry.path.clone()),
+                None,
+            ));
+        }
+        let path = root.join(&entry.path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+            })?;
+        }
+        fs::write(&path, bytes).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+    }
+    Ok(root)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,6 +191,15 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
         &mut self,
         envelope: &RemoteRunnerStagingEnvelope,
     ) -> Result<RemoteRunnerStagingReceipt> {
+        self.stage_durable_with_job_id(envelope, format!("staging-{}", envelope.handoff.run_id))
+    }
+
+    pub fn stage_durable_with_job_id(
+        &mut self,
+        envelope: &RemoteRunnerStagingEnvelope,
+        runner_job_id: impl Into<String>,
+    ) -> Result<RemoteRunnerStagingReceipt> {
+        let runner_job_id = runner_job_id.into();
         envelope.validate()?;
         if envelope.handoff.runner_id != self.runner_id {
             return Err(Error::validation_invalid_argument(
@@ -173,10 +238,7 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
         let artifacts = self.materializer.materialize(envelope)?;
         let receipt = RemoteRunnerStagingReceipt {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
-            handoff: DirectLabHandoffReceipt::accepted(
-                &envelope.handoff,
-                format!("staging-{}", envelope.handoff.run_id),
-            ),
+            handoff: DirectLabHandoffReceipt::accepted(&envelope.handoff, runner_job_id),
             artifacts: RunnerStagingArtifacts {
                 source_artifact: Some(source_artifact),
                 ..artifacts
@@ -662,7 +724,11 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
         ])
     }
 
-    fn stage(&self, request: serde_json::Value) -> Result<serde_json::Value> {
+    fn stage(
+        &self,
+        request: serde_json::Value,
+        jobs: &homeboy_core::api_jobs::JobStore,
+    ) -> Result<serde_json::Value> {
         let request: RemoteRunnerStagingRequest =
             serde_json::from_value(request).map_err(|error| {
                 Error::validation_invalid_argument(
@@ -694,7 +760,41 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
             compatible: true,
             store,
         };
-        let receipt = transport.stage_durable(&request.envelope)?;
+        let source_artifact = request
+            .envelope
+            .materialization
+            .source_artifact
+            .as_ref()
+            .expect("validated source artifact")
+            .descriptor();
+        let job =
+            jobs.submit_remote_runner_job(homeboy_core::api_jobs::RemoteRunnerJobRequest {
+                runner_id: request.envelope.handoff.runner_id.clone(),
+                project_id: None,
+                operation: "runner_staged_execution".to_string(),
+                command: request.envelope.handoff.recipe.normalized_args.clone(),
+                cwd: None,
+                env: std::collections::HashMap::new(),
+                secret_env_names: Vec::new(),
+                secret_env_plan: Default::default(),
+                env_materialization: None,
+                capture_patch: request.envelope.handoff.recipe.capture_patch,
+                source_snapshot: None,
+                path_materialization_plan: None,
+                require_paths: Vec::new(),
+                extension_env_providers: Vec::new(),
+                lab_runner_workload: None,
+                lifecycle: None,
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
+                metadata: Some(serde_json::json!({
+                    "submission_key": request.envelope.handoff.idempotency_key,
+                    "staged_source_artifact": source_artifact,
+                })),
+            })?;
+        let receipt = transport
+            .store
+            .stage_durable_with_job_id(&request.envelope, job.id.to_string())?;
         Ok(serde_json::json!({ "receipt": receipt }))
     }
 }
@@ -846,8 +946,10 @@ mod tests {
         let mut initial = transport(&path);
         let receipt = initial.stage_durable(&request).expect("stage");
         let source = receipt.artifacts.source_artifact.expect("source artifact");
+        let extracted = extract_staged_source_artifact(&path, &source, temp.path().join("extract"))
+            .expect("extract");
         assert_eq!(
-            initial.store.read_source_artifact(&source).expect("source"),
+            fs::read(extracted.join("source.bin")).expect("source"),
             b"source package"
         );
         fs::write(
@@ -889,7 +991,10 @@ mod tests {
 
     #[test]
     fn source_transfer_rejects_declared_size_above_bound() {
-        let mut source = SourceArtifactTransfer::from_bytes("source-package-1", b"source package");
+        let mut source = crate::runner_staging_operation::SourceArtifactTransfer::from_bytes(
+            "source-package-1",
+            b"source package",
+        );
         source.size_bytes = crate::runner_staging_operation::MAX_SOURCE_ARTIFACT_BYTES + 1;
         let error = source.decode_verified().expect_err("size bound");
         assert_eq!(
@@ -933,7 +1038,7 @@ mod tests {
                     .materialization
                     .source_artifact
                     .as_ref()
-                    .map(SourceArtifactTransfer::descriptor),
+                    .map(crate::runner_staging_operation::SourceArtifactTransfer::descriptor),
             },
         };
         let seen = Arc::new(Mutex::new(Vec::new()));

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -363,6 +363,11 @@ fn run_once_output(
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
+    materialize_staged_source_artifact(
+        &options.runner_id,
+        &claim.job.id.to_string(),
+        &mut execution_envelope,
+    )?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -991,6 +996,42 @@ fn reverse_worker_lab_offload(raw: &str) -> Result<serde_json::Value> {
             Some("parse reverse worker Lab offload metadata".to_string()),
         )
     })
+}
+
+/// A staged job's source is runner-owned durable storage, not a controller path.
+/// Verify and extract it before the normal queue executor consumes the command.
+fn materialize_staged_source_artifact(
+    runner_id: &str,
+    job_id: &str,
+    envelope: &mut RunnerExecutionEnvelope,
+) -> Result<()> {
+    let Some(source) = envelope.metadata.get("staged_source_artifact") else {
+        return Ok(());
+    };
+    let source = serde_json::from_value(source.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_source_artifact",
+            format!("invalid staged source artifact: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let session_path = homeboy_core::paths::runner_session_file(runner_id)?;
+    let store_path = session_path.with_file_name(format!("{runner_id}-staging/store.json"));
+    let workspace_root = session_path
+        .with_file_name(format!("{runner_id}-staging/workloads"))
+        .join(job_id);
+    let workspace = crate::runner_staging_store::extract_staged_source_artifact(
+        store_path,
+        &source,
+        &workspace_root,
+    )?;
+    let dispatch = envelope
+        .dispatch
+        .as_mut()
+        .ok_or_else(|| Error::internal_unexpected("staged runner job has no execution dispatch"))?;
+    dispatch.cwd = Some(workspace.display().to_string());
+    Ok(())
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -23,6 +23,7 @@ use super::support::{
     write_reverse_controller_session,
 };
 use super::worker_options;
+use crate::runner_staging_operation::SourceArtifactTransfer;
 
 #[test]
 fn reverse_worker_executes_claimed_job_and_finishes_it() {
@@ -927,6 +928,55 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
             result["data"]["execution_record"]["path_materialization_plan"]["entries"][0]
                 ["remote_path"],
             serde_json::json!("/tmp")
+        );
+    });
+}
+
+#[test]
+fn reverse_worker_executes_a_verified_staged_source_package() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let path = tempfile::tempdir()
+            .expect("tempdir")
+            .path()
+            .join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
+        let transfer = SourceArtifactTransfer::from_bytes("staged-source-1", b"staged output");
+        let artifact = transfer.descriptor();
+        let session_path = homeboy_core::paths::runner_session_file("lab").expect("session path");
+        let artifact_path = session_path
+            .parent()
+            .expect("session parent")
+            .join("lab-staging/source-artifacts/staged-source-1");
+        std::fs::create_dir_all(artifact_path.parent().expect("artifact parent"))
+            .expect("create artifact root");
+        std::fs::write(&artifact_path, transfer.decode_verified().expect("package"))
+            .expect("write staged package");
+        let mut request = run_id_echo_request();
+        request.command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat source.bin; printf ' side-effect' > result; cat result".to_string(),
+        ];
+        request.metadata = Some(serde_json::json!({
+            "submission_key": "staged-source-job-1",
+            "staged_source_artifact": artifact,
+        }));
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("submit staged job");
+        drop(store);
+        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job.expect("job").id, job.id);
+        handle.join().expect("mock broker joins");
+        let result = result_event_data(&store, job.id);
+        assert_eq!(
+            result["stdout"],
+            serde_json::json!("staged output side-effect")
         );
     });
 }


### PR DESCRIPTION
## Summary
- add a versioned sealed-staging request plus runner-owned durable staging store
- replay the persisted receipt and artifacts for the same idempotency key across direct/reverse channels and restart
- refuse disconnected, incompatible, or wrong-runner authority requests before materialization

## Tests
- `cargo test -p homeboy-lab-runner runner_staging --lib`

Refs #11581

AI assistance: OpenAI gpt-5.6-terra via OpenCode implemented the runner staging store, transports, and focused tests; Chris Huber remains responsible for every line.