### PR TITLE
Align runtime-tool readiness with declared command

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
@@ -39,7 +39,19 @@ pub(crate) fn resolve_runtime_tools(
                 failure_classification: AgentTaskFailureClassification::CapabilityMissing,
             });
         }
-        let readiness_command = std::iter::once(tool.command[0].as_str())
+        let executable = resolve_executable_candidate(&tool.command[0]).ok_or_else(|| {
+            RuntimeToolResolutionError {
+                class: "agent_task.runtime_tool_executable_missing",
+                message: format!(
+                    "runtime tool '{}' executable '{}' is unavailable on this execution host",
+                    tool.id, tool.command[0]
+                ),
+                data: json!({ "tool": tool.id, "command": tool.command, "readiness": "executable_missing" }),
+                failure_classification: AgentTaskFailureClassification::CapabilityMissing,
+            }
+        })?;
+        let readiness_command = std::iter::once(executable.as_str())
+            .chain(tool.command.iter().skip(1).map(String::as_str))
             .chain(tool.readiness.version_command.iter().map(String::as_str))
             .collect::<Vec<_>>()
             .join(" ");
@@ -56,17 +68,6 @@ pub(crate) fn resolve_runtime_tools(
                 failure_classification: AgentTaskFailureClassification::InvalidInput,
             });
         }
-        let executable = resolve_executable_candidate(&tool.command[0]).ok_or_else(|| {
-            RuntimeToolResolutionError {
-                class: "agent_task.runtime_tool_executable_missing",
-                message: format!(
-                    "runtime tool '{}' executable '{}' is unavailable on this execution host",
-                    tool.id, tool.command[0]
-                ),
-                data: json!({ "tool": tool.id, "command": tool.command, "readiness": "executable_missing" }),
-                failure_classification: AgentTaskFailureClassification::CapabilityMissing,
-            }
-        })?;
         let version = probe_version(tool, &executable)?;
         let capability_probe =
             probe_capabilities(tool, &executable, &request.request.policy.tools)?;
@@ -165,6 +166,7 @@ fn probe_capabilities(
         return Ok(None);
     };
     let command = std::iter::once(executable)
+        .chain(tool.command.iter().skip(1).map(String::as_str))
         .chain(probe.argv.iter().map(String::as_str))
         .collect::<Vec<_>>()
         .join(" ");
@@ -178,9 +180,11 @@ fn probe_capabilities(
     }
     let mut command = Command::new(executable);
     command
