### PR TITLE
fix(fuzz): an empty gate set is not a pass

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/report.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/report.rs
@@ -797,7 +797,26 @@ fn open_finding_count(campaign: &FuzzCampaign) -> usize {
         .count()
 }
 
+/// Aggregate verdict over an evaluated gate set.
+///
+/// An empty set is not a pass. `all` on an empty slice is `true`, so reporting
+/// `"passed"` would claim every gate held for a run that evaluated none — the
+/// shape #10685 exists to prevent, and #11645 found here.
+///
+/// This is a routine state rather than a defensive branch: the `measurement`
+/// gate profile declares no gates at all
+/// (`fuzz_gate_profile_contract` returns `(vec![], vec![])`), so every
+/// measurement-profile run reached this function with an empty slice and
+/// rendered `passed` having evaluated nothing.
+///
+/// `"not_gated"` keeps that distinguishable from a real pass without pretending
+/// it is a failure — nothing gates on this value, and the command's own exit
+/// code is decided separately and already declines to fail the measurement
+/// profile.
 pub(super) fn gate_status(gates: &[FuzzGateEvaluation]) -> String {
+    if gates.is_empty() {
+        return "not_gated".to_string();
+    }
     if gates.iter().all(|gate| gate.status == "passed") {
         "passed".to_string()
     } else {

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -1673,7 +1673,8 @@ fn fuzz_report_persists_result_envelope_artifact_for_run_id() {
             .performance_hotspots
             .hottest_metric_families
             .is_empty());
-        assert_eq!(output.status, "passed");
+        // No gates were declared, so there is no pass to report (#11645).
+        assert_eq!(output.status, "not_gated");
         assert!(output.gates.is_empty());
         assert!(output.envelope.gates.is_empty());
         assert!(output.envelope.required_artifacts.is_empty());

--- a/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/planning_tests.rs
@@ -1270,7 +1270,9 @@ fn fuzz_validate_accepts_case_log_artifact() {
     })
     .expect("validate fuzz campaign and case log");
 
-    assert_eq!(output.status, "passed");
+    // The measurement profile declares no gates, so the verdict is `not_gated`
+    // rather than a pass over an empty set (#11645).
+    assert_eq!(output.status, "not_gated");
     assert_eq!(output.case_log_entries, 1);
     assert_eq!(
         output.case_log_files,
@@ -1349,7 +1351,10 @@ fn fuzz_validate_measurement_profile_is_non_blocking_but_strict_profile_blocks()
     })
     .expect("validate strict campaign");
 
-    assert_eq!(measurement.status, "passed");
+    // The measurement profile is non-blocking, which is not the same as passing.
+    // This campaign has an open finding and evaluated no gates, so reporting
+    // `passed` would launder that finding into a green verdict (#11645).
+    assert_eq!(measurement.status, "not_gated");
     assert_eq!(measurement.open_findings, 1);
     assert!(measurement.gates.is_empty());
     assert_eq!(strict.status, "failed");

--- a/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/report_tests.rs
@@ -270,3 +270,27 @@ fn select_workload_rejects_empty_fuzz_selection() {
         .iter()
         .any(|hint| hint.message.contains("fuzz list")));
 }
