### PR TITLE
feat(lab): add deferred controller projection

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -25,6 +25,7 @@ use homeboy_upgrade::upgrade;
 
 const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
 const RUNNER_EXEC_RECOVERY_OWNER_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER";
+const CONTROLLER_FALLBACK_RECONCILIATION_ENV: &str = "HOMEBOY_CONTROLLER_FALLBACK_RECONCILIATION";
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
@@ -358,6 +359,15 @@ impl CliRuntime {
         }
 
         register_startup_providers_before_reconcile();
+        if std::env::var_os(CONTROLLER_FALLBACK_RECONCILIATION_ENV).is_some() {
+            let config = crate::core::defaults::load_config();
+            if register_startup_providers_after_reconcile(&config.agent_task).is_err() {
+                return std::process::ExitCode::from(2);
+            }
+            let _ =
+                crate::runner::controller_fallback_projection::reconcile_on_controller_startup();
+            return std::process::ExitCode::SUCCESS;
+        }
         if let Some(owner_id) = std::env::var_os(RUNNER_EXEC_RECOVERY_OWNER_ENV) {
             let _ = crate::runner::run_scheduled_terminal_runner_exec_recovery(
                 &owner_id.to_string_lossy(),
@@ -369,14 +379,9 @@ impl CliRuntime {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
-        // Runner-owned fallback staging may outlive the controller process. Its
-        // receipt ledger is replay-safe and finalizes staging exactly once.
-        if let Err(error) =
-            crate::runner::controller_fallback_projection::reconcile_on_controller_startup()
-        {
-            eprintln!("error: {error}");
-            return std::process::ExitCode::from(2);
-        }
+        // Runner-owned fallback staging may outlive the controller process. A
+        // detached bounded pass keeps command startup independent of remote I/O.
+        schedule_controller_fallback_reconciliation();
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
         if command_capability == CommandCapability::Mutation
@@ -720,6 +725,20 @@ fn schedule_runner_exec_recovery() {
             &error,
         );
     }
+}
+
+fn schedule_controller_fallback_reconciliation() {
+    let Ok(executable) = std::env::current_exe() else {
+        return;
+    };
+    let mut command = ProcessCommand::new(executable);
+    command
+        .env(CONTROLLER_FALLBACK_RECONCILIATION_ENV, "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    crate::core::process::detach_from_caller_session(&mut command);
+    let _ = command.spawn();
 }
 
 /// A cook has no durable run record until controller admission. Re-exec before

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -369,6 +369,14 @@ impl CliRuntime {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
+        // Runner-owned fallback staging may outlive the controller process. Its
+        // receipt ledger is replay-safe and finalizes staging exactly once.
+        if let Err(error) =
+            crate::runner::controller_fallback_projection::reconcile_on_controller_startup()
+        {
+            eprintln!("error: {error}");
+            return std::process::ExitCode::from(2);
+        }
         // Deferred records outlive their worker. Startup restarts the singleton
         // so expired claims recover without another deferral request.
         if command_capability == CommandCapability::Mutation

--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -985,6 +985,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deferred_staging_follow_up_commands_are_registered_cli_commands() {
+        for args in [
+            ["homeboy", "agent-task", "status", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "logs", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "cancel", "run-1"].as_slice(),
+            ["homeboy", "agent-task", "evidence", "run-1", "--full"].as_slice(),
+        ] {
+            assert!(
+                Cli::try_parse_from(args).is_ok(),
+                "deferred staging emitted an invalid command: {args:?}"
+            );
+        }
+    }
+
     /// Dry run is the default. Recovery mutates the daemon that owns the
     /// caller's durable jobs, so it may not happen because someone ran the
     /// obvious command to find out what it would do.

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -5616,6 +5616,16 @@ where
     Ok(())
 }
 
+/// Test-support network entry point for the production reverse-broker routes.
+/// Authentication and route handling remain identical to a daemon connection.
+#[cfg(any(test, feature = "test-support"))]
+pub fn handle_reverse_broker_test_connection(
+    stream: TcpStream,
+    job_store: &JobStore,
+) -> std::io::Result<()> {
+    handle_connection(stream, job_store, UnsupportedAnalysisJobRunner, false)
+}
+
 fn read_http_request(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
     let mut request = Vec::new();
     let mut buffer = [0; 8 * 1024];

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -753,6 +753,7 @@ fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
         auth: Some(ManagedSshSession {
             control_path: "/tmp/homeboy-%h-%p-%r".to_string(),
             persist: "4h".to_string(),
+            persist_source: super::super::ManagedSshSessionPersistSource::Configured,
         }),
         is_local: false,
         env: HashMap::new(),

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -208,6 +208,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: control_path.to_string_lossy().to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -568,6 +568,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: "/tmp/homeboy-control".to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeSet,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use tempfile::TempDir;
 
@@ -1287,6 +1291,105 @@ pub struct ReverseBrokerFixture {
     broker_url: String,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
+}
+
+/// An authenticated reverse broker backed by the daemon's production HTTP
+/// routes and durable job store. The Lab runner registers its staging provider
+/// before using this fixture.
+pub struct AuthenticatedReverseBrokerFixture {
+    pub store: JobStore,
+    runner_id: String,
+    broker_url: String,
+    token: String,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AuthenticatedReverseBrokerFixture {
+    pub fn start(runner_id: impl Into<String>) -> Self {
+        let runner_id = runner_id.into();
+        let mut auth = crate::broker_auth::BrokerAuthStore::default();
+        let credential = auth
+            .pair(
+                format!("test-{runner_id}"),
+                &runner_id,
+                [
+                    crate::broker_auth::BrokerScope::Submit,
+                    crate::broker_auth::BrokerScope::Work,
+                ]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            )
+            .expect("pair authenticated reverse broker fixture");
+        auth.save()
+            .expect("persist authenticated reverse broker fixture auth");
+        let token = credential.token;
+        let store = JobStore::default();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind authenticated reverse broker fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("make authenticated reverse broker fixture nonblocking");
+        let broker_url = format!("http://{}", listener.local_addr().expect("broker address"));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_store = store.clone();
+        let handle = std::thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make authenticated reverse broker fixture stream blocking");
+                        crate::daemon::handle_reverse_broker_test_connection(stream, &thread_store)
+                            .expect("serve authenticated reverse broker fixture request");
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => {
+                        panic!("accept authenticated reverse broker fixture request: {error}")
+                    }
+                }
+            }
+        });
+        Self {
+            store,
+            runner_id,
+            broker_url,
+            token,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.broker_url
+    }
+
+    pub fn runner_id(&self) -> &str {
+        &self.runner_id
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn jobs(&self) -> Vec<Job> {
+        self.store.list()
+    }
+}
+
+impl Drop for AuthenticatedReverseBrokerFixture {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.broker_url.trim_start_matches("http://"));
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .expect("authenticated reverse broker fixture joins");
+        }
+    }
 }
 
 impl ReverseBrokerFixture {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1425,7 +1425,9 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
-    let response = client
+    let broker_token =
+        homeboy_core::broker_auth::broker_submit_token_for_runner(&session.runner_id)?;
+    let request = client
         .post(format!(
             "{}/runner/sessions",
             broker_url.trim_end_matches('/')
@@ -1439,11 +1441,15 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
             "worker_identity": session.worker_identity,
             "worker_pid": session.worker_pid,
             "last_seen_at": session.last_seen_at,
-        }))
-        .send()
-        .map_err(|err| {
-            Error::internal_unexpected(format!("register reverse runner session: {err}"))
-        })?;
+        }));
+    let request = if let Some(token) = broker_token.as_deref() {
+        request.header(homeboy_core::broker_auth::BROKER_TOKEN_HEADER, token)
+    } else {
+        request
+    };
+    let response = request.send().map_err(|err| {
+        Error::internal_unexpected(format!("register reverse runner session: {err}"))
+    })?;
     let status_code = response.status().as_u16();
     let envelope: CliEnvelope = response.json().map_err(|err| {
         Error::internal_json(

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -66,7 +66,7 @@ pub struct RunnerTerminalEvidence {
 pub struct ControllerMissionProjection {
     pub mission_id: String,
     pub runner_id: String,
-    pub runner_job_id: String,
+    pub runner_staging_id: String,
     pub terminal_outcome: String,
     pub artifacts: RunnerStagingArtifacts,
     pub finalization_owner: String,
@@ -147,9 +147,30 @@ impl ControllerFallbackProjectionStore {
         Ok(receipt)
     }
 
-    /// Repeated controller startup projects exactly one mission and fails closed
-    /// if later runner evidence differs from the first terminal evidence.
-    pub fn reconcile_after_controller_restart(
+    /// Repeated controller startup projects each accepted runner staging receipt
+    /// exactly once. The receipt is terminal evidence for staging only; it does
+    /// not claim that the eventual provider workload has completed.
+    pub fn reconcile_after_controller_restart(&self) -> Result<Vec<ControllerMissionProjection>> {
+        let state = self.load()?;
+        state
+            .receipts
+            .iter()
+            .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
+            .map(|(mission_id, receipt)| {
+                self.project_terminal_evidence(
+                    mission_id,
+                    RunnerTerminalEvidence {
+                        outcome: "staged".to_string(),
+                        artifacts: receipt.runner_receipt.artifacts.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Projects explicit runner terminal evidence and fails closed if later
+    /// evidence differs from the first finalized projection.
+    pub fn project_terminal_evidence(
         &self,
         mission_id: &str,
         evidence: RunnerTerminalEvidence,
@@ -178,7 +199,7 @@ impl ControllerFallbackProjectionStore {
         let projection = ControllerMissionProjection {
             mission_id: mission_id.to_string(),
             runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
-            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            runner_staging_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
             terminal_outcome: evidence.outcome,
             artifacts: evidence.artifacts,
             finalization_owner: "controller".to_string(),
@@ -250,6 +271,14 @@ impl ControllerFallbackProjectionStore {
     }
 }
 
+/// Production startup reconciliation for deferred runner staging. An empty
+/// ledger is a no-op, preserving healthy controller startup behavior.
+pub fn reconcile_on_controller_startup() -> Result<usize> {
+    Ok(ControllerFallbackProjectionStore::open_default()?
+        .reconcile_after_controller_restart()?
+        .len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,27 +319,48 @@ mod tests {
     }
 
     #[test]
-    fn restart_projects_one_controller_mission_and_preserves_runner_artifacts() {
+    fn controller_restart_projects_each_staged_mission_once() {
         let store = store();
         let envelope = envelope();
         let mut runner = Transport::compatible();
         let receipt = store
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
-        let evidence = RunnerTerminalEvidence {
-            outcome: "succeeded".to_string(),
-            artifacts: receipt.runner_receipt.artifacts.clone(),
-        };
-        let projected = store
-            .reconcile_after_controller_restart(&receipt.mission_id, evidence.clone())
-            .expect("project");
-        assert_eq!(projected.artifacts, evidence.artifacts);
+        let projected = store.reconcile_after_controller_restart().expect("project");
+        assert_eq!(projected.len(), 1);
+        let projected = &projected[0];
+        assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
+        assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");
         assert_eq!(
             store
-                .reconcile_after_controller_restart(&receipt.mission_id, evidence)
-                .expect("idempotent projection"),
-            projected
+                .reconcile_after_controller_restart()
+                .expect("idempotent projection")
+                .len(),
+            0
         );
+    }
+
+    #[test]
+    fn explicit_terminal_evidence_cannot_replace_startup_projection() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit");
+        store
+            .reconcile_after_controller_restart()
+            .expect("startup projection");
+
+        assert!(store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts,
+                },
+            )
+            .is_err());
     }
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -97,6 +97,12 @@ pub struct ControllerFallbackProjectionStore {
 }
 
 impl ControllerFallbackProjectionStore {
+    /// Shared controller ledger survives daemon restarts independently of the
+    /// runner-owned staging store.
+    pub fn open_default() -> Result<Self> {
+        Self::open(homeboy_core::paths::homeboy_data()?.join("controller-fallback-projection.json"))
+    }
+
     pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
         let store = Self { path: path.into() };
         if store.load()?.schema != STORE_SCHEMA {

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -4,6 +4,9 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
 
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
@@ -17,6 +20,8 @@ use crate::runner_staging_operation::{
 };
 
 const STORE_SCHEMA: &str = "homeboy/controller-fallback-projection/v1";
+const STARTUP_RECONCILIATION_BATCH_SIZE: usize = 8;
+const REMOTE_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Controller-visible durable receipt for a runner-owned admission.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,6 +87,8 @@ struct State {
     schema: String,
     receipts: BTreeMap<String, DeferredControllerReceipt>,
     projections: BTreeMap<String, ControllerMissionProjection>,
+    #[serde(default)]
+    reconciliation: BTreeMap<String, ReconciliationObservation>,
 }
 
 impl Default for State {
@@ -90,8 +97,17 @@ impl Default for State {
             schema: STORE_SCHEMA.to_string(),
             receipts: BTreeMap::new(),
             projections: BTreeMap::new(),
+            reconciliation: BTreeMap::new(),
         }
     }
+}
+
+/// Durable status for work intentionally left for a later bounded pass.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReconciliationObservation {
+    pub state: String,
+    pub detail: String,
 }
 
 /// File-backed controller receipt/projection ledger. Runner admission is
@@ -158,42 +174,106 @@ impl ControllerFallbackProjectionStore {
     pub fn reconcile_after_controller_restart_with<Snapshot, Finalize>(
         &self,
         limit: usize,
-        mut snapshot: Snapshot,
-        mut finalize: Finalize,
+        snapshot: Snapshot,
+        finalize: Finalize,
     ) -> Result<Vec<ControllerMissionProjection>>
     where
-        Snapshot: FnMut(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>,
-        Finalize: FnMut(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+        Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+            + Send
+            + Sync
+            + 'static,
+        Finalize: Fn(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+    {
+        self.reconcile_after_controller_restart_with_timeout(
+            limit,
+            REMOTE_STATUS_TIMEOUT,
+            snapshot,
+            finalize,
+        )
+    }
+
+    fn reconcile_after_controller_restart_with_timeout<Snapshot, Finalize>(
+        &self,
+        limit: usize,
+        timeout: Duration,
+        snapshot: Snapshot,
+        finalize: Finalize,
+    ) -> Result<Vec<ControllerMissionProjection>>
+    where
+        Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+            + Send
+            + Sync
+            + 'static,
+        Finalize: Fn(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
     {
         let state = self.load()?;
-        state
+        let receipts = state
             .receipts
             .iter()
             .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
             .take(limit)
-            .filter_map(|(mission_id, receipt)| {
-                let snapshot = snapshot(
-                    &receipt.runner_receipt.handoff.runner_id,
-                    &receipt.runner_receipt.handoff.runner_job_id,
-                )
-                .ok()?;
-                snapshot
-                    .job
-                    .status
-                    .is_terminal()
-                    .then_some((mission_id, receipt, snapshot))
-            })
-            .map(|(mission_id, receipt, snapshot)| {
-                finalize(mission_id, &snapshot)?;
-                self.project_terminal_evidence(
-                    mission_id,
-                    RunnerTerminalEvidence {
-                        outcome: snapshot.job.status.daemon_status_label().to_string(),
-                        artifacts: receipt.runner_receipt.artifacts.clone(),
+            .map(|(mission_id, receipt)| (mission_id.clone(), receipt.clone()))
+            .collect::<Vec<_>>();
+        let snapshot = Arc::new(snapshot);
+        let mut projections = Vec::new();
+
+        for (mission_id, receipt) in receipts {
+            let result = remote_snapshot_with_timeout(
+                Arc::clone(&snapshot),
+                receipt.runner_receipt.handoff.runner_id.clone(),
+                receipt.runner_receipt.handoff.runner_job_id.clone(),
+                timeout,
+            );
+            let snapshot = match result {
+                Ok(snapshot) if snapshot.job.status.is_terminal() => snapshot,
+                Ok(snapshot) => {
+                    self.record_observation(
+                        &mission_id,
+                        "pending",
+                        format!(
+                            "runner job remains {}",
+                            snapshot.job.status.daemon_status_label()
+                        ),
+                    )?;
+                    continue;
+                }
+                Err(error) => {
+                    self.record_observation(&mission_id, "retryable", error.message)?;
+                    continue;
+                }
+            };
+
+            // The ledger lock serializes contenders before they enter lifecycle CAS.
+            // A restart or concurrent controller can then replay the same evidence safely.
+            let _lock = self.lock()?;
+            let mut state = self.load()?;
+            if state.projections.contains_key(&mission_id) {
+                continue;
+            }
+            if let Err(error) = finalize(&mission_id, &snapshot) {
+                state.reconciliation.insert(
+                    mission_id.clone(),
+                    ReconciliationObservation {
+                        state: "retryable".to_string(),
+                        detail: error.message,
                     },
-                )
-            })
-            .collect()
+                );
+                self.persist(&state)?;
+                continue;
+            }
+            let projection = self.project_terminal_evidence_in_state(
+                &mut state,
+                &mission_id,
+                RunnerTerminalEvidence {
+                    outcome: snapshot.job.status.daemon_status_label().to_string(),
+                    artifacts: receipt.runner_receipt.artifacts,
+                },
+            )?;
+            state.reconciliation.remove(&mission_id);
+            self.persist(&state)?;
+            projections.push(projection);
+        }
+        Ok(projections)
     }
 
     /// Projects explicit runner terminal evidence and fails closed if later
@@ -217,6 +297,18 @@ impl ControllerFallbackProjectionStore {
         }
         let _lock = self.lock()?;
         let mut state = self.load()?;
+        let projection =
+            self.project_terminal_evidence_in_state(&mut state, mission_id, evidence)?;
+        self.persist(&state)?;
+        Ok(projection)
+    }
+
+    fn project_terminal_evidence_in_state(
+        &self,
+        state: &mut State,
+        mission_id: &str,
+        evidence: RunnerTerminalEvidence,
+    ) -> Result<ControllerMissionProjection> {
         let receipt = state.receipts.get(mission_id).ok_or_else(|| {
             Error::validation_invalid_argument(
                 "mission_id",
@@ -247,8 +339,28 @@ impl ControllerFallbackProjectionStore {
         state
             .projections
             .insert(mission_id.to_string(), projection.clone());
-        self.persist(&state)?;
         Ok(projection)
+    }
+
+    fn record_observation(&self, mission_id: &str, state: &str, detail: String) -> Result<()> {
+        let _lock = self.lock()?;
+        let mut ledger = self.load()?;
+        if !ledger.projections.contains_key(mission_id) {
+            ledger.reconciliation.insert(
+                mission_id.to_string(),
+                ReconciliationObservation {
+                    state: state.to_string(),
+                    detail,
+                },
+            );
+            self.persist(&ledger)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn observation(&self, mission_id: &str) -> Result<Option<ReconciliationObservation>> {
+        Ok(self.load()?.reconciliation.get(mission_id).cloned())
     }
 
     fn load(&self) -> Result<State> {
@@ -353,24 +465,81 @@ impl ControllerFallbackProjectionStore {
 pub fn reconcile_on_controller_startup() -> Result<usize> {
     Ok(ControllerFallbackProjectionStore::open_default()?
         .reconcile_after_controller_restart_with(
-            8,
+            STARTUP_RECONCILIATION_BATCH_SIZE,
             crate::runner_job_log_snapshot,
             homeboy_agents::agent_task_lifecycle::project_terminal_runner_result,
         )?
         .len())
 }
 
+fn remote_snapshot_with_timeout<Snapshot>(
+    snapshot: Arc<Snapshot>,
+    runner_id: String,
+    job_id: String,
+    timeout: Duration,
+) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+where
+    Snapshot: Fn(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>
+        + Send
+        + Sync
+        + 'static,
+{
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = sender.send(snapshot(&runner_id, &job_id));
+    });
+    receiver.recv_timeout(timeout).map_err(|error| {
+        Error::internal_unexpected(format!(
+            "runner status query timed out after {}ms: {error}",
+            timeout.as_millis()
+        ))
+    })?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::runner_staging_operation::tests_support::{envelope, Transport};
+    use homeboy_core::api_jobs::{Job, JobStatus, RunnerJobLogSnapshot};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Barrier;
+    use std::time::Instant;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     fn store() -> ControllerFallbackProjectionStore {
         ControllerFallbackProjectionStore::open(
             tempdir().expect("temp").keep().join("controller.json"),
         )
         .expect("store")
+    }
+
+    fn snapshot(status: JobStatus) -> RunnerJobLogSnapshot {
+        RunnerJobLogSnapshot {
+            job: Job {
+                id: Uuid::new_v4(),
+                operation: "staged-agent-task".to_string(),
+                status,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+                started_at_ms: None,
+                finished_at_ms: None,
+                event_count: 0,
+                source_snapshot: None,
+                path_materialization_plan: None,
+                stale_reason: None,
+                daemon_lease_id: None,
+                target_runner_id: None,
+                target_project_id: None,
+                claim_id: None,
+                claimed_by_runner_id: None,
+                claimed_at_ms: None,
+                claim_expires_at_ms: None,
+                artifacts: Vec::new(),
+                runner_job_projection: None,
+            },
+            events: Vec::new(),
+        }
     }
 
     #[test]
@@ -446,5 +615,142 @@ mod tests {
                 },
             )
             .is_err());
+    }
+
+    #[test]
+    fn startup_reconciliation_returns_before_a_blocked_remote_query() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit deferred receipt");
+        let started = Instant::now();
+
+        let projected = store
+            .reconcile_after_controller_restart_with_timeout(
+                8,
+                Duration::from_millis(20),
+                |_, _| {
+                    thread::sleep(Duration::from_secs(1));
+                    Ok(snapshot(JobStatus::Succeeded))
+                },
+                |_, _| Ok(true),
+            )
+            .expect("bounded reconciliation");
+
+        assert!(started.elapsed() < Duration::from_millis(250));
+        assert!(projected.is_empty());
+        assert_eq!(
+            store.observation(&receipt.mission_id).expect("observation"),
+            Some(ReconciliationObservation {
+                state: "retryable".to_string(),
+                detail: "runner status query timed out after 20ms: timed out waiting on channel"
+                    .to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn nonterminal_runner_status_stays_pending_for_the_next_bounded_pass() {
+        let store = store();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope())
+            .expect("admit deferred receipt");
+
+        let projected = store
+            .reconcile_after_controller_restart_with(
+                8,
+                |_, _| Ok(snapshot(JobStatus::Running)),
+                |_, _| panic!("nonterminal status must not enter lifecycle finalization"),
+            )
+            .expect("nonterminal reconciliation");
+
+        assert!(projected.is_empty());
+        assert_eq!(
+            store.observation(&receipt.mission_id).expect("observation"),
+            Some(ReconciliationObservation {
+                state: "pending".to_string(),
+                detail: "runner job remains running".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn terminal_success_and_failure_project_the_staged_artifacts() {
+        for (status, outcome) in [
+            (JobStatus::Succeeded, "succeeded"),
+            (JobStatus::Failed, "failed"),
+        ] {
+            let store = store();
+            let envelope = envelope();
+            let mut runner = Transport::compatible();
+            let receipt = store
+                .submit_detached(&mut runner, &envelope)
+                .expect("admit deferred receipt");
+            let projected = store
+                .reconcile_after_controller_restart_with(
+                    8,
+                    move |_, _| Ok(snapshot(status)),
+                    |_, _| Ok(true),
+                )
+                .expect("terminal reconciliation");
+
+            assert_eq!(projected.len(), 1);
+            assert_eq!(projected[0].terminal_outcome, outcome);
+            assert_eq!(projected[0].artifacts, receipt.runner_receipt.artifacts);
+        }
+    }
+
+    #[test]
+    fn concurrent_reconcilers_enter_lifecycle_finalization_once_and_replay_after_restart() {
+        let directory = tempdir().expect("temp directory");
+        let path = directory.path().join("controller.json");
+        let store = ControllerFallbackProjectionStore::open(&path).expect("store");
+        let mut runner = Transport::compatible();
+        store
+            .submit_detached(&mut runner, &envelope())
+            .expect("admit deferred receipt");
+        let barrier = Arc::new(Barrier::new(2));
+        let finalizations = Arc::new(AtomicUsize::new(0));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            let finalizations = Arc::clone(&finalizations);
+            workers.push(thread::spawn(move || {
+                ControllerFallbackProjectionStore::open(path)
+                    .expect("concurrent store")
+                    .reconcile_after_controller_restart_with(
+                        8,
+                        move |_, _| {
+                            barrier.wait();
+                            Ok(snapshot(JobStatus::Succeeded))
+                        },
+                        move |_, _| {
+                            finalizations.fetch_add(1, Ordering::SeqCst);
+                            Ok(true)
+                        },
+                    )
+            }));
+        }
+        for worker in workers {
+            worker
+                .join()
+                .expect("worker join")
+                .expect("worker reconcile");
+        }
+        assert_eq!(finalizations.load(Ordering::SeqCst), 1);
+
+        let replay = ControllerFallbackProjectionStore::open(path)
+            .expect("restarted store")
+            .reconcile_after_controller_restart_with(
+                8,
+                |_, _| Ok(snapshot(JobStatus::Succeeded)),
+                |_, _| panic!("terminal lifecycle CAS must not be re-entered after restart"),
+            )
+            .expect("restart replay");
+        assert!(replay.is_empty());
     }
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -148,20 +148,43 @@ impl ControllerFallbackProjectionStore {
         Ok(receipt)
     }
 
-    /// Repeated controller startup projects each accepted runner staging receipt
-    /// exactly once. The receipt is terminal evidence for staging only; it does
-    /// not claim that the eventual provider workload has completed.
-    pub fn reconcile_after_controller_restart(&self) -> Result<Vec<ControllerMissionProjection>> {
+    /// Reconcile a bounded receipt batch against authoritative runner jobs.
+    /// Nonterminal jobs remain deferred; only a terminal snapshot reaches the
+    /// agent-task lifecycle finalizer and this projection ledger.
+    pub fn reconcile_after_controller_restart_with<Snapshot, Finalize>(
+        &self,
+        limit: usize,
+        mut snapshot: Snapshot,
+        mut finalize: Finalize,
+    ) -> Result<Vec<ControllerMissionProjection>>
+    where
+        Snapshot: FnMut(&str, &str) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot>,
+        Finalize: FnMut(&str, &homeboy_core::api_jobs::RunnerJobLogSnapshot) -> Result<bool>,
+    {
         let state = self.load()?;
         state
             .receipts
             .iter()
             .filter(|(mission_id, _)| !state.projections.contains_key(*mission_id))
-            .map(|(mission_id, receipt)| {
+            .take(limit)
+            .filter_map(|(mission_id, receipt)| {
+                let snapshot = snapshot(
+                    &receipt.runner_receipt.handoff.runner_id,
+                    &receipt.runner_receipt.handoff.runner_job_id,
+                )
+                .ok()?;
+                snapshot
+                    .job
+                    .status
+                    .is_terminal()
+                    .then_some((mission_id, receipt, snapshot))
+            })
+            .map(|(mission_id, receipt, snapshot)| {
+                finalize(mission_id, &snapshot)?;
                 self.project_terminal_evidence(
                     mission_id,
                     RunnerTerminalEvidence {
-                        outcome: "staged".to_string(),
+                        outcome: snapshot.job.status.daemon_status_label().to_string(),
                         artifacts: receipt.runner_receipt.artifacts.clone(),
                     },
                 )
@@ -272,11 +295,15 @@ impl ControllerFallbackProjectionStore {
     }
 }
 
-/// Production startup reconciliation for deferred runner staging. An empty
-/// ledger is a no-op, preserving healthy controller startup behavior.
+/// Production startup reconciliation for deferred runner staging. It reads at
+/// most eight runner jobs so ordinary CLI startup remains bounded by work count.
 pub fn reconcile_on_controller_startup() -> Result<usize> {
     Ok(ControllerFallbackProjectionStore::open_default()?
-        .reconcile_after_controller_restart()?
+        .reconcile_after_controller_restart_with(
+            8,
+            crate::runner_job_log_snapshot,
+            homeboy_agents::agent_task_lifecycle::project_terminal_runner_result,
+        )?
         .len())
 }
 
@@ -320,45 +347,24 @@ mod tests {
     }
 
     #[test]
-    fn controller_restart_projects_each_staged_mission_once() {
+    fn terminal_runner_evidence_projects_once_after_restart() {
         let store = store();
         let envelope = envelope();
         let mut runner = Transport::compatible();
         let receipt = store
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
-        let projected = store.reconcile_after_controller_restart().expect("project");
-        assert_eq!(projected.len(), 1);
-        let projected = &projected[0];
+        let projected = store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts.clone(),
+                },
+            )
+            .expect("project");
+        assert_eq!(projected.terminal_outcome, "succeeded");
         assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
-        assert_eq!(
-            projected
-                .artifacts
-                .source_artifact
-                .as_ref()
-                .expect("source artifact descriptor")
-                .artifact_id,
-            "source-package-1"
-        );
-        assert_eq!(
-            projected
-                .artifacts
-                .source_artifact
-                .as_ref()
-                .expect("source artifact descriptor")
-                .package
-                .format,
-            "homeboy/source-package-json/v1"
-        );
-        assert_eq!(projected.terminal_outcome, "staged");
-        assert_eq!(projected.finalization_owner, "controller");
-        assert_eq!(
-            store
-                .reconcile_after_controller_restart()
-                .expect("idempotent projection")
-                .len(),
-            0
-        );
     }
 
     #[test]
@@ -370,14 +376,19 @@ mod tests {
             .submit_detached(&mut runner, &envelope)
             .expect("admit");
         store
-            .reconcile_after_controller_restart()
-            .expect("startup projection");
-
-        assert!(store
             .project_terminal_evidence(
                 &receipt.mission_id,
                 RunnerTerminalEvidence {
                     outcome: "succeeded".to_string(),
+                    artifacts: receipt.runner_receipt.artifacts.clone(),
+                },
+            )
+            .expect("first terminal projection");
+        assert!(store
+            .project_terminal_evidence(
+                &receipt.mission_id,
+                RunnerTerminalEvidence {
+                    outcome: "failed".to_string(),
                     artifacts: receipt.runner_receipt.artifacts,
                 },
             )

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -66,7 +66,8 @@ pub struct RunnerTerminalEvidence {
 pub struct ControllerMissionProjection {
     pub mission_id: String,
     pub runner_id: String,
-    pub runner_staging_id: String,
+    #[serde(alias = "runner_staging_id")]
+    pub runner_job_id: String,
     pub terminal_outcome: String,
     pub artifacts: RunnerStagingArtifacts,
     pub finalization_owner: String,
@@ -199,7 +200,7 @@ impl ControllerFallbackProjectionStore {
         let projection = ControllerMissionProjection {
             mission_id: mission_id.to_string(),
             runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
-            runner_staging_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
             terminal_outcome: evidence.outcome,
             artifacts: evidence.artifacts,
             finalization_owner: "controller".to_string(),
@@ -338,6 +339,16 @@ mod tests {
                 .expect("source artifact descriptor")
                 .artifact_id,
             "source-package-1"
+        );
+        assert_eq!(
+            projected
+                .artifacts
+                .source_artifact
+                .as_ref()
+                .expect("source artifact descriptor")
+                .package
+                .format,
+            "homeboy/source-package-json/v1"
         );
         assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -1,0 +1,310 @@
+//! Durable controller fallback and later projection for sealed runner staging.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_core::{Error, Result};
+
+use crate::runner_staging_operation::{
+    submit_remote_runner_staging, RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt,
+    RemoteRunnerStagingTransport, RunnerStagingArtifacts,
+};
+
+const STORE_SCHEMA: &str = "homeboy/controller-fallback-projection/v1";
+
+/// Controller-visible durable receipt for a runner-owned admission.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DeferredControllerReceipt {
+    pub schema: String,
+    pub mission_id: String,
+    pub runner_receipt: RemoteRunnerStagingReceipt,
+    pub controller_projection: String,
+}
+
+impl DeferredControllerReceipt {
+    fn new(mission_id: impl Into<String>, runner_receipt: RemoteRunnerStagingReceipt) -> Self {
+        Self {
+            schema: STORE_SCHEMA.to_string(),
+            mission_id: mission_id.into(),
+            runner_receipt,
+            controller_projection: "deferred".to_string(),
+        }
+    }
+
+    fn validate_for(&self, envelope: &RemoteRunnerStagingEnvelope) -> Result<()> {
+        if self.schema != STORE_SCHEMA
+            || self.mission_id.trim().is_empty()
+            || self.controller_projection != "deferred"
+        {
+            return Err(Error::validation_invalid_argument(
+                "controller_fallback_receipt",
+                "deferred controller receipt is malformed",
+                Some(envelope.handoff.run_id.clone()),
+                None,
+            ));
+        }
+        self.runner_receipt.validate_for(envelope)
+    }
+}
+
+/// Terminal evidence from the runner-owned store. The controller copies these
+/// identities without replacing or re-materializing runner artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerTerminalEvidence {
+    pub outcome: String,
+    pub artifacts: RunnerStagingArtifacts,
+}
+
+/// The one controller-owned finalization projection for a deferred mission.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerMissionProjection {
+    pub mission_id: String,
+    pub runner_id: String,
+    pub runner_job_id: String,
+    pub terminal_outcome: String,
+    pub artifacts: RunnerStagingArtifacts,
+    pub finalization_owner: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct State {
+    schema: String,
+    receipts: BTreeMap<String, DeferredControllerReceipt>,
+    projections: BTreeMap<String, ControllerMissionProjection>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            schema: STORE_SCHEMA.to_string(),
+            receipts: BTreeMap::new(),
+            projections: BTreeMap::new(),
+        }
+    }
+}
+
+/// File-backed controller receipt/projection ledger. Runner admission is
+/// atomic in its own store; this ledger only records accepted receipts.
+pub struct ControllerFallbackProjectionStore {
+    path: PathBuf,
+}
+
+impl ControllerFallbackProjectionStore {
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let store = Self { path: path.into() };
+        if store.load()?.schema != STORE_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "controller_fallback_store",
+                "unsupported controller fallback projection store schema",
+                Some(store.path.display().to_string()),
+                None,
+            ));
+        }
+        Ok(store)
+    }
+
+    /// Preflight happens inside `submit_remote_runner_staging` before the
+    /// transport mutation boundary, so refusals spend no provider budget.
+    pub fn submit_detached<T: RemoteRunnerStagingTransport>(
+        &self,
+        transport: &mut T,
+        envelope: &RemoteRunnerStagingEnvelope,
+    ) -> Result<DeferredControllerReceipt> {
+        let receipt = DeferredControllerReceipt::new(
+            &envelope.handoff.run_id,
+            submit_remote_runner_staging(transport, envelope)?,
+        );
+        receipt.validate_for(envelope)?;
+        let mut state = self.load()?;
+        if let Some(existing) = state.receipts.get(&receipt.mission_id) {
+            if existing != &receipt {
+                return Err(Error::validation_invalid_argument(
+                    "idempotency_key",
+                    "controller fallback mission is already bound to a different runner receipt",
+                    Some(receipt.mission_id),
+                    None,
+                ));
+            }
+            return Ok(existing.clone());
+        }
+        state
+            .receipts
+            .insert(receipt.mission_id.clone(), receipt.clone());
+        self.persist(&state)?;
+        Ok(receipt)
+    }
+
+    /// Repeated controller startup projects exactly one mission and fails closed
+    /// if later runner evidence differs from the first terminal evidence.
+    pub fn reconcile_after_controller_restart(
+        &self,
+        mission_id: &str,
+        evidence: RunnerTerminalEvidence,
+    ) -> Result<ControllerMissionProjection> {
+        if evidence.outcome.trim().is_empty()
+            || evidence.artifacts.lifecycle_id.trim().is_empty()
+            || evidence.artifacts.source_artifact_id.trim().is_empty()
+            || evidence.artifacts.workspace_artifact_id.trim().is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner_terminal_evidence",
+                "runner terminal evidence requires an outcome and all staged artifacts",
+                Some(mission_id.to_string()),
+                None,
+            ));
+        }
+        let mut state = self.load()?;
+        let receipt = state.receipts.get(mission_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "mission_id",
+                "controller cannot project a mission without a deferred runner receipt",
+                Some(mission_id.to_string()),
+                None,
+            )
+        })?;
+        let projection = ControllerMissionProjection {
+            mission_id: mission_id.to_string(),
+            runner_id: receipt.runner_receipt.handoff.runner_id.clone(),
+            runner_job_id: receipt.runner_receipt.handoff.runner_job_id.clone(),
+            terminal_outcome: evidence.outcome,
+            artifacts: evidence.artifacts,
+            finalization_owner: "controller".to_string(),
+        };
+        if let Some(existing) = state.projections.get(mission_id) {
+            if existing != &projection {
+                return Err(Error::validation_invalid_argument(
+                    "runner_terminal_evidence",
+                    "controller mission already has a different terminal projection",
+                    Some(mission_id.to_string()),
+                    None,
+                ));
+            }
+            return Ok(existing.clone());
+        }
+        state
+            .projections
+            .insert(mission_id.to_string(), projection.clone());
+        self.persist(&state)?;
+        Ok(projection)
+    }
+
+    fn load(&self) -> Result<State> {
+        if !self.path.exists() {
+            return Ok(State::default());
+        }
+        serde_json::from_slice(&fs::read(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("read {}", self.path.display())),
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse {}", self.path.display())),
+            )
+        })
+    }
+
+    fn persist(&self, state: &State) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("create {}", parent.display())),
+                )
+            })?;
+        }
+        let temporary = self.path.with_extension("tmp");
+        let bytes = serde_json::to_vec(state).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize controller fallback projection".to_string()),
+            )
+        })?;
+        fs::write(&temporary, bytes).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write {}", temporary.display())),
+            )
+        })?;
+        fs::rename(&temporary, &self.path).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("publish {}", self.path.display())),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner_staging_operation::tests_support::{envelope, Transport};
+    use tempfile::tempdir;
+
+    fn store() -> ControllerFallbackProjectionStore {
+        ControllerFallbackProjectionStore::open(
+            tempdir().expect("temp").keep().join("controller.json"),
+        )
+        .expect("store")
+    }
+
+    #[test]
+    fn failed_controller_daemon_uses_compatible_runner_once_and_returns_deferred_receipt() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let first = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("fallback admission");
+        let repeated = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("replay");
+        assert_eq!(first, repeated);
+        assert_eq!(first.controller_projection, "deferred");
+        assert_eq!(runner.provider_budget(), 0);
+    }
+
+    #[test]
+    fn disconnected_or_incompatible_runner_refuses_before_provider_budget() {
+        let envelope = envelope();
+        for mut runner in [Transport::incompatible(), Transport::disconnected()] {
+            assert!(store().submit_detached(&mut runner, &envelope).is_err());
+            assert_eq!(runner.calls(), 0);
+            assert_eq!(runner.provider_budget(), 0);
+        }
+    }
+
+    #[test]
+    fn restart_projects_one_controller_mission_and_preserves_runner_artifacts() {
+        let store = store();
+        let envelope = envelope();
+        let mut runner = Transport::compatible();
+        let receipt = store
+            .submit_detached(&mut runner, &envelope)
+            .expect("admit");
+        let evidence = RunnerTerminalEvidence {
+            outcome: "succeeded".to_string(),
+            artifacts: receipt.runner_receipt.artifacts.clone(),
+        };
+        let projected = store
+            .reconcile_after_controller_restart(&receipt.mission_id, evidence.clone())
+            .expect("project");
+        assert_eq!(projected.artifacts, evidence.artifacts);
+        assert_eq!(projected.finalization_owner, "controller");
+        assert_eq!(
+            store
+                .reconcile_after_controller_restart(&receipt.mission_id, evidence)
+                .expect("idempotent projection"),
+            projected
+        );
+    }
+}

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -330,6 +330,15 @@ mod tests {
         assert_eq!(projected.len(), 1);
         let projected = &projected[0];
         assert_eq!(projected.artifacts, receipt.runner_receipt.artifacts);
+        assert_eq!(
+            projected
+                .artifacts
+                .source_artifact
+                .as_ref()
+                .expect("source artifact descriptor")
+                .artifact_id,
+            "source-package-1"
+        );
         assert_eq!(projected.terminal_outcome, "staged");
         assert_eq!(projected.finalization_owner, "controller");
         assert_eq!(

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -1,10 +1,13 @@
 //! Durable controller fallback and later projection for sealed runner staging.
 
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
 
 use homeboy_core::{Error, Result};
 
@@ -129,6 +132,7 @@ impl ControllerFallbackProjectionStore {
             submit_remote_runner_staging(transport, envelope)?,
         );
         receipt.validate_for(envelope)?;
+        let _lock = self.lock()?;
         let mut state = self.load()?;
         if let Some(existing) = state.receipts.get(&receipt.mission_id) {
             if existing != &receipt {
@@ -211,6 +215,7 @@ impl ControllerFallbackProjectionStore {
                 None,
             ));
         }
+        let _lock = self.lock()?;
         let mut state = self.load()?;
         let receipt = state.receipts.get(mission_id).ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -273,25 +278,73 @@ impl ControllerFallbackProjectionStore {
                 )
             })?;
         }
-        let temporary = self.path.with_extension("tmp");
         let bytes = serde_json::to_vec(state).map_err(|error| {
             Error::internal_json(
                 error.to_string(),
                 Some("serialize controller fallback projection".to_string()),
             )
         })?;
-        fs::write(&temporary, bytes).map_err(|error| {
+        let parent = self.path.parent().expect("ledger path has parent");
+        let mut temporary = NamedTempFile::new_in(parent).map_err(|error| {
             Error::internal_io(
                 error.to_string(),
-                Some(format!("write {}", temporary.display())),
+                Some(format!("create ledger temporary in {}", parent.display())),
             )
         })?;
-        fs::rename(&temporary, &self.path).map_err(|error| {
+        temporary.write_all(&bytes).map_err(|error| {
             Error::internal_io(
                 error.to_string(),
+                Some("write controller fallback projection".to_string()),
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("sync controller fallback projection".to_string()),
+            )
+        })?;
+        temporary.persist(&self.path).map_err(|error| {
+            Error::internal_io(
+                error.error.to_string(),
                 Some(format!("publish {}", self.path.display())),
             )
-        })
+        })?;
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("sync {}", parent.display())),
+                )
+            })
+    }
+
+    fn lock(&self) -> Result<File> {
+        let parent = self.path.parent().expect("ledger path has parent");
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(self.path.with_extension("lock"))
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("open controller fallback lock".to_string()),
+                )
+            })?;
+        file.lock_exclusive().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("lock controller fallback ledger".to_string()),
+            )
+        })?;
+        Ok(file)
     }
 }
 

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -99,18 +99,11 @@ impl DirectLabHandoffReceipt {
             controller_identity: envelope.controller_identity.clone(),
             acceptance_state: "accepted".to_string(),
             controller_projection: "deferred".to_string(),
-            status_command: format!(
-                "homeboy runner jobs show {} {}",
-                envelope.runner_id, runner_job_id
-            ),
-            cancel_command: format!(
-                "homeboy runner jobs cancel {} {}",
-                envelope.runner_id, runner_job_id
-            ),
-            evidence_command: format!(
-                "homeboy runner jobs evidence {} {}",
-                envelope.runner_id, runner_job_id
-            ),
+            // Sealed staging has no runner daemon job yet. The durable run is
+            // the status, cancellation, and evidence authority.
+            status_command: format!("homeboy agent-task status {}", envelope.run_id),
+            cancel_command: format!("homeboy agent-task cancel {}", envelope.run_id),
+            evidence_command: format!("homeboy agent-task evidence {} --full", envelope.run_id),
         }
     }
 
