### PR TITLE
feat(agent-task): supervise provider sessions with a resource policy

### DIFF
--- a/crates/homeboy-agents/src/agent_task.rs
+++ b/crates/homeboy-agents/src/agent_task.rs
@@ -19,6 +19,7 @@ mod policy;
 mod request;
 mod runtime_tools;
 mod schema;
+mod supervision_policy;
 
 #[cfg(test)]
 mod tests;
@@ -73,4 +74,10 @@ pub use schema::{
     AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA, AGENT_TASK_MATRIX_PLAN_SCHEMA,
     AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
     AGENT_TOOL_POLICY_SCHEMA, AGENT_TOOL_REQUEST_SCHEMA, AGENT_TOOL_RESULT_SCHEMA,
+};
+pub use supervision_policy::{
+    highest_supervision_action, AgentSupervisionAction, AgentSupervisionBudget,
+    AgentSupervisionDecision, AgentSupervisionMetric, AgentSupervisionPolicy,
+    AgentSupervisionSample, AGENT_SUPERVISION_POLICY_SCHEMA, DEFAULT_SUPERVISION_REASON,
+    SUPERVISION_STOP_REMEDIATION, SUPERVISION_WARNING_REMEDIATION,
 };

--- a/crates/homeboy-agents/src/agent_task/supervision_policy.rs
+++ b/crates/homeboy-agents/src/agent_task/supervision_policy.rs
@@ -1,0 +1,697 @@
+//! Declarative resource policy for a long-running provider session.
+//!
+//! The sibling `command_policy` module bounds *what* an agent may run. This
+//! module bounds *how much it may consume while running it*. They are
+//! complements, and
+//! neither substitutes for the other: a command policy cannot see an agent that
+//! stays inside its allowed commands and still grows to nine gigabytes across
+//! forty child processes, and an execution budget counting attempts cannot see
+//! it either. Homeboy waited on the process boundary and learned the cost only
+//! after the run ended (#7015).
+//!
+//! The model is deliberately small and runtime-neutral:
+//!
+//! - A **metric** is a number any host can observe about any provider —
+//!   wall-clock time, resident memory, child processes, time since the
+//!   workspace last changed. Nothing here knows what a provider is.
+//! - A **budget** is one threshold on one metric plus the action to take.
+//! - The **ladder** is `warn` → `nudge` → `stop`. Several budgets on the same
+//!   metric are how an operator expresses "tell me at 6 GiB, stop it at 10".
+//!
+//! ## Unobserved is not zero
+//!
+//! Every metric on a sample is optional and an absent metric never breaches a
+//! budget. A non-Unix host has no `ps` and therefore no memory reading; a cook
+//! with no destination worktree has no progress reading. Reporting those as
+//! `0` would make every budget fire immediately on exactly the hosts that can
+//! least afford a spurious kill, so absence is carried as absence all the way
+//! to the comparison.
+//!
+//! ## What this does not do
+//!
+//! The ladder's `nudge` rung records a decision and surfaces it; it does not
+//! yet inject structured feedback into a live provider session, because
+//! Homeboy has no channel into a running provider's reasoning (#7451, #7530).
+//! Until that channel exists `nudge` is an operator-visible escalation
+//! *between* `warn` and `stop`, which is honest, rather than a promise the
+//! runtime cannot keep.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const AGENT_SUPERVISION_POLICY_SCHEMA: &str = "homeboy/agent-supervision-policy/v1";
+
+/// Fallback explanation when neither the budget nor the policy supplies one.
+pub const DEFAULT_SUPERVISION_REASON: &str =
+    "this budget is declared by the operator's Homeboy supervision policy for this host";
+
+/// Guidance attached to a `stop`, so the run's evidence explains the kill
+/// rather than leaving a reader to infer it from a dead process.
+pub const SUPERVISION_STOP_REMEDIATION: &str =
+    "The provider process tree was terminated because it exceeded a declared resource budget. \
+Narrow the task, raise the budget in agent_task.supervision_policy, or route the expensive \
+step to CI.";
+
+/// Guidance attached to a `warn` or `nudge`.
+pub const SUPERVISION_WARNING_REMEDIATION: &str =
+    "The run continues. Watch it, or raise the budget in agent_task.supervision_policy if this \
+is the expected cost of the task.";
+
+pub(crate) fn agent_supervision_policy_schema() -> String {
+    AGENT_SUPERVISION_POLICY_SCHEMA.to_string()
+}
+
+/// A quantity any host can observe about any provider session.
+///
+/// Kept to numbers that a process table and a worktree answer, because the
+/// moment a metric needs provider-specific knowledge it stops being a core
+/// concern and belongs in an extension.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSupervisionMetric {
+    /// Wall-clock seconds since provider execution began.
+    ElapsedSeconds,
+    /// Resident memory held by the provider's process tree, in MiB.
+    RssMib,
+    /// Processes observed under the controller while the provider runs.
+    ChildProcesses,
+    /// Seconds since the destination worktree last changed.
+    ///
+    /// This is the stall detector, and it is the metric that distinguishes an
+    /// expensive run from a wedged one. A cook burning memory while writing
+    /// files is working; a cook burning memory having written nothing for
+    /// twenty minutes is the failure mode this whole module exists for.
+    NoProgressSeconds,
+}
+
+impl AgentSupervisionMetric {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ElapsedSeconds => "elapsed_seconds",
+            Self::RssMib => "rss_mib",
+            Self::ChildProcesses => "child_processes",
+            Self::NoProgressSeconds => "no_progress_seconds",
+        }
+    }
+
+    /// Unit suffix for operator-facing rendering.
+    pub fn unit(&self) -> &'static str {
+        match self {
+            Self::ElapsedSeconds | Self::NoProgressSeconds => "s",
+            Self::RssMib => " MiB",
+            Self::ChildProcesses => " process(es)",
+        }
+    }
+}
+
+/// The supervision ladder, ordered from least to most intervention.
+///
+/// Declaration order *is* the severity order — `Ord` is derived and the
+/// escalation logic compares actions directly — so a new rung must be inserted
+/// at its severity position, not appended.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSupervisionAction {
+    /// Record and surface the breach. The run continues untouched.
+    #[default]
+    Warn,
+    /// Record and surface the breach as an escalation. The run continues.
+    /// Reserved for structured feedback into the session once a channel into a
+    /// running provider exists (#7451, #7530).
+    Nudge,
+    /// Terminate the provider's process tree.
+    Stop,
+}
+
+impl AgentSupervisionAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Warn => "warn",
+            Self::Nudge => "nudge",
+            Self::Stop => "stop",
+        }
+    }
+
+    /// True when reaching this rung ends the provider session.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Stop)
+    }
+}
+
+/// One threshold on one metric.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSupervisionBudget {
+    pub metric: AgentSupervisionMetric,
+    /// The breach is strict: `observed > limit`. An operator writing
+    /// `child_processes: 8` means eight is fine.
+    pub limit: u64,
+    #[serde(default)]
+    pub action: AgentSupervisionAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl AgentSupervisionBudget {
+    pub fn new(metric: AgentSupervisionMetric, limit: u64, action: AgentSupervisionAction) -> Self {
+        Self {
+            metric,
+            limit,
+            action,
+            reason: None,
+        }
+    }
+
+    pub fn with_reason(
+        metric: AgentSupervisionMetric,
+        limit: u64,
+        action: AgentSupervisionAction,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            metric,
+            limit,
+            action,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn is_breached(&self, observed: u64) -> bool {
+        observed > self.limit
+    }
+}
+
+/// The resource budgets a provider session runs under.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSupervisionPolicy {
+    #[serde(default = "agent_supervision_policy_schema")]
+    pub schema: String,
+    /// Budgets applied to any backend without its own entry in `backends`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub budgets: Vec<AgentSupervisionBudget>,
+    /// Per-backend budget sets, keyed by executor backend id.
+    ///
+    /// A backend entry **replaces** `budgets` rather than extending it. Unlike
+    /// a command policy — where a forgotten deny rule re-opens a hazard and
+    /// extension is the safe default — a resource budget is a single number per
+    /// metric, and merging two of them would leave an operator unable to state
+    /// "this backend legitimately needs more" without also fighting the global
+    /// value.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub backends: BTreeMap<String, Vec<AgentSupervisionBudget>>,
+    /// Policy-wide explanation used when a budget carries none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl Default for AgentSupervisionPolicy {
+    fn default() -> Self {
+        Self {
+            schema: agent_supervision_policy_schema(),
+            budgets: Vec::new(),
+            backends: BTreeMap::new(),
+            reason: None,
+        }
+    }
+}
+
+impl AgentSupervisionPolicy {
+    /// True when the policy constrains nothing anywhere. An unconstrained
+    /// policy is the default, so supervision is opt-in: a host that has not
+    /// declared budgets behaves exactly as it did before this existed.
+    pub fn is_unconstrained(&self) -> bool {
+        self.budgets.is_empty() && self.backends.values().all(Vec::is_empty)
+    }
+
+    /// The budgets that apply to `backend`.
+    pub fn effective_budgets(&self, backend: Option<&str>) -> &[AgentSupervisionBudget] {
+        backend
+            .and_then(|backend| self.backends.get(backend))
+            .map(Vec::as_slice)
+            .unwrap_or(&self.budgets)
+    }
+
+    /// True when no budget applies to this backend, so [`Self::evaluate`]
+    /// cannot produce a decision for it however extreme the sample is.
+    pub fn is_unconstrained_for(&self, backend: Option<&str>) -> bool {
+        self.effective_budgets(backend).is_empty()
+    }
+
+    /// Decide what the sample warrants.
+    ///
+    /// At most one decision per metric: the most severe breached budget, and
+    /// among equally severe ones the highest limit, because "you passed 10 GiB"
+    /// is a strictly more informative statement than "you passed 6 GiB" when
+    /// both are true and both merely warn.
+    pub fn evaluate(
+        &self,
+        backend: Option<&str>,
+        sample: &AgentSupervisionSample,
+    ) -> Vec<AgentSupervisionDecision> {
+        let mut by_metric: BTreeMap<AgentSupervisionMetric, AgentSupervisionDecision> =
+            BTreeMap::new();
+        for budget in self.effective_budgets(backend) {
+            // An unobserved metric never breaches. This is the load-bearing
+            // line for non-Unix hosts and for cooks with no worktree.
+            let Some(observed) = sample.observed(budget.metric) else {
+                continue;
+            };
+            if !budget.is_breached(observed) {
+                continue;
+            }
+            let candidate = self.decision(budget, observed);
+            let supersedes = match by_metric.get(&budget.metric) {
+                Some(existing) => {
+                    (candidate.action, candidate.limit) > (existing.action, existing.limit)
+                }
+                None => true,
+            };
+            if supersedes {
+                by_metric.insert(budget.metric, candidate);
+            }
+        }
+        by_metric.into_values().collect()
+    }
+
+    fn decision(&self, budget: &AgentSupervisionBudget, observed: u64) -> AgentSupervisionDecision {
+        let reason = budget
+            .reason
+            .clone()
+            .or_else(|| self.reason.clone())
+            .unwrap_or_else(|| DEFAULT_SUPERVISION_REASON.to_string());
+        let remediation = if budget.action.is_terminal() {
+            SUPERVISION_STOP_REMEDIATION
+        } else {
+            SUPERVISION_WARNING_REMEDIATION
+        };
+        AgentSupervisionDecision {
+            metric: budget.metric,
+            action: budget.action,
+            limit: budget.limit,
+            observed,
+            reason,
+            remediation: remediation.to_string(),
+        }
+    }
+}
+
+/// One observation of a running provider session.
+///
+/// Every field is optional and `None` means "not observed", never "zero".
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSupervisionSample {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rss_mib: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_processes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_progress_seconds: Option<u64>,
+}
+
+impl AgentSupervisionSample {
+    pub fn observed(&self, metric: AgentSupervisionMetric) -> Option<u64> {
+        match metric {
+            AgentSupervisionMetric::ElapsedSeconds => self.elapsed_seconds,
+            AgentSupervisionMetric::RssMib => self.rss_mib,
+            AgentSupervisionMetric::ChildProcesses => self.child_processes,
+            AgentSupervisionMetric::NoProgressSeconds => self.no_progress_seconds,
+        }
+    }
+
+    /// True when nothing at all was observed, so recording the sample would add
+    /// a row of nulls to the timeline instead of evidence.
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+/// A supervision decision, as recorded in run evidence.
+///
+/// Carries the observation alongside the threshold so a post-hoc reader can see
+/// *why* a run was stopped without reconstructing the policy that was in force
+/// at the time — the policy is config and config changes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentSupervisionDecision {
+    pub metric: AgentSupervisionMetric,
+    pub action: AgentSupervisionAction,
+    pub limit: u64,
+    pub observed: u64,
+    pub reason: String,
+    pub remediation: String,
+}
+
+impl AgentSupervisionDecision {
+    /// Bounded operator-facing line: what was seen, against what, and what
+    /// Homeboy did about it.
+    pub fn message(&self) -> String {
+        format!(
+            "{}: {}{} exceeds the {} budget of {}{} ({})",
+            self.action.as_str(),
+            self.observed,
+            self.metric.unit(),
+            self.metric.as_str(),
+            self.limit,
+            self.metric.unit(),
+            self.reason,
+        )
+    }
+}
+
+/// The most severe action among a set of decisions.
+pub fn highest_supervision_action(
+    decisions: &[AgentSupervisionDecision],
+) -> Option<AgentSupervisionAction> {
+    decisions.iter().map(|decision| decision.action).max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(budgets: Vec<AgentSupervisionBudget>) -> AgentSupervisionPolicy {
+        AgentSupervisionPolicy {
+            budgets,
+            ..AgentSupervisionPolicy::default()
+        }
+    }
+
+    fn sample() -> AgentSupervisionSample {
+        AgentSupervisionSample {
+            elapsed_seconds: Some(600),
+            rss_mib: Some(9_216),
+            child_processes: Some(41),
+            no_progress_seconds: Some(120),
+        }
+    }
+
+    #[test]
+    fn an_undeclared_policy_supervises_nothing() {
+        let policy = AgentSupervisionPolicy::default();
+
+        assert!(policy.is_unconstrained());
+        assert!(policy.is_unconstrained_for(Some("opencode")));
+        assert!(policy.evaluate(None, &sample()).is_empty());
+    }
+
+    #[test]
+    fn a_breached_budget_reports_the_observation_and_the_threshold() {
+        // The dogfood shape from #7015: high peak RSS across many child
+        // processes, which was only visible after the run.
+        let policy = policy(vec![AgentSupervisionBudget::with_reason(
+            AgentSupervisionMetric::RssMib,
+            8_192,
+            AgentSupervisionAction::Warn,
+            "this box has 15Gi and four agents on it",
+        )]);
+
+        let decisions = policy.evaluate(None, &sample());
+
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].metric, AgentSupervisionMetric::RssMib);
+        assert_eq!(decisions[0].action, AgentSupervisionAction::Warn);
+        assert_eq!(decisions[0].observed, 9_216);
+        assert_eq!(decisions[0].limit, 8_192);
+        assert!(decisions[0].message().contains("9216 MiB"));
+        assert!(decisions[0].message().contains("four agents"));
+        assert_eq!(decisions[0].remediation, SUPERVISION_WARNING_REMEDIATION);
+    }
+
+    #[test]
+    fn the_limit_is_a_ceiling_not_a_trigger() {
+        let policy = policy(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::ChildProcesses,
+            41,
+            AgentSupervisionAction::Stop,
+        )]);
+
+        assert!(policy.evaluate(None, &sample()).is_empty());
+    }
+
+    #[test]
+    fn the_ladder_reports_only_the_highest_rung_reached_on_a_metric() {
+        // "Tell me at 6 GiB, stop it at 8" is two budgets on one metric, and a
+        // sample past both is one decision — the stop — not two.
+        let policy = policy(vec![
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                6_144,
+                AgentSupervisionAction::Warn,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                7_168,
+                AgentSupervisionAction::Nudge,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                8_192,
+                AgentSupervisionAction::Stop,
+            ),
+        ]);
+
+        let decisions = policy.evaluate(None, &sample());
+
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].action, AgentSupervisionAction::Stop);
+        assert_eq!(decisions[0].limit, 8_192);
+        assert_eq!(decisions[0].remediation, SUPERVISION_STOP_REMEDIATION);
+        assert_eq!(
+            highest_supervision_action(&decisions),
+            Some(AgentSupervisionAction::Stop)
+        );
+    }
+
+    #[test]
+    fn equally_severe_budgets_report_the_higher_threshold_crossed() {
+        let policy = policy(vec![
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                2_048,
+                AgentSupervisionAction::Warn,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                8_192,
+                AgentSupervisionAction::Warn,
+            ),
+        ]);
+
+        let decisions = policy.evaluate(None, &sample());
+
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].limit, 8_192);
+    }
+
+    #[test]
+    fn every_breached_metric_gets_its_own_decision() {
+        let policy = policy(vec![
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                8_192,
+                AgentSupervisionAction::Warn,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::ChildProcesses,
+                16,
+                AgentSupervisionAction::Nudge,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::NoProgressSeconds,
+                60,
+                AgentSupervisionAction::Stop,
+            ),
+        ]);
+
+        let decisions = policy.evaluate(None, &sample());
+
+        assert_eq!(decisions.len(), 3);
+        assert_eq!(
+            highest_supervision_action(&decisions),
+            Some(AgentSupervisionAction::Stop)
+        );
+    }
+
+    #[test]
+    fn an_unobserved_metric_never_breaches() {
+        // A non-Unix host has no process table and a worktree-less cook has no
+        // progress reading. Neither may be killed for it.
+        let policy = policy(vec![
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                1,
+                AgentSupervisionAction::Stop,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::ChildProcesses,
+                1,
+                AgentSupervisionAction::Stop,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::NoProgressSeconds,
+                1,
+                AgentSupervisionAction::Stop,
+            ),
+        ]);
+        let unobserved = AgentSupervisionSample {
+            elapsed_seconds: Some(600),
+            ..AgentSupervisionSample::default()
+        };
+
+        assert!(policy.evaluate(None, &unobserved).is_empty());
+        assert!(AgentSupervisionSample::default().is_empty());
+        assert!(!unobserved.is_empty());
+    }
+
+    #[test]
+    fn a_backend_entry_replaces_the_global_budgets_rather_than_merging_them() {
+        // A backend that legitimately needs more memory must be able to say so
+        // without the global number still firing underneath it.
+        let mut backends = BTreeMap::new();
+        backends.insert(
+            "opencode".to_string(),
+            vec![AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                12_288,
+                AgentSupervisionAction::Stop,
+            )],
+        );
+        let policy = AgentSupervisionPolicy {
+            budgets: vec![AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                4_096,
+                AgentSupervisionAction::Stop,
+            )],
+            backends,
+            ..AgentSupervisionPolicy::default()
+        };
+
+        assert!(policy.evaluate(Some("opencode"), &sample()).is_empty());
+        assert_eq!(policy.evaluate(Some("claude"), &sample()).len(), 1);
+        assert_eq!(policy.evaluate(None, &sample()).len(), 1);
+        assert!(!policy.is_unconstrained_for(Some("opencode")));
+    }
+
+    #[test]
+    fn a_backend_with_an_empty_budget_set_opts_out_of_supervision() {
+        let mut backends = BTreeMap::new();
+        backends.insert("bench".to_string(), Vec::new());
+        let policy = AgentSupervisionPolicy {
+            budgets: vec![AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                1,
+                AgentSupervisionAction::Stop,
+            )],
+            backends,
+            ..AgentSupervisionPolicy::default()
+        };
+
+        assert!(policy.is_unconstrained_for(Some("bench")));
+        assert!(policy.evaluate(Some("bench"), &sample()).is_empty());
+        assert!(!policy.is_unconstrained());
+    }
+
+    #[test]
+    fn budget_reason_beats_policy_reason_which_beats_the_default() {
+        let reasoned = AgentSupervisionPolicy {
+            budgets: vec![
+                AgentSupervisionBudget::with_reason(
+                    AgentSupervisionMetric::RssMib,
+                    1,
+                    AgentSupervisionAction::Warn,
+                    "memory is the binding constraint here",
+                ),
+                AgentSupervisionBudget::new(
+                    AgentSupervisionMetric::ChildProcesses,
+                    1,
+                    AgentSupervisionAction::Warn,
+                ),
+            ],
+            reason: Some("shared 15Gi VPS".to_string()),
+            ..AgentSupervisionPolicy::default()
+        };
+
+        let decisions = reasoned.evaluate(None, &sample());
+
+        let rss = decisions
+            .iter()
+            .find(|decision| decision.metric == AgentSupervisionMetric::RssMib)
+            .expect("rss decision");
+        assert_eq!(rss.reason, "memory is the binding constraint here");
+        let children = decisions
+            .iter()
+            .find(|decision| decision.metric == AgentSupervisionMetric::ChildProcesses)
+            .expect("child process decision");
+        assert_eq!(children.reason, "shared 15Gi VPS");
+
+        let bare = policy(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::RssMib,
+            1,
+            AgentSupervisionAction::Warn,
+        )]);
+        assert_eq!(
+            bare.evaluate(None, &sample())[0].reason,
+            DEFAULT_SUPERVISION_REASON
+        );
+    }
+
+    #[test]
+    fn the_ladder_orders_from_least_to_most_intervention() {
+        assert!(AgentSupervisionAction::Warn < AgentSupervisionAction::Nudge);
+        assert!(AgentSupervisionAction::Nudge < AgentSupervisionAction::Stop);
+        assert!(!AgentSupervisionAction::Nudge.is_terminal());
+        assert!(AgentSupervisionAction::Stop.is_terminal());
+        assert_eq!(
+            AgentSupervisionAction::default(),
+            AgentSupervisionAction::Warn
+        );
+    }
+
+    #[test]
+    fn policy_round_trips_through_json_with_schema_and_action_defaults() {
+        let raw = serde_json::json!({
+            "budgets": [
+                { "metric": "rss_mib", "limit": 8192, "action": "stop", "reason": "15Gi box" },
+                { "metric": "no_progress_seconds", "limit": 900 }
+            ],
+            "backends": {
+                "opencode": [{ "metric": "child_processes", "limit": 32, "action": "nudge" }]
+            },
+            "reason": "shared host"
+        });
+
+        let policy: AgentSupervisionPolicy = serde_json::from_value(raw).expect("policy");
+
+        assert_eq!(policy.schema, AGENT_SUPERVISION_POLICY_SCHEMA);
+        assert_eq!(policy.budgets.len(), 2);
+        // An omitted action is the gentlest rung, never the most severe one.
+        assert_eq!(policy.budgets[1].action, AgentSupervisionAction::Warn);
+        assert_eq!(
+            policy.backends["opencode"][0].metric,
+            AgentSupervisionMetric::ChildProcesses
+        );
+
+        let encoded = serde_json::to_value(&policy).expect("encode");
+        let decoded: AgentSupervisionPolicy = serde_json::from_value(encoded).expect("decode");
+        assert_eq!(decoded, policy);
+    }
+
+    #[test]
+    fn decisions_round_trip_through_their_durable_projection() {
+        let decision = policy(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::NoProgressSeconds,
+            60,
+            AgentSupervisionAction::Stop,
+        )])
+        .evaluate(None, &sample())
+        .remove(0);
+
+        let value = serde_json::to_value(&decision).expect("encode");
+        assert_eq!(value["metric"], "no_progress_seconds");
+        assert_eq!(value["action"], "stop");
+        let restored: AgentSupervisionDecision = serde_json::from_value(value).expect("decode");
+        assert_eq!(restored, decision);
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1566,6 +1566,113 @@ pub fn record_cook_observer_event(
     record.ok_or_else(|| Error::internal_unexpected("Cook observer event record was unchanged"))
 }
 
