### PR TITLE
Preserve compact lint summaries through fix paths

### DIFF
--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -475,6 +475,7 @@ fn run_fix(
 
     let lint_options = LintSourceOptions {
         selected_files,
+        summary: args.summary || args.json_summary,
         file: args.file.clone(),
         glob: args.glob.clone(),
         sniff_filters: args.sniff_filters.to_lint_sniff_filters(),
@@ -701,6 +702,7 @@ mod tests {
             vec![("mode".to_string(), serde_json::json!("strict"))],
             LintSourceOptions {
                 selected_files: Some(vec!["src/lib.rs".to_string()]),
+                summary: false,
                 file: None,
                 glob: Some("/tmp/demo/src/lib.rs".to_string()),
                 sniff_filters: homeboy_extension::lint::LintSniffFilters {

--- a/crates/homeboy-extension/src/lint/mod.rs
+++ b/crates/homeboy-extension/src/lint/mod.rs
@@ -155,7 +155,53 @@ fn split_lint_settings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::component::{Component, ScopedExtensionConfig};
     use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn summary_runner_captures_streams_for_evidence() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extension = home.path().join(".config/homeboy/extensions/fixture");
+            std::fs::create_dir_all(&extension).expect("extension directory");
+            std::fs::write(
+                extension.join("fixture.json"),
+                r#"{"name":"fixture","version":"1.0.0","lint":{"extension_script":"lint.sh"}}"#,
+            )
+            .expect("extension manifest");
+            let component = Component {
+                id: "fixture".to_string(),
+                extensions: Some(HashMap::from([(
+                    "fixture".to_string(),
+                    ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            };
+            let run_dir = RunDir::create().expect("run dir");
+
+            let summary = build_lint_runner(LintRunnerRequest {
+                component: &component,
+                path_override: None,
+                settings: &[],
+                summary: true,
+                file: None,
+                glob: None,
+                errors_only: false,
+                sniffs: None,
+                exclude_sniffs: None,
+                category: None,
+                step: None,
+                changed_files: None,
+                run_dir: &run_dir,
+            })
+            .expect("summary runner");
+
+            assert!(
+                !summary.is_passthrough(),
+                "summary mode captures full child output in run evidence"
+            );
+        });
+    }
 
     #[test]
     fn split_lint_settings_preserves_typed_json_values() {

--- a/crates/homeboy-extension/src/lint/run/findings.rs
+++ b/crates/homeboy-extension/src/lint/run/findings.rs
@@ -229,7 +229,10 @@ pub(super) fn build_lint_summary(
     LintSummaryOutput {
         total_findings: findings.len(),
         categories,
-        top_findings: findings.iter().take(20).cloned().collect(),
+        // Individual findings remain in the persisted lint evidence and the
+        // non-summary response. A summary must stay bounded regardless of the
+        // number of findings or the size of their messages.
+        top_findings: Vec::new(),
         producer_summaries: producer_summaries.to_vec(),
         exit_code,
     }

--- a/crates/homeboy-extension/src/lint/run/tests/findings.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/findings.rs
@@ -10,8 +10,8 @@ use homeboy_core::finding::HomeboyFinding;
 use std::path::Path;
 
 #[test]
-fn lint_summary_counts_categories_and_caps_top_findings() {
-    let findings = (0..25)
+fn lint_summary_counts_categories_and_omits_individual_findings() {
+    let findings = (0..1_000)
         .map(|index| {
             let category = if index % 2 == 0 {
                 "style"
@@ -36,12 +36,18 @@ fn lint_summary_counts_categories_and_caps_top_findings() {
     );
     let summary = build_lint_summary(&findings, &producers, 1);
 
-    assert_eq!(summary.total_findings, 25);
-    assert_eq!(summary.categories.get("style"), Some(&13));
-    assert_eq!(summary.categories.get("correctness"), Some(&12));
-    assert_eq!(summary.top_findings.len(), 20);
-    assert_eq!(summary.producer_summaries[0].finding_count, 25);
+    assert_eq!(summary.total_findings, 1_000);
+    assert_eq!(summary.categories.get("style"), Some(&500));
+    assert_eq!(summary.categories.get("correctness"), Some(&500));
+    assert!(summary.top_findings.is_empty());
+    assert_eq!(summary.producer_summaries[0].finding_count, 1_000);
     assert_eq!(summary.exit_code, 1);
+
+    let rendered = serde_json::to_value(&summary).expect("summary serializes");
+    assert!(
+        rendered.get("top_findings").is_none(),
+        "a compact summary must not serialize individual findings"
+    );
 }
 
 #[test]

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -189,7 +189,6 @@ pub fn run_main_lint_workflow(
                 "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
                 "1",
             )
-            .passthrough(!args.json_summary)
             .run()?;
         let stdout_artifact = write_command_artifact(run_dir, 0, "stdout", &output.stdout)?;
         let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;
@@ -503,7 +502,6 @@ fn run_scoped_lint_runs(
                 "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
                 "1",
             )
-            .passthrough(!args.json_summary)
             .run()?;
         let stdout_artifact = write_command_artifact(run_dir, index, "stdout", &output.stdout)?;
         let stderr_artifact = write_command_artifact(run_dir, index, "stderr", &output.stderr)?;

--- a/crates/homeboy-refactor/src/plan/sources.rs
+++ b/crates/homeboy-refactor/src/plan/sources.rs
@@ -96,6 +96,7 @@ pub fn build_test_refactor_request(
 #[derive(Debug, Clone, Default)]
 pub struct LintSourceOptions {
     pub selected_files: Option<Vec<String>>,
+    pub summary: bool,
     pub file: Option<String>,
     pub glob: Option<String>,
     pub sniff_filters: homeboy_extension::lint::LintSniffFilters,

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -317,7 +317,7 @@ pub(super) fn run_lint_stage(
             component,
             path_override: None,
             settings,
-            summary: false,
+            summary: options.summary,
             file: options.file.as_deref(),
             glob: effective_glob,
             errors_only: options.sniff_filters.errors_only,
@@ -876,7 +876,7 @@ mod tests {
         fs::write(
             extension.join("lint.sh"),
             format!(
-                "#!/bin/sh\nset -eu\nfile=\"$HOMEBOY_COMPONENT_PATH/src/example.fixture\"\necho \"${{HOMEBOY_FIX_ONLY:-diagnose}}:${{HOMEBOY_STEP:-all}}\" >> \"$HOMEBOY_COMPONENT_PATH/runner.log\"\nif [ \"${{HOMEBOY_FIX_ONLY:-}}\" = 1 ]; then\n  [ \"${{HOMEBOY_STEP:-}}\" = fixture-fixer ] || exit 91\n  {}\n  exit 0\nfi\nif grep -q unresolved \"$file\"; then\n  printf '%s\\n' '[{{\"tool\":\"fixture\",\"file\":\"src/example.fixture\",\"message\":\"unresolved fixture finding\",\"rule\":\"fixture.rule\",\"fixable\":true}}]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nelse\n  printf '%s\\n' '[]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nfi\n",
+                "#!/bin/sh\nset -eu\nfile=\"$HOMEBOY_COMPONENT_PATH/src/example.fixture\"\necho \"${{HOMEBOY_FIX_ONLY:-diagnose}}:${{HOMEBOY_STEP:-all}}:${{HOMEBOY_SUMMARY_MODE:-0}}\" >> \"$HOMEBOY_COMPONENT_PATH/runner.log\"\nif [ \"${{HOMEBOY_FIX_ONLY:-}}\" = 1 ]; then\n  [ \"${{HOMEBOY_STEP:-}}\" = fixture-fixer ] || exit 91\n  {}\n  exit 0\nfi\nif grep -q unresolved \"$file\"; then\n  printf '%s\\n' '[{{\"tool\":\"fixture\",\"file\":\"src/example.fixture\",\"message\":\"unresolved fixture finding\",\"rule\":\"fixture.rule\",\"fixable\":true}}]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nelse\n  printf '%s\\n' '[]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nfi\n",
                 if mutates { "printf 'resolved\\n' > \"$file\"" } else { ":" }
             ),
         )
@@ -941,7 +941,37 @@ mod tests {
             assert_eq!(stage.summary.files_modified, 1);
             assert_eq!(
                 fs::read_to_string(root.join("runner.log")).unwrap(),
-                "diagnose:all\n1:fixture-fixer\ndiagnose:all\n"
+                "diagnose:all:0\n1:fixture-fixer:0\ndiagnose:all:0\n"
+            );
+            let _ = fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn lint_fix_summary_mode_is_forwarded_to_diagnostics_and_fixer() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("summary-fix");
+            init_routed_lint_repo(&root);
+            write_routed_lint_extension(home.path(), "summary-fixture", true);
+            let run_dir = RunDir::create().unwrap();
+
+            run_lint_stage(
+                &routed_component(&root, "summary-fixture"),
+                &root,
+                &[],
+                &LintSourceOptions {
+                    summary: true,
+                    ..Default::default()
+                },
+                None,
+                true,
+                &run_dir,
+            )
+            .expect("summary fix should succeed");
+
+            assert_eq!(
+                fs::read_to_string(root.join("runner.log")).unwrap(),
+                "diagnose:all:1\n1:fixture-fixer:1\ndiagnose:all:1\n"
             );
             let _ = fs::remove_dir_all(root);
         });
@@ -978,7 +1008,7 @@ mod tests {
             assert!(error.message.contains("unresolved fixture finding"));
             assert_eq!(
                 fs::read_to_string(root.join("runner.log")).unwrap(),
-                "diagnose:all\n1:fixture-fixer\ndiagnose:all\n"
+                "diagnose:all:0\n1:fixture-fixer:0\ndiagnose:all:0\n"
             );
             let _ = fs::remove_dir_all(root);
         });


### PR DESCRIPTION
## Summary
- preserve captured summary mode through lint workflow execution
- forward summary mode through refactor diagnostics and fixer stages
- report aggregate producer/category totals without serializing individual findings
- retain full findings in durable evidence

Closes #10933.

## Verification
- `cargo fmt --check`
- focused homeboy-extension lint finding and runner tests
- focused homeboy-refactor summary propagation test
- focused homeboy-cli lint request test
- `git diff --check`

## AI assistance
OpenCode general coding subagent with OpenAI GPT-5.6 Sol traced summary-mode loss across workflow and refactor paths, implemented the compact result, and added 1,000-finding coverage. Chris Huber reviewed and remains responsible for every line.