### PR TITLE
fix(agents): gate executor root device/inode check to unix

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -105,18 +105,21 @@ impl ExecutorArtifactRootIdentity {
                 None,
             ));
         }
+        // Device/inode identity is the Unix expression of "same directory".
+        // Windows has no equivalent pair; its volume serial + file ID check
+        // below carries the same meaning, so this branch stays Unix-only in
+        // full — attribute and consumer together.
         #[cfg(unix)]
-        let res = {
+        {
             use std::os::unix::fs::MetadataExt;
-            current.dev() != self.device || current.ino() != self.inode
-        };
-        if res {
-            return Err(Error::validation_invalid_argument(
-                "artifacts_path",
-                "Homeboy executor artifact root changed during provider execution",
-                Some(self.path.display().to_string()),
-                None,
-            ));
+            if current.dev() != self.device || current.ino() != self.inode {
+                return Err(Error::validation_invalid_argument(
+                    "artifacts_path",
+                    "Homeboy executor artifact root changed during provider execution",
+                    Some(self.path.display().to_string()),
+                    None,
+                ));
+            }
         }
         #[cfg(windows)]
         {


### PR DESCRIPTION
`ArtifactRootGuard` / `ExecutorArtifactRootIdentity::verify()` bound `res` under `#[cfg(unix)]` but evaluated `if res` unconditionally, so the **Windows workspace compile** failed with `E0425: cannot find value res in this scope`. Introduced by `efa5e610f` (#11652), which rewrote a correct `#[cfg(unix)] if { … } { … }` into a gated binding with an ungated consumer.

Closes #11660.

## What the guard does on unix

`ExecutorArtifactRootIdentity` captures the executor artifact root's identity *before* the provider runs and re-verifies it after — a TOCTOU guard against the root being swapped, replaced, or turned into a symlink while a provider writes into it. On unix that identity is `(st_dev, st_ino)`; a mismatch means "this is no longer the directory I sealed" and finalization is rejected.

## What I chose for Windows, and why

**Gated the entire branch, not just the binding.** The check is genuinely unix-only: Windows has no `dev`/`ino` pair, and the equivalent already exists directly below in the `#[cfg(windows)]` block — volume serial number plus `FILE_ID_INFO` file ID, compared against the values captured in `capture()`. There was nothing to implement; the Windows path was already complete and was simply being preceded by a Linux-only expression.

The branch now reads as a `#[cfg(unix)] { … }` block containing the whole `if`, mirroring the windows arm's shape. This also avoids re-introducing whatever 1.95 lint pushed #11652 to hoist the binding in the first place, since the condition is no longer a block-in-condition. **Unix behavior is byte-for-byte unchanged** — same comparison, same error, same call sites.

## Test coverage

`finalization_rejects_replaced_executor_root` is already `#[cfg(any(unix, windows))]` and drives `verify()` through a rename-and-recreate of the root, so both the unix dev/ino arm and the windows volume/file-ID arm are covered by an existing test. No test added, none removed or ignored.

## Sweep

I swept every `#[cfg(unix|windows|not(unix)|target_os|target_family)]` attribute in the workspace sitting directly on a `let` / `const` / `static` / `use`, and audited the consumers.

**This was the only instance of the bug shape** (gated binding, ungated consumer). Everything else is one of:

- **Paired exhaustive arms** — `#[cfg(unix)] let x = …;` + `#[cfg(not(unix))] let x = …;` with an ungated consumer. Correct. e.g. `homeboy-cli/src/commands/cleanup.rs:972`, `homeboy-core/src/process.rs:805`, `homeboy-core/.../retention_tests.rs:15`, `homeboy-extension/src/self_check.rs:211`, `homeboy-core/src/server/client/local_exec.rs:140,557`.
- **Gated consts/statics consumed only from equally-gated code** — `homeboy-engine-primitives/src/command.rs`, `homeboy-core/src/process.rs`, `server/process_cleanup.rs`, `controller_runtime.rs`, `homeboy-error/src/lib.rs:519`, `homeboy-deploy/src/provider.rs:270`.
- **Gated extension-trait imports whose methods are only called under the same cfg** — `homeboy-agents/.../private_attachment.rs:141`, `.../process_activity.rs:18`, `homeboy-cli/src/commands/test.rs:19-25`.

Two things worth noting even though I did **not** change them (out of scope for a surgical cfg fix):

1. **`unix`/`windows` pairs with no `not(any(unix, windows))` fallback**, where the consumer is ungated: `homeboy-core/src/runtime_package.rs:651-655` (`let linked = symlink…` / `symlink_dir…`, then `linked.map_err(…)`) and `homeboy-extension/src/lifecycle/install_sources.rs:434-440` (same shape with `result`). These compile fine on both targets we actually build, but they are the *identical* failure mode on any third target family — same latent shape, one target away.
2. **`artifact_finalization.rs:82-83` stacks `#[cfg(not(unix))]` and `#[cfg(not(windows))]`** as two attributes on one item. That is an AND and is therefore correct, but it is easy to misread as an OR; `#[cfg(not(any(unix, windows)))]` (used elsewhere in the same file) says the same thing unambiguously.

## Compile risk — please read

**I could not compile this.** Per VPS build policy I ran only `cargo fmt`; no `cargo check`, `build`, `test`, or `clippy`. And even a local check would not have validated the thing that matters here — **this is a Windows-only error and this box is Linux**, which is exactly why `Windows Compile` caught it and a local `cargo check --workspace` structurally could not.

The change is reasoned from source: the deleted binding had exactly one consumer, that consumer is now inside the same `#[cfg(unix)]` scope, and `current` is still used unconditionally on line 100 so no `unused_variables` warning appears on Windows. But **CI is the proof**, and the Windows gate specifically is the one to watch.

## AI assistance

Anthropic `claude-sonnet-4-5` via OpenCode traced the regression to `efa5e610f`, chose the cfg scoping, and ran the workspace sweep. Chris Huber owns the work.