+        .args(tool.command.iter().skip(1))
         .args(&probe.argv)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    apply_probe_environment(&mut command, tool);
     let mut containment = AgentTaskProcessContainment::prepare(&mut command).map_err(|error| {
         RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_capability_probe_failed",
@@ -258,9 +262,11 @@ fn probe_version(
     }
     let mut command = Command::new(executable);
     command
+        .args(tool.command.iter().skip(1))
         .args(&tool.readiness.version_command)
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
+    apply_probe_environment(&mut command, tool);
     let mut containment = AgentTaskProcessContainment::prepare(&mut command).map_err(|error| {
         RuntimeToolResolutionError {
             class: "agent_task.runtime_tool_readiness_failed",
@@ -329,6 +335,10 @@ fn probe_version(
             Ok(None) => std::thread::sleep(std::time::Duration::from_millis(10)),
         }
     }
+}
+
+fn apply_probe_environment(command: &mut Command, tool: &AgentTaskRuntimeTool) {
+    command.env_clear().envs(&tool.env);
 }
 
 fn valid_identifier(value: &str) -> bool {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -308,7 +308,9 @@ process.stdin.on('end', () => {
 
 #[test]
 fn provider_adapter_receives_and_consumes_resolved_stdio_runtime_tool() {
-    let tool = script("process.stdout.write(process.env.FIXTURE_MODE + ':ping'); process.exit(0);");
+    let tool = script(
+        "if (process.env.FIXTURE_MODE !== 'isolated') process.exit(17); if (process.argv[2] !== undefined && (process.env.PROBE_HOME !== 'declared' || process.env.PATH !== undefined || process.env.HOME !== undefined)) process.exit(19); if (process.argv[2] === '--version') { process.stdout.write('fixture 1.0'); process.exit(0); } if (process.argv[2] === '--capability-probe') process.exit(0); if (process.argv[2] !== undefined) process.exit(18); process.stdout.write(process.env.FIXTURE_MODE + ':ping'); process.exit(0);",
+    );
     let provider_script = script(
         r#"const { spawnSync } = require('child_process');
 process.stdin.once('data', input => {
@@ -324,9 +326,10 @@ process.stdin.once('data', input => {
     request.runtime_tools = vec![serde_json::from_value(json!({
         "id": "fixture.mcp",
         "command": ["node", tool],
-        "env": { "FIXTURE_MODE": "isolated" },
+        "env": { "FIXTURE_MODE": "isolated", "PROBE_HOME": "declared" },
+        "secret_env": ["HOME"],
         "required_capabilities": ["browser"],
-        "readiness": { "capability_probe": { "argv": [] } }
+        "readiness": { "version_command": ["--version"], "capability_probe": { "argv": ["--capability-probe"] } }
     }))
     .expect("runtime tool")];
     request.policy.tools.tools.insert(
@@ -365,6 +368,10 @@ process.stdin.once('data', input => {
     assert_eq!(
         outcome.metadata["resolved_runtime_tools"][0]["capability_probe"]["status"],
         "succeeded"
+    );
+    assert_eq!(
+        outcome.metadata["resolved_runtime_tools"][0]["version"],
+        "fixture 1.0"
     );
     assert_eq!(
         outcome.metadata["capability_evidence"]["tool_contributed"][0]["capabilities"][0],
@@ -480,7 +487,7 @@ fn runtime_tool_readiness_obeys_the_command_policy() {
     );
     request.policy.tools.commands = serde_json::from_value(json!({
         "mode": "deny_list",
-        "deny": [{ "pattern": "node --version" }]
+        "deny": [{ "pattern": "*node * --version" }]
     }))
     .expect("command policy");
 
@@ -488,6 +495,52 @@ fn runtime_tool_readiness_obeys_the_command_policy() {
         request,
         AgentTaskExecutionContext {
             plan_id: "runtime-tool-policy-plan".to_string(),
+            run_id: None,
+            attempt: 1,
+            cancellation: Default::default(),
+        },
+    );
+
+    assert_eq!(
+        outcome.diagnostics[0].class,
+        "agent_task.runtime_tool_command_denied"
+    );
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::InvalidInput)
+    );
+}
+
+#[test]
+fn runtime_tool_capability_probe_obeys_the_command_policy() {
+    let script = script("process.exit(0);");
+    let (mut request, provider) =
+        request("runtime-tool-capability-policy", format!("node {script}"));
+    request.runtime_tools = vec![serde_json::from_value(json!({
+        "id": "fixture.mcp",
+        "command": ["node", script],
+        "required_capabilities": ["fixture"],
+        "readiness": { "capability_probe": { "argv": ["--capability-probe"] } }
+    }))
+    .expect("runtime tool")];
+    request.policy.tools.tools.insert(
+        "fixture.mcp".to_string(),
+        crate::agent_task::AgentToolPolicyRule {
+            execution_location: crate::agent_task::AgentToolExecutionLocation::Runner,
+            timeout_ms: None,
+            reason: None,
+        },
+    );
+    request.policy.tools.commands = serde_json::from_value(json!({
+        "mode": "deny_list",
+        "deny": [{ "pattern": "*node * --capability-probe" }]
+    }))
+    .expect("command policy");
+
+    let outcome = ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]).execute(
+        request,
+        AgentTaskExecutionContext {
+            plan_id: "runtime-tool-capability-policy-plan".to_string(),
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),


### PR DESCRIPTION
## Summary\n\n- run readiness probes as resolved executable + declared command tail + probe args\n- provide only declared non-secret tool environment, excluding ambient and secret values\n- evaluate command policy against the actual resolved version and capability invocations\n- cover version/capability parity, policy denial, env isolation, and secret exclusion\n\n## Verification\n\n- `cargo fmt --all -- --check`\n- `cargo test -p homeboy-agents agent_task_provider::tests::manifest_tests` (26 passed)\n- `git diff --check`\n- independent review iterations resolved command, policy, and environment-boundary findings\n\nCloses #11716.\n\nDownstream tracker: https://github.a8c.com/chubes4/wp-build/issues/1292\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode identified readiness/dispatch drift, implemented the generic probe fix, and coordinated independent reviews. Chris Huber reviewed and remains responsible for every line.