### PR TITLE
fix(release): gate publication on the complete declared asset set

### DIFF
--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Deterministic asset-completeness contract for a Homeboy GitHub Release.
+#
+# WHY THIS EXISTS (#11749, and #8687 before it)
+#
+# `verify-published` already re-drafts an incomplete release — but it is a job
+# inside `release.yml`, so it can only fire when `release.yml` actually runs the
+# publish chain. v0.333.0 was published at 17:15:59Z on 2026-08-06 with 7 of 13
+# assets and no Linux binary at all, and NO release run executed a single job in
+# that window: 27 of the last 30 runs had `total_count: 0` jobs, having been
+# displaced while still pending in the `release-refs/heads/main` concurrency
+# group. A guard that lives only on the happy path of a pipeline that is not
+# running is not a guard.
+#
+# So the contract moves here: one script, no cargo-dist invocation, no network
+# beyond a single inventory read, callable from
+#
+#   1. `release.yml`'s `host` job, BEFORE the finalizer publishes (a gate), and
+#   2. `release-integrity.yml`, on `release: published` and on a schedule, which
+#      fires no matter WHO published — including a local `homeboy release` from
+#      a laptop, which is what a 7-asset macOS-only inventory looks like.
+#
+# The required set is derived from `dist-workspace.toml`, so adding a target
+# there automatically widens the contract. It cannot drift from what the repo
+# declares it ships.
+#
+# Environment:
+#   RELEASE_TAG              (required) tag whose inventory is checked
+#   GITHUB_REPOSITORY        (optional) owner/repo, for `gh`
+#   DIST_WORKSPACE           (optional) path to dist-workspace.toml
+#   RELEASE_INVENTORY_JSON   (optional) pre-fetched `{"assets":[...]}` JSON.
+#                            When set, no `gh` call is made. This is the seam
+#                            the Rust tests drive the contract through.
+#   REQUIRE_ANNOUNCE_ASSETS  (optional, default true) require assets cargo-dist
+#                            attaches during announce (`dist-manifest.json`).
+#                            Set false for the pre-publication gate, where the
+#                            upload step has run but announce has not.
+#
+# Exit 0 = every required asset is present, uploaded and non-empty.
+# Exit 1 = incomplete, unreadable, or underivable. This gate fails CLOSED:
+#          failing a release run is strictly better than publishing an
+#          inventory that 404s for the platforms it dropped.
+
+set -uo pipefail
+
+DIST_WORKSPACE="${DIST_WORKSPACE:-dist-workspace.toml}"
+REQUIRE_ANNOUNCE_ASSETS="${REQUIRE_ANNOUNCE_ASSETS:-true}"
+RELEASE_TAG="${RELEASE_TAG:-}"
+
+# Deliberately no `$GITHUB_OUTPUT` writes. This script's verdict IS its exit
+# status, and both callers consume it that way. Emitting a `complete=true`
+# boolean as well would invent a second, redundant gating output that a
+# downstream `if:` could read -- exactly the class the gate-layer measurement
+# registry exists to keep accounted for.
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+if [ -z "${RELEASE_TAG}" ]; then
+  fail "RELEASE_TAG is required to check release asset completeness"
+fi
+
+# ── Required inventory, derived from what the repo declares it ships ──
+if [ ! -f "${DIST_WORKSPACE}" ]; then
+  fail "Cannot derive the release asset contract: ${DIST_WORKSPACE} is missing. Refusing to treat an underivable contract as a satisfied one."
+fi
+
+TARGETS_LINE="$(grep -E '^[[:space:]]*targets[[:space:]]*=' "${DIST_WORKSPACE}" | head -n 1)"
+TARGETS=()
+if [ -n "${TARGETS_LINE}" ]; then
+  while IFS= read -r target; do
+    [ -n "${target}" ] && TARGETS+=("${target}")
+  done < <(printf '%s\n' "${TARGETS_LINE}" | grep -oE '"[^"]+"' | tr -d '"')
+fi
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  fail "Cannot derive the release asset contract: no \`targets\` declared in ${DIST_WORKSPACE}. An empty platform contract would silently pass every incomplete release."
+fi
+
+REQUIRED=()
+for target in "${TARGETS[@]}"; do
+  REQUIRED+=("homeboy-${target}.tar.xz" "homeboy-${target}.tar.xz.sha256")
+done
+REQUIRED+=("source.tar.gz" "source.tar.gz.sha256" "sha256.sum")
+
+# The Homebrew formula is a published asset whenever the tap installer is on.
+if grep -qE '^[[:space:]]*installers[[:space:]]*=.*homebrew' "${DIST_WORKSPACE}"; then
+  REQUIRED+=("homeboy.rb")
+fi
+
+# cargo-dist attaches `dist-manifest.json` to the release it announces, and it
+# is absent on exactly the broken releases (v0.288.0 inverted the set and had
+# ONLY this file; v0.323.1, v0.328.1 and v0.333.0 have everything but it). That
+# makes it the cheapest possible completeness signal — no download required.
+if [ "${REQUIRE_ANNOUNCE_ASSETS}" = "true" ]; then
+  REQUIRED+=("dist-manifest.json")
+fi
+
+# ── Observed inventory ──
+INVENTORY=""
+# Presence, not non-emptiness. An explicitly supplied but EMPTY inventory means
+# "I looked and found nothing readable", which must fail closed below — falling
+# back to a live `gh` call there would turn an unreadable observation into a
+# fresh one and hide the very condition being tested.
+if [ -n "${RELEASE_INVENTORY_JSON+set}" ]; then
+  INVENTORY="${RELEASE_INVENTORY_JSON}"
+else
+  GH_ARGS=(release view "${RELEASE_TAG}" --json isDraft,assets)
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    GH_ARGS+=(--repo "${GITHUB_REPOSITORY}")
+  fi
+  if ! INVENTORY="$(gh "${GH_ARGS[@]}" 2>&1)"; then
+    fail "Could not read the asset inventory for ${RELEASE_TAG}: ${INVENTORY}"
+  fi
+fi
+
+if ! jq -e '.assets' >/dev/null 2>&1 <<< "${INVENTORY}"; then
+  fail "The asset inventory for ${RELEASE_TAG} is not readable JSON with an .assets array. An unreadable inventory is UNKNOWN, not complete."
+fi
+
+USABLE="$(jq -r '[.assets[]? | select(.state == "uploaded" and .size > 0) | .name] | .[]' <<< "${INVENTORY}")"
+
+MISSING=()
+for asset in "${REQUIRED[@]}"; do
+  if ! printf '%s\n' "${USABLE}" | grep -Fqx "${asset}"; then
+    MISSING+=("${asset}")
+  fi
+done
+
+if [ "${#MISSING[@]}" -gt 0 ]; then
+  echo "::error::Release ${RELEASE_TAG} does not satisfy the declared asset contract. Missing or unusable: ${MISSING[*]}"
+  echo "::error::Derived from ${DIST_WORKSPACE}: ${#REQUIRED[@]} assets required across ${#TARGETS[@]} targets. A release that cannot satisfy its own platform matrix must not be published — consumers on the missing platforms get a 404 from \`homeboy upgrade\` (#11749)."
+  exit 1
+fi
+
+echo "::notice::Release ${RELEASE_TAG} satisfies the declared asset contract (${#REQUIRED[@]} assets across ${#TARGETS[@]} targets)."
+exit 0

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -1,0 +1,156 @@
+# Release integrity sweeper — the asset-completeness guard that cannot be
+# bypassed by the release pipeline failing to run.
+#
+# WHY A SEPARATE WORKFLOW (#11749)
+#
+# `release.yml` already gates publication on the declared asset set, and
+# `verify-published` already re-drafts an incomplete release. Both live INSIDE
+# `release.yml`, which means both are unreachable whenever `release.yml` is not
+# the thing that published. On 2026-08-06 that was the actual situation:
+# v0.333.0 was published at 17:15:59Z with 7 of 13 assets and no Linux binary,
+# while 27 of the last 30 Release runs had dispatched ZERO jobs. Its inventory —
+# a raw macOS `homeboy` binary that CI never produces, one darwin tarball, no
+# `dist-manifest.json` — is the signature of a release published outside CI
+# entirely.
+#
+# `on: release` fires on the RELEASE OBJECT, not on the pipeline. It runs when a
+# human publishes from a laptop, when `gh release edit --draft=false` flips a
+# stranded draft, and when a recovery dispatch finishes — every path into
+# `latest`, including the ones `release.yml` never sees. The schedule is the
+# backstop for the case where even the release event is missed.
+#
+# This workflow is deliberately off the merge path: it triggers on release
+# events and a timer, never on `push`, so it cannot slow merges down.
+
+name: Release Integrity
+
+on:
+  release:
+    # `published` and `released` only. NOT `edited`: cargo-dist edits the
+    # release object repeatedly while uploading assets, and auditing a release
+    # mid-upload would let this workflow re-draft a perfectly healthy release
+    # that simply had not finished yet. A guard that can break the thing it
+    # guards is worse than the hole it closes.
+    types: [published, released]
+  schedule:
+    # Hourly. `latest` is what `homeboy upgrade` resolves, so the window in
+    # which a broken release can strand every controller is bounded by this.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to audit (defaults to the latest release)'
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+# Per-tag, so a sweep never queues behind another sweep of a different release
+# and can never be displaced while it holds a broken release open. This is the
+# same displacement failure `release.yml`'s concurrency group had (#11749).
+concurrency:
+  group: release-integrity-${{ github.event.release.tag_name || inputs.release_tag || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit published release assets
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # The default branch, not the tag: the audited tag may predate this
+      # contract, and the question being asked is whether the release the
+      # project ships TODAY is usable on every platform it declares today.
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve the release under audit
+        id: target
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -uo pipefail
+          TAG="${EVENT_TAG:-${INPUT_TAG:-}}"
+
+          if [ -z "${TAG}" ]; then
+            TAG="$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq '.tagName' 2>/dev/null || true)"
+          fi
+
+          if [ -z "${TAG}" ]; then
+            echo "::error::Could not resolve a release to audit. An unresolvable target is UNKNOWN, not healthy."
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Auditing release ${TAG}"
+
+      # Re-check before condemning. Whether cargo-dist attaches every asset
+      # strictly before it flips the draft flag is not a documented ordering,
+      # and `release: published` fires the instant that flag flips. A single
+      # observation could therefore catch a healthy release a few seconds
+      # early — and this workflow's remedy is to un-publish it, so a false
+      # positive here breaks a good release rather than merely reporting one.
+      #
+      # Settling for a few minutes makes the guard robust to any attach order
+      # while keeping the exposure window on a genuinely broken release to
+      # minutes. The scheduled sweep passes on the first attempt, so the cost
+      # is paid only by releases that actually look incomplete.
+      - name: Check the declared asset set
+        id: contract
+        continue-on-error: true
+        env:
+          RELEASE_TAG: ${{ steps.target.outputs.tag }}
+          SETTLE_ATTEMPTS: '5'
+          SETTLE_SECONDS: '60'
+        run: |
+          set -uo pipefail
+          attempt=1
+          while true; do
+            if bash .github/release-asset-completeness.sh; then
+              exit 0
+            fi
+            if [ "${attempt}" -ge "${SETTLE_ATTEMPTS}" ]; then
+              echo "::error::Release ${RELEASE_TAG} still fails the declared asset contract after ${attempt} observations over $(( (attempt - 1) * SETTLE_SECONDS ))s. This is a settled inventory, not an upload in flight."
+              exit 1
+            fi
+            echo "::notice::Attempt ${attempt}/${SETTLE_ATTEMPTS}: inventory incomplete; assets may still be uploading. Re-checking in ${SETTLE_SECONDS}s."
+            attempt=$(( attempt + 1 ))
+            sleep "${SETTLE_SECONDS}"
+          done
+
+      # Detecting a broken published release without containing it is what
+      # #8687 was reopened over. A release missing platform assets serves 404s
+      # for the platforms it dropped and, while it is `latest`, breaks
+      # `homeboy upgrade` for every controller on those platforms.
+      #
+      # Returning it to draft is reversible and non-destructive: the tag, the
+      # body and every uploaded asset are retained. Only the draft flag flips,
+      # which is what makes it unreachable to consumers until a recovery run
+      # completes it.
+      - name: Contain an incomplete published release
+        if: steps.contract.outcome == 'failure'
+        env:
+          RELEASE_TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -uo pipefail
+
+          if ! gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft > state.json; then
+            echo "::error::Release ${RELEASE_TAG} failed the asset contract and its state could not be read. Un-publish it by hand before any consumer resolves it: gh release edit ${RELEASE_TAG} --draft=true --repo ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+
+          if [ "$(jq -r '.isDraft' state.json)" = "true" ]; then
+            echo "::notice::Release ${RELEASE_TAG} is incomplete but is already a draft, so no consumer can resolve it. Complete it with a workflow_dispatch Release run using release_tag=${RELEASE_TAG}."
+            exit 1
+          fi
+
+          if gh release edit "${RELEASE_TAG}" --draft=true --repo "${GITHUB_REPOSITORY}"; then
+            echo "::error::Release ${RELEASE_TAG} was returned to DRAFT because it was published without every declared platform asset. Its tag and uploaded assets are retained. Complete it with a workflow_dispatch Release run using release_tag=${RELEASE_TAG}, which republishes once the asset set verifies."
+          else
+            echo "::error::Release ${RELEASE_TAG} is published and incomplete, and could not be returned to draft. Un-publish it by hand before any consumer resolves it: gh release edit ${RELEASE_TAG} --draft=true --repo ${GITHUB_REPOSITORY}"
+          fi
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,45 @@ env:
   # re-attaches HEAD to this branch so the action's branch guard can resolve it.
   RELEASE_BRANCH: main
 
-# Only one release pipeline at a time. If a push arrives while a release
-# is already running, it queues (never cancels). The queued run starts
-# after the first finishes and its check job exits in seconds because
-# HEAD is already tagged — zero wasted work.
+# ── Concurrency: never queue a push release behind another one (#11749) ──
+#
+# This used to be `release-${{ inputs.release_tag || github.ref }}`, so every
+# push run on main shared ONE group, on the theory quoted below: "the queued run
+# starts after the first finishes and its check job exits in seconds because
+# HEAD is already tagged — zero wasted work."
+#
+# The queued run never started. GitHub keeps at most ONE pending run per
+# concurrency group and CANCELS the previously pending one when a newer run is
+# queued — `cancel-in-progress: false` only protects runs that are already
+# in progress, not runs that are waiting. At ~65 merges/day the pending slot is
+# displaced long before a ~35-minute release finishes, so runs were displaced,
+# not deferred. Measured on 2026-08-06: 27 of the last 30 Release runs ended
+# `cancelled` with `total_count: 0` jobs — they never dispatched a single job,
+# so not one of their guards, including `verify-published`, could fire.
+#
+# A push run now gets a group of its OWN. Nothing is ever queued behind another
+# release, so nothing can displace it. Serialization was never what made this
+# correct anyway: the `check` job's supersession test (HEAD vs the branch tip)
+# and `homeboy release`'s tag idempotency (`release-already-at-head`) are what
+# stop two runs preparing the same version, and both cost seconds rather than a
+# 35-minute queue slot. Superseded runs now skip the dry run outright, so the
+# merge path is not slowed and the wasted work is genuinely near zero.
+#
+# A recovery dispatch still serializes per TAG: two runs repairing the same
+# release must never race on its assets.
+#
+# The tradeoff, stated rather than hidden: two pushes landing close enough that
+# both observe themselves as the branch tip can now both reach `prepare` and
+# compute the same next version. That collision resolves at the tag push, where
+# the loser fails loudly — a red run plus a failed-SHA marker — and, if it dies
+# holding a prepared tag, `detect-stranded-release.sh` picks the tag up on a
+# later push. Both are machinery this repo already has. It is a strictly better
+# failure than the one being fixed: a colliding run cannot publish anything,
+# because publication is now gated on the complete declared asset set below,
+# whereas the displacement this replaces was shipping `latest` releases with no
+# Linux binary at all.
 concurrency:
-  group: release-${{ inputs.release_tag || github.ref }}
+  group: release-${{ inputs.release_tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -197,9 +230,21 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      # `steps.attach.outputs.superseded != 'true'` is what makes per-run
+      # concurrency cheap (#11749). The attach step above already PROVED this
+      # commit is behind the branch tip, and the decide step below turns that
+      # proof into `should-release=false` on its own — so running the dry run
+      # anyway burns ~12 minutes of runner time to re-derive an answer already
+      # in hand. Skipping it is what makes the design comment on `concurrency`
+      # ("zero wasted work") true rather than aspirational.
+      #
+      # Skipping leaves `release-check.outcome == 'skipped'` and an empty
+      # `skipped-reason`, which the decide step's supersession branch already
+      # accepts (`wrong-branch|''`). It cannot reach the #10685 hard failure,
+      # which requires `outcome == 'success'`.
       - name: Dry-run release check
         id: release-check
-        if: inputs.release_tag == '' && steps.failed-release.outputs.blocked != 'true' && steps.stranded.outputs['stranded-tag'] == '' && steps.stranded.outputs['hold-reason'] == ''
+        if: inputs.release_tag == '' && steps.attach.outputs.superseded != 'true' && steps.failed-release.outputs.blocked != 'true' && steps.stranded.outputs['stranded-tag'] == '' && steps.stranded.outputs['hold-reason'] == ''
         uses: Extra-Chill/homeboy-action@v2
         with:
           source: '.'
@@ -1292,6 +1337,34 @@ jobs:
             # bootstrapped by this run — the exact trap #10519 describes.
             echo "::warning::Recovery control binary was built from the release target commit ${TARGET_SHA}; a publisher fix merged after ${RELEASE_TAG} cannot be bootstrapped by this run (#10519). Re-dispatch from an updated default branch if recovery keeps failing in the publisher."
           fi
+
+      # ── Publication gate: the declared asset set is the contract (#11749) ──
+      #
+      # The step below is what turns the draft into a published release. Every
+      # asset check that existed before this one ran AFTER it — `verify-published`
+      # detects an incomplete release and re-drafts it, which is compensation,
+      # not prevention. Compensation requires the compensating job to run, and
+      # the runs that produce incomplete releases are exactly the runs that do
+      # not get that far: v0.323.1 published 2 of 14 assets and stayed live,
+      # v0.333.0 published 7 of 13 with no Linux binary at all.
+      #
+      # So publication is now conditional on the complete declared asset set,
+      # checked immediately before it happens. If the inventory cannot satisfy
+      # `dist-workspace.toml`, this job fails and the release stays a draft —
+      # a failed run is strictly better than a published release that 404s for
+      # the platforms it dropped, because a draft is recoverable and a bad
+      # `latest` is what pinned this controller 453 commits behind.
+      #
+      # `REQUIRE_ANNOUNCE_ASSETS: false` because cargo-dist attaches
+      # `dist-manifest.json` when it announces, which has not happened yet at
+      # this point. `verify-published` still re-checks the full inventory,
+      # `dist-manifest.json` included, once the release is live.
+      - name: Gate publication on the declared asset set
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          REQUIRE_ANNOUNCE_ASSETS: 'false'
+        run: |
+          bash .github/release-asset-completeness.sh
 
       - name: Finish Homeboy release pipeline at tag
         uses: Extra-Chill/homeboy-action@v2

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -360,6 +360,41 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                needs a fixture git repo plus a `gh` stub, which is why there is no fixture yet.",
     },
     GateLayerSite {
+        file: ".github/release-asset-completeness.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: Some(
+            "asset_contract_accepts_a_complete_release_and_rejects_the_one_that_shipped_broken",
+        ),
+        note: "#11749. The green here means `every declared release asset is present, uploaded \
+               and non-empty`, and it gates publication, so an empty population would be the \
+               whole bug: a contract derived from nothing passes everything. Both populations \
+               are independently established and neither may be empty. The required set is \
+               derived from `dist-workspace.toml`'s own `targets`, and an absent file or an \
+               empty target list is a hard `exit 1` rather than a vacuous pass -- that is the \
+               `EmptyPopulation` hole closed by construction. The observed set is GitHub's asset \
+               inventory, which is likewise refused when it is unreadable, absent, or has no \
+               `.assets` array. Each required asset is then matched individually, so the \
+               aggregate green exists only if every unit was checked against a population proven \
+               non-empty.",
+    },
+    GateLayerSite {
+        file: ".github/release-asset-completeness.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: Some("asset_contract_fails_closed_on_an_unreadable_inventory"),
+        note: "#11749, the refusal path: a missing asset, an underivable contract, or an \
+               unreadable inventory. A non-zero exit cannot manufacture a pass, so it carries no \
+               measurement obligation of its own; it is registered because the scan keys on every \
+               exit in a gate script and an unregistered one is indistinguishable from an \
+               unexamined one. It is fixtured anyway, because the direction that matters for this \
+               gate is that UNKNOWN lands here rather than on `exit 0` -- publication proceeding \
+               on an inventory nobody could read is precisely how v0.333.0 shipped without a \
+               Linux binary.",
+    },
+    GateLayerSite {
         file: ".github/release-quality-policy.sh",
         decision: "exit \"${failed}\"",
         basis: MeasurementBasis::SharedPredicate,

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -323,8 +323,55 @@ fn release_ci_disables_homeboy_update_checks() {
 #[test]
 fn release_concurrency_scopes_recovery_runs_to_the_requested_tag() {
     assert!(release_workflow().contains(
-        "concurrency:\n  group: release-${{ inputs.release_tag || github.ref }}\n  cancel-in-progress: false"
+        "concurrency:\n  group: release-${{ inputs.release_tag || github.run_id }}\n  cancel-in-progress: false"
     ));
+}
+
+/// A push release run must never be QUEUED behind another one (#11749).
+///
+/// `cancel-in-progress: false` protects a run that is already executing. It
+/// does not protect a run that is waiting: GitHub keeps at most one *pending*
+/// run per concurrency group and cancels the previously pending one whenever a
+/// newer run is queued. With every push on main sharing
+/// `release-refs/heads/main`, and merges arriving faster than a ~35-minute
+/// release finishes, the pending slot was displaced continuously — 27 of the
+/// last 30 Release runs on 2026-08-06 ended `cancelled` having dispatched
+/// **zero** jobs, so none of their guards could fire and releases published
+/// with partial platform assets.
+///
+/// The branch-shaped group is therefore the bug, and pinning its absence is the
+/// point of this test. Correctness comes from the `check` job's supersession
+/// test and tag idempotency, not from the concurrency queue.
+#[test]
+fn release_push_runs_are_never_queued_behind_another_release() {
+    let workflow = release_workflow();
+
+    assert!(
+        workflow.contains("group: release-${{ inputs.release_tag || github.run_id }}"),
+        "a push release must get a concurrency group of its own so nothing can displace it"
+    );
+    assert!(
+        !workflow.contains("group: release-${{ inputs.release_tag || github.ref }}"),
+        "a branch-shaped concurrency group makes every push run queue behind the last one, \
+         where a newer push cancels it before it dispatches a single job (#11749)"
+    );
+
+    // Recovery keeps serializing per TAG: two runs repairing the same release
+    // must not race on its assets.
+    assert!(
+        workflow.contains("inputs.release_tag ||"),
+        "a recovery dispatch must still be scoped to the tag it repairs"
+    );
+
+    // Per-run concurrency is only affordable if a superseded run is cheap, so
+    // the expensive dry run must be skipped once supersession is proven.
+    let check = job_section(workflow, "check");
+    let dry_run = release_step_block(check, "name: Dry-run release check");
+    assert!(
+        dry_run.contains("steps.attach.outputs.superseded != 'true'"),
+        "a run already proven superseded must not spend ~12 minutes re-deriving that \
+         answer through the dry run; got:\n{dry_run}"
+    );
 }
 
 #[test]
@@ -333,7 +380,7 @@ fn release_is_a_direct_non_cancellable_rolling_main_pipeline() {
 
     assert!(workflow.contains("push:\n    branches: [main]"));
     assert!(workflow.contains(
-        "concurrency:\n  group: release-${{ inputs.release_tag || github.ref }}\n  cancel-in-progress: false"
+        "concurrency:\n  group: release-${{ inputs.release_tag || github.run_id }}\n  cancel-in-progress: false"
     ));
     assert!(!workflow.contains("workflow_run:"));
     assert!(!workflow.contains("release-qualification:"));
@@ -1787,5 +1834,303 @@ fn release_check_skips_a_superseded_push_but_still_fails_an_unmeasured_one() {
     assert_ne!(
         code, 0,
         "release-output-missing is unmeasured even when superseded: {out}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #11749 — a release either carries its complete declared asset set or it is
+// not published.
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn release_integrity_workflow() -> &'static str {
+    include_str!("../.github/workflows/release-integrity.yml")
+}
+
+/// The exact published inventory of `v0.332.0` — the last healthy release.
+const HEALTHY_RELEASE_ASSETS: &[&str] = &[
+    "dist-manifest.json",
+    "homeboy-aarch64-apple-darwin.tar.xz",
+    "homeboy-aarch64-apple-darwin.tar.xz.sha256",
+    "homeboy-aarch64-unknown-linux-gnu.tar.xz",
+    "homeboy-aarch64-unknown-linux-gnu.tar.xz.sha256",
+    "homeboy-x86_64-apple-darwin.tar.xz",
+    "homeboy-x86_64-apple-darwin.tar.xz.sha256",
+    "homeboy-x86_64-unknown-linux-gnu.tar.xz",
+    "homeboy-x86_64-unknown-linux-gnu.tar.xz.sha256",
+    "homeboy.rb",
+    "sha256.sum",
+    "source.tar.gz",
+    "source.tar.gz.sha256",
+];
+
+/// The exact published inventory of `v0.333.0` — 7 assets, no Linux binary, no
+/// `dist-manifest.json`, plus a raw `homeboy` binary CI never produces. This is
+/// the artifact `homeboy upgrade` 404s against.
+const BROKEN_RELEASE_ASSETS: &[&str] = &[
+    "homeboy",
+    "homeboy-aarch64-apple-darwin.tar.xz",
+    "homeboy-aarch64-apple-darwin.tar.xz.sha256",
+    "homeboy.rb",
+    "sha256.sum",
+    "source.tar.gz",
+    "source.tar.gz.sha256",
+];
+
+fn release_inventory(names: &[&str]) -> String {
+    let assets = names
+        .iter()
+        .map(|name| format!("{{\"name\":\"{name}\",\"state\":\"uploaded\",\"size\":1024}}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{\"isDraft\":false,\"assets\":[{assets}]}}")
+}
+
+/// Drive the asset contract the way both callers do, through a pre-fetched
+/// inventory so no network or `gh` is involved.
+fn asset_contract(inventory: &str, require_announce_assets: &str) -> (i32, String) {
+    let output = std::process::Command::new("bash")
+        .arg(".github/release-asset-completeness.sh")
+        .env("RELEASE_TAG", "v9.9.9")
+        .env("RELEASE_INVENTORY_JSON", inventory)
+        .env("REQUIRE_ANNOUNCE_ASSETS", require_announce_assets)
+        // Never let a test append to the surrounding job's real step output.
+        .env_remove("GITHUB_OUTPUT")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("release asset completeness script should run");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+fn declared_dist_targets() -> Vec<String> {
+    let line = dist_workspace_manifest()
+        .lines()
+        .find(|line| line.trim_start().starts_with("targets"))
+        .expect("dist-workspace.toml must declare targets");
+
+    line.split('"')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
+/// The whole point, stated as behaviour: the inventory that shipped as
+/// `v0.333.0` must be rejected, and the inventory that shipped as `v0.332.0`
+/// must be accepted.
+#[test]
+fn asset_contract_accepts_a_complete_release_and_rejects_the_one_that_shipped_broken() {
+    let (code, out) = asset_contract(&release_inventory(HEALTHY_RELEASE_ASSETS), "true");
+    assert_eq!(
+        code, 0,
+        "the last healthy release inventory must satisfy the contract: {out}"
+    );
+
+    let (code, out) = asset_contract(&release_inventory(BROKEN_RELEASE_ASSETS), "true");
+    assert_ne!(
+        code, 0,
+        "a release with no Linux binary must not satisfy the contract: {out}"
+    );
+    assert!(
+        out.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz"),
+        "the failure must name the missing platform archive, not just a count: {out}"
+    );
+    assert!(
+        out.contains("dist-manifest.json"),
+        "`dist-manifest.json` is absent on exactly the broken releases and must be \
+         part of the published contract: {out}"
+    );
+}
+
+/// The required set is DERIVED from `dist-workspace.toml`, not transcribed
+/// beside it. Adding a target must widen the contract automatically; a
+/// hardcoded list would leave the new platform silently un-gated.
+#[test]
+fn asset_contract_covers_every_target_the_repo_declares() {
+    let targets = declared_dist_targets();
+    assert!(
+        targets.len() >= 2,
+        "expected a real multi-platform target list, got {targets:?}"
+    );
+
+    for target in &targets {
+        let archive = format!("homeboy-{target}.tar.xz");
+        let reduced: Vec<&str> = HEALTHY_RELEASE_ASSETS
+            .iter()
+            .copied()
+            .filter(|name| *name != archive.as_str())
+            .collect();
+
+        let (code, out) = asset_contract(&release_inventory(&reduced), "true");
+        assert_ne!(
+            code, 0,
+            "dropping {archive} must fail the contract for declared target {target}: {out}"
+        );
+        assert!(
+            out.contains(archive.as_str()),
+            "the failure must name {archive}: {out}"
+        );
+    }
+}
+
+/// An asset that is present but unusable is not present. GitHub reports both
+/// states in the same inventory, and a zero-byte or still-uploading archive
+/// serves a broken download just as surely as a missing one.
+#[test]
+fn asset_contract_rejects_present_but_unusable_assets() {
+    let inventory = release_inventory(HEALTHY_RELEASE_ASSETS).replace(
+        "{\"name\":\"homeboy-x86_64-unknown-linux-gnu.tar.xz\",\"state\":\"uploaded\",\"size\":1024}",
+        "{\"name\":\"homeboy-x86_64-unknown-linux-gnu.tar.xz\",\"state\":\"uploaded\",\"size\":0}",
+    );
+
+    let (code, out) = asset_contract(&inventory, "true");
+    assert_ne!(code, 0, "a zero-byte platform archive must fail: {out}");
+    assert!(
+        out.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz"),
+        "{out}"
+    );
+}
+
+/// This gate decides whether a release becomes reachable, so every unknown must
+/// land on "do not publish". An inventory that cannot be read is not evidence
+/// of completeness.
+#[test]
+fn asset_contract_fails_closed_on_an_unreadable_inventory() {
+    for inventory in ["", "not json", "{}", "{\"assets\":null}"] {
+        let (code, out) = asset_contract(inventory, "true");
+        assert_ne!(
+            code, 0,
+            "an unreadable inventory ({inventory:?}) must fail closed: {out}"
+        );
+    }
+}
+
+/// The pre-publication caller runs before cargo-dist announces, so
+/// `dist-manifest.json` is not yet attached. That relaxation must apply to that
+/// asset alone — the platform matrix is still fully required.
+#[test]
+fn asset_contract_pre_publication_still_requires_every_platform_archive() {
+    let without_manifest: Vec<&str> = HEALTHY_RELEASE_ASSETS
+        .iter()
+        .copied()
+        .filter(|name| *name != "dist-manifest.json")
+        .collect();
+
+    let (code, out) = asset_contract(&release_inventory(&without_manifest), "false");
+    assert_eq!(
+        code, 0,
+        "an announce-time asset must not block the pre-publication gate: {out}"
+    );
+
+    let (code, out) = asset_contract(&release_inventory(BROKEN_RELEASE_ASSETS), "false");
+    assert_ne!(
+        code, 0,
+        "the pre-publication gate must still reject a missing platform matrix: {out}"
+    );
+    assert!(
+        out.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz"),
+        "{out}"
+    );
+}
+
+/// #8687's guard is `verify-published`, and it runs AFTER `host` has already
+/// published. Detect-then-revert is compensation, and compensation only works
+/// if the compensating job runs — the runs that ship incomplete releases are
+/// precisely the runs that never get there.
+///
+/// So the contract must also be a PRECONDITION of publication, evaluated
+/// immediately before the finalizer that flips the draft flag. This is the
+/// existing guard moved upstream of the act it guards, not a second guard
+/// beside it: `verify-published` is deliberately left intact below.
+#[test]
+fn publication_is_gated_on_the_declared_asset_set_before_it_happens() {
+    let workflow = release_workflow();
+    let host = job_section(workflow, "host");
+
+    let gate = release_step_block(host, "name: Gate publication on the declared asset set");
+    assert!(
+        gate.contains("release-asset-completeness.sh"),
+        "the gate must evaluate the shared asset contract; got:\n{gate}"
+    );
+    assert!(
+        gate.contains("REQUIRE_ANNOUNCE_ASSETS: 'false'"),
+        "the pre-publication gate runs before announce attaches dist-manifest.json; got:\n{gate}"
+    );
+
+    let gate_at = host
+        .find("name: Gate publication on the declared asset set")
+        .expect("publication gate must exist");
+    let publish_at = host
+        .find("name: Finish Homeboy release pipeline at tag")
+        .expect("finalizer must exist");
+    assert!(
+        gate_at < publish_at,
+        "the asset contract must be checked BEFORE the finalizer publishes, otherwise it \
+         is detection after the fact — which is exactly what #8687 shipped and what let \
+         v0.323.1 and v0.333.0 stay live and incomplete"
+    );
+
+    // Moving the check upstream must not remove the containment that catches a
+    // release which somehow reaches `published` anyway.
+    assert!(
+        workflow.contains("verify-published:"),
+        "the post-publication containment guard must be retained, not replaced"
+    );
+}
+
+/// The reason #8687's guard did not fire for `v0.333.0` is not that its logic
+/// was wrong — it is that nothing ran it. 27 of the last 30 Release runs
+/// dispatched zero jobs, and `v0.333.0`'s own inventory (a raw macOS binary CI
+/// never builds, one darwin tarball, no `dist-manifest.json`) is the signature
+/// of a release published outside the pipeline entirely.
+///
+/// `on: release` fires on the RELEASE OBJECT, so it covers every path into
+/// `latest` including the ones `release.yml` never sees.
+#[test]
+fn release_integrity_sweeper_guards_publications_the_pipeline_never_made() {
+    let workflow = release_integrity_workflow();
+
+    assert!(
+        workflow.contains("  release:\n") && workflow.contains("types: [published, released]"),
+        "the sweeper must trigger on the release object so it covers publications this \
+         workflow never performed"
+    );
+    assert!(
+        !workflow.contains("edited]") && !workflow.contains(", edited"),
+        "auditing on `edited` would inspect a release mid-upload and could re-draft a \
+         healthy one; a guard must not be able to break what it guards"
+    );
+    assert!(
+        workflow.contains("cron:"),
+        "a scheduled backstop must cover a missed release event"
+    );
+    assert!(
+        !workflow.contains("push:"),
+        "the sweeper must stay off the merge path"
+    );
+
+    assert!(
+        workflow.contains("release-asset-completeness.sh"),
+        "the sweeper must evaluate the same shared contract as the publication gate"
+    );
+    assert!(
+        workflow.contains("contents: write") && workflow.contains("--draft=true"),
+        "detecting a broken published release without containing it is what #8687 was \
+         reopened over"
+    );
+    assert!(
+        workflow.contains("SETTLE_ATTEMPTS"),
+        "a single observation could catch a healthy release a few seconds early, and the \
+         remedy here is to un-publish it -- the inventory must be re-checked before it is \
+         condemned"
+    );
+    assert!(
+        workflow.contains("could not be returned to draft"),
+        "a failed un-publish must escalate with the manual command, never pass silently"
     );
 }


### PR DESCRIPTION
Closes #11749.

## Why #8687's guard did not fire

#8687 installed `verify-published`, which re-drafts a published release missing planned assets. It is correct code. It did not fire, for two independent reasons.

**1. Nothing ran it.** It is a job inside `release.yml`, and `release.yml` was not running. Measured on 2026-08-06:

```
31124343048 | cancelled | jobs=0
31123691621 | cancelled | jobs=0
31122501970 | cancelled | jobs=0   <- "release: v0.333.0"
31121333597 | cancelled | jobs=0
...
31118436375 | success   | jobs=15  <- check passed, every other job SKIPPED
```

Every cancelled run has `total_count: 0` jobs, and each one's `updated_at` is the instant the *next* push run was created. They were displaced while pending and never dispatched a single job, so no `if: always()` job could run — `always()` resurrects a job whose upstream failed within a run that is still executing; it cannot start a job in a run that was cancelled before dispatch.

The mechanism is that `cancel-in-progress: false` protects a run that is already **executing**, not one that is **waiting**. GitHub keeps at most one pending run per concurrency group and cancels the previously pending one when a newer run is queued. Every push on main shared `release-refs/heads/main`, and at ~65 merges/day the pending slot was displaced long before a ~35-minute release could finish. The workflow comment claimed the queued run "starts after the first finishes… zero wasted work". It never started.

**2. Even when it runs, it runs too late.** `verify-published` executes after `host` has published. Detect-then-revert is compensation, and compensation requires the compensating job to run. v0.323.1 shipped 2 of 14 assets and stayed live exactly that way.

There is also a third path the guard cannot reach at all: `v0.333.0`'s inventory is a raw macOS `homeboy` binary that CI never produces, one darwin tarball, `homeboy.rb`, `sha256.sum`, `source.tar.gz` — and **no `dist-manifest.json`**. No release run executed any job between 17:13 and 17:16Z. That release was published outside the workflow entirely, where a guard inside the workflow is structurally unreachable.

So I moved the existing guard's contract upstream of the act it guards and out to a trigger that fires on the release object. I did not add a second guard beside it — `verify-published` is retained unchanged.

## What changed

**`.github/release-asset-completeness.sh` (new)** — one shared contract, no cargo-dist invocation. The required set is *derived* from `dist-workspace.toml`'s own `targets`, so adding a platform widens the contract automatically. It fails closed on an underivable contract (missing file, empty target list) or an unreadable inventory — an empty population would be the whole bug for a gate like this.

**Publication gate (`release.yml`, `host`)** — the contract is evaluated immediately before the finalizer that flips the draft flag. A release that cannot satisfy its own platform matrix now fails the run and stays a draft. `REQUIRE_ANNOUNCE_ASSETS: 'false'` there, because cargo-dist attaches `dist-manifest.json` at announce; `verify-published` still re-checks the full set including it once live.

**`.github/workflows/release-integrity.yml` (new)** — `on: release: [published, released]` plus an hourly sweep. This fires on the release **object**, so it covers every path into `latest`, including publications this pipeline never made. Deliberately **not** `edited`: cargo-dist edits the release repeatedly while uploading, and auditing mid-upload would let this workflow re-draft a healthy release. For the same reason it re-checks for up to 5 minutes before condemning — its remedy is to un-publish, so a false positive here would break a good release.

**Concurrency** — push runs now get a per-run group. Nothing is queued behind another release, so nothing can displace it.

## The concurrency tradeoff

Merges are not slowed; this is entirely in the release workflow. Rolling releases at high velocity are preserved — in fact restored, since the current state is ~0 completed releases.

Serialization was never what made this correct. The `check` job's supersession test (HEAD vs branch tip) and `homeboy release`'s tag idempotency are what stop two runs preparing the same version, and both cost seconds instead of a 35-minute queue slot. To keep per-run concurrency cheap I also skip the ~12-minute dry run once `attach` has already **proven** supersession — that makes the "zero wasted work" claim in the original comment true rather than aspirational.

Stated rather than hidden: two pushes landing close enough that both observe themselves as the tip can now both reach `prepare` and compute the same version. That collision resolves at the tag push — the loser fails loudly with a failed-SHA marker, and a stranded prepared tag is picked up by the existing `detect-stranded-release.sh`. Both are machinery this repo already has and exercises. Critically, a colliding run **cannot publish anything incomplete**, because publication is now gated on the asset set.

I considered job-level concurrency on `prepare` to serialize only the mutating phase, and rejected it: job-level groups have the same pending-displacement semantics, and it would introduce a cancellation surface in the middle of tag creation.

## Tests

`tests/release_workflow_test.rs` — the established pattern, extended with executable coverage rather than only string matching. The two constants are the **real** published inventories of `v0.332.0` (13 assets, healthy) and `v0.333.0` (7 assets, broken), so the acceptance case is the actual artifact:

- the healthy inventory passes; the broken one fails and names the missing Linux archive and `dist-manifest.json`
- dropping **each** target declared in `dist-workspace.toml` fails — pins that the derivation is live, not transcribed
- present-but-unusable (zero-byte) assets are rejected
- fails closed on `""`, `"not json"`, `"{}"`, `{"assets":null}`
- the pre-publication relaxation applies to `dist-manifest.json` alone; the platform matrix stays fully required
- the gate step precedes the finalizer (index comparison, not just presence), and `verify-published` is still present
- the sweeper triggers on the release object, has a schedule, is not on `push`, does not audit on `edited`, and can re-draft

The two existing concurrency tests were updated, not deleted — `release_push_runs_are_never_queued_behind_another_release` now pins the absence of the branch-shaped group with the measurement that condemned it. No test was removed or `#[ignore]`d.

I also had to register the new script's `exit 0` / `exit 1` in `GATE_LAYER_SITES` (`measurement_registry_test.rs`), which scans every `.github/**/*.sh` exit. Both are fixtured by the tests above. I deliberately gave the script **no** `$GITHUB_OUTPUT` writes — its verdict is its exit status, and emitting a `complete=true` boolean would have invented a redundant gating output.

## Compile risk

**I could not compile.** Five agents share one 15Gi VPS and cargo builds are prohibited, so no `cargo check/test` was run. What I did instead:

- `cargo fmt` passes clean, which means rustfmt parsed both edited Rust files
- both workflows parse as YAML; the script passes `bash -n`
- every assertion in the new Rust tests was replicated in Python/bash against the real files and the real `v0.332.0`/`v0.333.0` inventories from the GitHub API — 41/41 pass
- the gate-layer scan was reimplemented in Python and diffed against `GATE_LAYER_SITES`: no unregistered decisions, no stale registrations, ordering correct, both named fixtures exist
- the pre-existing `verify-published`, `host` and `plan` assertions were re-run against the edited workflow, and `release_expected_assets_test.rs` reads only the untouched `plan` job

Residual risk is Rust type-level, concentrated in the new test helpers (`String`/`&str` boundaries in `asset_contract_covers_every_target_the_repo_declares`), which rustfmt parses but does not type-check.

One behavioural assumption I could not verify from here: that `dist host --steps=upload` uploads every platform archive before the finalizer announces. The gate is scoped so that if that assumption is wrong it is wrong only for `dist-manifest.json`, which is why announce-time assets are excluded from it.
