### PR TITLE
feat(lab): type the agent-task dispatch-handoff seam over Lab offload

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/workload.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/workload.rs
@@ -50,6 +50,34 @@ pub struct LabRunnerWorkloadAgentTask {
     pub resolved_provider_policy: Option<crate::agent_task_config::ResolvedAgentTaskProviderPolicy>,
     pub dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind,
     pub lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy,
+    /// How the controller should recover a cook/dispatch handoff document.
+    ///
+    /// `lifecycle_mirror_policy` only covers the `run-plan` aggregate replay.
+    /// The cook/dispatch handoff took a different route entirely: the
+    /// controller scraped stdout and stderr for a
+    /// `homeboy/agent-task-lab-handoff/v1` (or legacy
+    /// `homeboy/agent-task-dispatch/v1`) document, so any change to what the
+    /// remote command printed silently broke failure-evidence mirroring even
+    /// though the workload itself carried the run identity all along.
+    ///
+    /// This is `Option` rather than a new `lifecycle_mirror_policy` variant on
+    /// purpose. `lifecycle_mirror_policy` is a required field, so a peer that
+    /// predates a new variant would fail to deserialize the *entire* workload.
+    /// A new optional field is ignored by such a peer instead, and `None` here
+    /// unambiguously means "the emitting side predates the typed handoff
+    /// event", which is exactly when the stdout fallback must still run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_mirror_policy: Option<LabRunnerWorkloadAgentTaskHandoffMirrorPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LabRunnerWorkloadAgentTaskHandoffMirrorPolicy {
+    /// This workload has no dispatch handoff to mirror (`run-plan`).
+    None,
+    /// The runner emits a typed dispatch-handoff event keyed by
+    /// [`LabRunnerWorkloadAgentTask::run_id`]; the controller mirrors from it.
+    DispatchHandoff,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -260,5 +288,156 @@ mod tests {
         let round_tripped: JobArtifactMetadata =
             serde_json::from_value(value).expect("artifact deserializes");
         assert_eq!(round_tripped, artifact);
+    }
+
+    fn workload_payload(agent_task: Option<serde_json::Value>) -> serde_json::Value {
+        let mut payload = json!({
+            "schema": LAB_RUNNER_WORKLOAD_SCHEMA,
+            "workload_id": "lab-workload",
+            "kind": { "command_label": "agent-task cook", "command_family": "agent_task" },
+            "workspace_mappings": {
+                "source_path_mode": "snapshot",
+                "workspace_mode_policy": "snapshot",
+                "mapping_ref": null
+            },
+            "required_capabilities": [],
+            "required_secrets": { "categories": [] },
+            "required_extensions": [],
+            "mutation_policy": {
+                "capture_patch": true,
+                "mutation_flag": null,
+                "allow_dirty_lab_workspace": false
+            },
+            "assignment": { "runner_id": "homeboy-lab", "runner_mode": null, "source": null },
+            "state": { "status": "submitted", "remote_workspace": null, "fallback_reason": null },
+            "result_refs": { "plan_id": "lab-workload", "proof_id": null, "workspace_mapping_ref": null }
+        });
+        if let Some(agent_task) = agent_task {
+            payload["agent_task"] = agent_task;
+        }
+        payload
+    }
+
+    /// `agent_task` is an optional section. A workload written by a peer that
+    /// never populates it (any non-agent-task command, and every binary that
+    /// predates the section) must still deserialize.
+    #[test]
+    fn workload_without_an_agent_task_section_still_parses() {
+        let workload: LabRunnerWorkload =
+            serde_json::from_value(workload_payload(None)).expect("workload without agent_task");
+
+        assert!(workload.agent_task.is_none());
+
+        // ... and the absent section stays absent on the wire.
+        let reserialized = serde_json::to_value(&workload).expect("workload serializes");
+        assert!(reserialized.get("agent_task").is_none());
+    }
+
+    /// `handoff_mirror_policy` was added after `agent_task` shipped. A workload
+    /// emitted by a peer that predates the field must deserialize with the
+    /// field absent — and re-serialize byte-identically, so a controller that
+    /// merely relays a workload does not fabricate a policy the emitter never
+    /// declared. `None` is what selects the retained stdout fallback.
+    #[test]
+    fn agent_task_section_without_a_handoff_mirror_policy_round_trips_unchanged() {
+        let agent_task = json!({
+            "run_id": "cook-7530",
+            "dispatch_kind": "cook",
+            "lifecycle_mirror_policy": "none"
+        });
+        let workload: LabRunnerWorkload =
+            serde_json::from_value(workload_payload(Some(agent_task.clone())))
+                .expect("workload with a pre-typed agent_task section");
+
+        let parsed = workload.agent_task.as_ref().expect("agent_task section");
+        assert_eq!(parsed.run_id, "cook-7530");
+        assert_eq!(parsed.plan_ref, None);
+        assert_eq!(
+            parsed.dispatch_kind,
+            LabRunnerWorkloadAgentTaskDispatchKind::Cook
+        );
+        assert_eq!(
+            parsed.lifecycle_mirror_policy,
+            LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None
+        );
+        assert_eq!(parsed.handoff_mirror_policy, None);
+
+        let reserialized = serde_json::to_value(parsed).expect("agent_task serializes");
+        assert_eq!(reserialized, agent_task);
+    }
+
+    /// The added field is additive: populated, it serializes alongside the
+    /// original four, and a consumer that ignores it still sees the pre-typed
+    /// shape.
+    #[test]
+    fn handoff_mirror_policy_is_additive_and_snake_case() {
+        let agent_task = LabRunnerWorkloadAgentTask {
+            run_id: "cook-7530".to_string(),
+            plan_ref: None,
+            resolved_provider_policy: None,
+            dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::Dispatch,
+            lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+            handoff_mirror_policy: Some(
+                LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff,
+            ),
+        };
+
+        let value = serde_json::to_value(&agent_task).expect("agent_task serializes");
+        assert_eq!(
+            value,
+            json!({
+                "run_id": "cook-7530",
+                "dispatch_kind": "dispatch",
+                "lifecycle_mirror_policy": "none",
+                "handoff_mirror_policy": "dispatch_handoff"
+            })
+        );
+
+        let round_tripped: LabRunnerWorkloadAgentTask =
+            serde_json::from_value(value).expect("agent_task deserializes");
+        assert_eq!(round_tripped, agent_task);
+
+        let run_plan = json!({
+            "run_id": "run-plan-7530",
+            "plan_ref": "@plan.json",
+            "dispatch_kind": "run_plan",
+            "lifecycle_mirror_policy": "run_plan_aggregate",
+            "handoff_mirror_policy": "none"
+        });
+        let parsed: LabRunnerWorkloadAgentTask =
+            serde_json::from_value(run_plan).expect("run-plan agent_task deserializes");
+        assert_eq!(
+            parsed.handoff_mirror_policy,
+            Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None)
+        );
+    }
+
+    /// Adding a *spelling* to `handoff_mirror_policy` is not free the way
+    /// adding the field was. An old peer rejects the unknown spelling, and
+    /// because `agent_task` is deserialized as a whole that rejection fails the
+    /// entire workload parse — not just the section.
+    ///
+    /// This test pins that so the blast radius is visible at review time: a new
+    /// policy spelling is a breaking change for old peers and must be rolled
+    /// out behind another new optional field instead, exactly as this field was
+    /// rolled out rather than as a `lifecycle_mirror_policy` variant.
+    #[test]
+    fn an_unknown_handoff_policy_spelling_is_a_breaking_change_for_old_peers() {
+        let payload = workload_payload(Some(json!({
+            "run_id": "cook-7530",
+            "dispatch_kind": "cook",
+            "lifecycle_mirror_policy": "none",
+            "handoff_mirror_policy": "a_policy_from_the_future"
+        })));
+
+        let section: std::result::Result<LabRunnerWorkloadAgentTask, _> =
+            serde_json::from_value(payload["agent_task"].clone());
+        assert!(section.is_err(), "unknown spelling is rejected");
+
+        let workload: std::result::Result<LabRunnerWorkload, _> = serde_json::from_value(payload);
+        assert!(
+            workload.is_err(),
+            "and that rejection propagates to the whole workload"
+        );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_handoff_event.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_handoff_event.rs
@@ -1,0 +1,473 @@
+//! Typed dispatch-handoff event for agent-task cook/dispatch over Lab offload.
+//!
+//! Background (#7530). The run-plan half of the agent-task offload lifecycle is
+//! already typed: the daemon emits a
+//! `homeboy/agent-task-run-plan-lifecycle-event/v1` job event keyed by the
+//! workload's `agent_task` section, and the controller mirrors the aggregate
+//! from it (see [`super::agent_task_lifecycle_event`]).
+//!
+//! The cook/dispatch half was not. The controller recovered the handoff by
+//! scanning the offloaded command's stdout, then its stderr, for any JSON
+//! object that happened to carry a `homeboy/agent-task-lab-handoff/v1` or
+//! `homeboy/agent-task-dispatch/v1` schema. That made failure-evidence
+//! mirroring a function of what the remote command printed rather than of the
+//! contract both sides already agreed on — a formatting change on the runner
+//! silently degraded `agent-task status`/`logs` on the controller even though
+//! the remote job itself had succeeded or failed cleanly.
+//!
+//! This module gives that half the same shape as the run-plan half:
+//!
+//! - The **runner/daemon** side extracts the handoff document once, on the side
+//!   that owns the output, and only when
+//!   [`LabRunnerWorkloadAgentTask::handoff_mirror_policy`] says this workload
+//!   has one. It then republishes it as a schema-tagged job event carrying the
+//!   run identity taken from the workload, not from the text.
+//! - The **controller** side reads that typed event and never has to know the
+//!   output format.
+//!
+//! The extraction itself is still a text scan today, because the current
+//! `agent-task cook` binary prints its handoff to stdout. The win is that the
+//! scan happens once, on the side that knows what it dispatched, gated by the
+//! contract — and that a future runner can emit
+//! [`AgentTaskDispatchHandoffEvent`] directly with no stdout involved and no
+//! controller change. Until every runner does, the controller keeps its stdout
+//! fallback; see `agent_task_bridge::resolve_offloaded_agent_task_handoff`.
+
+use homeboy_core::api_jobs::{JobEvent, JobEventKind};
+use homeboy_core::lab_contract::{
+    AgentTaskDispatchIdentity, LabRunnerWorkload, LabRunnerWorkloadAgentTask,
+    LabRunnerWorkloadAgentTaskHandoffMirrorPolicy,
+};
+use serde_json::Value;
+
+/// Schema of the typed handoff document an agent-task cook/dispatch produces.
+pub const AGENT_TASK_LAB_HANDOFF_SCHEMA: &str = "homeboy/agent-task-lab-handoff/v1";
+
+/// Schema of the older dispatch envelope, still emitted by pre-typed binaries.
+pub const AGENT_TASK_DISPATCH_ENVELOPE_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
+
+/// Schema of [`AgentTaskDispatchHandoffEvent`] itself.
+pub const AGENT_TASK_DISPATCH_HANDOFF_EVENT_SCHEMA: &str =
+    "homeboy/agent-task-dispatch-handoff-event/v1";
+
+/// Schema of the job-event wrapper the daemon appends. Mirrors the naming of
+/// the run-plan wrapper (`homeboy/runner-workload-agent-task-lifecycle-event/v1`).
+pub const AGENT_TASK_DISPATCH_HANDOFF_WORKLOAD_EVENT_SCHEMA: &str =
+    "homeboy/runner-workload-agent-task-handoff-event/v1";
+
+/// Key under which the typed event is attached to a job event / result payload.
+pub const AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY: &str = "agent_task_dispatch_handoff_event";
+
+/// A cook/dispatch handoff, bound to the run identity the workload declared.
+///
+/// `handoff` is deliberately kept as an opaque [`Value`]: the concrete handoff
+/// struct lives in the runner crate, and this crate must not depend on it. What
+/// this type adds over the raw document is the binding to `run_id`, which the
+/// controller can check without trusting the document's own contents.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AgentTaskDispatchHandoffEvent {
+    #[serde(default = "agent_task_dispatch_handoff_event_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub identity: AgentTaskDispatchIdentity,
+    /// The controller-owned agent-task run id, taken from the workload's
+    /// `agent_task` section rather than parsed out of the handoff document.
+    pub run_id: String,
+    /// The handoff document, verbatim.
+    pub handoff: Value,
+}
+
+fn agent_task_dispatch_handoff_event_schema() -> String {
+    AGENT_TASK_DISPATCH_HANDOFF_EVENT_SCHEMA.to_string()
+}
+
+/// True when this workload declared that it produces a dispatch handoff.
+///
+/// A `None` policy means the emitting peer predates the field, which is exactly
+/// the case where the consumer must fall back to output scraping.
+pub fn agent_task_mirrors_dispatch_handoff(agent_task: &LabRunnerWorkloadAgentTask) -> bool {
+    agent_task.handoff_mirror_policy
+        == Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff)
+}
+
+/// Return `value` (or its `data` child) when it is a handoff document.
+pub fn agent_task_handoff_document(value: &Value) -> Option<&Value> {
+    fn is_handoff(value: &Value) -> bool {
+        value
+            .get("schema")
+            .and_then(Value::as_str)
+            .is_some_and(|schema| {
+                schema == AGENT_TASK_LAB_HANDOFF_SCHEMA
+                    || schema == AGENT_TASK_DISPATCH_ENVELOPE_SCHEMA
+            })
+    }
+
+    if is_handoff(value) {
+        return Some(value);
+    }
+    value.get("data").filter(|data| is_handoff(data))
+}
+
+/// Scan one output stream for a handoff document.
+///
+/// Mirrors the controller-side scanner's tolerance: the stream may be a single
+/// JSON document, or arbitrary log lines with a JSON document embedded.
+pub fn agent_task_handoff_document_from_output(output: &str) -> Option<Value> {
+    if let Ok(value) = serde_json::from_str::<Value>(output) {
+        if let Some(document) = agent_task_handoff_document(&value) {
+            return Some(document.clone());
+        }
+    }
+
+    for (index, _) in output.match_indices('{') {
+        let mut stream = serde_json::Deserializer::from_str(&output[index..]).into_iter();
+        if let Some(Ok(value)) = stream.next() {
+            if let Some(document) = agent_task_handoff_document(&value) {
+                return Some(document.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Scan a terminal result payload for a handoff document: first the structured
+/// result body, then its captured streams.
+pub fn agent_task_handoff_document_from_result(result: &Value) -> Option<Value> {
+    if let Some(document) = agent_task_handoff_document(result) {
+        return Some(document.clone());
+    }
+    if let Some(data) = result.get("data") {
+        if let Some(document) = agent_task_handoff_document(data) {
+            return Some(document.clone());
+        }
+    }
+    ["stdout", "stderr"]
+        .into_iter()
+        .filter_map(|field| {
+            result
+                .get(field)
+                .or_else(|| result.pointer(&format!("/data/{field}")))
+                .and_then(Value::as_str)
+        })
+        .find_map(agent_task_handoff_document_from_output)
+}
+
+/// Build the typed event from a runner terminal result, keyed by the workload
+/// contract. Returns `None` when this workload declares no dispatch handoff,
+/// which is the correct answer for run-plan and for every non-agent-task exec.
+pub fn agent_task_dispatch_handoff_event_from_workload_result(
+    workload: Option<&LabRunnerWorkload>,
+    runner_id: &str,
+    runner_job_id: &str,
+    result: &Value,
+) -> Option<AgentTaskDispatchHandoffEvent> {
+    let agent_task = workload.and_then(|workload| workload.agent_task.as_ref())?;
+    if !agent_task_mirrors_dispatch_handoff(agent_task) {
+        return None;
+    }
+    if let Some(event) = agent_task_dispatch_handoff_event_from_value(result) {
+        return Some(event);
+    }
+    let handoff = agent_task_handoff_document_from_result(result)?;
+    Some(AgentTaskDispatchHandoffEvent {
+        schema: AGENT_TASK_DISPATCH_HANDOFF_EVENT_SCHEMA.to_string(),
+        identity: AgentTaskDispatchIdentity {
+            runner_id: runner_id.to_string(),
+            runner_job_id: runner_job_id.to_string(),
+            persisted_run_id: Some(agent_task.run_id.clone()),
+            run_id: Some(agent_task.run_id.clone()),
+            ..AgentTaskDispatchIdentity::default()
+        },
+        run_id: agent_task.run_id.clone(),
+        handoff,
+    })
+}
+
+/// Recover the typed event from a job-event payload or a result envelope,
+/// unwrapping the daemon's wrapper and any number of `data` layers.
+pub fn agent_task_dispatch_handoff_event_from_value(
+    value: &Value,
+) -> Option<AgentTaskDispatchHandoffEvent> {
+    if value.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_DISPATCH_HANDOFF_EVENT_SCHEMA)
+    {
+        return serde_json::from_value(value.clone()).ok();
+    }
+    if let Some(event) = value
+        .get(AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY)
+        .and_then(agent_task_dispatch_handoff_event_from_value)
+    {
+        return Some(event);
+    }
+    value
+        .get("data")
+        .and_then(agent_task_dispatch_handoff_event_from_value)
+}
+
+/// Build the daemon's job-event payload for a typed handoff event.
+///
+/// The wrapper mirrors the run-plan lifecycle wrapper so both agent-task seams
+/// look the same in a job-event stream. Constructed field by field rather than
+/// through `json!` so the key constant is used literally by both the producer
+/// here and [`agent_task_dispatch_handoff_event_from_value`].
+pub fn agent_task_dispatch_handoff_workload_event_payload(
+    event: &AgentTaskDispatchHandoffEvent,
+) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "schema".to_string(),
+        Value::String(AGENT_TASK_DISPATCH_HANDOFF_WORKLOAD_EVENT_SCHEMA.to_string()),
+    );
+    payload.insert(
+        AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY.to_string(),
+        serde_json::to_value(event).unwrap_or(Value::Null),
+    );
+    Value::Object(payload)
+}
+
+/// Controller-side entry point: find the most recent typed handoff event in a
+/// runner job's event stream.
+pub fn agent_task_dispatch_handoff_event_from_job_events(
+    job_events: Option<&[JobEvent]>,
+) -> Option<AgentTaskDispatchHandoffEvent> {
+    job_events?.iter().rev().find_map(|event| {
+        if event.kind != JobEventKind::Result && event.kind != JobEventKind::Progress {
+            return None;
+        }
+        agent_task_dispatch_handoff_event_from_value(event.data.as_ref()?)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::lab_contract::{
+        LabRunnerWorkloadAgentTaskDispatchKind, LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy,
+    };
+    use serde_json::json;
+
+    fn workload(agent_task: Option<serde_json::Value>) -> LabRunnerWorkload {
+        let mut payload = json!({
+            "schema": "homeboy/runner-workload/v1",
+            "workload_id": "lab-agent-task",
+            "kind": { "command_label": "agent-task cook", "command_family": "agent_task" },
+            "workspace_mappings": { "source_path_mode": "snapshot", "workspace_mode_policy": "snapshot", "mapping_ref": null },
+            "required_capabilities": [],
+            "required_secrets": { "categories": [] },
+            "required_extensions": [],
+            "mutation_policy": { "capture_patch": true, "mutation_flag": null, "allow_dirty_lab_workspace": false },
+            "assignment": { "runner_id": "homeboy-lab", "runner_mode": null, "source": null },
+            "state": { "status": "submitted", "remote_workspace": null, "fallback_reason": null },
+            "result_refs": { "plan_id": "lab-agent-task", "proof_id": null, "workspace_mapping_ref": null }
+        });
+        if let Some(agent_task) = agent_task {
+            payload["agent_task"] = agent_task;
+        }
+        serde_json::from_value(payload).expect("workload fixture")
+    }
+
+    fn cook_workload() -> LabRunnerWorkload {
+        workload(Some(json!({
+            "run_id": "cook-7530",
+            "dispatch_kind": "cook",
+            "lifecycle_mirror_policy": "none",
+            "handoff_mirror_policy": "dispatch_handoff"
+        })))
+    }
+
+    fn handoff_document() -> serde_json::Value {
+        json!({
+            "schema": AGENT_TASK_LAB_HANDOFF_SCHEMA,
+            "run_id": "cook-7530",
+            "record_summary": {
+                "run_id": "cook-7530",
+                "plan_id": "plan-7530",
+                "state": "failed",
+                "task_count": 1
+            }
+        })
+    }
+
+    #[test]
+    fn typed_event_is_keyed_by_the_workload_run_id_not_the_document() {
+        // The document's own `run_id` is deliberately different: the workload
+        // contract is authoritative for identity, output text is not.
+        let mut document = handoff_document();
+        document["run_id"] = json!("some-id-printed-by-the-remote-binary");
+        let result = json!({ "exit_code": 1, "stdout": document.to_string(), "stderr": "" });
+
+        let event = agent_task_dispatch_handoff_event_from_workload_result(
+            Some(&cook_workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .expect("cook handoff event");
+
+        assert_eq!(event.run_id, "cook-7530");
+        assert_eq!(event.identity.run_id.as_deref(), Some("cook-7530"));
+        assert_eq!(event.identity.runner_id, "homeboy-lab");
+        assert_eq!(
+            event.handoff["run_id"],
+            "some-id-printed-by-the-remote-binary"
+        );
+    }
+
+    #[test]
+    fn handoff_is_recovered_from_stderr_and_from_log_noise() {
+        let noisy = format!(
+            "HOMEBOY_RUNNER_PROGRESS {{\"phase\":\"finished\"}}\n{}\ntrailing log line\n",
+            handoff_document()
+        );
+        let result = json!({ "exit_code": 1, "stdout": "", "stderr": noisy });
+
+        let event = agent_task_dispatch_handoff_event_from_workload_result(
+            Some(&cook_workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .expect("handoff embedded in stderr log noise");
+
+        assert_eq!(event.handoff["schema"], AGENT_TASK_LAB_HANDOFF_SCHEMA);
+    }
+
+    #[test]
+    fn legacy_dispatch_envelope_is_still_recognized() {
+        let envelope = json!({
+            "schema": AGENT_TASK_DISPATCH_ENVELOPE_SCHEMA,
+            "run_id": "cook-7530"
+        });
+        let result = json!({ "data": { "stdout": envelope.to_string() } });
+
+        let event = agent_task_dispatch_handoff_event_from_workload_result(
+            Some(&cook_workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .expect("legacy dispatch envelope");
+
+        assert_eq!(event.handoff["schema"], AGENT_TASK_DISPATCH_ENVELOPE_SCHEMA);
+    }
+
+    /// A workload whose emitter predates `handoff_mirror_policy` produces no
+    /// typed event, so the consumer's retained stdout fallback is what runs.
+    #[test]
+    fn pre_typed_workload_emits_no_event() {
+        let pre_typed = workload(Some(json!({
+            "run_id": "cook-7530",
+            "dispatch_kind": "cook",
+            "lifecycle_mirror_policy": "none"
+        })));
+        let result = json!({ "stdout": handoff_document().to_string() });
+
+        assert!(agent_task_dispatch_handoff_event_from_workload_result(
+            Some(&pre_typed),
+            "homeboy-lab",
+            "runner-job-1",
+            &result,
+        )
+        .is_none());
+    }
+
+    /// A run-plan declares `none`, and a generic exec has no `agent_task`
+    /// section at all. Neither may produce a handoff event, no matter what its
+    /// stdout happens to contain (the #9459 failure mode, one seam over).
+    #[test]
+    fn run_plan_and_generic_exec_emit_no_event() {
+        let run_plan = workload(Some(json!({
+            "run_id": "run-plan-7530",
+            "plan_ref": "@plan.json",
+            "dispatch_kind": "run_plan",
+            "lifecycle_mirror_policy": "run_plan_aggregate",
+            "handoff_mirror_policy": "none"
+        })));
+        let result = json!({ "stdout": handoff_document().to_string() });
+
+        for candidate in [Some(run_plan), Some(workload(None)), None] {
+            assert!(agent_task_dispatch_handoff_event_from_workload_result(
+                candidate.as_ref(),
+                "homeboy-lab",
+                "runner-job-1",
+                &result,
+            )
+            .is_none());
+        }
+    }
+
+    #[test]
+    fn plain_command_output_yields_no_handoff() {
+        for stdout in [
+            "/home/runner/workspace\n",
+            "",
+            "line one\nline two\n",
+            "{ not valid json",
+            r#"{"status":"fail","findings":3}"#,
+        ] {
+            let result = json!({ "stdout": stdout, "stderr": "" });
+            assert!(
+                agent_task_dispatch_handoff_event_from_workload_result(
+                    Some(&cook_workload()),
+                    "homeboy-lab",
+                    "runner-job-1",
+                    &result,
+                )
+                .is_none(),
+                "plain stdout `{stdout:?}` must not look like a handoff"
+            );
+        }
+    }
+
+    #[test]
+    fn event_round_trips_through_the_daemon_job_event_wrapper() {
+        let event = agent_task_dispatch_handoff_event_from_workload_result(
+            Some(&cook_workload()),
+            "homeboy-lab",
+            "runner-job-1",
+            &json!({ "stdout": handoff_document().to_string() }),
+        )
+        .expect("cook handoff event");
+
+        let job_event = JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::nil(),
+            kind: JobEventKind::Progress,
+            timestamp_ms: 1,
+            message: Some("agent-task dispatch handoff".to_string()),
+            data: Some(agent_task_dispatch_handoff_workload_event_payload(&event)),
+        };
+
+        let recovered = agent_task_dispatch_handoff_event_from_job_events(Some(&[job_event]))
+            .expect("typed event recovered from job events");
+        assert_eq!(recovered.run_id, "cook-7530");
+        assert_eq!(recovered.handoff["schema"], AGENT_TASK_LAB_HANDOFF_SCHEMA);
+    }
+
+    #[test]
+    fn typed_helper_agrees_with_the_contract_spellings() {
+        let agent_task = LabRunnerWorkloadAgentTask {
+            run_id: "cook-7530".to_string(),
+            plan_ref: None,
+            resolved_provider_policy: None,
+            dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::Cook,
+            lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+            handoff_mirror_policy: Some(
+                LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff,
+            ),
+        };
+        assert!(agent_task_mirrors_dispatch_handoff(&agent_task));
+
+        let no_handoff = LabRunnerWorkloadAgentTask {
+            handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
+            ..agent_task.clone()
+        };
+        assert!(!agent_task_mirrors_dispatch_handoff(&no_handoff));
+
+        let pre_typed = LabRunnerWorkloadAgentTask {
+            handoff_mirror_policy: None,
+            ..agent_task
+        };
+        assert!(!agent_task_mirrors_dispatch_handoff(&pre_typed));
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/agent_task_lifecycle_event.rs
@@ -309,6 +309,7 @@ mod tests {
                 resolved_provider_policy: None,
                 dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+                handoff_mirror_policy: Some(homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
             },
             "workspace_mappings": { "source_path_mode": "snapshot", "workspace_mode_policy": "snapshot", "mapping_ref": null },
             "required_capabilities": [],

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -31,6 +31,7 @@ use lifecycle_store as store;
 
 mod acceptance_verifier;
 pub mod activity_provider;
+pub mod agent_task_handoff_event;
 pub mod agent_task_lifecycle_event;
 mod artifact_materialization;
 mod cancellation;

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -345,6 +345,12 @@ pub(super) fn exec_via_daemon(
         &runner.id,
         &job_id,
     )?;
+    append_agent_task_dispatch_handoff_workload_event(
+        &mut events,
+        lab_runner_workload.as_ref(),
+        &runner.id,
+        &job_id,
+    );
 
     let RunnerJobResultFields {
         result,
@@ -2131,6 +2137,56 @@ fn append_agent_task_lifecycle_workload_event(
         })),
     });
     Ok(())
+}
+
+/// The cook/dispatch counterpart of [`append_agent_task_lifecycle_workload_event`].
+///
+/// Extracts the dispatch handoff on the side that owns the output, gated by the
+/// workload's `agent_task.handoff_mirror_policy`, and republishes it as a typed
+/// event carrying the workload's run id. The controller mirrors from this event
+/// instead of rescanning stdout/stderr (#7530).
+///
+/// Infallible on purpose: a missing or unrecognized handoff is not a job
+/// failure, it just means the controller's retained output fallback runs. This
+/// is the opposite of the run-plan path, where a malformed aggregate is a hard
+/// error because the controller has no other source for it.
+fn append_agent_task_dispatch_handoff_workload_event(
+    events: &mut Vec<JobEvent>,
+    lab_runner_workload: Option<&LabRunnerWorkload>,
+    runner_id: &str,
+    runner_job_id: &str,
+) {
+    let Some(result) = result_event_data(events) else {
+        return;
+    };
+    let Some(event) =
+        crate::agent_task_handoff_event::agent_task_dispatch_handoff_event_from_workload_result(
+            lab_runner_workload,
+            runner_id,
+            runner_job_id,
+            &result,
+        )
+    else {
+        return;
+    };
+    events.push(JobEvent {
+        sequence: events
+            .last()
+            .map(|event| event.sequence.saturating_add(1))
+            .unwrap_or(1),
+        job_id: events
+            .last()
+            .map(|event| event.job_id)
+            .unwrap_or_else(uuid::Uuid::nil),
+        kind: homeboy_core::api_jobs::JobEventKind::Progress,
+        timestamp_ms: events.last().map(|event| event.timestamp_ms).unwrap_or(0),
+        message: Some("agent-task dispatch handoff".to_string()),
+        data: Some(
+            crate::agent_task_handoff_event::agent_task_dispatch_handoff_workload_event_payload(
+                &event,
+            ),
+        ),
+    });
 }
 
 /// Stream + metric fields derived from a runner job's terminal result event.

--- a/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
+++ b/crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs
@@ -11,6 +11,9 @@
 #[cfg(test)]
 use std::fs;
 
+use crate::agent_task_handoff_event::{
+    agent_task_dispatch_handoff_event_from_job_events, agent_task_mirrors_dispatch_handoff,
+};
 use crate::agent_task_lifecycle_event::{
     agent_task_run_plan_lifecycle_event_from_job_events, is_agent_task_run_plan_envelope,
     parse_offloaded_run_plan_envelope,
@@ -30,6 +33,8 @@ use homeboy_core::api_jobs::JobEvent;
 use homeboy_core::api_jobs::JobEventKind;
 use homeboy_core::artifact_manifest::ArtifactManifest;
 use homeboy_core::engine::local_files::write_file_owner_only;
+#[cfg(test)]
+use homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskHandoffMirrorPolicy;
 use homeboy_core::lab_contract::{
     LabRunnerWorkloadAgentTask, LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy,
 };
@@ -191,6 +196,52 @@ fn agent_task_run_plan_lifecycle_output<'a>(
     output_file_content: Option<&'a str>,
 ) -> &'a str {
     output_file_content.unwrap_or(stdout)
+}
+
+/// Resolve the cook/dispatch handoff for an offloaded agent-task run.
+///
+/// Typed path first: when the workload declared
+/// `agent_task.handoff_mirror_policy = dispatch_handoff`, the runner emits a
+/// `homeboy/agent-task-dispatch-handoff-event/v1` job event carrying the
+/// handoff document and the controller-owned run id. Mirroring from that means
+/// a change to what the offloaded command prints can no longer break
+/// failure-evidence mirroring for a job that ran fine (#7530).
+///
+/// The stdout/stderr scan is retained as the fallback and is NOT dead code: it
+/// is the only path for a runner that predates the typed event, and the typed
+/// path cannot be proven end to end without a connected Lab runner. Deleting
+/// the fallback is a separate change, gated on that proof.
+pub(super) fn resolve_offloaded_agent_task_handoff(
+    agent_task: Option<&LabRunnerWorkloadAgentTask>,
+    job_events: Option<&[JobEvent]>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<Option<AgentTaskLabHandoff>> {
+    if let Some(handoff) = typed_offloaded_agent_task_handoff(agent_task, job_events)? {
+        return Ok(Some(handoff));
+    }
+    parse_offloaded_agent_task_handoff_from_outputs(stdout, stderr)
+}
+
+fn typed_offloaded_agent_task_handoff(
+    agent_task: Option<&LabRunnerWorkloadAgentTask>,
+    job_events: Option<&[JobEvent]>,
+) -> Result<Option<AgentTaskLabHandoff>> {
+    let Some(agent_task) = agent_task else {
+        return Ok(None);
+    };
+    if !agent_task_mirrors_dispatch_handoff(agent_task) {
+        return Ok(None);
+    }
+    let Some(event) = agent_task_dispatch_handoff_event_from_job_events(job_events) else {
+        return Ok(None);
+    };
+    // Identity is checked against the workload, not against the document. A
+    // stale or misrouted event is treated as absent so the fallback still runs.
+    if event.run_id != agent_task.run_id {
+        return Ok(None);
+    }
+    agent_task_handoff_value(&event.handoff)
 }
 
 pub(super) fn parse_offloaded_agent_task_handoff_from_outputs(
@@ -979,6 +1030,136 @@ mod tests {
         assert!(err.message.contains("artifact path must be relative"));
     }
 
+    fn dispatch_agent_task(
+        run_id: &str,
+        handoff_mirror_policy: Option<LabRunnerWorkloadAgentTaskHandoffMirrorPolicy>,
+    ) -> LabRunnerWorkloadAgentTask {
+        LabRunnerWorkloadAgentTask {
+            run_id: run_id.to_string(),
+            plan_ref: None,
+            resolved_provider_policy: None,
+            dispatch_kind: homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskDispatchKind::Cook,
+            lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+            handoff_mirror_policy,
+        }
+    }
+
+    fn typed_handoff_job_event(run_id: &str, handoff_run_id: &str) -> JobEvent {
+        JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::nil(),
+            kind: JobEventKind::Progress,
+            timestamp_ms: 1,
+            message: Some("agent-task dispatch handoff".to_string()),
+            data: Some(serde_json::json!({
+                "schema": "homeboy/runner-workload-agent-task-handoff-event/v1",
+                "agent_task_dispatch_handoff_event": {
+                    "schema": "homeboy/agent-task-dispatch-handoff-event/v1",
+                    "identity": {
+                        "runner_id": "lab-default",
+                        "runner_job_id": "job-typed",
+                        "run_id": run_id
+                    },
+                    "run_id": run_id,
+                    "handoff": {
+                        "schema": "homeboy/agent-task-lab-handoff/v1",
+                        "run_id": handoff_run_id
+                    }
+                }
+            })),
+        }
+    }
+
+    /// #7530: the controller mirrors the cook/dispatch handoff from the typed
+    /// event, so stdout can be anything at all — including output that would
+    /// previously have been scraped into a *different* handoff.
+    #[test]
+    fn typed_dispatch_handoff_is_taken_from_the_job_event_not_stdout() {
+        let agent_task = dispatch_agent_task(
+            "run-typed-handoff",
+            Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff),
+        );
+        let events = vec![typed_handoff_job_event("run-typed-handoff", "from-event")];
+        let decoy = concat!(
+            "{\"schema\":\"homeboy/agent-task-lab-handoff/v1\",",
+            "\"run_id\":\"from-stdout\"}\n"
+        );
+
+        let handoff = resolve_offloaded_agent_task_handoff(
+            Some(&agent_task),
+            Some(&events),
+            decoy,
+            "not json at all",
+        )
+        .expect("typed handoff resolves")
+        .expect("handoff found");
+
+        assert_eq!(handoff.run_id.as_deref(), Some("from-event"));
+    }
+
+    /// The stdout fallback is retained, not replaced. Every one of these is a
+    /// shape a connected Lab runner can still produce, and the typed path is
+    /// unproven end to end until one is connected.
+    #[test]
+    fn dispatch_handoff_falls_back_to_output_scraping() {
+        let stdout = concat!(
+            "{\"schema\":\"homeboy/agent-task-lab-handoff/v1\",",
+            "\"run_id\":\"from-stdout\"}\n"
+        );
+
+        let cases: Vec<(
+            &str,
+            Option<LabRunnerWorkloadAgentTask>,
+            Option<Vec<JobEvent>>,
+        )> = vec![
+            // No workload contract at all (pre-typed controller path).
+            ("no workload", None, None),
+            // Workload emitted before `handoff_mirror_policy` existed.
+            (
+                "pre-typed workload",
+                Some(dispatch_agent_task("run-typed-handoff", None)),
+                Some(vec![typed_handoff_job_event(
+                    "run-typed-handoff",
+                    "from-event",
+                )]),
+            ),
+            // Contract says mirror, but the runner emitted no typed event.
+            (
+                "typed workload, untyped runner",
+                Some(dispatch_agent_task(
+                    "run-typed-handoff",
+                    Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff),
+                )),
+                None,
+            ),
+            // A typed event for a different run must not be adopted.
+            (
+                "mismatched run identity",
+                Some(dispatch_agent_task(
+                    "run-typed-handoff",
+                    Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff),
+                )),
+                Some(vec![typed_handoff_job_event(
+                    "some-other-run",
+                    "from-event",
+                )]),
+            ),
+        ];
+
+        for (label, agent_task, events) in cases {
+            let handoff = resolve_offloaded_agent_task_handoff(
+                agent_task.as_ref(),
+                events.as_deref(),
+                stdout,
+                "",
+            )
+            .unwrap_or_else(|error| panic!("{label}: {error:?}"))
+            .unwrap_or_else(|| panic!("{label}: fallback must still find the handoff"));
+
+            assert_eq!(handoff.run_id.as_deref(), Some("from-stdout"), "{label}");
+        }
+    }
+
     #[test]
     fn typed_run_plan_lifecycle_ignores_stdout_without_job_event() {
         let args = vec![
@@ -1000,6 +1181,7 @@ mod tests {
                 homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
             lifecycle_mirror_policy:
                 LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+            handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
         };
 
         mirror_agent_task_run_plan_lifecycle(&args, Some(&agent_task), None, stdout, None, None)
@@ -1024,6 +1206,7 @@ mod tests {
                     homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:
                     LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+                handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
             };
             let events = vec![JobEvent {
                 sequence: 1,
@@ -1081,6 +1264,7 @@ mod tests {
                     homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:
                     LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+                handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
             };
             let events = vec![JobEvent {
                 sequence: 1,
@@ -1216,6 +1400,7 @@ mod tests {
                     homeboy_core::lab_contract::LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:
                     LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+                handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
             };
             let events = vec![JobEvent {
                 sequence: 1,

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -981,9 +981,12 @@ pub(crate) fn exec_lab_context(
         );
         append_runner_failure_context_summary(&mut stderr, &exec_output);
         if let Some(run_id) = context.agent_task_run_id.as_deref() {
-            if let Some(handoff) =
-                parse_offloaded_agent_task_handoff_from_outputs(&stdout, &exec_output.stderr)?
-            {
+            if let Some(handoff) = resolve_offloaded_agent_task_handoff(
+                agent_task_workload.as_ref(),
+                exec_output.job_events.as_deref(),
+                &stdout,
+                &exec_output.stderr,
+            )? {
                 if let Some(record) = agent_task_lifecycle::record_remote_dispatch_failure(
                     agent_task_lifecycle::AgentTaskRemoteDispatchFailure {
                         identity: agent_task_lifecycle::RunDispatchIdentity { run_id, runner_id },

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -134,7 +134,7 @@ use super::super::workload::{
 use super::agent_task_bridge::{
     agent_task_dispatch_run_isolation_token, ensure_agent_task_lifecycle_identity_with,
     lab_pre_dispatch_failure_message, mirror_agent_task_run_plan_lifecycle,
-    parse_offloaded_agent_task_handoff_from_outputs,
+    resolve_offloaded_agent_task_handoff,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::fallback::{

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -15,6 +15,10 @@ use homeboy_core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSetting
 // exported here so runner-internal `super::agent_task_lifecycle_event` /
 // `crate::agent_task_lifecycle_event` call sites resolve unchanged.
 pub(crate) use homeboy_agents::agent_task_lifecycle::agent_task_lifecycle_event;
+// The cook/dispatch counterpart of `agent_task_lifecycle_event`: turns a
+// runner terminal result into a typed, contract-keyed handoff event so the
+// controller stops depending on the offloaded command's output format (#7530).
+pub(crate) use homeboy_agents::agent_task_lifecycle::agent_task_handoff_event;
 mod apply;
 pub mod artifact_attach;
 mod availability_provider;

--- a/crates/homeboy-lab-runner/src/worker/result.rs
+++ b/crates/homeboy-lab-runner/src/worker/result.rs
@@ -2,6 +2,10 @@ use base64::Engine;
 use serde_json::json;
 use std::collections::HashSet;
 
+use crate::agent_task_handoff_event::{
+    agent_task_dispatch_handoff_event_from_job_events,
+    agent_task_dispatch_handoff_event_from_workload_result, AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY,
+};
 use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events;
 use homeboy_core::api_jobs::{
     Job, JobArtifactMetadata, RemoteRunnerJobRequest, RemoteRunnerJobResult,
@@ -56,6 +60,28 @@ pub(super) fn remote_runner_result_from_exec_output(
     {
         data["agent_task_lifecycle_event"] =
             serde_json::to_value(lifecycle_event).unwrap_or(serde_json::Value::Null);
+    }
+    // Same treatment for the cook/dispatch handoff seam (#7530): carry the
+    // typed, contract-keyed event on the terminal result so a controller
+    // reading only the result never has to rescan streams. Prefer an event the
+    // inner daemon already emitted; otherwise derive it here, where both the
+    // workload and the streams are in hand.
+    if let Some(handoff_event) =
+        agent_task_dispatch_handoff_event_from_job_events(exec_output.job_events.as_deref())
+            .or_else(|| {
+                agent_task_dispatch_handoff_event_from_workload_result(
+                    lab_runner_workload.as_ref(),
+                    &exec_output.runner_id,
+                    exec_output.job_id.as_deref().unwrap_or_default(),
+                    &json!({
+                        "stdout": &exec_output.stdout,
+                        "stderr": &exec_output.stderr,
+                    }),
+                )
+            })
+    {
+        data[AGENT_TASK_DISPATCH_HANDOFF_EVENT_KEY] =
+            serde_json::to_value(handoff_event).unwrap_or(serde_json::Value::Null);
     }
     if let Some(lab_runner_workload) = lab_runner_workload {
         data["runner_workload"] = serde_json::to_value(

--- a/crates/homeboy-lab-runner/src/workload.rs
+++ b/crates/homeboy-lab-runner/src/workload.rs
@@ -2,8 +2,9 @@ use homeboy_agents::agent_task_dispatch_service::ResolvedAgentTaskProviderPolicy
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::{
     lab_capability_is_pipeline_enforced, LabRunnerWorkload, LabRunnerWorkloadAgentTask,
-    LabRunnerWorkloadAgentTaskDispatchKind, LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy,
-    LabRunnerWorkloadAssignment, LabRunnerWorkloadCapability, LabRunnerWorkloadCommandFamily,
+    LabRunnerWorkloadAgentTaskDispatchKind, LabRunnerWorkloadAgentTaskHandoffMirrorPolicy,
+    LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy, LabRunnerWorkloadAssignment,
+    LabRunnerWorkloadCapability, LabRunnerWorkloadCommandFamily,
     LabRunnerWorkloadExtensionRevision, LabRunnerWorkloadKind, LabRunnerWorkloadMutationPolicy,
     LabRunnerWorkloadResultRefs, LabRunnerWorkloadSecrets, LabRunnerWorkloadState,
     LabRunnerWorkloadWorkspaceMappings, LAB_CAPABILITY_EXTENSION_PARITY,
@@ -170,12 +171,18 @@ pub(crate) fn lab_runner_workload_agent_task_from_command(
     let agent_task_index = args.iter().position(|arg| arg == "agent-task")?;
     let action = args.get(agent_task_index + 1)?.as_str();
     match action {
+        // Cook and dispatch produce a handoff document, not a run-plan
+        // aggregate, so they declare the handoff mirror policy and leave the
+        // lifecycle (aggregate) mirror policy at `None`.
         "cook" => run_id.map(|run_id| LabRunnerWorkloadAgentTask {
             run_id: run_id.to_string(),
             plan_ref: None,
             resolved_provider_policy: resolved_provider_policy_from_command(args),
             dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::Cook,
             lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+            handoff_mirror_policy: Some(
+                LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff,
+            ),
         }),
         "dispatch" => run_id.map(|run_id| LabRunnerWorkloadAgentTask {
             run_id: run_id.to_string(),
@@ -183,6 +190,9 @@ pub(crate) fn lab_runner_workload_agent_task_from_command(
             resolved_provider_policy: resolved_provider_policy_from_command(args),
             dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::Dispatch,
             lifecycle_mirror_policy: LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+            handoff_mirror_policy: Some(
+                LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff,
+            ),
         }),
         "run-plan" => {
             let plan_ref = option_value_after(args, agent_task_index + 1, "--plan")?;
@@ -196,6 +206,10 @@ pub(crate) fn lab_runner_workload_agent_task_from_command(
                 dispatch_kind: LabRunnerWorkloadAgentTaskDispatchKind::RunPlan,
                 lifecycle_mirror_policy:
                     LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate,
+                // A run-plan has no dispatch handoff. Declaring `None` rather
+                // than leaving the field unset keeps "no handoff to mirror"
+                // distinguishable from "emitter predates the field".
+                handoff_mirror_policy: Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None),
             })
         }
         _ => None,
@@ -1707,6 +1721,59 @@ mod tests {
             agent_task.lifecycle_mirror_policy,
             LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::RunPlanAggregate
         );
+        // A run-plan has no dispatch handoff, and says so explicitly rather
+        // than leaving the field unset (which means "emitter predates it").
+        assert_eq!(
+            agent_task.handoff_mirror_policy,
+            Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::None)
+        );
+    }
+
+    /// Cook and dispatch are the seam #7530 is about: they produce a handoff
+    /// document, not a run-plan aggregate, so they must declare the handoff
+    /// mirror policy that turns on the controller's typed mirror.
+    #[test]
+    fn lab_runner_workload_agent_task_contract_declares_dispatch_handoff_mirroring() {
+        for action in ["cook", "dispatch"] {
+            let agent_task = lab_runner_workload_agent_task_from_command(
+                &[
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    action.to_string(),
+                    "--run-id".to_string(),
+                    "run-7530".to_string(),
+                ],
+                Some("run-7530"),
+            )
+            .unwrap_or_else(|| panic!("agent task workload contract for {action}"));
+
+            assert_eq!(agent_task.run_id, "run-7530");
+            assert_eq!(agent_task.plan_ref, None);
+            assert_eq!(
+                agent_task.lifecycle_mirror_policy,
+                LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy::None,
+                "{action} mirrors a handoff, not a run-plan aggregate"
+            );
+            assert_eq!(
+                agent_task.handoff_mirror_policy,
+                Some(LabRunnerWorkloadAgentTaskHandoffMirrorPolicy::DispatchHandoff)
+            );
+        }
+    }
+
+    /// Without a run id there is no identity to key a typed mirror on, so no
+    /// section is emitted at all and the consumer keeps its output fallback.
+    #[test]
+    fn lab_runner_workload_agent_task_contract_is_absent_without_a_run_id() {
+        assert!(lab_runner_workload_agent_task_from_command(
+            &[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            None,
+        )
+        .is_none());
     }
 
     #[test]


### PR DESCRIPTION
Refs #7530 (dependency of epic #8282).

## The issue's paths are stale — re-mapped first

#7530 was filed 2026-07-04 against `src/core/runner/lab/...`, which no longer exists. Current locations are `crates/homeboy-lab-runner/src/lab/agent_task_bridge.rs` and `crates/homeboy-lab-runner/src/lab/offload/`. I re-located all three cited seams by behavior.

## Seam inventory: what I found

| # | Seam as filed | State on `main` @ `3cd143b24` |
|---|---|---|
| 1 | lifecycle replay recognizing `agent-task run-plan --plan --record-run-id` in argv | **Already typed.** `mirror_agent_task_run_plan_lifecycle` dispatches to `mirror_typed_agent_task_run_plan_lifecycle` when the workload carries `agent_task`; `agent_task_run_plan_recording_args(args)` survives only in the explicitly-labelled legacy branch. |
| 2 | aggregates parsed out of mixed stdout/stderr or output files | **Already typed.** Recovered from `homeboy/agent-task-run-plan-lifecycle-event/v1` job events, emitted by `daemon::append_agent_task_lifecycle_workload_event` and keyed on `agent_task.lifecycle_mirror_policy`. `legacy_agent_task_run_plan_aggregate(stdout, output_file_content)` remains as fallback. |
| 3 | handoff JSON scraped from stdout/stderr; dispatch run-id injection by argv surgery | **Still untyped — this PR.** `offload/inner.rs` called `parse_offloaded_agent_task_handoff_from_outputs(&stdout, &exec_output.stderr)` as the *only* source. `agent_task.lifecycle_mirror_policy` was hardcoded `None` for both `Cook` and `Dispatch`, so the contract carried the run id and nothing consumed it. |

That the first two are already done is itself the finding: `LabRunnerWorkloadAgentTask { run_id, plan_ref, dispatch_kind, lifecycle_mirror_policy }` — the exact section #7530 asks for — already exists in `crates/contracts/homeboy-lab-contract/src/lab/workload.rs`. This PR extends it rather than adding it.

### Not addressed
The argv-surgery half of seam 3 (`ensure_agent_task_dispatch_run_id_with` injecting `--run-id`/`--attempt-run-id` via `ArgEditor`) is left alone. That is identity *injection into a command that must still be a valid CLI invocation*, not identity *recovery from output*, and removing it means changing the dispatched command shape. Out of scope here.

## What this PR builds

**Contract** — optional `agent_task.handoff_mirror_policy: Option<LabRunnerWorkloadAgentTaskHandoffMirrorPolicy>` (`none` | `dispatch_handoff`), `#[serde(default, skip_serializing_if = "Option::is_none")]`.

Deliberately a new optional *field* rather than a new `lifecycle_mirror_policy` *variant*: `lifecycle_mirror_policy` is a required field, so an added spelling would fail the **entire** workload parse on an older peer, not just the section. A new optional field is ignored instead. `None` unambiguously means "emitting side predates the field", which is exactly when the fallback must run — which is why run-plan declares `Some(None)` rather than leaving it unset.

**Emit** — `homeboy-agents/src/agent_task_lifecycle/agent_task_handoff_event.rs`. The daemon (`append_agent_task_dispatch_handoff_workload_event`) and the reverse worker's result builder extract the handoff document once, on the side that owns the output, gated by the policy, and republish it as `homeboy/agent-task-dispatch-handoff-event/v1` carrying the workload's `run_id`. Infallible by design: a missing handoff is not a job failure, it just means the consumer's fallback runs.

**Mirror** — `agent_task_bridge::resolve_offloaded_agent_task_handoff` replaces the direct scrape at the `inner.rs` call site. Typed event first, identity checked **against the workload, not against the document**; fallback otherwise.

The extraction is still a text scan today, because the current `agent-task cook` prints its handoff to stdout. The win is that it happens once, on the side that knows what it dispatched, gated by the contract — and a future runner can emit the typed event directly with zero controller change.

## ⚠️ The typed path is UNPROVEN end to end

**There is no Lab runner on this controller, so the offload path could not be executed.** Everything above is proven only by unit tests against synthetic job events and results. Per the issue's own instruction, **the stdout/stderr fallback is retained, not deleted** — removing it is a separate change gated on a real Lab-runner proof.

## ⚠️ Not compiled

**I could not run `cargo check`/`build`/`test`** (build prohibition on this VPS — four agents share one 15Gi box). Only `cargo fmt` was run. A serialized `cargo check --workspace --tests` follows separately.

Compile risk, honestly assessed:
- **Struct field addition swept exhaustively.** `LabRunnerWorkloadAgentTask` gained a required-in-Rust field. All 8 literal sites updated: `workload.rs` ×3 (production), `agent_task_bridge.rs` ×4 (tests), `agent_task_lifecycle_event.rs` ×1 (test). Verified by grep that no site destructures the struct in a pattern and that no `match` is exhaustive over `LabRunnerWorkloadAgentTaskLifecycleMirrorPolicy`.
- No `#[cfg(unix)]`-gated bindings introduced; nothing platform-specific.
- Serde/clap spelling divergence N/A — the new enum is serde-only, and the snake_case wire spellings (`none`, `dispatch_handoff`) are asserted directly in a test rather than assumed.
- No assertion anywhere relates a path to `std::env::temp_dir()`.
- Residual risk is ordinary type/inference error in the ~340 new lines, concentrated in the new module's test fixtures.

## Test coverage

Contract (`homeboy-lab-contract`):
- `workload_without_an_agent_task_section_still_parses` — **the requested backward-compat round trip**: a payload with no `agent_task` at all parses, and the section stays absent on re-serialization.
- `agent_task_section_without_a_handoff_mirror_policy_round_trips_unchanged` — a pre-typed section deserializes and re-serializes **byte-identically**, so a relaying controller cannot fabricate a policy the emitter never declared.
- `handoff_mirror_policy_is_additive_and_snake_case` — pins the wire spellings.
- `an_unknown_handoff_policy_spelling_is_a_breaking_change_for_old_peers` — pins that adding a *spelling* later is not free, so the blast radius is visible at review time.

Note: the pre-existing fixture in `homeboy-core/src/daemon/mod.rs` omits `handoff_mirror_policy` and is now an incidental regression test for the same property.

Emit (`agent_task_handoff_event`): identity taken from the workload and not from a deliberately-conflicting document `run_id`; recovery from stderr and from log noise; legacy `agent-task-dispatch/v1` envelope; no event for a pre-typed workload, a run-plan, a generic exec, or plain command output (the #9459 failure mode, one seam over); wrapper round trip.

Mirror (`agent_task_bridge`): typed event beats a decoy handoff in stdout; fallback still fires for all four conditions — no workload, pre-typed workload, typed workload with an untyped runner, and a typed event bound to a different run.

No tests deleted or `#[ignore]`d.

---
🤖 chubes-bot via opencode