### PR TITLE
fix(test): fund the attempts the wrong-schema cook fixture declares

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -466,8 +466,12 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                         tasks_json: None,
                         provider_config: None,
                         client_context: None,
-                        attempts: Some(1),
-                        same_provider_retries: Some(0),
+                        // `max_attempts: 2` below needs a budget that can fund two
+                        // provider-backed attempts and one same-provider remediation,
+                        // or `validate_effective_cook_budget` rejects at preflight and
+                        // the wrong-schema behaviour under test is never reached.
+                        attempts: Some(2),
+                        same_provider_retries: Some(1),
                         provider_rotations: Some(0),
                         queue_only: false,
                         timeout_ms: None,


### PR DESCRIPTION
`cook_preserves_successful_candidate_when_provider_response_has_wrong_schema` is **red on `main`**.

## Cause

The fixture declares `max_attempts: 2` but a budget of `attempts: Some(1)`, `same_provider_retries: Some(0)`. `validate_effective_cook_budget` correctly rejects that at preflight:

```
Invalid argument 'max-provider-executions': Cook requests 2 attempts but
--max-provider-executions 1 can fund only 1 provider-backed attempt(s).
```

So the test never reaches the wrong-schema candidate-preservation behaviour it exists to cover — it fails on an argument-validation error instead.

Introduced when #11486 made the three budget flags `Option<u32>`. The sibling fixture at the bottom of the same file pairs `max_attempts: 1` with one execution and is consistent, which is why only this one went red.

## Fix

Fund what the fixture declares: two provider executions and one same-provider remediation, with a comment stating the dependency so the pairing is not silently broken again. The validator is untouched — it was right.

## Verification

`cargo test -p homeboy-cli --lib promotion_review` → **10 passed, 0 failed** (was 9 passed, 1 failed).

Found while verifying an unrelated PR: the branch and `main` failed identically, which is what identified it as pre-existing.

🤖 Authored by chubes-bot