### PR TITLE
fix(agents): avoid lazy notification result

### DIFF
--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -135,7 +135,7 @@ fn safe_transport_result(result: Option<&Value>) -> Option<Value> {
             _ => {}
         }
     }
-    (!safe.is_empty()).then(|| Value::Object(safe))
+    (!safe.is_empty()).then_some(Value::Object(safe))
 }
 
 fn cook_subject(cook_id: &str, run_id: &str, component: Option<&str>) -> NotifySubject {


### PR DESCRIPTION
Closes #11739

## Summary
Replace the eager `then` closure in cook notification transport-result filtering with the behavior-equivalent `then_some` primitive.

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo fmt`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo test -p homeboy-agents agent_task_notify::tests` (16 passed)
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo clippy -p homeboy-cli -- -D warnings` reached `homeboy-lab-runner` and fails on two unrelated existing diagnostics: unspecified `OpenOptions::truncate` in `controller_fallback_projection.rs:443`, and `large_enum_variant` in `lab_staging_controller.rs:1079`. The issue-specific `agent_task_notify.rs:138` warning is resolved.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the one-line behavior-preserving repair and ran the focused checks. Chris Huber remains responsible for every line.