### PR TITLE
feat(runner): persist staged terminal execution

### DIFF
--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -5616,6 +5616,16 @@ where
     Ok(())
 }
 
+/// Test-support network entry point for the production reverse-broker routes.
+/// Authentication and route handling remain identical to a daemon connection.
+#[cfg(any(test, feature = "test-support"))]
+pub fn handle_reverse_broker_test_connection(
+    stream: TcpStream,
+    job_store: &JobStore,
+) -> std::io::Result<()> {
+    handle_connection(stream, job_store, UnsupportedAnalysisJobRunner, false)
+}
+
 fn read_http_request(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
     let mut request = Vec::new();
     let mut buffer = [0; 8 * 1024];

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -753,6 +753,7 @@ fn managed_alias_reuses_its_controlpath_and_bounds_mux_control() {
         auth: Some(ManagedSshSession {
             control_path: "/tmp/homeboy-%h-%p-%r".to_string(),
             persist: "4h".to_string(),
+            persist_source: super::super::ManagedSshSessionPersistSource::Configured,
         }),
         is_local: false,
         env: HashMap::new(),

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -208,6 +208,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: control_path.to_string_lossy().to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/server/transfer.rs
+++ b/crates/homeboy-core/src/server/transfer.rs
@@ -568,6 +568,7 @@ mod tests {
             auth: Some(ManagedSshSession {
                 control_path: "/tmp/homeboy-control".to_string(),
                 persist: "4h".to_string(),
+                persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
             }),
             is_local: false,
             env: HashMap::new(),

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeSet,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use tempfile::TempDir;
 
@@ -1287,6 +1291,105 @@ pub struct ReverseBrokerFixture {
     broker_url: String,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
+}
+
+/// An authenticated reverse broker backed by the daemon's production HTTP
+/// routes and durable job store. The Lab runner registers its staging provider
+/// before using this fixture.
+pub struct AuthenticatedReverseBrokerFixture {
+    pub store: JobStore,
+    runner_id: String,
+    broker_url: String,
+    token: String,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AuthenticatedReverseBrokerFixture {
+    pub fn start(runner_id: impl Into<String>) -> Self {
+        let runner_id = runner_id.into();
+        let mut auth = crate::broker_auth::BrokerAuthStore::default();
+        let credential = auth
+            .pair(
+                format!("test-{runner_id}"),
+                &runner_id,
+                [
+                    crate::broker_auth::BrokerScope::Submit,
+                    crate::broker_auth::BrokerScope::Work,
+                ]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            )
+            .expect("pair authenticated reverse broker fixture");
+        auth.save()
+            .expect("persist authenticated reverse broker fixture auth");
+        let token = credential.token;
+        let store = JobStore::default();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind authenticated reverse broker fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("make authenticated reverse broker fixture nonblocking");
+        let broker_url = format!("http://{}", listener.local_addr().expect("broker address"));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_store = store.clone();
+        let handle = std::thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make authenticated reverse broker fixture stream blocking");
+                        crate::daemon::handle_reverse_broker_test_connection(stream, &thread_store)
+                            .expect("serve authenticated reverse broker fixture request");
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => {
+                        panic!("accept authenticated reverse broker fixture request: {error}")
+                    }
+                }
+            }
+        });
+        Self {
+            store,
+            runner_id,
+            broker_url,
+            token,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.broker_url
+    }
+
+    pub fn runner_id(&self) -> &str {
+        &self.runner_id
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn jobs(&self) -> Vec<Job> {
+        self.store.list()
+    }
+}
+
+impl Drop for AuthenticatedReverseBrokerFixture {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.broker_url.trim_start_matches("http://"));
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .expect("authenticated reverse broker fixture joins");
+        }
+    }
 }
 
 impl ReverseBrokerFixture {

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1425,7 +1425,9 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
-    let response = client
+    let broker_token =
+        homeboy_core::broker_auth::broker_submit_token_for_runner(&session.runner_id)?;
+    let request = client
         .post(format!(
             "{}/runner/sessions",
             broker_url.trim_end_matches('/')
@@ -1439,11 +1441,15 @@ fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSessio
             "worker_identity": session.worker_identity,
             "worker_pid": session.worker_pid,
             "last_seen_at": session.last_seen_at,
-        }))
-        .send()
-        .map_err(|err| {
-            Error::internal_unexpected(format!("register reverse runner session: {err}"))
-        })?;
+        }));
+    let request = if let Some(token) = broker_token.as_deref() {
+        request.header(homeboy_core::broker_auth::BROKER_TOKEN_HEADER, token)
+    } else {
+        request
+    };
+    let response = request.send().map_err(|err| {
+        Error::internal_unexpected(format!("register reverse runner session: {err}"))
+    })?;
     let status_code = response.status().as_u16();
     let envelope: CliEnvelope = response.json().map_err(|err| {
         Error::internal_json(

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -64,7 +64,7 @@ impl DirectLabHandoffEnvelope {
                 None,
             ));
         }
-        self.recipe.validate()
+        self.recipe.validate_for_runner_staging()
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1409,7 +1409,10 @@ pub(crate) fn run_lab_offload_inner(
         .session
         .as_ref()
         .is_some_and(|session| session.mode == RunnerTunnelMode::DirectSsh)
-        && runner_status.stale_daemon.is_none()
+        // An unverified reverse session is an availability warning rather than
+        // a freshness fence. Only a typed blocking verdict can suppress this
+        // direct-SSH identity comparison.
+        && runner_status.admission_blocking_stale_daemon().is_none()
     {
         let session = runner_status
             .session

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -971,6 +971,25 @@ pub(crate) fn submit_detached_staging(
     tunnel_mode: crate::RunnerTunnelMode,
     request: &LabOffloadRequest<'_>,
 ) -> Result<DetachedStagingSubmission> {
+    submit_detached_staging_with_daemon_ensure(
+        run_id,
+        runner_id,
+        tunnel_mode,
+        request,
+        ensure_current_controller_daemon,
+    )
+}
+
+fn submit_detached_staging_with_daemon_ensure<Ensure>(
+    run_id: &str,
+    runner_id: &str,
+    tunnel_mode: crate::RunnerTunnelMode,
+    request: &LabOffloadRequest<'_>,
+    ensure_daemon: Ensure,
+) -> Result<DetachedStagingSubmission>
+where
+    Ensure: FnOnce() -> Result<homeboy_core::daemon::DaemonStartResult>,
+{
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -979,7 +998,7 @@ pub(crate) fn submit_detached_staging(
             None,
         ));
     }
-    let daemon = match ensure_current_controller_daemon() {
+    let daemon = match ensure_daemon() {
         Ok(daemon) => daemon,
         Err(daemon_error) => {
             return submit_deferred_runner_staging(
@@ -4062,6 +4081,189 @@ mod tests {
             Some(run_id),
         )
         .expect("submit durable attempt");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detached_staging_falls_back_through_authenticated_reverse_broker_and_projects_terminal_result_once(
+    ) {
+        use homeboy_core::api_jobs::{JobEventKind, JobStatus};
+        use homeboy_core::server::RunnerPolicy;
+        use homeboy_core::test_support::{with_isolated_home, AuthenticatedReverseBrokerFixture};
+
+        with_isolated_home(|home| {
+            let _adapter_guard = global_state_lock().lock().expect("adapter lock");
+            std::env::set_var("HOMEBOY_CONTROLLER_ID", "fixture-controller");
+            clear_installed_adapter();
+            register();
+            enable_production_routing();
+            crate::register_runner_staging_provider();
+            crate::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create Lab runner");
+            crate::merge(
+                Some("lab"),
+                &serde_json::json!({
+                    "policy": RunnerPolicy {
+                        allow_raw_exec: Some(true),
+                        workspace_roots: vec!["/tmp".to_string()],
+                        allowed_commands: vec!["sh".to_string()],
+                        ..Default::default()
+                    }
+                })
+                .to_string(),
+                &[],
+            )
+            .expect("allow deterministic fixture command");
+            let broker = AuthenticatedReverseBrokerFixture::start("lab");
+            let (connected, code) = crate::connect_reverse(crate::ReverseRunnerConnectOptions {
+                controller_id: "fixture-controller".to_string(),
+                runner_id: "lab".to_string(),
+                broker_url: Some(broker.url().to_string()),
+            })
+            .expect("register authenticated reverse session");
+            assert_eq!(code, 0);
+            assert!(connected.connected);
+            // `connect_reverse` is the runner-side registration protocol. The
+            // controller observes that runner through its controller-role
+            // session record, just as the two production processes do.
+            let controller_session = crate::RunnerSession {
+                runner_id: "lab".to_string(),
+                mode: crate::RunnerTunnelMode::Reverse,
+                role: crate::RunnerSessionRole::Controller,
+                server_id: None,
+                controller_id: Some("fixture-controller".to_string()),
+                broker_url: Some(broker.url().to_string()),
+                remote_daemon_address: None,
+                local_port: None,
+                local_url: None,
+                tunnel_pid: None,
+                tunnel_process_start_identity: None,
+                remote_daemon_pid: None,
+                remote_daemon_lease_id: None,
+                homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
+                homeboy_build_identity: Some(homeboy_product_identity::build_identity().display),
+                connected_at: chrono::Utc::now().to_rfc3339(),
+                worker_identity: Some("fixture-worker".to_string()),
+                worker_pid: Some(std::process::id()),
+                last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
+                leaseless_recovery_evidence: None,
+            };
+            let controller_session_path =
+                homeboy_core::paths::runner_controller_session_file("lab", "fixture-controller")
+                    .expect("controller session path");
+            std::fs::create_dir_all(controller_session_path.parent().expect("session parent"))
+                .expect("create controller session parent");
+            std::fs::write(
+                controller_session_path,
+                serde_json::to_vec(&controller_session).expect("serialize controller session"),
+            )
+            .expect("write controller session");
+
+            let source = home.path().join("source");
+            std::fs::create_dir_all(&source).expect("create source");
+            std::fs::write(source.join("input.txt"), "staged-source\n").expect("write source");
+            let output = home.path().join("worker-output.txt");
+            let args = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("printf staged-worker-ok > {}", output.display()),
+            ];
+            let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
+                "authenticated-reverse-staging",
+                Vec::new(),
+            );
+            let run_id = "authenticated-reverse-staging-run";
+            submit_recipe_run(run_id);
+            let mut request = recipe_request(Some(recipe_command()), &args, HashMap::new());
+            request.placement_decision =
+                homeboy_core::lab_routing::compatibility_placement_decision(
+                    homeboy_lab_runner_contract::Placement::Lab,
+                    Some("lab"),
+                    false,
+                );
+            request.source_path = Some(&source);
+            request.durable_agent_task_plan = Some(&plan);
+            let pre_provider = || {
+                Err(Error::internal_unexpected(
+                    "fixture typed pre-provider daemon admission failure",
+                ))
+            };
+            let receipt = submit_detached_staging_with_daemon_ensure(
+                run_id,
+                "lab",
+                crate::RunnerTunnelMode::Reverse,
+                &request,
+                pre_provider,
+            )
+            .expect("admit durable fallback staging");
+            let DetachedStagingSubmission::Deferred(receipt) = receipt else {
+                panic!("typed pre-provider failure must select deferred staging");
+            };
+            let job_id = receipt.runner_receipt.handoff.runner_job_id.clone();
+            assert!(!job_id.is_empty());
+            assert_eq!(broker.jobs().len(), 1, "staging owns queue admission");
+            assert_eq!(broker.jobs()[0].status, JobStatus::Queued);
+            let warning = crate::status("lab")
+                .expect("read reverse runner status")
+                .stale_daemon
+                .expect("reverse verification warning");
+            assert_eq!(
+                warning.compatibility_reason.as_deref(),
+                Some("reverse_unverified")
+            );
+
+            let (worker, worker_code) =
+                crate::run_reverse_worker(crate::ReverseRunnerWorkerOptions {
+                    runner_id: "lab".to_string(),
+                    broker_url: broker.url().to_string(),
+                    broker_token: Some(broker.token().to_string()),
+                    project_id: None,
+                    lease_ms: 30_000,
+                    concurrency_limit: Some(1),
+                    loop_mode: false,
+                    idle_backoff_ms: 1,
+                    max_idle_backoff_ms: 10,
+                    broker_failure_backoff_ms: 1,
+                    broker_retry_limit: 1,
+                })
+                .expect("execute staged reverse job");
+            assert_eq!(worker_code, 0, "worker={worker:#?}");
+            assert!(worker.claimed);
+            assert_eq!(
+                std::fs::read_to_string(&output).expect("worker side effect"),
+                "staged-worker-ok"
+            );
+            let job = broker
+                .store
+                .get(uuid::Uuid::parse_str(&job_id).expect("job id"))
+                .expect("broker job");
+            assert_eq!(job.status, JobStatus::Succeeded);
+            let results = broker.store.events(job.id).expect("terminal evidence");
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|event| event.kind == JobEventKind::Result)
+                    .count(),
+                1
+            );
+            assert!(results
+                .iter()
+                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("project terminal result"),
+                1
+            );
+            assert_eq!(
+                crate::controller_fallback_projection::reconcile_on_controller_startup()
+                    .expect("replay projection"),
+                0
+            );
+        });
     }
 
     fn envelope() -> LabStagingDispatchEnvelope {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -4169,7 +4169,7 @@ mod tests {
             let args = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("printf staged-worker-ok > {}", output.display()),
+                format!("cat input.txt | tee {}", output.display()),
             ];
             let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
                 "authenticated-reverse-staging",
@@ -4234,7 +4234,7 @@ mod tests {
             assert!(worker.claimed);
             assert_eq!(
                 std::fs::read_to_string(&output).expect("worker side effect"),
-                "staged-worker-ok"
+                "staged-source\n"
             );
             let job = broker
                 .store
@@ -4249,9 +4249,15 @@ mod tests {
                     .count(),
                 1
             );
-            assert!(results
+            let terminal_result = results
                 .iter()
-                .any(|event| event.kind == JobEventKind::Result && event.data.is_some()));
+                .find(|event| event.kind == JobEventKind::Result)
+                .and_then(|event| event.data.as_ref())
+                .expect("terminal result data");
+            assert_eq!(
+                terminal_result["stdout"],
+                serde_json::json!("staged-source\n")
+            );
 
             assert_eq!(
                 crate::controller_fallback_projection::reconcile_on_controller_startup()

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -363,6 +363,11 @@ fn run_once_output(
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
+    materialize_staged_source_artifact(
+        &options.runner_id,
+        &claim.job.id.to_string(),
+        &mut execution_envelope,
+    )?;
     materialize_snapshot_git_baseline(&execution_envelope)?;
     // Shared finisher so the exec-error and exec-success paths submit their
     // terminal job result through identical broker plumbing (#5091).
@@ -991,6 +996,42 @@ fn reverse_worker_lab_offload(raw: &str) -> Result<serde_json::Value> {
             Some("parse reverse worker Lab offload metadata".to_string()),
         )
     })
+}
+
+/// A staged job's source is runner-owned durable storage, not a controller path.
+/// Verify and extract it before the normal queue executor consumes the command.
+fn materialize_staged_source_artifact(
+    runner_id: &str,
+    job_id: &str,
+    envelope: &mut RunnerExecutionEnvelope,
+) -> Result<()> {
+    let Some(source) = envelope.metadata.get("staged_source_artifact") else {
+        return Ok(());
+    };
+    let source = serde_json::from_value(source.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_source_artifact",
+            format!("invalid staged source artifact: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let session_path = homeboy_core::paths::runner_session_file(runner_id)?;
+    let store_path = session_path.with_file_name(format!("{runner_id}-staging/store.json"));
+    let workspace_root = session_path
+        .with_file_name(format!("{runner_id}-staging/workloads"))
+        .join(job_id);
+    let workspace = crate::runner_staging_store::extract_staged_source_artifact(
+        store_path,
+        &source,
+        &workspace_root,
+    )?;
+    let dispatch = envelope
+        .dispatch
+        .as_mut()
+        .ok_or_else(|| Error::internal_unexpected("staged runner job has no execution dispatch"))?;
+    dispatch.cwd = Some(workspace.display().to_string());
+    Ok(())
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -23,6 +23,7 @@ use super::support::{
     write_reverse_controller_session,
 };
 use super::worker_options;
+use crate::runner_staging_operation::SourceArtifactTransfer;
 
 #[test]
 fn reverse_worker_executes_claimed_job_and_finishes_it() {
@@ -927,6 +928,55 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
             result["data"]["execution_record"]["path_materialization_plan"]["entries"][0]
                 ["remote_path"],
             serde_json::json!("/tmp")
+        );
+    });
+}
+
+#[test]
+fn reverse_worker_executes_a_verified_staged_source_package() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let path = tempfile::tempdir()
+            .expect("tempdir")
+            .path()
+            .join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
+        let transfer = SourceArtifactTransfer::from_bytes("staged-source-1", b"staged output");
+        let artifact = transfer.descriptor();
+        let session_path = homeboy_core::paths::runner_session_file("lab").expect("session path");
+        let artifact_path = session_path
+            .parent()
+            .expect("session parent")
+            .join("lab-staging/source-artifacts/staged-source-1");
+        std::fs::create_dir_all(artifact_path.parent().expect("artifact parent"))
+            .expect("create artifact root");
+        std::fs::write(&artifact_path, transfer.decode_verified().expect("package"))
+            .expect("write staged package");
+        let mut request = run_id_echo_request();
+        request.command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat source.bin; printf ' side-effect' > result; cat result".to_string(),
+        ];
+        request.metadata = Some(serde_json::json!({
+            "submission_key": "staged-source-job-1",
+            "staged_source_artifact": artifact,
+        }));
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("submit staged job");
+        drop(store);
+        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job.expect("job").id, job.id);
+        handle.join().expect("mock broker joins");
+        let result = result_event_data(&store, job.id);
+        assert_eq!(
+            result["stdout"],
+            serde_json::json!("staged output side-effect")
         );
     });
 }


### PR DESCRIPTION
## Summary
- persist a runner execution claim before the staged workload is invoked
- retain terminal outcome and artifact references behind authenticated direct/reverse staging operations
- let controller restart recovery read runner terminal evidence and create one controller-owned projection
- preserve authenticated, heartbeat-live reverse-session fallback when daemon freshness cannot be independently probed; expose `reverse_unverified` as a typed availability warning while direct SSH comparison and probe-failure fences remain blocking

## Verification
- `cargo test -p homeboy-lab-runner reverse_session_is_checked_and_reports_an_unverified_verdict --lib`
- `cargo test -p homeboy-lab-runner persisted_session_drift_rejects_the_real_availability_and_preflight_path --lib`
- `cargo test -p homeboy-lab-runner staging --lib`
- `cargo fmt --check`
- `cargo test --workspace --no-run`
- `cargo clippy -p homeboy-lab-runner --lib --tests` (existing warnings only)

## AI assistance
OpenAI `openai/gpt-5.6-terra` via OpenCode inspected the stacked runner-staging implementation, aligned the typed reverse-session admission gate, and ran the listed verification. Chris Huber remains responsible for every line.