### PR TITLE
Preserve provider inventory across Lab routing

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/lab/types.rs
+++ b/crates/contracts/homeboy-lab-contract/src/lab/types.rs
@@ -60,6 +60,9 @@ pub struct LabRoutingPolicy {
     /// commands (bench/audit/test/agent-task) leave it `false` and offload as
     /// soon as the machine leaves `ok`.
     pub offload_only_when_hot: bool,
+    /// Whether a remote command's structured result payload is the caller-facing
+    /// result and must survive terminal-output compaction.
+    pub preserve_result_payload: bool,
 }
 
 impl LabRoutingPolicy {
@@ -235,6 +238,7 @@ impl LabCommandContract {
                 requires_extension_parity,
                 read_only_polling: false,
                 offload_only_when_hot: false,
+                preserve_result_payload: false,
             },
         }
     }
@@ -310,6 +314,12 @@ impl LabCommandContract {
         }
     }
 
+    /// Keep the remote command-result `data` payload as the caller result.
+    pub fn preserve_result_payload(mut self) -> Self {
+        self.routing_policy.preserve_result_payload = true;
+        self
+    }
+
     pub fn local_only(hot_label: &'static str, reason: &'static str) -> Self {
         Self {
             hot_label,
@@ -327,6 +337,7 @@ impl LabCommandContract {
                 requires_extension_parity: false,
                 read_only_polling: false,
                 offload_only_when_hot: false,
+                preserve_result_payload: false,
             },
         }
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
@@ -23,6 +23,7 @@ fn providers_output_includes_core_capability_contract() {
         // An absent `--backend` leaves the presentation unscoped (#9654).
         assert_eq!(value["scope"]["filtered"], false);
         assert!(value["scope"]["backend"].is_null());
+        assert!(value["providers"].is_array());
         assert_eq!(
             value["capability_contract"]["schema"],
             AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
@@ -89,6 +90,7 @@ fn providers_output_declares_the_scope_it_observed() {
         // callers that already parse this output.
         assert_eq!(value["schema"], "homeboy/agent-task-providers/v1");
         assert_eq!(value["scope"]["filtered"], false);
+        assert!(value["providers"].is_array());
     });
 }
 

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -110,7 +110,8 @@ impl Commands {
             // probe answers before any workload workspace is built (#9763).
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command: agent_task::AgentTaskCommand::Providers(_),
-            }) => LabCommandContract::runner_resident(AGENT_TASK_PROVIDERS_LAB_LABEL),
+            }) => LabCommandContract::runner_resident(AGENT_TASK_PROVIDERS_LAB_LABEL)
+                .preserve_result_payload(),
             Commands::AgentTask(agent_task::AgentTaskArgs {
                 command:
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -532,6 +532,7 @@ fn agent_task_providers_supports_explicit_runner_discovery() {
     assert!(lab_runner_supports_contract_label(command.hot_label));
     assert!(command.is_portable());
     assert!(!command.routing_policy.default_lab_offload);
+    assert!(command.routing_policy.preserve_result_payload);
     assert!(!command.routing_policy.requires_extension_parity);
     assert!(command.required_extensions.is_empty());
     assert!(!command.routing_policy.infer_source_path_tools);

--- a/crates/homeboy-core/src/lab_routing.rs
+++ b/crates/homeboy-core/src/lab_routing.rs
@@ -322,13 +322,23 @@ pub fn dispatch_lab_offload(
     runner_id: Option<&str>,
     observer: Box<dyn LabDispatchObserver>,
 ) -> Result<LabRouteOutcome> {
-    lab_offload_outcome_to_route_outcome(route_lab_offload(request), runner_id, observer)
+    let preserve_result_payload = request
+        .command
+        .as_ref()
+        .is_some_and(|command| command.command.routing_policy.preserve_result_payload);
+    lab_offload_outcome_to_route_outcome(
+        route_lab_offload(request),
+        runner_id,
+        observer,
+        preserve_result_payload,
+    )
 }
 
 fn lab_offload_outcome_to_route_outcome(
     outcome: Result<crate::lab_offload::LabOffloadOutcome>,
     runner_id: Option<&str>,
     observer: Box<dyn LabDispatchObserver>,
+    preserve_result_payload: bool,
 ) -> Result<LabRouteOutcome> {
     match outcome {
         Err(err) => {
@@ -391,6 +401,7 @@ fn lab_offload_outcome_to_route_outcome(
                 runner_id,
                 exit_code,
                 retrieval.as_ref(),
+                preserve_result_payload,
             );
             Ok(LabRouteOutcome::Offloaded(LabRouteOutput {
                 stdout,
@@ -493,7 +504,13 @@ fn compact_lab_terminal_output(
     runner_id: Option<&str>,
     exit_code: i32,
     retrieval: Option<&PersistedRunRetrieval>,
+    preserve_result_payload: bool,
 ) -> (String, String) {
+    if preserve_result_payload {
+        if let Some(payload) = command_result_payload(stdout) {
+            return (payload, stderr.to_string());
+        }
+    }
     let Some(mut rendered) = compact_command_result_output(stdout) else {
         return (
             stdout_with_persisted_run_retrieval(stdout, retrieval),
@@ -518,6 +535,20 @@ fn compact_lab_terminal_output(
     // command failure, so avoid printing that transcript a second time.
     let _ = stderr;
     (bound_terminal_output(rendered), String::new())
+}
+
+fn command_result_payload(stream: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(stream).ok()?;
+    if value.get("schema").and_then(serde_json::Value::as_str) != Some("homeboy/command-result/v3")
+    {
+        return None;
+    }
+    serde_json::to_string_pretty(value.get("data")?)
+        .ok()
+        .map(|mut payload| {
+            payload.push('\n');
+            payload
+        })
 }
 
 fn command_result_root_cause(value: &serde_json::Value) -> Option<String> {
@@ -1038,6 +1069,7 @@ mod tests {
                 requires_extension_parity: true,
                 read_only_polling: false,
                 offload_only_when_hot: false,
+                preserve_result_payload: false,
             },
         }
     }
@@ -1360,6 +1392,7 @@ mod tests {
             Some("homeboy-lab"),
             0,
             Some(&PersistedRunRetrieval::for_run("fuzz-1")),
+            false,
         );
 
         assert!(stdout.contains("Lab runner: homeboy-lab"));
@@ -1381,6 +1414,7 @@ mod tests {
             Some("homeboy-lab"),
             1,
             None,
+            false,
         );
 
         assert!(stdout.contains("Root cause: workspace staging failed: dependency install failed"));
@@ -1397,11 +1431,26 @@ mod tests {
             Some("homeboy-lab"),
             1,
             Some(&PersistedRunRetrieval::for_run("fuzz-fail")),
+            false,
         );
 
         assert!(stdout.contains("Root cause: Error: Cannot find module 'tar'"));
         assert_eq!(stdout.matches("Cannot find module 'tar'").count(), 1);
         assert!(stdout.len() <= COMPACT_COMMAND_RESULT_LIMIT_BYTES);
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn lab_provider_catalog_preserves_remote_rows_and_scope() {
+        let nested = r#"{"schema":"homeboy/command-result/v3","command":"agent-task","operation":"providers","success":true,"status":"passed","data":{"schema":"homeboy/agent-task-providers/v1","observed_scope":{"location":"runner","runner_id":"homeboy-lab"},"scope":{"shown":0,"matched":0,"total":0},"providers":[]}}"#;
+        let (stdout, stderr) =
+            compact_lab_terminal_output(nested, "", Some("homeboy-lab"), 0, None, true);
+
+        let value: serde_json::Value = serde_json::from_str(&stdout).expect("provider payload");
+        assert_eq!(value["observed_scope"]["location"], "runner");
+        assert_eq!(value["observed_scope"]["runner_id"], "homeboy-lab");
+        assert_eq!(value["scope"]["matched"], 0);
+        assert_eq!(value["providers"], serde_json::json!([]));
         assert!(stderr.is_empty());
     }
 
@@ -1445,6 +1494,7 @@ mod tests {
             }),
             Some("homeboy-lab"),
             observer,
+            false,
         )
         .expect("route outcome");
 
@@ -1540,6 +1590,7 @@ mod tests {
             }),
             Some("homeboy-lab"),
             observer,
+            false,
         )
         .expect("route outcome");
 
@@ -1579,6 +1630,7 @@ mod tests {
             }),
             Some("homeboy-lab"),
             Box::new(NoopLabDispatchObserver),
+            false,
         )
         .expect("route outcome");
 
@@ -1609,6 +1661,7 @@ mod tests {
             }),
             Some("homeboy-lab"),
             observer,
+            false,
         )
         .expect("route outcome");
 


### PR DESCRIPTION
## Summary
- preserve structured result payloads for Lab-routed provider discovery
- keep bare provider discovery controller-local
- return observed scope and explicit empty provider data
- add local and Lab routing regression coverage

Closes #11703.

## Verification
- `cargo fmt --check`
- focused provider payload and routing tests
- controller-local default-placement regression
- Lab payload scope and empty-provider regression
- `git diff --check`

## AI assistance
OpenCode general coding subagent with OpenAI GPT-5.6 Sol traced the inventory loss to generic Lab result compaction, implemented selective payload preservation, and added focused tests. Chris Huber reviewed and remains responsible for every line.