+/// Entries retained in the durable resource timeline.
+///
+/// At the fifteen-second heartbeat interval this is a rolling hour. A timeline
+/// is only useful if it survives the run that produced it, and an unbounded one
+/// would not: a long cook would grow its run record without limit, and the
+/// record is rewritten on every heartbeat.
+const MAX_COOK_RESOURCE_SAMPLES: usize = 240;
+
+/// Supervision events retained. Decisions are announced on escalation only, so
+/// a run reaches a handful of these, not hundreds.
+const MAX_COOK_SUPERVISION_EVENTS: usize = 32;
+
+/// Persist one supervision tick: the resource observation, plus any decision
+/// the policy reached on it.
+///
+/// The two land in different places on purpose. The **timeline** is a rolling
+/// window of what the run cost, which answers "was this expensive?" and is
+/// naturally lossy at the head. The **events** are the decisions Homeboy took,
+/// which answer "why was this stopped?" and must not be evicted by a long tail
+/// of routine samples. Collapsing them into one array would let an hour of
+/// quiet heartbeats push the stop decision out of the evidence that exists to
+/// explain the stop (#7015).
+pub fn record_cook_supervision(
+    run_id: &str,
+    attempt: u32,
+    sample: Option<Value>,
+    decisions: Vec<Value>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let now = now_timestamp();
+        let metadata = record.ensure_metadata_object();
+        if let Some(sample) = sample {
+            let timeline = metadata
+                .entry("cook_resource_timeline".to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            let timeline = timeline
+                .as_array_mut()
+                .expect("cook resource timeline is an array");
+            timeline.push(json!({
+                "at": now,
+                "attempt": attempt,
+                "sample": sample,
+            }));
+            if timeline.len() > MAX_COOK_RESOURCE_SAMPLES {
+                timeline.drain(..timeline.len() - MAX_COOK_RESOURCE_SAMPLES);
+            }
+        }
+        if !decisions.is_empty() {
+            let events = metadata
+                .entry("cook_supervision_events".to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            let events = events
+                .as_array_mut()
+                .expect("cook supervision events are an array");
+            for decision in &decisions {
+                events.push(json!({
+                    "kind": "budget_breached",
+                    "at": now,
+                    "attempt": attempt,
+                    "decision": decision,
+                }));
+            }
+            if events.len() > MAX_COOK_SUPERVISION_EVENTS {
+                events.drain(..events.len() - MAX_COOK_SUPERVISION_EVENTS);
+            }
+        }
+        true
+    })?;
+    record.ok_or_else(|| Error::internal_unexpected("Cook supervision record was unchanged"))
+}
+
+/// Persist the outcome of a supervision-ordered termination.
+///
+/// Recorded separately from the decision that ordered it because the two can
+/// disagree: a policy can order a stop that the host then fails to carry out
+/// (a pid that survives SIGKILL, a non-Unix host with no process-tree
+/// cancellation at all). Evidence that shows only the order would let a reader
+/// conclude a run was stopped when it was not.
+pub fn record_cook_supervision_stop(
+    run_id: &str,
+    attempt: u32,
+    outcome: Value,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let record = store::mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let events = metadata
+            .entry("cook_supervision_events".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let events = events
+            .as_array_mut()
+            .expect("cook supervision events are an array");
+        events.push(json!({
+            "kind": "stop_executed",
+            "at": now_timestamp(),
+            "attempt": attempt,
+            "outcome": outcome,
+        }));
+        if events.len() > MAX_COOK_SUPERVISION_EVENTS {
+            events.drain(..events.len() - MAX_COOK_SUPERVISION_EVENTS);
+        }
+        true
+    })?;
+    record.ok_or_else(|| Error::internal_unexpected("Cook supervision stop was unchanged"))
+}
+
 /// Bind the Cook's authoritative command result to its terminal progress
 /// record. Provider and gate state alone cannot establish whether publication
 /// completed, so readers use this positive completion fact rather than a list

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -198,6 +198,103 @@ fn cook_progress_carries_provider_activity_and_survives_a_failed_probe() {
 }
 
 #[test]
+fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
+    // #7015: the point of the evidence is to answer "why was this stopped?"
+    // after the fact. If the decision shared an array with the sample stream, a
+    // long run would evict the answer with the noise.
+    with_isolated_home(|_| {
+        let run_id = "cook-supervision-evidence";
+        submit_plan(&test_plan(), Some(run_id)).expect("submit run");
+
+        let stopped = record_cook_supervision(
+            run_id,
+            1,
+            Some(json!({ "rss_mib": 10_500, "child_processes": 41 })),
+            vec![json!({
+                "metric": "rss_mib",
+                "action": "stop",
+                "limit": 10_240,
+                "observed": 10_500
+            })],
+        )
+        .expect("record the breach");
+        assert_eq!(
+            stopped.metadata["cook_supervision_events"][0]["decision"]["action"],
+            "stop"
+        );
+
+        let executed = record_cook_supervision_stop(
+            run_id,
+            1,
+            json!({ "status": "terminated", "signal": "SIGTERM" }),
+        )
+        .expect("record the termination outcome");
+        assert_eq!(
+            executed.metadata["cook_supervision_events"][1]["kind"],
+            "stop_executed"
+        );
+
+        // Enough routine heartbeats to overrun the bounded timeline window.
+        let mut record = executed;
+        for beat in 0..300 {
+            record =
+                record_cook_supervision(run_id, 1, Some(json!({ "rss_mib": beat })), Vec::new())
+                    .expect("record a routine sample");
+        }
+
+        let timeline = record.metadata["cook_resource_timeline"]
+            .as_array()
+            .expect("timeline is an array");
+        assert_eq!(
+            timeline.len(),
+            240,
+            "the timeline is a bounded rolling window"
+        );
+        assert_eq!(
+            timeline.last().expect("newest sample")["sample"]["rss_mib"],
+            299,
+            "the window keeps the most recent samples"
+        );
+
+        let events = record.metadata["cook_supervision_events"]
+            .as_array()
+            .expect("events are an array");
+        assert_eq!(
+            events.len(),
+            2,
+            "routine samples never displace a supervision decision"
+        );
+        assert_eq!(events[1]["kind"], "stop_executed");
+    });
+}
+
+#[test]
+fn a_termination_the_host_could_not_carry_out_is_recorded_as_a_failure() {
+    // A policy can order a stop that the host then fails to execute. Evidence
+    // that showed only the order would let a reader conclude a run was stopped
+    // when it is still running.
+    with_isolated_home(|_| {
+        let run_id = "cook-supervision-failed-stop";
+        submit_plan(&test_plan(), Some(run_id)).expect("submit run");
+
+        let record = record_cook_supervision_stop(
+            run_id,
+            1,
+            json!({
+                "status": "termination_failed",
+                "error": "process-tree cancellation is only supported on Unix hosts"
+            }),
+        )
+        .expect("record the failed termination");
+
+        assert_eq!(
+            record.metadata["cook_supervision_events"][0]["outcome"]["status"],
+            "termination_failed"
+        );
+    });
+}
+
+#[test]
 fn provider_run_result_reads_declared_output_alias() {
     let role_aliases: AgentTaskProviderRoleAliases = serde_json::from_value(json!({
         "outputs": {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -46,6 +46,7 @@ use super::cook_promotion::{
     refreshed_moving_base_recovery, retryable_provider_discovery_failure, CookReportInput,
     MovingBaseCookRecovery,
 };
+use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
 use super::AgentTaskRunResult;
 
@@ -2747,23 +2748,94 @@ where
                     );
                     // The provider runs as a descendant of this controller
                     // process, so the controller pid is the root of the tree to
-                    // sample.
+                    // sample — and, when a budget orders a stop, the root of
+                    // the tree to terminate. `terminate_process_tree` excludes
+                    // the calling process, so this ends the provider's work
+                    // without ending the controller that has to record why.
                     let heartbeat_owner_pid = std::process::id();
+                    // Resolved before the thread so a malformed policy document
+                    // fails the attempt loudly. An operator who declared a stop
+                    // budget and silently got none believes this host is
+                    // protected and is not (#7015).
+                    let supervision_policy = resolve_supervision_policy()?;
+                    let supervision_backend = dispatch_plan
+                        .tasks
+                        .first()
+                        .map(|task| task.executor.backend.clone());
                     std::thread::scope(|scope| {
                         scope.spawn(move || {
+                            let mut supervisor =
+                                CookSupervisor::new(supervision_policy, supervision_backend);
                             while let Err(mpsc::RecvTimeoutError::Timeout) =
                                 heartbeat_wait.recv_timeout(COOK_HEARTBEAT_INTERVAL)
                             {
                                 let activity = heartbeat_activity.sample(heartbeat_owner_pid);
+                                let tick = supervisor.observe(&activity);
+                                let detail = tick.detail_line();
                                 let _ = report_cook_progress_with_activity(
                                     durable_observer,
                                     &heartbeat_cook_id,
                                     &heartbeat_run_id,
                                     "heartbeat",
                                     attempt,
-                                    Some("provider execution is still running"),
+                                    Some(
+                                        detail
+                                            .as_deref()
+                                            .unwrap_or("provider execution is still running"),
+                                    ),
                                     (!activity.is_empty()).then_some(&activity),
                                 );
+                                // Supervision evidence is written even when the
+                                // policy is undeclared: the resource timeline is
+                                // how "was this run expensive?" stops being a
+                                // question only answerable by having watched it.
+                                if !tick.is_empty() {
+                                    let _ = agent_task_lifecycle::record_cook_supervision(
+                                        &heartbeat_run_id,
+                                        attempt,
+                                        (!tick.sample.is_empty())
+                                            .then(|| serde_json::to_value(tick.sample))
+                                            .and_then(std::result::Result::ok),
+                                        tick.decisions
+                                            .iter()
+                                            .filter_map(|decision| {
+                                                serde_json::to_value(decision).ok()
+                                            })
+                                            .collect(),
+                                    );
+                                }
+                                if tick.stop_now {
+                                    let outcome = match homeboy_core::process::terminate_process_tree(
+                                        heartbeat_owner_pid,
+                                    ) {
+                                        Ok(termination) => serde_json::json!({
+                                            "status": "terminated",
+                                            "signal": termination.signal,
+                                            "signalled_pids": termination.signalled_pids,
+                                            "killed_pids": termination.killed_pids,
+                                            "surviving_pids": termination.surviving_pids,
+                                            "recovery_commands": termination.recovery_commands,
+                                        }),
+                                        // A host that cannot terminate a tree
+                                        // (no process-tree cancellation, a pid
+                                        // that outlives SIGKILL) must say so.
+                                        // Recording the order alone would let a
+                                        // reader conclude the run was stopped.
+                                        Err(error) => serde_json::json!({
+                                            "status": "termination_failed",
+                                            "error": error.to_string(),
+                                            "recovery_commands":
+                                                homeboy_core::process::process_tree_recovery_commands(
+                                                    heartbeat_owner_pid,
+                                                ),
+                                        }),
+                                    };
+                                    let _ = agent_task_lifecycle::record_cook_supervision_stop(
+                                        &heartbeat_run_id,
+                                        attempt,
+                                        outcome,
+                                    );
+                                }
                             }
                         });
                         let result = run_loaded_plan_with_derived_cook_baseline(

--- a/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_activity.rs
@@ -79,6 +79,26 @@ pub struct CookProviderActivity {
     /// current activity.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub elapsed_seconds: Option<u64>,
+    /// Resident memory held by the selected provider command alone, in MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rss_mib: Option<u64>,
+    /// Resident memory summed across every process under the cook, in MiB.
+    ///
+    /// This is the number that matters to a host: a provider holding 300 MiB
+    /// while four linkers hold two gigabytes each is not a light run. Summing
+    /// double-counts shared pages, so it is an upper bound — the safe side for
+    /// a supervision budget, and the number an operator watching a box run out
+    /// of memory is already reasoning about.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tree_rss_mib: Option<u64>,
+    /// Processes observed under the cook, Homeboy's own included.
+    ///
+    /// Set whenever the process table was read at all, including when no
+    /// process in it could be attributed to the provider — "we looked, there
+    /// are nineteen processes, none of them is the provider" is a coherent and
+    /// useful statement. Absent only when no sample was taken.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub child_processes: Option<usize>,
 }
 
 impl CookProviderActivity {
@@ -120,6 +140,16 @@ impl CookProviderActivity {
             // process sample that found nothing (#11598).
             parts.push(format!("provider command unavailable: {reason}"));
         }
+        // Cost reads next to progress on purpose: "no files written yet" and
+        // "9216 MiB across 41 processes" are the same sentence in an operator's
+        // head, and splitting them is why the cost of a run was only ever
+        // discovered afterwards (#7015).
+        if let Some(rss) = self.tree_rss_mib.or(self.rss_mib) {
+            parts.push(format!("{rss} MiB RSS"));
+        }
+        if let Some(children) = self.child_processes {
+            parts.push(format!("{children} process(es)"));
+        }
         if let Some(seconds) = self.elapsed_seconds {
             parts.push(format!("{} elapsed", format_duration(seconds)));
         }
@@ -130,6 +160,16 @@ impl CookProviderActivity {
     pub fn to_record_value(&self) -> Option<Value> {
         (!self.is_empty()).then(|| serde_json::to_value(self).unwrap_or(Value::Null))
     }
+}
+
+/// Convert a `ps` KiB reading to the MiB a supervision budget is written in.
+///
+/// Rounds down, so a budget is never breached by a rounding artefact. The
+/// resolution loss is irrelevant at the scale budgets are set at, and erring
+/// toward "under the limit" is the correct direction for something that can
+/// terminate a run.
+fn kib_to_mib(kib: u64) -> u64 {
+    kib / 1_024
 }
 
 /// Render seconds the way an operator reads them off a stalled cook.
@@ -185,12 +225,23 @@ impl CookActivityProbe {
         // suppress it.
         let ProviderActivitySample {
             activity: provider_process,
+            descendant_count,
+            tree_rss_kib,
             unavailable,
-            ..
         } = process_activity::descendant_activity(owner_pid);
+        // A tree whose provider could not be identified was still counted and
+        // still weighed. Resource facts therefore attach to *any* successful
+        // read of the process table, not only to one that produced a command;
+        // a sample that was never taken (no `ps`, non-Unix host) leaves them
+        // absent rather than reporting an empty machine.
+        if provider_process.is_some() || unavailable.is_some() {
+            activity.child_processes = Some(descendant_count);
+        }
+        activity.tree_rss_mib = tree_rss_kib.map(kib_to_mib);
         if let Some(DescendantActivity {
             pid,
             elapsed_seconds,
+            rss_kib,
             command,
             source,
             activity_type,
@@ -200,6 +251,7 @@ impl CookActivityProbe {
             activity.command = Some(command);
             activity.command_pid = Some(pid);
             activity.command_elapsed_seconds = Some(elapsed_seconds);
+            activity.rss_mib = rss_kib.map(kib_to_mib);
             activity.activity_source = Some(source.to_string());
             activity.activity_type = Some(activity_type.to_string());
         } else if let Some(unavailable) = unavailable {
@@ -361,6 +413,74 @@ mod tests {
     }
 
     #[test]
+    fn resource_cost_reads_alongside_progress_in_the_summary_line() {
+        // The #7015 dogfood shape: an expensive run whose cost was only visible
+        // after it ended. It has to be one line, next to the edit count.
+        let activity = CookProviderActivity {
+            files_changed: Some(0),
+            command: Some("cargo build".to_string()),
+            command_elapsed_seconds: Some(372),
+            tree_rss_mib: Some(9_216),
+            rss_mib: Some(310),
+            child_processes: Some(41),
+            elapsed_seconds: Some(400),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(summary.starts_with("no files written yet"));
+        // The tree figure wins: one process holding 310 MiB inside a tree
+        // holding nine gigabytes is not the number that matters.
+        assert!(summary.contains("9216 MiB RSS"));
+        assert!(!summary.contains("310 MiB"));
+        assert!(summary.contains("41 process(es)"));
+        assert!(summary.contains("6m40s elapsed"));
+    }
+
+    #[test]
+    fn a_sample_without_a_tree_reading_falls_back_to_the_command_footprint() {
+        let activity = CookProviderActivity {
+            rss_mib: Some(310),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            activity.summary_line().as_deref(),
+            Some("310 MiB RSS"),
+            "a partial reading is still worth reporting"
+        );
+    }
+
+    #[test]
+    fn unmeasured_resources_are_absent_rather_than_reported_as_zero() {
+        // A non-Unix host, or one whose `ps` failed, must not render as a
+        // machine with no memory and no processes.
+        let activity = CookProviderActivity {
+            files_changed: Some(2),
+            elapsed_seconds: Some(30),
+            ..Default::default()
+        };
+
+        let summary = activity.summary_line().expect("activity renders");
+
+        assert!(!summary.contains("MiB"));
+        assert!(!summary.contains("process(es)"));
+        assert_eq!(activity.child_processes, None);
+        assert_eq!(activity.tree_rss_mib, None);
+    }
+
+    #[test]
+    fn kib_readings_round_down_into_the_unit_budgets_are_written_in() {
+        // Rounding down keeps a rounding artefact from crossing a threshold
+        // that can terminate a run.
+        assert_eq!(kib_to_mib(0), 0);
+        assert_eq!(kib_to_mib(1_023), 0);
+        assert_eq!(kib_to_mib(1_024), 1);
+        assert_eq!(kib_to_mib(9_437_183), 9_215);
+    }
+
+    #[test]
     fn an_empty_sample_renders_nothing_rather_than_an_empty_line() {
         let activity = CookProviderActivity::default();
 
@@ -427,6 +547,9 @@ mod tests {
             command_unavailable: None,
             command_elapsed_seconds: Some(12),
             elapsed_seconds: Some(30),
+            rss_mib: Some(512),
+            tree_rss_mib: Some(2_048),
+            child_processes: Some(7),
         };
 
         let value = activity.to_record_value().expect("non-empty activity");

--- a/crates/homeboy-agents/src/agent_task_service/cook_supervision.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_supervision.rs
@@ -1,0 +1,478 @@
+//! Supervision of a running Cook against its declared resource budgets.
+//!
+//! The sibling `cook_activity` module answers "what is the provider doing, and
+//! what is it holding". This module turns that observation into a decision.
+//! Without it Homeboy sampled a running cook every fifteen seconds, wrote the
+//! sample down, and then waited for the process boundary regardless of what the
+//! sample said — the orchestrator watched the fire and did not own an
+//! extinguisher (#7015).
+//!
+//! Three things live here and nothing else:
+//!
+//! 1. **Projection.** A [`CookProviderActivity`] sample becomes a generic
+//!    [`AgentSupervisionSample`]. This is the seam that keeps the policy
+//!    runtime-neutral: the policy never sees a worktree, a `ps` row, or a
+//!    provider.
+//! 2. **Stall accounting.** "Seconds since the worktree last changed" is the
+//!    one metric that cannot be read from a single sample, so the supervisor
+//!    carries the minimum state needed to derive it across ticks.
+//! 3. **Escalation.** A breached budget is announced once, and again only when
+//!    it climbs the ladder. A heartbeat that repeats the same warning every
+//!    fifteen seconds trains an operator to ignore the whole channel.
+//!
+//! Enforcement of a `stop` is not here: this module decides, and the cook
+//! orchestration acts, because terminating a process tree is a lifecycle
+//! concern and this file deliberately owns no lifecycle.
+
+use std::collections::BTreeMap;
+
+use crate::agent_task::{
+    AgentSupervisionAction, AgentSupervisionDecision, AgentSupervisionMetric,
+    AgentSupervisionPolicy, AgentSupervisionSample,
+};
+use homeboy_core::{defaults, Error, Result};
+
+use super::cook_activity::CookProviderActivity;
+
+/// Load the host's supervision policy.
+///
+/// A malformed document is an error rather than a silently ignored one. The
+/// alternative is an operator who declared a stop budget, believes the host is
+/// protected, and is not — which is worse than having declared nothing, because
+/// it is indistinguishable from working.
+pub fn resolve_supervision_policy() -> Result<AgentSupervisionPolicy> {
+    match defaults::load_config().agent_task.supervision_policy {
+        Some(raw) => serde_json::from_value::<AgentSupervisionPolicy>(raw).map_err(|error| {
+            Error::validation_invalid_argument(
+                "agent_task.supervision_policy",
+                format!(
+                    "configured agent_task.supervision_policy is not a valid \
+homeboy/agent-supervision-policy/v1 document: {error}"
+                ),
+                None,
+                Some(vec![
+                    "Example: homeboy config set /agent_task/supervision_policy '{\"budgets\":[{\"metric\":\"rss_mib\",\"limit\":8192,\"action\":\"stop\",\"reason\":\"shared 15Gi host\"}]}' --json".to_string(),
+                ]),
+            )
+        }),
+        None => Ok(AgentSupervisionPolicy::default()),
+    }
+}
+
+/// What one supervision tick concluded.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CookSupervisionTick {
+    /// The generic sample, for the durable resource timeline.
+    pub sample: AgentSupervisionSample,
+    /// Decisions reached *on this tick*: a first breach, or an escalation of
+    /// one already reported. A budget that stays breached at the same rung
+    /// yields nothing, so the supervision channel stays worth reading.
+    pub decisions: Vec<AgentSupervisionDecision>,
+    /// True on the single tick that first reaches `stop`. The caller terminates
+    /// the provider tree exactly once; a repeated stop would signal a tree that
+    /// is already being torn down.
+    pub stop_now: bool,
+}
+
+impl CookSupervisionTick {
+    /// One bounded line for the heartbeat's detail field.
+    pub fn detail_line(&self) -> Option<String> {
+        if self.decisions.is_empty() {
+            return None;
+        }
+        Some(
+            self.decisions
+                .iter()
+                .map(AgentSupervisionDecision::message)
+                .collect::<Vec<_>>()
+                .join("; "),
+        )
+    }
+
+    /// True when the tick produced nothing worth writing down.
+    pub fn is_empty(&self) -> bool {
+        self.sample.is_empty() && self.decisions.is_empty()
+    }
+}
+
+/// Stateful supervisor for one provider execution.
+pub struct CookSupervisor {
+    policy: AgentSupervisionPolicy,
+    backend: Option<String>,
+    /// Worktree progress as last observed: `(files_changed, commits_written)`.
+    ///
+    /// A commit clears the pending-edit count, so progress has to be the pair.
+    /// Watching `files_changed` alone would read a provider that just committed
+    /// as a provider that has undone its work.
+    last_progress: Option<(usize, usize)>,
+    /// Elapsed reading at which `last_progress` was first seen.
+    last_progress_at_seconds: u64,
+    /// Highest rung already announced per metric.
+    announced: BTreeMap<AgentSupervisionMetric, AgentSupervisionAction>,
+    stop_issued: bool,
+}
+
+impl CookSupervisor {
+    pub fn new(policy: AgentSupervisionPolicy, backend: Option<String>) -> Self {
+        Self {
+            policy,
+            backend,
+            last_progress: None,
+            last_progress_at_seconds: 0,
+            announced: BTreeMap::new(),
+            stop_issued: false,
+        }
+    }
+
+    /// True when no budget applies to this execution, so no decision can be
+    /// reached however extreme the samples get.
+    ///
+    /// Sampling continues regardless: supervision is opt-in but *observation*
+    /// is not, and the resource timeline is what turns "was this run
+    /// expensive?" from a question you had to be watching to answer into one
+    /// the run record answers afterwards.
+    pub fn is_inactive(&self) -> bool {
+        self.policy.is_unconstrained_for(self.backend.as_deref())
+    }
+
+    /// True once a `stop` has been issued for this execution.
+    pub fn stop_issued(&self) -> bool {
+        self.stop_issued
+    }
+
+    /// Fold one activity sample into the supervision state.
+    pub fn observe(&mut self, activity: &CookProviderActivity) -> CookSupervisionTick {
+        let sample = self.project(activity);
+        if self.is_inactive() {
+            return CookSupervisionTick {
+                sample,
+                decisions: Vec::new(),
+                stop_now: false,
+            };
+        }
+        let evaluated = self.policy.evaluate(self.backend.as_deref(), &sample);
+        let mut decisions = Vec::new();
+        for decision in evaluated {
+            let escalates = match self.announced.get(&decision.metric) {
+                Some(announced) => decision.action > *announced,
+                None => true,
+            };
+            if escalates {
+                self.announced.insert(decision.metric, decision.action);
+                decisions.push(decision);
+            }
+        }
+        let stop_now = !self.stop_issued
+            && decisions
+                .iter()
+                .any(|decision| decision.action.is_terminal());
+        if stop_now {
+            self.stop_issued = true;
+        }
+        CookSupervisionTick {
+            sample,
+            decisions,
+            stop_now,
+        }
+    }
+
+    /// Project a Cook-shaped observation onto the runtime-neutral metrics.
+    ///
+    /// Every absent field stays absent. The temptation to substitute a zero is
+    /// exactly the bug that would make a Windows host — where there is no `ps`
+    /// and therefore no memory or process reading at all — breach a memory
+    /// budget on its first heartbeat.
+    fn project(&mut self, activity: &CookProviderActivity) -> AgentSupervisionSample {
+        AgentSupervisionSample {
+            elapsed_seconds: activity.elapsed_seconds,
+            rss_mib: activity.tree_rss_mib.or(activity.rss_mib),
+            child_processes: activity.child_processes.map(|count| count as u64),
+            no_progress_seconds: self.no_progress_seconds(activity),
+        }
+    }
+
+    /// Seconds since the worktree last changed, or `None` when progress is not
+    /// measurable at all.
+    ///
+    /// Unmeasurable is the honest answer for a cook with no destination
+    /// worktree and for one whose worktree could not be read: a stall budget
+    /// must not fire on a cook whose progress nobody can see.
+    fn no_progress_seconds(&mut self, activity: &CookProviderActivity) -> Option<u64> {
+        let elapsed = activity.elapsed_seconds?;
+        let progress = (
+            activity.files_changed?,
+            activity.commits_written.unwrap_or(0),
+        );
+        if self.last_progress != Some(progress) {
+            self.last_progress = Some(progress);
+            self.last_progress_at_seconds = elapsed;
+        }
+        Some(elapsed.saturating_sub(self.last_progress_at_seconds))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task::AgentSupervisionBudget;
+    use std::collections::BTreeMap;
+
+    fn supervisor(budgets: Vec<AgentSupervisionBudget>) -> CookSupervisor {
+        CookSupervisor::new(
+            AgentSupervisionPolicy {
+                budgets,
+                ..AgentSupervisionPolicy::default()
+            },
+            Some("opencode".to_string()),
+        )
+    }
+
+    fn activity(elapsed: u64, rss_mib: u64, children: usize) -> CookProviderActivity {
+        CookProviderActivity {
+            elapsed_seconds: Some(elapsed),
+            tree_rss_mib: Some(rss_mib),
+            child_processes: Some(children),
+            files_changed: Some(0),
+            commits_written: Some(0),
+            ..CookProviderActivity::default()
+        }
+    }
+
+    #[test]
+    fn an_undeclared_policy_samples_without_deciding_anything() {
+        // Supervision is opt-in: an unconfigured host keeps behaving exactly as
+        // it did, while the evidence gets richer for free.
+        let mut supervisor = supervisor(Vec::new());
+
+        let tick = supervisor.observe(&activity(60, 9_216, 41));
+
+        assert!(supervisor.is_inactive());
+        assert!(tick.decisions.is_empty());
+        assert!(!tick.stop_now);
+        assert_eq!(tick.sample.rss_mib, Some(9_216));
+        assert_eq!(tick.sample.child_processes, Some(41));
+        assert_eq!(tick.detail_line(), None);
+    }
+
+    #[test]
+    fn a_breach_is_announced_once_and_again_only_when_it_escalates() {
+        // A heartbeat that repeats the same warning every fifteen seconds
+        // teaches an operator to stop reading heartbeats.
+        let mut supervisor = supervisor(vec![
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                4_096,
+                AgentSupervisionAction::Warn,
+            ),
+            AgentSupervisionBudget::new(
+                AgentSupervisionMetric::RssMib,
+                8_192,
+                AgentSupervisionAction::Stop,
+            ),
+        ]);
+
+        let first = supervisor.observe(&activity(15, 5_000, 4));
+        assert_eq!(first.decisions.len(), 1);
+        assert_eq!(first.decisions[0].action, AgentSupervisionAction::Warn);
+        assert!(!first.stop_now);
+
+        // Still warning, still over: nothing new to say.
+        let repeat = supervisor.observe(&activity(30, 6_000, 4));
+        assert!(repeat.decisions.is_empty());
+        assert!(!repeat.stop_now);
+
+        let escalated = supervisor.observe(&activity(45, 9_216, 4));
+        assert_eq!(escalated.decisions.len(), 1);
+        assert_eq!(escalated.decisions[0].action, AgentSupervisionAction::Stop);
+        assert!(escalated.stop_now);
+        assert!(supervisor.stop_issued());
+
+        // The stop is issued exactly once; the tree is already being torn down.
+        let after = supervisor.observe(&activity(60, 9_216, 4));
+        assert!(!after.stop_now);
+    }
+
+    #[test]
+    fn a_stall_is_measured_from_the_last_worktree_change() {
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::NoProgressSeconds,
+            60,
+            AgentSupervisionAction::Stop,
+        )]);
+
+        // Baseline: the first observation is the reference, not a stall.
+        let first = supervisor.observe(&activity(15, 100, 2));
+        assert_eq!(first.sample.no_progress_seconds, Some(0));
+        assert!(first.decisions.is_empty());
+
+        let stalling = supervisor.observe(&activity(70, 100, 2));
+        assert_eq!(stalling.sample.no_progress_seconds, Some(55));
+        assert!(stalling.decisions.is_empty());
+
+        let stalled = supervisor.observe(&activity(90, 100, 2));
+        assert_eq!(stalled.sample.no_progress_seconds, Some(75));
+        assert!(stalled.stop_now);
+    }
+
+    #[test]
+    fn writing_a_file_resets_the_stall_clock() {
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::NoProgressSeconds,
+            60,
+            AgentSupervisionAction::Stop,
+        )]);
+
+        supervisor.observe(&activity(15, 100, 2));
+        assert_eq!(
+            supervisor
+                .observe(&activity(60, 100, 2))
+                .sample
+                .no_progress_seconds,
+            Some(45)
+        );
+
+        let mut edited = activity(70, 100, 2);
+        edited.files_changed = Some(3);
+        assert_eq!(
+            supervisor.observe(&edited).sample.no_progress_seconds,
+            Some(0)
+        );
+
+        let mut still_editing = activity(100, 100, 2);
+        still_editing.files_changed = Some(3);
+        assert_eq!(
+            supervisor
+                .observe(&still_editing)
+                .sample
+                .no_progress_seconds,
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn a_commit_is_progress_even_though_it_clears_the_pending_edit_count() {
+        // A provider that commits leaves a clean tree. Watching `files_changed`
+        // alone would read that as having undone its work and start a stall
+        // clock on a cook that just succeeded at something.
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::NoProgressSeconds,
+            60,
+            AgentSupervisionAction::Stop,
+        )]);
+
+        let mut editing = activity(15, 100, 2);
+        editing.files_changed = Some(4);
+        supervisor.observe(&editing);
+
+        let mut committed = activity(80, 100, 2);
+        committed.files_changed = Some(0);
+        committed.commits_written = Some(1);
+
+        let tick = supervisor.observe(&committed);
+
+        assert_eq!(tick.sample.no_progress_seconds, Some(0));
+        assert!(tick.decisions.is_empty());
+        assert!(!tick.stop_now);
+    }
+
+    #[test]
+    fn an_unmeasurable_worktree_never_starts_a_stall_clock() {
+        // A cook with no destination worktree, or one whose worktree could not
+        // be read, has no progress signal. Killing it for that would punish the
+        // probe's failure rather than the provider's.
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::NoProgressSeconds,
+            1,
+            AgentSupervisionAction::Stop,
+        )]);
+        let unmeasurable = CookProviderActivity {
+            elapsed_seconds: Some(6_000),
+            ..CookProviderActivity::default()
+        };
+
+        let tick = supervisor.observe(&unmeasurable);
+
+        assert_eq!(tick.sample.no_progress_seconds, None);
+        assert!(tick.decisions.is_empty());
+        assert!(!tick.stop_now);
+    }
+
+    #[test]
+    fn a_host_that_cannot_read_its_process_table_is_never_stopped_for_memory() {
+        // The non-Unix case, and the failed-`ps` case. Both must decline to
+        // decide rather than decide on a fabricated zero.
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::new(
+            AgentSupervisionMetric::RssMib,
+            0,
+            AgentSupervisionAction::Stop,
+        )]);
+        let unsampled = CookProviderActivity {
+            elapsed_seconds: Some(600),
+            files_changed: Some(2),
+            ..CookProviderActivity::default()
+        };
+
+        let tick = supervisor.observe(&unsampled);
+
+        assert_eq!(tick.sample.rss_mib, None);
+        assert_eq!(tick.sample.child_processes, None);
+        assert!(tick.decisions.is_empty());
+        assert!(!tick.stop_now);
+    }
+
+    #[test]
+    fn a_backend_specific_budget_supervises_only_that_backend() {
+        let mut backends = BTreeMap::new();
+        backends.insert(
+            "opencode".to_string(),
+            vec![AgentSupervisionBudget::new(
+                AgentSupervisionMetric::ChildProcesses,
+                8,
+                AgentSupervisionAction::Stop,
+            )],
+        );
+        let policy = AgentSupervisionPolicy {
+            backends,
+            ..AgentSupervisionPolicy::default()
+        };
+
+        let mut supervised = CookSupervisor::new(policy.clone(), Some("opencode".to_string()));
+        assert!(supervised.observe(&activity(15, 100, 41)).stop_now);
+
+        let mut unsupervised = CookSupervisor::new(policy, Some("claude".to_string()));
+        assert!(unsupervised.is_inactive());
+        assert!(!unsupervised.observe(&activity(15, 100, 41)).stop_now);
+    }
+
+    #[test]
+    fn the_detail_line_states_the_observation_the_threshold_and_the_reason() {
+        let mut supervisor = supervisor(vec![AgentSupervisionBudget::with_reason(
+            AgentSupervisionMetric::RssMib,
+            8_192,
+            AgentSupervisionAction::Stop,
+            "this box has 15Gi and four agents on it",
+        )]);
+
+        let tick = supervisor.observe(&activity(15, 9_216, 41));
+        let line = tick.detail_line().expect("a decision renders");
+
+        assert!(line.starts_with("stop:"));
+        assert!(line.contains("9216 MiB"));
+        assert!(line.contains("8192 MiB"));
+        assert!(line.contains("four agents"));
+        assert!(!tick.is_empty());
+    }
+
+    #[test]
+    fn a_malformed_policy_document_does_not_parse_into_a_permissive_policy() {
+        // `resolve_supervision_policy` turns this into a hard error rather than
+        // silently supervising nothing: an operator who declared a stop budget
+        // and got a silently ignored one believes the host is protected and is
+        // not.
+        let parsed = serde_json::from_value::<AgentSupervisionPolicy>(serde_json::json!({
+            "budgets": [{ "metric": "gigabytes", "limit": 8 }]
+        }));
+
+        assert!(parsed.is_err());
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -13,6 +13,8 @@ mod cook_budget;
 mod cook_pre_execution;
 mod cook_promotion;
 mod cook_recipe;
+/// Resource supervision of a running Cook against its declared budgets.
+mod cook_supervision;
 mod discovery;
 mod execution;
 /// Read-only process-tree activity sampling for a running Cook.
@@ -35,6 +37,7 @@ pub use cook_budget::*;
 pub(crate) use cook_pre_execution::*;
 pub use cook_promotion::*;
 pub use cook_recipe::*;
+pub use cook_supervision::{resolve_supervision_policy, CookSupervisionTick, CookSupervisor};
 pub use discovery::*;
 pub use execution::*;
 pub use promotion_service::*;

--- a/crates/homeboy-agents/src/agent_task_service/process_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/process_activity.rs
@@ -26,11 +26,25 @@ use std::process::Command;
 /// and its leading arguments — so truncate rather than drop.
 pub const MAX_ACTIVITY_COMMAND_CHARS: usize = 200;
 
+/// The `ps` projection [`descendant_activity`] requests.
+///
+/// `rss` is in the projection because supervision needs a resource number, and
+/// the walk that already answers "what is this tree doing" is the cheapest
+/// place to also answer "how much is it holding". One `ps` still, one column
+/// wider.
+pub const PS_ACTIVITY_FORMAT: &str = "pid=,ppid=,rss=,etime=,args=";
+
 /// One row of the process table, as sampled from `ps`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProcessActivityRow {
     pub pid: u32,
     pub ppid: u32,
+    /// Resident set size in KiB, when the projection carried one.
+    ///
+    /// `None` rather than `0` when the column is absent: a `ps` that did not
+    /// report memory is not a process holding no memory, and a supervision
+    /// budget must never fire on a fabricated zero.
+    pub rss_kib: Option<u64>,
     /// Wall-clock seconds since this process started.
     pub elapsed_seconds: u64,
     pub command: String,
@@ -44,6 +58,8 @@ pub struct DescendantActivity {
     /// provider process itself); `2` and deeper is work the provider spawned.
     pub depth: usize,
     pub elapsed_seconds: u64,
+    /// Resident set size of the selected process alone, in KiB, when observed.
+    pub rss_kib: Option<u64>,
     /// Command line, truncated to [`MAX_ACTIVITY_COMMAND_CHARS`].
     pub command: String,
     /// Process-table evidence, rather than a controller lifecycle assertion.
@@ -97,6 +113,15 @@ pub struct ProviderActivitySample {
     pub activity: Option<DescendantActivity>,
     /// Descendants observed under the owner, Homeboy's own processes included.
     pub descendant_count: usize,
+    /// Summed resident set size across every observed descendant, in KiB.
+    ///
+    /// Summing double-counts pages shared between a provider and the tools it
+    /// spawned, so this is an upper bound on the tree's footprint rather than a
+    /// precise figure. It is the number an operator watching a box run out of
+    /// memory actually reasons about, and an upper bound is the safe side for a
+    /// budget. `None` when no sampled row carried an `rss` column at all —
+    /// never `0`, which would read as "this tree holds nothing".
+    pub tree_rss_kib: Option<u64>,
     pub unavailable: Option<ActivityUnavailable>,
 }
 
@@ -108,31 +133,53 @@ impl ProviderActivitySample {
     }
 }
 
-/// Parse `ps -axo pid=,ppid=,etime=,args=` output into activity rows.
+/// Parse `ps` activity output into rows.
 ///
 /// Kept separate from the `ps` invocation so selection behavior is testable on
 /// every platform, including ones where the probe itself returns nothing.
+///
+/// Two projections parse here: the current [`PS_ACTIVITY_FORMAT`]
+/// (`pid ppid rss etime args`) and the original memory-free
+/// `pid ppid etime args`. Tolerating both is not backwards compatibility
+/// theatre — durable evidence and recovery commands recorded before the `rss`
+/// column existed are still read back, and a `ps` that silently drops a column
+/// must narrow the sample rather than discard every row in it.
 pub fn parse_process_activity_rows(ps_output: &str) -> Vec<ProcessActivityRow> {
     ps_output
         .lines()
-        .filter_map(|line| {
-            let mut fields = line.split_whitespace();
-            let pid = fields.next()?.parse().ok()?;
-            let ppid = fields.next()?.parse().ok()?;
-            let etime = fields.next()?;
-            let elapsed_seconds = parse_ps_elapsed_seconds(etime)?;
-            // `args` is the remainder of the line, spaces included. Recover it
-            // from the original line rather than re-joining split fields so
-            // internal spacing survives.
-            let command = remainder_after_fields(line, 3).trim().to_string();
-            Some(ProcessActivityRow {
-                pid,
-                ppid,
-                elapsed_seconds,
-                command,
-            })
-        })
+        .filter_map(parse_process_activity_row)
         .collect()
+}
+
+fn parse_process_activity_row(line: &str) -> Option<ProcessActivityRow> {
+    let mut fields = line.split_whitespace();
+    let pid = fields.next()?.parse().ok()?;
+    let ppid = fields.next()?.parse().ok()?;
+    let third = fields.next()?;
+    // `rss` is a bare integer and `etime` is `[[dd-]hh:]mm:ss`, which overlap
+    // only when `etime` is a bare seconds count. Prefer the wider projection
+    // when the field after a numeric third field is itself a valid `etime`,
+    // because that is the shape this module actually asks `ps` for.
+    let (rss_kib, elapsed_seconds, leading_fields) = match third.parse::<u64>().ok() {
+        Some(rss) => match fields.next().and_then(parse_ps_elapsed_seconds) {
+            Some(elapsed) => (Some(rss), elapsed, 4),
+            None => (None, parse_ps_elapsed_seconds(third)?, 3),
+        },
+        None => (None, parse_ps_elapsed_seconds(third)?, 3),
+    };
+    // `args` is the remainder of the line, spaces included. Recover it from the
+    // original line rather than re-joining split fields so internal spacing
+    // survives.
+    let command = remainder_after_fields(line, leading_fields)
+        .trim()
+        .to_string();
+    Some(ProcessActivityRow {
+        pid,
+        ppid,
+        rss_kib,
+        elapsed_seconds,
+        command,
+    })
 }
 
 /// Skip `count` whitespace-separated fields and return the rest of the line.
@@ -222,6 +269,14 @@ pub fn select_provider_activity(
         .filter(|(row, _)| !excluded.contains(&row.pid))
         .collect();
     let descendant_count = descendants.len();
+    // Footprint is a property of the whole tree, not of the one process that
+    // best answers "what is it doing": a provider that spawned four linkers is
+    // holding what the linkers hold. Homeboy's own descendants are counted too
+    // — they are still occupying this host's memory.
+    let tree_rss_kib = descendants
+        .iter()
+        .filter_map(|(row, _)| row.rss_kib)
+        .reduce(u64::saturating_add);
     let selected = descendants
         .iter()
         .filter(|(row, _)| !row.command.is_empty())
@@ -233,17 +288,20 @@ pub fn select_provider_activity(
                 pid: row.pid,
                 depth: *depth,
                 elapsed_seconds: row.elapsed_seconds,
+                rss_kib: row.rss_kib,
                 command: truncate_command(&row.command),
                 source: "process_tree",
                 activity_type: if *depth == 1 { "executor" } else { "tool" },
                 descendant_count,
             }),
             descendant_count,
+            tree_rss_kib,
             unavailable: None,
         },
         None => ProviderActivitySample {
             activity: None,
             descendant_count,
+            tree_rss_kib,
             unavailable: Some(if descendant_count == 0 {
                 ActivityUnavailable::NoDescendants
             } else {
@@ -373,7 +431,7 @@ pub fn descendant_activity(owner_pid: u32) -> ProviderActivitySample {
     #[cfg(unix)]
     {
         let Some(output) = Command::new("ps")
-            .args(["-axo", "pid=,ppid=,etime=,args="])
+            .args(["-axo", PS_ACTIVITY_FORMAT])
             .stdin(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .output()
@@ -426,6 +484,77 @@ mod tests {
             rows[0].command,
             "timeout 1200 cargo test -q -p homeboy-agents"
         );
+    }
+
+    #[test]
+    fn parses_the_resident_set_size_column_of_the_current_projection() {
+        let ps = "4242 100 1048576 06:12 cargo test -q -p homeboy-agents\n";
+
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, 4242);
+        assert_eq!(rows[0].rss_kib, Some(1_048_576));
+        assert_eq!(rows[0].elapsed_seconds, 372);
+        assert_eq!(rows[0].command, "cargo test -q -p homeboy-agents");
+    }
+
+    #[test]
+    fn a_projection_without_memory_narrows_the_row_instead_of_dropping_it() {
+        // The original `pid ppid etime args` projection still parses, and the
+        // absent column reads as "not observed" rather than as zero memory.
+        let ps = "4242 100 06:12 cargo test -q\n";
+
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].rss_kib, None);
+        assert_eq!(rows[0].elapsed_seconds, 372);
+        assert_eq!(rows[0].command, "cargo test -q");
+    }
+
+    #[test]
+    fn a_bare_seconds_etime_is_not_mistaken_for_a_memory_column() {
+        // `etime` degenerates to a bare integer under a minute, which is the
+        // one shape the two projections could be confused over.
+        let ps = "4242 100 05 opencode run\n";
+
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(rows[0].rss_kib, None);
+        assert_eq!(rows[0].elapsed_seconds, 5);
+        assert_eq!(rows[0].command, "opencode run");
+    }
+
+    #[test]
+    fn tree_memory_is_summed_across_every_observed_descendant() {
+        // The supervision question is what the whole tree is holding on this
+        // host, so a provider plus the compilers it launched is one number.
+        let ps = concat!(
+            "100 1 262144 06:20 opencode run --format json\n",
+            "200 100 524288 06:12 cargo test -q\n",
+            "300 200 1048576 00:03 rustc --crate-name homeboy_agents\n",
+        );
+        let rows = parse_process_activity_rows(ps);
+
+        let sample = select_provider_activity(&rows, 1, &[]);
+
+        assert_eq!(sample.tree_rss_kib, Some(1_835_008));
+        assert_eq!(sample.descendant_count, 3);
+        let activity = sample.activity.expect("provider is observable");
+        // The selected process reports only its own footprint.
+        assert_eq!(activity.rss_kib, Some(524_288));
+    }
+
+    #[test]
+    fn an_unmeasured_tree_reports_no_memory_rather_than_zero() {
+        // A budget that fired on a fabricated zero would be worse than no
+        // budget at all, so the absence has to survive selection.
+        let ps = "100 1 06:20 opencode run\n";
+        let rows = parse_process_activity_rows(ps);
+
+        assert_eq!(select_provider_activity(&rows, 1, &[]).tree_rss_kib, None);
+        assert_eq!(ProviderActivitySample::unsampled().tree_rss_kib, None);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/process_activity.rs
+++ b/crates/homeboy-agents/src/agent_task_service/process_activity.rs
@@ -542,8 +542,12 @@ mod tests {
         assert_eq!(sample.tree_rss_kib, Some(1_835_008));
         assert_eq!(sample.descendant_count, 3);
         let activity = sample.activity.expect("provider is observable");
-        // The selected process reports only its own footprint.
-        assert_eq!(activity.rss_kib, Some(524_288));
+        // Selection is longest-running non-homeboy descendant (#11598 removed
+        // the depth preference that reported the controller). `opencode run`
+        // has been alive longest, so it is what is reported — and it carries
+        // only its own footprint, which is why the tree sum above exists.
+        assert_eq!(activity.command, "opencode run --format json");
+        assert_eq!(activity.rss_kib, Some(262_144));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -42,6 +42,13 @@ pub use super::agent_task::{
 };
 
 pub use super::agent_task::{
+    highest_supervision_action, AgentSupervisionAction, AgentSupervisionBudget,
+    AgentSupervisionDecision, AgentSupervisionMetric, AgentSupervisionPolicy,
+    AgentSupervisionSample, AGENT_SUPERVISION_POLICY_SCHEMA, DEFAULT_SUPERVISION_REASON,
+    SUPERVISION_STOP_REMEDIATION, SUPERVISION_WARNING_REMEDIATION,
+};
+
+pub use super::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutionHandle,
     AgentTaskExecutionHandleKind, AgentTaskExecutionState, AgentTaskExecutor,
     AgentTaskExecutorCapabilities, AgentTaskFailureClassification, AgentTaskFollowUp,
@@ -459,19 +466,20 @@ pub mod service {
         reconcile_terminal_artifact_projection, reconstruct_adoption_options_with_dispatcher,
         reconstruct_options_with_dispatcher, record_replacement_gate_proof, recover_cook_pr,
         recover_terminal_transport_proxy_evidence, register_promotion_job_driver,
-        resolve_cook_continuation_run_id, resume, resume_cook, resume_cook_batch, retry, run_cook,
-        run_cook_batch, run_cook_with_durable_observer, run_loaded_plan, run_next,
-        run_next_with_cook_dispatcher, run_status, run_submitted, run_submitted_with_timeout,
-        run_terminal_cook_continuation, source_worktree_path, status, submit_plan_spec,
-        terminal_review_form_continuation_is_eligible, terminal_transport_recovery_required,
-        validate_initial_recipe_compatibility, validate_recipe_attempt_record,
-        AgentTaskCandidateAdoptionOptions, AgentTaskCookAttemptReport,
-        AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions, AgentTaskCookBatchReport,
-        AgentTaskCookReport, AgentTaskCookServiceOptions, AgentTaskDiscoveryCommands,
-        AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter, AgentTaskDiscoveryReport,
-        AgentTaskDiscoveryRun, AgentTaskHydratedEvidence, AgentTaskPromotionJob,
-        AgentTaskPromotionJobDriver, AgentTaskPromotionJobPhase, AgentTaskPromotionRequest,
-        AgentTaskRetryServiceResult, AgentTaskRunResult, CookActivityProbe, CookProgressEvent,
-        CookProviderActivity, AGENT_TASK_PROMOTION_JOB_TYPE, AGENT_TASK_PROMOTION_JOB_VERSION,
+        resolve_cook_continuation_run_id, resolve_supervision_policy, resume, resume_cook,
+        resume_cook_batch, retry, run_cook, run_cook_batch, run_cook_with_durable_observer,
+        run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status, run_submitted,
+        run_submitted_with_timeout, run_terminal_cook_continuation, source_worktree_path, status,
+        submit_plan_spec, terminal_review_form_continuation_is_eligible,
+        terminal_transport_recovery_required, validate_initial_recipe_compatibility,
+        validate_recipe_attempt_record, AgentTaskCandidateAdoptionOptions,
+        AgentTaskCookAttemptReport, AgentTaskCookBatchCellReport, AgentTaskCookBatchOptions,
+        AgentTaskCookBatchReport, AgentTaskCookReport, AgentTaskCookServiceOptions,
+        AgentTaskDiscoveryCommands, AgentTaskDiscoveryCounts, AgentTaskDiscoveryFilter,
+        AgentTaskDiscoveryReport, AgentTaskDiscoveryRun, AgentTaskHydratedEvidence,
+        AgentTaskPromotionJob, AgentTaskPromotionJobDriver, AgentTaskPromotionJobPhase,
+        AgentTaskPromotionRequest, AgentTaskRetryServiceResult, AgentTaskRunResult,
+        CookActivityProbe, CookProgressEvent, CookProviderActivity, CookSupervisionTick,
+        CookSupervisor, AGENT_TASK_PROMOTION_JOB_TYPE, AGENT_TASK_PROMOTION_JOB_VERSION,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -3049,6 +3049,7 @@ fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateStat
             "local_owner": local_provider_ownership,
         },
         "provider_activity": provider_activity_summary(metadata),
+        "supervision": supervision_summary(metadata),
         "stale_reason": metadata.get("stale_running_reason"),
         "runner_queue": metadata.get("runner_queue"),
         "next_action": if terminal && candidate_recoverable {
@@ -3099,6 +3100,40 @@ fn provider_activity_summary(metadata: &Value) -> Value {
         }
     }
     summary
+}
+
+/// Project the durable resource timeline and supervision decisions into the
+/// status summary.
+///
+/// The decisions are reported in full and the timeline is not: a run reaches a
+/// handful of decisions and hundreds of samples, and a status summary that
+/// inlined the whole timeline would bury the one fact a reader came for. The
+/// latest sample plus a count is enough to say "this is holding nine gigabytes
+/// and has been sampled forty times"; the full timeline stays in the run record
+/// for anyone who wants the curve.
+///
+/// Absent when nothing was recorded, so a run from before supervision existed
+/// does not acquire a misleading empty report.
+fn supervision_summary(metadata: &Value) -> Value {
+    let timeline = metadata
+        .get("cook_resource_timeline")
+        .and_then(Value::as_array);
+    let events = metadata
+        .get("cook_supervision_events")
+        .and_then(Value::as_array);
+    if timeline.is_none() && events.is_none() {
+        return Value::Null;
+    }
+    json!({
+        "resource_samples": timeline.map_or(0, |timeline| timeline.len()),
+        "latest_resource_sample": timeline.and_then(|timeline| timeline.last()).cloned(),
+        "events": events.cloned().unwrap_or_default(),
+        "stopped_by_policy": events.is_some_and(|events| {
+            events
+                .iter()
+                .any(|event| event.get("kind").and_then(Value::as_str) == Some("stop_executed"))
+        }),
+    })
 }
 
 /// Project the durable `provider_executions` metadata into a compact list of the
@@ -4123,6 +4158,50 @@ mod tests {
         );
 
         assert!(summary["liveness"]["provider_activity"].is_null());
+        // A run recorded before supervision existed must not acquire an empty
+        // supervision report that reads as "supervised, nothing to say".
+        assert!(summary["liveness"]["supervision"].is_null());
+    }
+
+    #[test]
+    fn compact_status_reports_why_a_run_was_stopped_by_policy() {
+        // #7015: the resource cost of a session used to be discoverable only by
+        // having watched it. The decision that ended a run has to survive in the
+        // status envelope, and it must not be buried under the sample stream.
+        let summary = compact_status_summary(
+            &json!({
+                "run_id": "agent-task-supervised",
+                "state": "failed",
+                "tasks": [],
+                "metadata": {
+                    "cook_resource_timeline": [
+                        { "at": "2026-08-06T00:00:00Z", "attempt": 1,
+                          "sample": { "rss_mib": 4096, "child_processes": 12 } },
+                        { "at": "2026-08-06T00:00:15Z", "attempt": 1,
+                          "sample": { "rss_mib": 10_500, "child_processes": 41 } }
+                    ],
+                    "cook_supervision_events": [
+                        { "kind": "budget_breached", "attempt": 1, "decision": {
+                            "metric": "rss_mib", "action": "stop",
+                            "limit": 10_240, "observed": 10_500,
+                            "reason": "15Gi box", "remediation": "narrow the task"
+                        }},
+                        { "kind": "stop_executed", "attempt": 1,
+                          "outcome": { "status": "terminated", "signal": "SIGTERM" } }
+                    ]
+                }
+            }),
+            "agent-task-supervised",
+        );
+
+        let supervision = &summary["liveness"]["supervision"];
+        assert_eq!(supervision["resource_samples"], 2);
+        assert_eq!(
+            supervision["latest_resource_sample"]["sample"]["rss_mib"],
+            10_500
+        );
+        assert_eq!(supervision["events"][0]["decision"]["action"], "stop");
+        assert_eq!(supervision["stopped_by_policy"], true);
     }
 
     #[test]

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -606,6 +606,23 @@ pub struct AgentTaskConfig {
     /// (`homeboy/agent-command-policy/v1`) when building a plan.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command_policy: Option<serde_json::Value>,
+    /// Host-level resource budgets every long-running provider session on this
+    /// machine is supervised against, settable via
+    /// `homeboy config set /agent_task/supervision_policy <json> --json`
+    /// (#7015).
+    ///
+    /// The command policy above bounds *what* an agent may run; this bounds
+    /// *how much it may consume while running it*. Neither substitutes for the
+    /// other — an agent can stay entirely inside its permitted commands and
+    /// still grow to nine gigabytes across forty child processes, which is what
+    /// Homeboy previously learned only after the process boundary closed.
+    ///
+    /// Carried opaquely as JSON for the same reason as `rotation` and
+    /// `command_policy`: core config does not depend on the agent-task
+    /// subsystem. The agent-task layer deserializes it into
+    /// `AgentSupervisionPolicy` (`homeboy/agent-supervision-policy/v1`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervision_policy: Option<serde_json::Value>,
     /// Optional independent acceptance authority. The command receives a typed
     /// request on stdin and returns a signed verdict on stdout.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -191,6 +191,69 @@ deliberate and stated here rather than papered over; closing it requires the
 runtime to route its shell tool through the dispatch command Homeboy already
 hands it in `HOMEBOY_AGENT_TOOL_DISPATCH_COMMAND`.
 
+### Supervision policy: how much a provider session may consume
+
+The command policy bounds *what* an agent may run. It cannot see an agent that
+stays entirely inside its permitted commands and still grows to nine gigabytes
+across forty child processes, and neither can an execution budget that counts
+attempts. Homeboy used to learn the cost of a session only after the process
+boundary closed.
+
+`agent_task.supervision_policy` is the resource half. It is host config, and it
+is opt-in: with nothing declared, a cook behaves exactly as it did before.
+
+```bash
+homeboy config set /agent_task/supervision_policy '{
+  "budgets": [
+    { "metric": "rss_mib", "limit": 6144, "action": "warn" },
+    { "metric": "rss_mib", "limit": 10240, "action": "stop",
+      "reason": "15Gi box with four agents on it" },
+    { "metric": "no_progress_seconds", "limit": 1800, "action": "stop" }
+  ],
+  "backends": {
+    "bench": []
+  },
+  "reason": "shared host"
+}' --json
+```
+
+**Metrics** are things any host can observe about any provider, so supervision
+stays runtime-neutral:
+
+| Metric | Meaning |
+|---|---|
+| `elapsed_seconds` | Wall-clock time since provider execution began. |
+| `rss_mib` | Resident memory across the provider's whole process tree. Summing double-counts shared pages, so it is an upper bound. |
+| `child_processes` | Processes observed under the cook. |
+| `no_progress_seconds` | Time since the destination worktree last changed. This is the stall detector: a cook burning memory while writing files is working, one that has written nothing for twenty minutes is not. |
+
+**The ladder** is `warn` → `nudge` → `stop`. Several budgets on one metric are
+how you say "tell me at 6 GiB, stop it at 10". A breach is announced once and
+again only when it climbs a rung, so the heartbeat channel stays worth reading.
+A `stop` terminates the provider's process tree (SIGTERM, then SIGKILL for
+survivors) and leaves the controller alive to record why.
+
+`nudge` currently records and surfaces an escalation between `warn` and `stop`;
+it does **not** yet inject feedback into the running session, because Homeboy
+has no channel into a live provider's reasoning (#7451, #7530).
+
+A `backends` entry **replaces** the global budgets for that backend rather than
+extending them — unlike the command policy, where extension is the safe default.
+An empty list opts a backend out entirely.
+
+**Unobserved is never zero.** Every metric is optional at the sample, and an
+absent metric never breaches a budget. A host with no `ps` has no memory or
+process reading; a cook with no destination worktree has no progress reading.
+Reporting those as `0` would make every budget fire immediately on exactly the
+hosts that can least afford a spurious kill.
+
+**Evidence.** Each heartbeat appends to `cook_resource_timeline` (a rolling
+window of samples) and every decision appends to `cook_supervision_events`,
+which also records whether an ordered termination actually succeeded. The two
+are separate arrays so an hour of quiet samples cannot evict the decision that
+explains a stop. `agent-task status` projects both under
+`liveness.supervision`.
+
 | Subcommand | Purpose |
 |---|---|
 | `cook` | Run one workspace task through the patch-artifact handoff workflow. |


### PR DESCRIPTION
Refs #7015 (dependency of epic #8282).

## The problem

Homeboy sampled a running cook every fifteen seconds, wrote the sample down, and then waited on the process boundary regardless of what the sample said. The cost of a session — peak RSS, child-process count — was only discoverable by having watched it, or by reading a post-mortem. The orchestrator watched the fire and did not own an extinguisher.

## What I built

Three pieces, in the priority order given, on top of the substrate that already exists (`process_activity.rs`, `cook_activity.rs`, `command_policy.rs`). No second process walker.

**1. Resource sampling on the existing heartbeat.** `process_activity`'s `ps` projection gains an `rss` column (`pid=,ppid=,rss=,etime=,args=`), so the one walk that already answers "what is this tree doing" also answers "what is it holding". The parser accepts both the new and the original four-field projection, so every existing test fixture and every previously recorded sample still parses. Tree RSS is summed across descendants — an upper bound, which is the safe side for a budget — and carried alongside the descendant count that was already being sampled. Both land on `CookProviderActivity` and therefore in the heartbeat summary line and `agent-task status`.

**2. A declarative supervision policy, beside the command policy.** New `crates/homeboy-agents/src/agent_task/supervision_policy.rs`: `homeboy/agent-supervision-policy/v1`, a set of budgets (one threshold on one metric plus a rung on the `warn` → `nudge` → `stop` ladder), configured per host and per backend via `agent_task.supervision_policy` — the same opaque-JSON pattern `rotation` and `command_policy` already use, so core config still does not depend on the agent-task subsystem. Metrics are things any host can observe about any provider (`elapsed_seconds`, `rss_mib`, `child_processes`, `no_progress_seconds`), so no provider-specific logic enters core. Several budgets on one metric are how an operator writes "tell me at 6 GiB, stop it at 10". A breach is announced once and again only on escalation, so the heartbeat channel stays worth reading. A `stop` calls `terminate_process_tree` on the controller pid, which excludes the calling process — the provider's work ends, the controller lives to record why.

Supervision is opt-in: with nothing declared, a cook behaves exactly as it did before.

**3. Supervision events in evidence.** Each heartbeat appends to `cook_resource_timeline` (bounded rolling window, 240 entries ≈ one hour at the 15s interval); each decision appends to `cook_supervision_events` (bounded 32), which also records whether an ordered termination *actually succeeded* — a policy can order a stop the host then fails to carry out, and evidence showing only the order would let a reader conclude a run was stopped when it is still running. The two are separate arrays on purpose: collapsing them would let an hour of quiet samples evict the decision that exists to explain the stop. `agent-task status` projects both under `liveness.supervision`, with the events in full and the timeline as a count plus its newest entry.

**Unobserved is never zero, at every layer.** An absent metric cannot breach a budget. A host with no `ps` has no memory or process reading; a cook with no destination worktree has no progress reading. Fabricating a zero would fire every budget immediately on exactly the hosts that can least afford a spurious kill. The `ps` branch is `cfg(unix)`-gated as a whole and non-Unix returns the existing `ProviderActivitySample::unsampled()`, which is distinguishable from a sample that found nothing.

## What I deliberately left

**Structured nudges that steer the agent's reasoning** — scope drift, repeated expensive checks. That needs a channel back into a running provider session, which #7451 and #7530 are about. The `nudge` rung is implemented as an operator-visible escalation *between* `warn` and `stop`; it records and surfaces, it does not inject. Stated as such in the module docs and in `docs/commands/agent-task.md` rather than shipped as a promise the runtime cannot keep.

Also not done: **transcript/session tail capture** from the issue's wish list. That is provider-specific transcript mechanics and belongs in an extension, per the runtime-neutrality constraint.

So this is `Refs #7015`, not `Closes` — two of the five acceptance criteria are outside what core can own today.

## I could not compile

Four agents share a 15Gi VPS and cargo builds are prohibited there. I ran `cargo fmt` and verified every touched file parses and is formatted with `rustfmt --edition 2021 --check`. **This has not been type-checked.** Please run `cargo check --workspace --tests` before merging.

Sweeps I did by hand instead:

- `ProcessActivityRow` +`rss_kib`, `DescendantActivity` +`rss_kib`, `ProviderActivitySample` +`tree_rss_kib`: grepped every construction and destructuring site workspace-wide, including `tests/` at repo root. All literals are inside `process_activity.rs`; the only exhaustive destructuring is in `cook_activity::sample`, updated to bind all four fields.
- `CookProviderActivity` +3 fields: every other literal uses `..Default::default()`; the one full literal (its round-trip test) is updated. `status.rs` deserializes it from a partial JSON object, which existing tests prove works, so the new `Option` fields are safe there.
- `AgentTaskConfig` +`supervision_policy`: both literal sites use `..AgentTaskConfig::default()`.
- No signature changed. `CookProgressEvent` was deliberately **not** extended — supervision reaches the observer through the existing `detail` string — precisely to avoid an `E0063` sweep across its two full-literal test constructions.
- No new `cfg(unix)` bindings; the existing gated branch is unchanged in shape.
- `highest_supervision_action` rather than `highest_action` at the `agent_task` re-export root, to avoid a name that could collide.

The riskiest thing here is not a compile error, it is behavioural: a misconfigured `stop` budget kills a healthy run. It is gated behind config that defaults to empty, the decision and its outcome are both durable, and the ladder is unit-tested over synthetic samples without spawning anything.

## Tests

All new coverage is over synthetic samples — no process spawning, no timing dependence:

- `supervision_policy.rs`: ladder ordering, per-metric collapse, backend override semantics, reason precedence, the unobserved-metric guarantee, JSON round-trip with schema/action defaults.
- `cook_supervision.rs`: escalate-once behaviour, stall clock and its reset on a commit (which clears `files_changed`), unmeasurable progress, a host that cannot read its process table.
- `process_activity.rs`: both `ps` projections, the bare-seconds `etime` ambiguity, tree RSS summing, absence surviving selection.
- `cook_activity.rs`: resource facts in the summary line, tree-over-command precedence, KiB→MiB rounding down.
- `lifecycle_ops`: a stop decision surviving 300 routine samples; a failed termination recorded as failed.
- `status.rs`: the supervision projection, and its absence on a pre-supervision run.

No tests deleted or `#[ignore]`d.
