### PR TITLE
perf(ci): skip the duplicated pre-test lint on every Test shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,16 @@ jobs:
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
       commands: review test
+      # `review test` defaults to running the extension's pre-test lint, which
+      # for Rust is a full `cargo clippy` over the workspace. The `Lint` job in
+      # the homeboy-fast matrix above already runs `review lint`, so every shard
+      # was repeating work that is covered once, costing roughly three minutes
+      # each across all `test-shards`.
+      #
+      # This matches the umbrella `review` command, which sets `skip_lint: true`
+      # when building its test stage for the same reason, and matches
+      # release.yml, which already passes `--skip-lint` here.
+      args: --skip-lint
       expected-commands: review audit,review lint,review test
       component: homeboy
       source: .


### PR DESCRIPTION
## The duplication

`review test` defaults `skip_lint` to `false`:

```rust
// crates/homeboy-cli/src/commands/test.rs:48-50
/// Skip linting before running tests
#[arg(long)]
pub skip_lint: bool,
```

so the Rust extension runs its pre-test lint — a full `cargo clippy` over the workspace, ~3 minutes:

```bash
# homeboy-extensions/rust/scripts/test-runner.sh:510-518
# ── Step 1: Pre-test lint (unless skipped) ──
elif should_run_step "lint" && [ "${HOMEBOY_SKIP_LINT:-}" != "1" ]; then
    HOMEBOY_SUMMARY_MODE=1 bash "$LINT_RUNNER"
```

Observed in shard-13:
```
Running cargo clippy...
Finished `dev` profile ... in 3m 08s
cargo clippy: passed
Rust lint checks passed
```

That ran in **all 16 shards**, while the `homeboy-fast` matrix already runs `review lint` exactly once as the dedicated `Lint` job:

```
homeboy-fast matrix commands: ['review audit', 'review lint']
homeboy job:                  commands: review test | test-shards: 16
```

## Two existing call sites already do this

This isn't a new policy — PR CI was the only path still paying for it.

1. The umbrella `review` command sets it explicitly, for exactly this reason:
   ```rust
   // crates/homeboy-cli/src/commands/review/mod.rs:881-885
   fn build_test_args(args: &ReviewArgs, ...) -> test::TestArgs {
       test::TestArgs {
           ...
           skip_lint: true,
   ```
   because `review` runs lint as its own stage.

2. `release.yml:532` already passes it to this same gate:
   ```yaml
   args: ${{ github.event.before && format('--skip-lint --changed-since {0}', ...) || '--skip-lint' }}
   ```

## Impact

~3 minutes off each of 16 shards — **~40 runner-minutes per PR**, and ~3 minutes off the critical path since shards run in parallel.

It also buys headroom against `test-timeout-seconds: 1500`, which shards have been exceeding.

## Verification

Workflow parses; `args: '--skip-lint'` confirmed on the `homeboy` job, and the `homeboy-fast` matrix confirmed to still own `review lint`.

## Context

Third of three CI-unblocking changes:
- #11743 — build script declaring `rerun-if-changed` on a nonexistent path, rebuilding all 29 crates every cargo invocation (the primary cause of shard timeouts)
- Extra-Chill/homeboy-action#356 — missing shard failure re-raise, which is why 16 green shards produced one red aggregator
- this PR