### PR TITLE
fix(agent-task): attribute cook activity to the provider, not homeboy

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
@@ -15,7 +15,10 @@
 //!    a running cook, and unlike a process sample it is true regardless of what
 //!    the provider claims to be doing.
 //! 2. **The provider's current shell command and its age**, sampled from the
-//!    process tree.
+//!    process tree. Identity is the hard part: the sample is only useful if it
+//!    names a process the *provider* is running, and #11598 shipped one that
+//!    named Homeboy's own cook controller instead. A command that cannot be
+//!    attributed to the provider is reported as unavailable, never guessed.
 //!
 //! Both are diagnostics, so both fail soft: an unreadable worktree or an
 //! unavailable `ps` yields an absent field, never an error that can stop a
@@ -28,7 +31,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use super::process_activity::{self, DescendantActivity};
+use super::process_activity::{self, DescendantActivity, ProviderActivitySample};
 
 /// A single sample of what a running Cook's provider is doing.
 ///
@@ -46,10 +49,22 @@ pub struct CookProviderActivity {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commits_written: Option<usize>,
     /// The provider's current command line, truncated.
+    ///
+    /// Only ever a process the provider is running. Homeboy's own orchestration
+    /// — the cook controller, a nested local cook, a gate, a CLI call the agent
+    /// made as a tool — is never reported here: #11598 shipped a heartbeat that
+    /// named the cook's own `agent-task cook` command for twenty minutes while
+    /// zero files were written, which reads as authoritative and is worse than
+    /// saying nothing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_pid: Option<u32>,
+    /// Why no provider command is reported, when the process tree was sampled
+    /// and nothing in it qualified. Never set alongside `command`, and never
+    /// set when no sample was taken at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_unavailable: Option<String>,
     /// How long that command has been running.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command_elapsed_seconds: Option<u64>,
@@ -92,6 +107,11 @@ impl CookProviderActivity {
                 Some(seconds) => format!("{} in `{command}`", format_duration(seconds)),
                 None => format!("running `{command}`"),
             });
