### PR TITLE
Honor explicit wait across local Cook re-execution

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -126,10 +126,12 @@ fn runner_side_detach_error() -> Error {
 
 /// The argv the detached cook executes.
 ///
-/// It is the caller's own argv with two edits: the detach request is consumed
-/// by the launcher, and the cook id is pinned so the launcher can name the run
-/// it just handed off. Everything else is preserved byte for byte — a detached
-/// cook that silently differs from the requested one is worse than no detach.
+/// It is the caller's own argv with three edits: the detach request is consumed
+/// by the launcher, `--wait` makes the child's terminal-report policy explicit,
+/// and the cook id is pinned so the launcher can name the run it just handed
+/// off. The parent is the only process authorized to detach; the child must not
+/// infer a handoff policy from its noninteractive stdio. Everything else is
+/// preserved byte for byte.
 fn detached_cook_child_args(
     normalized_args: &[String],
     cook_id: &str,
@@ -147,6 +149,7 @@ fn detached_cook_child_args(
         args.push("--run-id".to_string());
         args.push(cook_id.to_string());
     }
+    args.push("--wait".to_string());
     args
 }
 
@@ -440,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn child_args_drop_the_detach_request_and_pin_a_generated_cook_id() {
+    fn child_args_replace_detach_with_explicit_wait_and_pin_a_generated_cook_id() {
         let normalized = args(&[
             "homeboy",
             "--placement",
@@ -465,6 +468,7 @@ mod tests {
                 "fix it",
                 "--run-id",
                 "cook-generated",
+                "--wait",
             ])
         );
     }
@@ -495,7 +499,7 @@ mod tests {
             !child.iter().any(|arg| arg == "--detach-after-handoff"),
             "{child:?}"
         );
-        assert_eq!(child.last().map(String::as_str), Some("fix it"));
+        assert_eq!(child.last().map(String::as_str), Some("--wait"));
     }
 
     /// The re-executed cook must be the requested cook. Anything the launcher

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -237,6 +237,37 @@ fn cook_detaches_local_placement_instead_of_rejecting_it() {
     }
 }
 
+/// Piped stdio is not permission to turn an explicit local wait into a durable
+/// handoff. This target fails during foreground resolution, which makes the
+/// assertion bounded while proving the launcher did not emit a detach envelope.
+#[test]
+fn non_tty_local_wait_stays_foreground() {
+    let output = homeboy(&[
+        "--placement",
+        "local",
+        "--wait",
+        "agent-task",
+        "cook",
+        "--prompt",
+        "implement the fix",
+        "--to-worktree",
+        "missing@worktree",
+        "--verify",
+        "true",
+    ]);
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("homeboy/agent-task-cook-local-detach-handoff/v1"),
+        "explicit --wait must not return a detach handoff: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"status\": \"in_flight\""),
+        "explicit --wait must not return an in-flight Cook report: {stdout}"
+    );
+}
+
 /// Historical runner recovery is a distinct owner, never an admission gate for
 /// an accepted Cook. This invokes the actual detached Cook command path rather
 /// than a scheduler helper so its output and durable handoff remain observable.


### PR DESCRIPTION
## Summary
- make the detached local launcher the sole detach authority
- re-execute the local Cook child with explicit `--wait`
- cover piped non-TTY wait and explicit detach behavior

Closes #10527.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli local_detach::tests --lib`
- `cargo test --test cook_lab_handoff_test non_tty_local_wait_stays_foreground -- --exact`
- `cargo test --test cook_lab_handoff_test cook_detaches_local_placement_instead_of_rejecting_it -- --exact`

## AI assistance
OpenCode general coding subagent with OpenAI GPT-5.6 Sol traced the local re-execution ambiguity, made wait policy explicit, and added noninteractive coverage. Chris Huber reviewed and remains responsible for every line.