### PR TITLE
Produce Homeboy's declared release artifact locally

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1836,7 +1836,7 @@
   "id": "homeboy",
   "scripts": {
     "build": [
-      "cargo build --release"
+      "CARGO_TARGET_DIR=target cargo build --release"
     ]
   },
   "version_targets": [


### PR DESCRIPTION
## Summary

Pin Homeboy's component-owned release build to `CARGO_TARGET_DIR=target` so the build produces the declared `target/release/homeboy` artifact even when the Rust environment provider supplies shared Cargo storage.

Fixes #11726.

## Verification

- `jq empty homeboy.json`
- `git diff --check`
- The Homeboy release package step will provide the end-to-end artifact collection proof after merge.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the build-artifact contract mismatch and prepared this minimal correction. Chris Huber remains responsible for every line.