### PR TITLE
fix(routing): keep a controller-local run controller-owned for its whole lifecycle

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/execution_placement.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/execution_placement.rs
@@ -91,7 +91,23 @@ pub struct ExecutionPlacementOutcome {
     pub runner_id: Option<String>,
 }
 
+/// Policy id of the decision a submission authors for itself when no router
+/// supplied one.
+///
+/// It is authoritative about ownership — a run submitted and executed by this
+/// controller really is controller-owned — but it is *derived*, not routed. A
+/// real routing decision for the same run therefore supersedes it, and a
+/// verifier that holds no routing decision treats it as absent rather than
+/// contradicting it.
+pub const CONTROLLER_LOCAL_SUBMISSION_POLICY_ID: &str = "controller-local-submission";
+
 impl ExecutionPlacementDecision {
+    /// Whether this decision was derived by a submission in the absence of
+    /// routing. See [`CONTROLLER_LOCAL_SUBMISSION_POLICY_ID`].
+    pub fn is_submission_stamp(&self) -> bool {
+        self.policy_id == CONTROLLER_LOCAL_SUBMISSION_POLICY_ID
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         policy_id: impl Into<String>,
@@ -129,6 +145,39 @@ impl ExecutionPlacementDecision {
             fallback,
             override_authorization,
         }
+    }
+
+    /// The canonical decision for a run that executes on the controller.
+    ///
+    /// A controller-local run is still a *routed* run: it has an owner, and
+    /// recovery, retry, and outcome verification all read that owner off this
+    /// record. Leaving it null — which is what every purely local submission
+    /// used to do — made an explicitly local run unrecoverable, because retry
+    /// could not decode a decision that was never written (#11600).
+    pub fn controller_local(
+        policy_id: impl Into<String>,
+        policy_revision: impl Into<String>,
+        identity: ExecutionPlacementIdentity,
+        requested: Placement,
+    ) -> Self {
+        let authorized = requested == Placement::Local;
+        Self::new(
+            policy_id,
+            policy_revision,
+            identity,
+            requested,
+            ExecutionPlacementRequirement::Either,
+            EffectiveExecutionPlacement::Local,
+            None,
+            ExecutionPlacementFallback {
+                local_allowed: false,
+                reason: None,
+            },
+            ExecutionPlacementOverrideAuthorization {
+                authorized,
+                authority: authorized.then(|| "operator --placement local".to_string()),
+            },
+        )
     }
 
     pub fn permits_local_execution(&self) -> bool {

--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -25,6 +25,7 @@ pub use execution_placement::{
     EffectiveExecutionPlacement, ExecutionPlacementDecision, ExecutionPlacementFallback,
     ExecutionPlacementIdentity, ExecutionPlacementOutcome, ExecutionPlacementOverrideAuthorization,
     ExecutionPlacementRequirement, ExecutionPlacementRunnerSelection, RunnerSelectionSource,
+    CONTROLLER_LOCAL_SUBMISSION_POLICY_ID,
 };
 pub use placement::Placement;
 pub use provider_source_types::AgentTaskProviderRunnerSource;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -314,6 +314,96 @@ pub fn submit_plan(
     })
 }
 
+/// Build the canonical decision for a run this controller is about to execute
+/// itself. Identity is read off the plan's own workspace so the durable record
+/// names the same checkout the run operates on.
+fn controller_local_placement_decision(
+    plan: &AgentTaskPlan,
+) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
+    let workspace_root = plan
+        .tasks
+        .first()
+        .and_then(|task| task.workspace.root.as_deref());
+    // `local_override` is the preflight record of an operator's explicit
+    // `--placement local`. Carrying it here is what gives a locally-created run
+    // an authorized owner rather than a merely-default one.
+    let requested = if homeboy_core::resource_policy_context::captured_context()
+        .is_some_and(|context| context.local_override)
+    {
+        homeboy_lab_runner_contract::Placement::Local
+    } else {
+        homeboy_lab_runner_contract::Placement::Auto
+    };
+    homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+        homeboy_lab_runner_contract::CONTROLLER_LOCAL_SUBMISSION_POLICY_ID,
+        "v1",
+        homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+            repository: workspace_root
+                .and_then(|root| std::path::Path::new(root).file_name())
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "controller-local".to_string()),
+            workspace: workspace_root
+                .map(str::to_string)
+                .unwrap_or_else(|| "controller-local".to_string()),
+            task: plan
+                .tasks
+                .first()
+                .map(|task| task.task_id.clone())
+                .unwrap_or_else(|| plan.plan_id.clone()),
+            candidate: None,
+            base: None,
+        },
+        requested,
+    )
+}
+
+/// Adopt a canonical placement decision for a durable run that has none.
+///
+/// Records written before placement decisions were canonical — and records
+/// written by submission paths that never authored one — carry a null
+/// `execution_placement_decision`. That is not a contradiction to fail closed
+/// on; it is missing evidence, and the routing decision the caller is holding
+/// *is* the authoritative one for the execution about to be verified. Adopting
+/// it (and saying so, under `execution_placement_normalized`) is what lets an
+/// older local run be diagnosed and retried instead of dead-ending (#11600).
+///
+/// Never overwrites a routed decision. A submission stamp is superseded,
+/// because it was authored in the absence of routing precisely so this moment
+/// would have something to supersede.
+pub fn normalize_missing_execution_placement_decision(
+    run_id: &str,
+    decision: &homeboy_lab_runner_contract::ExecutionPlacementDecision,
+) -> Result<bool> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let persisted =
+        serde_json::from_value::<homeboy_lab_runner_contract::ExecutionPlacementDecision>(
+            record.metadata["execution_placement_decision"].clone(),
+        )
+        .ok();
+    let reason = match persisted {
+        Some(persisted) if persisted.decision_id == decision.decision_id => return Ok(false),
+        Some(persisted) if persisted.is_submission_stamp() => {
+            "durable run carried a submission-derived placement decision"
+        }
+        Some(_) => return Ok(false),
+        None => "durable run had no canonical placement decision",
+    };
+    record.metadata["execution_placement_decision"] =
+        serde_json::to_value(decision).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize normalized placement decision".to_string()),
+            )
+        })?;
+    record.metadata["execution_placement_normalized"] = json!({
+        "at": now_timestamp(),
+        "reason": reason,
+        "adopted_decision_id": decision.decision_id,
+    });
+    store::write_record(&record)?;
+    Ok(true)
+}
+
 /// Append a provider-verified placement outcome to the durable run without
 /// re-evaluating policy. A mismatched decision id is a stale/replayed attempt
 /// and fails closed.
