### PR TITLE
Fix fanout AI disclosure override parity

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -73,6 +73,11 @@ pub struct AgentTaskFanoutCookBatchArgs {
     pub secret_env: Vec<String>,
     #[arg(long = "provider-config", value_name = "JSON")]
     pub provider_config: Option<String>,
+    /// AI tool disclosure recorded in every child PR's assistance attribution.
+    /// When omitted, each child derives its disclosure from its effective provider
+    /// and model selection.
+    #[arg(long = "ai-tool", value_name = "TEXT")]
+    pub ai_tool: Option<String>,
     #[command(flatten)]
     pub gates: VerifyGateArgs,
     #[arg(long = "dry-run")]
@@ -132,4 +137,8 @@ pub struct AgentTaskFanoutRunPlanArgs {
     pub input: AgentTaskFanoutInputArgs,
     #[arg(long = "record-run-id", value_name = "ID")]
     pub record_run_id: Option<String>,
+    /// AI tool disclosure recorded in every child PR's assistance attribution.
+    /// Overrides the persisted plan value for this execution.
+    #[arg(long = "ai-tool", value_name = "TEXT")]
+    pub ai_tool: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1069,6 +1069,7 @@ fn batch_artifacts(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
 
 fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
+    plan.apply_ai_tool_override(args.ai_tool.as_deref());
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1082,6 +1083,7 @@ pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
     attempt_dispatcher: &CookAttemptDispatcherFactory,
 ) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
+    plan.apply_ai_tool_override(args.ai_tool.as_deref());
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1639,6 +1641,13 @@ impl BatchCookFanoutPlan {
         self.fanout_id = fanout_id;
     }
 
+    fn apply_ai_tool_override(&mut self, ai_tool: Option<&str>) {
+        let Some(ai_tool) = ai_tool else { return };
+        for cook in &mut self.cooks {
+            cook.ai_tool = ai_tool.to_string();
+        }
+    }
+
     fn dependency_nodes(&self) -> Vec<AgentTaskDependencyNode> {
         self.cooks
             .iter()
@@ -2099,7 +2108,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
             title: Some(format!("Fix {}", issue.key)),
             commit_message: Some(format!("fix: address {}", issue.key)),
             protected_branches: super::review::default_protected_branches(),
-            ai_tool: default_ai_tool(),
+            ai_tool: args.ai_tool.clone().unwrap_or_else(default_ai_tool),
             ai_used_for: default_ai_used_for(),
         });
     }
@@ -2448,18 +2457,7 @@ fn default_gate_no_progress_timeout_seconds() -> u64 {
 }
 
 fn default_ai_tool() -> String {
-    AgentTaskProviderCatalog::discover()
-        .providers()
-        .iter()
-        .find_map(|provider| provider.cli.default_ai_disclosure.clone())
-        .or_else(|| {
-            AgentTaskProviderCatalog::discover()
-                .providers()
-                .iter()
-                .flat_map(|provider| provider.cli.profiles.iter())
-                .find_map(|profile| profile.ai_disclosure.clone())
-        })
-        .unwrap_or_else(|| GENERIC_AI_DISCLOSURE.to_string())
+    GENERIC_AI_DISCLOSURE.to_string()
 }
 
 /// Generic fallback disclosure used when no provider supplies one. Also the
@@ -3240,6 +3238,7 @@ fi
             provider_profile: None,
             secret_env: vec!["AI_PROVIDER_OPENAI_CODEX_TOKEN".to_string()],
             provider_config: Some(r#"{"runtime":"opencode"}"#.to_string()),
+            ai_tool: None,
             gates: super::super::args::VerifyGateArgs {
                 accept_inherited_failures: false,
                 gate_package_artifacts: Vec::new(),
@@ -3378,6 +3377,71 @@ fi
                 Some(workspace.path())
             );
         });
