### PR TITLE
fix(command): reap the remaining process group before joining capture readers

### DIFF
--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -471,6 +471,13 @@ pub fn wait_with_bounded_output_until_cancelled_with_stdout_observer(
 
     let status = loop {
         if let Some(status) = child.try_wait()? {
+            // The command exited, but a background descendant can still hold
+            // the inherited stdout/stderr pipes open. Joining the capture
+            // readers first would block until that descendant exits, which is
+            // an unbounded wait after the work is already done (#11702). Reap
+            // the remaining group before joining, exactly as the supervised
+            // sibling loop does.
+            terminate_remaining_process_group(child.id())?;
             break status;
         }
         if is_cancelled() {
@@ -1542,6 +1549,45 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_secs(3));
         assert_eq!(result.termination, SupervisedCommandTermination::Completed);
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellable_wait_does_not_deadlock_on_a_background_output_holder() {
+        // The sibling of the supervised case above, for the cancellable path
+        // `review lint --fix` runs through. A fixer that leaves a background
+        // descendant holding the inherited pipes used to strand the capture
+        // join after the command had already exited and written its edits,
+        // so the run only ended at the caller's timeout (#11702).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let script = format!(
+            "sleep 30 & echo $! > {}; printf fixed",
+            crate::shell::quote_path(&pid_file.display().to_string())
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        command.stdout(std::process::Stdio::piped());
+        command.stderr(std::process::Stdio::piped());
+        isolate_process_tree(&mut command);
+        let mut child = command.spawn().expect("spawn process tree");
+
+        let started = std::time::Instant::now();
+        let output = wait_with_bounded_output_until_cancelled(&mut child, 64, || false)
+            .expect("completed command returns a terminal result");
+
+        // The point of the fix: this returns promptly instead of blocking for
+        // as long as the descendant lives.
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"fixed");
+
         let descendant_pid = std::fs::read_to_string(&pid_file)
             .expect("descendant pid")
             .trim()


### PR DESCRIPTION
Closes #11702

## The hang

`homeboy review lint --fix` applied 120 PHPCBF fixes, printed completed fixer output, modified files on disk — and never returned a terminal result. The caller killed it at 1,200 seconds.

## Root cause

`wait_with_bounded_output_until_cancelled_with_stdout_observer` breaks its wait loop the moment the **direct child** exits:

```rust
let status = loop {
    if let Some(status) = child.try_wait()? {
        break status;                       // ← direct child is gone
    }
    ...
};
let stdout = join_capture(stdout_handle)?;  // ← blocks until EOF
let stderr = join_capture(stderr_handle)?;
```

`join_capture` waits for the capture threads, and those read until EOF. A fixer that leaves a **background descendant** holding the inherited stdout/stderr pipes keeps them open indefinitely — so the join is unbounded *after the work is already finished*. That is exactly the reported shape: edits applied, output printed, no result.

## The fix already existed and simply wasn't called here

`terminate_remaining_process_group` documents this precise hazard:

> A command can exit before a background descendant closes inherited output pipes. Stop that remaining process group before joining capture readers.

Its **supervised** sibling loop calls it on normal exit. The cancellable path did not. One call, same semantics, same placement:

```rust
if let Some(status) = child.try_wait()? {
    terminate_remaining_process_group(child.id())?;
    break status;
}
```

Both `join_capture` call sites in the file are now guarded on the normal-exit path; the cancellation paths already went through `terminate_process_tree_and_reap`.

## Regression test — verified to actually catch it

`cancellable_wait_does_not_deadlock_on_a_background_output_holder`, the sibling of the existing supervised test. It runs `sleep 30 & ...; printf fixed` so a descendant outlives the command holding the pipes.

I confirmed it fails without the fix rather than assuming:

| | result |
|---|---|
| fix reverted | **FAILED after 30.00s** (the descendant's full lifetime) |
| fix applied | **ok in 0.11s** |

## Verification

`cargo check --workspace --tests` → 0 errors, 0 warnings. `cargo test -p homeboy-engine-primitives --lib background_output_holder` → 2 passed.

## Note on scope

This fixes the generic command primitive, so it covers every caller of the cancellable path, not just `lint --fix`. The issue's remaining asks — naming the exact stalled phase and child process in timeout evidence, and a multi-producer fix run exercised end to end — are not addressed here.

🤖 Authored by chubes-bot