@@ -423,6 +513,136 @@ mod execution_placement_tests {
                 status.metadata["execution_placement_outcome"]["decision_id"],
                 decision().decision_id
             );
+        });
+    }
+
+    #[test]
+    fn a_plan_without_a_routing_decision_persists_a_canonical_local_one() {
+        // The originating defect in #11600: an explicitly local Cook submitted
+        // a plan that had never been routed anywhere, so nothing wrote a
+        // canonical decision and `execution_placement_decision` stayed null.
+        // Retry then could not decode the owner of the run it was recovering.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let plan = super::super::tests::test_plan();
+            let record = submit_plan_with_runtime_admission(&plan, Some("local-run"), |_| {
+                Ok(json!({ "runtime": "test" }))
+            })
+            .expect("submit plan");
+
+            let decision: homeboy_lab_runner_contract::ExecutionPlacementDecision =
+                serde_json::from_value(record.metadata["execution_placement_decision"].clone())
+                    .expect("a controller-local run records a decodable canonical decision");
+            assert_eq!(decision.selected, EffectiveExecutionPlacement::Local);
+            assert!(decision.runner.is_none());
+            assert!(decision.permits_local_execution());
+
+            // The whole point of recording it: the local outcome now verifies.
+            record_execution_placement_outcome(
+                "local-run",
+                decision
+                    .outcome(EffectiveExecutionPlacement::Local, None)
+                    .expect("a controller-local decision authorizes a local outcome"),
+            )
+            .expect("record verified local outcome");
+        });
+    }
+
+    #[test]
+    fn a_null_decision_is_normalized_to_the_routing_decision_that_verified_it() {
+        // Records written before the canonical decision existed carry a null.
+        // That is missing evidence, not a contradiction — adopting the routing
+        // decision in hand (and saying so) is what makes an older local run
+        // recoverable instead of a dead end (#11600).
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let plan = super::super::tests::test_plan();
+            submit_plan_with_runtime_admission(&plan, Some("legacy-run"), |_| Ok(json!({})))
+                .expect("submit plan");
+            let mut record = store::read_record("legacy-run").expect("read record");
+            record.metadata["execution_placement_decision"] = Value::Null;
+            store::write_record(&record).expect("write legacy record");
+
+            let routed = homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+                "lab-route-contract",
+                "v1",
+                ExecutionPlacementIdentity {
+                    repository: "homeboy".to_string(),
+                    workspace: "/workspace/homeboy".to_string(),
+                    task: "legacy-task".to_string(),
+                    candidate: None,
+                    base: None,
+                },
+                Placement::Local,
+            );
+
+            assert!(
+                normalize_missing_execution_placement_decision("legacy-run", &routed)
+                    .expect("normalize legacy record"),
+                "a null decision is adopted"
+            );
+            assert!(
+                !normalize_missing_execution_placement_decision("legacy-run", &routed)
+                    .expect("normalize is idempotent"),
+                "an already-canonical decision is never overwritten"
+            );
+
+            let record = store::read_record("legacy-run").expect("read normalized record");
+            assert_eq!(
+                record.metadata["execution_placement_decision"]["decision_id"],
+                json!(routed.decision_id)
+            );
+            assert_eq!(
+                record.metadata["execution_placement_normalized"]["adopted_decision_id"],
+                json!(routed.decision_id)
+            );
+            record_execution_placement_outcome(
+                "legacy-run",
+                routed
+                    .outcome(EffectiveExecutionPlacement::Local, None)
+                    .expect("local outcome"),
+            )
+            .expect("a normalized record accepts its verified local outcome");
+        });
+    }
+
+    #[test]
+    fn a_submission_stamp_is_superseded_by_the_routing_decision_that_verified_it() {
+        // The stamp exists so a purely local run has an owner. It is derived,
+        // not routed, so when routing later produces its own decision for the
+        // same run the routed one wins — otherwise the stamp would collide with
+        // the outcome it was introduced to make recordable.
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let plan = super::super::tests::test_plan();
+            submit_plan_with_runtime_admission(&plan, Some("stamped-run"), |_| Ok(json!({})))
+                .expect("submit plan");
+            let stamped = store::read_record("stamped-run").expect("read record");
+            assert_eq!(
+                stamped.metadata["execution_placement_decision"]["policy_id"],
+                json!(homeboy_lab_runner_contract::CONTROLLER_LOCAL_SUBMISSION_POLICY_ID)
+            );
+
+            let routed = homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+                "lab-route-contract",
+                "v1",
+                ExecutionPlacementIdentity {
+                    repository: "homeboy".to_string(),
+                    workspace: "/workspace/homeboy".to_string(),
+                    task: "routed-task".to_string(),
+                    candidate: None,
+                    base: None,
+                },
+                Placement::Local,
+            );
+            assert!(
+                normalize_missing_execution_placement_decision("stamped-run", &routed)
+                    .expect("supersede the submission stamp")
+            );
+            record_execution_placement_outcome(
+                "stamped-run",
+                routed
+                    .outcome(EffectiveExecutionPlacement::Local, None)
+                    .expect("local outcome"),
+            )
+            .expect("the routed decision now owns the record");
         });
     }
 
