### PR TITLE
fix(runner): complete session test fixtures

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -29,6 +29,7 @@ fn healthy_session_health_probe_is_observational() {
         local_url: Some(format!("http://{addr}")),
         tunnel_pid: Some(1234),
         tunnel_process_start_identity: None,
+        proxy_forward: None,
         remote_daemon_pid: Some(4242),
         remote_daemon_lease_id: Some("lease-doctor".to_string()),
         homeboy_version: "test".to_string(),

--- a/crates/homeboy-cli/src/commands/runner/jobs.rs
+++ b/crates/homeboy-cli/src/commands/runner/jobs.rs
@@ -422,6 +422,7 @@ mod tests {
             local_url: Some(url),
             tunnel_pid,
             tunnel_process_start_identity: None,
+            proxy_forward: None,
             remote_daemon_pid: Some(4242),
             remote_daemon_lease_id: Some("lease-authoritative".to_string()),
             homeboy_version: "test".to_string(),

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -1649,6 +1649,7 @@ mod tests {
                 local_url: Some("http://127.0.0.1:7331".to_string()),
                 tunnel_pid: Some(12345),
                 tunnel_process_start_identity: None,
+                proxy_forward: None,
                 remote_daemon_pid: Some(23456),
                 remote_daemon_lease_id: Some("lease-23456".to_string()),
                 homeboy_version: "homeboy 0.259.0".to_string(),

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -24,6 +24,32 @@ use super::super::status::{
 use super::super::types::RunnerConnectionOutput;
 use crate::cli_surface::Cli;
 
+fn runner_session_fixture() -> RunnerSession {
+    RunnerSession {
+        runner_id: String::new(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: runner::RunnerSessionRole::Controller,
+        server_id: None,
+        controller_id: None,
+        broker_url: None,
+        remote_daemon_address: None,
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        tunnel_process_start_identity: None,
+        proxy_forward: None,
+        remote_daemon_pid: None,
+        remote_daemon_lease_id: None,
+        homeboy_version: String::new(),
+        homeboy_build_identity: None,
+        connected_at: String::new(),
+        worker_identity: None,
+        worker_pid: None,
+        last_seen_at: None,
+        leaseless_recovery_evidence: None,
+    }
+}
+
 #[test]
 fn runner_job_event_format_includes_sequence_kind_message_and_data() {
     let event = JobEvent {
@@ -68,6 +94,7 @@ fn reverse_runner_status_commands_include_lifecycle_operations() {
             worker_pid: None,
             last_seen_at: Some("2026-06-19T00:00:01Z".to_string()),
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: None,
         daemon_freshness: None,
@@ -197,6 +224,7 @@ fn direct_runner_status_exposes_the_explicit_generation_reconcile_command() {
             worker_pid: None,
             last_seen_at: None,
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: None,
         daemon_freshness: None,
@@ -247,6 +275,7 @@ fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
             worker_pid: None,
             last_seen_at: None,
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: None,
         daemon_freshness: Some(DaemonFreshnessReport {
@@ -729,6 +758,7 @@ fn runner_status_artifact_diagnostics_surface_controller_runner_checks_and_drift
             worker_pid: None,
             last_seen_at: Some("2026-06-19T00:00:01Z".to_string()),
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: None,
         daemon_freshness: None,
@@ -792,6 +822,7 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
             worker_pid: None,
             last_seen_at: None,
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: None,
         daemon_freshness: None,
@@ -858,6 +889,7 @@ fn compact_status_names_runner_version_skew_when_the_controller_is_dirty() {
             worker_pid: None,
             last_seen_at: None,
             leaseless_recovery_evidence: None,
+            ..runner_session_fixture()
         }),
         stale_daemon: Some(
             homeboy::runner::runners::RunnerStaleDaemonWarning::new(


### PR DESCRIPTION
Fixes #11762

## Summary
- Set the semantically absent `proxy_forward` state on all three standalone runner-session test fixtures.
- Centralize the six status-test fixture defaults behind one complete local `RunnerSession` baseline, so future required contract fields are supplied in one place.
- Leave production runner-session construction and proxy-forward behavior unchanged.

## Test evidence
- `cargo fmt --check`
- `cargo check`
- `cargo test -p homeboy-cli --no-run`
- `cargo test -p homeboy-cli fanout` (57 passed)
- `cargo test -p homeboy-cli commands::runner::tests::status` (20 passed)
- `cargo test -p homeboy-cli commands::runner::doctor::tests::daemon::healthy_session_health_probe_is_observational` (1 passed)
- `cargo test -p homeboy-cli commands::runner::jobs::tests::cursor_resume_command_preserves_runner_job_and_polling_contract` (1 passed)

## Residual risk
`cargo test -p homeboy-cli commands::runner` compiles and runs 159 tests, with 157 passing and two existing failures outside this change: the stale-daemon hint expects a runtime-derived build ref, and a reconnect test supplies no tunnel process-start identity while asserting identity-guarded cleanup terminates `sleep`.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the compiler failures, implemented the fixture-only repair, and ran the listed verification commands. Chris Huber reviewed and remains responsible for every line.