### PR TITLE
fix(agent-task): report partial-failure runs as terminal in liveness

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -135,15 +135,7 @@ pub(crate) fn continue_cook(args: CookContinueArgs) -> CmdResult<Value> {
         })?;
     let run_id = agent_task_service::resolve_cook_continuation_run_id(&args.cook_or_attempt_id)?;
     let record = agent_task_service::reconcile_recipe_attempt_for_continuation(&recipe, &run_id)?;
-    if !matches!(
-        record.state,
-        agent_task_lifecycle::AgentTaskRunState::Succeeded
-            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-            | agent_task_lifecycle::AgentTaskRunState::Failed
-            | agent_task_lifecycle::AgentTaskRunState::Cancelled
-    ) {
+    if !record.state.is_terminal() {
         return Ok((
             cook_continuation_status(&recipe.cook_id, &run_id, &format!("{:?}", record.state)),
             0,
@@ -314,15 +306,7 @@ pub(crate) fn preflight_continue_cook(args: CookContinueArgs) -> CmdResult<Value
             ))
         }
     };
-    if !matches!(
-        record.state,
-        agent_task_lifecycle::AgentTaskRunState::Succeeded
-            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-            | agent_task_lifecycle::AgentTaskRunState::Failed
-            | agent_task_lifecycle::AgentTaskRunState::Cancelled
-    ) {
+    if !record.state.is_terminal() {
         let error = homeboy::core::Error::validation_invalid_argument(
             "cook_or_attempt_id",
             "selected Cook attempt is not terminal and cannot be admitted to dispatch",

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -3121,6 +3121,27 @@ fn bounded_value(value: &Value) -> Value {
     }
 }
 
+/// Terminality of an untyped durable record, delegating to the single
+/// definition in `AgentTaskRunState::is_terminal`.
+///
+/// `status` reads records as untyped JSON, so the state has to be parsed back
+/// into the lifecycle enum instead of compared against an inline string list.
+/// An inline list is exactly how `partial_failure`, `partial_recoverable`, and
+/// `candidate_recoverable` runs came to be reported as `liveness.status:
+/// "active"` forever — the list named only `succeeded`/`failed`/`cancelled`, so
+/// an orchestrator polling liveness never saw those runs finish.
+///
+/// An absent or unparseable state is non-terminal: a record this build does not
+/// understand keeps its prior reading rather than being asserted as finished.
+fn record_state_is_terminal(record: &Value) -> bool {
+    record
+        .get("state")
+        .and_then(|state| {
+            serde_json::from_value::<agent_task_lifecycle::AgentTaskRunState>(state.clone()).ok()
+        })
+        .is_some_and(agent_task_lifecycle::AgentTaskRunState::is_terminal)
+}
+
 fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateState) -> Value {
     let metadata = record.get("metadata").unwrap_or(&Value::Null);
     let provider_handle_count = record
@@ -3135,10 +3156,7 @@ fn liveness_summary(record: &Value, run_id: &str, candidate_state: CandidateStat
         .get("runner_job_id")
         .and_then(Value::as_str)
         .filter(|job_id| !job_id.trim().is_empty());
-    let terminal = record
-        .get("state")
-        .and_then(Value::as_str)
-        .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
+    let terminal = record_state_is_terminal(record);
     let waiting_for_capacity = metadata
         .get("runner_queue")
         .and_then(|queue| queue.get("state"))
@@ -4934,6 +4952,51 @@ mod tests {
         assert_eq!(boundary["status"], "absent");
         assert_eq!(boundary["active_execution_count"], 0);
         assert!(boundary["active_executions"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn every_terminal_run_state_reports_terminal_liveness() {
+        // `liveness` used to compare `state` against an inline
+        // `"succeeded" | "failed" | "cancelled"` list, so a run that finished in
+        // `partial_failure`, `partial_recoverable`, or `candidate_recoverable`
+        // reported `status: "active"` forever and an orchestrator polling
+        // liveness never saw it finish. Terminality now has exactly one
+        // definition — `AgentTaskRunState::is_terminal` — and this pins every
+        // member of that set through the same untyped read path.
+        for state in [
+            "succeeded",
+            "candidate_recoverable",
+            "partial_recoverable",
+            "partial_failure",
+            "failed",
+            "cancelled",
+        ] {
+            let summary = liveness_summary(
+                &json!({ "run_id": "agent-task-terminal", "state": state, "tasks": [] }),
+                "agent-task-terminal",
+                CandidateState::Unknown,
+            );
+            assert_eq!(summary["status"], "terminal", "{state}");
+        }
+
+        for state in ["queued", "running"] {
+            let summary = liveness_summary(
+                &json!({ "run_id": "agent-task-active", "state": state, "tasks": [] }),
+                "agent-task-active",
+                CandidateState::Unknown,
+            );
+            assert_eq!(summary["status"], "active", "{state}");
+        }
+
+        // A state this build cannot parse keeps the prior non-terminal reading
+        // rather than being asserted as finished.
+        let unknown = liveness_summary(
+            &json!({ "run_id": "agent-task-unknown", "state": "not_a_state", "tasks": [] }),
+            "agent-task-unknown",
+            CandidateState::Unknown,
+        );
+        assert_eq!(unknown["status"], "active");
+        assert!(!record_state_is_terminal(&json!({ "tasks": [] })));
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`AgentTaskRunState::is_terminal()` documents itself as the single definition of terminality:

> Every place that used to enumerate this set inline (`matches!(state, Succeeded | CandidateRecoverable | ...)`) delegates here, **so adding or reclassifying a run state cannot leave a stale copy behind.**

Three stale copies existed anyway.

**`status.rs:3138`** — the liveness projection:
```rust
let terminal = record.get("state").and_then(Value::as_str)
    .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
```

It omits `partial_failure`, `partial_recoverable`, and `candidate_recoverable` — **all of which are terminal.** That feeds:
```rust
"status": if terminal { "terminal" } else if stale { ... } else { "active" },
```

**Consequence:** a run in `partial_failure` is reported by `agent-task status` as `liveness.status: "active"` forever. **An orchestrator polling liveness never sees these runs finish**, and `next_action` points at `status --full` instead of review.

**`run.rs:137`** and **`run.rs:309`** (`preflight_continue_cook`) carried the same inline enumeration. The second was *currently* correct but is the identical drift hazard — its own error string says "is not terminal".

## The fix

All three now call `.is_terminal()`. `status.rs` works with untyped `serde_json::Value`, so terminality goes through one new helper:

```rust
fn record_state_is_terminal(record: &Value) -> bool
```

which deserializes into `AgentTaskRunState` (snake_case) and delegates. An absent or unparseable state stays non-terminal, preserving today's behaviour.

## Copies deliberately left alone

Checked and judged **not** terminality:

| Site | Why |
|---|---|
| `run.rs:145` `Succeeded \| CandidateRecoverable \| PartialRecoverable` | the *recoverable* subset — a distinct predicate |
| `lifecycle_runner_projection.rs:305` | runner `JobStatus` vocabulary, different domain |
| `lab_staging_controller.rs:1418,2025` | Lab staging job status |
| `utils/response.rs:1126` | command-envelope exit-code projection |

## Flagged, not fixed

- **`agent_task_batch.rs:370`** — a byte-exact stale copy of `AgentTaskDependencyState::is_terminal()`. Same bug class, different enum, currently correct. Left for a focused follow-up.
- **`agent_task_summary/mod.rs:673`** — `status_attempted_task_count` omits the three partial states, so a `partial_failure` task isn't counted as attempted, which feeds `effective_run_state`'s `no_patch_produced` branch. Plausible second-order bug, different predicate.
- **`args/definitions/command.rs:237`** — the `--state` value_parser allow-list omits the partial states, so you cannot filter for them.

## Test

Table-driven over all 8 states: 6 terminal → `"terminal"`, 2 non-terminal → `"active"`, plus unparseable and missing-`state` → non-terminal.

## Verification

`cargo check --workspace --tests -j2` clean (on top of #11767, which fixed an unrelated main breakage).