### PR TITLE
test(audit): ratchet the audit suppression baseline so it can only shrink

### DIFF
--- a/docs/audit/baseline-ratchet.md
+++ b/docs/audit/baseline-ratchet.md
@@ -1,0 +1,162 @@
+# Audit Baseline Ratchet
+
+`homeboy.json` carries a permanent suppression list for `homeboy audit` at
+`baselines.audit.known_fingerprints`. This document explains what is in it, why
+it may only shrink, and how to change the ceiling that enforces that.
+
+The ratchet is enforced by `tests/audit_baseline_ratchet_test.rs`.
+
+## What the baseline is
+
+When `homeboy audit --update-baseline` runs, every finding of the current run is
+reduced to a fingerprint string and stored. On later runs,
+`homeboy_engine_primitives::baseline::compare` treats any finding whose
+fingerprint is already in that list as *not new*. Only findings absent from the
+list set `drift_increased` and fail the audit.
+
+The list is therefore not a record of history. It is live configuration that
+decides what the audit is allowed to report.
+
+## A row is not one finding
+
+This is the part worth internalizing before adding a row.
+
+`AuditFinding::fingerprint` (in `crates/homeboy-code-audit/src/baseline.rs`) builds:
+
+```
+convention::file::Kind
+```
+
+The description is deliberately excluded, because structural findings embed
+volatile values — the test `fingerprint_ignores_description` pins that a
+`GodFile` finding keeps one identity as the file grows from 2,484 to 2,645
+lines. No fingerprint contains a line number.
+
+Matching is then plain set membership on that string.
+
+The consequence: **baselining is per file + kind, not per instance.** One row
+suppresses every finding of that kind in that file — the ones that existed when
+the row was written, and every one added afterward. A file baselined for
+`IntraMethodDuplicate` is silent on that detector forever, no matter how many
+new duplicated blocks land in it.
+
+`CoreBoundaryLeak` is the only exception. It appends a description whose line
+numbers are normalized (`... at line <line>`), giving:
+
+```
+convention::file::description::Kind
+```
+
+so it is per file + kind + message. Still not per instance.
+
+Of the current rows, 821 are the three-segment per-file+kind form (covering 821
+distinct file+kind pairs across 582 files) and 312 are the four-segment
+`CoreBoundaryLeak` form.
+
+## Two ways the list grows on its own
+
+1. `homeboy audit --update-baseline` re-saves whatever the current run found.
+2. A conflicted `homeboy.json` is resolved by `baseline_merge` to the **union**
+   of both sides' fingerprints, on the reasoning that each side accepted some
+   debt.
+
+Neither path asks anyone to justify a new row, and nothing ages rows out. That
+is why the size needs an external check.
+
+## The rule
+
+**`baselines.audit.known_fingerprints` may only shrink.**
+
+`tests/audit_baseline_ratchet_test.rs` pins `AUDIT_BASELINE_CEILING` to the
+exact current count and fails if the list exceeds it. A second assertion fails
+if the list is *below* the ceiling, which forces the ceiling down as debt is
+paid — a ceiling with slack in it is room for silent re-growth.
+
+### Adding a suppression
+
+In order of preference:
+
+1. Fix the finding. This is the default and usually the cheaper option.
+2. Retire an existing suppression in the same PR, so the total does not rise.
+3. Raise `AUDIT_BASELINE_CEILING` in the same PR, and justify it in the PR body.
+   Expect to be asked why the finding cannot be fixed.
+
+### Lowering the ceiling
+
+When suppressions are retired, set `AUDIT_BASELINE_CEILING` to the new exact
+count in the same PR. Get the number with:
+
+```sh
+jq '.baselines.audit.known_fingerprints | length' homeboy.json
+```
+
+The `audit_baseline_ceiling_leaves_no_slack` test will tell you the number if
+you forget.
+
+## Current debt, by finding kind
+
+1,133 rows as of the commit that introduced this ratchet. This table exists so
+the debt is visible rather than hidden inside a 158 KB JSON blob — that array is
+93% of `homeboy.json` by byte count.
+
+| Kind | Entries |
+|---|---:|
+| `CoreBoundaryLeak` | 312 |
+| `SkeletonDuplicate` | 147 |
+| `HighItemCount` | 133 |
+| `ConstantBypassLiteral` | 128 |
+| `IntraMethodDuplicate` | 114 |
+| `GodFile` | 94 |
+| `UnreferencedExport` | 47 |
+| `CommandWrapperBypass` | 37 |
+| `NearDuplicate` | 24 |
+| `DirectAggregateConstruction` | 15 |
+| `ParallelImplementation` | 15 |
+| `RemoteExecutionPreflight` | 15 |
+| `MissingMethod` | 8 |
+| `DuplicateFunction` | 7 |
+| `StaleDocReference` | 5 |
+| `UnboundedOutputCapture` | 5 |
+| `ThinCommandAdapterViolation` | 4 |
+| `VacuousTest` | 4 |
+| `DeadCodeMarker` | 3 |
+| `RepeatedEnumDispatchContract` | 3 |
+| `UnusedParameter` | 3 |
+| `DirectorySprawl` | 2 |
+| `GlobalEnvMutationGuard` | 2 |
+| `LayerOwnershipViolation` | 2 |
+| `BrokenDocReference` | 1 |
+| `MissingInterface` | 1 |
+| `NamingMismatch` | 1 |
+| `ParallelRunnerSetup` | 1 |
+| **Total** | **1133** |
+
+Roughly: 307 duplication findings, 227 size findings, 47 dead public exports.
+
+Regenerate with:
+
+```sh
+jq -r '.baselines.audit.known_fingerprints[] | split("::") | .[-1]' homeboy.json \
+  | sort | uniq -c | sort -rn
+```
+
+Burning this list down is separate work from the ratchet. The ratchet only stops
+it from getting worse.
+
+## Known wrinkles
+
+- **`metadata.item_count` is stale.** It reads 1137 while the array holds 1133.
+  `normalize_loaded_baseline` only recomputes `item_count` when a policy section
+  enumerates fingerprints, and the sections now use the `fingerprint_prefix`
+  form with empty enumerations, so that branch never runs. `compare` uses
+  `item_count` for its reported `delta`, so that number is off by four. It does
+  not affect `drift_increased`, which is computed from the fingerprint set, so
+  suppression behavior is correct. The ratchet measures the array length, not
+  `item_count`.
+- **Rows are not sorted.** `save` sorts, but 363 of the 1,133 rows are out of
+  sorted position, so order is not an invariant and no test pins it.
+- **The baseline is not in a separate file.** Splitting it out would make config
+  diffs readable, but `BaselineConfig::json_path()` hardcodes `homeboy.json`,
+  and so do the git-ref reader (`git show <ref>:homeboy.json`) and the whole
+  `baseline_merge` conflict driver. There is no external-baseline-path option
+  today, so the split is a real change rather than a config tweak.

