### PR TITLE
Fix warning-clean Lab staging

### DIFF
--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -443,6 +443,9 @@ impl ControllerFallbackProjectionStore {
             .create(true)
             .read(true)
             .write(true)
+            // This separate lock file protects read-modify-write ledger updates;
+            // ledger state itself is atomically replaced by `persist`.
+            .truncate(false)
             .open(self.path.with_extension("lock"))
             .map_err(|error| {
                 Error::internal_io(

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/durable_fallbacks.rs
@@ -44,7 +44,9 @@ fn deferred_staging_emits_only_durable_run_commands() {
         controller_projection: "deferred".to_string(),
     };
     let output = detached_staging_submission_output(
-        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(receipt.clone()),
+        crate::lab_staging_controller::DetachedStagingSubmission::Deferred(Box::new(
+            receipt.clone(),
+        )),
         "run-1",
     );
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1003,7 +1003,7 @@ where
                 request,
                 daemon_error,
             )
-            .map(DetachedStagingSubmission::Deferred);
+            .map(|receipt| DetachedStagingSubmission::Deferred(Box::new(receipt)));
         }
     };
     let recipe = persist_lab_staging_recipe_for_transport(
@@ -1078,7 +1078,7 @@ where
 /// staging. They have separate status and reconciliation authorities.
 pub(crate) enum DetachedStagingSubmission {
     Controller { job_id: String },
-    Deferred(crate::controller_fallback_projection::DeferredControllerReceipt),
+    Deferred(Box<crate::controller_fallback_projection::DeferredControllerReceipt>),
 }
 
 /// Explicit detached fallback after local controller admission has failed. The


### PR DESCRIPTION
Closes #11742

## Summary
- Explicitly preserve the non-truncating lock-file contract for fallback projection read-modify-write updates.
- Box deferred staging receipts to keep the detached submission enum compact without changing response fields.

## Verification
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo test -p homeboy-lab-runner controller_fallback_projection` (8 passed)
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo test -p homeboy-lab-runner detached_staging` (2 passed)
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy@fix-11731-invalid-extension-listing/target cargo clippy -p homeboy-cli -- -D warnings`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the fallback-projection and detached-staging contracts, implement the focused lint fixes, and run verification. Chris Huber remains responsible for every line.