### PR TITLE
fix(lab): refuse extension parity proven only by a stale git SHA

### DIFF
--- a/crates/homeboy-core/src/extension_update_check.rs
+++ b/crates/homeboy-core/src/extension_update_check.rs
@@ -95,6 +95,97 @@ pub fn read_source_revision_at(extension_dir: &Path) -> Option<String> {
     read_source_metadata_value(extension_dir, "revision")
 }
 
+/// Files Homeboy generates inside an installed extension directory. They are
+/// install-local provenance, not extension source, so they never make a
+/// checkout dirty for parity purposes.
+const GENERATED_SOURCE_METADATA: [&str; 3] =
+    [".source-url", ".source-revision", ".source-requested-ref"];
+
+/// Whether a committed revision still describes the bytes on disk.
+///
+/// A git SHA is only a faithful stand-in for extension content while the
+/// checkout is clean. Once it is dirty the SHA describes what was *committed*,
+/// not what is *there*, which is why revision-only parity silently accepts an
+/// edited-but-uncommitted extension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExtensionSourceCleanliness {
+    /// Git checkout with no uncommitted, in-scope changes: the revision is a
+    /// sound content identity.
+    Clean,
+    /// Git checkout with uncommitted changes: the revision is NOT a content
+    /// identity. `changed_paths` is repo-root-relative and capped for display.
+    Dirty { changed_paths: Vec<String> },
+    /// Not a git checkout, or git could not answer. Cleanliness is unknown, so
+    /// the revision is provenance only and local edits cannot be detected.
+    Unknown,
+}
+
+/// Maximum number of dirty paths carried into a parity diagnostic. Enough to
+/// identify what changed without pasting an entire working tree into an error.
+const MAX_REPORTED_DIRTY_PATHS: usize = 10;
+
+pub fn read_source_cleanliness(extension_id: &str) -> ExtensionSourceCleanliness {
+    let Ok(extension_dir) = paths::extension(extension_id) else {
+        return ExtensionSourceCleanliness::Unknown;
+    };
+    read_source_cleanliness_at(&extension_dir)
+}
+
+/// Classify the extension checkout at an explicit path.
+///
+/// Scoped to the extension directory itself: a monorepo of extensions must not
+/// report `rust` as dirty because `nodejs` was edited.
+pub fn read_source_cleanliness_at(extension_dir: &Path) -> ExtensionSourceCleanliness {
+    if !extension_dir.exists() {
+        return ExtensionSourceCleanliness::Unknown;
+    }
+
+    // The directory must actually be versioned by the repository that contains
+    // it. A stray enclosing repository — a home directory under version
+    // control, a temp root inside a checkout — would otherwise report every
+    // untracked extension file as an uncommitted edit. Nothing tracked here
+    // means the enclosing repository does not describe this extension, so its
+    // revision says nothing about these bytes either.
+    if git::output_optional(extension_dir, &["ls-files", "--", "."]).is_none() {
+        return ExtensionSourceCleanliness::Unknown;
+    }
+
+    let Some(status) = git::status_porcelain_scoped(extension_dir) else {
+        return ExtensionSourceCleanliness::Unknown;
+    };
+
+    let changed_paths = status
+        .lines()
+        .filter_map(dirty_path_from_status_line)
+        .filter(|path| !is_generated_source_metadata_path(path))
+        .take(MAX_REPORTED_DIRTY_PATHS)
+        .collect::<Vec<_>>();
+
+    if changed_paths.is_empty() {
+        ExtensionSourceCleanliness::Clean
+    } else {
+        ExtensionSourceCleanliness::Dirty { changed_paths }
+    }
+}
+
+fn dirty_path_from_status_line(line: &str) -> Option<String> {
+    let path = line.get(3..)?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    // Renames report `old -> new`; the new path is the one that exists now.
+    let path = path
+        .rsplit_once(" -> ")
+        .map(|(_, new_path)| new_path)
+        .unwrap_or(path);
+    Some(path.trim_matches('"').replace('\\', "/"))
+}
+
+fn is_generated_source_metadata_path(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    GENERATED_SOURCE_METADATA.contains(&name)
+}
+
 pub fn read_source_metadata_value(extension_dir: &Path, kind: &str) -> Option<String> {
     let sidecar =
         source_metadata_dir(extension_dir).join(source_metadata_file(extension_dir, kind));
@@ -141,4 +232,174 @@ fn source_metadata_file(extension_dir: &std::path::Path, kind: &str) -> String {
     }
 
     format!(".source-{kind}")
+}
+
+#[cfg(test)]
+mod cleanliness_tests {
+    use super::*;
+
+    #[test]
+    fn modified_and_untracked_status_lines_yield_paths() {
+        assert_eq!(
+            dirty_path_from_status_line(" M rust/lint.sh").as_deref(),
+            Some("rust/lint.sh")
+        );
+        assert_eq!(
+            dirty_path_from_status_line("?? rust/new-step.sh").as_deref(),
+            Some("rust/new-step.sh")
+        );
+        assert_eq!(
+            dirty_path_from_status_line("M  rust/lint.sh").as_deref(),
+            Some("rust/lint.sh")
+        );
+    }
+
+    #[test]
+    fn rename_status_lines_report_the_current_path() {
+        assert_eq!(
+            dirty_path_from_status_line("R  rust/old.sh -> rust/new.sh").as_deref(),
+            Some("rust/new.sh")
+        );
+    }
+
+    #[test]
+    fn generated_install_metadata_is_not_extension_source() {
+        assert!(is_generated_source_metadata_path(".source-url"));
+        assert!(is_generated_source_metadata_path("rust/.source-revision"));
+        assert!(is_generated_source_metadata_path(
+            "rust/.source-requested-ref"
+        ));
+        assert!(!is_generated_source_metadata_path("rust/lint.sh"));
+        assert!(!is_generated_source_metadata_path("rust/source-url.md"));
+    }
+
+    #[test]
+    fn a_missing_extension_directory_is_unknown_not_clean() {
+        let missing = Path::new("/nonexistent/homeboy/extension/for/cleanliness");
+
+        assert_eq!(
+            read_source_cleanliness_at(missing),
+            ExtensionSourceCleanliness::Unknown
+        );
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_all(path: &Path) {
+        git(path, &["init", "-b", "main"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Homeboy Test"]);
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "initial"]);
+    }
+
+    #[test]
+    fn a_non_git_extension_directory_is_unknown_not_clean() {
+        let dir = tempfile::tempdir().expect("extension dir");
+        std::fs::write(dir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+
+        assert_eq!(
+            read_source_cleanliness_at(dir.path()),
+            ExtensionSourceCleanliness::Unknown
+        );
+    }
+
+    #[test]
+    fn a_committed_extension_checkout_is_clean() {
+        let dir = tempfile::tempdir().expect("extension dir");
+        std::fs::write(dir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        commit_all(dir.path());
+
+        assert_eq!(
+            read_source_cleanliness_at(dir.path()),
+            ExtensionSourceCleanliness::Clean
+        );
+    }
+
+    #[test]
+    fn an_edited_but_uncommitted_extension_checkout_is_dirty() {
+        let dir = tempfile::tempdir().expect("extension dir");
+        std::fs::write(dir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        std::fs::write(dir.path().join("lint.sh"), "echo committed\n").expect("step");
+        commit_all(dir.path());
+        std::fs::write(dir.path().join("lint.sh"), "echo edited\n").expect("edit");
+
+        assert_eq!(
+            read_source_cleanliness_at(dir.path()),
+            ExtensionSourceCleanliness::Dirty {
+                changed_paths: vec!["lint.sh".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn generated_install_metadata_does_not_make_a_checkout_dirty() {
+        let dir = tempfile::tempdir().expect("extension dir");
+        std::fs::write(dir.path().join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+        commit_all(dir.path());
+        std::fs::write(dir.path().join(".source-url"), "https://example.test/rust")
+            .expect("source url");
+        std::fs::write(dir.path().join(".source-revision"), "abc123").expect("source revision");
+        std::fs::write(dir.path().join(".source-requested-ref"), "main").expect("requested ref");
+
+        assert_eq!(
+            read_source_cleanliness_at(dir.path()),
+            ExtensionSourceCleanliness::Clean
+        );
+    }
+
+    /// A repository that merely encloses the extension directory without
+    /// tracking any of it does not describe those bytes, so cleanliness is
+    /// unknown rather than dirty. Without this, an untracked extension under a
+    /// version-controlled home would fail parity on every dispatch.
+    #[test]
+    fn an_untracked_directory_inside_an_enclosing_repo_is_unknown_not_dirty() {
+        let repo = tempfile::tempdir().expect("enclosing repo");
+        std::fs::write(repo.path().join("README.md"), "enclosing\n").expect("readme");
+        commit_all(repo.path());
+        let extension_dir = repo.path().join("untracked/extensions/rust");
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::write(extension_dir.join("rust.json"), r#"{"id":"rust"}"#).expect("manifest");
+
+        assert_eq!(
+            read_source_cleanliness_at(&extension_dir),
+            ExtensionSourceCleanliness::Unknown
+        );
+    }
+
+    #[test]
+    fn a_dirty_sibling_extension_does_not_make_this_extension_dirty() {
+        let repo = tempfile::tempdir().expect("monorepo");
+        let rust = repo.path().join("rust");
+        let nodejs = repo.path().join("nodejs");
+        std::fs::create_dir_all(&rust).expect("rust dir");
+        std::fs::create_dir_all(&nodejs).expect("nodejs dir");
+        std::fs::write(rust.join("lint.sh"), "echo rust\n").expect("rust step");
+        std::fs::write(nodejs.join("lint.sh"), "echo nodejs\n").expect("nodejs step");
+        commit_all(repo.path());
+        std::fs::write(nodejs.join("lint.sh"), "echo edited\n").expect("edit sibling");
+
+        assert_eq!(
+            read_source_cleanliness_at(&rust),
+            ExtensionSourceCleanliness::Clean
+        );
+        assert_eq!(
+            read_source_cleanliness_at(&nodejs),
+            ExtensionSourceCleanliness::Dirty {
+                changed_paths: vec!["nodejs/lint.sh".to_string()]
+            }
+        );
+    }
 }

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -92,8 +92,8 @@ pub use primitives::{is_git_repo, is_tracked_path};
 pub use primitives_query::{
     current_branch, head_sha, head_sha_short, head_sha_within, output_allow_empty, output_optional,
     output_optional_bytes, output_optional_within, remote_origin_url, remote_url, repo_root,
-    rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
-    BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
+    rev_parse, short_head_revision, status_porcelain, status_porcelain_bytes,
+    status_porcelain_scoped, toplevel, BoundedGitRead, DEFAULT_GIT_READ_PROBE_TIMEOUT,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/homeboy-core/src/git/primitives_query.rs
+++ b/crates/homeboy-core/src/git/primitives_query.rs
@@ -163,6 +163,23 @@ pub fn status_porcelain_bytes(git_root: &Path) -> Option<Vec<u8>> {
     output_optional_bytes(git_root, &["status", "--porcelain=v1", "-z"])
 }
 
+/// Get porcelain status text limited to `dir` itself rather than the whole
+/// repository.
+///
+/// `git status` reports the entire repository no matter which subdirectory it
+/// runs from. Callers that ask "did *this* directory change" — a single
+/// extension inside a monorepo checkout of many extensions, for example — need
+/// the `-- .` pathspec so an unrelated sibling's edits do not answer for it.
+/// Paths in the output stay repo-root-relative, as porcelain always reports
+/// them.
+///
+/// Returns `None` when `dir` is not inside a git repository or git could not
+/// answer; `Some("")` is a clean, in-scope tree.
+pub fn status_porcelain_scoped(dir: &Path) -> Option<String> {
+    output_optional_bytes(dir, &["status", "--porcelain=v1", "--", "."])
+        .map(|output| String::from_utf8_lossy(&output).to_string())
+}
+
 /// Get porcelain status text from a git directory.
 pub fn status_porcelain(git_root: &Path) -> Option<String> {
     output_optional_bytes(git_root, &["status", "--porcelain=v1"])

--- a/crates/homeboy-lab-runner/src/execution/extension_parity.rs
+++ b/crates/homeboy-lab-runner/src/execution/extension_parity.rs
@@ -889,27 +889,38 @@ fn validate_runner_extension_revision(
         );
     }
 
-    let local_revision = homeboy_core::extension_update_check::read_source_revision(extension_id);
-    let remote_revision = remote_extension_source_revision(remote_stdout);
-    if matches!(
-        (
-            local_revision
-                .as_deref()
-                .filter(|revision| !revision.trim().is_empty()),
-            remote_revision
-                .as_deref()
-                .filter(|revision| !revision.trim().is_empty()),
-        ),
-        (Some(local), Some(remote)) if local == remote
-    ) {
-        return Ok(());
+    let local_revision = homeboy_core::extension_update_check::read_source_revision(extension_id)
+        .filter(|revision| !revision.trim().is_empty());
+    let remote_revision = remote_extension_source_revision(remote_stdout)
+        .filter(|revision| !revision.trim().is_empty());
+
+    // Content identity is the parity gate; the git revision is provenance.
+    //
+    // A committed SHA only describes the bytes on disk while the controller
+    // checkout is clean. Edit an extension without committing and both sides
+    // still report the same SHA, so revision-only parity passed and the Lab
+    // silently ran the *committed* code instead of the edited code. A dirty
+    // controller checkout is therefore stale parity by definition, whatever the
+    // revisions say.
+    let cleanliness = homeboy_core::extension_update_check::read_source_cleanliness(extension_id);
+    if let homeboy_core::extension_update_check::ExtensionSourceCleanliness::Dirty {
+        changed_paths,
+    } = &cleanliness
+    {
+        return Err(uncommitted_controller_extension_source_error(
+            runner_id,
+            homeboy_path,
+            extension_id,
+            local_revision.as_deref(),
+            remote_revision.as_deref(),
+            changed_paths,
+        ));
     }
 
-    let Some(local_revision) = local_revision.filter(|revision| !revision.trim().is_empty()) else {
+    let Some(local_revision) = local_revision else {
         return Ok(());
     };
-    let Some(remote_revision) = remote_revision.filter(|revision| !revision.trim().is_empty())
-    else {
+    let Some(remote_revision) = remote_revision else {
         return Err(Error::validation_invalid_argument(
             "runner_extension",
             format!(
@@ -927,6 +938,7 @@ fn validate_runner_extension_revision(
     };
 
     if local_revision == remote_revision {
+        warn_revision_only_extension_parity(runner_id, extension_id, &local_revision, &cleanliness);
         return Ok(());
     }
 
@@ -944,6 +956,87 @@ fn validate_runner_extension_revision(
             ),
         ]),
     ))
+}
+
+/// Warn when parity rested on the revision alone.
+///
+/// A non-git extension install (monorepo extraction, snapshot install) has no
+/// working tree to inspect, so matching revisions are the only evidence
+/// available and an uncommitted local edit is undetectable. Say so rather than
+/// letting the operator read a silent pass as a content guarantee.
+fn warn_revision_only_extension_parity(
+    runner_id: &str,
+    extension_id: &str,
+    local_revision: &str,
+    cleanliness: &homeboy_core::extension_update_check::ExtensionSourceCleanliness,
+) {
+    if !matches!(
+        cleanliness,
+        homeboy_core::extension_update_check::ExtensionSourceCleanliness::Unknown
+    ) {
+        return;
+    }
+
+    eprintln!(
+        "warning: runner '{runner_id}' extension parity for '{extension_id}' was verified by revision only ({local_revision}). The controller-local extension is not a git checkout, so uncommitted local edits cannot be detected and the runner may execute different bytes. Use `homeboy runner dev-sync {runner_id} --extensions {extension_id}=<source-path>` to pin parity by content hash."
+    );
+}
+
+/// The controller-local extension has uncommitted edits, so its revision is not
+/// a content identity and the runner is holding the committed bytes instead.
+///
+/// Reported as stale parity on purpose: that classification routes into the
+/// existing auto-materialization path, which snapshots the actual controller
+/// bytes onto the runner and records a content-hash dev overlay. Subsequent
+/// dispatches then validate by content hash rather than revision.
+fn uncommitted_controller_extension_source_error(
+    runner_id: &str,
+    homeboy_path: &str,
+    extension_id: &str,
+    local_revision: Option<&str>,
+    remote_revision: Option<&str>,
+    changed_paths: &[String],
+) -> Error {
+    let local_revision = local_revision.unwrap_or("<missing>");
+    let remote_revision = remote_revision.unwrap_or("<missing>");
+    let dev_sync_command = format!(
+        "homeboy runner dev-sync {} --extensions {}=<source-path>",
+        shell::quote_arg(runner_id),
+        shell::quote_arg(extension_id)
+    );
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument 'runner_extension': Runner '{runner_id}' has stale extension parity for '{extension_id}' before command execution because the controller-local extension has uncommitted changes"
+        ),
+        serde_json::json!({
+            "field": "runner_extension",
+            "problem": "controller_extension_source_uncommitted",
+            "id": extension_id,
+            "diagnostic": {
+                "code": "runner_extension.controller_source_uncommitted",
+                "location": "controller",
+                "runner_id": runner_id,
+                "extension_id": extension_id,
+                "homeboy_path": homeboy_path,
+                "local_source_revision": local_revision,
+                "runner_extension_source_revision": remote_revision,
+                "uncommitted_paths": changed_paths,
+                "remediation_command": dev_sync_command,
+            },
+            "tried": [
+                format!("Local extension source_revision (provenance only): {local_revision}"),
+                format!("Runner extension source_revision (provenance only): {remote_revision}"),
+                format!(
+                    "Controller-local extension has uncommitted changes: {}",
+                    changed_paths.join(", ")
+                ),
+                "Matching revisions do not prove matching content: the runner holds the committed bytes, not the edited ones.",
+                format!("Sync the working bytes to the runner before dispatch: {dev_sync_command}"),
+                format!("Or commit the edits so the revision describes them: {homeboy_path} extension update {extension_id}"),
+            ]
+        }),
+    )
 }
 
 fn validate_dev_overlay_extension_revision(
@@ -1133,14 +1226,14 @@ mod tests {
     use super::{
         controller_extension_metadata_required_error, controller_local_source_path,
         dev_sync_extension_overlay, ensure_extension_materialized,
-        ensure_extension_materialized_with_exec, plan_extension_parity,
-        record_materialized_extension_overlay, remote_extension_core_compatibility,
-        remote_extension_ready_status, remote_extension_setting_ids,
-        remote_extension_source_revision, requested_setting_keys_for_command,
-        runner_extension_sync_command, validate_extension_ready,
-        validate_runner_extension_core_compatibility, validate_runner_extension_ready,
-        validate_runner_extension_revision, validate_runner_extension_settings,
-        ExtensionParityPlan, ExtensionParityPlanStep,
+        ensure_extension_materialized_with_exec, is_stale_runner_extension_parity_error,
+        plan_extension_parity, record_materialized_extension_overlay,
+        remote_extension_core_compatibility, remote_extension_ready_status,
+        remote_extension_setting_ids, remote_extension_source_revision,
+        requested_setting_keys_for_command, runner_extension_sync_command,
+        validate_extension_ready, validate_runner_extension_core_compatibility,
+        validate_runner_extension_ready, validate_runner_extension_revision,
+        validate_runner_extension_settings, ExtensionParityPlan, ExtensionParityPlanStep,
     };
     use homeboy_core::test_support::with_isolated_home;
 
@@ -1746,6 +1839,178 @@ mod tests {
         });
     }
 
+    fn git(path: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Commit an extension checkout and return its HEAD SHA, which is what both
+    /// sides report as `source_revision`.
+    fn commit_extension_checkout(dir: &std::path::Path) -> String {
+        git(dir, &["init", "-b", "main"]);
+        git(dir, &["config", "user.email", "test@example.com"]);
+        git(dir, &["config", "user.name", "Homeboy Test"]);
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-m", "initial"]);
+        let output = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(dir)
+            .output()
+            .expect("run git rev-parse");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn extension_show_stdout(extension_id: &str, source_revision: &str) -> String {
+        format!(
+            r#"{{"success":true,"data":{{"extension":{{"id":"{extension_id}","ready":true,"source_revision":"{source_revision}"}}}}}}"#
+        )
+    }
+
+    /// The bug this gate exists to catch: different bytes, same commit.
+    ///
+    /// Edit an extension locally without committing and both sides still report
+    /// the same SHA, so revision-only parity passed and the Lab ran the
+    /// committed code instead of the edited code.
+    #[test]
+    fn revision_parity_rejects_uncommitted_controller_extension_edits() {
+        with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/wordpress");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("wordpress.json"),
+                r#"{"id":"wordpress"}"#,
+            )
+            .expect("manifest");
+            fs::write(extension_dir.join("lint.sh"), "echo committed\n").expect("step");
+            let revision = commit_extension_checkout(&extension_dir);
+            fs::write(extension_dir.join("lint.sh"), "echo edited\n").expect("uncommitted edit");
+            let remote_stdout = extension_show_stdout("wordpress", &revision);
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
+
+            let err = validate_runner_extension_revision(
+                "homeboy-lab",
+                &runner,
+                "homeboy",
+                "wordpress",
+                &remote_stdout,
+            )
+            .expect_err("uncommitted controller edits must not pass parity on a matching revision");
+
+            assert_eq!(
+                err.details["diagnostic"]["code"],
+                "runner_extension.controller_source_uncommitted"
+            );
+            assert_eq!(err.details["diagnostic"]["uncommitted_paths"][0], "lint.sh");
+            // The revision is still recorded, as provenance.
+            assert_eq!(
+                err.details["diagnostic"]["local_source_revision"],
+                revision.as_str()
+            );
+            assert_eq!(
+                err.details["diagnostic"]["runner_extension_source_revision"],
+                revision.as_str()
+            );
+            // Classified as stale parity so the existing auto-materialization
+            // path picks it up and snapshots the working bytes to the runner.
+            assert!(is_stale_runner_extension_parity_error(&err));
+        });
+    }
+
+    #[test]
+    fn revision_parity_accepts_a_clean_controller_extension_checkout() {
+        with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/wordpress");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("wordpress.json"),
+                r#"{"id":"wordpress"}"#,
+            )
+            .expect("manifest");
+            fs::write(extension_dir.join("lint.sh"), "echo committed\n").expect("step");
+            let revision = commit_extension_checkout(&extension_dir);
+            let remote_stdout = extension_show_stdout("wordpress", &revision);
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
+
+            validate_runner_extension_revision(
+                "homeboy-lab",
+                &runner,
+                "homeboy",
+                "wordpress",
+                &remote_stdout,
+            )
+            .expect("a clean checkout at the runner's revision is genuine parity");
+        });
+    }
+
+    /// Homeboy writes `.source-url` / `.source-revision` / `.source-requested-ref`
+    /// into installed extension directories. They are install-local provenance,
+    /// not extension source, and must never be read as uncommitted edits.
+    #[test]
+    fn revision_parity_ignores_generated_install_metadata_when_classifying_edits() {
+        with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/wordpress");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("wordpress.json"),
+                r#"{"id":"wordpress"}"#,
+            )
+            .expect("manifest");
+            let revision = commit_extension_checkout(&extension_dir);
+            fs::write(
+                extension_dir.join(".source-url"),
+                "https://example.test/wordpress",
+            )
+            .expect("source url");
+            fs::write(extension_dir.join(".source-requested-ref"), "main").expect("requested ref");
+            let remote_stdout = extension_show_stdout("wordpress", &revision);
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
+
+            validate_runner_extension_revision(
+                "homeboy-lab",
+                &runner,
+                "homeboy",
+                "wordpress",
+                &remote_stdout,
+            )
+            .expect("generated install metadata is not an uncommitted source edit");
+        });
+    }
+
+    /// Backward compatibility: a non-git install (monorepo extraction, snapshot
+    /// install, or any runner/controller predating content-addressed parity)
+    /// has no working tree to inspect. Parity falls back to the revision and
+    /// warns that uncommitted local edits cannot be detected.
+    #[test]
+    fn revision_parity_falls_back_to_revision_for_a_non_git_controller_extension() {
+        with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/wordpress");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(extension_dir.join(".source-revision"), "abc123\n").expect("revision");
+            let remote_stdout = extension_show_stdout("wordpress", "abc123");
+            let runner = runner_with_overlay("other", "/tmp/other", "unused");
+
+            validate_runner_extension_revision(
+                "homeboy-lab",
+                &runner,
+                "homeboy",
+                "wordpress",
+                &remote_stdout,
+            )
+            .expect("revision-only parity still passes when cleanliness is unknowable");
+        });
+    }
+
+    /// Same bytes, different commit: already the contract on the dev-overlay
+    /// path, which is content-addressed rather than revision-addressed.
     #[test]
     fn revision_parity_accepts_matching_dev_overlay_content_hash() {
         let tempdir = tempfile::tempdir().expect("source dir");


### PR DESCRIPTION
> **Reviewer: this PR does NOT do what its branch name says, and that is deliberate. Please read section 1.**

## The reported bug

Edit an extension's files locally, don't commit → the Lab **silently runs the old code**. No error, no warning.

Cause: `validate_runner_extension_revision` compares committed git SHAs (`read_source_revision` → `git::head_sha`). An uncommitted edit doesn't move the SHA, so parity passes.

## 1. Why content hash is NOT the cross-machine default

The task was "make content hash the default." I traced it and **it is unsound**, so I did not.

`remote_stdout` comes from `<homeboy> extension show <id>` on the runner, which serializes `ExtensionDetail`: `source_revision`, `path`, `ready*`, `settings`, `core_compatibility`. **No content hash.** Adding one is trivial. Making it a sound *gate* is not, because **the two directories are not byte-comparable:**

- **Homeboy writes install-local metadata inside the extension dir.** `write_source_metadata` writes `.source-url`/`.source-revision`, `write_requested_source_ref` writes `.source-requested-ref` — but only when the dir is not a symlink. A linked controller extension puts them in the parent; a git-cloned runner install puts them inside. **Guaranteed divergence.** `is_generated_extension_metadata_path` exists precisely because these are generated noise.
- **`extension setup` runs with `cwd` = the extension dir** and can write into it. The existing fixture literally does `printf setup >> setup-count.txt`.
- **The hash includes dependency trees.** `controller_snapshot_ignores_appledouble_metadata` hashes a tree containing `node_modules/eslint-plugin-jest/...`. A macOS controller and a Linux runner will never produce identical npm/venv/build trees.

A hard content-hash gate would fail parity on essentially every real dispatch — and not benignly: stale parity routes into `ensure_extension_materialized`, so you'd get a full re-sync on every dispatch that then *still* fails, because the hash can never converge. **Worse product than the bug.**

The dev-overlay path gets away with content hashing because it **is not a remote comparison**: it compares the controller's current hash against the hash recorded *at sync time*. Making that universal means making controller snapshots the universal materialization mechanism — the six-mechanism consolidation, explicitly out of scope here.

## 2. What this does instead

The root cause is controller-local: **a git SHA is only a valid content proxy while the checkout is clean.** Once dirty, the SHA describes what was committed, not what is there. So a SHA is no longer accepted as parity proof on its own.

- New `read_source_cleanliness{,_at}` → `Clean | Dirty { changed_paths } | Unknown`
- `Dirty` → `runner_extension.controller_source_uncommitted`, listing the offending paths, with both revisions recorded as provenance
- The message contains `"stale extension parity"` on purpose, so `is_stale_runner_extension_parity_error` routes it into existing auto-materialization. For a linked/local-path extension — the dev-iteration case — that snapshots the **working** bytes onto the runner and records a content-hash dev overlay. Both call sites reload the runner and re-validate, so it **converges within the same dispatch**, and every subsequent dispatch validates by content hash. That is the rapid-iteration loop, closed.

Dirt detection is deliberately narrow: scoped `-- .` (a dirty sibling in an extensions monorepo must not fail `rust`), ignores the three generated `.source-*` files, and requires the dir to be tracked so a stray ancestor checkout can't report everything as edited.

## 3. Compatibility

The wire protocol is **unchanged** — `extension show` still emits only `source_revision`, and the new check is entirely controller-local. A controller running this against any runner, new or old, behaves exactly as before **unless its own checkout is dirty**. No version negotiation, no hard-fail-against-older-runner path. Where cleanliness can't be established (non-git install, snapshot install, untracked dir) the result is `Unknown` and falls through to the existing comparison with a diagnostic: *"verified by revision only ... uncommitted local edits cannot be detected"*, plus the `runner dev-sync` remediation.

## 4. ⚠️ Behaviour change with real blast radius — reviewer decision

An extension installed from a **remote git URL** with a **dirty controller checkout** now hard-fails dispatch instead of silently running old code. Materialization picks `RemoteGit` and re-checks-out the committed SHA, which **cannot converge**.

Loud failure beats silently-wrong, but **it will block someone.** I deliberately did *not* add "coerce dirty → ControllerSnapshot" (which would self-heal) because that means rsyncing an *installed* dir, with its `.source-*` and setup artifacts, rather than a source dir. That is a good next PR; it is not this one.

Same shape: a git checkout with no resolvable source URL now hits `controller_extension_metadata_required` on a dirty tree where it previously passed silently.

**Also:** untracked files count as dirt (justified — `is_extension_update_workdir_clean` already applies that predicate to the same directories). If a real extension's `setup` drops a non-gitignored artifact into its own directory, it will fail parity every dispatch. The error names the exact paths, so it is a one-look diagnosis, but watch for it.

## Deferred

- **Keyed-map dev_sync overlays** — persisted operator state (`schema: homeboy/runner-dev-sync/v1`) with two independent writers. Needs a write-migration or a tolerant read side that keeps `overlay_is_newer` anyway. Not small, not safe.
- **The `git status` call is unbounded.** `BoundedGitRead` exists, but `output_optional_within` collapses "clean tree" (empty stdout) into `Unresolved`, and the adjacent `read_source_revision` already does an unbounded `git rev-parse` on the same dir — so the hang-exposure class is unchanged. Still two extra unbounded `git` invocations per extension per parity check.
- **Duplication:** `git_dirty`/`git_dirty_fingerprint` already exist in `extension_materialization.rs:852` (unscoped, unfiltered) and *record* dirtiness without gating on it. Consolidation is a follow-up.

## Tests

4 in `extension_parity.rs` (uncommitted edit → **fail** with provenance and stale classification; clean checkout at runner's revision → pass; generated install metadata ignored; non-git install → revision-only fallback) and 7 in `extension_update_check.rs` (status-line parsing, clean/dirty/non-git, generated metadata, monorepo scoping, untracked-under-enclosing-repo).

## Verification

`cargo check --workspace --tests -j2` clean.