@@ -248,7 +241,12 @@ mod tests {
         assert_eq!(first, repeated);
         assert_eq!(receiver.receipts.len(), 1);
         assert_eq!(first.controller_projection, "deferred");
-        assert!(first.status_command.contains("runner-job-1"));
+        assert_eq!(first.status_command, "homeboy agent-task status run-1");
+        assert_eq!(first.cancel_command, "homeboy agent-task cancel run-1");
+        assert_eq!(
+            first.evidence_command,
+            "homeboy agent-task evidence run-1 --full"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -64,7 +64,7 @@ impl DirectLabHandoffEnvelope {
                 None,
             ));
         }
-        self.recipe.validate()
+        self.recipe.validate_for_runner_staging()
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2296,7 +2296,7 @@ pub(crate) fn detached_staging_submission_output(
         }
         crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt) => {
             output["status"] = serde_json::json!("staged");
-            output["runner_staging_id"] =
+            output["runner_job_id"] =
                 serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
             output["controller_projection"] = serde_json::json!(receipt.controller_projection);
         }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1409,7 +1409,10 @@ pub(crate) fn run_lab_offload_inner(
         .session
         .as_ref()
         .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh)
-        && runner_status.stale_daemon.is_none()
+        // An unverified reverse session is an availability warning rather than
+        // a freshness fence. Only a typed blocking verdict can suppress this
+        // direct-SSH identity comparison.
+        && runner_status.admission_blocking_stale_daemon().is_none()
     {
         let session = runner_status
             .session

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2298,6 +2298,10 @@ pub(crate) fn detached_staging_submission_output(
             output["status"] = serde_json::json!("staged");
             output["runner_job_id"] =
                 serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
+            // Older clients consumed this name before staging admitted a real
+            // runner daemon job. Keep it additive while they migrate.
+            output["runner_staging_id"] =
+                serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
             output["controller_projection"] = serde_json::json!(receipt.controller_projection);
         }
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1189,13 +1189,13 @@ pub(crate) fn run_lab_offload_inner(
             request.local_output_file,
             &mut messages,
         );
-        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+        let submission = match crate::lab_staging_controller::submit_detached_staging(
             run_id,
             runner_id,
             selection.mode.clone(),
             &request,
         ) {
-            Ok(controller_job_id) => controller_job_id,
+            Ok(submission) => submission,
             Err(error) => {
                 if error.retryable != Some(true) {
                     if let Some(durable_plan) = request.durable_agent_task_plan {
@@ -1214,29 +1214,17 @@ pub(crate) fn run_lab_offload_inner(
                 ));
             }
         };
-        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
+        let submission = detached_staging_submission_output(submission, run_id);
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
-            "data": {
-                "status": "materializing",
-                "durable_run_id": run_id,
-                "controller_job_id": controller_job_id,
-                "retrieval_commands": {
-                    "status": format!("homeboy agent-task status {run_id}"),
-                    "controller_job": controller_job_commands.show,
-                    "controller_job_watch": controller_job_commands.watch,
-                },
-            }
+            "data": submission,
         }))
