### PR TITLE
fix(runner): bind refresh generations to binary bytes

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -97,6 +97,8 @@ pub(crate) fn rotate_daemon_generation(
     runner_id: &str,
     candidate_homeboy: &str,
     candidate_identity: &str,
+    candidate_generation: &str,
+    candidate_binary_sha256: Option<&str>,
     draining_job_ids: &[String],
 ) -> Result<()> {
     let current = read_session_or_live_peer(runner_id)?.ok_or_else(|| {
@@ -116,7 +118,7 @@ pub(crate) fn rotate_daemon_generation(
             None,
         ));
     };
-    let generation = candidate_identity
+    let generation = candidate_generation
         .chars()
         .filter(|character| character.is_ascii_alphanumeric())
         .take(48)
@@ -214,6 +216,37 @@ pub(crate) fn rotate_daemon_generation(
                 ));
             }
         };
+    if let Some(expected_binary_sha256) = candidate_binary_sha256 {
+        let freshness = daemon_http_freshness(runner_id, &local_url, "", candidate_identity);
+        let hash_matches = freshness.as_ref().is_ok_and(|report| {
+            report.fresh && report.binary_hash.as_deref() == Some(expected_binary_sha256)
+        });
+        if !hash_matches {
+            if let Some(lease_id) = daemon.lease_id.as_deref() {
+                let command = format!(
+                    "{} daemon stop --force --lease-id {}",
+                    shell::quote_arg(candidate_homeboy),
+                    shell::quote_arg(lease_id),
+                );
+                let _ = client.execute(&command);
+            }
+            if let Some(pid) = tunnel_pid {
+                terminate_pid(pid);
+            }
+            return Err(Error::validation_invalid_argument(
+                "reconnect",
+                freshness.err().map_or_else(
+                    || {
+                        "candidate daemon did not report the validated binary SHA-256 as fresh"
+                            .to_string()
+                    },
+                    |error| format!("candidate daemon freshness verification failed: {error}"),
+                ),
+                Some(runner_id.to_string()),
+                None,
+            ));
+        }
+    }
     let candidate = RunnerSession {
         runner_id: runner_id.to_string(),
         mode: RunnerTunnelMode::DirectSsh,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -479,6 +479,7 @@ pub fn refresh_homeboy_binary(
     // A Cook pin reserves its exact runtime from provider preflight through
     // durable runner-job binding. A refresh must drain that reservation rather
     // than rotating the configured binary underneath an admitted handoff.
+    let selected_binary_path = refreshed_binary_path(&plan, &exec_output.stdout)?;
     let promotion_candidate = parse_identity(&exec_output.stdout)
         .ok()
         .and_then(|identity| identity_commit(&identity))
@@ -579,7 +580,7 @@ pub fn refresh_homeboy_binary(
                 },
             )?;
             let updated_fields =
-                promote_verified_runner_binary(&plan.runner_id, &plan.binary_path)?;
+                promote_verified_runner_binary(&plan.runner_id, &selected_binary_path)?;
             Ok(SshBootstrapPromotion {
                 identity,
                 source_sha: source_sha_from_output(&exec_output.stdout),
@@ -670,19 +671,24 @@ pub fn refresh_homeboy_binary(
                 .and_then(Value::as_str)
                 .unwrap_or("candidate")
                 .to_string();
+            let candidate_binary_sha256 = materialized_binary_sha256(&exec_output.stdout);
+            let candidate_generation =
+                refreshed_generation_key(&candidate_identity, candidate_binary_sha256.clone());
             let draining_job_ids = active_jobs
                 .iter()
                 .map(|job| job.job_id.clone())
                 .collect::<Vec<_>>();
             if let Err(error) = rotate_daemon_generation(
                 &plan.runner_id,
-                &plan.binary_path,
+                &selected_binary_path,
                 &candidate_identity,
+                &candidate_generation,
+                candidate_binary_sha256.as_deref(),
                 &draining_job_ids,
             ) {
                 restore_runner_homeboy_path_if_selected(
                     &plan.runner_id,
-                    &plan.binary_path,
+                    &selected_binary_path,
                     previous_homeboy_path.as_deref(),
                 )?;
                 let mut phases = phase_summary.clone();
@@ -702,7 +708,7 @@ pub fn refresh_homeboy_binary(
                     phase_summary,
                     daemon_refreshed: true,
                     interrupted_job_ids: Vec::new(),
-                    selected_binary_path: plan.binary_path.clone(),
+                    selected_binary_path: selected_binary_path.clone(),
                     reconnect_required: false,
                     followup_commands: Vec::new(),
                     reconnect_deferred: None,
@@ -722,7 +728,7 @@ pub fn refresh_homeboy_binary(
             Err(_) => {
                 let deferred = defer_reconnect_after_promotion_race(
                     &plan.runner_id,
-                    &plan.binary_path,
+                    &selected_binary_path,
                     previous_homeboy_path.as_deref(),
                     &active_jobs,
                 )?;
@@ -738,7 +744,7 @@ pub fn refresh_homeboy_binary(
                         phase_summary,
                         daemon_refreshed: false,
                         interrupted_job_ids: Vec::new(),
-                        selected_binary_path: plan.binary_path.clone(),
+                        selected_binary_path: selected_binary_path.clone(),
                         reconnect_required: true,
                         followup_commands: deferred.followup_commands.clone(),
                         reconnect_deferred: Some(deferred),
@@ -756,7 +762,7 @@ pub fn refresh_homeboy_binary(
             return rollback_refresh_error_with(error, || {
                 restore_runner_homeboy_path_if_selected(
                     &plan.runner_id,
-                    &plan.binary_path,
+                    &selected_binary_path,
                     previous_homeboy_path.as_deref(),
                 )
                 .map(|_| ())
@@ -790,7 +796,7 @@ pub fn refresh_homeboy_binary(
                     || {
                         restore_runner_homeboy_path_if_selected(
                             &plan.runner_id,
-                            &plan.binary_path,
+                            &selected_binary_path,
                             previous_homeboy_path.as_deref(),
                         )
                         .map(|_| ())
@@ -872,7 +878,7 @@ pub fn refresh_homeboy_binary(
                     phase_summary,
                     daemon_refreshed: false,
                     interrupted_job_ids,
-                    selected_binary_path: plan.binary_path.clone(),
+                    selected_binary_path: selected_binary_path.clone(),
                     reconnect_required: true,
                     followup_commands: plan.followup_commands.clone(),
                     reconnect_deferred: None,
@@ -931,7 +937,7 @@ pub fn refresh_homeboy_binary(
                         phase_summary,
                         daemon_refreshed: false,
                         interrupted_job_ids,
-                        selected_binary_path: plan.binary_path.clone(),
+                        selected_binary_path: selected_binary_path.clone(),
                         reconnect_required: true,
                         followup_commands: plan.followup_commands.clone(),
                         reconnect_deferred: None,
@@ -970,7 +976,7 @@ pub fn refresh_homeboy_binary(
             phase_summary,
             daemon_refreshed,
             interrupted_job_ids,
-            selected_binary_path: plan.binary_path.clone(),
+            selected_binary_path: selected_binary_path.clone(),
             reconnect_required: !daemon_refreshed,
             followup_commands: plan.followup_commands,
             reconnect_deferred: None,
@@ -1325,7 +1331,8 @@ where
         Error::validation_invalid_argument("identity", message, Some(plan.runner_id.clone()), None)
     })?;
     let source_sha = source_sha_from_output(&stdout);
-    let (updated_fields, rollback) = promote(&plan.binary_path, &identity)?;
+    let binary_path = refreshed_binary_path(plan, &stdout)?;
+    let (updated_fields, rollback) = promote(&binary_path, &identity)?;
     Ok(SshBootstrapPromotion {
         identity,
         source_sha,
@@ -1935,7 +1942,7 @@ fn materialize_script(
     allow_downgrade: bool,
 ) -> String {
     format!(
-        "set -e\nsource={}\nref={}\ndir={}\nbinary={}\nallow_downgrade={}\nmkdir -p \"$(dirname \"$dir\")\"\ncheckout_existed=false\nif [ -d \"$dir/.git\" ]; then\n  checkout_existed=true\nelse\n  git clone \"$source\" \"$dir\"\nfi\ncurrent_remote=$(git -C \"$dir\" config --get remote.origin.url 2>/dev/null || true)\nif [ \"$current_remote\" != \"$source\" ]; then\n  git -C \"$dir\" remote set-url origin \"$source\" 2>/dev/null || git -C \"$dir\" remote add origin \"$source\"\nfi\ngit -C \"$dir\" fetch --prune origin\nrequested=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/$ref\" || git -C \"$dir\" rev-parse --verify --quiet \"$ref\")\nif [ -z \"$requested\" ]; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ntarget=$(git -C \"$dir\" rev-parse --verify --quiet \"${{requested}}^{{commit}}\")\ncurrent=\nif [ \"$checkout_existed\" = true ]; then\n  current=$(git -C \"$dir\" rev-parse --verify --quiet HEAD || true)\nfi\nif [ -n \"$current\" ] && [ \"$current\" != \"$target\" ] && git -C \"$dir\" merge-base --is-ancestor \"$target\" \"$current\"; then\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$current\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_REQUESTED=$ref\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_RESOLVED=$target\" >&2\n  if [ \"$allow_downgrade\" != true ]; then\n    echo \"Refusing Homeboy runner downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n    exit 1\n  fi\nfi\ngit -C \"$dir\" checkout --quiet --force --detach \"$target\"\ngit -C \"$dir\" reset --hard \"$target\"\necho \"HOMEBOY_REFRESH_SOURCE_SHA=$target\"\ncargo build --release --bin homeboy --manifest-path \"$dir/Cargo.toml\"\n\"$binary\" self identity\n",
+        "set -e\nsource={}\nref={}\ndir={}\nbinary={}\nallow_downgrade={}\nhash_binary() {{ (sha256sum \"$1\" 2>/dev/null || shasum -a 256 \"$1\") | awk '{{print $1}}'; }}\nmkdir -p \"$(dirname \"$dir\")\"\ncheckout_existed=false\nif [ -d \"$dir/.git\" ]; then\n  checkout_existed=true\nelse\n  git clone \"$source\" \"$dir\"\nfi\ncurrent_remote=$(git -C \"$dir\" config --get remote.origin.url 2>/dev/null || true)\nif [ \"$current_remote\" != \"$source\" ]; then\n  git -C \"$dir\" remote set-url origin \"$source\" 2>/dev/null || git -C \"$dir\" remote add origin \"$source\"\nfi\ngit -C \"$dir\" fetch --prune origin\nrequested=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/$ref\" || git -C \"$dir\" rev-parse --verify --quiet \"$ref\")\nif [ -z \"$requested\" ]; then\n  echo \"Homeboy ref not found: $ref\" >&2\n  exit 1\nfi\ntarget=$(git -C \"$dir\" rev-parse --verify --quiet \"${{requested}}^{{commit}}\")\ncurrent=\nif [ \"$checkout_existed\" = true ]; then\n  current=$(git -C \"$dir\" rev-parse --verify --quiet HEAD || true)\nfi\nif [ -n \"$current\" ] && [ \"$current\" != \"$target\" ] && git -C \"$dir\" merge-base --is-ancestor \"$target\" \"$current\"; then\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_PREVIOUS=$current\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_REQUESTED=$ref\" >&2\n  echo \"HOMEBOY_REFRESH_DOWNGRADE_RESOLVED=$target\" >&2\n  if [ \"$allow_downgrade\" != true ]; then\n    echo \"Refusing Homeboy runner downgrade; use --allow-downgrade only for an intentional rollback\" >&2\n    exit 1\n  fi\nfi\ngit -C \"$dir\" checkout --quiet --force --detach \"$target\"\ngit -C \"$dir\" reset --hard \"$target\"\necho \"HOMEBOY_REFRESH_SOURCE_SHA=$target\"\ncargo build --release --bin homeboy --manifest-path \"$dir/Cargo.toml\"\nbinary_sha=$(hash_binary \"$binary\")\nif [ -z \"$binary_sha\" ]; then\n  echo \"could not hash materialized Homeboy binary\" >&2\n  exit 1\nfi\nslot_dir=\"$(dirname \"$dir\")/homeboy-$binary_sha\"\nimmutable_binary=\"$slot_dir/homeboy\"\nmkdir -p \"$slot_dir\"\nif [ -e \"$immutable_binary\" ]; then\n  existing_sha=$(hash_binary \"$immutable_binary\")\n  if [ \"$existing_sha\" != \"$binary_sha\" ]; then\n    echo \"immutable Homeboy binary slot hash mismatch\" >&2\n    exit 1\n  fi\nelse\n  staged_binary=$(mktemp \"$slot_dir/.homeboy.XXXXXX\")\n  trap 'rm -f \"$staged_binary\"' EXIT HUP INT TERM\n  cp \"$binary\" \"$staged_binary\"\n  chmod 0755 \"$staged_binary\"\n  staged_sha=$(hash_binary \"$staged_binary\")\n  if [ \"$staged_sha\" != \"$binary_sha\" ]; then\n    echo \"staged Homeboy binary hash mismatch\" >&2\n    exit 1\n  fi\n  if ! ln \"$staged_binary\" \"$immutable_binary\"; then\n    if [ ! -e \"$immutable_binary\" ] || [ \"$(hash_binary \"$immutable_binary\")\" != \"$binary_sha\" ]; then\n      echo \"immutable Homeboy binary slot publication failed\" >&2\n      exit 1\n    fi\n  fi\n  rm -f \"$staged_binary\"\n  trap - EXIT HUP INT TERM\nfi\necho \"HOMEBOY_REFRESH_BINARY_SHA256=$binary_sha\"\necho \"HOMEBOY_REFRESH_BINARY_PATH=$immutable_binary\"\n\"$immutable_binary\" self identity\n",
         quote_path(source),
         quote_path(git_ref),
         quote_path(target_dir),
@@ -1950,6 +1957,45 @@ fn source_sha_from_output(stdout: &str) -> Option<String> {
             .filter(|sha| !sha.is_empty())
             .map(str::to_string)
     })
+}
+
+fn materialized_binary_sha256(stdout: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("HOMEBOY_REFRESH_BINARY_SHA256=")
+            .filter(|sha| sha.len() == 64 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+            .map(str::to_string)
+    })
+}
+
+fn refreshed_binary_path(plan: &HomeboyBinaryRefreshPlan, stdout: &str) -> Result<String> {
+    if plan.mode != "materialize" {
+        return Ok(plan.binary_path.clone());
+    }
+    let path = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("HOMEBOY_REFRESH_BINARY_PATH="))
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "identity",
+                "materialized refresh did not report its immutable binary path",
+                Some(plan.runner_id.clone()),
+                None,
+            )
+        })?;
+    if materialized_binary_sha256(stdout).is_none() {
+        return Err(Error::validation_invalid_argument(
+            "identity",
+            "materialized refresh did not report its binary SHA-256",
+            Some(plan.runner_id.clone()),
+            None,
+        ));
+    }
+    Ok(path.to_string())
+}
+
+fn refreshed_generation_key(identity: &str, binary_sha256: Option<String>) -> String {
+    binary_sha256.unwrap_or_else(|| identity.to_string())
 }
 
 fn identity_probe_script(binary_path: &str) -> String {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/mod.rs
@@ -21,5 +21,5 @@ pub(super) fn ssh_bootstrap_plan() -> HomeboyBinaryRefreshPlan {
 }
 
 pub(super) fn verified_bootstrap_output(sha: &str) -> String {
-    format!("HOMEBOY_REFRESH_SOURCE_SHA={sha}\n{{\"data\":{{\"git_commit\":\"{sha}\",\"git_dirty\":false}}}}")
+    format!("HOMEBOY_REFRESH_SOURCE_SHA={sha}\nHOMEBOY_REFRESH_BINARY_SHA256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\nHOMEBOY_REFRESH_BINARY_PATH=/verified/homeboy\n{{\"data\":{{\"git_commit\":\"{sha}\",\"git_dirty\":false}}}}")
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -899,6 +899,38 @@ fn materialize_script_records_the_peeled_commit_for_tags_and_direct_commits() {
             &parse_identity(&stdout).expect("source-built binary identity"),
         )
         .expect("peeled source identity matches the nested-workspace build commit");
+
+        let immutable_binary = refreshed_binary_path(&ssh_bootstrap_plan(), &stdout)
+            .expect("materialization reports immutable binary path");
+        let repeated = fixture_build_shell(&script)
+            .output()
+            .expect("repeat materialize script");
+        assert!(
+            repeated.status.success(),
+            "matching immutable slot is reusable: {}",
+            String::from_utf8_lossy(&repeated.stderr)
+        );
+        assert_eq!(
+            refreshed_binary_path(
+                &ssh_bootstrap_plan(),
+                &String::from_utf8(repeated.stdout).expect("repeat output is UTF-8"),
+            )
+            .expect("repeat reports immutable path"),
+            immutable_binary
+        );
+
+        if index == 2 {
+            std::fs::write(&immutable_binary, "corrupt immutable slot")
+                .expect("corrupt immutable slot for validation coverage");
+            let corrupt = fixture_build_shell(&script)
+                .output()
+                .expect("run materialize script against corrupt slot");
+            assert!(
+                !corrupt.status.success(),
+                "corrupt slot is never overwritten"
+            );
+            assert!(String::from_utf8_lossy(&corrupt.stderr).contains("slot hash mismatch"));
+        }
     }
 }
 
@@ -1414,6 +1446,16 @@ fn default_target_dir_is_ref_scoped() {
         default_target_dir("/runner/ws/", "origin/main"),
         "/runner/ws/_homeboy_binaries/homeboy-origin-main"
     );
+    let target_dir = default_target_dir("/home/chubes/Developer", "main");
+    let script = materialize_script(
+        "https://example.test/homeboy.git",
+        "main",
+        &target_dir,
+        &format!("{target_dir}/target/release/homeboy"),
+        false,
+    );
+    assert!(script.contains("slot_dir=\"$(dirname \"$dir\")/homeboy-$binary_sha\""));
+    assert!(!script.contains("_homeboy_binaries/$binary_sha"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -984,6 +984,40 @@ fn refresh_rotation_predicate_preserves_owned_generations_without_changing_force
 }
 
 #[test]
+fn same_revision_rebuild_rotates_active_daemon_to_a_distinct_byte_generation() {
+    let revision = "homeboy 1.0.0+same-revision";
+    let old_hash = "a".repeat(64);
+    let rebuilt_hash = "b".repeat(64);
+    let old_generation = refreshed_generation_key(revision, Some(old_hash));
+    let rebuilt_generation = refreshed_generation_key(revision, Some(rebuilt_hash));
+    assert_ne!(old_generation, rebuilt_generation);
+
+    let mut generations = crate::RollingGenerations::new(old_generation.clone(), "old-daemon");
+    generations.admit_job("active-job");
+    assert_eq!(
+        generations.begin(rebuilt_generation.clone(), "rebuilt-daemon"),
+        crate::RollingStart::Start
+    );
+    assert!(generations.activate(&rebuilt_generation));
+    assert_eq!(generations.admission_owner, rebuilt_generation);
+    assert_eq!(
+        generations.job_owner("active-job"),
+        Some(old_generation.as_str())
+    );
+}
+
+#[test]
+fn materialized_refresh_requires_an_immutable_binary_hash_and_path() {
+    let plan = ssh_bootstrap_plan();
+    let error = refreshed_binary_path(
+        &plan,
+        "HOMEBOY_REFRESH_SOURCE_SHA=abc123\n{\"data\":{\"git_commit\":\"abc123\"}}",
+    )
+    .expect_err("materialized refresh must bind the selected path to its bytes");
+    assert!(error.message.contains("immutable binary path"));
+}
+
+#[test]
 fn concurrent_runner_config_edit_survives_ssh_bootstrap_promotion() {
     test_support::with_isolated_home(|_| {
         crate::create(r#"{"id":"lab-local","kind":"local","homeboy_path":"/old","env":{"OLD":"1"},"resources":{"dev_sync":{"old":true}}}"#, false).expect("runner");


### PR DESCRIPTION
Closes #11673

## Summary
- publish refreshed binaries into immutable SHA-256-addressed sibling slots
- use atomic no-overwrite publication and validate concurrent publishers
- key daemon generations by selected binary bytes and verify candidate hash freshness before activation
- preserve active jobs on their original generation

## Verification
- `cargo test -p homeboy-lab-runner homeboy_refresh -- --nocapture` (80 passed)
- `cargo check -p homeboy-lab-runner`
- `cargo fmt`
- `git diff --check`

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: Root-cause analysis, immutable publication design, implementation, tests, and review with Chris Huber.