### PR TITLE
feat(test): local differential test verdict with a sha-keyed baseline cache

### DIFF
--- a/crates/homeboy-extension/src/test/differential/cache.rs
+++ b/crates/homeboy-extension/src/test/differential/cache.rs
@@ -1,0 +1,317 @@
+//! Sha-keyed cache of base-branch test measurements.
+//!
+//! # Why keyed by sha
+//!
+//! The expensive half of a differential verdict is measuring the base branch.
+//! Keying that measurement by the base revision's sha means it is paid **once
+//! per base-branch movement** rather than once per branch: every branch cut
+//! from the same `main` reuses one measurement, and a `main` that has moved is
+//! a *miss* rather than a stale answer. Without this the whole feature is just
+//! automating the thing that was already too slow.
+//!
+//! # Why the scope is part of the key
+//!
+//! `cargo test -p homeboy-core --lib` and a whole-workspace run are different
+//! measurements of different things, and comparing one against the other
+//! produces confident nonsense. The scope string is therefore part of the key,
+//! and it is compared **verbatim**: a different argument order is a different
+//! key. That costs an occasional avoidable miss and buys the guarantee that a
+//! hit is always a like-for-like comparison. A miss is cheap; a wrong hit is a
+//! false verdict.
+//!
+//! # Why every mismatch degrades to a miss
+//!
+//! [`BaselineCache::load`] returns `None` for an absent file, unreadable JSON,
+//! an unknown schema, or any recorded identity that disagrees with the key.
+//! None of those are errors the caller can act on, and all of them mean the
+//! same thing: there is nothing here that can honestly be compared. The verdict
+//! layer turns that into [`super::DifferentialVerdict::NoBaseline`], which
+//! blocks — so a corrupted cache degrades to "prove it yourself", never to a
+//! clean verdict.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_core::error::{Error, Result};
+use homeboy_core::paths;
+
+use super::{BaselineEvidence, TestMeasurement};
+
+/// Named store below the Homeboy data root.
+pub const BASELINE_CACHE_STORE: &str = "test-differential-baselines";
+
+/// Bumped whenever the on-disk record shape changes. An unknown schema is a
+/// miss, not an error.
+pub const BASELINE_CACHE_SCHEMA: u32 = 1;
+
+/// Scope string used when a run selected no explicit scope.
+pub const WHOLE_SUITE_SCOPE: &str = "whole-suite";
+
+/// Longest sanitized scope prefix kept in a cache file name, before the hash
+/// suffix that actually guarantees uniqueness.
+const SCOPE_NAME_PREFIX_LIMIT: usize = 48;
+
+/// Default cache root: `<homeboy data>/test-differential-baselines`.
+pub fn default_root() -> Result<PathBuf> {
+    paths::homeboy_data_store(BASELINE_CACHE_STORE)
+}
+
+/// Canonical scope key for a test invocation.
+///
+/// Trims and drops empty arguments, then joins verbatim. Order is preserved
+/// deliberately — see the module docs on why a miss beats a wrong hit.
+pub fn scope_key(args: &[String]) -> String {
+    let joined = args
+        .iter()
+        .map(|arg| arg.trim())
+        .filter(|arg| !arg.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if joined.is_empty() {
+        WHOLE_SUITE_SCOPE.to_string()
+    } else {
+        joined
+    }
+}
+
+/// The identity a cached measurement must match to be usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineCacheKey {
+    pub component_id: String,
+    /// The base ref as the caller named it, e.g. `origin/main`.
+    pub reference: String,
+    /// The revision `reference` resolves to.
+    pub revision: String,
+    /// Canonical scope string from [`scope_key`].
+    pub scope: String,
+}
+
+impl BaselineCacheKey {
+    pub fn new(
+        component_id: impl Into<String>,
+        reference: impl Into<String>,
+        revision: impl Into<String>,
+        scope: impl Into<String>,
+    ) -> Self {
+        Self {
+            component_id: component_id.into().trim().to_string(),
+            reference: reference.into().trim().to_string(),
+            revision: revision.into().trim().to_string(),
+            scope: scope.into().trim().to_string(),
+        }
+    }
+
+    /// Filesystem-safe, collision-resistant name for this scope.
+    ///
+    /// A readable prefix keeps the cache inspectable by hand; the hash suffix
+    /// is what makes distinct scopes distinct after sanitization has collapsed
+    /// punctuation.
+    pub fn scope_fingerprint(&self) -> String {
+        let sanitized = paths::sanitize_path_segment(&self.scope);
+        let prefix: String = sanitized.chars().take(SCOPE_NAME_PREFIX_LIMIT).collect();
+        format!("{prefix}-{:016x}", fnv1a64(self.scope.as_bytes()))
+    }
+
+    /// `<component>/<revision>/<scope>.json`, relative to the cache root.
+    pub fn relative_path(&self) -> PathBuf {
+        PathBuf::from(paths::sanitize_path_segment(&self.component_id))
+            .join(paths::sanitize_path_segment(&self.revision))
+            .join(format!("{}.json", self.scope_fingerprint()))
+    }
+
+    /// Directory holding every revision recorded for this component.
+    fn component_dir(&self) -> PathBuf {
+        PathBuf::from(paths::sanitize_path_segment(&self.component_id))
+    }
+}
+
+/// One cached base-branch measurement, as stored on disk.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CachedBaselineRecord {
+    pub schema: u32,
+    pub component_id: String,
+    pub reference: String,
+    pub revision: String,
+    pub scope: String,
+    /// RFC 3339 timestamp of when this measurement was recorded.
+    pub recorded_at: String,
+    pub measurement: TestMeasurement,
+}
+
+impl CachedBaselineRecord {
+    /// Whether this record can honestly answer `key`.
+    ///
+    /// Component, revision, and scope are all compared: a file found at the
+    /// right path but carrying a different identity has been corrupted or
+    /// hand-edited, and trusting the path over the contents would turn that
+    /// into a silent wrong answer. The *reference* is deliberately not
+    /// compared — `main` and `origin/main` resolving to the same sha are the
+    /// same measurement.
+    pub fn matches(&self, key: &BaselineCacheKey) -> bool {
+        self.schema == BASELINE_CACHE_SCHEMA
+            && self.component_id == key.component_id
+            && self.revision == key.revision
+            && self.scope == key.scope
+    }
+
+    pub fn into_evidence(self) -> BaselineEvidence {
+        BaselineEvidence {
+            reference: self.reference,
+            revision: self.revision,
+            recorded_at: self.recorded_at,
+            measurement: self.measurement,
+        }
+    }
+}
+
+/// A directory of cached base-branch measurements.
+#[derive(Debug, Clone)]
+pub struct BaselineCache {
+    root: PathBuf,
+}
+
+impl BaselineCache {
+    /// Open a cache rooted at an explicit directory.
+    ///
+    /// Tests use this rather than the default root so they never depend on the
+    /// ambient home directory or on any relationship between the cache and the
+    /// process temp directory.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Open the cache at the default location under the Homeboy data root.
+    pub fn open() -> Result<Self> {
+        Ok(Self::at(default_root()?))
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn path_for(&self, key: &BaselineCacheKey) -> PathBuf {
+        self.root.join(key.relative_path())
+    }
+
+    /// The cached measurement for `key`, or `None` for any reason at all.
+    pub fn load(&self, key: &BaselineCacheKey) -> Option<BaselineEvidence> {
+        self.load_record(key)
+            .map(CachedBaselineRecord::into_evidence)
+    }
+
+    /// The cached record for `key`, retaining the storage-level fields.
+    pub fn load_record(&self, key: &BaselineCacheKey) -> Option<CachedBaselineRecord> {
+        let raw = std::fs::read_to_string(self.path_for(key)).ok()?;
+        let record: CachedBaselineRecord = serde_json::from_str(&raw).ok()?;
+        record.matches(key).then_some(record)
+    }
+
+    /// Record a measurement of the base branch.
+    pub fn store(
+        &self,
+        key: &BaselineCacheKey,
+        measurement: &TestMeasurement,
+        recorded_at: impl Into<String>,
+    ) -> Result<PathBuf> {
+        let record = CachedBaselineRecord {
+            schema: BASELINE_CACHE_SCHEMA,
+            component_id: key.component_id.clone(),
+            reference: key.reference.clone(),
+            revision: key.revision.clone(),
+            scope: key.scope.clone(),
+            recorded_at: recorded_at.into(),
+            measurement: measurement.clone().normalized(),
+        };
+
+        let path = self.path_for(key);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    format!(
+                        "Failed to create differential baseline cache directory {}: {error}",
+                        parent.display()
+                    ),
+                    Some("test.differential.cache.store".to_string()),
+                )
+            })?;
+        }
+
+        let body = serde_json::to_string_pretty(&record).map_err(|error| {
+            Error::internal_io(
+                format!("Failed to serialize differential baseline record: {error}"),
+                Some("test.differential.cache.store".to_string()),
+            )
+        })?;
+        std::fs::write(&path, format!("{body}\n")).map_err(|error| {
+            Error::internal_io(
+                format!(
+                    "Failed to write differential baseline record {}: {error}",
+                    path.display()
+                ),
+                Some("test.differential.cache.store".to_string()),
+            )
+        })?;
+
+        Ok(path)
+    }
+
+    /// Drop every recorded revision for this component except `key`'s.
+    ///
+    /// The base branch moves constantly, so without this the cache grows one
+    /// directory per observed sha forever. Returns how many revision
+    /// directories were removed.
+    pub fn prune_superseded(&self, key: &BaselineCacheKey) -> Result<usize> {
+        let component_dir = self.root.join(key.component_dir());
+        let keep = paths::sanitize_path_segment(&key.revision);
+
+        let entries = match std::fs::read_dir(&component_dir) {
+            Ok(entries) => entries,
+            // Nothing recorded yet is not a failure to prune.
+            Err(_) => return Ok(0),
+        };
+
+        let mut removed = 0usize;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if name == keep {
+                continue;
+            }
+            std::fs::remove_dir_all(&path).map_err(|error| {
+                Error::internal_io(
+                    format!(
+                        "Failed to prune superseded differential baseline {}: {error}",
+                        path.display()
+                    ),
+                    Some("test.differential.cache.prune".to_string()),
+                )
+            })?;
+            removed += 1;
+        }
+
+        Ok(removed)
+    }
+}
+
+/// FNV-1a, 64-bit. Chosen because it is three lines and needs no dependency:
+/// this hash only has to separate scope strings inside one directory, and it is
+/// never a security or integrity boundary — the record's own fields are
+/// re-checked on load.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}