+    }
+
+    #[test]
+    fn fanout_ai_tool_override_is_typed_persisted_and_applied_to_every_child() {
+        with_isolated_home(|_| {
+            let mut cook_args = cook_batch_args();
+            cook_args.ai_tool = Some("OpenAI GPT-5.6 Sol via OpenCode".to_string());
+            let plan =
+                build_cook_batch_plan(&cook_args).expect("build plan with disclosure override");
+            assert!(plan
+                .cooks
+                .iter()
+                .all(|cook| cook.ai_tool == "OpenAI GPT-5.6 Sol via OpenCode"));
+
+            let serialized = serde_json::to_value(&plan).expect("serialize plan");
+            let mut loaded =
+                BatchCookFanoutPlan::from_value(serialized, &args()).expect("load persisted plan");
+            loaded.apply_ai_tool_override(Some("OpenAI GPT-5.6 Terra via OpenCode"));
+            persist_batch_cook_recipes(&loaded).expect("persist child recipes");
+            for cook in &loaded.cooks {
+                let invocation = cook.to_cook_invocation(&loaded).expect("cook invocation");
+                assert_eq!(
+                    invocation.options.ai_tool,
+                    "OpenAI GPT-5.6 Terra via OpenCode"
+                );
+                let recipe = agent_task_service::load_recipe(&cook.run_id())
+                    .expect("load persisted child recipe");
+                assert_eq!(
+                    recipe.finalization["ai_tool"],
+                    "OpenAI GPT-5.6 Terra via OpenCode"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn fanout_plan_keeps_child_disclosures_without_an_override() {
+        let plan = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "mixed-disclosures",
+                "cooks": [
+                    {"cook_id":"sol","prompt":"sol","cwd":env!("CARGO_MANIFEST_DIR"),"to_worktree":"homeboy@sol","verify":["true"],"ai_tool":"OpenAI GPT-5.6 Sol via OpenCode"},
+                    {"cook_id":"terra","prompt":"terra","cwd":env!("CARGO_MANIFEST_DIR"),"to_worktree":"homeboy@terra","verify":["true"],"ai_tool":"OpenAI GPT-5.6 Terra via OpenCode"}
+                ]
+            }),
+            &args(),
+        )
+        .expect("load mixed-provider plan");
+        assert_eq!(
+            plan.cooks[0]
+                .to_cook_invocation(&plan)
+                .expect("sol invocation")
+                .options
+                .ai_tool,
+            "OpenAI GPT-5.6 Sol via OpenCode"
+        );
+        assert_eq!(
+            plan.cooks[1]
+                .to_cook_invocation(&plan)
+                .expect("terra invocation")
+                .options
+                .ai_tool,
+            "OpenAI GPT-5.6 Terra via OpenCode"
+        );
     }
 
     #[test]
@@ -3935,6 +3999,8 @@ fi
             "opencode-codex-gpt55",
             "--verify",
             "cargo test --lib",
+            "--ai-tool",
+            "OpenAI GPT-5.6 Sol via OpenCode",
             "https://github.com/Extra-Chill/homeboy/issues/6453",
             "https://github.com/Extra-Chill/homeboy/issues/6454",
         ])
@@ -3951,10 +4017,42 @@ fi
         };
         assert_eq!(args.issues.len(), 2);
         assert_eq!(args.gates.verify, vec!["cargo test --lib"]);
+        assert_eq!(
+            args.ai_tool.as_deref(),
+            Some("OpenAI GPT-5.6 Sol via OpenCode")
+        );
         assert_eq!(args.from, "origin/main");
         assert_eq!(
             args.provider_profile,
             Some("opencode-codex-gpt55".to_string())
+        );
+    }
+
+    #[test]
+    fn run_plan_cli_parses_ai_tool_override() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@plan.json",
+            "--ai-tool",
+            "OpenAI GPT-5.6 Sol via OpenCode",
+        ])
+        .expect("run-plan parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Fanout(fanout) = agent_task.command else {
+            panic!("fanout command");
+        };
+        let AgentTaskFanoutCommand::RunPlan(args) = fanout.command else {
+            panic!("run-plan command");
+        };
+        assert_eq!(
+            args.ai_tool.as_deref(),
+            Some("OpenAI GPT-5.6 Sol via OpenCode")
         );
     }
 


### PR DESCRIPTION
Fixes #11747

## Summary
- add typed `--ai-tool` overrides to `fanout cook-batch` and `fanout run-plan`
- persist each child disclosure through its durable Cook recipe finalization metadata
- retain per-child derived disclosures when no override is supplied

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-agents cook_recipe::tests --lib`
- `cargo test -p homeboy-cli fanout::tests --lib` is blocked by pre-existing `RunnerSession` initializers missing `proxy_forward`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the Cook and fanout contracts, implemented typed disclosure propagation and focused tests, and ran the listed verification. Chris Huber remains responsible for every line.