@@ -565,8 +785,27 @@ where
     // The plan is the immutable cross-process carrier. Project the identical
     // decision onto the run record so status, finalization, and PR evidence do
     // not infer placement from ambient runner metadata.
-    if let Some(decision) = plan.metadata.get("execution_placement_decision") {
-        metadata["execution_placement_decision"] = decision.clone();
+    match plan.metadata.get("execution_placement_decision") {
+        Some(decision) if !decision.is_null() => {
+            metadata["execution_placement_decision"] = decision.clone();
+        }
+        // A plan that carries no routing decision was not routed anywhere: this
+        // controller is submitting a run it is about to execute itself. That is
+        // a placement, and it has to be *recorded* rather than inferred later.
+        //
+        // Leaving it null is what made an explicitly local Cook unrecoverable —
+        // retry decodes the originating record's canonical decision, and there
+        // was nothing there to decode (#11600).
+        //
+        // A submission carrying `execution_runner_id` is a runner-side
+        // projection of a decision the controller already owns; it is not this
+        // process's to author.
+        _ if execution_runner_id.is_none() => {
+            metadata["execution_placement_decision"] =
+                serde_json::to_value(controller_local_placement_decision(plan))
+                    .expect("controller-local placement decision is serializable");
+        }
+        _ => {}
     }
     // A replacement decision is only reviewable after it reaches the durable
     // run record. Keep its invalidation evidence alongside the decision rather

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -373,6 +373,14 @@ fn record_verified_lab_placement_outcome(record: &mut AgentTaskRunRecord) -> Res
                 None,
             )
         })?;
