### PR TITLE
refactor(observation): route runs findings/hotspots through the runs_service facade

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/findings.rs
+++ b/crates/homeboy-cli/src/commands/runs/findings.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::core::observation::{FindingListFilter, ObservationStore, RecordedHomeboyFinding};
+use homeboy::core::observation::{
+    runs_service, FindingListFilter, ObservationStore, RecordedHomeboyFinding,
+};
 use homeboy::core::Error;
 
 use crate::commands::{
@@ -80,7 +82,12 @@ pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
         .run_id
         .ok_or_else(|| Error::validation_missing_argument(vec!["run_id".to_string()]))?;
     let store = ObservationStore::open_initialized()?;
-    require_run(&store, &run_id)?;
+    // Route run lookup through the observation facade so `runs findings` shares
+    // the one activity-aware surface: durable label aliases, Lab mirror
+    // resolution, and the stable missing-run error with runner guidance (#6768).
+    // Filter on the resolved record id — the facade accepts labels, which are
+    // not themselves finding `run_id` values.
+    let run_id = runs_service::require_run(&store, &run_id)?.id;
     let findings = store
         .list_findings(FindingListFilter {
             run_id: Some(run_id.clone()),
@@ -160,14 +167,139 @@ pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<()> {
-    if store.get_run(run_id)?.is_some() {
-        return Ok(());
+#[cfg(test)]
+mod tests {
+    use homeboy::core::observation::{NewFindingRecord, NewRunRecord, ObservationStore};
+    use homeboy::test_support::with_isolated_home;
+    use serde_json::json;
+
+    use super::*;
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
     }
-    Err(Error::validation_invalid_argument(
-        "run_id",
-        format!("run record not found: {run_id}"),
-        Some(run_id.to_string()),
-        None,
-    ))
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    fn labeled_run(store: &ObservationStore, label: &str) -> String {
+        store
+            .start_run(
+                NewRunRecord::builder("bench")
+                    .component_id("homeboy")
+                    .command(format!("homeboy bench homeboy --run-id {label}"))
+                    .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+                    .homeboy_version("test-version")
+                    .rig_id("studio")
+                    .metadata(json!({ "requested_run_id": label }))
+                    .build(),
+            )
+            .expect("run")
+            .id
+    }
+
+    fn record_finding(store: &ObservationStore, run_id: &str) {
+        store
+            .record_finding(&NewFindingRecord {
+                run_id: run_id.to_string(),
+                tool: "lint".to_string(),
+                rule: Some("style".to_string()),
+                file: Some("src/lib.rs".to_string()),
+                line: Some(7),
+                severity: Some("error".to_string()),
+                fingerprint: Some("lint::style".to_string()),
+                message: "style violation".to_string(),
+                fixable: None,
+                metadata_json: json!({}),
+            })
+            .expect("finding");
+    }
+
+    #[test]
+    fn findings_resolve_a_durable_run_label_and_report_the_record_id() {
+        // #6768: this command used to carry a private `require_run` that only
+        // matched record ids, and then filtered findings on the *caller's*
+        // string. Routing through `runs_service::require_run` resolves the
+        // alias, and filtering on the resolved id is what makes the lookup
+        // return the run's findings instead of an empty list.
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run_id = labeled_run(&store, "findings-label");
+            record_finding(&store, &run_id);
+
+            let (output, exit) = findings(RunsFindingsArgs {
+                run_id: Some("findings-label".to_string()),
+                limit: 100,
+                ..Default::default()
+            })
+            .expect("durable run label resolves through runs_service::require_run");
+
+            assert_eq!(exit, 0);
+            let RunsOutput::Findings(output) = output else {
+                panic!("expected findings output");
+            };
+            assert_eq!(output.run_id, run_id);
+            assert_eq!(output.findings.len(), 1);
+        });
+    }
+
+    #[test]
+    fn findings_still_resolve_an_exact_record_id() {
+        // Behavior preservation: the facade tries the exact record id first, so
+        // the pre-existing contract is unchanged.
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run_id = labeled_run(&store, "findings-exact");
+            record_finding(&store, &run_id);
+
+            let (output, _) = findings(RunsFindingsArgs {
+                run_id: Some(run_id.clone()),
+                limit: 100,
+                ..Default::default()
+            })
+            .expect("record id resolves");
+
+            let RunsOutput::Findings(output) = output else {
+                panic!("expected findings output");
+            };
+            assert_eq!(output.run_id, run_id);
+            assert_eq!(output.findings.len(), 1);
+        });
+    }
+
+    #[test]
+    fn findings_report_the_facade_missing_run_error() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let _store = ObservationStore::open_initialized().expect("store");
+            // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
+            let error = match findings(RunsFindingsArgs {
+                run_id: Some("definitely-missing-run".to_string()),
+                limit: 100,
+                ..Default::default()
+            }) {
+                Ok(_) => panic!("expected a missing-run error"),
+                Err(error) => error,
+            };
+            assert!(
+                error.message.contains("run record not found"),
+                "unexpected message: {}",
+                error.message
+            );
+        });
+    }
 }

