### PR TITLE
perf(test-support): stop copying the test binary on every isolated-home test

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -19,6 +19,17 @@ pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE";
+/// Names the executable [`TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV`]'s fixture is
+/// copied from.
+///
+/// The fixture is materialized on first *read* rather than when the hermetic
+/// home is built, so the destination path can name a file that does not exist
+/// yet. This variable is what lets any process holding the destination —
+/// including a child test process that inherited it — produce those bytes
+/// itself. See `test_support::ensure_test_controller_fixture`.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const TEST_CONTROLLER_RUNTIME_SOURCE_ENV: &str =
+    "HOMEBOY_TEST_CONTROLLER_RUNTIME_SOURCE";
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_STORE_ENV: &str = "HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE";
 #[cfg(any(test, feature = "test-support"))]
@@ -647,7 +658,12 @@ pub fn pin_current_queued(
 fn current_executable() -> Result<PathBuf> {
     #[cfg(any(test, feature = "test-support"))]
     if let Some(executable) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) {
-        return Ok(PathBuf::from(executable));
+        let executable = PathBuf::from(executable);
+        // The fixture is materialized here, on first read, instead of when the
+        // hermetic home was built: only the handful of readers of this contract
+        // need its bytes, and the copy is of a multi-hundred-megabyte binary.
+        crate::test_support::ensure_test_controller_fixture(&executable);
+        return Ok(executable);
     }
 
     std::env::current_exe().map_err(|error| {
@@ -2075,6 +2091,7 @@ fn executable_identity(path: &Path, verified_digest: Option<&str>) -> Result<Str
 fn test_controller_identity(path: &Path, verified_digest: Option<&str>) -> Option<Result<String>> {
     let source = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)?;
     let identity = std::env::var(TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok()?;
+    crate::test_support::ensure_test_controller_fixture(Path::new(&source));
     let source_digest = test_controller_fixture_digest(Path::new(&source)).map_err(|error| {
         Error::validation_invalid_argument(
             "controller_runtime",
@@ -2184,6 +2201,7 @@ fn controller_executable_digest(path: &Path) -> Result<String> {
     if std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
         .is_some_and(|source| Path::new(&source) == path)
     {
+        crate::test_support::ensure_test_controller_fixture(path);
         return test_controller_fixture_digest(path);
     }
     executable_digest(path)

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -21,6 +21,15 @@ static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_HOMEBOY_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_CONTROLLER_RUNTIME_STORE: OnceLock<TempDir> = OnceLock::new();
+/// Destinations whose controller fixture bytes this process has already
+/// published. Keeps the copy to at most once per process per fixture path —
+/// including a path inherited from a parent test process — and serializes
+/// concurrent materialization so two threads never copy the same binary twice.
+static PUBLISHED_CONTROLLER_FIXTURES: Mutex<BTreeSet<PathBuf>> = Mutex::new(BTreeSet::new());
+/// File name every controller-runtime fixture is published under. Reading it
+/// back off the destination path is what lets `ensure_test_controller_fixture`
+/// tell *our* fixture apart from a binary a test chose for itself.
+const CONTROLLER_FIXTURE_FILE_NAME: &str = "homeboy-controller-fixture";
 static EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 static SHORT_EXEC_CAPABLE_TEMP_BASE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 /// Runs the leaked-tempdir sweep exactly once per test process.
@@ -105,13 +114,7 @@ impl HermeticTestContext {
     }
 
     pub fn binary_path(&self, binary: TestBinary) -> PathBuf {
-        match binary {
-            TestBinary::CurrentTest => std::env::current_exe().expect("current test executable"),
-            TestBinary::HomeboyFixture => PathBuf::from(
-                std::env::var_os("CARGO_BIN_EXE_homeboy")
-                    .expect("CARGO_BIN_EXE_homeboy fixture binary"),
-            ),
-        }
+        test_binary_path(binary)
     }
 
     /// Build a command whose Homeboy state is wholly owned by this context.
@@ -151,9 +154,16 @@ impl HermeticTestContext {
                 crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
                 TEST_DAEMON_BINARY_SHA,
             )
+            // Destination and source travel together. The child materializes
+            // the fixture itself the first time it reads the contract, so this
+            // parent never copies a binary the child may not even need.
             .env(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
-                test_controller_fixture(binary),
+                test_controller_fixture_path(binary),
+            )
+            .env(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV,
+                test_binary_path(binary),
             )
             .env(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
@@ -422,6 +432,7 @@ pub struct HomeGuard {
     prior_no_update_check: Option<String>,
     prior_daemon_binary_sha: Option<String>,
     prior_controller_runtime_executable: Option<String>,
+    prior_controller_runtime_source: Option<String>,
     prior_controller_runtime_identity: Option<String>,
     context: HermeticTestContext,
     _guard: MutexGuard<'static, ()>,
@@ -512,6 +523,8 @@ impl HomeGuard {
             std::env::var(crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV).ok();
         let prior_controller_runtime_executable =
             std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV).ok();
+        let prior_controller_runtime_source =
+            std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV).ok();
         let prior_controller_runtime_identity =
             std::env::var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV).ok();
         // The isolated HOME hosts `~/.config/homeboy/extensions/**/*.sh`
@@ -553,9 +566,17 @@ impl HomeGuard {
             crate::daemon::DAEMON_BINARY_SHA_OVERRIDE_ENV,
             TEST_DAEMON_BINARY_SHA,
         );
+        // Name the fixture and its source, but do not copy anything: the copy
+        // is a multi-hundred-megabyte binary and almost no test on this path
+        // ever reads the contract. `ensure_test_controller_fixture` produces
+        // the bytes at the few call sites that do.
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
-            test_controller_fixture(TestBinary::CurrentTest),
+            test_controller_fixture_path(TestBinary::CurrentTest),
+        );
+        std::env::set_var(
+            crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV,
+            test_binary_path(TestBinary::CurrentTest),
         );
         std::env::set_var(
             crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
@@ -573,6 +594,7 @@ impl HomeGuard {
             prior_no_update_check,
             prior_daemon_binary_sha,
             prior_controller_runtime_executable,
+            prior_controller_runtime_source,
             prior_controller_runtime_identity,
             context,
             _guard: guard,
@@ -949,6 +971,15 @@ impl Drop for HomeGuard {
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
             ),
         }
+        match &self.prior_controller_runtime_source {
+            Some(value) => std::env::set_var(
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV,
+                value,
+            ),
+            None => {
+                std::env::remove_var(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV)
+            }
+        }
         match &self.prior_controller_runtime_identity {
             Some(value) => std::env::set_var(
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
@@ -962,33 +993,126 @@ impl Drop for HomeGuard {
     }
 }
 
-fn test_controller_fixture(binary: TestBinary) -> PathBuf {
+/// The executable a hermetic test command runs, and the source a controller
+/// fixture for that selection is copied from.
+fn test_binary_path(binary: TestBinary) -> PathBuf {
+    match binary {
+        TestBinary::CurrentTest => std::env::current_exe().expect("current test executable"),
+        TestBinary::HomeboyFixture => PathBuf::from(
+            std::env::var_os("CARGO_BIN_EXE_homeboy")
+                .expect("CARGO_BIN_EXE_homeboy fixture binary"),
+        ),
+    }
+}
+
+/// Where this process publishes its controller-runtime fixture for `binary`.
+///
+/// Allocating the path is cheap — one tempdir per process, shared by every
+/// isolated home. The expensive part, copying the source executable, is
+/// deferred to [`ensure_test_controller_fixture`].
+fn test_controller_fixture_path(binary: TestBinary) -> PathBuf {
     let fixture = match binary {
         TestBinary::CurrentTest => &SHARED_CONTROLLER_RUNTIME_FIXTURE,
         TestBinary::HomeboyFixture => &SHARED_HOMEBOY_CONTROLLER_RUNTIME_FIXTURE,
     };
     fixture
-        .get_or_init(|| {
-            let directory = exec_capable_tempdir();
-            let path = directory.path().join("homeboy-controller-fixture");
-            fs::copy(
-                match binary {
-                    TestBinary::CurrentTest => {
-                        std::env::current_exe().expect("current test executable")
-                    }
-                    TestBinary::HomeboyFixture => PathBuf::from(
-                        std::env::var_os("CARGO_BIN_EXE_homeboy")
-                            .expect("CARGO_BIN_EXE_homeboy fixture binary"),
-                    ),
-                },
-                &path,
-            )
-            .expect("copy controller fixture");
-            make_test_controller_fixture_read_only(&path);
-            directory
-        })
+        .get_or_init(exec_capable_tempdir)
         .path()
-        .join("homeboy-controller-fixture")
+        .join(CONTROLLER_FIXTURE_FILE_NAME)
+}
+
+/// Materialize the controller-runtime fixture named by `path`, once.
+///
+/// The fixture is a byte-identical copy of the running test binary, which is
+/// ~700 MB unoptimized (see the `profile.dev.package.sha2` note in the
+/// workspace `Cargo.toml`). It used to be copied eagerly from
+/// [`HomeGuard::new`], i.e. once per *process*. Under `cargo test` that is once
+/// per test binary — already paid by every binary whose tests never touch the
+/// contract. Under nextest, which runs one process per test, it is once per
+/// **test**: all ~2,600 `with_isolated_home` call sites paying for the handful
+/// that read `TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV`. Those readers call this
+/// instead, so the copy happens only where the bytes are actually used.
+///
+/// Deliberately defensive, because it can be handed any path a test put in the
+/// contract. It writes only when *all* of the following hold:
+/// - nothing exists at `path` yet,
+/// - `path` carries the fixture's own file name,
+/// - `path` is exactly what the contract currently names, and
+/// - a source executable is recorded alongside it.
+///
+/// A test that points the contract at a binary of its own therefore keeps
+/// precisely the bytes it chose.
+pub(crate) fn ensure_test_controller_fixture(path: &Path) {
+    // The branch every call after the first takes, in this process or in the
+    // parent that handed the path down.
+    if path.exists() {
+        return;
+    }
+    if path.file_name().and_then(|name| name.to_str()) != Some(CONTROLLER_FIXTURE_FILE_NAME) {
+        return;
+    }
+    let Some(destination) =
+        std::env::var_os(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
+    else {
+        return;
+    };
+    if Path::new(&destination) != path {
+        return;
+    }
+    let Some(source) =
+        std::env::var_os(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_SOURCE_ENV)
+    else {
+        return;
+    };
+    let source = PathBuf::from(source);
+
+    let mut published = PUBLISHED_CONTROLLER_FIXTURES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Re-check under the lock. A sibling thread may have published while we
+    // waited, and paying the copy twice is the one thing this exists to avoid.
+    if published.contains(path) || path.exists() {
+        return;
+    }
+    publish_test_controller_fixture(&source, path);
+    published.insert(path.to_path_buf());
+}
+
+/// Copy `source` into place at `destination` so that `destination` never
+/// appears in a partial state.
+///
+/// The copy lands on a per-process staging name and is linked into place, which
+/// fails cleanly if someone else got there first. That matters because one
+/// destination can now be shared by more than one process: a child test process
+/// materializes into the tempdir its parent named, and a plain `fs::copy`
+/// straight to the destination would let one observe the other's half-written
+/// file. The two racers copy the same source bytes, so either winner is correct.
+///
+/// The link is deliberately *staging to destination* and never *source to
+/// destination*: the fixture is sealed read-only, and a hard link to the source
+/// would seal the real test binary along with it.
+fn publish_test_controller_fixture(source: &Path, destination: &Path) {
+    let parent = destination
+        .parent()
+        .expect("controller fixture destination has a parent directory");
+    fs::create_dir_all(parent).expect("create controller fixture directory");
+    let staging = parent.join(format!(
+        "{CONTROLLER_FIXTURE_FILE_NAME}.staging.{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_file(&staging);
+    fs::copy(source, &staging).expect("copy controller fixture");
+    make_test_controller_fixture_read_only(&staging);
+    match fs::hard_link(&staging, destination) {
+        Ok(()) => {}
+        // Another process published the same source bytes first.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => panic!(
+            "publish controller fixture at {}: {error}",
+            destination.display()
+        ),
+    }
+    let _ = fs::remove_file(&staging);
 }
 
 /// Return the process-wide immutable controller-runtime pin store for tests
@@ -1018,11 +1142,16 @@ fn make_test_controller_fixture_read_only(path: &Path) {
 }
 
 /// Source executable selected by the hermetic controller-runtime test contract.
+///
+/// Materializes the fixture, so callers may execute, hash, or stat the returned
+/// path exactly as they could when the copy was made eagerly.
 pub fn controller_runtime_test_executable() -> PathBuf {
-    PathBuf::from(
+    let executable = PathBuf::from(
         std::env::var_os(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
             .expect("controller runtime test executable"),
-    )
+    );
+    ensure_test_controller_fixture(&executable);
+    executable
 }
 
 pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {


### PR DESCRIPTION
## The defect

`HomeGuard::new` eagerly evaluated the controller fixture:

```rust
std::env::set_var(
    crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV,
    test_controller_fixture(TestBinary::CurrentTest),   // <- evaluated NOW
);
```

which does `fs::copy(std::env::current_exe(), ...)`. `Cargo.toml:104` records the size: **"That binary is ~700 MB unoptimized"**.

The `OnceLock` makes that once per **process**. Under `cargo test` (one process per binary) it's harmless. Under a **process-per-test** runner it is once per test.

**~2,633 `with_isolated_home`/`HomeGuard::new` call sites. ~7 readers of the env var.**

## The fix

`HomeGuard::new` now sets two cheap facts and copies nothing:
- `HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE` → the destination path (one `OnceLock` mkdir per process)
- `HOMEBOY_TEST_CONTROLLER_RUNTIME_SOURCE` → the source executable *(new)*

`test_support::ensure_test_controller_fixture(path)` is the single materialization point; all readers call it. After the first call it is one `path.exists()` stat.

### Why the second env var

The naive "materialize on read" breaks across `fork`/`exec`. `HermeticTestContext::command` does **not** `env_remove` the contract, so any subprocess spawned inside a `with_isolated_home` test inherits the destination path. Previously the parent had always already copied the bytes; with a lazy copy it may never have, and **a child cannot reconstruct a file whose source it doesn't know.**

Recording the source makes any process self-sufficient, and the two `controller_runtime_command` call sites get correct behaviour with zero special-casing — the child pays the copy, which is where it was always needed.

### Rejected alternative

An opt-in `with_isolated_home_and_controller_runtime()` changes behaviour *by omission*: a non-opted-in test that pins would fall back to `current_exe()` and copy the real 700MB binary (worse), and `test_controller_identity` would return `None`, exec'ing the libtest harness with `self identity` args. Silent breakage on any mis-classified call site.

## Deliberately NOT done, with reasons

- **hard_link from the source for speed** — **unsafe.** `make_test_controller_fixture_read_only` chmods the fixture to `0o500`; a hard link shares the inode, so that would strip the write bit off the real test binary in `target/debug/deps`. `fs::hard_link` *is* used staging→destination inside the same tempdir for atomic publication, and the comment says so, so nobody "optimizes" it later.
- **Disabling the tempdir leak sweep under nextest** — the sweep is what reclaims tempdirs from SIGKILLed processes, and nothing else does during a shard. Process-per-test is the *maximal* leak surface, so that is exactly where disabling it is most dangerous (#9173: 130 dirs / ~18G, host to 100%; #11353: ~16G/hour). This change also shrinks each leaked home by ~700MB, reducing the pressure that made the sweep urgent.
- **Collapsing the two exec-probe caches** — they differ meaningfully. `SHORT_EXEC_CAPABLE_TEMP_BASE` filters candidates to `len <= 40` for the `sockaddr_un` budget, pinned by `the_invocation_tempdir_still_fits_the_socket_budget`. Merging would break socket paths to save one fork.

## Verification

`cargo check --workspace --tests -j2` clean. No test deleted, no observable test behaviour changed.

`tests/reverse_cook_queue_acceptance.rs:186` sets the env var to the real `homeboy` binary rather than a fixture copy — `path.exists()` is true, so `ensure` is a no-op and it is untouched.

## Note on the estimate

The per-shard saving depends on the harness actually being process-per-test. The commit message states both cases rather than asserting one.