-        .unwrap_or_else(|_| {
-            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
-        });
+        .unwrap_or_else(|_| format!("Lab staging accepted for {run_id}"));
         return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: format!("{stdout}\n"),
             stderr: format!(
-                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
-                controller_job_commands.show, controller_job_commands.watch,
+                "Lab staging continues for durable run `{run_id}`.\nNext: homeboy agent-task status {run_id}\nNext: homeboy agent-task logs {run_id}\n",
             ),
             exit_code: 0,
             output_file_content: Some(format!("{stdout}\n")),
@@ -1686,13 +1674,13 @@ pub(crate) fn run_lab_offload_inner(
             request.local_output_file,
             &mut messages,
         );
-        let controller_job_id = match crate::lab_staging_controller::submit_detached_staging(
+        let submission = match crate::lab_staging_controller::submit_detached_staging(
             run_id,
             runner_id,
             selection.mode.clone(),
             &request,
         ) {
-            Ok(controller_job_id) => controller_job_id,
+            Ok(submission) => submission,
             Err(error) => {
                 // A retryable transport failure can follow durable acceptance.
                 // Keep the parent nonterminal so replay can reconcile the same
@@ -1714,33 +1702,17 @@ pub(crate) fn run_lab_offload_inner(
                 ));
             }
         };
