### PR TITLE
Route controller-owned lifecycle reads locally

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -533,13 +533,13 @@ fn discovery_run(
     let command_prefix = if metadata_string(&record.metadata, "lifecycle_store_owner").as_deref()
         == Some("controller")
     {
-        "homeboy agent-task".to_string()
+        "homeboy --placement local agent-task".to_string()
     } else {
         match runner_id.as_deref() {
             // Lifecycle records resident on a runner must execute there. The
             // global `--runner` flag is only for portable Lab offload commands.
             Some(runner_id) => format!("homeboy runner exec {runner_id} -- homeboy agent-task"),
-            None => "homeboy agent-task".to_string(),
+            None => "homeboy --placement local agent-task".to_string(),
         }
     };
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1409,7 +1409,7 @@ fn discovery_keeps_controller_handoff_commands_resolvable_after_runner_reconnect
             .expect("unaccepted controller handoff listed");
         assert_eq!(
             queued.commands.status,
-            "homeboy agent-task status controller-handoff-reconnect"
+            "homeboy --placement local agent-task status controller-handoff-reconnect"
         );
         agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
             run_id: "controller-handoff-reconnect",
@@ -1430,11 +1430,11 @@ fn discovery_keeps_controller_handoff_commands_resolvable_after_runner_reconnect
         assert_eq!(run.runner_id.as_deref(), Some("homeboy-lab"));
         assert_eq!(
             run.commands.status,
-            "homeboy agent-task status controller-handoff-reconnect"
+            "homeboy --placement local agent-task status controller-handoff-reconnect"
         );
         assert_eq!(
             run.commands.logs,
-            "homeboy agent-task logs controller-handoff-reconnect"
+            "homeboy --placement local agent-task logs controller-handoff-reconnect"
         );
         assert!(agent_task_lifecycle::status(&run.run_id).is_ok());
         assert!(agent_task_lifecycle::logs(&run.run_id).is_ok());
@@ -1489,7 +1489,7 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
         assert_eq!(run.liveness, Some(AgentTaskLiveness::Unreconciled));
         assert_eq!(
             run.commands.status,
-            "homeboy agent-task status controller-handoff-unaccepted"
+            "homeboy --placement local agent-task status controller-handoff-unaccepted"
         );
 
         let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -45,9 +45,9 @@ pub(crate) fn durable_cook_identity_lines(cook_id: Option<&str>, run_id: &str) -
         .unwrap_or_default();
     vec![
         format!("cook: durable run id `{run_id}`{cook_suffix} — persisted before materialization."),
-        format!("cook: status -> homeboy agent-task status {run_id}"),
-        format!("cook: logs   -> homeboy agent-task logs {run_id}"),
-        format!("cook: cancel -> homeboy agent-task cancel {run_id}"),
+        format!("cook: status -> homeboy --placement local agent-task status {run_id}"),
+        format!("cook: logs   -> homeboy --placement local agent-task logs {run_id}"),
+        format!("cook: cancel -> homeboy --placement local agent-task cancel {run_id}"),
     ]
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -195,6 +195,7 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
         bound_full_reader_payload(&mut value);
         attach_runner_probe(&mut value, &runner_probe);
         attach_agent_task_status_actionable(&mut value, run_id);
+        preserve_controller_owner_placement(&mut value, run_id);
         let exit_code = status_exit_code(&value);
         return Ok((value, exit_code));
     }
@@ -206,6 +207,7 @@ pub(super) fn status(args: StatusArgs) -> CmdResult<Value> {
     }
     attach_runner_probe(&mut summary, &runner_probe);
     attach_agent_task_status_actionable(&mut summary, run_id);
+    preserve_controller_owner_placement(&mut summary, run_id);
     let exit_code = status_exit_code(&summary);
     Ok((summary, exit_code))
 }
@@ -1001,6 +1003,47 @@ fn attach_actionable_metadata(value: &mut Value, metadata: CommandActionableMeta
     }
 }
 
+/// Follow-up lifecycle commands must retain the controller-local ownership of
+/// the record even when a default Lab runner becomes available between reads.
+fn preserve_controller_owner_placement(value: &mut Value, run_id: &str) {
+    match value {
+        Value::String(command) => {
+            let prefix = "homeboy agent-task ";
+            let lifecycle_command = command
+                .strip_prefix(prefix)
+                .and_then(|rest| rest.split_whitespace().next())
+                .is_some_and(|operation| {
+                    matches!(
+                        operation,
+                        "status"
+                            | "logs"
+                            | "artifacts"
+                            | "evidence"
+                            | "diagnose"
+                            | "review"
+                            | "retry"
+                            | "reconcile"
+                            | "cancel"
+                    )
+                });
+            if lifecycle_command && command.contains(run_id) {
+                *command = command.replacen(prefix, "homeboy --placement local agent-task ", 1);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                preserve_controller_owner_placement(value, run_id);
+            }
+        }
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                preserve_controller_owner_placement(value, run_id);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(super) fn logs(args: LogsArgs) -> CmdResult<Value> {
     let log = if args.raw {
         agent_task_service_direct::logs_with_raw(&args.run_id)?
@@ -1030,6 +1073,7 @@ pub(super) fn artifacts(args: StatusArgs) -> CmdResult<Value> {
             ),
         );
     }
+    preserve_controller_owner_placement(&mut value, &args.run_id);
     Ok((value, 0))
 }
 
@@ -1115,6 +1159,7 @@ pub(super) fn evidence(args: EvidenceArgs) -> CmdResult<Value> {
             ),
         );
     }
