### PR TITLE
fix(upgrade): converge versioned runner source pins

### DIFF
--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -269,11 +269,11 @@ fn fails_when_configured_runner_path_remains_older_than_local_after_successful_u
 }
 
 #[test]
-fn binary_store_source_pin_realigns_to_materialized_controller_binary() {
+fn version_addressed_binary_store_source_pin_realigns_to_materialized_controller_binary() {
     let source_dir = git_source_checkout();
     let expected_identity = source_checkout_build_identity(source_dir.path()).unwrap();
     let stale_path =
-        "/home/user/Developer/_homeboy_binaries/homeboy-2f9a1eb64e0bb84d/target/release/homeboy";
+        "/home/user/Developer/_homeboy_binaries/homeboy-v0-331-0/target/release/homeboy";
     let remote_source = "/home/user/Developer/_homeboy_binaries/homeboy-current";
     let selected_binary = format!("{remote_source}/target/release/homeboy");
     let runner = ssh_runner("lab", Some(stale_path));
@@ -314,6 +314,9 @@ fn binary_store_source_pin_realigns_to_materialized_controller_binary() {
     assert_eq!(updated[0].homeboy_path, selected_binary);
     assert_eq!(updates, vec![("lab".to_string(), selected_binary)]);
     assert!(is_homeboy_source_build_path(stale_path));
+    assert_eq!(commands[2][0], stale_path);
+    assert_eq!(commands[2][commands[2].len() - 2], "--source-path");
+    assert_eq!(commands[2][commands[2].len() - 1], remote_source);
     assert!(!commands
         .iter()
         .any(|command| command.first() == Some(&"homeboy".to_string())));

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_c.rs
@@ -389,7 +389,7 @@ fn source_drift_recovery_retains_selected_immutable_revision() {
 fn snapshot_recovery_selects_the_verified_materialized_binary() {
     let commands = runner_recovery_commands(
         "lab",
-        "/home/user/Developer/_homeboy_binaries/homeboy-stale/target/release/homeboy",
+        "/home/user/Developer/_homeboy_binaries/homeboy-v0-331-0/target/release/homeboy",
         Some(&"identity mismatch".to_string()),
         Some("0.228.4"),
         Some("0.228.5"),
@@ -403,6 +403,9 @@ fn snapshot_recovery_selects_the_verified_materialized_binary() {
         commands[0],
         "homeboy runner refresh-homeboy lab --select /home/user/Developer/_lab_workspaces/snapshot/target/release/homeboy --reconnect"
     );
+    assert!(!commands
+        .iter()
+        .any(|command| command.contains("homeboy upgrade --force --upgrade-runner")));
 }
 
 #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -250,7 +250,7 @@ pub fn run_upgrade_with_method(
                         force,
                         runner_method_override,
                         source_upgrade_path.as_deref(),
-                        source_path.is_some(),
+                        source_upgrade_path.is_some(),
                         None,
                         runner_targets,
                         &extensions_updated,
@@ -334,7 +334,9 @@ pub fn run_upgrade_with_method(
             provider.preflight_configured_runners_for_upgrade(
                 runner_method_override,
                 source_upgrade_path.as_deref(),
-                source_path.is_some(),
+                // A resolved source workspace is the controller-selected build
+                // input, even when it was inferred from the source install.
+                source_upgrade_path.is_some(),
                 runner_targets,
             )
         })?
@@ -388,7 +390,7 @@ pub fn run_upgrade_with_method(
                 force,
                 runner_method_override,
                 source_upgrade_path.as_deref(),
-                source_path.is_some(),
+                source_upgrade_path.is_some(),
                 new_build_identity.as_deref(),
                 runner_targets,
                 &extensions_updated,


### PR DESCRIPTION
Closes #11672

## Summary
- treat inferred source workspaces as the controller-selected runner build input
- realign version-addressed managed runner paths before rebuilding stale source
- prevent recovery guidance from repeating the failed upgrade-runner loop

## Verification
- `cargo test -p homeboy-upgrade --no-fail-fast` (150 passed)
- targeted Lab runner upgrade path regressions passed
- `cargo check -p homeboy-upgrade -p homeboy-lab-runner`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: Root-cause analysis, implementation, regression tests, review, and verification with Chris Huber.