-        let controller_job_commands = controller_job_retrieval_commands(&controller_job_id);
+        let submission = detached_staging_submission_output(submission, run_id);
         let stdout = serde_json::to_string_pretty(&serde_json::json!({
             "success": true,
-            "data": {
-                "status": "materializing",
-                "durable_run_id": run_id,
-                "controller_job_id": controller_job_id,
-                "retrieval_commands": {
-                    "status": format!("homeboy agent-task status {run_id}"),
-                    "controller_job": controller_job_commands.show,
-                    "controller_job_watch": controller_job_commands.watch,
-                },
-                "next_actions": [
-                    format!("Show controller job: {}", controller_job_commands.show),
-                    format!("Watch controller job: {}", controller_job_commands.watch),
-                ],
-            }
+            "data": submission,
         }))
-        .unwrap_or_else(|_| {
-            format!("Lab staging controller job {controller_job_id} accepted for {run_id}")
-        });
+        .unwrap_or_else(|_| format!("Lab staging accepted for {run_id}"));
         return Ok(LabOffloadOutcome::InFlight {
             plan,
             stdout: format!("{stdout}\n"),
             stderr: format!(
-                "Lab staging continues in controller job `{controller_job_id}`.\nNext: homeboy agent-task status {run_id}\nNext: {}\nNext: {}\n",
-                controller_job_commands.show, controller_job_commands.watch,
+                "Lab staging continues for durable run `{run_id}`.\nNext: homeboy agent-task status {run_id}\nNext: homeboy agent-task logs {run_id}\n",
             ),
             exit_code: 0,
             output_file_content: Some(format!("{stdout}\n")),
@@ -2300,6 +2272,36 @@ pub(crate) fn controller_job_retrieval_commands(job_id: &str) -> ControllerJobRe
         show: format!("homeboy activity show {job_id}"),
         watch: format!("homeboy activity watch {job_id}"),
     }
+}
+
+pub(crate) fn detached_staging_submission_output(
+    submission: crate::lab_staging_controller::DetachedStagingSubmission,
+    run_id: &str,
+) -> serde_json::Value {
+    let mut output = serde_json::json!({
+        "durable_run_id": run_id,
+        "retrieval_commands": {
+            "status": format!("homeboy agent-task status {run_id}"),
+            "logs": format!("homeboy agent-task logs {run_id}"),
+        },
+    });
+    match submission {
+        crate::lab_staging_controller::DetachedStagingSubmission::Controller { job_id } => {
+            let commands = controller_job_retrieval_commands(&job_id);
+            output["status"] = serde_json::json!("materializing");
+            output["controller_job_id"] = serde_json::json!(job_id);
+            output["retrieval_commands"]["controller_job"] = serde_json::json!(commands.show);
+            output["retrieval_commands"]["controller_job_watch"] =
+                serde_json::json!(commands.watch);
+        }
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt) => {
+            output["status"] = serde_json::json!("staged");
+            output["runner_staging_id"] =
+                serde_json::json!(receipt.runner_receipt.handoff.runner_job_id);
+            output["controller_projection"] = serde_json::json!(receipt.controller_projection);
+        }
+    }
+    output
 }
 
 /// Keep the generated direct command and the reverse-transport command in

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -124,6 +124,8 @@ use crate::runtime_materializer::{
 
 #[cfg(test)]
 pub(super) use inner::accepted_runner_job_id_with;
+#[cfg(test)]
+pub(super) use inner::detached_staging_submission_output;
 
 use super::super::workload::{
     build_lab_runner_workload_for_dispatched_command, lab_runner_workload_agent_task_from_command,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -19,7 +19,7 @@ fn deferred_staging_emits_only_durable_run_commands() {
                 schema: "homeboy/direct-lab-handoff-receipt/v1".to_string(),
                 run_id: "run-1".to_string(),
                 runner_id: "runner-1".to_string(),
-                runner_job_id: "staging-run-1".to_string(),
+                runner_job_id: "00000000-0000-0000-0000-000000000001".to_string(),
                 idempotency_key: "run-1".to_string(),
                 controller_identity: "controller-1".to_string(),
                 acceptance_state: "accepted".to_string(),
@@ -44,12 +44,16 @@ fn deferred_staging_emits_only_durable_run_commands() {
         controller_projection: "deferred".to_string(),
     };
     let output = detached_staging_submission_output(
-        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt),
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt.clone()),
         "run-1",
     );
 
     assert_eq!(output["status"], "staged");
-    assert_eq!(output["runner_staging_id"], "staging-run-1");
+    assert_eq!(
+        output["runner_job_id"],
+        "00000000-0000-0000-0000-000000000001"
+    );
+    assert!(output.get("runner_staging_id").is_none());
     assert!(output.get("controller_job_id").is_none());
     assert!(output["retrieval_commands"].get("controller_job").is_none());
     assert_eq!(
@@ -60,6 +64,13 @@ fn deferred_staging_emits_only_durable_run_commands() {
         output["retrieval_commands"]["logs"],
         "homeboy agent-task logs run-1"
     );
+    let source = receipt
+        .runner_receipt
+        .artifacts
+        .source_artifact
+        .expect("source artifact descriptor");
+    assert_eq!(source.package.extraction_root, "workspace");
+    assert_eq!(source.package.entries[0].path, "source.bin");
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -9,6 +9,53 @@ fn detached_staging_controller_job_commands_use_activity_surface() {
 }
 
 #[test]
+fn deferred_staging_emits_only_durable_run_commands() {
+    let receipt = crate::controller_fallback_projection::DeferredControllerReceipt {
+        schema: "homeboy/controller-fallback-projection/v1".to_string(),
+        mission_id: "run-1".to_string(),
+        runner_receipt: crate::runner_staging_operation::RemoteRunnerStagingReceipt {
+            schema: "homeboy/remote-runner-staging-receipt/v1".to_string(),
+            handoff: crate::direct_lab_handoff::DirectLabHandoffReceipt {
+                schema: "homeboy/direct-lab-handoff-receipt/v1".to_string(),
+                run_id: "run-1".to_string(),
+                runner_id: "runner-1".to_string(),
+                runner_job_id: "staging-run-1".to_string(),
+                idempotency_key: "run-1".to_string(),
+                controller_identity: "controller-1".to_string(),
+                acceptance_state: "accepted".to_string(),
+                controller_projection: "deferred".to_string(),
+                status_command: "homeboy agent-task status run-1".to_string(),
+                cancel_command: "homeboy agent-task cancel run-1".to_string(),
+                evidence_command: "homeboy agent-task evidence run-1 --full".to_string(),
+            },
+            artifacts: crate::runner_staging_operation::RunnerStagingArtifacts {
+                lifecycle_id: "staging-run-1".to_string(),
+                source_artifact_id: "source-1".to_string(),
+                workspace_artifact_id: "workspace-1".to_string(),
+            },
+        },
+        controller_projection: "deferred".to_string(),
+    };
+    let output = detached_staging_submission_output(
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt),
+        "run-1",
+    );
+
+    assert_eq!(output["status"], "staged");
+    assert_eq!(output["runner_staging_id"], "staging-run-1");
+    assert!(output.get("controller_job_id").is_none());
+    assert!(output["retrieval_commands"].get("controller_job").is_none());
+    assert_eq!(
+        output["retrieval_commands"]["status"],
+        "homeboy agent-task status run-1"
+    );
+    assert_eq!(
+        output["retrieval_commands"]["logs"],
+        "homeboy agent-task logs run-1"
+    );
+}
+
+#[test]
 fn emit_durable_run_id_writes_json_to_output_before_execution() {
     let dir = tempfile::tempdir().expect("temp dir");
     let output_path = dir.path().join("cook-output.json");

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -53,7 +53,10 @@ fn deferred_staging_emits_only_durable_run_commands() {
         output["runner_job_id"],
         "00000000-0000-0000-0000-000000000001"
     );
-    assert!(output.get("runner_staging_id").is_none());
+    assert_eq!(
+        output["runner_staging_id"],
+        "00000000-0000-0000-0000-000000000001"
+    );
     assert!(output.get("controller_job_id").is_none());
     assert!(output["retrieval_commands"].get("controller_job").is_none());
     assert_eq!(

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -32,6 +32,13 @@ fn deferred_staging_emits_only_durable_run_commands() {
                 lifecycle_id: "staging-run-1".to_string(),
                 source_artifact_id: "source-1".to_string(),
                 workspace_artifact_id: "workspace-1".to_string(),
+                source_artifact: Some(
+                    crate::runner_staging_operation::SourceArtifactTransfer::from_bytes(
+                        "source-run-1",
+                        b"sealed source package",
+                    )
+                    .descriptor(),
+                ),
             },
         },
         controller_projection: "deferred".to_string(),

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -971,6 +971,25 @@ pub(crate) fn submit_detached_staging(
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
 ) -> Result<DetachedStagingSubmission> {
+    submit_detached_staging_with_daemon_ensure(
+        run_id,
+        runner_id,
+        tunnel_mode,
+        request,
+        ensure_current_controller_daemon,
+    )
+}
+
+fn submit_detached_staging_with_daemon_ensure<Ensure>(
+    run_id: &str,
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    request: &LabOffloadRequest<'_>,
+    ensure_daemon: Ensure,
+) -> Result<DetachedStagingSubmission>
+where
+    Ensure: FnOnce() -> Result<homeboy_core::daemon::DaemonStartResult>,
+{
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -979,7 +998,7 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let daemon = match ensure_current_controller_daemon() {
+    let daemon = match ensure_daemon() {
         Ok(daemon) => daemon,
         Err(daemon_error) => {
             return submit_deferred_runner_staging(
@@ -4062,6 +4081,189 @@ mod tests {
             Some(run_id),
         )
         .expect("submit durable attempt");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detached_staging_falls_back_through_authenticated_reverse_broker_and_projects_terminal_result_once(
+    ) {
+        use homeboy_core::api_jobs::{JobEventKind, JobStatus};
+        use homeboy_core::server::RunnerPolicy;
+        use homeboy_core::test_support::{with_isolated_home, AuthenticatedReverseBrokerFixture};
+
+        with_isolated_home(|home| {
+            let _adapter_guard = global_state_lock().lock().expect("adapter lock");
+            std::env::set_var("HOMEBOY_CONTROLLER_ID", "fixture-controller");
+            clear_installed_adapter();
+            register();
+            enable_production_routing();
+            crate::register_runner_staging_provider();
+            crate::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create Lab runner");
+            crate::merge(
+                Some("lab"),
+                &serde_json::json!({
+                    "policy": RunnerPolicy {
+                        allow_raw_exec: Some(true),
+                        workspace_roots: vec!["/tmp".to_string()],
+                        allowed_commands: vec!["sh".to_string()],
+                        ..Default::default()
+                    }
+                })
+                .to_string(),
+                &[],
+            )
+            .expect("allow deterministic fixture command");
+            let broker = AuthenticatedReverseBrokerFixture::start("lab");
+            let (connected, code) = crate::connect_reverse(crate::ReverseRunnerConnectOptions {
+                controller_id: "fixture-controller".to_string(),
+                runner_id: "lab".to_string(),
+                broker_url: Some(broker.url().to_string()),
+            })
+            .expect("register authenticated reverse session");
+            assert_eq!(code, 0);
+            assert!(connected.connected);
+            // `connect_reverse` is the runner-side registration protocol. The
+            // controller observes that runner through its controller-role
+            // session record, just as the two production processes do.
+            let controller_session = crate::RunnerSession {
+                runner_id: "lab".to_string(),
+                mode: crate::RunnerTunnelMode::Reverse,
+                role: crate::RunnerSessionRole::Controller,
+                server_id: None,
+                controller_id: Some("fixture-controller".to_string()),
+                broker_url: Some(broker.url().to_string()),
+                remote_daemon_address: None,
+                local_port: None,
+                local_url: None,
+                tunnel_pid: None,
+                tunnel_process_start_identity: None,
+                remote_daemon_pid: None,
+                remote_daemon_lease_id: None,
+                homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
+                homeboy_build_identity: Some(homeboy_product_identity::build_identity().display),
+                connected_at: chrono::Utc::now().to_rfc3339(),
+                worker_identity: Some("fixture-worker".to_string()),
+                worker_pid: Some(std::process::id()),
+                last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
+                leaseless_recovery_evidence: None,
+            };
+            let controller_session_path =
+                homeboy_core::paths::runner_controller_session_file("lab", "fixture-controller")
+                    .expect("controller session path");
+            std::fs::create_dir_all(controller_session_path.parent().expect("session parent"))
+                .expect("create controller session parent");
+            std::fs::write(
+                controller_session_path,
+                serde_json::to_vec(&controller_session).expect("serialize controller session"),
+            )
+            .expect("write controller session");
+
+            let source = home.path().join("source");
+            std::fs::create_dir_all(&source).expect("create source");
+            std::fs::write(source.join("input.txt"), "staged-source\n").expect("write source");
+            let output = home.path().join("worker-output.txt");
+            let args = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("printf staged-worker-ok > {}", output.display()),
+            ];
+            let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
+                "authenticated-reverse-staging",
+                Vec::new(),
+            );
+            let run_id = "authenticated-reverse-staging-run";
+            submit_recipe_run(run_id);
+            let mut request = recipe_request(Some(recipe_command()), &args, HashMap::new());
+            request.placement_decision =
+                homeboy_core::lab_routing::compatibility_placement_decision(
+                    homeboy_lab_runner_contract::Placement::Lab,
+                    Some("lab"),
+                    false,
+                );
+            request.source_path = Some(&source);
+            request.durable_agent_task_plan = Some(&plan);
+            let pre_provider = || {
+                Err(Error::internal_unexpected(
+                    "fixture typed pre-provider daemon admission failure",
+                ))
+            };
+            let receipt = submit_detached_staging_with_daemon_ensure(
+                run_id,
+                "lab",
+                crate::RunnerTunnelMode::Reverse,
+                &request,
+                pre_provider,
+            )
+            .expect("admit durable fallback staging");
+            let DetachedStagingSubmission::Deferred(receipt) = receipt else {
+                panic!("typed pre-provider failure must select deferred staging");
+            };
+            let job_id = receipt.runner_receipt.handoff.runner_job_id.clone();
+            assert!(!job_id.is_empty());
+            assert_eq!(broker.jobs().len(), 1, "staging owns queue admission");
+            assert_eq!(broker.jobs()[0].status, JobStatus::Queued);
+            let warning = crate::status("lab")
+                .expect("read reverse runner status")
+                .stale_daemon
+                .expect("reverse verification warning");
+            assert_eq!(
+                warning.compatibility_reason.as_deref(),
+                Some("reverse_unverified")
+            );
+
+            let (worker, worker_code) =
+                crate::run_reverse_worker(crate::ReverseRunnerWorkerOptions {
+                    runner_id: "lab".to_string(),
+                    broker_url: broker.url().to_string(),
+                    broker_token: Some(broker.token().to_string()),
+                    project_id: None,
+                    lease_ms: 30_000,
+                    concurrency_limit: Some(1),
+                    loop_mode: false,
+                    idle_backoff_ms: 1,
+                    max_idle_backoff_ms: 10,
+                    broker_failure_backoff_ms: 1,
+                    broker_retry_limit: 1,
+                })
+                .expect("execute staged reverse job");
+            assert_eq!(worker_code, 0, "worker={worker:#?}");
+            assert!(worker.claimed);
+            assert_eq!(
+                std::fs::read_to_string(&output).expect("worker side effect"),
+                "staged-worker-ok"
+            );
+            let job = broker
+                .store
+                .get(uuid::Uuid::parse_str(&job_id).expect("job id"))
+                .expect("broker job");
+            assert_eq!(job.status, JobStatus::Succeeded);
+            let results = broker.store.events(job.id).expect("terminal evidence");
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|event| event.kind == JobEventKind::Result)
+                    .count(),
+                1
+            );
+            assert!(results
+                .iter()
+                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("project terminal result"),
+                1
+            );
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("replay projection"),
+                0
+            );
+        });
     }
 
     fn envelope() -> LabStagingDispatchEnvelope {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1092,7 +1092,7 @@ fn submit_deferred_runner_staging(
         request,
         request.local_output_file.is_some(),
     )?;
-    let _source_path = recipe.source_path.take().ok_or_else(|| {
+    let source_path = recipe.source_path.take().ok_or_else(|| {
         Error::validation_invalid_argument(
             "source_path",
             "controller fallback requires a source path to seal before detached staging",
@@ -1116,7 +1116,7 @@ fn submit_deferred_runner_staging(
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
     let source_artifact =
-        SourceArtifactTransfer::from_bytes(format!("source-{run_id}"), &sealed_payload);
+        SourceArtifactTransfer::from_directory(format!("source-{run_id}"), &source_path)?;
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -969,7 +969,7 @@ pub(crate) fn submit_detached_staging(
     runner_id: &str,
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
-) -> Result<String> {
+) -> Result<DetachedStagingSubmission> {
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -988,7 +988,7 @@ pub(crate) fn submit_detached_staging(
                 request,
                 daemon_error,
             )
-            .map(|receipt| receipt.handoff.runner_job_id);
+            .map(DetachedStagingSubmission::Deferred);
         }
     };
     let recipe = persist_lab_staging_recipe_for_transport(
@@ -1056,7 +1056,14 @@ pub(crate) fn submit_detached_staging(
             started.id, job.id
         )));
     }
-    Ok(job_id)
+    Ok(DetachedStagingSubmission::Controller { job_id })
+}
+
+/// The initiating client must distinguish a controller job from runner-owned
+/// staging. They have separate status and reconciliation authorities.
+pub(crate) enum DetachedStagingSubmission {
+    Controller { job_id: String },
+    Deferred(crate::controller_fallback_projection::DeferredControllerReceipt),
 }
 
 /// Explicit detached fallback after local controller admission has failed. The
@@ -1068,7 +1075,7 @@ fn submit_deferred_runner_staging(
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
     daemon_error: Error,
-) -> Result<crate::runner_staging_operation::RemoteRunnerStagingReceipt> {
+) -> Result<crate::controller_fallback_projection::DeferredControllerReceipt> {
     let plan = request.durable_agent_task_plan.ok_or_else(|| {
         Error::validation_invalid_argument(
             "durable_agent_task_plan",
@@ -1136,25 +1143,24 @@ fn submit_deferred_runner_staging(
             });
             error
         })?;
-    let receipt =
+    let deferred_receipt =
         crate::controller_fallback_projection::ControllerFallbackProjectionStore::open_default()?
-            .submit_detached(&mut transport, &envelope)?
-            .runner_receipt;
+            .submit_detached(&mut transport, &envelope)?;
     homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
         run_id,
         DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND,
-        &receipt,
+        &deferred_receipt.runner_receipt,
     )?;
     homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
         homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
             run_id,
             runner_id,
-            runner_job_id: &receipt.handoff.runner_job_id,
+            runner_job_id: &deferred_receipt.runner_receipt.handoff.runner_job_id,
             remote_workspace: "runner-staging",
             remote_command: &[],
         },
     )?;
-    Ok(receipt)
+    Ok(deferred_receipt)
 }
 
 /// A response can be lost after the daemon accepted the request. Create uses

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -4169,7 +4169,7 @@ mod tests {
             let args = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("printf staged-worker-ok > {}", output.display()),
+                format!("cat input.txt | tee {}", output.display()),
             ];
             let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
                 "authenticated-reverse-staging",
@@ -4234,7 +4234,7 @@ mod tests {
             assert!(worker.claimed);
             assert_eq!(
                 std::fs::read_to_string(&output).expect("worker side effect"),
-                "staged-worker-ok"
+                "staged-source\n"
             );
             let job = broker
                 .store
@@ -4249,9 +4249,15 @@ mod tests {
                     .count(),
                 1
             );
-            assert!(results
+            let terminal_result = results
                 .iter()
-                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+                .find(|event| event.kind == JobEventKind::Result)
+                .and_then(|event| event.data.as_ref())
+                .expect("terminal result data");
+            assert_eq!(
+                terminal_result["stdout"],
+                serde_json::json!("staged-source\n")
+            );
 
             assert_eq!(
                 crate::controller_fallback_projection::reconcile_on_controller_startup()

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -24,6 +24,10 @@ use homeboy_core::lab_contract::{
 use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
 use homeboy_core::{Error, Result};
 
+use crate::direct_lab_handoff::DirectLabHandoffEnvelope;
+use crate::runner_staging_operation::{
+    RemoteRunnerStagingEnvelope, RunnerMaterializationAuthority, SealedSourceAuthority,
+};
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
 pub const LAB_STAGING_DISPATCH_JOB_TYPE: &str = "lab.staging-dispatch";
@@ -37,6 +41,7 @@ const DURABLE_LAB_RUNTIME_STAGE_ATTACHMENT_KIND: &str = "durable-lab-runtime-sta
 const DURABLE_LAB_HYDRATION_STAGE_ATTACHMENT_KIND: &str = "durable-lab-hydration-stage";
 const DURABLE_LAB_DISPATCH_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-dispatch-receipt";
 const DURABLE_LAB_TERMINAL_RECEIPT_ATTACHMENT_KIND: &str = "durable-lab-terminal-receipt";
+const DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND: &str = "deferred-runner-staging-receipt";
 const CONTROLLER_SUBMISSION_ATTEMPTS: usize = 3;
 
 /// Serializable, owned counterpart to the static Lab command contract.
@@ -973,7 +978,19 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let daemon = ensure_current_controller_daemon()?;
+    let daemon = match ensure_current_controller_daemon() {
+        Ok(daemon) => daemon,
+        Err(daemon_error) => {
+            return submit_deferred_runner_staging(
+                run_id,
+                runner_id,
+                tunnel_mode,
+                request,
+                daemon_error,
+            )
+            .map(|receipt| receipt.handoff.runner_job_id);
+        }
+    };
     let recipe = persist_lab_staging_recipe_for_transport(
         run_id,
         runner_id,
@@ -1040,6 +1057,104 @@ pub(crate) fn submit_detached_staging(
         )));
     }
     Ok(job_id)
+}
+
+/// Explicit detached fallback after local controller admission has failed. The
+/// resolver performs connectivity/capability observation before the runner's
+/// durable staging mutation; no provider execution is available at this layer.
+fn submit_deferred_runner_staging(
+    run_id: &str,
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    request: &LabOffloadRequest<'_>,
+    daemon_error: Error,
+) -> Result<crate::runner_staging_operation::RemoteRunnerStagingReceipt> {
+    let plan = request.durable_agent_task_plan.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "durable_agent_task_plan",
+            "controller fallback requires an explicit detached durable plan",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let mut recipe = LabStagingRecipe::from_request_with_transport(
+        run_id,
+        runner_id,
+        tunnel_mode,
+        request,
+        request.local_output_file.is_some(),
+    )?;
+    let _source_path = recipe.source_path.take().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source_path",
+            "controller fallback requires a source path to seal before detached staging",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    // The portable recipe is the sealed staging authority. It deliberately
+    // excludes the controller-local source path before crossing the runner API.
+    let sealed_payload = canonical_json_bytes(&serde_json::to_value(&recipe).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize deferred staging recipe".to_string()),
+        )
+    })?)
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("canonicalize deferred staging recipe".to_string()),
+        )
+    })?;
+    let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
+    let handoff = DirectLabHandoffEnvelope::new(
+        homeboy_product_identity::build_identity().display,
+        recipe,
+        plan.clone(),
+    );
+    let envelope = RemoteRunnerStagingEnvelope::from_direct_handoff(
+        &handoff,
+        RunnerMaterializationAuthority {
+            authority_id: format!("staging-{run_id}"),
+            workspace_key: run_id.to_string(),
+            source: SealedSourceAuthority::new(
+                digest,
+                String::from_utf8(sealed_payload).map_err(|error| {
+                    Error::internal_unexpected(format!(
+                        "deferred staging payload is not UTF-8: {error}"
+                    ))
+                })?,
+            ),
+        },
+    )?;
+    let mut transport =
+        crate::resolve_runner_staging_transport(runner_id).map_err(|mut error| {
+            error.details["controller_daemon_fallback"] = json!({
+                "daemon_error": daemon_error.message,
+                "phase": "pre_provider",
+                "provider_budget_consumed": false,
+            });
+            error
+        })?;
+    let receipt =
+        crate::controller_fallback_projection::ControllerFallbackProjectionStore::open_default()?
+            .submit_detached(&mut transport, &envelope)?
+            .runner_receipt;
+    homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
+        run_id,
+        DEFERRED_RUNNER_STAGING_RECEIPT_ATTACHMENT_KIND,
+        &receipt,
+    )?;
+    homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
+        homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
+            run_id,
+            runner_id,
+            runner_job_id: &receipt.handoff.runner_job_id,
+            remote_workspace: "runner-staging",
+            remote_command: &[],
+        },
+    )?;
+    Ok(receipt)
 }
 
 /// A response can be lost after the daemon accepted the request. Create uses

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -27,6 +27,7 @@ use homeboy_core::{Error, Result};
 use crate::direct_lab_handoff::DirectLabHandoffEnvelope;
 use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RunnerMaterializationAuthority, SealedSourceAuthority,
