### PR TITLE
fix(cli): stop reading forwarded remote arguments as Homeboy's own

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -10,7 +10,8 @@ use crate::cli_surface::{
     ExtensionCommandHealth, ExtensionCommandManifest,
 };
 use crate::command_capability::{
-    classify as classify_command_capability, requires_startup_reconciliation, CommandCapability,
+    classify as classify_command_capability, homeboy_owned_args, requires_startup_reconciliation,
+    CommandCapability,
 };
 use crate::commands;
 use crate::commands::cli;
@@ -83,10 +84,17 @@ fn startup_fast_path_output(args: &[String]) -> Option<StartupFastPathOutput> {
         // Rendered help never displays readiness, so probing it was pure cost
         // on the hottest command in the CLI (#10616).
         StartupFastPath::Help => {
-            let error = CliRuntime::new()
+            // Fall through to normal parsing rather than asserting. This used
+            // to `expect_err`, so any argv the fast path read as help but clap
+            // parsed successfully aborted the process instead of running the
+            // command (#11577). The fast path is an optimization; disagreeing
+            // with clap must cost a slow path, never a panic.
+            let Err(error) = CliRuntime::new()
                 .build_augmented_command()
                 .try_get_matches_from(args)
-                .expect_err("an explicit help flag must stop argument parsing");
+            else {
+                return None;
+            };
             if error.kind() != clap::error::ErrorKind::DisplayHelp {
                 return None;
             }
@@ -1148,7 +1156,13 @@ fn startup_fast_path(args: &[String]) -> Option<StartupFastPath> {
     }
 
     match args {
-        [_, rest @ ..] if rest.iter().any(|arg| arg == "--help" || arg == "-h") => {
+        // Only Homeboy's own arguments can request help. A forwarded remote
+        // command may legitimately contain `-h` (#11577).
+        [_, rest @ ..]
+            if homeboy_owned_args(rest)
+                .iter()
+                .any(|arg| arg == "--help" || arg == "-h") =>
+        {
             Some(StartupFastPath::Help)
         }
         [_, flag] if flag == "--version" || flag == "-V" => Some(StartupFastPath::Version),

--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -55,8 +55,24 @@ pub enum CommandCapability {
     Mutation,
 }
 
+/// The arguments Homeboy itself owns: everything before the first bare `--`.
+///
+/// Everything after it is forwarded verbatim to a remote or child command —
+/// `homeboy ssh <target> -- df -h /` — so it must never influence how Homeboy
+/// classifies or routes its own invocation. Reading through the separator let a
+/// remote `-h` short-circuit this function to `ReadOnly` on an `ssh` invocation
+/// that is otherwise `Mutation`, and made the startup help fast path claim an
+/// invocation clap would go on to parse successfully (#11577).
+pub fn homeboy_owned_args(args: &[String]) -> &[String] {
+    match args.iter().position(|arg| arg == "--") {
+        Some(separator) => &args[..separator],
+        None => args,
+    }
+}
+
 pub fn classify(args: &[String]) -> CommandCapability {
     let args = args.get(1..).unwrap_or_default();
+    let args = homeboy_owned_args(args);
 
     if args.iter().any(|arg| arg == "--help" || arg == "-h") {
         return CommandCapability::ReadOnly;
@@ -272,5 +288,51 @@ mod tests {
         ] {
             assert!(requires_startup_reconciliation(&command));
         }
+    }
+
+    #[test]
+    fn a_forwarded_remote_argument_cannot_reclassify_the_invocation() {
+        // `homeboy ssh <target> --timeout 30 -- df -h /` is a mutation that
+        // happens to forward `-h`. Reading through the separator classified it
+        // ReadOnly and skipped the mutation path entirely (#11577).
+        let ssh_with_remote_help = args(&[
+            "homeboy",
+            "ssh",
+            "chubes-net",
+            "--timeout",
+            "30",
+            "--",
+            "df",
+            "-h",
+            "/",
+        ]);
+        assert_eq!(classify(&ssh_with_remote_help), CommandCapability::Mutation);
+
+        // Homeboy's own help is still help, before or after other flags.
+        assert_eq!(
+            classify(&args(&["homeboy", "ssh", "--help"])),
+            CommandCapability::ReadOnly
+        );
+
+        // A remote command whose own flags mimic Homeboy's read-only surface
+        // must not borrow that classification either.
+        assert_eq!(
+            classify(&args(&["homeboy", "ssh", "host", "--", "runner", "status"])),
+            CommandCapability::Mutation
+        );
+    }
+
+    #[test]
+    fn homeboy_owned_args_stops_at_the_first_separator() {
+        let forwarded = args(&["ssh", "host", "--", "df", "-h"]);
+        assert_eq!(homeboy_owned_args(&forwarded), &args(&["ssh", "host"])[..]);
+
+        // No separator means every argument is Homeboy's.
+        let all = args(&["runner", "status"]);
+        assert_eq!(homeboy_owned_args(&all), &all[..]);
+
+        // Only the first separator delimits; later ones belong to the remote.
+        let nested = args(&["ssh", "host", "--", "sh", "-c", "--", "x"]);
+        assert_eq!(homeboy_owned_args(&nested), &args(&["ssh", "host"])[..]);
     }
 }


### PR DESCRIPTION
Closes #11577

## Reported

```sh
homeboy ssh chubes-net --timeout 30 -- df -h /
```

panicked at `cli_runtime.rs` with `an explicit help flag must stop argument parsing`.

## Root cause — two sites, one blind spot

Both scanned the entire argv for `-h` / `--help` with no awareness of the bare `--` separator, so a **remote** command's flag was read as **Homeboy's**.

**1. `command_capability::classify` — the more serious half.**

```rust
if args.iter().any(|arg| arg == "--help" || arg == "-h") {
    return CommandCapability::ReadOnly;
}
```

`ssh` is not in the read-only table, so it correctly falls through to `Mutation` — but a forwarded `-h` short-circuited above that and **silently downgraded the invocation's capability classification**. That governs startup reconciliation and mutation handling, so this was a safety-policy bug, not only a crash. It never surfaced because the panic happened first.

**2. `startup_fast_path` — the visible half.**

It claimed `Help`, then:

```rust
.expect_err("an explicit help flag must stop argument parsing")
```

clap parses `-h` after `--` as a trailing positional, exactly as it should, and returns `Ok`. `expect_err` turned that disagreement into a process abort.

## Fix

`homeboy_owned_args` truncates at the first `--`, used at both sites. Everything after the separator is forwarded verbatim to a remote or child command and must never classify or route Homeboy itself.

The fast path now falls through to normal parsing rather than asserting. It is an optimization; disagreeing with clap should cost a slow path, never the process.

## Verification

**Regression tests confirmed to actually catch it** — I reverted the fix and re-ran rather than assuming:

| | `classify(ssh … -- df -h /)` |
|---|---|
| fix reverted | **FAILED** — `left: ReadOnly, right: Mutation` |
| fix applied | ok |

Also covers a remote command mimicking Homeboy's read-only surface (`ssh host -- runner status` stays `Mutation`), and that only the *first* separator delimits.

**Built the binary and ran the exact reported command:**

```
$ homeboy ssh chubes-net --timeout 30 -- df -h /
[ssh] phase=command-finished
[ssh] phase=cleanup-finished
{ "schema": "homeboy/command-result/v3", "success": true, "exit_code": 0, ... }
```

No panic; the remote command ran and returned a structured result. `homeboy --help` and `homeboy ssh --help` both still render normally.

`cargo check --workspace --tests` → 0 errors, 0 warnings. `cargo test -p homeboy-cli --lib command_capability` → 7 passed.

🤖 Authored by chubes-bot