--- a/tests/audit_baseline_ratchet_test.rs
+++ b/tests/audit_baseline_ratchet_test.rs
@@ -1,0 +1,198 @@
+//! Monotonic growth ratchet for the audit suppression baseline in `homeboy.json`.
+//!
+//! `baselines.audit.known_fingerprints` is a permanent-suppression list for
+//! `homeboy audit`. Every row in it silences a finding the repo's own audit
+//! engine already produced. Nothing in the loader caps the list, ages rows out,
+//! or requires a rationale, and two of the write paths *grow* it by default:
+//!
+//! * `homeboy audit --update-baseline` re-saves whatever the current run found.
+//! * the baseline merge driver resolves a conflicted `homeboy.json` by taking
+//!   the **union** of both sides' fingerprints (see `baseline_merge`), on the
+//!   reasoning that each side accepted some debt.
+//!
+//! Union-on-conflict plus save-on-demand is a one-way size ratchet pointing the
+//! wrong way. This test points it the other way: the list may only shrink.
+//!
+//! ## Why entry count is the right thing to pin
+//!
+//! A row is not one suppressed finding. `AuditFinding::fingerprint` in
+//! `homeboy-code-audit::baseline` builds `convention::file::Kind` and
+//! deliberately excludes the description, because structural findings embed
+//! volatile numbers (`fingerprint_ignores_description` pins exactly that).
+//! Matching is then plain set membership on that string, in
+//! `homeboy_engine_primitives::baseline::compare`.
+//!
+//! So one row suppresses *every* finding of that kind in that file, now and
+//! forever — including ones written after the row was added. `CoreBoundaryLeak`
+//! is the single exception: it appends a line-number-normalized description, so
+//! it is per-file+kind+message. Nothing is per-instance; no fingerprint carries
+//! a line number.
+//!
+//! That makes the row count a floor on the suppressed surface, never an
+//! overestimate — and makes each added row cheap to add and expensive to notice.
+//!
+//! ## Changing the ceiling
+//!
+//! Down, in the same PR that removes the rows. Never up. See
+//! `docs/audit/baseline-ratchet.md`.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// Maximum permitted size of `baselines.audit.known_fingerprints`.
+///
+/// This is the exact count as of the commit that introduced this ratchet. It is
+/// a ceiling, not a target: lower it whenever suppressions are retired, and
+/// never raise it. Raising this number is the one edit this test exists to make
+/// someone argue for in review.
+const AUDIT_BASELINE_CEILING: usize = 1133;
+
+fn baseline_fingerprints() -> Vec<String> {
+    let config: Value =
+        serde_json::from_str(include_str!("../homeboy.json")).expect("homeboy.json parses");
+
+    config["baselines"]["audit"]["known_fingerprints"]
+        .as_array()
+        .expect("baselines.audit.known_fingerprints is an array")
+        .iter()
+        .map(|row| {
+            row.as_str()
+                .expect("every baseline fingerprint is a string")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Tally rows by the trailing `::Kind` segment of the fingerprint.
+///
+/// Holds for both serialized shapes: `convention::file::Kind` and the
+/// `CoreBoundaryLeak` form `convention::file::description::Kind`.
+fn entries_by_kind(fingerprints: &[String]) -> BTreeMap<&str, usize> {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for fingerprint in fingerprints {
+        let kind = fingerprint.rsplit("::").next().unwrap_or("<malformed>");
+        *counts.entry(kind).or_default() += 1;
+    }
+    counts
+}
+
+/// Descending per-kind breakdown, so a failure names where the debt actually is.
+fn breakdown_by_kind(fingerprints: &[String]) -> String {
+    let mut rows: Vec<(&str, usize)> = entries_by_kind(fingerprints).into_iter().collect();
+    rows.sort_by(|(left_kind, left_count), (right_kind, right_count)| {
+        right_count.cmp(left_count).then(left_kind.cmp(right_kind))
+    });
+
+    rows.iter()
+        .map(|(kind, count)| format!("    {count:>5}  {kind}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn audit_baseline_may_only_shrink() {
+    let fingerprints = baseline_fingerprints();
+    let actual = fingerprints.len();
+    let ceiling = AUDIT_BASELINE_CEILING;
+    let over = actual.saturating_sub(ceiling);
+    let breakdown = breakdown_by_kind(&fingerprints);
+
+    assert!(
+        actual <= ceiling,
+        r#"
+audit suppression baseline grew.
+
+  ceiling: {ceiling}
+  actual:  {actual}   (+{over})
+
+`baselines.audit.known_fingerprints` in homeboy.json may only SHRINK.
+
+Each row permanently silences an audit finding. Because a fingerprint is
+`convention::file::Kind` and carries no line number, one row silences EVERY
+finding of that kind in that file — including ones not written yet.
+
+To land this change, do one of:
+
+  1. Fix the finding instead of baselining it. This is the default.
+  2. Retire {over} existing suppression(s) in this same PR, so the total does
+     not rise.
+  3. If the ceiling is genuinely wrong, raise AUDIT_BASELINE_CEILING in
+     tests/audit_baseline_ratchet_test.rs in this same PR and say why in the
+     PR body. Expect to be asked.
+
+If you got here from `homeboy audit --update-baseline`, note that it re-saves
+every current finding, and that a conflicted homeboy.json resolves to the UNION
+of both sides' fingerprints. Both grow this list silently.
+
+Current baseline by finding kind:
+{breakdown}
+
+See docs/audit/baseline-ratchet.md
+"#
+    );
+}
+
+#[test]
+fn audit_baseline_ceiling_leaves_no_slack() {
+    let actual = baseline_fingerprints().len();
+    let ceiling = AUDIT_BASELINE_CEILING;
+    let under = ceiling.saturating_sub(actual);
+
+    assert!(
+        actual >= ceiling,
+        r#"
+audit suppression baseline shrank — good. Now lock it in.
+
+  ceiling: {ceiling}
+  actual:  {actual}   (-{under})
+
+Lower AUDIT_BASELINE_CEILING in tests/audit_baseline_ratchet_test.rs to {actual}
+in this same PR.
+
+The gap is not harmless: a ceiling above the real count is room for {under} new
+suppression(s) to be added later without any test noticing. A ratchet that keeps
+slack is not a ratchet. This assertion is what lets the ceiling be trusted to
+mean "the current count".
+
+See docs/audit/baseline-ratchet.md
+"#
+    );
+}
+
+#[test]
+fn audit_baseline_rows_are_unique() {
+    let fingerprints = baseline_fingerprints();
+
+    let mut seen: BTreeMap<&str, usize> = BTreeMap::new();
+    for fingerprint in &fingerprints {
+        *seen.entry(fingerprint.as_str()).or_default() += 1;
+    }
+
+    let duplicate_rows: Vec<String> = seen
+        .iter()
+        .filter(|(_, count)| **count > 1)
+        .map(|(fingerprint, count)| format!("    {count}x  {fingerprint}"))
+        .collect();
+    let duplicates = duplicate_rows.join("\n");
+    let total = fingerprints.len();
+
+    assert!(
+        duplicate_rows.is_empty(),
+        r#"
+audit baseline contains duplicate fingerprints:
+
+{duplicates}
+
+Suppression is set membership, so a duplicate row suppresses nothing extra. It
+only inflates the count this file's ratchet measures, which would let real
+suppressions be added under the ceiling by deleting duplicates first.
+
+Baselines written by `homeboy audit` are sorted and deduped, so a duplicate
+means homeboy.json was hand-edited or hand-merged.
+
+Note: rows are NOT required to be sorted, and this suite does not check order.
+Many of the current {total} rows are out of sorted position.
+"#
+    );
+}


### PR DESCRIPTION
## The finding

`baselines.audit.known_fingerprints` in `homeboy.json` holds **1,133 permanently-suppressed audit findings** — 158,623 of the file's 185,531 bytes (**85.5%**).

| Kind | n | | Kind | n |
|---|--:|---|---|--:|
| CoreBoundaryLeak | 312 | | MissingMethod | 8 |
| SkeletonDuplicate | 147 | | DuplicateFunction | 7 |
| HighItemCount | 133 | | StaleDocReference | 5 |
| ConstantBypassLiteral | 128 | | UnboundedOutputCapture | 5 |
| IntraMethodDuplicate | 114 | | ThinCommandAdapter / VacuousTest | 4 ea |
| GodFile | 94 | | DeadCodeMarker / RepeatedEnumDispatch / UnusedParameter | 3 ea |
| UnreferencedExport | 47 | | DirectorySprawl / GlobalEnvMutationGuard / LayerOwnership | 2 ea |
| CommandWrapperBypass | 37 | | BrokenDocRef / MissingInterface / NamingMismatch / ParallelRunnerSetup | 1 ea |
| NearDuplicate | 24 | | | |
| DirectAggregateConstruction / ParallelImplementation / RemoteExecutionPreflight | 15 ea | | **Total** | **1133** |

**307 are duplication findings. 227 are size findings. 47 are dead public exports.** The repo owns a 51k-LOC audit engine that already found exactly this debt, and then absorbed its own output. Nothing capped the list's growth and nothing aged entries out.

## Fingerprints are per-file+kind, never per-instance

`crates/homeboy-code-audit/src/baseline.rs:151`:
```rust
format!("{}::{}::{:?}", self.0.convention, file, self.0.kind)
```
No line number — and `Finding` *has* a `line: Option<usize>` that goes unused. Pinned deliberately by `fingerprint_ignores_description` ("fingerprint should not change when line count changes").

Matching is bare set membership, and the `seen_new.insert(fingerprint)` dedupe in `homeboy-engine-primitives/src/baseline.rs:416` exists precisely because **multiple current findings routinely collapse to one fingerprint**.

821 rows are 3-segment and cover exactly 821 distinct (file, kind) pairs — a perfect 1:1. The 312 `CoreBoundaryLeak` rows append a description, but line numbers are normalized out first.

**So 1,133 is a floor on suppressed surface, never an overestimate.**

Also: `baseline_merge.rs` resolves a conflicted `homeboy.json` by taking the **union** of both sides — a second silent growth path this closes.

## The change

Three tests in `tests/audit_baseline_ratchet_test.rs`:

- `audit_baseline_may_only_shrink` — fails if count > 1133, with a message giving ceiling, actual, overage, the shrink-only rule, three remedies, the union-merge warning, and a live per-kind breakdown
- `audit_baseline_ceiling_leaves_no_slack` — fails if count < 1133, forcing the ceiling *down* when debt is paid, so slack never becomes refill room
- `audit_baseline_rows_are_unique` — duplicates would inflate the measured count and create headroom by deletion

`include_str!("../homeboy.json")` makes the baseline a compile-time dependency, so editing it forces this test to rebuild — it cannot go stale. Root `Cargo.toml` has no `autotests = false`, so `tests/*.rs` is auto-discovered.

Plus `docs/audit/baseline-ratchet.md`.

**No baseline entries are removed.** The ratchet only stops growth; burning the 1,133 down is separate work.

## Pre-existing bug found, deliberately not fixed

`metadata.item_count` says **1137**; the array holds **1133**. `normalize_loaded_baseline` only recomputes `item_count` inside `if !section_fingerprints.is_empty()`, and the policy sections now use the `fingerprint_prefix` form with empty enumerations — so that branch never runs and the stale on-disk value survives. `compare` computes `delta = current_set.len() - baseline.item_count`, so **the reported delta is off by 4.**

It does not affect `drift_increased` (computed from the set), so suppression behaviour is correct. This PR pins the **array length**, not `item_count` — pinning a bug would be wrong. Worth a separate fix.

## Note on the equality pin

The two-test pair means a legitimate `--update-baseline` that *resolves* findings will fail CI until the ceiling is lowered. That is the intended "make it visible" behaviour, and the failure message states the exact number to write.

## Verification

`cargo check --workspace --tests -j2` clean. All three tests simulated against the real file: PASS/PASS/PASS at 1133.