+        } else if let Some(reason) = self.command_unavailable.as_deref() {
+            // Stated as an absence, not dressed up as an observation. The edit
+            // count above it is the reliable signal and has to survive a
+            // process sample that found nothing (#11598).
+            parts.push(format!("provider command unavailable: {reason}"));
         }
         if let Some(seconds) = self.elapsed_seconds {
             parts.push(format!("{} elapsed", format_duration(seconds)));
@@ -152,16 +172,27 @@ impl CookActivityProbe {
                 .as_deref()
                 .and_then(|base| commits_since(root, base));
         }
-        if let Some(process) = process_activity::descendant_activity(owner_pid) {
-            let DescendantActivity {
-                pid,
-                elapsed_seconds,
-                command,
-                ..
-            } = process;
+        // Process sampling runs after the worktree signals and only ever adds
+        // fields: the edit count is the signal an operator acts on, and a
+        // process table that yields nothing must narrow the sample rather than
+        // suppress it.
+        let ProviderActivitySample {
+            activity: provider_process,
+            unavailable,
+            ..
+        } = process_activity::descendant_activity(owner_pid);
+        if let Some(DescendantActivity {
+            pid,
+            elapsed_seconds,
+            command,
+            ..
+        }) = provider_process
+        {
             activity.command = Some(command);
             activity.command_pid = Some(pid);
             activity.command_elapsed_seconds = Some(elapsed_seconds);
+        } else if let Some(unavailable) = unavailable {
+            activity.command_unavailable = Some(unavailable.reason().to_string());
         }
         activity
     }
@@ -260,6 +291,45 @@ mod tests {
     }
 
     #[test]
+    fn an_unavailable_command_narrows_the_summary_instead_of_suppressing_the_edit_count() {
+        // The regression in #11598 was a heartbeat that named Homeboy's own
+        // cook process. Reporting nothing is correct; reporting nothing must
+        // not also cost the operator the one signal that is always reliable.
+        let activity = CookProviderActivity {
+            files_changed: Some(0),
+            command_unavailable: Some(
+                "only homeboy's own processes observed under the cook".into(),
+            ),
+            elapsed_seconds: Some(1_216),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(summary.starts_with("no files written yet"));
+        assert!(summary.contains("provider command unavailable"));
+        assert!(summary.contains("20m16s elapsed"));
+        assert!(!summary.contains('`'));
+    }
+
+    #[test]
+    fn an_observed_command_wins_over_an_unavailability_note() {
+        // The two are mutually exclusive by construction; the renderer must not
+        // print both if a caller ever sets both.
+        let activity = CookProviderActivity {
+            command: Some("cargo test -q".to_string()),
+            command_elapsed_seconds: Some(60),
+            command_unavailable: Some("no provider process observed under the cook".into()),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(summary.contains("1m00s in `cargo test -q`"));
+        assert!(!summary.contains("unavailable"));
+    }
+
+    #[test]
     fn committed_work_is_not_reported_as_no_progress() {
         // A provider that committed leaves a clean tree. Reporting that as
         // "no files written yet" would send the operator to kill a working cook.
@@ -336,6 +406,7 @@ mod tests {
             commits_written: Some(1),
             command: Some("cargo test".to_string()),
             command_pid: Some(4242),
+            command_unavailable: None,
             command_elapsed_seconds: Some(12),
             elapsed_seconds: Some(30),
         };

--- a/crates/homeboy-agents/src/agent_task_service/process_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/process_activity.rs
@@ -51,6 +51,59 @@ pub struct DescendantActivity {
     pub descendant_count: usize,
 }
 
+/// Why a sampled tree carries no provider activity.
+///
+/// Reported instead of a command because #11598 showed the failure mode of the
+/// alternative: a heartbeat that named Homeboy's own `agent-task cook` process
+/// for twenty minutes read as an authoritative statement about the provider
+/// while the provider was doing nothing at all. "We looked and found no
+/// provider process" is a weaker claim, and it is the true one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivityUnavailable {
+    /// The owner has no observable descendants.
+    NoDescendants,
+    /// Every descendant is Homeboy's own machinery — a nested controller
+    /// process, a gate, or a CLI call the agent made — so none of them answers
+    /// "what is the provider doing right now".
+    OnlyHomeboyProcesses,
+}
+
+impl ActivityUnavailable {
+    /// A bounded operator-facing reason string.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::NoDescendants => "no provider process observed under the cook",
+            Self::OnlyHomeboyProcesses => "only homeboy's own processes observed under the cook",
+        }
+    }
+}
+
+/// The result of one selection pass over a process table.
+///
+/// Carries three distinguishable states, because collapsing them is what made
+/// the original signal misleading:
+///
+/// - `activity: Some(_)` — a provider process was observed.
+/// - `activity: None`, `unavailable: Some(_)` — the tree was sampled and
+///   nothing in it qualified.
+/// - `activity: None`, `unavailable: None` — no sample was taken at all
+///   (no `ps`, a failed probe, a non-Unix host).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ProviderActivitySample {
+    pub activity: Option<DescendantActivity>,
+    /// Descendants observed under the owner, Homeboy's own processes included.
+    pub descendant_count: usize,
+    pub unavailable: Option<ActivityUnavailable>,
+}
+
+impl ProviderActivitySample {
+    /// The state for "we never looked", which must not be dressed up as a
+    /// measurement of an idle tree.
+    pub fn unsampled() -> Self {
+        Self::default()
+    }
+}
+
 /// Parse `ps -axo pid=,ppid=,etime=,args=` output into activity rows.
 ///
 /// Kept separate from the `ps` invocation so selection behavior is testable on
@@ -124,44 +177,154 @@ pub fn truncate_command(command: &str) -> String {
     truncated
 }
 