+
+/// An empty gate set must not report a pass (#11645).
+///
+/// `all` on an empty slice is `true`, so the obvious implementation greens a run
+/// that evaluated nothing. This is not hypothetical: the `measurement` gate
+/// profile declares no gates, so every run using it took that branch.
+#[test]
+fn an_empty_gate_set_is_not_a_pass() {
+    assert_eq!(gate_status(&[]), "not_gated");
+}
+
+/// The empty-set guard must not swallow real verdicts.
+#[test]
+fn a_gate_set_still_reports_pass_and_fail() {
+    let gate = |status: &str| super::super::types_extra::FuzzGateEvaluation {
+        gate_id: "no-open-findings".to_string(),
+        status: status.to_string(),
+        metric: "open_findings".to_string(),
+        observed: 0.0,
+        expected: 0.0,
+    };
+    assert_eq!(gate_status(&[gate("passed")]), "passed");
+    assert_eq!(gate_status(&[gate("passed"), gate("failed")]), "failed");
+}

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -157,15 +157,14 @@ const VERDICT_SITES: &[VerdictSite] = &[
     },
     VerdictSite {
         file: "crates/homeboy-cli/src/commands/fuzz/report.rs",
-        basis: MeasurementBasis::Unguarded,
-        note: "gate_status returns \"passed\" when `gates.iter().all(..)` holds, and `all` on an \
-               empty slice is true -- a campaign that evaluated no gates renders passed having \
-               measured nothing. This is the invariant, not an exception to it. Left as a debt \
-               marker rather than changed here because the fix is a behaviour change to fuzz \
-               reporting and belongs with an owner who can say what an empty gate set should \
-               mean. Blast radius: the `fuzz` command's rendered gate status only; it feeds no \
-               release or merge gate. It became visible when production_lines stopped \
-               truncating at a #[cfg(test)] import.",
+        basis: MeasurementBasis::EmptyPopulation,
+        note: "gate_status refuses to aggregate a pass over an empty gate set. The population is \
+               established independently of the campaign, by fuzz_gate_profile_contract, and the \
+               `measurement` profile declares no gates at all -- so the empty case is routine, \
+               not defensive, and every measurement-profile run used to render `passed` having \
+               evaluated nothing (#11645). Zero gates now reports `not_gated`, which is neither \
+               a pass nor a failure; the command's exit code is decided separately and already \
+               declines to fail that profile.",
     },
     VerdictSite {
         file: "crates/homeboy-cli/src/commands/trace/guardrails.rs",


### PR DESCRIPTION
Closes #11645.

```rust
pub(super) fn gate_status(gates: &[FuzzGateEvaluation]) -> String {
    if gates.iter().all(|gate| gate.status == "passed") {
```

`all` on an empty slice is `true`, so zero gates rendered `"passed"`.

## Not a hypothetical edge

`fuzz_gate_profile_contract` returns `(vec![], vec![])` for
`FuzzGateProfile::Measurement`. That profile declares **no gates at all**, so
every run using it reported a pass having evaluated nothing.

A test encoded exactly that, which is the clearest statement of the bug:

```rust
assert_eq!(measurement.status, "passed");
assert_eq!(measurement.open_findings, 1);
assert!(measurement.gates.is_empty());
```

An open finding, no gates, and a green verdict.

## Fix

Zero gates now reports `"not_gated"` — neither a pass nor a failure.

The measurement profile stays non-blocking, which was always the intent and is
decided somewhere else entirely:

```rust
let campaign_failed = gate_profile != FuzzGateProfile::Measurement
    && results.is_some_and(fuzz_campaign_reports_failure);
```

That is untouched. This changes what the run *reports*, not what it *enforces*.

## Why in `gate_status` and not on the envelope

#11645 offered a marker field as the smallest option, and I went the other way
after counting the callers. Four verdict sites share this function — `report`,
`execution`, the run-gates blob, and the compare snapshot — and all four had the
same hole. One honest function closes all four; a marker on the envelope would
have closed two and left the snapshot and the blob still claiming a pass.

## Blast radius

Nothing branches on this value:

- the envelope contract requires only that `status` be non-empty
  (`artifact_envelope.rs:133`)
- compare's regression detection reads **per-gate** statuses from a
  `BTreeMap<gate_id, status>` built at `compare.rs:85`, not the aggregate, so
  `"passed" -> "failed"` detection is unaffected
- no `.md`, `.json`, `.sh`, or `.yml` under `docs/` or `.github/` references it

Three test expectations updated, each of which was asserting the old behaviour;
two new tests pin the contract directly — an empty set is `not_gated`, and a
non-empty set still reports `passed`/`failed` so the guard cannot swallow real
verdicts.

## Registry

The measurement-registry entry moves from `Unguarded`, where I recorded it as
debt in #11617, to `EmptyPopulation` — the gate population is established by the
profile contract, independently of the campaign.

## Verification

```
homeboy-cli fuzz                  183 passed
homeboy-engine-primitives --lib   253 passed, 0 failed
cargo check --workspace --tests   clean
cargo fmt --all --check           clean
```

One `homeboy-cli` failure remains,
`commands::infra::route::tests::handoff::fuzz_doctor_routes_locally_without_explicit_lab_runner`.
It is pre-existing on `main` and fails identically with this patch reverted from
the same tree.