### PR TITLE
fix(runner): verify refresh admission readiness

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -101,6 +101,11 @@ pub struct HomeboyBinaryRefreshOutput {
     pub selected_binary_path: String,
     pub reconnect_required: bool,
     pub followup_commands: Vec<String>,
+    /// The observed admission postcondition after a reconnect. A rotated daemon
+    /// may be healthy while older generations still own work, so daemon startup
+    /// alone is not convergence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<HomeboyRefreshReadiness>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconnect_deferred: Option<HomeboyReconnectDeferred>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,6 +114,28 @@ pub struct HomeboyBinaryRefreshOutput {
     pub bootstrap_provenance: Option<HomeboyBootstrapProvenance>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rollback: Option<HomeboyBinaryRefreshRollback>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyRefreshReadinessState {
+    Ready,
+    Draining,
+    Blocked,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyRefreshReadiness {
+    pub state: HomeboyRefreshReadinessState,
+    pub accepting_jobs: bool,
+    pub daemon_fresh: bool,
+    /// Exact generation or lease owners that still fence convergence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owners: Vec<String>,
+    /// One command that resumes the blocked lifecycle from its current state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -379,6 +406,7 @@ pub fn refresh_homeboy_binary(
                 selected_binary_path: plan.binary_path.clone(),
                 reconnect_required: !plan.reconnect,
                 followup_commands: plan.followup_commands.clone(),
+                readiness: None,
                 reconnect_deferred: None,
                 failure: None,
                 bootstrap_provenance: None,
@@ -422,6 +450,7 @@ pub fn refresh_homeboy_binary(
                 selected_binary_path: plan.binary_path.clone(),
                 reconnect_required: !plan.reconnect,
                 followup_commands: plan.followup_commands.clone(),
+                readiness: Some(failed_refresh_readiness(&plan)),
                 reconnect_deferred: None,
                 failure: Some(refresh_failure(&plan, exec_output, exit_code)),
                 bootstrap_provenance: None,
@@ -461,6 +490,13 @@ pub fn refresh_homeboy_binary(
                 selected_binary_path: plan.binary_path.clone(),
                 reconnect_required: true,
                 followup_commands: followup_commands.clone(),
+                readiness: Some(HomeboyRefreshReadiness {
+                    state: HomeboyRefreshReadinessState::Draining,
+                    accepting_jobs: false,
+                    daemon_fresh: false,
+                    owners: active_job_ids.clone(),
+                    continuation: followup_commands.last().cloned(),
+                }),
                 reconnect_deferred: Some(HomeboyReconnectDeferred {
                     reason: "active_daemon_jobs",
                     active_job_ids,
@@ -623,6 +659,7 @@ pub fn refresh_homeboy_binary(
                     selected_binary_path: plan.binary_path.clone(),
                     reconnect_required: !plan.reconnect,
                     followup_commands: plan.followup_commands.clone(),
+                    readiness: Some(failed_refresh_readiness(&plan)),
                     reconnect_deferred: None,
                     failure: Some(failure),
                     bootstrap_provenance: None,
@@ -690,6 +727,14 @@ pub fn refresh_homeboy_binary(
                 return Err(refresh_error_with_phase_summary(error, &phases));
             }
             phase_summary.push(refresh_phase("generation_rotation", true, 0));
+            let readiness = refresh_readiness_postcondition(&plan.runner_id)?;
+            let converged = readiness.state == HomeboyRefreshReadinessState::Ready;
+            phase_summary.push(refresh_phase(
+                "admission_readiness",
+                true,
+                if converged { 0 } else { 1 },
+            ));
+            let followup_commands = readiness.continuation.clone().into_iter().collect();
             return Ok((
                 HomeboyBinaryRefreshOutput {
                     variant: "refresh_homeboy",
@@ -700,17 +745,21 @@ pub fn refresh_homeboy_binary(
                     identity: Some(identity.clone()),
                     updated_fields: updated_fields.clone(),
                     phase_summary,
+                    // Rotation completed even when older generations still
+                    // fence admission. `readiness` and the exit code report
+                    // convergence without rewriting this operation fact.
                     daemon_refreshed: true,
                     interrupted_job_ids: Vec::new(),
                     selected_binary_path: plan.binary_path.clone(),
-                    reconnect_required: false,
-                    followup_commands: Vec::new(),
+                    reconnect_required: reconnect_required_after_refresh(true),
+                    followup_commands,
+                    readiness: Some(readiness),
                     reconnect_deferred: None,
                     failure: None,
                     bootstrap_provenance: None,
                     rollback: rollback.clone(),
                 },
-                0,
+                if converged { 0 } else { 1 },
             ));
         }
         interrupted_job_ids = match protect_active_jobs_before_reconnect(
@@ -741,6 +790,13 @@ pub fn refresh_homeboy_binary(
                         selected_binary_path: plan.binary_path.clone(),
                         reconnect_required: true,
                         followup_commands: deferred.followup_commands.clone(),
+                        readiness: Some(HomeboyRefreshReadiness {
+                            state: HomeboyRefreshReadinessState::Draining,
+                            accepting_jobs: false,
+                            daemon_fresh: false,
+                            owners: deferred.active_job_ids.clone(),
+                            continuation: deferred.followup_commands.last().cloned(),
+                        }),
                         reconnect_deferred: Some(deferred),
                         failure: None,
                         bootstrap_provenance: None,
@@ -875,6 +931,7 @@ pub fn refresh_homeboy_binary(
                     selected_binary_path: plan.binary_path.clone(),
                     reconnect_required: true,
                     followup_commands: plan.followup_commands.clone(),
+                    readiness: Some(failed_refresh_readiness(&plan)),
                     reconnect_deferred: None,
                     failure: Some(refresh_reconnect_failure(
                         &plan,
@@ -934,6 +991,7 @@ pub fn refresh_homeboy_binary(
                         selected_binary_path: plan.binary_path.clone(),
                         reconnect_required: true,
                         followup_commands: plan.followup_commands.clone(),
+                        readiness: Some(failed_refresh_readiness(&plan)),
                         reconnect_deferred: None,
                         failure: Some(refresh_reconnect_failure(
                             &plan,
@@ -955,9 +1013,21 @@ pub fn refresh_homeboy_binary(
         interrupted_job_ids = Vec::new();
     }
 
+    let readiness = options
+        .reconnect
+        .then(|| refresh_readiness_postcondition(&plan.runner_id))
+        .transpose()?;
+    let converged = readiness
+        .as_ref()
+        .is_none_or(|readiness| readiness.state == HomeboyRefreshReadinessState::Ready);
     if daemon_refreshed {
         clear_refresh_partial_state(&plan.runner_id)?;
     }
+    let followup_commands = readiness
+        .as_ref()
+        .and_then(|readiness| readiness.continuation.clone())
+        .map(|continuation| vec![continuation])
+        .unwrap_or_else(|| plan.followup_commands.clone());
     Ok((
         HomeboyBinaryRefreshOutput {
             variant: "refresh_homeboy",
@@ -971,8 +1041,9 @@ pub fn refresh_homeboy_binary(
             daemon_refreshed,
             interrupted_job_ids,
             selected_binary_path: plan.binary_path.clone(),
-            reconnect_required: !daemon_refreshed,
-            followup_commands: plan.followup_commands,
+            reconnect_required: reconnect_required_after_refresh(daemon_refreshed),
+            followup_commands,
+            readiness,
             reconnect_deferred: None,
             failure: None,
             bootstrap_provenance: Some(HomeboyBootstrapProvenance {
@@ -996,7 +1067,7 @@ pub fn refresh_homeboy_binary(
             }),
             rollback,
         },
-        0,
+        if converged { 0 } else { 1 },
     ))
 }
 
@@ -1031,6 +1102,110 @@ fn should_rotate_daemon_generation(
     force: bool,
 ) -> bool {
     !force && (has_active_jobs || preserve_generations)
+}
+
+fn failed_refresh_readiness(plan: &HomeboyBinaryRefreshPlan) -> HomeboyRefreshReadiness {
+    HomeboyRefreshReadiness {
+        state: HomeboyRefreshReadinessState::Failed,
+        accepting_jobs: false,
+        daemon_fresh: false,
+        owners: Vec::new(),
+        continuation: Some(format!(
+            "homeboy runner refresh-homeboy {} --reconnect",
+            shell_arg(&plan.runner_id)
+        )),
+    }
+}
+
+/// `daemon_refreshed` records a completed daemon operation. A later readiness
+/// failure can require reconciliation without requiring another reconnect.
+fn reconnect_required_after_refresh(daemon_refreshed: bool) -> bool {
+    !daemon_refreshed
+}
+
+/// Evaluate refresh completion from the admission authority, not from daemon
+/// process startup. This is intentionally shared with `runner status`'s status
+/// and generation projections so refresh cannot certify a state status rejects.
+fn refresh_readiness_postcondition(runner_id: &str) -> Result<HomeboyRefreshReadiness> {
+    let report = super::status(runner_id)?;
+    let generations =
+        super::runner_generation_inventory_for_session(runner_id, report.session.as_ref())?;
+    Ok(refresh_readiness_from_status(
+        runner_id,
+        &report,
+        &generations,
+    ))
+}
+
+fn refresh_readiness_from_status(
+    runner_id: &str,
+    report: &super::RunnerStatusReport,
+    generations: &[super::RunnerDaemonGenerationStatus],
+) -> HomeboyRefreshReadiness {
+    let draining_count = generations
+        .iter()
+        .filter(|generation| !generation.admission_owner)
+        .count();
+    let summary = report.admission_summary_with_generations(generations, draining_count);
+    if summary.accepting_jobs {
+        return HomeboyRefreshReadiness {
+            state: HomeboyRefreshReadinessState::Ready,
+            accepting_jobs: true,
+            daemon_fresh: true,
+            owners: Vec::new(),
+            continuation: None,
+        };
+    }
+    let owners = generations
+        .iter()
+        .filter(|generation| !generation.admission_owner && generation.active_job_count > 0)
+        .map(|generation| {
+            generation
+                .remote_daemon_lease_id
+                .clone()
+                .unwrap_or_else(|| generation.generation.clone())
+        })
+        .collect::<Vec<_>>();
+    if !owners.is_empty() {
+        return HomeboyRefreshReadiness {
+            state: HomeboyRefreshReadinessState::Draining,
+            accepting_jobs: false,
+            daemon_fresh: summary.daemon_fresh,
+            owners,
+            continuation: Some(format!("homeboy runner reconcile {}", shell_arg(runner_id))),
+        };
+    }
+    HomeboyRefreshReadiness {
+        state: HomeboyRefreshReadinessState::Blocked,
+        accepting_jobs: false,
+        daemon_fresh: summary.daemon_fresh,
+        owners: generations
+            .iter()
+            .filter(|generation| generation.admission_owner)
+            .map(|generation| {
+                generation
+                    .remote_daemon_lease_id
+                    .clone()
+                    .unwrap_or_else(|| generation.generation.clone())
+            })
+            .chain(
+                generations
+                    .is_empty()
+                    .then(|| {
+                        report
+                            .daemon_freshness
+                            .as_ref()
+                            .and_then(|freshness| freshness.lease_id.clone())
+                    })
+                    .flatten(),
+            )
+            .collect(),
+        continuation: Some(
+            summary.next_action.unwrap_or_else(|| {
+                format!("homeboy runner status {} --full", shell_arg(runner_id))
+            }),
+        ),
+    }
 }
 
 fn refresh_owned_lease(session: super::RunnerSession) -> Option<String> {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
@@ -4,7 +4,162 @@ use std::cell::RefCell;
 use std::time::{Duration, Instant};
 
 use super::*;
+use crate::{
+    RollingDrainState, RunnerActiveJobState, RunnerDaemonGenerationStatus, RunnerSessionState,
+    RunnerStatusReport,
+};
+use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
 use homeboy_core::error::Error;
+
+fn readiness_report(freshness: DaemonFreshnessReport) -> RunnerStatusReport {
+    RunnerStatusReport {
+        runner_id: "homeboy-lab".to_string(),
+        connected: true,
+        state: RunnerSessionState::Connected,
+        session: None,
+        stale_daemon: None,
+        daemon_freshness: Some(freshness),
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        stale_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: None,
+        active_job_error: None,
+        active_job_recovery_evidence: None,
+        session_path: "test".to_string(),
+    }
+}
+
+fn freshness(
+    fresh: bool,
+    stale_reason_code: Option<DaemonStaleReasonCode>,
+) -> DaemonFreshnessReport {
+    DaemonFreshnessReport {
+        fresh,
+        stale_reason_code,
+        restartable: true,
+        lease_id: Some("lease-new".to_string()),
+        pid: Some(1234),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: None,
+        daemon_build_identity: None,
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    }
+}
+
+fn generation(
+    name: &str,
+    admission_owner: bool,
+    active_job_count: usize,
+) -> RunnerDaemonGenerationStatus {
+    RunnerDaemonGenerationStatus {
+        generation: name.to_string(),
+        admission_owner,
+        drain_state: if admission_owner {
+            RollingDrainState::Admitting
+        } else {
+            RollingDrainState::Draining
+        },
+        active_job_count,
+        observed_active_job_count: Some(active_job_count),
+        active_job_count_authoritative: true,
+        job_owner_count: active_job_count,
+        run_owner_count: 0,
+        artifact_owner_count: 0,
+        homeboy_build_identity: None,
+        remote_daemon_lease_id: Some(name.to_string()),
+        remote_daemon_address: None,
+        local_url: None,
+    }
+}
+
+#[test]
+fn refresh_readiness_reports_active_draining_generation_with_its_exact_owner() {
+    let mut report = readiness_report(freshness(true, None));
+    report.active_job_count = 1;
+    let readiness = refresh_readiness_from_status(
+        "homeboy-lab",
+        &report,
+        &[
+            generation("lease-old", false, 1),
+            generation("lease-new", true, 0),
+        ],
+    );
+
+    assert_eq!(readiness.state, HomeboyRefreshReadinessState::Draining);
+    assert_eq!(readiness.owners, ["lease-old"]);
+    assert_eq!(
+        readiness.continuation.as_deref(),
+        Some("homeboy runner reconcile homeboy-lab")
+    );
+}
+
+#[test]
+fn refresh_readiness_blocks_a_post_refresh_binary_hash_mismatch() {
+    let readiness = refresh_readiness_from_status(
+        "homeboy-lab",
+        &readiness_report(freshness(
+            false,
+            Some(DaemonStaleReasonCode::BinaryHashMismatch),
+        )),
+        &[generation("lease-new", true, 0)],
+    );
+
+    assert_eq!(readiness.state, HomeboyRefreshReadinessState::Blocked);
+    assert!(!readiness.daemon_fresh);
+    assert!(!readiness.accepting_jobs);
+    assert_eq!(readiness.owners, ["lease-new"]);
+    assert_eq!(
+        readiness.continuation.as_deref(),
+        Some("homeboy runner doctor homeboy-lab --scope lab-offload")
+    );
+}
+
+#[test]
+fn refresh_readiness_certifies_immediate_admission_only_when_ready() {
+    let readiness = refresh_readiness_from_status(
+        "homeboy-lab",
+        &readiness_report(freshness(true, None)),
+        &[generation("lease-new", true, 0)],
+    );
+
+    assert_eq!(readiness.state, HomeboyRefreshReadinessState::Ready);
+    assert!(readiness.daemon_fresh);
+    assert!(readiness.accepting_jobs);
+    assert!(readiness.continuation.is_none());
+}
+
+#[test]
+fn incomplete_readiness_does_not_rewrite_daemon_refresh_compatibility_facts() {
+    let mut report = readiness_report(freshness(true, None));
+    report.active_job_count = 1;
+    let readiness = refresh_readiness_from_status(
+        "homeboy-lab",
+        &report,
+        &[
+            generation("lease-old", false, 1),
+            generation("lease-new", true, 0),
+        ],
+    );
+
+    assert_eq!(readiness.state, HomeboyRefreshReadinessState::Draining);
+    // A completed rotation remains a completed daemon operation. The non-ready
+    // readiness state and nonzero refresh result express incomplete convergence.
+    assert!(!reconnect_required_after_refresh(true));
+    assert!(reconnect_required_after_refresh(false));
+    assert_eq!(
+        readiness.continuation.as_deref(),
+        Some("homeboy runner reconcile homeboy-lab")
+    );
+}
 
 fn not_fresh_error() -> Error {
     // Shape mirrors `reserve_daemon_admission` when the daemon refuses the


### PR DESCRIPTION
Closes #11676

## Summary
- add backward-compatible refresh readiness states: ready, draining, blocked, failed
- verify aggregate admission postconditions after daemon rotation/reconnect
- return nonzero with exact owners and one continuation when convergence is incomplete
- preserve factual daemon refresh and reconnect semantics independently from runner readiness

## Verification
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests --lib` (82 passed)
- `cargo fmt`
- `git diff --check`

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: Postcondition design, implementation, compatibility review, tests, and verification with Chris Huber.