### PR TITLE
fix(cli): enforce the argv separator rule with a source guard

### DIFF
--- a/crates/homeboy-cli/src/command_capability.rs
+++ b/crates/homeboy-cli/src/command_capability.rs
@@ -55,6 +55,19 @@ pub enum CommandCapability {
     Mutation,
 }
 
+/// Position of the bare `--` that divides Homeboy's arguments from the ones it
+/// forwards verbatim, if the invocation has one.
+///
+/// This is the single separator primitive. Only the FIRST bare `--` divides:
+/// any later one is part of the forwarded command (`homeboy ssh host -- sh -c
+/// -- x`) and belongs to whoever receives it. Every question about the boundary
+/// — "which arguments may Homeboy read" ([`homeboy_owned_args`]) and "where
+/// does the passthrough begin" (`mark_explicit_passthrough`) — resolves through
+/// this one answer rather than through a private rescan (#11755).
+pub fn argv_separator_index(args: &[String]) -> Option<usize> {
+    args.iter().position(|arg| arg == "--")
+}
+
 /// The arguments Homeboy itself owns: everything before the first bare `--`.
 ///
 /// Everything after it is forwarded verbatim to a remote or child command —
@@ -63,8 +76,13 @@ pub enum CommandCapability {
 /// remote `-h` short-circuit this function to `ReadOnly` on an `ssh` invocation
 /// that is otherwise `Mutation`, and made the startup help fast path claim an
 /// invocation clap would go on to parse successfully (#11577).
+///
+/// This is the only sanctioned way to inspect argv for a flag Homeboy owns.
+/// `owned_args_guard_test` fails the build when a new raw argv flag scan
+/// appears outside it, because the two sites above were written months apart
+/// and nothing but review stood between them and a third.
 pub fn homeboy_owned_args(args: &[String]) -> &[String] {
-    match args.iter().position(|arg| arg == "--") {
+    match argv_separator_index(args) {
         Some(separator) => &args[..separator],
         None => args,
     }
@@ -335,4 +353,35 @@ mod tests {
         let nested = args(&["ssh", "host", "--", "sh", "-c", "--", "x"]);
         assert_eq!(homeboy_owned_args(&nested), &args(&["ssh", "host"])[..]);
     }
+
+    #[test]
+    fn the_separator_primitive_names_only_the_first_boundary() {
+        assert_eq!(argv_separator_index(&args(&["runner", "status"])), None);
+        assert_eq!(
+            argv_separator_index(&args(&["ssh", "host", "--", "df"])),
+            Some(2)
+        );
+
+        // A nested separator is the forwarded command's own argument.
+        let nested = args(&["ssh", "host", "--", "sh", "-c", "--", "x"]);
+        assert_eq!(argv_separator_index(&nested), Some(2));
+
+        // The two views agree by construction: the owned prefix ends exactly
+        // where the primitive says the boundary is.
+        for argv in [
+            args(&["runner", "status"]),
+            args(&["ssh", "host", "--", "df"]),
+            nested,
+        ] {
+            let owned = homeboy_owned_args(&argv);
+            assert_eq!(
+                owned.len(),
+                argv_separator_index(&argv).unwrap_or(argv.len())
+            );
+        }
+    }
 }
+
+#[cfg(test)]
+#[path = "owned_args_guard_test.rs"]
+mod owned_args_guard_test;

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -9,6 +9,7 @@
 use clap::{Arg, ArgAction, Args, Command, CommandFactory};
 
 use crate::cli_surface::Cli;
+use crate::command_capability::argv_separator_index;
 use homeboy::core::component::{self, Component};
 use homeboy::core::scope::{Scope, ScopeKind};
 
@@ -91,6 +92,16 @@ pub(crate) fn filter_passthrough_args(command: PassthroughCommand, args: &[Strin
 }
 
 /// Mark explicit passthrough arguments so Homeboy-owned flag filtering preserves them.
+///
+/// This is the other half of the same boundary `homeboy_owned_args` answers:
+/// that function names the prefix Homeboy may read, this one names where the
+/// forwarded suffix begins. Both resolve through [`argv_separator_index`] so
+/// there is one rule about the bare separator rather than a private rescan in
+/// each (#11755).
+///
+/// Only the FIRST separator is marked. A later one is the runner's own
+/// argument — `homeboy bench comp -- sh -c -- inner` — and marking it injected
+/// the sentinel into the argv Homeboy forwards verbatim.
 pub(crate) fn mark_explicit_passthrough(args: Vec<String>) -> Vec<String> {
     let explicit_passthrough = matches!(args.get(1).map(String::as_str), Some("bench"))
         || matches!(
@@ -104,15 +115,12 @@ pub(crate) fn mark_explicit_passthrough(args: Vec<String>) -> Vec<String> {
         return args;
     }
 
-    let mut result = Vec::new();
-    for arg in args.iter() {
-        if arg == "--" {
-            result.push(arg.clone());
-            result.push(EXPLICIT_PASSTHROUGH_SENTINEL.to_string());
-            continue;
-        }
-        result.push(arg.clone());
-    }
+    let Some(separator) = argv_separator_index(&args) else {
+        return args;
+    };
+
+    let mut result = args;
+    result.insert(separator + 1, EXPLICIT_PASSTHROUGH_SENTINEL.to_string());
     result
 }
 
@@ -656,6 +664,97 @@ mod normalize_tests {
         assert_eq!(
             super::filter_passthrough_args(super::PassthroughCommand::Test, &args),
             argv(&["--coverage", "--baseline", "runner-value"])
+        );
+    }
+
+    #[test]
+    fn only_the_first_separator_is_marked_so_a_nested_one_reaches_the_runner() {
+        // A second separator is the runner's own argument. Marking every one
+        // of them injected the sentinel into the argv Homeboy forwards
+        // verbatim, so `sh -c -- inner` reached the runner with a homeboy
+        // token wedged into it.
+        let input = argv(&[
+            "homeboy", "bench", "my-comp", "--", "sh", "-c", "--", "inner",
+        ]);
+        let normalized = normalize(input);
+
+        assert_eq!(
+            normalized,
+            argv(&[
+                "homeboy",
+                "bench",
+                "my-comp",
+                "--",
+                EXPLICIT_PASSTHROUGH_SENTINEL,
+                "sh",
+                "-c",
+                "--",
+                "inner",
+            ])
+        );
+
+        // What clap hands the `last = true` field, filtered: the runner's
+        // command, nested separator intact and sentinel-free.
+        let passthrough: Vec<String> = normalized
+            .iter()
+            .skip_while(|arg| arg.as_str() != "--")
+            .skip(1)
+            .cloned()
+            .collect();
+        assert_eq!(
+            super::filter_passthrough_args(super::PassthroughCommand::Bench, &passthrough),
+            argv(&["sh", "-c", "--", "inner"])
+        );
+    }
+
+    #[test]
+    fn review_test_forwards_a_runner_owned_format_flag_verbatim() {
+        // #11555 recorded that `test` could not adopt `--format` because the
+        // owned-flag filter would swallow libtest's own `--format <fmt>`.
+        // The explicit separator is what prevents that, and it covers
+        // `review test` exactly as it covers `bench`.
+        let normalized = normalize(argv(&[
+            "homeboy",
+            "review",
+            "test",
+            "my-comp",
+            "--json-summary",
+            "--",
+            "--format",
+            "json",
+            "--test-threads",
+            "1",
+        ]));
+
+        let passthrough: Vec<String> = normalized
+            .iter()
+            .skip_while(|arg| arg.as_str() != "--")
+            .skip(1)
+            .cloned()
+            .collect();
+
+        assert_eq!(
+            super::filter_passthrough_args(super::PassthroughCommand::Test, &passthrough),
+            argv(&["--format", "json", "--test-threads", "1"])
+        );
+    }
+
+    #[test]
+    fn without_the_separator_the_filter_still_strips_a_command_owned_flag() {
+        // The other side of the same contract, on a flag the command really
+        // does own today: `bench` declares `--format` via `PresentationArgs`.
+        // Unmarked, the filter removes it and the value it consumes — which is
+        // exactly why the separator has to be marked, and exactly what would
+        // have happened to libtest's `--format` without it.
+        let unmarked = argv(&["--format", "json"]);
+        assert!(
+            super::filter_passthrough_args(super::PassthroughCommand::Bench, &unmarked).is_empty()
+        );
+
+        let marked = argv(&[EXPLICIT_PASSTHROUGH_SENTINEL, "--format", "json"]);
+        assert_eq!(
+            super::filter_passthrough_args(super::PassthroughCommand::Bench, &marked),
+            argv(&["--format", "json"])
         );
     }
 }
@@ -1298,12 +1397,20 @@ pub enum DetailLevel {
 /// Still on their own vocabulary, and why:
 ///
 /// * `--json-summary` / `--summary` (`audit`, `lint`, `test`, `trace`,
-///   `bench`'s run group) are the *detail* axis, not the format axis. `test`
-///   in particular cannot take a `--format` flag yet: `filter_passthrough_args`
-///   strips homeboy-owned flags from `homeboy test -- <runner args>`, and the
-///   test path has no explicit-passthrough sentinel, so declaring `--format`
-///   here would silently swallow libtest's own `--format <fmt>`. (`bench` is
-///   safe because `mark_explicit_passthrough` marks `homeboy bench -- ...`.)
+///   `bench`'s run group) are the *detail* axis, not the format axis.
+///
+///   `test` was recorded here as unable to take a `--format` flag at all, on
+///   the grounds that `filter_passthrough_args` strips homeboy-owned flags from
+///   `homeboy review test -- <runner args>` and the test path had no
+///   explicit-passthrough sentinel, so declaring `--format` would swallow
+///   libtest's own `--format <fmt>`. That is no longer true, and #11755 is
+///   where it was checked: `mark_explicit_passthrough` marks
+///   `("review", "test")` exactly as it marks `bench`, and
+///   `filter_passthrough_args` returns everything after that sentinel verbatim.
+///   `review_test_forwards_a_runner_owned_format_flag_verbatim` pins the whole
+///   path end to end. Adopting the group on `test` is now a presentation
+///   decision (which of `--json-summary`'s two senses `--detail` folds onto),
+///   not a passthrough hazard.
 /// * `lint` declares `--summary` *and* `--json-summary` as separate fields
 ///   that `review` couples with `|=`; collapsing them is a behavior decision.
 /// * `--full` (`status`, `agent-task`), `--compact` (`runner`), `--format`

--- a/crates/homeboy-cli/src/owned_args_guard_test.rs
+++ b/crates/homeboy-cli/src/owned_args_guard_test.rs
@@ -1,0 +1,386 @@
+//! Source guard: a raw argv flag scan must route through the separator
+//! primitive.
+//!
+//! Two sites scanned argv for a flag Homeboy owns without stopping at the bare
+//! separator, so a forwarded remote argument was read as Homeboy's own: a
+//! remote short help flag downgraded a mutating `ssh` invocation to `ReadOnly`,
+//! and the startup help fast path claimed an invocation clap went on to parse
+//! successfully (#11577). They were written months apart by different changes,
+//! which is the tell — the shape reads correct, and the failure is a silent
+//! misclassification rather than a crash.
+//!
+//! [`super::homeboy_owned_args`] fixed both. This guard is what stops a third:
+//! it walks this crate's sources, finds every function that takes a full-argv
+//! slice and compares an element against a flag literal, and requires each one
+//! to either route through the primitive or appear in the inventory below with
+//! a stated reason. Adding a scan is then a deliberate act with a written
+//! justification instead of an unnoticed regression (#11755).
+//!
+//! Following the `core-agnostic-source` precedent, this reads source text, so
+//! it is deliberately shape-based rather than semantic. Lines that begin with a
+//! comment marker are skipped, so prose describing the shape is not a finding.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Every function in this crate that reads a flag literal out of a full-argv
+/// slice without going through [`super::homeboy_owned_args`], with the reason
+/// it is accepted.
+///
+/// This inventory is the artifact #11755 asked for. The three statuses below
+/// are load-bearing:
+///
+/// * *stops at the separator itself* — correct, but a fourth hand-rolled copy
+///   of the same rule. These are the unification candidates.
+/// * *cannot be reached through a separator* — correct by construction.
+/// * *scans past the separator* — the #11577 shape, unaudited. Each is a
+///   latent misread of a forwarded argument, tracked rather than fixed here
+///   because the correct behavior differs per call site.
+const ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS: &[(&str, &str)] = &[
+    (
+        "cli_runtime.rs::explicit_runner_from_args",
+        "stops at the separator itself: returns None on the first bare separator",
+    ),
+    (
+        "cli_runtime.rs::is_runs_artifact_get_runner_option",
+        "scans past the separator: a forwarded runner flag can satisfy this predicate",
+    ),
+    (
+        "cli_runtime.rs::is_runs_list_runner_option",
+        "scans past the separator: a forwarded runner flag can satisfy this predicate",
+    ),
+    (
+        "cli_runtime.rs::is_top_level_version_request",
+        "cannot be reached through a separator: an exact two-element slice pattern",
+    ),
+    (
+        "commands/infra/route.rs::explicit_run_id",
+        "scans past the separator: a forwarded run-id flag is read as Homeboy's own",
+    ),
+    (
+        "commands/infra/route.rs::has_lab_changed_files_json",
+        "scans past the separator: a forwarded flag of the same name satisfies this",
+    ),
+    (
+        "commands/infra/route.rs::inline_portable_settings_profiles",
+        "stops at the separator itself: copies the tail verbatim once it is reached",
+    ),
+    (
+        "commands/infra/route.rs::is_runs_list_runner_option",
+        "scans past the separator: a forwarded runner flag can satisfy this predicate",
+    ),
+    (
+        "commands/infra/route.rs::portable_deferred_args",
+        "scans past the separator: strips placement flags from forwarded arguments too",
+    ),
+    (
+        "commands/infra/route.rs::retry_handoff_prefix",
+        "scans past the separator: strips path flags from forwarded arguments too",
+    ),
+    (
+        "commands/infra/route.rs::source_path_for_generic_detached_lab_handoff",
+        "stops at the separator itself: breaks out on the first bare separator",
+    ),
+    (
+        "commands/infra/route.rs::strip_component_target_args",
+        "stops at the separator itself: flips to verbatim passthrough on reaching it",
+    ),
+    (
+        "commands/infra/route/local_detach.rs::detached_cook_child_args",
+        "scans past the separator: filters a detach flag out of forwarded arguments too",
+    ),
+    (
+        "commands/infra/route/local_detach.rs::stdin_prompt_index",
+        "scans past the separator: a forwarded prompt flag is read as Homeboy's own",
+    ),
+    (
+        "commands/utils/execution_provenance.rs::redact_execution_argv",
+        "intentionally covers forwarded arguments: a secret is no less secret past the separator",
+    ),
+    (
+        "commands/utils/resource_policy/messages.rs::append_local_placement",
+        "scans past the separator: a forwarded placement flag suppresses the suggestion",
+    ),
+    (
+        "commands/utils/resource_policy/mod.rs::rerun_command",
+        "scans past the separator: a forwarded runner flag suppresses the suggestion",
+    ),
+];
+
+/// Sites that already route through the primitive. Pinned so a refactor that
+/// quietly drops the call is a failure here rather than a silent regression.
+const SANCTIONED_ARGV_FLAG_SCANS: &[&str] = &[
+    "cli_runtime.rs::startup_fast_path",
+    "command_capability.rs::classify",
+];
+
+/// The comparison shapes that read a Homeboy-owned flag out of an argument.
+///
+/// The separator is deliberately not one of them: a bare separator carries no
+/// flag name, so the trailing character must be alphabetic for a line to count.
+const FLAG_LITERAL_COMPARISONS: &[&str] = &["== \"-", "starts_with(\"-"];
+
+/// Parameter spellings that carry a full argv slice. A narrower parameter (an
+/// already-split tail, a recorded command's own arguments) is a different
+/// question and is out of scope.
+const ARGV_PARAMETERS: &[&str] = &["args: &[String]", "argv: &[String]"];
+
+fn crate_source_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn is_test_source(relative_path: &str) -> bool {
+    relative_path.contains("/tests/")
+        || relative_path.ends_with("_test.rs")
+        || relative_path.ends_with("_tests.rs")
+        || relative_path.ends_with("/tests.rs")
+        || relative_path == "tests.rs"
+}
+
+fn collect_rust_sources(directory: &Path, root: &Path, collected: &mut Vec<(String, String)>) {
+    let entries = std::fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()));
+
+    for entry in entries {
+        let entry = entry.expect("readable directory entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_sources(&path, root, collected);
+            continue;
+        }
+        if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+            continue;
+        }
+        let relative_path = path
+            .strip_prefix(root)
+            .expect("collected path is under the source root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_test_source(&relative_path) {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {relative_path}: {error}"));
+        collected.push((relative_path, content));
+    }
+}
+
+/// The name of the function this line declares, if it declares one.
+fn declared_fn_name(line: &str) -> Option<&str> {
+    let mut search = 0;
+    while let Some(offset) = line[search..].find("fn ") {
+        let start = search + offset;
+        let preceded_by_identifier = line[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_');
+        if !preceded_by_identifier {
+            let rest = &line[start + 3..];
+            let end = rest
+                .find(|character: char| !(character.is_alphanumeric() || character == '_'))
+                .unwrap_or(rest.len());
+            if end > 0 {
+                return Some(&rest[..end]);
+            }
+        }
+        search = start + 3;
+    }
+    None
+}
+
+/// Whether this line compares an argument against a named flag literal.
+fn compares_against_a_flag_literal(line: &str) -> bool {
+    FLAG_LITERAL_COMPARISONS.iter().any(|shape| {
+        line.match_indices(*shape).any(|(index, _)| {
+            line[index + shape.len()..]
+                .trim_start_matches('-')
+                .chars()
+                .next()
+                .is_some_and(char::is_alphabetic)
+        })
+    })
+}
+
+fn is_comment_line(line: &str) -> bool {
+    line.trim_start().starts_with("//")
+}
+
+/// Every argv flag scan in this crate, mapped to whether it routes through the
+/// sanctioned primitive.
+///
+/// A scan is attributed to the nearest preceding function declaration, the same
+/// way the shipped source-policy detector resolves a finding's enclosing
+/// context. That is an approximation, and a deliberate one: it needs no parser,
+/// and over-attribution only ever widens what the guard asks a human to look at.
+fn raw_argv_flag_scans() -> BTreeMap<String, bool> {
+    let root = crate_source_root();
+    let mut sources = Vec::new();
+    collect_rust_sources(&root, &root, &mut sources);
+    assert!(
+        !sources.is_empty(),
+        "no rust sources found under {}",
+        root.display()
+    );
+
+    let mut scans = BTreeMap::new();
+    for (relative_path, content) in &sources {
+        let lines: Vec<&str> = content.lines().collect();
+        let declarations: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, line)| !is_comment_line(line))
+            .filter(|(_, line)| declared_fn_name(line).is_some())
+            .map(|(index, _)| index)
+            .collect();
+
+        for (index, line) in lines.iter().enumerate() {
+            if is_comment_line(line) || !compares_against_a_flag_literal(line) {
+                continue;
+            }
+            let Some(position) = declarations
+                .iter()
+                .rposition(|declaration| *declaration <= index)
+            else {
+                continue;
+            };
+            let start = declarations[position];
+            let end = declarations
+                .get(position + 1)
+                .copied()
+                .unwrap_or(lines.len());
+            let region = &lines[start..end];
+
+            let signature_end = region
+                .iter()
+                .position(|line| line.contains('{'))
+                .map_or(region.len(), |offset| offset + 1);
+            let signature = region[..signature_end].join("\n");
+            if !ARGV_PARAMETERS
+                .iter()
+                .any(|parameter| signature.contains(parameter))
+            {
+                continue;
+            }
+
+            let name = declared_fn_name(lines[start]).expect("declaration line names a function");
+            let routes_through_primitive = region.join("\n").contains("homeboy_owned_args");
+            scans.insert(format!("{relative_path}::{name}"), routes_through_primitive);
+        }
+    }
+    scans
+}
+
+#[test]
+fn a_new_raw_argv_flag_scan_is_a_failure() {
+    let scans = raw_argv_flag_scans();
+    let unsanctioned: Vec<String> = scans
+        .iter()
+        .filter(|(site, routes_through_primitive)| {
+            !*routes_through_primitive
+                && !ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS
+                    .iter()
+                    .any(|(acknowledged, _)| *acknowledged == site.as_str())
+        })
+        .map(|(site, _)| site.clone())
+        .collect();
+
+    assert!(
+        unsanctioned.is_empty(),
+        "these functions read a flag literal out of raw argv without stopping at the bare \
+         separator, so a forwarded argument can be read as Homeboy's own (#11577): {unsanctioned:?}. \
+         Call `homeboy_owned_args` first, or add the site to \
+         ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS with the reason it is safe."
+    );
+}
+
+#[test]
+fn an_acknowledged_scan_that_no_longer_exists_is_a_failure() {
+    // A stale entry is how an inventory stops describing the tree it guards.
+    // The row must still name a real scan, and that scan must still be raw:
+    // a site that has since adopted the primitive belongs in the sanctioned
+    // list, not in the acknowledged one.
+    let scans = raw_argv_flag_scans();
+    let stale: Vec<&str> = ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS
+        .iter()
+        .filter(|(site, _)| scans.get(*site) != Some(&false))
+        .map(|(site, _)| *site)
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS names scans that no longer exist as raw argv \
+         scans: {stale:?}. Remove the stale rows."
+    );
+}
+
+#[test]
+fn every_acknowledged_scan_states_a_reason() {
+    for (site, reason) in ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS {
+        assert!(
+            reason.len() > 20,
+            "{site} is acknowledged without a usable reason"
+        );
+    }
+}
+
+#[test]
+fn the_sanctioned_sites_still_route_through_the_primitive() {
+    let scans = raw_argv_flag_scans();
+    for site in SANCTIONED_ARGV_FLAG_SCANS {
+        assert_eq!(
+            scans.get(*site),
+            Some(&true),
+            "{site} no longer routes its argv flag scan through homeboy_owned_args"
+        );
+    }
+}
+
+#[test]
+fn the_guard_recognizes_the_shape_it_is_written_to_catch() {
+    // The two #11577 sites, as they were written.
+    assert!(compares_against_a_flag_literal(
+        r#"if args.iter().any(|arg| arg == "--help" || arg == "-h") {"#
+    ));
+    assert!(compares_against_a_flag_literal(
+        r#"index > list_index && (arg == "--runner" || arg.starts_with("--runner="))"#
+    ));
+
+    // The separator carries no flag name, so the primitive's own scan for it
+    // is not a finding — otherwise the guard would flag its own foundation.
+    assert!(!compares_against_a_flag_literal(
+        r#"args.iter().position(|arg| arg == "--")"#
+    ));
+    // A subcommand token is not a flag.
+    assert!(!compares_against_a_flag_literal(
+        r#"args.iter().position(|arg| arg == "runs")"#
+    ));
+    // A negative number is not a flag either.
+    assert!(!compares_against_a_flag_literal(r#"value == "-1""#));
+}
+
+#[test]
+fn function_attribution_names_the_enclosing_declaration() {
+    assert_eq!(
+        declared_fn_name("pub fn homeboy_owned_args(args: &[String]) -> &[String] {"),
+        Some("homeboy_owned_args")
+    );
+    assert_eq!(
+        declared_fn_name("    fn is_top_level_version_request(args: &[String]) -> bool {"),
+        Some("is_top_level_version_request")
+    );
+    assert_eq!(
+        declared_fn_name("    let owned = separator_index(argv);"),
+        None
+    );
+    // A word ending in `fn` must not be read as a declaration keyword.
+    assert_eq!(declared_fn_name("    let asfn = 1;"), None);
+}
+
+#[test]
+fn test_sources_are_out_of_scope() {
+    assert!(is_test_source("commands/runner/tests/status.rs"));
+    assert!(is_test_source("commands/bench/parse_tests.rs"));
+    assert!(is_test_source("owned_args_guard_test.rs"));
+    assert!(!is_test_source("cli_runtime.rs"));
+    assert!(!is_test_source("commands/infra/route.rs"));
+}


### PR DESCRIPTION
Refs #11755, refs #11555.

Two argv scanners read *through* the bare `--` separator and treated a forwarded remote argument as Homeboy's own (#11577). `homeboy_owned_args` fixed both. Nothing stopped a third — the shape reads correct, and the failure is a silent misclassification rather than a crash.

## The guard

`crates/homeboy-cli/src/owned_args_guard_test.rs` walks this crate's sources, finds every function that takes a full-argv slice (`args: &[String]` / `argv: &[String]`) and compares an element against a **flag** literal, and requires each one to either route through `homeboy_owned_args` or appear in `ACKNOWLEDGED_RAW_ARGV_FLAG_SCANS` with a stated reason.

It follows the `core-agnostic-source` precedent — shape-based text scanning, comment lines skipped so prose describing the shape is not a finding — rather than inventing a new mechanism. The bare separator itself is deliberately not a match (no flag name follows it), so the primitive's own scan is not flagged.

Four tests, both directions: a new unsanctioned scan fails; a stale acknowledgement fails; the two sanctioned sites must keep routing through the primitive; every acknowledgement must state a reason. Plus unit tests on the detector shapes themselves.

### The inventory this produced

19 argv flag scans in `homeboy-cli`. 2 route through the primitive (`command_capability::classify`, `cli_runtime::startup_fast_path`). The other 17 are acknowledged in three classes:

| class | count | meaning |
|---|---|---|
| stops at the separator itself | 4 | correct, but a hand-rolled fourth copy of the rule — unification candidates |
| cannot be reached through a separator | 2 | correct by construction (exact slice pattern; deliberate full-argv redaction) |
| **scans past the separator** | **11** | the #11577 shape, unaudited — each a latent misread of a forwarded argument |

Those 11 are tracked, not fixed: the correct behaviour differs per call site and none can be changed safely in a single pass. This is why the commit says `Refs` and not `Closes` — the issue also asks to extend coverage to the forwarding commands, and that is now *inventoried and enforced against regression* but not repaired.

## Why a test and not an `OwnedArgs` newtype

The issue asked me to weigh it. A newtype would make a raw `&[String]` scan a *type* error rather than a review question — genuinely stronger. But it only pays off if every site goes through it, which means touching all 19 plus their callers in one change, and the four that already hand-roll a correct separator stop each want a different shape (one returns `None` at the separator, one copies the tail verbatim, one breaks, one flips a passthrough flag). The guard gets the same "a new scan is a deliberate act" property at a fraction of the blast radius, and it *names why each existing site is accepted* — information a mechanical newtype conversion would erase.

## Unifying the treatments

`argv_separator_index` now answers the boundary question once. `homeboy_owned_args` (the prefix Homeboy may read) and `mark_explicit_passthrough` (where the forwarded suffix begins) are both expressed in terms of it instead of rescanning privately.

That also fixed a real leak. `mark_explicit_passthrough` marked *every* separator, so `homeboy bench comp -- sh -c -- inner` forwarded `sh -c -- __homeboy_explicit_passthrough__ inner` to the runner. Only the first separator is marked now — byte-identical for every single-separator invocation, verified against the previous implementation across the existing cases.

## The third treatment did not need collapsing — and that retired a stale blocker

#11555 recorded that `test` could not adopt `--format` because `filter_passthrough_args` strips homeboy-owned flags and "the test path has no explicit-passthrough sentinel", so declaring `--format` would swallow libtest's own `--format <fmt>`.

That is not true. `mark_explicit_passthrough` marks `("review", "test")` exactly as it marks `bench`, `PassthroughCommand::Test.path()` is `["review", "test"]`, and `filter_passthrough_args` returns everything after the sentinel verbatim. There is no top-level `homeboy test` — only `homeboy review test`.

Corrected the note and added the coverage the constraint requires:

- `review_test_forwards_a_runner_owned_format_flag_verbatim` — `homeboy review test my-comp --json-summary -- --format json --test-threads 1` reaches the runner intact, end to end through `normalize`.
- `without_the_separator_the_filter_still_strips_a_command_owned_flag` — the negative case on `bench`, which genuinely *does* declare `--format` via `PresentationArgs`: unmarked, the filter removes the flag and the value it consumes. That is exactly what would happen to libtest's `--format`, and exactly what the separator prevents.
- `only_the_first_separator_is_marked_so_a_nested_one_reaches_the_runner` — the nested-separator fix.

Adopting `PresentationArgs` on `test` is now a presentation decision (which sense of `--json-summary` `--detail` folds onto), not a passthrough hazard. Not done here — it adds a field to `TestArgs`, which has five literal constructions across the tree.

## Files

- `crates/homeboy-cli/src/command_capability.rs` — `argv_separator_index`; `homeboy_owned_args` expressed in terms of it; primitive test; guard wiring
- `crates/homeboy-cli/src/owned_args_guard_test.rs` — new
- `crates/homeboy-cli/src/commands/utils/args.rs` — `mark_explicit_passthrough` on the shared primitive; corrected #11555 note; three passthrough tests

## Verification

Full `cargo` was not run (shared VPS). Instead:

- `cargo fmt` clean.
- The guard file was compiled standalone with `rustc --edition 2021 --test -D warnings` and **run against this worktree**: 7/7 pass. It caught one real error I would otherwise have shipped (`E0277`, `&str == str`).
- Injected a synthetic third scanner into `command_capability.rs` and confirmed the guard fails with its name, then reverted.
- The rewritten `mark_explicit_passthrough` was compiled and diff-tested standalone against the previous implementation over the existing normalize cases: identical output on every single-separator argv, differing only where a nested separator exists.

Remaining compile risk is the small edits inside the two existing files (one new import, one `let ... else`, three test fns using in-scope helpers) — `cargo check --workspace --tests` still wanted.