--- a/crates/homeboy-cli/src/commands/runs/hotspots.rs
+++ b/crates/homeboy-cli/src/commands/runs/hotspots.rs
@@ -260,11 +260,17 @@ fn load_fuzz_artifacts_for_runs(
     store: &ObservationStore,
     run_ids: &[String],
 ) -> homeboy::core::Result<LoadedFuzzArtifacts> {
+    // Route run lookup through the observation facade so `runs hotspots` shares
+    // the one activity-aware surface: durable label aliases, Lab mirror
+    // resolution, and the stable missing-run error with runner guidance (#6768).
     let runs = run_ids
         .iter()
-        .map(|run_id| require_run(store, run_id))
+        .map(|run_id| runs_service::require_run(store, run_id))
         .collect::<homeboy::core::Result<Vec<_>>>()?;
-    let mut artifacts_by_run = store.list_artifacts_for_runs(run_ids)?;
+    // The facade accepts labels as well as record ids, so the batched artifact
+    // read must key on the resolved record ids, not the caller-supplied strings.
+    let resolved_run_ids = runs.iter().map(|run| run.id.clone()).collect::<Vec<_>>();
+    let mut artifacts_by_run = store.list_artifacts_for_runs(&resolved_run_ids)?;
     let mut artifacts = Vec::new();
     let mut skipped = Vec::new();
     let mut inspected_artifact_count = 0;
@@ -295,17 +301,6 @@ fn load_fuzz_artifacts_for_runs(
         artifacts,
         skipped,
         inspected_artifact_count,
-    })
-}
-
-fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<RunRecord> {
-    store.get_run(run_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            format!("run record not found: {run_id}"),
-            Some(run_id.to_string()),
-            None,
-        )
     })
 }
 