+    SourceArtifactTransfer,
 };
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
@@ -1114,6 +1115,8 @@ fn submit_deferred_runner_staging(
         )
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
+    let source_artifact =
+        SourceArtifactTransfer::from_bytes(format!("source-{run_id}"), &sealed_payload);
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,
@@ -1132,6 +1135,7 @@ fn submit_deferred_runner_staging(
                     ))
                 })?,
             ),
+            source_artifact: Some(source_artifact),
         },
     )?;
     let mut transport =

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -41,6 +41,7 @@ mod command_path;
 )]
 mod connection;
 mod continuation_provider;
+pub mod controller_fallback_projection;
 mod daemon_exec_driver;
 mod daemon_health;
 mod daemon_http_get;

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -9,6 +9,8 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
 
 use homeboy_core::{Error, Result};
 
@@ -56,6 +58,125 @@ pub struct SourceArtifactTransfer {
 }
 
 impl SourceArtifactTransfer {
+    /// Packages a controller-owned source tree into the versioned runner
+    /// manifest. Traversal is lexical and deterministic; links and non-files
+    /// are refused rather than crossing a controller filesystem boundary.
+    pub fn from_directory(artifact_id: impl Into<String>, root: &Path) -> Result<Self> {
+        fn collect(
+            root: &Path,
+            directory: &Path,
+            files: &mut BTreeMap<String, Vec<u8>>,
+        ) -> Result<()> {
+            let mut entries = fs::read_dir(directory)
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+                })?;
+            entries.sort_by_key(|entry| entry.file_name());
+            for entry in entries {
+                let path = entry.path();
+                let metadata = fs::symlink_metadata(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+                if metadata.file_type().is_symlink() || !(metadata.is_file() || metadata.is_dir()) {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package accepts only regular files and directories",
+                        Some(path.display().to_string()),
+                        None,
+                    ));
+                }
+                if metadata.is_dir() {
+                    collect(root, &path, files)?;
+                    continue;
+                }
+                if metadata.len() > MAX_SOURCE_PACKAGE_FILE_BYTES {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package file exceeds the configured size bound",
+                        Some(path.display().to_string()),
+                        None,
+                    ));
+                }
+                let relative = path.strip_prefix(root).expect("walk remains under root");
+                let relative = relative.to_string_lossy().replace('\\', "/");
+                let bytes = fs::read(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+                files.insert(relative, bytes);
+                if files.len() > MAX_SOURCE_PACKAGE_ENTRIES
+                    || files.values().map(|bytes| bytes.len() as u64).sum::<u64>()
+                        > MAX_SOURCE_ARTIFACT_BYTES
+                {
+                    return Err(Error::validation_invalid_argument(
+                        "source_path",
+                        "source package exceeds configured entry or total size bounds",
+                        Some(root.display().to_string()),
+                        None,
+                    ));
+                }
+            }
+            Ok(())
+        }
+
+        if !root.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "source_path",
+                "source package root must be a readable directory",
+                Some(root.display().to_string()),
+                None,
+            ));
+        }
+        let mut files = BTreeMap::new();
+        collect(root, root, &mut files)?;
+        if files.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "source_path",
+                "source package root must contain at least one regular file",
+                Some(root.display().to_string()),
+                None,
+            ));
+        }
+        let entries = files
+            .iter()
+            .map(|(path, bytes)| SourcePackageEntry {
+                path: path.clone(),
+                sha256: format!("sha256:{:x}", Sha256::digest(bytes)),
+                size_bytes: bytes.len() as u64,
+            })
+            .collect::<Vec<_>>();
+        let package = serde_json::to_vec(
+            &files
+                .iter()
+                .map(|(path, bytes)| {
+                    (
+                        path,
+                        base64::engine::general_purpose::STANDARD.encode(bytes),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        )
+        .expect("source package serializes");
+        let transfer = Self {
+            schema: SOURCE_ARTIFACT_TRANSFER_SCHEMA.to_string(),
+            artifact_id: artifact_id.into(),
+            sha256: format!("sha256:{:x}", Sha256::digest(&package)),
+            size_bytes: package.len() as u64,
+            content_base64: base64::engine::general_purpose::STANDARD.encode(package),
+            package: SourcePackageManifest {
+                schema: "homeboy/source-package-manifest/v1".into(),
+                format: "homeboy/source-package-json/v1".into(),
+                extraction_root: "workspace".into(),
+                entries,
+            },
+        };
+        transfer.decode_verified()?;
+        Ok(transfer)
+    }
+
     pub fn from_bytes(artifact_id: impl Into<String>, bytes: &[u8]) -> Self {
         let package = serde_json::to_vec(&BTreeMap::from([(
             "source.bin",
@@ -679,5 +800,30 @@ pub(crate) mod tests_support {
         assert_eq!(error.code, homeboy_core::ErrorCode::RunnerCapabilityMissing);
         assert_eq!(incompatible.calls, 0);
         assert_eq!(incompatible.provider_budget, 0);
+    }
+
+    #[test]
+    fn source_tree_package_is_deterministic_and_preserves_manifest_entries() {
+        let source = tempfile::tempdir().expect("source");
+        std::fs::create_dir(source.path().join("nested")).expect("nested");
+        std::fs::write(source.path().join("z.txt"), b"z").expect("z");
+        std::fs::write(source.path().join("nested/a.txt"), b"a").expect("a");
+
+        let first =
+            SourceArtifactTransfer::from_directory("source-1", source.path()).expect("pack");
+        let second =
+            SourceArtifactTransfer::from_directory("source-1", source.path()).expect("repack");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .package
+                .entries
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["nested/a.txt", "z.txt"]
+        );
+        first.decode_verified().expect("verified package");
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -497,7 +497,7 @@ pub(crate) mod tests_support {
     use crate::lab_staging_controller::LabStagingRecipe;
     use homeboy_core::lab_contract::LabCommandContract;
 
-    struct Transport {
+    pub(crate) struct Transport {
         connected: bool,
         compatible: bool,
         source_artifact_compatible: bool,
@@ -540,8 +540,35 @@ pub(crate) mod tests_support {
             };
             self.receipts
                 .insert(envelope.handoff.idempotency_key.clone(), receipt.clone());
-            self.provider_budget += 1;
             Ok(receipt)
+        }
+    }
+
+    impl Transport {
+        pub(crate) fn compatible() -> Self {
+            transport()
+        }
+
+        pub(crate) fn incompatible() -> Self {
+            Self {
+                compatible: false,
+                ..transport()
+            }
+        }
+
+        pub(crate) fn disconnected() -> Self {
+            Self {
+                connected: false,
+                ..transport()
+            }
+        }
+
+        pub(crate) fn calls(&self) -> usize {
+            self.calls
+        }
+
+        pub(crate) fn provider_budget(&self) -> usize {
+            self.provider_budget
         }
     }
 
@@ -617,7 +644,7 @@ pub(crate) mod tests_support {
         let replay = submit_remote_runner_staging(&mut transport, &envelope).expect("replay");
         assert_eq!(first, replay);
         assert_eq!(transport.receipts.len(), 1);
-        assert_eq!(transport.provider_budget, 1);
+        assert_eq!(transport.provider_budget, 0);
         assert_eq!(first.artifacts.lifecycle_id, "runner-lifecycle-1");
     }
 

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -363,6 +363,11 @@ fn run_once_output(
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
+    materialize_staged_source_artifact(
+        &options.runner_id,
+        &claim.job.id.to_string(),
+        &mut execution_envelope,
+    )?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -991,6 +996,42 @@ fn reverse_worker_lab_offload(raw: &str) -> Result<serde_json::Value> {
             Some("parse reverse worker Lab offload metadata".to_string()),
         )
     })
+}
+
+/// A staged job's source is runner-owned durable storage, not a controller path.
+/// Verify and extract it before the normal queue executor consumes the command.
+fn materialize_staged_source_artifact(
+    runner_id: &str,
+    job_id: &str,
+    envelope: &mut RunnerExecutionEnvelope,
+) -> Result<()> {
+    let Some(source) = envelope.metadata.get("staged_source_artifact") else {
+        return Ok(());
+    };
+    let source = serde_json::from_value(source.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_source_artifact",
+            format!("invalid staged source artifact: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let session_path = homeboy_core::paths::runner_session_file(runner_id)?;
+    let store_path = session_path.with_file_name(format!("{runner_id}-staging/store.json"));
+    let workspace_root = session_path
+        .with_file_name(format!("{runner_id}-staging/workloads"))
+        .join(job_id);
+    let workspace = crate::runner_staging_store::extract_staged_source_artifact(
+        store_path,
+        &source,
+        &workspace_root,
+    )?;
+    let dispatch = envelope
+        .dispatch
+        .as_mut()
+        .ok_or_else(|| Error::internal_unexpected("staged runner job has no execution dispatch"))?;
+    dispatch.cwd = Some(workspace.display().to_string());
+    Ok(())
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -23,6 +23,7 @@ use super::support::{
     write_reverse_controller_session,
 };
 use super::worker_options;
+use crate::runner_staging_operation::SourceArtifactTransfer;
 
 #[test]
 fn reverse_worker_executes_claimed_job_and_finishes_it() {
@@ -927,6 +928,55 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
             result["data"]["execution_record"]["path_materialization_plan"]["entries"][0]
                 ["remote_path"],
             serde_json::json!("/tmp")
+        );
+    });
+}
+
+#[test]
+fn reverse_worker_executes_a_verified_staged_source_package() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let path = tempfile::tempdir()
+            .expect("tempdir")
+            .path()
+            .join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
+        let transfer = SourceArtifactTransfer::from_bytes("staged-source-1", b"staged output");
+        let artifact = transfer.descriptor();
+        let session_path = homeboy_core::paths::runner_session_file("lab").expect("session path");
+        let artifact_path = session_path
+            .parent()
+            .expect("session parent")
+            .join("lab-staging/source-artifacts/staged-source-1");
+        std::fs::create_dir_all(artifact_path.parent().expect("artifact parent"))
+            .expect("create artifact root");
+        std::fs::write(&artifact_path, transfer.decode_verified().expect("package"))
+            .expect("write staged package");
+        let mut request = run_id_echo_request();
+        request.command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat source.bin; printf ' side-effect' > result; cat result".to_string(),
+        ];
+        request.metadata = Some(serde_json::json!({
+            "submission_key": "staged-source-job-1",
+            "staged_source_artifact": artifact,
+        }));
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("submit staged job");
+        drop(store);
+        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job.expect("job").id, job.id);
+        handle.join().expect("mock broker joins");
+        let result = result_event_data(&store, job.id);
+        assert_eq!(
+            result["stdout"],
+            serde_json::json!("staged output side-effect")
         );
     });
 }


### PR DESCRIPTION
## Summary
- merge the live direct/reverse sealed runner staging transport from #11655
- fall back to `resolve_runner_staging_transport()` only when local controller-daemon admission fails
- persist the returned runner receipt in the controller fallback ledger and the attempt attachment before recording the detached runner handoff

## Tests
- `cargo test -p homeboy-lab-runner controller_fallback_projection --lib --no-fail-fast`
- `cargo test -p homeboy-lab-runner runner_staging --lib --no-fail-fast`
- `cargo test -p homeboy-lab-runner lab_staging_controller --lib --no-fail-fast`

Refs #11581

Remaining implementation gap: production sealed staging currently persists a portable recipe payload and workspace identity only. It does not materialize and execute the selected workload, expose runner terminal outcome/artifacts through a read API, or invoke controller restart reconciliation from that evidence. The detached submission result also needs a typed receipt output rather than the existing controller-job-id-shaped return. Consequently the complete issue acceptance criteria are not yet met.

AI assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode merged the supplied runner transport base, wired controller-daemon fallback to the resolver, ran focused tests, and updated this PR; Chris Huber remains responsible for every line.