--- a/crates/homeboy-extension/src/test/differential/mod.rs
+++ b/crates/homeboy-extension/src/test/differential/mod.rs
@@ -1,0 +1,674 @@
+//! Local differential test verdict — "is this red because of my change, or was
+//! it already red on the base branch?"
+//!
+//! # The question this answers
+//!
+//! `main` carries known-red tests and merges dozens of pull requests a day, so
+//! a fresh failure on a branch is as likely to be *inherited* as *authored*.
+//! Answering that locally used to cost a second checkout of the base branch and
+//! a second test build — several minutes and several gigabytes of `target/` —
+//! and most of the time the answer was "your branch is fine". That is pure
+//! overhead paid over and over. See Extra-Chill/homeboy#11753.
+//!
+//! # Why the cache is the feature
+//!
+//! Comparing against the base branch is only worth doing if the expensive half
+//! is paid **once per base-branch movement**, not once per branch. So the
+//! baseline measurement is stored keyed by the base revision's sha (see
+//! [`cache`]): every branch cut from the same `main` sha reuses one
+//! measurement, and a `main` that moved is a cache miss rather than a stale
+//! answer.
+//!
+//! # Why this vocabulary and not a new one
+//!
+//! `homeboy-action`'s `scripts/core/apply-differential-gate.py` already defines
+//! `baseline_red`, `inconclusive`, and `no_measurement`, and it already worked
+//! out the non-obvious cases. This module mirrors those meanings exactly rather
+//! than inventing a second, subtly different set:
+//!
+//! * `current == base && base > 0` is **`baseline_red`, not `pass`**. Equal
+//!   counts with something still red is not an improvement, and reporting
+//!   `pass` renders a green result with no annotation anywhere — so a test that
+//!   is red on the base branch stays red forever because no run ever says so.
+//! * A **timeout against a healthy baseline keeps blocking**. Counts from a
+//!   suite that was killed mid-run are not comparable to counts from one that
+//!   finished; a killed run usually reports *fewer* failures (often zero,
+//!   because the sidecar was never written), so a naive `current <= base` reads
+//!   "the suite never finished" as a clean sweep.
+//! * A command that **failed while reporting zero failures** is
+//!   `inconclusive`, not `pass`: its own failure went uncounted. Changed-scope
+//!   (`Scoped`) metrics are exempt, because there zero *is* the measurement.
+//! * When **neither side produced counts**, the verdict is `no_measurement`.
+//!   `baseline_red` asserts something specific — that this failure is
+//!   pre-existing — and that claim needs an observation on the candidate side
+//!   to rest on. A double timeout knows nothing about either side, and dressing
+//!   that up as a diagnosis is how absence of evidence becomes evidence of
+//!   absence.
+//!
+//! # What this adds beyond the CI gate
+//!
+//! * [`DifferentialVerdict::NoBaseline`] — the local-only honest degradation.
+//!   The CI gate always has a baseline job; locally there may simply be nothing
+//!   cached and no budget to build one. That must never render as a clean
+//!   verdict, so it is its own state and it blocks.
+//! * **Comparison by test name, not only by count.** Three failures before and
+//!   three after can still be three *different* tests, which every count-only
+//!   rule reads as `baseline_red`. When both sides name their failures, the
+//!   verdict is driven by the set difference and count parity cannot launder a
+//!   swapped failure set. Name knowledge strictly refines the count rule and
+//!   never turns a non-blocking verdict into a blocking one.
+
+pub mod cache;
+mod render;
+
+#[cfg(test)]
+mod tests;
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use homeboy_extension_contract::test_result::TestCounts;
+use homeboy_extension_contract::test_results::TestCommandOutput;
+
+pub use cache::{
+    default_root as default_cache_root, scope_key, BaselineCache, BaselineCacheKey,
+    CachedBaselineRecord, BASELINE_CACHE_SCHEMA, BASELINE_CACHE_STORE, WHOLE_SUITE_SCOPE,
+};
+pub use render::render_report;
+
+/// How a side's failure count was derived.
+///
+/// Mirrors `SCOPED`/`TOTAL` in `apply-differential-gate.py`. The distinction is
+/// load-bearing for the zero guard in [`classify`]: zero means opposite things
+/// depending on provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    /// A deliberate measurement of what *this change* introduced. Zero is the
+    /// success case: the repository may be red, but the candidate added nothing
+    /// to it.
+    Scoped,
+    /// A raw count of everything the run found. Zero here, on a run that
+    /// nonetheless failed, is not a measurement of success — it means the
+    /// failure went uncounted.
+    Total,
+}
+
+/// The terminal state of one side's test invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunOutcome {
+    Passed,
+    Failed,
+    /// The run exhausted its execution budget and was killed. Neither a test
+    /// failure nor a broken harness: the suite is *incomplete*.
+    TimedOut,
+}
+
+/// One side of a differential comparison.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TestMeasurement {
+    pub outcome: RunOutcome,
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counts: Option<TestCounts>,
+    /// Fully qualified names of the failing tests, when the runner named them.
+    /// Sorted and deduplicated by [`TestMeasurement::normalized`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_tests: Vec<String>,
+    pub metric_kind: MetricKind,
+    /// Whether this run produced parseable counts or a failure list at all.
+    ///
+    /// Distinct from "reported zero failures": a run that died before writing
+    /// its results sidecar is unstructured, and its absent counts must not be
+    /// read as a clean sweep.
+    pub structured_output: bool,
+}
+
+impl TestMeasurement {
+    /// A green run.
+    pub fn passed(counts: TestCounts) -> Self {
+        Self {
+            outcome: RunOutcome::Passed,
+            exit_code: 0,
+            counts: Some(counts),
+            failed_tests: Vec::new(),
+            metric_kind: MetricKind::Total,
+            structured_output: true,
+        }
+    }
+
+    /// A red run that reported counts, and optionally named its failures.
+    pub fn failed(counts: TestCounts, failed_tests: Vec<String>) -> Self {
+        Self {
+            outcome: RunOutcome::Failed,
+            exit_code: 1,
+            counts: Some(counts),
+            failed_tests,
+            metric_kind: MetricKind::Total,
+            structured_output: true,
+        }
+    }
+
+    /// A run that produced no comparable measurement at all — killed, crashed,
+    /// or failed before writing a results sidecar.
+    pub fn unmeasured(outcome: RunOutcome, exit_code: i32) -> Self {
+        Self {
+            outcome,
+            exit_code,
+            counts: None,
+            failed_tests: Vec::new(),
+            metric_kind: MetricKind::Total,
+            structured_output: false,
+        }
+    }
+
+    /// A run killed by its execution budget.
+    pub fn timed_out() -> Self {
+        Self::unmeasured(RunOutcome::TimedOut, TIMEOUT_EXIT_CODE)
+    }
+
+    pub fn with_metric_kind(mut self, kind: MetricKind) -> Self {
+        self.metric_kind = kind;
+        self
+    }
+
+    pub fn with_exit_code(mut self, exit_code: i32) -> Self {
+        self.exit_code = exit_code;
+        self
+    }
+
+    /// Sort and deduplicate the failure names so set arithmetic and cache
+    /// records are order-independent.
+    pub fn normalized(mut self) -> Self {
+        self.failed_tests.sort();
+        self.failed_tests.dedup();
+        self
+    }
+
+    /// The comparable failure count, or `None` when nothing comparable exists.
+    ///
+    /// Mirrors `test_count()` in `apply-differential-gate.py`: prefer reported
+    /// counts, fall back to the length of the failure list, and report absence
+    /// rather than zero when neither is present.
+    pub fn failure_count(&self) -> Option<u64> {
+        if let Some(counts) = &self.counts {
+            return Some(counts.failed);
+        }
+        if self.structured_output {
+            return Some(self.failed_tests.len() as u64);
+        }
+        None
+    }
+
+    /// Whether the named failures fully account for the reported failure count.
+    ///
+    /// A partial name list degrades to count comparison rather than producing a
+    /// set difference over an incomplete set, which would invent regressions.
+    pub fn names_account_for_failures(&self) -> bool {
+        self.structured_output
+            && self
+                .failure_count()
+                .is_some_and(|count| count == self.failed_tests.len() as u64)
+    }
+
+    fn is_green(&self) -> bool {
+        self.outcome == RunOutcome::Passed
+    }
+}
+
+/// A cached measurement of the base branch, with the identity it was taken at.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BaselineEvidence {
+    /// The ref the caller asked about, e.g. `origin/main`.
+    pub reference: String,
+    /// The revision `reference` resolved to when the measurement was recorded.
+    pub revision: String,
+    /// RFC 3339 timestamp of when this measurement was recorded.
+    pub recorded_at: String,
+    pub measurement: TestMeasurement,
+}
+
+impl BaselineEvidence {
+    pub fn normalized(mut self) -> Self {
+        self.measurement = self.measurement.normalized();
+        self
+    }
+
+    /// Sliced by character, not byte, so a non-hex identifier cannot panic on a
+    /// UTF-8 boundary.
+    fn short_revision(&self) -> String {
+        self.revision.chars().take(9).collect()
+    }
+}
+
+/// Everything [`classify`] needs. The reference is carried separately from the
+/// baseline so a *missing* baseline can still say what it was missing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DifferentialInput {
+    /// The base ref the caller asked to compare against.
+    pub reference: String,
+    /// The revision `reference` currently resolves to, when git could tell us.
+    pub revision: Option<String>,
+    pub candidate: TestMeasurement,
+    pub baseline: Option<BaselineEvidence>,
+}
+
+/// The classification vocabulary, mirroring `apply-differential-gate.py`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DifferentialVerdict {
+    /// Nothing to attribute: the candidate is green, or it strictly improved on
+    /// a baseline that named no failures the candidate still carries.
+    Pass,
+    /// The candidate introduced failures the baseline does not have.
+    Fail,
+    /// The candidate did not finish while the baseline is healthy. Its counts
+    /// are not comparable, so this keeps blocking.
+    Timeout,
+    /// The failures reproduce unchanged on the base branch. Non-blocking:
+    /// nothing regressed — but nothing improved either, and saying so is the
+    /// whole point.
+    BaselineRed,
+    /// Counts were unavailable on one side, or the candidate failed while
+    /// reporting zero failures. Warns; never accepted as an improvement.
+    Inconclusive,
+    /// Neither side produced comparable counts. Nothing at all is known — this
+    /// is deliberately *not* `baseline_red`, which would overstate it.
+    NoMeasurement,
+    /// Local-only: no cached baseline exists for this revision and scope, and
+    /// none was built. An absent measurement must never render as a pass.
+    NoBaseline,
+}
+
+impl DifferentialVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Timeout => "timeout",
+            Self::BaselineRed => "baseline_red",
+            Self::Inconclusive => "inconclusive",
+            Self::NoMeasurement => "no_measurement",
+            Self::NoBaseline => "no_baseline",
+        }
+    }
+
+    /// Whether this verdict should stop the caller.
+    ///
+    /// `baseline_red`, `inconclusive`, and `no_measurement` are non-blocking
+    /// for the same reason they are in CI: a candidate is not answerable for a
+    /// condition it did not cause. `no_baseline` blocks because it is reached
+    /// only with a red candidate and no evidence of inheritance whatsoever —
+    /// clearing it would be laundering absence into approval.
+    pub fn blocks(self) -> bool {
+        matches!(self, Self::Fail | Self::Timeout | Self::NoBaseline)
+    }
+}
+
+/// Which evidence the verdict actually rests on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonBasis {
+    /// Both sides named every failure they counted; the verdict is a set
+    /// difference.
+    TestNames,
+    /// At least one side did not name its failures; the verdict is a count
+    /// comparison, exactly as in CI.
+    FailureCounts,
+    /// No comparison was possible.
+    Unavailable,
+}
+
+/// The full differential result.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DifferentialReport {
+    pub verdict: DifferentialVerdict,
+    pub basis: ComparisonBasis,
+    pub reference: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_revision: Option<String>,
+    pub candidate: TestMeasurement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<BaselineEvidence>,
+    /// Failures present on the candidate and absent from the baseline.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub new_failures: Vec<String>,
+    /// Failures present on the baseline and absent from the candidate.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fixed_failures: Vec<String>,
+    /// Failures present on both sides.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub inherited_failures: Vec<String>,
+    pub explanation: String,
+}
+
+impl DifferentialReport {
+    pub fn blocks(&self) -> bool {
+        self.verdict.blocks()
+    }
+
+    /// Render the operator-facing verdict block.
+    pub fn render(&self) -> String {
+        render_report(self)
+    }
+}
+
+/// Exit status assigned to a child terminated for exhausting its execution
+/// budget. Duplicated from `crate::test::report` deliberately: this module must
+/// be usable without pulling in the report envelope.
+pub const TIMEOUT_EXIT_CODE: i32 = 124;
+
+/// Classify a candidate run against a cached baseline.
+///
+/// Pure: no filesystem, no git, no clock. Every branch is reachable from
+/// synthetic inputs, which is what makes the rules testable without executing a
+/// single real test.
+pub fn classify(input: DifferentialInput) -> DifferentialReport {
+    let DifferentialInput {
+        reference,
+        revision,
+        candidate,
+        baseline,
+    } = input;
+
+    let candidate = candidate.normalized();
+    let baseline = baseline.map(BaselineEvidence::normalized);
+
+    let (new_failures, fixed_failures, inherited_failures) = match baseline.as_ref() {
+        // Without a baseline, nothing is known about which failures are new.
+        // Reporting the candidate's failures as "new" would assert exactly the
+        // thing that could not be measured.
+        None => (Vec::new(), Vec::new(), Vec::new()),
+        Some(evidence) => diff_names(&candidate, &evidence.measurement),
+    };
+
+    let basis = comparison_basis(&candidate, baseline.as_ref());
+    let (verdict, explanation) = decide(
+        &candidate,
+        baseline.as_ref(),
+        basis,
+        &new_failures,
+        &reference,
+    );
+
+    DifferentialReport {
+        verdict,
+        basis,
+        reference,
+        requested_revision: revision,
+        candidate,
+        baseline,
+        new_failures,
+        fixed_failures,
+        inherited_failures,
+        explanation,
+    }
+}
+
+/// Resolve the base ref to the revision its cached measurement is keyed by.
+///
+/// `None` when git cannot resolve it — an unfetched `origin/main`, a detached
+/// checkout, or no repository at all. The caller must treat that as a cache
+/// miss rather than guessing a revision, because a measurement filed under the
+/// wrong sha is worse than no measurement.
+pub fn resolve_baseline_revision(repository_root: &Path, reference: &str) -> Option<String> {
+    homeboy_core::git::rev_parse(repository_root, reference)
+}
+
+/// Look up the cached baseline for `key` and classify `candidate` against it.
+///
+/// The single call a command needs. A cache miss becomes
+/// [`DifferentialVerdict::NoBaseline`] rather than an error, so an unavailable
+/// measurement can never be mistaken for a clean one.
+pub fn classify_against_cache(
+    cache: &BaselineCache,
+    key: &BaselineCacheKey,
+    candidate: TestMeasurement,
+) -> DifferentialReport {
+    let baseline = cache.load(key);
+    classify(DifferentialInput {
+        reference: key.reference.clone(),
+        revision: Some(key.revision.clone()),
+        candidate,
+        baseline,
+    })
+}
+
+fn comparison_basis(
+    candidate: &TestMeasurement,
+    baseline: Option<&BaselineEvidence>,
+) -> ComparisonBasis {
+    let Some(evidence) = baseline else {
+        return ComparisonBasis::Unavailable;
+    };
+    if candidate.names_account_for_failures() && evidence.measurement.names_account_for_failures() {
+        ComparisonBasis::TestNames
+    } else if candidate.failure_count().is_some() && evidence.measurement.failure_count().is_some()
+    {
+        ComparisonBasis::FailureCounts
+    } else {
+        ComparisonBasis::Unavailable
+    }
+}
+
+/// Set arithmetic over failure names, but only when both sides fully named
+/// their failures. A partial list on either side yields empty sets so the
+/// count rule stays in charge.
+fn diff_names(
+    candidate: &TestMeasurement,
+    baseline: &TestMeasurement,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    if !(candidate.names_account_for_failures() && baseline.names_account_for_failures()) {
+        return (Vec::new(), Vec::new(), Vec::new());
+    }
+
+    let candidate_set: BTreeSet<String> = candidate.failed_tests.iter().cloned().collect();
+    let baseline_set: BTreeSet<String> = baseline.failed_tests.iter().cloned().collect();
+
+    (
+        candidate_set.difference(&baseline_set).cloned().collect(),
+        baseline_set.difference(&candidate_set).cloned().collect(),
+        candidate_set.intersection(&baseline_set).cloned().collect(),
+    )
+}
+
+fn decide(
+    candidate: &TestMeasurement,
+    baseline: Option<&BaselineEvidence>,
+    basis: ComparisonBasis,
+    new_failures: &[String],
+    reference: &str,
+) -> (DifferentialVerdict, String) {
+    // Mirrors `if status not in {"fail", "timeout"}: continue` — a green
+    // candidate never enters the gate.
+    if candidate.is_green() {
+        return (
+            DifferentialVerdict::Pass,
+            "the candidate suite is green, so there is nothing to attribute".to_string(),
+        );
+    }
+
+    let timed_out = candidate.outcome == RunOutcome::TimedOut;
+
+    let Some(evidence) = baseline else {
+        return (
+            DifferentialVerdict::NoBaseline,
+            format!(
+                "no cached baseline measurement for {reference} at this scope, so nothing was \
+                 compared; this is not evidence that the failure is pre-existing"
+            ),
+        );
+    };
+
+    let current = candidate.failure_count();
+    let base = evidence.measurement.failure_count();
+    let base_failed = !evidence.measurement.is_green() || evidence.measurement.exit_code != 0;
+    let base_structured = evidence.measurement.structured_output;
+
+    if base_failed && (base.is_none() || !base_structured) {
+        // `baseline_red` asserts this failure is pre-existing, and that claim
+        // needs an observation on the candidate side to rest on. A double
+        // timeout has none.
+        if timed_out || current.is_none() {
+            return (
+                DifferentialVerdict::NoMeasurement,
+                format!(
+                    "neither the candidate nor the baseline produced comparable counts (baseline \
+                     at {} exited {}); nothing is known about this run",
+                    evidence.short_revision(),
+                    evidence.measurement.exit_code
+                ),
+            );
+        }
+        return (
+            DifferentialVerdict::BaselineRed,
+            format!(
+                "the baseline at {} exited {} before comparable counts were available",
+                evidence.short_revision(),
+                evidence.measurement.exit_code
+            ),
+        );
+    }
+
+    // Past this point the baseline is healthy, so an incomplete candidate run
+    // is the candidate's problem and must keep blocking. This guard precedes
+    // every count-based branch: a killed suite typically reports *fewer*
+    // failures than the baseline, so `current <= base` would read as an
+    // improvement and silently pass.
+    if timed_out {
+        return (
+            DifferentialVerdict::Timeout,
+            "the candidate run did not finish, so its counts are not comparable to the baseline; \
+             raise the execution budget or reduce suite duration rather than reading this as a \
+             test failure"
+                .to_string(),
+        );
+    }
+
+    let (Some(current), Some(base)) = (current, base) else {
+        return (
+            DifferentialVerdict::Inconclusive,
+            format!(
+                "counts were unavailable on one side (candidate={}, baseline={})",
+                describe_count(current),
+                describe_count(base)
+            ),
+        );
+    };
+
+    match basis {
+        ComparisonBasis::TestNames => {
+            if !new_failures.is_empty() {
+                return (
+                    DifferentialVerdict::Fail,
+                    format!(
+                        "{} failure(s) are present here and absent on {reference}: {}",
+                        new_failures.len(),
+                        new_failures.join(", ")
+                    ),
+                );
+            }
+            if current > 0 {
+                return (
+                    DifferentialVerdict::BaselineRed,
+                    format!(
+                        "the {current} failure(s) reproduce unchanged on {reference}; nothing \
+                         regressed, but this scope is red on the base branch"
+                    ),
+                );
+            }
+        }
+        _ => {
+            if current > base {
+                return (
+                    DifferentialVerdict::Fail,
+                    format!(
+                        "failures increased against {reference} (current={current} base={base})"
+                    ),
+                );
+            }
+            // Equal counts with something still red is not an improvement, and
+            // `pass` is an actively false statement about it.
+            if current == base && base > 0 {
+                return (
+                    DifferentialVerdict::BaselineRed,
+                    format!(
+                        "{current} failure(s) reproduce unchanged on {reference} (current={current} \
+                         base={base}); nothing regressed, but nothing improved either"
+                    ),
+                );
+            }
+        }
+    }
+
+    // Zero failures on a run that nonetheless failed is not a clean result; it
+    // is an uncounted failure. `Scoped` is exempt because there zero *is* the
+    // measurement.
+    if current == 0 && candidate.metric_kind != MetricKind::Scoped {
+        return (
+            DifferentialVerdict::Inconclusive,
+            format!(
+                "the candidate failed but reported 0 failures (baseline={base}), so its own \
+                 failure is uncounted; an incomplete, killed, or non-reporting run is never \
+                 accepted as an improvement"
+            ),
+        );
+    }
+
+    (
+        DifferentialVerdict::Pass,
+        format!(
+            "the candidate carries fewer failures than {reference} (current={current} base={base})"
+        ),
+    )
+}
+
+fn describe_count(value: Option<u64>) -> String {
+    value.map_or_else(|| "unavailable".to_string(), |value| value.to_string())
+}
+
+/// Project a completed test command envelope into a comparable measurement.
+///
+/// This is the seam the CLI calls: everything above it is pure, and everything
+/// below it is the existing test-run plumbing.
+pub fn measurement_from_test_output(output: &TestCommandOutput) -> TestMeasurement {
+    let outcome = if output.exit_code == 0 {
+        RunOutcome::Passed
+    } else if output.exit_code == TIMEOUT_EXIT_CODE {
+        RunOutcome::TimedOut
+    } else {
+        RunOutcome::Failed
+    };
+
+    let failed_tests = output
+        .summary
+        .as_ref()
+        .map(|summary| {
+            summary
+                .failures
+                .iter()
+                .map(|failure| failure.test_name.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    // A changed-scope run measures what the change introduced, so its zero is a
+    // measurement rather than the absence of one.
+    let metric_kind = match output.test_scope.as_ref() {
+        Some(scope) if scope.changed_since.is_some() => MetricKind::Scoped,
+        _ => MetricKind::Total,
+    };
+
+    TestMeasurement {
+        outcome,
+        exit_code: output.exit_code,
+        counts: output.test_counts.clone(),
+        failed_tests,
+        metric_kind,
+        structured_output: output.test_counts.is_some() || output.summary.is_some(),
+    }
+    .normalized()
+}

--- a/crates/homeboy-extension/src/test/differential/render.rs
+++ b/crates/homeboy-extension/src/test/differential/render.rs
@@ -1,0 +1,139 @@
+//! Operator-facing rendering of a differential verdict.
+//!
+//! The block is deliberately four short lines, because it is read *while
+//! waiting on something else*:
+//!
+//! ```text
+//! candidate: 202 passed, 3 failed
+//! baseline:  197 passed, 3 failed   (cached, origin/main @ 1a2b3c4de)
+//! verdict:   baseline_red — the 3 failures reproduce unchanged on origin/main
+//!            new failures: 0
+//! ```
+//!
+//! Two things are load-bearing about that shape:
+//!
+//! * The baseline line always says whether it came from cache and which
+//!   revision it describes. A comparison against an unnamed baseline is not
+//!   checkable, and an unnamed *stale* baseline is worse than none.
+//! * `new failures` is always printed, including when it is zero. Zero new
+//!   failures is the answer the reader came for; leaving it implicit means
+//!   inferring it from two counts, which is exactly the manual arithmetic this
+//!   whole feature exists to remove.
+
+use super::{
+    ComparisonBasis, DifferentialReport, DifferentialVerdict, RunOutcome, TestMeasurement,
+};
+
+/// Label column, padded to a common width so the two count lines align.
+const CANDIDATE_LABEL: &str = "candidate: ";
+const BASELINE_LABEL: &str = "baseline:  ";
+const VERDICT_LABEL: &str = "verdict:   ";
+/// Continuation indent, the same width as the labels above.
+const CONTINUATION_INDENT: &str = "           ";
+
+/// Longest failure-name list printed before it is truncated with a count.
+const MAX_LISTED_FAILURES: usize = 10;
+
+pub fn render_report(report: &DifferentialReport) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "{CANDIDATE_LABEL}{}",
+        describe_measurement(&report.candidate)
+    ));
+    lines.push(format!("{BASELINE_LABEL}{}", describe_baseline(report)));
+    lines.push(format!(
+        "{VERDICT_LABEL}{} — {}",
+        report.verdict.as_str(),
+        report.explanation
+    ));
+    lines.push(format!(
+        "{CONTINUATION_INDENT}new failures: {}",
+        report.new_failures.len()
+    ));
+
+    for line in name_lines(&report.new_failures) {
+        lines.push(format!("{CONTINUATION_INDENT}  {line}"));
+    }
+    if !report.fixed_failures.is_empty() {
+        lines.push(format!(
+            "{CONTINUATION_INDENT}fixed on this branch: {}",
+            report.fixed_failures.len()
+        ));
+    }
+    if report.basis == ComparisonBasis::FailureCounts {
+        lines.push(format!(
+            "{CONTINUATION_INDENT}compared by count only — at least one side did not name its \
+             failures"
+        ));
+    }
+    if report.verdict == DifferentialVerdict::NoBaseline {
+        lines.push(format!(
+            "{CONTINUATION_INDENT}record a baseline from a checkout of {} to make this \
+             comparison cheap for every branch cut from that revision",
+            report.reference
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn describe_measurement(measurement: &TestMeasurement) -> String {
+    match (&measurement.counts, measurement.outcome) {
+        (Some(counts), _) => format!("{} passed, {} failed", counts.passed, counts.failed),
+        (None, RunOutcome::TimedOut) => {
+            format!("no counts (timed out, exit {})", measurement.exit_code)
+        }
+        (None, _) if measurement.structured_output => format!(
+            "{} failed (no totals reported)",
+            measurement.failed_tests.len()
+        ),
+        (None, _) => format!("no structured counts (exit {})", measurement.exit_code),
+    }
+}
+
+fn describe_baseline(report: &DifferentialReport) -> String {
+    match report.baseline.as_ref() {
+        Some(evidence) => format!(
+            "{}   (cached, {} @ {}, recorded {})",
+            describe_measurement(&evidence.measurement),
+            report.reference,
+            short_revision(&evidence.revision),
+            evidence.recorded_at
+        ),
+        None => format!(
+            "none cached for {}{}",
+            report.reference,
+            requested_suffix(report)
+        ),
+    }
+}
+
+fn requested_suffix(report: &DifferentialReport) -> String {
+    match report.requested_revision.as_deref() {
+        Some(revision) => format!(" @ {}", short_revision(revision)),
+        None => String::new(),
+    }
+}
+
+fn name_lines(names: &[String]) -> Vec<String> {
+    let mut lines: Vec<String> = names
+        .iter()
+        .take(MAX_LISTED_FAILURES)
+        .map(|name| format!("- {name}"))
+        .collect();
+    if names.len() > MAX_LISTED_FAILURES {
+        lines.push(format!(
+            "- ... and {} more",
+            names.len() - MAX_LISTED_FAILURES
+        ));
+    }
+    lines
+}
+
+/// First nine characters of a revision, matching the short form the rest of
+/// Homeboy's human-facing output uses. Sliced by character so a non-hex
+/// identifier cannot panic on a byte boundary.
+fn short_revision(revision: &str) -> String {
+    revision.chars().take(9).collect()
+}

--- a/crates/homeboy-extension/src/test/differential/tests.rs
+++ b/crates/homeboy-extension/src/test/differential/tests.rs
@@ -1,0 +1,750 @@
+//! Verdict rules exercised over synthetic candidate/baseline pairs.
+//!
+//! The classifier is pure, so every rule — including the ones that only appear
+//! when a suite is killed mid-run or when a runner writes no sidecar at all — is
+//! reachable without executing a single real test. That is deliberate: this
+//! module orchestrates test runs, and a design that could only be verified by
+//! running them would be untestable on exactly the constrained hosts it exists
+//! to serve.
+
+use super::*;
+
+fn counts(total: u64, passed: u64, failed: u64) -> TestCounts {
+    TestCounts::new(total, passed, failed, 0)
+}
+
+fn names(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+fn evidence(measurement: TestMeasurement) -> BaselineEvidence {
+    BaselineEvidence {
+        reference: "origin/main".to_string(),
+        revision: "1a2b3c4de5f60718293a4b5c6d7e8f9012345678".to_string(),
+        recorded_at: "2026-08-06T12:00:00Z".to_string(),
+        measurement,
+    }
+}
+
+fn input(candidate: TestMeasurement, baseline: Option<BaselineEvidence>) -> DifferentialInput {
+    DifferentialInput {
+        reference: "origin/main".to_string(),
+        revision: Some("1a2b3c4de5f60718293a4b5c6d7e8f9012345678".to_string()),
+        candidate,
+        baseline,
+    }
+}
+
+fn verdict(candidate: TestMeasurement, baseline: Option<BaselineEvidence>) -> DifferentialVerdict {
+    classify(input(candidate, baseline)).verdict
+}
+
+// ---------------------------------------------------------------------------
+// pass
+// ---------------------------------------------------------------------------
+
+/// A green candidate never enters the gate, mirroring the CI script's
+/// `if status not in {"fail", "timeout"}: continue`.
+#[test]
+fn a_green_candidate_passes_without_consulting_the_baseline() {
+    let report = classify(input(TestMeasurement::passed(counts(202, 202, 0)), None));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Pass);
+    assert!(!report.blocks());
+    assert!(report.new_failures.is_empty());
+}
+
+/// Strictly fewer failures than a baseline that named none of them is the one
+/// count-only improvement the CI script accepts as `pass`.
+#[test]
+fn fewer_failures_than_an_unnamed_baseline_passes() {
+    let candidate = TestMeasurement::failed(counts(200, 198, 2), Vec::new());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 195, 5), Vec::new()));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Pass);
+    assert_eq!(report.basis, ComparisonBasis::FailureCounts);
+    assert!(!report.blocks());
+}
+
+/// Zero findings on a *changed-scope* run is the measurement, not the absence
+/// of one, so the zero guard must not fire. This is the entire point of
+/// changed-scope gating.
+#[test]
+fn a_scoped_run_reporting_zero_introduced_failures_passes() {
+    let candidate =
+        TestMeasurement::failed(counts(0, 0, 0), Vec::new()).with_metric_kind(MetricKind::Scoped);
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), Vec::new()));
+
+    assert_eq!(
+        verdict(candidate, Some(baseline)),
+        DifferentialVerdict::Pass
+    );
+}
+
+// ---------------------------------------------------------------------------
+// baseline_red
+// ---------------------------------------------------------------------------
+
+/// The headline case from #11753: identical counts, identical names, branch
+/// clean. This must not render as `pass` — a scope that is red on the base
+/// branch stays red forever if no run ever says so.
+#[test]
+fn identical_named_failures_are_baseline_red_not_pass() {
+    let failures = names(&["a::one", "b::two", "c::three"]);
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), failures.clone());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), failures));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert_eq!(report.basis, ComparisonBasis::TestNames);
+    assert!(!report.blocks());
+    assert!(report.new_failures.is_empty());
+    assert_eq!(report.inherited_failures.len(), 3);
+}
+
+/// `current == base && base > 0` is `baseline_red` even without names. Equal
+/// counts with something still red is not an improvement.
+#[test]
+fn equal_unnamed_failure_counts_are_baseline_red() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), Vec::new());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), Vec::new()));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert_eq!(report.basis, ComparisonBasis::FailureCounts);
+}
+
+/// Names strictly refine counts: fixing one inherited failure while the rest
+/// still reproduce is honestly `baseline_red`, not a clean `pass` that hides a
+/// still-red scope. It stays non-blocking, so nothing that was mergeable
+/// becomes blocked.
+#[test]
+fn fixing_some_inherited_failures_is_still_baseline_red() {
+    let candidate = TestMeasurement::failed(counts(205, 203, 2), names(&["a::one", "b::two"]));
+    let baseline = evidence(TestMeasurement::failed(
+        counts(200, 197, 3),
+        names(&["a::one", "b::two", "c::three"]),
+    ));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert!(!report.blocks());
+    assert_eq!(report.fixed_failures, names(&["c::three"]));
+    assert!(report.new_failures.is_empty());
+}
+
+/// A baseline that failed before producing counts still licenses `baseline_red`
+/// — but only because the candidate *did* produce an observation for the claim
+/// to rest on.
+#[test]
+fn an_unmeasured_baseline_with_a_measured_candidate_is_baseline_red() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), names(&["a::one"]));
+    let baseline = evidence(TestMeasurement::unmeasured(RunOutcome::Failed, 101));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert!(!report.blocks());
+}
+
+// ---------------------------------------------------------------------------
+// fail
+// ---------------------------------------------------------------------------
+
+/// Three failed before and three failed after can still be three *different*
+/// tests. Every count-only rule calls this `baseline_red`; comparing by name is
+/// the only thing that catches it.
+#[test]
+fn equal_counts_with_a_swapped_failure_set_is_a_regression() {
+    let candidate = TestMeasurement::failed(
+        counts(205, 202, 3),
+        names(&["a::one", "b::two", "z::brand_new"]),
+    );
+    let baseline = evidence(TestMeasurement::failed(
+        counts(200, 197, 3),
+        names(&["a::one", "b::two", "c::three"]),
+    ));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Fail);
+    assert!(report.blocks());
+    assert_eq!(report.new_failures, names(&["z::brand_new"]));
+    assert_eq!(report.fixed_failures, names(&["c::three"]));
+}
+
+#[test]
+fn more_failures_than_an_unnamed_baseline_is_a_regression() {
+    let candidate = TestMeasurement::failed(counts(205, 200, 5), Vec::new());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), Vec::new()));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Fail);
+    assert!(report.blocks());
+}
+
+#[test]
+fn a_new_failure_against_a_green_baseline_is_a_regression() {
+    let candidate = TestMeasurement::failed(counts(205, 204, 1), names(&["z::brand_new"]));
+    let baseline = evidence(TestMeasurement::passed(counts(200, 200, 0)));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Fail);
+    assert_eq!(report.new_failures, names(&["z::brand_new"]));
+}
+
+// ---------------------------------------------------------------------------
+// timeout
+// ---------------------------------------------------------------------------
+
+/// A timeout against a healthy baseline keeps blocking. A killed suite usually
+/// reports *fewer* failures than the baseline, so a naive `current <= base`
+/// would read "the suite never finished" as a clean sweep.
+#[test]
+fn a_timeout_against_a_healthy_baseline_keeps_blocking() {
+    let baseline = evidence(TestMeasurement::passed(counts(200, 200, 0)));
+
+    let report = classify(input(TestMeasurement::timed_out(), Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Timeout);
+    assert!(report.blocks());
+}
+
+/// Partial counts from a killed run are not comparable either, even though they
+/// look like an improvement.
+#[test]
+fn a_timeout_with_partial_counts_still_blocks() {
+    let candidate = TestMeasurement {
+        outcome: RunOutcome::TimedOut,
+        exit_code: TIMEOUT_EXIT_CODE,
+        ..TestMeasurement::failed(counts(40, 40, 0), Vec::new())
+    };
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), Vec::new()));
+
+    assert_eq!(
+        verdict(candidate, Some(baseline)),
+        DifferentialVerdict::Timeout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// inconclusive
+// ---------------------------------------------------------------------------
+
+/// A run that failed while reporting zero failures has an uncounted failure.
+/// Compile errors and harness crashes land here.
+#[test]
+fn a_failure_reporting_zero_failures_is_inconclusive() {
+    let candidate = TestMeasurement::failed(counts(0, 0, 0), Vec::new());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), Vec::new()));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Inconclusive);
+    assert!(!report.blocks());
+}
+
+/// A healthy baseline plus an unmeasurable candidate leaves nothing comparable
+/// on one side.
+#[test]
+fn an_unmeasured_candidate_against_a_healthy_baseline_is_inconclusive() {
+    let candidate = TestMeasurement::unmeasured(RunOutcome::Failed, 101);
+    let baseline = evidence(TestMeasurement::passed(counts(200, 200, 0)));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::Inconclusive);
+    assert!(!report.blocks());
+}
+
+// ---------------------------------------------------------------------------
+// no_measurement
+// ---------------------------------------------------------------------------
+
+/// Both sides ran out of clock. Nothing at all is known, and reporting that as
+/// `baseline_red` would overstate it — `baseline_red` claims the failure is
+/// pre-existing, and that claim needs a candidate-side observation.
+#[test]
+fn a_double_timeout_is_no_measurement_not_baseline_red() {
+    let baseline = evidence(TestMeasurement::timed_out());
+
+    let report = classify(input(TestMeasurement::timed_out(), Some(baseline)));
+
+    assert_eq!(report.verdict, DifferentialVerdict::NoMeasurement);
+    assert!(!report.blocks());
+}
+
+#[test]
+fn two_unmeasured_sides_are_no_measurement() {
+    let candidate = TestMeasurement::unmeasured(RunOutcome::Failed, 101);
+    let baseline = evidence(TestMeasurement::unmeasured(RunOutcome::Failed, 101));
+
+    assert_eq!(
+        verdict(candidate, Some(baseline)),
+        DifferentialVerdict::NoMeasurement
+    );
+}
+
+// ---------------------------------------------------------------------------
+// no_baseline
+// ---------------------------------------------------------------------------
+
+/// The honest local degradation. An absent measurement must never render as a
+/// pass, so this blocks and says exactly what was missing.
+#[test]
+fn a_red_candidate_without_a_cached_baseline_is_no_baseline_and_blocks() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), names(&["a::one"]));
+
+    let report = classify(input(candidate, None));
+
+    assert_eq!(report.verdict, DifferentialVerdict::NoBaseline);
+    assert!(report.blocks());
+    assert_eq!(report.basis, ComparisonBasis::Unavailable);
+}
+
+/// Without a baseline nothing is known about which failures are new, so the
+/// candidate's failures must not be reported as new ones.
+#[test]
+fn no_baseline_does_not_invent_new_failures() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), names(&["a::one", "b::two"]));
+
+    let report = classify(input(candidate, None));
+
+    assert!(report.new_failures.is_empty());
+    assert!(report.inherited_failures.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// comparison basis
+// ---------------------------------------------------------------------------
+
+/// A partial name list must not drive a set difference: the unnamed failures
+/// would look like they disappeared, inventing a fix that did not happen.
+#[test]
+fn a_partial_name_list_degrades_to_count_comparison() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), names(&["a::one"]));
+    let baseline = evidence(TestMeasurement::failed(
+        counts(200, 197, 3),
+        names(&["a::one", "b::two", "c::three"]),
+    ));
+
+    let report = classify(input(candidate, Some(baseline)));
+
+    assert_eq!(report.basis, ComparisonBasis::FailureCounts);
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert!(report.new_failures.is_empty());
+}
+
+#[test]
+fn failure_names_are_sorted_and_deduplicated() {
+    let candidate =
+        TestMeasurement::failed(counts(205, 203, 2), names(&["b::two", "a::one", "b::two"]));
+
+    let report = classify(input(candidate, None));
+
+    assert_eq!(report.candidate.failed_tests, names(&["a::one", "b::two"]));
+}
+
+// ---------------------------------------------------------------------------
+// blocking policy
+// ---------------------------------------------------------------------------
+
+/// Non-blocking verdicts are exactly the ones where the candidate is not
+/// answerable for the condition. Pinned so a later edit cannot quietly make an
+/// absent measurement clear a branch.
+#[test]
+fn only_regression_timeout_and_missing_baseline_block() {
+    for verdict in [
+        DifferentialVerdict::Pass,
+        DifferentialVerdict::BaselineRed,
+        DifferentialVerdict::Inconclusive,
+        DifferentialVerdict::NoMeasurement,
+    ] {
+        assert!(!verdict.blocks(), "{} must not block", verdict.as_str());
+    }
+    for verdict in [
+        DifferentialVerdict::Fail,
+        DifferentialVerdict::Timeout,
+        DifferentialVerdict::NoBaseline,
+    ] {
+        assert!(verdict.blocks(), "{} must block", verdict.as_str());
+    }
+}
+
+/// The wire spellings are the CI gate's, not a second vocabulary.
+#[test]
+fn verdict_spellings_match_the_ci_gate() {
+    assert_eq!(DifferentialVerdict::BaselineRed.as_str(), "baseline_red");
+    assert_eq!(DifferentialVerdict::Inconclusive.as_str(), "inconclusive");
+    assert_eq!(
+        DifferentialVerdict::NoMeasurement.as_str(),
+        "no_measurement"
+    );
+    assert_eq!(DifferentialVerdict::Pass.as_str(), "pass");
+    assert_eq!(DifferentialVerdict::Fail.as_str(), "fail");
+    assert_eq!(DifferentialVerdict::Timeout.as_str(), "timeout");
+    assert_eq!(DifferentialVerdict::NoBaseline.as_str(), "no_baseline");
+}
+
+/// The serialized spelling and the rendered spelling must be the same string.
+/// Two spellings for one verdict is exactly the "second vocabulary" this module
+/// exists to avoid, and it is the kind of drift nothing else would catch.
+#[test]
+fn serialized_and_rendered_verdict_spellings_agree() {
+    for verdict in [
+        DifferentialVerdict::Pass,
+        DifferentialVerdict::Fail,
+        DifferentialVerdict::Timeout,
+        DifferentialVerdict::BaselineRed,
+        DifferentialVerdict::Inconclusive,
+        DifferentialVerdict::NoMeasurement,
+        DifferentialVerdict::NoBaseline,
+    ] {
+        let serialized = serde_json::to_string(&verdict).expect("serialize verdict");
+        assert_eq!(serialized, format!("\"{}\"", verdict.as_str()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rendering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_rendered_block_names_both_sides_and_the_new_failure_count() {
+    let failures = names(&["a::one", "b::two", "c::three"]);
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), failures.clone());
+    let baseline = evidence(TestMeasurement::failed(counts(200, 197, 3), failures));
+
+    let rendered = classify(input(candidate, Some(baseline))).render();
+
+    assert!(
+        rendered.contains("candidate: 202 passed, 3 failed"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("baseline:  197 passed, 3 failed"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("(cached, origin/main @ 1a2b3c4de"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("verdict:   baseline_red"), "{rendered}");
+    assert!(rendered.contains("new failures: 0"), "{rendered}");
+}
+
+/// A missing baseline must be visible as missing, never blank.
+#[test]
+fn the_rendered_block_says_when_no_baseline_is_cached() {
+    let candidate = TestMeasurement::failed(counts(205, 202, 3), names(&["a::one"]));
+
+    let rendered = classify(input(candidate, None)).render();
+
+    assert!(
+        rendered.contains("none cached for origin/main"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("verdict:   no_baseline"), "{rendered}");
+}
+
+#[test]
+fn the_rendered_block_lists_new_failures() {
+    let candidate = TestMeasurement::failed(counts(205, 204, 1), names(&["z::brand_new"]));
+    let baseline = evidence(TestMeasurement::passed(counts(200, 200, 0)));
+
+    let rendered = classify(input(candidate, Some(baseline))).render();
+
+    assert!(rendered.contains("new failures: 1"), "{rendered}");
+    assert!(rendered.contains("- z::brand_new"), "{rendered}");
+}
+
+// ---------------------------------------------------------------------------
+// cache
+// ---------------------------------------------------------------------------
+
+fn key(revision: &str, scope: &str) -> BaselineCacheKey {
+    BaselineCacheKey::new("homeboy", "origin/main", revision, scope)
+}
+
+#[test]
+fn a_stored_measurement_round_trips() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let stored = TestMeasurement::failed(counts(200, 197, 3), names(&["b::two", "a::one"]));
+
+    cache
+        .store(
+            &key("abc123", "-p homeboy-core --lib"),
+            &stored,
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+    let loaded = cache
+        .load(&key("abc123", "-p homeboy-core --lib"))
+        .expect("cached baseline");
+
+    assert_eq!(loaded.revision, "abc123");
+    assert_eq!(loaded.reference, "origin/main");
+    assert_eq!(
+        loaded.measurement.failed_tests,
+        names(&["a::one", "b::two"])
+    );
+}
+
+/// The whole value of the cache: a branch cut from the same base sha reuses the
+/// measurement, so the expensive half is paid once per base-branch movement.
+#[test]
+fn a_second_branch_at_the_same_revision_hits_the_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let measurement = TestMeasurement::failed(counts(200, 197, 3), Vec::new());
+
+    cache
+        .store(
+            &key("abc123", WHOLE_SUITE_SCOPE),
+            &measurement,
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    assert!(cache.load(&key("abc123", WHOLE_SUITE_SCOPE)).is_some());
+}
+
+/// A base branch that moved must be a miss, not a stale answer.
+#[test]
+fn a_moved_base_revision_is_a_cache_miss() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let measurement = TestMeasurement::failed(counts(200, 197, 3), Vec::new());
+
+    cache
+        .store(
+            &key("abc123", WHOLE_SUITE_SCOPE),
+            &measurement,
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    assert!(cache.load(&key("def456", WHOLE_SUITE_SCOPE)).is_none());
+}
+
+/// A scoped measurement cannot answer for a whole-suite run, or vice versa.
+#[test]
+fn a_different_scope_is_a_cache_miss() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let measurement = TestMeasurement::failed(counts(200, 197, 3), Vec::new());
+
+    cache
+        .store(
+            &key("abc123", "-p homeboy-core --lib"),
+            &measurement,
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    assert!(cache.load(&key("abc123", "-p homeboy-cli --lib")).is_none());
+    assert!(cache.load(&key("abc123", WHOLE_SUITE_SCOPE)).is_none());
+}
+
+/// A record whose contents disagree with the path it was found at has been
+/// corrupted or hand-edited. Trusting the path over the contents would turn
+/// that into a silent wrong answer.
+#[test]
+fn a_record_whose_identity_disagrees_with_its_path_is_a_miss() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let requested = key("abc123", WHOLE_SUITE_SCOPE);
+
+    cache
+        .store(
+            &requested,
+            &TestMeasurement::failed(counts(200, 197, 3), Vec::new()),
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    let path = cache.path_for(&requested);
+    let body = std::fs::read_to_string(&path).expect("read record");
+    std::fs::write(&path, body.replace("\"abc123\"", "\"tampered\"")).expect("rewrite record");
+
+    assert!(cache.load(&requested).is_none());
+}
+
+#[test]
+fn an_unknown_schema_is_a_miss() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let requested = key("abc123", WHOLE_SUITE_SCOPE);
+
+    cache
+        .store(
+            &requested,
+            &TestMeasurement::failed(counts(200, 197, 3), Vec::new()),
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    let path = cache.path_for(&requested);
+    let body = std::fs::read_to_string(&path).expect("read record");
+    std::fs::write(
+        &path,
+        body.replace(
+            &format!("\"schema\": {BASELINE_CACHE_SCHEMA}"),
+            "\"schema\": 999",
+        ),
+    )
+    .expect("rewrite record");
+
+    assert!(cache.load(&requested).is_none());
+}
+
+#[test]
+fn unreadable_and_absent_records_are_misses_not_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let requested = key("abc123", WHOLE_SUITE_SCOPE);
+
+    assert!(cache.load(&requested).is_none());
+
+    let path = cache.path_for(&requested);
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("create dirs");
+    std::fs::write(&path, "{ not json").expect("write junk");
+
+    assert!(cache.load(&requested).is_none());
+}
+
+/// A cache miss must reach the verdict layer as `no_baseline`, which blocks.
+/// A corrupted cache degrades to "prove it yourself", never to a clean verdict.
+#[test]
+fn a_cache_miss_produces_a_blocking_no_baseline_verdict() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+
+    let report = classify_against_cache(
+        &cache,
+        &key("abc123", WHOLE_SUITE_SCOPE),
+        TestMeasurement::failed(counts(205, 202, 3), names(&["a::one"])),
+    );
+
+    assert_eq!(report.verdict, DifferentialVerdict::NoBaseline);
+    assert!(report.blocks());
+}
+
+/// The end-to-end shape a command uses: record once at a base revision, then
+/// every branch cut from that revision reads the verdict without paying for a
+/// second measurement.
+#[test]
+fn a_recorded_baseline_answers_a_later_branch_from_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let requested = key("abc123", "-p homeboy-core --lib");
+    let failures = names(&["a::one", "b::two", "c::three"]);
+
+    cache
+        .store(
+            &requested,
+            &TestMeasurement::failed(counts(200, 197, 3), failures.clone()),
+            "2026-08-06T12:00:00Z",
+        )
+        .expect("store baseline");
+
+    let report = classify_against_cache(
+        &cache,
+        &requested,
+        TestMeasurement::failed(counts(205, 202, 3), failures),
+    );
+
+    assert_eq!(report.verdict, DifferentialVerdict::BaselineRed);
+    assert!(!report.blocks());
+    assert!(report.new_failures.is_empty());
+    assert!(report.render().contains("new failures: 0"));
+}
+
+/// The base branch moves constantly, so without pruning the cache grows one
+/// directory per observed sha forever.
+#[test]
+fn pruning_keeps_only_the_current_revision() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+    let measurement = TestMeasurement::failed(counts(200, 197, 3), Vec::new());
+
+    for revision in ["abc123", "def456", "aaa999"] {
+        cache
+            .store(
+                &key(revision, WHOLE_SUITE_SCOPE),
+                &measurement,
+                "2026-08-06T12:00:00Z",
+            )
+            .expect("store baseline");
+    }
+
+    let removed = cache
+        .prune_superseded(&key("aaa999", WHOLE_SUITE_SCOPE))
+        .expect("prune");
+
+    assert_eq!(removed, 2);
+    assert!(cache.load(&key("aaa999", WHOLE_SUITE_SCOPE)).is_some());
+    assert!(cache.load(&key("abc123", WHOLE_SUITE_SCOPE)).is_none());
+}
+
+#[test]
+fn pruning_an_empty_cache_is_not_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = BaselineCache::at(dir.path());
+
+    assert_eq!(
+        cache
+            .prune_superseded(&key("abc123", WHOLE_SUITE_SCOPE))
+            .expect("prune"),
+        0
+    );
+}
+
+/// Different scopes must land in different files even after sanitization has
+/// collapsed their punctuation to underscores.
+#[test]
+fn distinct_scopes_get_distinct_file_names() {
+    let one = key("abc123", "-p homeboy-core --lib");
+    let two = key("abc123", "-p homeboy-cli --lib");
+
+    assert_ne!(one.scope_fingerprint(), two.scope_fingerprint());
+    assert_ne!(one.relative_path(), two.relative_path());
+}
+
+#[test]
+fn scope_keys_drop_empty_arguments_and_default_to_the_whole_suite() {
+    let no_args: Vec<String> = Vec::new();
+    assert_eq!(scope_key(&no_args), WHOLE_SUITE_SCOPE);
+    assert_eq!(
+        scope_key(&["  ".to_string(), String::new()]),
+        WHOLE_SUITE_SCOPE
+    );
+    assert_eq!(
+        scope_key(&[
+            " -p ".to_string(),
+            "homeboy-core".to_string(),
+            "--lib".to_string()
+        ]),
+        "-p homeboy-core --lib"
+    );
+}
+
+/// Cache file names must be usable on any filesystem: the scope is arbitrary
+/// runner-argument text.
+#[test]
+fn cache_paths_are_filesystem_safe() {
+    let path = key("abc/../123", "-p a/b --lib=*").relative_path();
+    let rendered = path.to_string_lossy();
+
+    assert!(!rendered.contains(".."), "{rendered}");
+    assert!(!rendered.contains('*'), "{rendered}");
+    assert_eq!(path.components().count(), 3, "{rendered}");
+}

--- a/crates/homeboy-extension/src/test/mod.rs
+++ b/crates/homeboy-extension/src/test/mod.rs
@@ -2,6 +2,7 @@ pub use homeboy_extension_contract::test_result::TestScopeOutput;
 
 pub mod analyze;
 pub mod baseline;
+pub mod differential;
 pub mod drift;
 pub mod durations;
 pub mod parsing;
@@ -24,6 +25,12 @@ pub use analyze::{FailureCategory, FailureCluster, TestAnalysis, TestAnalysisInp
 pub use baseline::{
     compare as compare_baseline, load_baseline, load_baseline_from_ref, save_baseline,
     TestBaseline, TestBaselineComparison, TestCounts,
+};
+pub use differential::{
+    classify as classify_differential, classify_against_cache, measurement_from_test_output,
+    render_report, resolve_baseline_revision, BaselineCache, BaselineCacheKey, BaselineEvidence,
+    ComparisonBasis, DifferentialInput, DifferentialReport, DifferentialVerdict, MetricKind,
+    RunOutcome, TestMeasurement,
 };
 pub use drift::{ChangeType, DriftReport, DriftedTest, ProductionChange};
 pub use durations::{


### PR DESCRIPTION
Closes the local half of #11753 — the classification, cache, and reporting. The CLI flag surface is deliberately left unwired; see **What is not wired** below.

## The problem

There is no local way to ask *"is this test red because of my change, or already red on `main`?"* Answering it costs a second checkout of `main` and a second test build — several minutes and several GB of `target/` — and on 2026-08-06 three of the four times that was paid, the answer was "your branch is fine". `main` carries 5 known-red `--lib` tests (#11667) and merges ~65 PRs/day, so a fresh failure is as likely to be inherited as authored.

## What this adds

`homeboy_extension::test::differential` — four pieces:

| piece | file |
|---|---|
| measurement types + classifier | `differential/mod.rs` |
| sha-keyed baseline cache | `differential/cache.rs` |
| rendered verdict block | `differential/render.rs` |
| synthetic verdict tests | `differential/tests.rs` |

```text
candidate: 202 passed, 3 failed
baseline:  197 passed, 3 failed   (cached, origin/main @ 1a2b3c4de, recorded 2026-08-06T12:00:00Z)
verdict:   baseline_red — the 3 failures reproduce unchanged on origin/main
           new failures: 0
```

### The cache is the feature

Baseline measurements are keyed by **base revision sha + component + exact invocation scope**, so the expensive half is paid once per base-branch movement rather than once per branch. Every branch cut from the same `main` sha reuses one measurement.

- A base branch that moved is a **miss**, never a stale answer.
- A scoped measurement (`-p homeboy-core --lib`) can never answer for a whole-suite run — scope is part of the key and compared verbatim. A different argument order is a miss; a miss is cheap, a wrong hit is a false verdict.
- Absent file, unreadable JSON, unknown schema, or a record whose identity disagrees with its path all degrade to a **miss**, which the verdict layer turns into `no_baseline` — which blocks. A corrupted cache degrades to "prove it yourself", never to a clean verdict.
- `prune_superseded` drops every revision but the current one, so the cache does not grow one directory per observed sha forever.

### Vocabulary is reused, not reinvented

Mirrors `homeboy-action`'s `scripts/core/apply-differential-gate.py` exactly, including the cases it already worked out:

- `current == base && base > 0` is **`baseline_red`, not `pass`** — equal counts with something still red is not an improvement, and `pass` renders green with no annotation anywhere, so a base-branch failure stays invisible forever.
- A **timeout against a healthy baseline keeps blocking**. A killed suite typically reports *fewer* failures, so `current <= base` would read "never finished" as a clean sweep.
- A run that **failed while reporting zero failures** is `inconclusive`. Changed-scope (`Scoped`) metrics are exempt, because there zero *is* the measurement.
- **Neither side produced counts** is `no_measurement`, not `baseline_red`. `baseline_red` claims the failure is pre-existing, and that claim needs a candidate-side observation to rest on.

Blocking policy matches CI: `baseline_red` / `inconclusive` / `no_measurement` warn without blocking; `fail` / `timeout` block.

### Two additions beyond the CI gate

1. **`no_baseline`** — the honest local degradation. CI always has a baseline job; locally there may be nothing cached and no budget to build one. It blocks, because an absent measurement must never render as a pass. It also does not invent `new_failures` — without a baseline, nothing is known about which failures are new.
2. **Comparison by test name, not only by count.** Three failed before and three after can still be three *different* tests, which every count-only rule reads as `baseline_red`. When both sides fully name their failures the verdict is a set difference. A partial name list on either side degrades to the count rule rather than inventing regressions. Name knowledge strictly refines the count rule and never turns a non-blocking verdict into a blocking one.

## Test coverage

40 unit tests over synthetic candidate/baseline pairs. Every verdict is covered, including the ones only reachable when a suite is killed mid-run or writes no sidecar:

`pass` (green candidate, count improvement, scoped zero) · `fail` (swapped failure set at equal count, count increase, new failure vs green baseline) · `timeout` (clean and with partial counts) · `baseline_red` (identical names, equal counts, partial fix, unmeasured baseline) · `inconclusive` (failed-with-zero, unmeasured candidate) · `no_measurement` (double timeout, two unmeasured sides) · `no_baseline` (miss, and that it invents no new failures) · cache round-trip, moved revision, scope mismatch, tampered record, unknown schema, junk JSON, pruning, filesystem-safe paths · serde spelling == `as_str()` spelling, so the two-vocabulary drift this PR exists to avoid cannot creep back in.

The classifier is pure — no filesystem, no git, no clock — which is what makes it verifiable on exactly the constrained hosts it exists to serve.

## What is not wired

- **The `homeboy test --differential` clap flags.** Adding args to `TestArgs` changes the generated CLI reference, which `generated_command_docs_match_the_live_clap_tree` pins byte-for-byte against `docs/reference/cli/command-surface.json` + `docs/reference/cli/commands/review.md`. Regenerating requires `cargo run -p homeboy-cli --bin generate-cli-reference`; hand-editing two generated files to match the generator exactly is not a safe trade here.
- **Executing a baseline run when none is cached.** The cache is populated by an explicit record; nothing in this PR checks out the base branch or builds it.

The seams the remaining wiring needs are all public:

- `measurement_from_test_output(&TestCommandOutput) -> TestMeasurement`
- `resolve_baseline_revision(&Path, &str) -> Option<String>`
- `classify_against_cache(&BaselineCache, &BaselineCacheKey, TestMeasurement) -> DifferentialReport`
- `BaselineCache::{open, load, store, prune_superseded}`

## Compile risk

Low. **No existing struct, signature, enum, or call site was changed** — the only edit outside the new directory is three added lines of `pub mod` / `pub use` in `crates/homeboy-extension/src/test/mod.rs`, checked for name collisions against every other re-export in that module. New module only; nothing else in the workspace can break.

No `#[cfg(unix)]` code. No assertions about `std::env::temp_dir()` relationships — cache tests inject an explicit root via `BaselineCache::at(dir.path())` and never touch `HOME`. `cargo fmt --all --check` is clean; `rustfmt --check` parses all four new files.

Refs #11753