@@ -887,6 +882,83 @@ mod tests {
             assert!(output.skipped_artifacts[0]
                 .reason
                 .contains("homeboy runs artifact get"));
+        });
+    }
+
+    #[test]
+    fn hotspot_run_lookup_resolves_a_durable_run_label_through_the_facade() {
+        // #6768: this command used to carry a private `require_run` that only
+        // matched record ids, so a durable run label errored out. Routing
+        // through `runs_service::require_run` resolves the alias, and the
+        // batched artifact read must key on the resolved record id — keying on
+        // the caller-supplied label would silently yield zero artifacts.
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("bench")
+                        .component_id("homeboy")
+                        .command("homeboy bench homeboy --run-id hotspot-label")
+                        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+                        .homeboy_version("test-version")
+                        .git_sha(Some("abc123".to_string()))
+                        .rig_id("studio")
+                        .metadata(json!({ "requested_run_id": "hotspot-label" }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish run");
+            let directory = home.path().join("fuzz-artifacts");
+            std::fs::create_dir_all(&directory).expect("directory");
+            std::fs::write(directory.join("result.json"), b"{}").expect("file");
+            store
+                .record_directory_artifact(&run.id, "fuzz_artifacts", &directory)
+                .expect("directory artifact");
+
+            let (output, _) = runs_hotspots(RunsHotspotsArgs {
+                run_ids: vec!["hotspot-label".to_string()],
+                baseline_runs: Vec::new(),
+                candidate_runs: Vec::new(),
+                limit: 20,
+            })
+            .expect("durable run label resolves through runs_service::require_run");
+
+            let RunsOutput::Hotspots(output) = output else {
+                panic!("expected hotspots output");
+            };
+            // A non-zero skipped count proves the artifact read was keyed on
+            // the resolved record id rather than the label.
+            assert_eq!(output.skipped_artifact_count, 1);
+            assert!(output.skipped_artifacts[0]
+                .reason
+                .contains(&format!("homeboy runs artifacts {} --pull", run.id)));
+        });
+    }
+
+    #[test]
+    fn hotspot_run_lookup_reports_the_facade_missing_run_error() {
+        // The facade's missing-run error carries runner guidance the private
+        // helper never produced. Preserve the stable argument/message contract.
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
+            let error = match runs_hotspots(RunsHotspotsArgs {
+                run_ids: vec!["definitely-missing-run".to_string()],
+                baseline_runs: Vec::new(),
+                candidate_runs: Vec::new(),
+                limit: 20,
+            }) {
+                Ok(_) => panic!("expected a missing-run error"),
+                Err(error) => error,
+            };
+            assert!(
+                error.message.contains("run record not found"),
+                "unexpected message: {}",
+                error.message
+            );
         });
     }
 

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -767,6 +767,15 @@ fn api_reconcile_metadata(run: &RunRecord, reason: &str) -> Value {
     })
 }
 