-/// Select the descendant that best answers "what is this tree working on?".
+/// Select the descendant that best answers "what is the *provider* working on?".
 ///
-/// Selection prefers the *longest-running spawned work* (depth >= 2) over the
-/// direct child itself, breaking ties toward the deeper process. That is what
-/// makes a six-minute build command — spawned by an agent that has also been up
-/// six minutes — win over both the agent and the three-second compiler process
-/// the build just launched. When the tree has no grandchildren the direct child
-/// is reported instead, so a quiet agent still shows up.
+/// The original heuristic (#11492) preferred spawned work at depth >= 2 and
+/// fell back to the deepest direct child. It read the question as a shape
+/// question — "how far down the tree is this?" — and the shape does not
+/// identify the process. A locally placed Cook re-enters Homeboy as a *child*
+/// of the observing process, so the cook's own command line sits at depth 1
+/// with the age of the whole run and won every fallback: #11598 saw
+/// `homeboy agent-task cook --placement local --wait …` reported as provider
+/// activity for twenty minutes while zero files were written. Depth arithmetic
+/// cannot exclude that, because the offending process is genuinely a
+/// descendant.
+///
+/// So identity is now the filter and age is only the ranking:
+///
+/// 1. Exclude the walk root and its ancestry outright, rather than trusting
+///    depth to keep them out of the candidate set.
+/// 2. Exclude every Homeboy-owned process. A nested `agent-task cook`, a gate,
+///    and the `contract constants all` call an agent made as a tool are all
+///    Homeboy's own orchestration; none of them is the provider's work, and
+///    the short-lived ones were winning the early heartbeats.
+/// 3. Among what remains, take the longest-running process, breaking ties
+///    toward the deeper one. A six-minute build spawned by an agent that has
+///    also been up six minutes still beats both the agent and the three-second
+///    compiler the build just launched.
+/// 4. If nothing remains, report [`ActivityUnavailable`] — never a Homeboy
+///    command relabelled as provider activity.
 ///
 /// `ignore_pids` exists because the probe's own `ps` process is a direct child
 /// of the owner and would otherwise be a candidate.