+    // A submission stamp is a placeholder authored in the absence of routing.
+    // Reconciliation holds no routing decision of its own, so it has nothing to
+    // supersede the stamp with — and verifying a Lab result against a
+    // placeholder that says "local" would manufacture a contradiction out of
+    // missing evidence. Skip exactly as this did before the stamp existed.
+    if decision.is_submission_stamp() {
+        return Ok(());
+    }
     let runner_id = record.runner_id().map(str::to_string).ok_or_else(|| {
         Error::validation_invalid_argument(
             "execution_placement_outcome",

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -249,20 +249,30 @@ pub fn route_after_parse_with_provenance(
         return Ok(Some(exit_code));
     }
 
-    let run_handoff = if lab_command.is_some() && inferred_runner_id.is_some() {
+    // Split-placement coordinators (cook, fanout) above own their own runner
+    // selection: they stay controller-local by contract and hand only their
+    // child provider attempts to a runner. Everything below is the *generic*
+    // Lab route, and it may only consume a policy-selected default runner when
+    // the command's own contract authorizes an automatic offload.
+    //
+    // Without this gate a default Lab runner was attached to every command that
+    // merely *had* a Lab contract, baked into the canonical placement decision
+    // as `selected: lab`, and then dispatched — which is how read-only
+    // lifecycle commands ended up querying a machine that does not own their
+    // durable record (#11597, #11599) and how an explicitly local run acquired
+    // a Lab handoff it could not later recover (#11600).
+    let route_runner_id = generic_route_runner_id(cli, lab_command.as_ref(), &inferred_runner_id);
+    let run_handoff = if lab_command.is_some() && route_runner_id.is_some() {
         materialize_agent_task_run_handoff(cli, &normalized_args)?
     } else {
         None
     };
-    let retry_handoff = if lab_command.is_some() && inferred_runner_id.is_some() {
+    let retry_handoff = if lab_command.is_some() && route_runner_id.is_some() {
         materialize_agent_task_retry_handoff(cli, &normalized_args)?
     } else {
         None
     };
-    stage_retry_lab_handoff_before_preacceptance(
-        retry_handoff.as_ref(),
-        inferred_runner_id.as_deref(),
-    )?;
+    stage_retry_lab_handoff_before_preacceptance(retry_handoff.as_ref(), route_runner_id)?;
     let normalized_args = run_handoff
         .as_ref()
         .map(|handoff| handoff.args.as_slice())
@@ -302,7 +312,7 @@ pub fn route_after_parse_with_provenance(
     } else {
         lab_command
     };
-    let cook_plan = if lab_command.is_some() && inferred_runner_id.is_some() {
+    let cook_plan = if lab_command.is_some() && route_runner_id.is_some() {
         materialize_agent_task_cook_plan(cli, provenance)?
     } else {
         None
@@ -310,12 +320,12 @@ pub fn route_after_parse_with_provenance(
     let normalized_args =
         inject_agent_task_cook_attempt_plan(&normalized_args, cook_plan.as_ref())?;
     let needs_generic_detached_handoff = lab_command.is_some()
-        && inferred_runner_id.is_some()
+        && route_runner_id.is_some()
         && cli.detach_after_handoff
         && run_handoff.is_none()
         && retry_handoff.is_none()
         && cook_plan.is_none();
-    let observer = lab_dispatch_observer(cli, &normalized_args, inferred_runner_id.as_deref());
+    let observer = lab_dispatch_observer(cli, &normalized_args, route_runner_id);
 
     let capture_mutation_patch = cli.command.lab_offload_captures_mutation_patch();
     let mutation_flag = cli.command.lab_offload_mutation_flag();
@@ -363,7 +373,7 @@ pub fn route_after_parse_with_provenance(
         .unwrap_or("command");
     let placement_decision = placement_decision(
         cli,
-        inferred_runner_id.as_deref(),
+        route_runner_id,
         placement_task,
         Some(&routing_source_path),
     )?;
@@ -457,7 +467,7 @@ pub fn route_after_parse_with_provenance(
             reuse_compatible_snapshot: retry_handoff.is_some(),
             job_overrides,
         },
-        inferred_runner_id.as_deref(),
+        route_runner_id,
         observer,
     )
     .map_err(|error| match retry_handoff.as_ref() {
@@ -500,6 +510,34 @@ pub fn route_after_parse_with_provenance(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+/// The runner the *generic* Lab route may use, given what the command's
+/// contract actually authorizes.
+///
+/// An operator-pinned `--runner` always passes: pinning names the runner
+/// directly and is its own authority. A policy-selected default runner has to
+/// earn its place through
+/// [`lab_routing::authorizes_policy_lab_runner`], which is the same predicate
+/// the offload executor applies — so the canonical placement decision this
+/// controller writes and the dispatch the executor performs can never disagree
+/// about whether a command was entitled to leave this machine.
+fn generic_route_runner_id<'a>(
+    cli: &Cli,
+    lab_command: Option<&runners::LabOffloadCommand>,
+    inferred_runner_id: &'a Option<String>,
+) -> Option<&'a str> {
+    let runner_id = inferred_runner_id.as_deref()?;
+    if cli.runner.is_some() {
+        return Some(runner_id);
+    }
+    let command = lab_command?;
+    lab_routing::authorizes_policy_lab_runner(
+        &command.command,
+        cli.placement,
+        lab_routing::captured_pressure_severity().as_deref(),
+    )
+    .then_some(runner_id)
 }
 
 fn placement_decision(

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -1145,3 +1145,159 @@ fn rewrite_ad_hoc_lab_workspace_skips_registered_component_or_path() {
     )
     .is_none());
 }
+
+/// The run id from #11599's reproduction. A controller-local Cook whose reads
+/// all failed with `agent-task run record not found` because they were answered
+/// by a runner that never owned the record.
+const OWNER_LOCAL_RUN_ID: &str = "agent-task-a7fdaeff-8fb8-4ab2-b7da-d985f4228dcd";
+
+/// The condition under which the regression fired: a connected default Lab
+/// runner that readiness happily selects for anything holding a Lab contract.
+fn connected_default_lab_runner() -> Option<String> {
+    Some("homeboy-lab".to_string())
+}
+
+fn route_runner_for(args: &[&str], inferred: &Option<String>) -> Option<String> {
+    let cli = Cli::try_parse_from(args).expect("generated command parses");
+    let lab_command = lab_offload_command(&cli.command)
+        .expect("lab route contract resolves")
+        .expect("agent-task commands carry a Lab contract");
+    generic_route_runner_id(&cli, Some(&lab_command), inferred).map(str::to_string)
+}
+
+#[test]
+fn controller_local_lifecycle_reads_never_acquire_a_default_lab_runner() {
+    // These are read-only introspection commands over a durable record this
+    // controller owns. Relocating them does not just cost a round trip — it
+    // asks a machine that has never seen the record to answer for it, which is
+    // exactly the `agent-task run record not found` in #11599.
+    let inferred = connected_default_lab_runner();
+    for args in [
+        ["homeboy", "agent-task", "providers"].as_slice(),
+        ["homeboy", "agent-task", "status", OWNER_LOCAL_RUN_ID].as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "status",
+            OWNER_LOCAL_RUN_ID,
+            "--full",
+        ]
+        .as_slice(),
+        ["homeboy", "agent-task", "logs", OWNER_LOCAL_RUN_ID].as_slice(),
+        ["homeboy", "agent-task", "diagnose", OWNER_LOCAL_RUN_ID].as_slice(),
+        ["homeboy", "agent-task", "evidence", OWNER_LOCAL_RUN_ID].as_slice(),
+    ] {
+        assert_eq!(
+            route_runner_for(args, &inferred),
+            None,
+            "{args:?} must resolve against the owner of its durable record",
+        );
+    }
+}
+
+#[test]
+fn every_generated_next_action_command_round_trips_to_the_record_owner() {
+    // A generated next action that walks the operator back into the failure it
+    // was printed to resolve is worse than no guidance at all (#11599). Each of
+    // these strings is emitted verbatim by a diagnosis/status projection.
+    let inferred = connected_default_lab_runner();
+    for generated in [
+        format!("homeboy agent-task status {OWNER_LOCAL_RUN_ID} --full"),
+        format!("homeboy agent-task logs {OWNER_LOCAL_RUN_ID}"),
+        format!("homeboy agent-task diagnose {OWNER_LOCAL_RUN_ID}"),
+        format!("homeboy agent-task diagnose {OWNER_LOCAL_RUN_ID} --full"),
+        format!("homeboy agent-task evidence {OWNER_LOCAL_RUN_ID}"),
+    ] {
+        let args: Vec<&str> = generated.split_whitespace().collect();
+        assert_eq!(
+            route_runner_for(&args, &inferred),
+            None,
+            "`{generated}` must resolve against the controller that owns the record",
+        );
+    }
+}
+
+#[test]
+fn explicit_local_placement_keeps_a_retry_controller_owned() {
+    // `--placement local` at creation is an ownership statement for the whole
+    // lifecycle. Acquiring a Lab runner here is what staged a retry handoff for
+    // a controller-local Cook and left its successor unable to decode a
+    // canonical placement decision (#11600).
+    assert_eq!(
+        route_runner_for(
+            &[
+                "homeboy",
+                "--placement",
+                "local",
+                "agent-task",
+                "retry",
+                OWNER_LOCAL_RUN_ID,
+                "--run",
+            ],
+            &connected_default_lab_runner(),
+        ),
+        None,
+    );
+}
+
+#[test]
+fn an_explicit_runner_still_reaches_the_runner_for_provider_discovery() {
+    // Pinning is its own authority: a runner catalog read is exactly what
+    // `--runner` is for, and #9651/#9763 kept that probe available.
+    assert_eq!(
+        route_runner_for(
+            &[
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "providers",
+            ],
+            &connected_default_lab_runner(),
+        ),
+        Some("homeboy-lab".to_string()),
+    );
+}
+
+#[test]
+fn explicit_lab_placement_still_reaches_the_default_runner() {
+    assert_eq!(
+        route_runner_for(
+            &["homeboy", "--placement", "lab", "agent-task", "providers",],
+            &connected_default_lab_runner(),
+        ),
+        Some("homeboy-lab".to_string()),
+    );
+}
+
+#[test]
+fn genuine_lab_workloads_still_offload_automatically() {
+    // The fix must not turn off automatic offload for the commands whose
+    // contracts actually declare it.
+    let inferred = connected_default_lab_runner();
+    for args in [
+        ["homeboy", "agent-task", "run-plan", "--plan", "-"].as_slice(),
+        [
+            "homeboy",
+            "agent-task",
+            "retry",
+            OWNER_LOCAL_RUN_ID,
+            "--run",
+        ]
+        .as_slice(),
+    ] {
+        assert_eq!(
+            route_runner_for(args, &inferred),
+            Some("homeboy-lab".to_string()),
+            "{args:?} declares automatic Lab offload and must keep it",
+        );
+    }
+}
+
+#[test]
+fn no_connected_runner_yields_no_route_runner_regardless_of_contract() {
+    assert_eq!(
+        route_runner_for(&["homeboy", "agent-task", "run-plan", "--plan", "-"], &None),
+        None,
+    );
+}

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -87,6 +87,59 @@ pub fn compatibility_placement_decision(
     )
 }
 
+/// Does `contract` authorize routing this command to a *policy-selected*
+/// default Lab runner?
+///
+/// This is the single definition of "may an automatic offload happen here",
+/// and it exists because the answer has to be identical in two places: the
+/// controller, which decides whether a policy-selected runner enters the
+/// canonical [`homeboy_lab_runner_contract::ExecutionPlacementDecision`], and
+/// the offload executor, which decides whether to dispatch. When those two
+/// disagreed, a controller-owned read-only command (`agent-task providers`,
+/// `status`, `logs`, `diagnose`) acquired a default runner it was never
+/// entitled to and ran against a machine that does not own its durable record
+/// (#11597, #11599).
+///
+/// An operator-pinned `--runner` is a *different* authority and never passes
+/// through here: pinning names the runner directly.
+pub fn authorizes_policy_lab_runner(
+    contract: &LabCommandContract,
+    placement: homeboy_lab_runner_contract::Placement,
+    pressure_severity: Option<&str>,
+) -> bool {
+    // An explicit `--placement lab`/`lab-or-local` is the operator's request,
+    // not policy's inference. Keep the runner so the command's own contract
+    // answers — either by dispatching, or by explaining its local-only reason
+    // — instead of a generic "no ready runner".
+    if placement.requests_lab() {
+        return true;
+    }
+    // `--placement local` is an explicit ownership statement. A run created
+    // locally must stay locally owned for its whole lifecycle (#11600).
+    if placement == homeboy_lab_runner_contract::Placement::Local {
+        return false;
+    }
+    if !contract.is_portable() {
+        return false;
+    }
+    if contract.routing_policy.default_lab_offload {
+        return true;
+    }
+    // Pressure-driven promotion mirrors the executor exactly: runner-resident
+    // reads are exempt, because relocating a read changes what its answer means
+    // (#9763).
+    placement == homeboy_lab_runner_contract::Placement::Auto
+        && contract.source_path_mode != LabSourcePathMode::RunnerResident
+        && pressure_severity
+            .is_some_and(|severity| contract.routing_policy.should_pressure_offload(severity))
+}
+
+/// The captured controller pressure severity, when this process took a
+/// resource-policy snapshot at preflight.
+pub fn captured_pressure_severity() -> Option<String> {
+    crate::resource_policy_context::captured_context().map(|context| context.severity)
+}
+
 /// Phase tag used for Lab trace dispatch observation metadata payloads. Kept in
 /// core so the routing service owns the observation envelope shape rather than
 /// the CLI adapter.
@@ -1104,6 +1157,117 @@ mod tests {
         assert!(matches!(
             outcome,
             crate::lab_offload::LabOffloadOutcome::RunLocal { .. }
+        ));
+    }
+
+    /// A read-only lifecycle/discovery contract: `runner_resident`, no
+    /// automatic offload. This is the shape shared by `agent-task providers`
+    /// and by `agent-task status/logs/diagnose/evidence`.
+    fn runner_resident_read_contract() -> LabCommandContract {
+        LabCommandContract::runner_resident_read_polling("agent-task status")
+    }
+
+    #[test]
+    fn a_runner_resident_read_never_authorizes_a_policy_selected_runner() {
+        // Controller and runner differ in extensions, runtime defaults,
+        // secrets, provider readiness — and, decisively, in which durable run
+        // records they own. Relocating a read changes what its answer means, so
+        // no severity and no default runner may promote it (#9763, #11597,
+        // #11599).
+        let contract = runner_resident_read_contract();
+        for severity in [None, Some("ok"), Some("warm"), Some("hot")] {
+            assert!(
+                !authorizes_policy_lab_runner(
+                    &contract,
+                    homeboy_lab_runner_contract::Placement::Auto,
+                    severity,
+                ),
+                "severity {severity:?} must not relocate a runner-resident read",
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_local_placement_never_authorizes_a_policy_selected_runner() {
+        // `--placement local` is an ownership statement about the whole
+        // lifecycle of whatever it creates, not a hint (#11600).
+        for contract in [
+            runner_resident_read_contract(),
+            LabCommandContract::portable(
+                "agent-task run",
+                None,
+                false,
+                crate::lab_contract::LAB_NO_EXTRA_CAPABILITIES,
+            ),
+        ] {
+            assert!(!authorizes_policy_lab_runner(
+                &contract,
+                homeboy_lab_runner_contract::Placement::Local,
+                Some("hot"),
+            ));
+        }
+    }
+
+    #[test]
+    fn an_explicit_lab_request_always_authorizes_the_selected_runner() {
+        // The operator asked. Keep the runner so the command's own contract
+        // answers — dispatching, or explaining its local-only reason — rather
+        // than a generic "no ready runner".
+        for placement in [
+            homeboy_lab_runner_contract::Placement::Lab,
+            homeboy_lab_runner_contract::Placement::LabOrLocal,
+        ] {
+            assert!(authorizes_policy_lab_runner(
+                &runner_resident_read_contract(),
+                placement,
+                None,
+            ));
+            assert!(authorizes_policy_lab_runner(
+                &LabCommandContract::local_only("agent-task cook", "controller-owned coordinator"),
+                placement,
+                None,
+            ));
+        }
+    }
+
+    #[test]
+    fn a_default_offload_contract_still_authorizes_its_policy_runner() {
+        assert!(authorizes_policy_lab_runner(
+            &LabCommandContract::portable(
+                "agent-task run",
+                None,
+                false,
+                crate::lab_contract::LAB_NO_EXTRA_CAPABILITIES,
+            ),
+            homeboy_lab_runner_contract::Placement::Auto,
+            None,
+        ));
+    }
+
+    #[test]
+    fn pressure_promotion_still_reaches_a_non_runner_resident_contract() {
+        // `explicit_runner_simple` declines automatic offload but is not a
+        // runner-resident read, so a loaded controller may still promote it.
+        // Losing this would have traded one regression for another.
+        let contract = LabCommandContract::explicit_runner_simple("runtime refresh");
+        assert!(!authorizes_policy_lab_runner(
+            &contract,
+            homeboy_lab_runner_contract::Placement::Auto,
+            Some("ok"),
+        ));
+        assert!(authorizes_policy_lab_runner(
+            &contract,
+            homeboy_lab_runner_contract::Placement::Auto,
+            Some("warm"),
+        ));
+    }
+
+    #[test]
+    fn a_local_only_contract_is_never_relocated_by_policy() {
+        assert!(!authorizes_policy_lab_runner(
+            &LabCommandContract::local_only("agent-task cook", "controller-owned coordinator"),
+            homeboy_lab_runner_contract::Placement::Auto,
+            Some("hot"),
         ));
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/execute.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/execute.rs
@@ -25,11 +25,26 @@ pub(crate) fn record_synced_remapped_workspace_entry(
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
     let placement = request.placement_decision.requested;
-    let explicit_runner = request
-        .placement_decision
-        .runner
-        .as_ref()
-        .map(|runner| runner.runner_id.as_str());
+    // A *pinned* runner is a caller's authority to leave this machine. A
+    // *policy-selected* default runner is not — it is only a preference, and
+    // the contract still decides whether an automatic offload may happen.
+    //
+    // Reading this straight off `placement_decision.runner` erased that
+    // distinction, because the canonical decision carries the policy-selected
+    // default too. Every guard below then behaved as if the operator had typed
+    // `--runner`, so controller-owned read-only commands silently relocated to
+    // the default Lab runner and could not find their own durable record
+    // (#11597, #11599).
+    let pinned_runner = request.explicit_runner.or_else(|| {
+        request
+            .placement_decision
+            .runner
+            .as_ref()
+            .filter(|runner| {
+                runner.source == homeboy_lab_runner_contract::RunnerSelectionSource::Explicit
+            })
+            .map(|runner| runner.runner_id.as_str())
+    });
     let allow_local_fallback = request.placement_decision.permits_local_fallback();
     if request.placement_decision.selected
         == homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local
@@ -68,7 +83,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     }
     if should_skip_managed_runner_placement(
         placement,
-        explicit_runner,
+        pinned_runner,
         homeboy_core::resource_policy_context::is_managed_runner_placement_context(),
     ) {
         record_local_outcome(&request)?;
@@ -95,7 +110,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     };
     let mut plan = base_lab_plan(request.command.as_ref());
     let Some(mut contract) = request.command.clone() else {
-        if let Some(runner_id) = explicit_runner {
+        if let Some(runner_id) = pinned_runner {
             if is_build_command(request.normalized_args) {
                 return Err(unsupported_build_lab_error("runner", Some(runner_id)));
             }
@@ -124,7 +139,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if let homeboy_core::lab_contract::LabCommandPortability::LocalOnly(reason) =
         contract.portability
     {
-        if let Some(runner_id) = explicit_runner {
+        if let Some(runner_id) = pinned_runner {
             let message = format!(
                 "--runner is unavailable for this local-only resource-pressure command. {reason}"
             );
@@ -159,7 +174,12 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         contract.routing_policy.default_lab_offload = true;
     }
 
-    if explicit_runner.is_none()
+    // Restores the pre-#11332 contract guard: without a pinned runner, a
+    // contract that declares no automatic Lab offload stays on the controller.
+    // This is what keeps `agent-task status/logs/diagnose/evidence` and
+    // `agent-task providers` resolving against the machine that owns their
+    // durable record (#11597, #11599).
+    if pinned_runner.is_none()
         && !contract.routing_policy.default_lab_offload
         && !placement.requests_lab()
     {
@@ -423,6 +443,14 @@ pub(crate) fn record_local_outcome(request: &LabOffloadRequest<'_>) -> Result<()
         return Ok(());
     };
     let run_id = target.agent_task_run_id();
+    // A record with no canonical decision predates this contract (or was
+    // written by a submission path that never authored one). The decision this
+    // route is holding is the authoritative one for the execution being
+    // verified, so adopt it rather than dead-ending recovery (#11600).
+    homeboy_agents::agent_task_lifecycle::normalize_missing_execution_placement_decision(
+        run_id,
+        &request.placement_decision,
+    )?;
     let outcome = request
         .placement_decision
         .outcome(

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -821,6 +821,13 @@ pub(crate) fn exec_lab_context(
         PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::Success).build(),
     );
     if let Some(run_id) = context.agent_task_run_id.as_deref() {
+        // This route's decision is the authoritative one for the execution
+        // being verified. Adopt it when the record carries none, or carries
+        // only a submission-derived placeholder (#11600).
+        agent_task_lifecycle::normalize_missing_execution_placement_decision(
+            run_id,
+            &request.placement_decision,
+        )?;
         let outcome = request
             .placement_decision
             .outcome(


### PR DESCRIPTION
## Root cause — one defect, three symptoms

`route_after_parse_with_provenance` selected a default Lab runner for **every** command that merely *had* a Lab contract:

```rust
let mut inferred_runner_id = if lab_command.is_some() {
    cli.runner.clone().or_else(|| readiness.selected_runner_id.clone())
} else { None };
```

No reference to the command's `routing_policy.default_lab_offload`, and no reference to the requested placement.

That was survivable while the executor still made its own contract-aware decision. #11332 (`c8d3b2957 feat(routing): persist canonical placement decisions`) made the canonical `ExecutionPlacementDecision` the sole placement input, and rewrote `execute_lab_offload` to read the runner off it:

```rust
let explicit_runner = request.placement_decision.runner.as_ref()
    .map(|runner| runner.runner_id.as_str());
```

The decision carries the *policy-selected* default too. So both guards that previously kept a non-offloading contract on the controller stopped working at once:

- `explicit_runner.is_none() && !default_lab_offload && !placement.requests_lab()` — never fired, because a policy runner now looked exactly like `--runner`.
- `resolve_lab_runner_selection`, which only resolved a default runner when `default_lab_offload || placement.requests_lab()`, was replaced by a straight projection of `placement_decision.runner`.

Everything else follows:

| symptom | mechanism |
|---|---|
| **#11597** `agent-task providers` auto-offloads | `runner_resident` declares no automatic offload; the policy runner bypassed the guard. Recreates exactly what #9651/#9763 closed. |
| **#11599** `status` / `logs` / `diagnose` fail `agent-task run record not found` | `runner_resident_read_polling`, same guard, same bypass — the read was answered by a machine that never owned the record. |
| **#11600** retry rejects a null `execution_placement_decision` | `--placement local` was ignored by runner inference too, so a controller-local retry still materialized a Lab handoff. Separately, a purely local submission never wrote a canonical decision at all — there was nothing for retry to decode. |

## Fix

**One predicate, applied in both places that must agree.** `homeboy_core::lab_routing::authorizes_policy_lab_runner(contract, placement, pressure_severity)` is now the single definition of "may an automatic offload happen here":

- `--placement lab` / `lab-or-local` always passes (so the command's own contract answers — dispatching, or explaining its local-only reason — rather than a generic "no ready runner").
- `--placement local` never passes.
- local-only contracts never pass.
- `default_lab_offload` passes.
- otherwise, pressure promotion, mirroring the executor exactly (runner-resident reads exempt).

The controller consults it before a policy runner may enter the canonical decision; the executor keeps its own guard and once again distinguishes a **pinned** runner (`request.explicit_runner`, or `RunnerSelectionSource::Explicit`) from a policy-selected one, so no default can impersonate `--runner`.

**Placement recorded, not inferred.** `submit_plan` stamps a canonical controller-local decision when a plan carries none and no `execution_runner_id` is set — a run this controller is about to execute itself *has* a placement, and it belongs on the record. `normalize_missing_execution_placement_decision` lets a route adopt its own authoritative decision over a missing/undecodable one or over a submission stamp, recording that under `execution_placement_normalized`. Reconciliation, which holds no routing decision, treats a stamp as absent rather than manufacturing a contradiction from missing evidence.

**Generated next-action commands** need no owner-placement argument threaded through dozens of emit sites: owner-resolution is now the default for reads, so `homeboy agent-task status <id> --full` round-trips by construction. Covered by test.

## Not broken

- `--runner <id>` provider discovery still reaches the runner (#9651/#9763's explicit probe).
- `--placement lab` still reaches the default runner.
- `agent-task run-plan`, `retry --run`, `bench`, `trace`, `review` — contracts that declare automatic offload — still offload.
- Pressure-driven promotion of `explicit_runner_simple` contracts on a warm/hot controller still happens.

Also incidentally fixes `agent-task promote <run-id>` under Auto placement with a connected runner, which hit the local-only branch's `--runner is unavailable for this local-only resource-pressure command` error for a runner the operator never asked for.

## Coverage

- `crates/homeboy-core/src/lab_routing.rs` — predicate matrix: runner-resident reads never promoted at any severity; explicit local never promotes; explicit lab always does; default-offload contracts unchanged; pressure promotion preserved for non-runner-resident contracts.
- `crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs` — with a *connected default Lab runner*: every read path (`providers`/`status`/`logs`/`diagnose`/`evidence`) stays local; every generated next-action command string round-trips; `--placement local ... retry --run` stays controller-owned; explicit runner and explicit lab placement still offload; genuine Lab workloads still offload.
- `crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs` — a plan without a routing decision persists a decodable, non-null, local, `permits_local_execution` decision whose local outcome verifies; a null decision is normalized and is idempotent; a submission stamp is superseded by the routing decision.

## Compile status

**I could not compile this.** The VPS has a hard build prohibition (three agents, one 15Gi box); only `cargo fmt` was run, and it passed on every touched file. `cargo check --workspace --tests` has not been run.

Risk concentrates in three places worth a careful look:
1. the `pinned_runner` borrow in `execute_lab_offload` (same shape as the code it replaces, but it now unifies `request.explicit_runner`'s lifetime with a borrow of `request`),
2. `generic_route_runner_id`'s explicit `'a` tie to `inferred_runner_id` while `lab_command`'s lifetime stays elided,
3. the `match` guard on `execution_runner_id.is_none()` inside `submit_plan_with_runtime_admission_on_runner_with_metadata`, which borrows a parameter used both before and after.

## AI assistance

Claude (Sonnet 4.5) via OpenCode diagnosed the shared mechanism across #11597/#11599/#11600, implemented the fix, and drafted this PR. Chris Huber remains responsible for the change.