+    preserve_controller_owner_placement(&mut value, run_id);
     Ok((value, 0))
 }
 
@@ -1211,6 +1256,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         retry.action.as_ref(),
     );
     bound_full_reader_payload(&mut value);
+    preserve_controller_owner_placement(&mut value, run_id);
     Ok((value, 0))
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -872,10 +872,9 @@ fn diagnose_derives_next_actions_from_the_failure_classification() {
         assert_eq!(
             value["next_commands"],
             json!([
-                format!("homeboy agent-task status {run_id} --full"),
-                format!("homeboy agent-task artifacts {run_id}"),
-                format!("homeboy agent-task review {run_id}"),
-                format!("homeboy agent-task retry {run_id} --run"),
+                format!("homeboy --placement local agent-task status {run_id} --full"),
+                format!("homeboy --placement local agent-task artifacts {run_id}"),
+                format!("homeboy --placement local agent-task review {run_id}"),
             ])
         );
 
@@ -886,7 +885,7 @@ fn diagnose_derives_next_actions_from_the_failure_classification() {
         assert_eq!(actionable["run"]["location"], "local");
         assert_eq!(
             actionable["run"]["status_command"],
-            format!("homeboy agent-task status {run_id} --full")
+            format!("homeboy --placement local agent-task status {run_id} --full")
         );
         assert_eq!(actionable["refs"]["agent_tasks"][0]["id"], run_id);
         assert!(actionable["evidence"]
@@ -907,12 +906,10 @@ fn diagnose_derives_next_actions_from_the_failure_classification() {
         assert_eq!(
             commands,
             vec![
-                format!("homeboy agent-task evidence {run_id} --task task-a --failure-only"),
-                format!("homeboy agent-task review {run_id}"),
-                format!("homeboy agent-task retry {run_id} --run"),
+                format!("homeboy --placement local agent-task evidence {run_id} --task task-a --failure-only"),
+                format!("homeboy --placement local agent-task review {run_id}"),
             ]
         );
-        assert_eq!(actionable["next_actions"][2]["kind"], "repair");
     });
 }
 

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -3163,6 +3163,7 @@ fn controller_owns_agent_task_lifecycle_command(cli: &Cli) -> homeboy::core::Res
         AgentTaskCommand::Diagnose(args) => Some(&args.run_id),
         AgentTaskCommand::Review(args) => Some(&args.run_id),
         AgentTaskCommand::Retry(args) => Some(&args.run_id),
+        AgentTaskCommand::Reconcile(args) => Some(&args.run_id),
         _ => None,
     };
     run_id

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -1270,6 +1270,46 @@ fn controller_local_lifecycle_reads_never_acquire_a_default_lab_runner() {
 }
 
 #[test]
+fn controller_local_record_owns_lifecycle_reads_before_default_lab_selection() {
+    crate::test_support::with_isolated_home(|_| {
+        let inferred = connected_default_lab_runner();
+        let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+            "local-owner-routing",
+            vec![serde_json::from_value(serde_json::json!({
+                "task_id": "local-owner-task",
+                "executor": { "backend": "fixture" },
+                "instructions": "exercise local lifecycle ownership"
+            }))
+            .expect("task")],
+        );
+        agent_task_lifecycle::submit_plan(&plan, Some(OWNER_LOCAL_RUN_ID))
+            .expect("controller-local record");
+
+        for args in [
+            ["homeboy", "agent-task", "status", OWNER_LOCAL_RUN_ID].as_slice(),
+            ["homeboy", "agent-task", "logs", OWNER_LOCAL_RUN_ID].as_slice(),
+            ["homeboy", "agent-task", "evidence", OWNER_LOCAL_RUN_ID].as_slice(),
+            ["homeboy", "agent-task", "diagnose", OWNER_LOCAL_RUN_ID].as_slice(),
+            ["homeboy", "agent-task", "review", OWNER_LOCAL_RUN_ID].as_slice(),
+            ["homeboy", "agent-task", "reconcile", OWNER_LOCAL_RUN_ID].as_slice(),
+        ] {
+            let cli = Cli::try_parse_from(args).expect("lifecycle command parses");
+            assert!(
+                controller_owns_agent_task_lifecycle_command(&cli).expect("owner resolves"),
+                "{args:?} must remain controller-local before the connected default Lab is selected"
+            );
+            let route_runner =
+                if controller_owns_agent_task_lifecycle_command(&cli).expect("owner resolves") {
+                    None
+                } else {
+                    route_runner_for(args, &inferred)
+                };
+            assert_eq!(route_runner, None, "{args:?} must not use homeboy-lab");
+        }
+    });
+}
+
+#[test]
 fn every_generated_next_action_command_round_trips_to_the_record_owner() {
     // A generated next action that walks the operator back into the failure it
     // was printed to resolve is worse than no guidance at all (#11599). Each of


### PR DESCRIPTION
## Summary
- resolve controller-local run ownership before default Lab placement
- include reconcile in ownership-first routing
- preserve local placement in generated lifecycle and recovery commands
- cover a controller-owned run with a connected default Lab

Closes #11599.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli controller_local_record_owns_lifecycle_reads_before_default_lab_selection`
- `cargo test -p homeboy-cli diagnose_derives_next_actions_from_the_failure_classification`
- `cargo test -p homeboy-agents discovery_keeps_controller_handoff_commands_resolvable_after_runner_reconnect`
- `git diff --check`

## AI assistance
OpenCode general coding subagent with OpenAI GPT-5.6 Sol traced the ownership regression, repaired routing and generated commands, and added focused tests. Chris Huber reviewed and remains responsible for every line.