### PR TITLE
fix: unbreak main — scope terminator returned Result<()> as Result<bool>

### DIFF
--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -1026,7 +1026,10 @@ fn terminate_linux_scope_members_with_grace(scope: &str, grace: Duration) -> Res
     signal_pids(&survivors, libc::SIGKILL)?;
     if !wait_for_linux_scope_exit(scope, SIGKILL_REAP_GRACE)? {
         let survivors = linux_scope_pids(scope)?;
-        return ensure_sigkill_reaped("owned process scope", 0, &survivors);
+        // Errors when anything outlived SIGKILL; returns Ok once the scope is
+        // empty. Either way this path did escalate, so the caller is told the
+        // grace period was not enough.
+        ensure_sigkill_reaped("owned process scope", 0, &survivors)?;
     }
     Ok(true)
 }


### PR DESCRIPTION
**`main` does not compile.**

```
error[E0308]: mismatched types
    --> crates/homeboy-core/src/process.rs:1029:16
     |
1019 | fn terminate_linux_scope_members_with_grace(scope: &str, grace: Duration) -> Result<bool> {
     |                                                                              ------------ expected `Result<bool, Error>` because of return type
...
1029 |         return ensure_sigkill_reaped("owned process scope", 0, &survivors);

error: could not compile `homeboy-core` (lib) due to 1 previous error
```

Introduced by **#11693** (`feat(services): support bounded cleanup deadlines`). `ensure_sigkill_reaped` returns `Result<()>`; the enclosing function returns `Result<bool>`.

## Fix

The `bool` reports whether escalation past the grace period was needed. The survivor branch has escalated by definition, so propagate the error and return `true`:

```rust
ensure_sigkill_reaped("owned process scope", 0, &survivors)?;
```

`ensure_sigkill_reaped` errors when anything outlived `SIGKILL` and returns `Ok(())` once the scope is empty, so both outcomes stay correct.

## Note on why CI did not catch it earlier

The function is `#[cfg(target_os = "linux")]`, so this is the mirror of the recent Windows-only breaks — neither the `Windows Compile` gate nor a non-Linux check can see it. Found by `cargo check --workspace --tests` on a Linux host.

`cargo check --workspace --tests` → 0 errors, 0 warnings.

🤖 Authored by chubes-bot