+/// Exact-id run lookup for HTTP handlers.
+///
+/// Intentionally **not** routed through
+/// [`crate::observation::runs_service::require_run`] (#6768). The facade adds
+/// durable label aliasing plus a connected-runner probe that mirrors remote run
+/// records into the local store — a network round trip and a write. This module
+/// is a read-only, transport-free contract whose handlers must stay latency
+/// bounded, so it resolves record ids only. Every other run read path (CLI
+/// `runs`, `fuzz`, dossier, evidence) uses the facade.
 fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
     store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(


### PR DESCRIPTION
Closes part of #6768 (dependency of epic #8282).

## Measured state first

#6768 was filed 2026-06-27. Re-measuring against `origin/main` @ `3cd143b24`, **facade adoption is already largely done** — the issue's list of "remaining" sites has mostly been absorbed by drift. Counts for run-lookup call sites (excluding facade-internal and test code):

| | before | after |
|---|---|---|
| consumer `require_run` call sites | 28 | 28 |
| → routed through `runs_service::require_run` | **22 (79%)** | **24 (86%)** |
| → bypassing on a private duplicate | 6 | 4 |
| → **undocumented** bypasses | **6** | **0** |
| private duplicate `require_run` impls outside the facade | 3 | **1** (documented) |

Across all facade surfaces there are now **68 `runs_service::*` call sites** in consumers (`require_run` 21, `list_artifacts_for_run` 9, `download_remote_artifact` 5, `resolve_artifact_for_run` 4, …).

## What I migrated

**`commands/runs/findings.rs`** and **`commands/runs/hotspots.rs`** each carried a private `require_run` that re-implemented the facade's missing-run error while resolving record ids only — no durable label alias, no Lab mirror fallback, no runner guidance in the error. Both now call `runs_service::require_run`.

Two latent bugs fell out of that, both fixed here:

- `hotspots` keyed its batched `store.list_artifacts_for_runs(run_ids)` on the **caller-supplied** strings. The facade accepts labels, so that read now keys on the **resolved** record ids — otherwise a label lookup would succeed and then silently yield zero artifacts.
- `findings` filtered `FindingListFilter { run_id }` on the caller's string for the same reason; it now filters on the resolved id.

## What I deliberately did NOT migrate

**`homeboy-core/src/http_api.rs`** keeps its exact-id `require_run` (4 call sites). This is now a documented decision rather than an accidental duplicate. `runs_service::require_run` falls through to `mirror_connected_runner_run`, which opens the store, polls connected runners over the network, and **writes** mirror records. `http_api` is documented as a *"read-only local HTTP API contract"* whose handlers must stay latency bounded. Routing it through the facade would be a real behavior change, not an interface consolidation.

## Remaining, with counts (audited, not migrated)

Per the issue's bullet 2, decided per-site:

- `runs refs` (1 raw `list_artifacts`) — emits **un-enriched** artifact refs by design. Stays.
- `runs latest` (1) — filter-based `latest_run`, no run id to resolve. Stays.
- `runs compare` (1), `runs reconcile` (3) — `list_artifacts(...).len()` counts only; link enrichment is irrelevant. Stay.
- `runs resources` (3 `get_run`), `utils/response.rs` (1) — status/classification enrichment on a best-effort path, no error contract. Stay.
- `review::attach_to_persisted_review` (1) — has its own distinct `run-id` error message and guidance. Migrating would change the error. Stays.
- `daemon/artifact_download.rs` (3) — daemon-internal existence pre-checks, not user read paths. Stay.
- ~60 `get_run` sites in `lab-runner/recovery`, `agents/lifecycle_store`, `agents/runner_exec`, `deploy` — **write-path** lookups that must be exact-id by construction. Correctly store-level; `require_run`'s label resolution and runner probe would be wrong there.

Issue bullet 1 (`build_run_evidence_report`) **is already landed** and consumed by `commands/runs/evidence.rs`.

Issue bullet 3 (shared `load_run_with_artifacts` for `dossier` + `evidence`) is **obsolete**: `dossier` now opens the store `open_readonly()` and deliberately avoids `list_artifacts_for_run` because that helper refreshes and indexes remote evidence — both writes. The two paths intentionally differ; a shared helper would have to re-introduce the divergence as a flag. Not worth it, and it would be exactly the single-call wrapper this refactor is trying to avoid.

## Behavior

No regression. `runs_service::require_run` tries `store.get_run(run_id)` **first** and returns immediately on hit, so every input that resolved before resolves identically. Only previously-*erroring* inputs gain resolution (durable label → record) and richer error guidance.

## Tests

Added 5, deleted/ignored none:

- `hotspots::hotspot_run_lookup_resolves_a_durable_run_label_through_the_facade` — pins both the label resolution *and* the resolved-id artifact keying (a non-zero skipped count is only reachable if the artifact read used the resolved id).
- `hotspots::hotspot_run_lookup_reports_the_facade_missing_run_error`
- `findings::findings_resolve_a_durable_run_label_and_report_the_record_id`
- `findings::findings_still_resolve_an_exact_record_id` — behavior preservation.
- `findings::findings_report_the_facade_missing_run_error`

`findings.rs` had no test module before; it has one now.

## Compile status

**I could not compile this.** The VPS runs four agents in parallel and a `cargo test` build consumes 28G of disk, so builds are serialized outside the agent. Only `cargo fmt` was run (clean).

Reviewed by hand for the usual traps:
- `RunsOutput` derives only `Serialize`, **not `Debug`** — both negative tests use `match { Ok(_) => panic!, Err(e) => e }` rather than `expect_err`, which would not compile.
- Removed-import sweep: `Error` still used in both files (3 and 2 sites), `RunRecord`/`ObservationStore` still used in `hotspots.rs`, so no unused-import warnings.
- Both removed `require_run` fns were private and file-local — no external call sites, confirmed by grep across `crates/` and root `tests/`.
- No `#[cfg(unix)]`, no `ValueEnum`, no signature/field/variant changes to shared types.
- Test fixtures copied verbatim from the proven `hotspots.rs` / `runs_service/tests.rs` patterns (`with_isolated_home` + `XdgGuard::unset()`); `with_isolated_home` resets the runner-evidence provider to the no-op, so the missing-run tests make no network calls.
- No assertions about `std::env::temp_dir()` path relationships.

Refs #6768