-pub fn select_descendant_activity(
+pub fn select_provider_activity(
     rows: &[ProcessActivityRow],
     owner_pid: u32,
     ignore_pids: &[u32],
-) -> Option<DescendantActivity> {
+) -> ProviderActivitySample {
+    let excluded = excluded_pids(rows, owner_pid, ignore_pids);
     let descendants: Vec<(&ProcessActivityRow, usize)> = descendants_with_depth(rows, owner_pid)
         .into_iter()
-        .filter(|(row, _)| !ignore_pids.contains(&row.pid))
+        .filter(|(row, _)| !excluded.contains(&row.pid))
         .collect();
     let descendant_count = descendants.len();
-    let candidate = descendants
+    let selected = descendants
         .iter()
-        .filter(|(row, _)| !row.command.is_empty());
-    let spawned_work = candidate
-        .clone()
-        .filter(|(_, depth)| *depth >= 2)
+        .filter(|(row, _)| !row.command.is_empty())
+        .filter(|(row, _)| !is_homeboy_process(&row.command))
         .max_by_key(|(row, depth)| (row.elapsed_seconds, *depth, row.pid));
-    let selected =
-        spawned_work.or_else(|| candidate.max_by_key(|(row, depth)| (*depth, row.elapsed_seconds)));
-    let (row, depth) = selected?;
-    Some(DescendantActivity {
-        pid: row.pid,
-        depth: *depth,
-        elapsed_seconds: row.elapsed_seconds,
-        command: truncate_command(&row.command),
-        descendant_count,
-    })
+    match selected {
+        Some((row, depth)) => ProviderActivitySample {
+            activity: Some(DescendantActivity {
+                pid: row.pid,
+                depth: *depth,
+                elapsed_seconds: row.elapsed_seconds,
+                command: truncate_command(&row.command),
+                descendant_count,
+            }),
+            descendant_count,
+            unavailable: None,
+        },
+        None => ProviderActivitySample {
+            activity: None,
+            descendant_count,
+            unavailable: Some(if descendant_count == 0 {
+                ActivityUnavailable::NoDescendants
+            } else {
+                ActivityUnavailable::OnlyHomeboyProcesses
+            }),
+        },
+    }
+}
+
+/// Pids that can never be reported: the walk root, everything above it, and
+/// whatever the caller asked to ignore.
+///
+/// A well-formed process table cannot present an ancestor as a descendant, so
+/// this is belt-and-braces against a torn snapshot — but it is also the point:
+/// the rule "never report the cook or anything that spawned it" is stated
+/// directly instead of being an emergent property of a depth comparison.
+fn excluded_pids(rows: &[ProcessActivityRow], owner_pid: u32, ignore_pids: &[u32]) -> Vec<u32> {
+    let mut excluded = ignore_pids.to_vec();
+    excluded.push(owner_pid);
+    let mut current = owner_pid;
+    for _ in 0..MAX_PROCESS_WALK_DEPTH {
+        let Some(row) = rows.iter().find(|row| row.pid == current) else {
+            break;
+        };
+        if row.ppid == 0 || excluded.contains(&row.ppid) {
+            break;
+        }
+        excluded.push(row.ppid);
+        current = row.ppid;
+    }
+    excluded
+}
+
+/// Maximum hops taken when walking the process table in either direction.
+///
+/// A pid cycle cannot exist in a well-formed table, but a torn `ps` snapshot
+/// can still produce one, and the heartbeat thread must not spin on it.
+const MAX_PROCESS_WALK_DEPTH: usize = 16;
+
+/// Wrapper programs that front a real command, so the program that matters is
+/// a later token.
+///
+/// Deliberately short: guessing wrong here means misreading the program name,
+/// and the provider's own command line embeds the whole task prompt — which is
+/// exactly why this looks at the program token and never at the command line
+/// as a whole. A prompt that mentions Homeboy must not make the provider look
+/// like Homeboy.
+const COMMAND_WRAPPERS: &[&str] = &[
+    "env", "sh", "bash", "zsh", "dash", "timeout", "nice", "setsid", "stdbuf", "nohup", "time",
+];
+
+/// True when the sampled command line is one of Homeboy's own processes.
+pub fn is_homeboy_process(command: &str) -> bool {
+    let program = command_program(command);
+    program == "homeboy" || program.starts_with("homeboy-") || program.starts_with("homeboy.")
+}
+
+/// The program a command line actually runs, as a bare file name.
+///
+/// Skips a bounded number of leading wrapper tokens (`timeout 1200 cargo …`,
+/// `sh -c homeboy …`) and their flag/numeric arguments so a wrapped Homeboy
+/// invocation is still recognized as Homeboy.
+fn command_program(command: &str) -> &str {
+    let mut tokens = command.split_whitespace();
+    let mut program = "";
+    for _ in 0..8 {
+        let Some(token) = tokens.next() else { break };
+        // Flags, `KEY=value` env prefixes and bare numeric arguments belong to
+        // the wrapper that preceded them, not to the program being run.
+        if token.starts_with('-') || token.contains('=') || token.parse::<u64>().is_ok() {
+            continue;
+        }
+        program = base_name(token);
+        if !COMMAND_WRAPPERS.contains(&program) {
+            break;
+        }
+    }
+    program
+}
+
+/// The final path segment of a token, for both `/` and `\` separated paths.
+fn base_name(token: &str) -> &str {
+    token
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(token)
+        .trim_matches('"')
 }
 
 /// Walk the owner's descendants, recording hop depth for each.
@@ -175,7 +338,7 @@ fn descendants_with_depth(
         // A pid cycle cannot exist in a well-formed process table, but a
         // torn `ps` snapshot can still produce one. Bound the walk by depth so
         // a malformed sample cannot spin the heartbeat thread.
-        if depth >= 16 {
+        if depth >= MAX_PROCESS_WALK_DEPTH {
             continue;
         }
         for row in rows {
@@ -194,32 +357,38 @@ fn descendants_with_depth(
 
 /// Sample the current activity of `owner_pid`'s process tree.
 ///
-/// Returns `None` when the platform has no `ps`, the sample fails, or the tree
-/// has no observable descendants. Activity is a diagnostic: a failed sample
-/// must never be an error a caller has to handle.
-pub fn descendant_activity(owner_pid: u32) -> Option<DescendantActivity> {
+/// Returns [`ProviderActivitySample::unsampled`] when the platform has no `ps`
+/// or the probe fails — distinct from a successful sample that found no
+/// provider work, because "we could not look" and "we looked and the provider
+/// is not running anything" are different facts about a stalled cook. Activity
+/// is a diagnostic: a failed sample must never be an error a caller has to
+/// handle.
+pub fn descendant_activity(owner_pid: u32) -> ProviderActivitySample {
     #[cfg(unix)]
     {
-        let output = Command::new("ps")
+        let Some(output) = Command::new("ps")
             .args(["-axo", "pid=,ppid=,etime=,args="])
             .stdin(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .output()
-            .ok()?;
+            .ok()
+        else {
+            return ProviderActivitySample::unsampled();
+        };
         if !output.status.success() {
-            return None;
+            return ProviderActivitySample::unsampled();
         }
         let stdout = String::from_utf8_lossy(&output.stdout);
         let rows = parse_process_activity_rows(&stdout);
         // The probe's own `ps` is a direct child of the owner whenever the
         // owner is this process; never report the observation as the activity.
-        select_descendant_activity(&rows, owner_pid, &[std::process::id()])
+        select_provider_activity(&rows, owner_pid, &[std::process::id()])
     }
 
     #[cfg(not(unix))]
     {
         let _ = owner_pid;
-        None
+        ProviderActivitySample::unsampled()
     }
 }
 
@@ -276,7 +445,9 @@ mod tests {
         );
         let rows = parse_process_activity_rows(ps);
 
-        let activity = select_descendant_activity(&rows, 100, &[]).expect("activity is observable");
+        let activity = select_provider_activity(&rows, 100, &[])
+            .activity
+            .expect("activity is observable");
 
         assert_eq!(activity.pid, 300);
         assert_eq!(activity.depth, 2);
@@ -292,7 +463,9 @@ mod tests {
         let ps = "100 1 02:00 opencode run --format json\n";
         let rows = parse_process_activity_rows(ps);
 
-        let activity = select_descendant_activity(&rows, 1, &[]).expect("provider is observable");
+        let activity = select_provider_activity(&rows, 1, &[])
+            .activity
+            .expect("provider is observable");
 
         assert_eq!(activity.pid, 100);
         assert_eq!(activity.depth, 1);
@@ -307,8 +480,9 @@ mod tests {
         );
         let rows = parse_process_activity_rows(ps);
 
-        let activity =
-            select_descendant_activity(&rows, 1, &[999]).expect("provider is observable");
+        let activity = select_provider_activity(&rows, 1, &[999])
+            .activity
+            .expect("provider is observable");
 
         assert_eq!(activity.pid, 100);
     }
@@ -317,7 +491,121 @@ mod tests {
     fn returns_nothing_when_the_tree_has_no_descendants() {
         let rows = parse_process_activity_rows("100 1 06:20 opencode run\n");
 
-        assert_eq!(select_descendant_activity(&rows, 4242, &[]), None);
+        let sample = select_provider_activity(&rows, 4242, &[]);
+
+        assert_eq!(sample.activity, None);
+        assert_eq!(sample.descendant_count, 0);
+        assert_eq!(sample.unavailable, Some(ActivityUnavailable::NoDescendants));
+    }
+
+    #[test]
+    fn never_reports_the_cook_controller_that_homeboy_re_entered_locally() {
+        // The #11598 regression, verbatim. A locally placed cook re-enters
+        // Homeboy, so the observing controller has a child running the same
+        // `agent-task cook` argv with the age of the whole run. Depth put it at
+        // 1 and age put it first, so it was reported as provider activity for
+        // twenty minutes while nothing was written.
+        let ps = concat!(
+            "100 1 20:16 /usr/local/bin/homeboy agent-task cook --placement local --wait\n",
+            "200 100 20:14 /usr/local/bin/homeboy agent-task cook --placement local --wait\n",
+            "300 200 20:10 opencode run --format json # Task: fix homeboy cook attribution\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let sample = select_provider_activity(&rows, 100, &[]);
+
+        let activity = sample.activity.expect("the provider is observable");
+        assert_eq!(activity.pid, 300);
+        assert!(activity.command.starts_with("opencode run"));
+        assert_eq!(sample.unavailable, None);
+    }
+
+    #[test]
+    fn a_tree_of_only_homeboy_processes_reports_no_activity_rather_than_the_controller() {
+        // Same shape with the provider gone: the honest answer is that no
+        // provider process was observed. Naming the nested cook here is what
+        // made the signal look authoritative while being wrong.
+        let ps = concat!(
+            "100 1 20:16 /usr/local/bin/homeboy agent-task cook --placement local --wait\n",
+            "200 100 20:14 /usr/local/bin/homeboy agent-task cook --placement local --wait\n",
+            "300 200 00:13 homeboy contract constants all\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let sample = select_provider_activity(&rows, 100, &[]);
+
+        assert_eq!(sample.activity, None);
+        assert_eq!(sample.descendant_count, 2);
+        assert_eq!(
+            sample.unavailable,
+            Some(ActivityUnavailable::OnlyHomeboyProcesses)
+        );
+    }
+
+    #[test]
+    fn a_short_lived_homeboy_tool_call_never_outranks_the_provider() {
+        // The early heartbeats in #11598 reported `homeboy contract constants
+        // all`, thirteen seconds old, because it was the deepest process in the
+        // tree. Tool calls the agent makes into Homeboy are Homeboy's work, not
+        // the provider's.
+        let ps = concat!(
+            "100 1 06:20 opencode run --format json\n",
+            "200 100 00:13 homeboy contract constants all\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let activity = select_provider_activity(&rows, 1, &[])
+            .activity
+            .expect("the provider is observable");
+
+        assert_eq!(activity.pid, 100);
+        assert!(activity.command.starts_with("opencode run"));
+    }
+
+    #[test]
+    fn an_ancestor_of_the_walk_root_is_never_reported() {
+        // A torn snapshot can present a cycle in which an ancestor looks like a
+        // descendant. The exclusion is stated on identity, so it holds anyway.
+        let ps = concat!(
+            "100 200 30:00 /usr/local/bin/homeboy agent-task cook --wait\n",
+            "200 100 29:00 opencode run --format json\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let sample = select_provider_activity(&rows, 200, &[]);
+
+        assert_eq!(sample.activity, None);
+        assert_eq!(sample.unavailable, Some(ActivityUnavailable::NoDescendants));
+    }
+
+    #[test]
+    fn homeboy_is_recognized_however_it_was_invoked_and_never_from_a_prompt() {
+        // A provider command line embeds the whole task prompt, so anything
+        // that matched on the command line as a whole would classify the
+        // provider itself as Homeboy and report nothing at all.
+        assert!(is_homeboy_process("homeboy agent-task cook --wait"));
+        assert!(is_homeboy_process("/usr/local/bin/homeboy review lint"));
+        assert!(is_homeboy_process("sh -c homeboy contract constants all"));
+        assert!(is_homeboy_process("timeout 600 homeboy agent-task status"));
+        assert!(is_homeboy_process("homeboy-lab-runner exec"));
+        assert!(!is_homeboy_process(
+            "opencode run --format json # Task: fix homeboy agent-task cook"
+        ));
+        assert!(!is_homeboy_process(
+            "timeout 1200 cargo test -p homeboy-agents"
+        ));
+        assert!(!is_homeboy_process(""));
+    }
+
+    #[test]
+    fn a_probe_that_could_not_look_is_not_a_measurement() {
+        // "No sample" and "sampled, found no provider" are different facts and
+        // must stay distinguishable downstream.
+        let unsampled = ProviderActivitySample::unsampled();
+
+        assert_eq!(unsampled.activity, None);
+        assert_eq!(unsampled.unavailable, None);
+        assert_eq!(unsampled.descendant_count, 0);
     }
 
     #[test]
@@ -338,7 +626,9 @@ mod tests {
         let ps = "100 100 01:00 wedged\n200 100 01:00 child\n";
         let rows = parse_process_activity_rows(ps);
 
-        let activity = select_descendant_activity(&rows, 100, &[]).expect("child is observable");
+        let activity = select_provider_activity(&rows, 100, &[])
+            .activity
+            .expect("child is observable");
 
         assert_eq!(activity.pid, 200);
     }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -430,7 +430,8 @@ it on both the heartbeat line and `agent-task status`, under
 |---|---|
 | `files_changed` | Uncommitted files in the destination worktree, untracked included. `0` after several minutes is the clearest sign a cook is not producing work. Homeboy's own `.homeboy/` run state is excluded, so this counts provider edits only. |
 | `commits_written` | Commits made in that worktree since the provider started. A provider that commits leaves a clean tree, so this is what distinguishes "finished" from "did nothing". |
-| `command` / `command_elapsed_seconds` | The longest-running command the provider has spawned, and its age — `cargo test -p homeboy-agents`, six minutes in. |
+| `command` / `command_elapsed_seconds` | The longest-running command the *provider* is running, and its age — `cargo test -p homeboy-agents`, six minutes in. Homeboy's own processes are never reported here: not the cook controller, not the nested controller a `--placement local` cook re-enters through, not a gate, and not a `homeboy …` call the agent made as a tool. |
+| `command_unavailable` | Present instead of `command` when the process tree was sampled and no provider process was found. Homeboy states the absence rather than naming its own command, which is what made this signal misleading in #11598. |
 | `elapsed_seconds` | Time since provider execution began. |
 | `observed_at` | When the sample was taken. A retained sample keeps its own observation time, so a stale reading is visible as stale. |
 


### PR DESCRIPTION
Regression fix for #11492 (`feat(agent-task): carry provider activity on cook heartbeats and status`). Closes #11598.

## What went wrong

The activity signal fired on the right condition and named the wrong process. Early heartbeats reported `homeboy contract constants all` (13s); later heartbeats reported `.../homeboy agent-task cook --placement local --wait …` for 20m16s while zero files were written. An operator reading that learns nothing about the provider and is told something that looks authoritative.

## Why the parent was selected

The heuristic asked a *shape* question — prefer spawned work at depth >= 2, fall back to the deepest direct child — and shape does not identify a process.

The walk root is correct (`std::process::id()` of the cook controller) and depth 0 is genuinely excluded. The offending process is not the walk root: a `--placement local` cook re-enters Homeboy, so a **second `agent-task cook` process carrying the same argv and the age of the whole run sits at depth 1** underneath the observing controller. When no depth-2 process existed at sampling time, the fallback picked it — deepest available, longest running. Depth arithmetic cannot exclude that, because it really is a descendant. The same gap explains the early heartbeats: a short-lived `homeboy …` tool call the agent made was the deepest process in the tree and won the depth-first preference.

## What selection does now

Identity is the filter; age is only the ranking.

1. **Exclude the walk root and its ancestry by pid**, stated directly instead of relying on depth. Also hardens the torn-snapshot case where a pid cycle can present an ancestor as a descendant.
2. **Exclude every Homeboy-owned process** — nested controllers, gates, and `homeboy …` calls the agent makes as tools. Matching is on the *program token only* (path basename, stepping over `sh -c` / `timeout N` / `env` wrappers), never on the whole command line: a provider argv embeds the entire task prompt, so a substring match would classify the provider itself as Homeboy.
3. Among survivors, take the **longest-running**, ties broken toward the deeper process. The #11482 case still resolves to `cargo test` over both the agent and the three-second `rustc` beneath it.
4. If nothing survives, report **no activity** with a reason (`command_unavailable`), never a Homeboy command relabelled as provider work.

`descendant_activity` returns `ProviderActivitySample`, which keeps three states distinct: sampled-with-activity, sampled-with-nothing (`unavailable`), and **unsampled** (no `ps`, failed probe, non-Unix). That is #11492's own rule that an unsampled state must not be dressed up as a measurement.

The companion signal is protected: `files_changed` / `commits_written` are computed first and independently, and `summary_line` renders the edit count then the unavailability note, so a wrong or absent command narrows the heartbeat rather than suppressing the one signal that is always reliable.

Trade-off worth flagging: a legitimately long `homeboy review lint` the agent ran as a tool is now reported as unavailable rather than as activity. That is deliberate — under "longest running wins", admitting Homeboy processes is exactly what let a 20-minute controller outrank the provider. The issue's fuller ask (labelling provider vs gate vs controller work) can build on `ActivityUnavailable` later.

## Tests

Selection was already table-driven; new coverage over synthetic process tables:

- `never_reports_the_cook_controller_that_homeboy_re_entered_locally` — the #11598 shape verbatim, provider still present
- `a_tree_of_only_homeboy_processes_reports_no_activity_rather_than_the_controller` — same shape, provider gone
- `a_short_lived_homeboy_tool_call_never_outranks_the_provider` — the early-heartbeat shape
- `an_ancestor_of_the_walk_root_is_never_reported` — cycle in a torn snapshot
- `homeboy_is_recognized_however_it_was_invoked_and_never_from_a_prompt` — wrapper/path forms match, a prompt mentioning homeboy does not
- `a_probe_that_could_not_look_is_not_a_measurement`
- `an_unavailable_command_narrows_the_summary_instead_of_suppressing_the_edit_count` and `an_observed_command_wins_over_an_unavailability_note`

No tests deleted or ignored. Output stays bounded — same truncation cap, same heartbeat sampling cadence.

## Compile risk

**I could not compile or run tests** (shared VPS, disk-bound; parallel agents). `cargo fmt` is clean and is the only cargo invocation run. To compensate I mirrored the new selection algorithm in Python and ran it against both a live `ps -axo pid=,ppid=,etime=,args=` table and every synthetic table in the test module; all nine cases produce exactly the asserted pid/depth/elapsed/`descendant_count`/unavailable values.

Risk areas for a reviewer to check on the first CI run:
- `select_descendant_activity` → `select_provider_activity` with a new return type; the only non-test caller is `descendant_activity`, and the only consumer of that is `CookActivityProbe::sample`. Swept both.
- New `command_unavailable` field on `CookProviderActivity`. Every other construction site uses `..Default::default()`; the one exhaustive literal (the round-trip test) was updated. Deserialization of existing durable records is unaffected — missing `Option` fields deserialize as `None`, as the other optional fields already rely on.
- No new `cfg(unix)` bindings; the non-Unix arm returns `ProviderActivitySample::unsampled()` and still consumes `owner_pid`.

Docs: `docs/commands/agent-task.md` provider-activity table updated for the new `command` contract and `command_unavailable`.