### PR TITLE
Materialize runner exec script files

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -425,8 +425,8 @@ pub(super) enum RunnerCommand {
         #[arg(long = "require-path")]
         require_paths: Vec<String>,
 
-        /// Read a shell script from this path and execute it on the runner with bash.
-        /// Use `-` to read the script from stdin; stdin must contain at least one byte.
+        /// Read a shell script from this path and execute its materialized runner copy with bash.
+        /// Use `-` to read stdin on the controller; it is captured with the same bounded semantics.
         /// Whitespace-only scripts are executed verbatim.
         #[arg(long = "script-file")]
         script_file: Option<String>,

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -9,6 +9,7 @@ use homeboy::core::source_snapshot::SourceSnapshot;
 use homeboy::core::stream_capture::StreamCaptureMetadata;
 use homeboy::core::Error;
 use homeboy::runner::runners::{self as runner, RunnerExecOutput, RunnerKind};
+use homeboy_engine_primitives::content_hash;
 
 use super::super::CmdResult;
 
@@ -467,13 +468,37 @@ pub(super) fn prepare_runner_exec_command(
         (true, true) => Ok(vec![
             "bash".to_string(),
             "-c".to_string(),
-            format!(
-                "printf '%s' {} | bash -s",
-                shell::quote_arg(script.expect("script is present"))
-            ),
+            runner_exec_script_wrapper(script.expect("script is present")),
         ]),
         (false, false) => Ok(command),
     }
+}
+
+/// Build the runner-side script lifecycle wrapper. `HOMEBOY_RUNNER_JOB_ID` is
+/// injected after daemon admission, so the path is stable for a durable job
+/// without trusting a controller-provided temporary path.
+fn runner_exec_script_wrapper(script: &str) -> String {
+    let digest = content_hash::sha256_hex(script.as_bytes());
+    format!(
+        r#"set -e
+job_id="${{HOMEBOY_RUNNER_JOB_ID:-local-$$}}"
+case "$job_id" in
+  ''|*[!A-Za-z0-9._-]*) job_id="local-$$" ;;
+esac
+script_root="${{XDG_RUNTIME_DIR:-/tmp}}/homeboy-runner-exec/$job_id"
+(umask 077; mkdir -p "$script_root")
+chmod 700 "$script_root"
+script_path="$script_root/script-{digest}.sh"
+cleanup() {{ rm -f "$script_path"; rmdir "$script_root" 2>/dev/null || true; }}
+trap cleanup EXIT
+umask 077
+printf '%s' {} > "$script_path"
+chmod 500 "$script_path"
+export HOMEBOY_RUNNER_EXEC_SCRIPT="$script_path"
+export HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256="sha256:{digest}"
+bash "$script_path""#,
+        shell::quote_arg(script),
+    )
 }
 
 /// Validate only CLI-provided shape before a script source is opened. In

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -370,16 +370,60 @@ fn script_file_accepts_whitespace_only_and_preserves_non_empty_newlines() {
 }
 
 #[test]
-fn script_file_prepares_bash_stdin_command() {
-    let command = prepare_runner_exec_command(Some(&"echo '$GREETING'".to_string()), Vec::new())
-        .expect("script command");
+fn script_file_materializes_a_content_addressed_file_for_bash() {
+    let source = "printf '%s\\n%s\\n%s' \"$0\" \"$HOMEBOY_RUNNER_EXEC_SCRIPT\" \"$HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256\"";
+    let command =
+        prepare_runner_exec_command(Some(&source.to_string()), Vec::new()).expect("script command");
 
     assert_eq!(command[0], "bash");
     assert_eq!(command[1], "-c");
-    assert!(command[2].contains("printf '%s'"));
-    assert!(command[2].contains("bash -s"));
-    assert!(!command[2].contains("HOMEBOY_RUNNER_EXEC_SCRIPT"));
-    assert!(command[2].contains("'echo '\\''$GREETING'\\'''"));
+    assert!(command[2].contains("script-"));
+    assert!(command[2].contains("HOMEBOY_RUNNER_JOB_ID"));
+    assert!(command[2].contains("HOMEBOY_RUNNER_EXEC_SCRIPT"));
+    assert!(command[2].contains("HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256"));
+    assert!(command[2].contains("chmod 500"));
+    assert!(command[2].contains("trap cleanup EXIT"));
+    assert!(!command[2].contains("bash -s"));
+
+    let output = std::process::Command::new(&command[0])
+        .args(&command[1..])
+        .env("HOMEBOY_RUNNER_JOB_ID", "test-job")
+        .output()
+        .expect("run materialized script command");
+    assert!(output.status.success());
+    let lines = String::from_utf8(output.stdout)
+        .expect("script output")
+        .lines()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0], lines[1]);
+    assert!(lines[0].contains("homeboy-runner-exec/test-job/script-"));
+    assert_eq!(
+        lines[2],
+        format!(
+            "sha256:{}",
+            homeboy_engine_primitives::content_hash::sha256_hex(source.as_bytes())
+        )
+    );
+    assert!(!std::path::Path::new(&lines[0]).exists());
+}
+
+#[test]
+fn materialized_script_preserves_bash_exit_status() {
+    let source = "printf '%s' \"$HOMEBOY_RUNNER_EXEC_SCRIPT\"; exit 17";
+    let command =
+        prepare_runner_exec_command(Some(&source.to_string()), Vec::new()).expect("script command");
+
+    let output = std::process::Command::new(&command[0])
+        .args(&command[1..])
+        .env("HOMEBOY_RUNNER_JOB_ID", "test-failure")
+        .output()
+        .expect("run materialized script command");
+
+    assert_eq!(output.status.code(), Some(17));
+    let script_path = String::from_utf8(output.stdout).expect("script path");
+    assert!(!std::path::Path::new(&script_path).exists());
 }
 
 #[test]

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -864,7 +864,9 @@ homeboy runner env <runner-id>
 
 `exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
 
-`--script-file -` reads stdin verbatim and requires at least one byte. Zero-byte stdin is a validation error before Homeboy builds or submits a runner execution plan. Whitespace-only stdin is valid and is passed to Bash verbatim, including newlines.
+`--script-file <path>` reads the controller-side source, then materializes it as a private, content-addressed `script-<sha256>.sh` under `${XDG_RUNTIME_DIR:-/tmp}/homeboy-runner-exec/<job-id>/` on the runner. Bash executes that file directly, so `$0` is its runner path. The job exports `HOMEBOY_RUNNER_EXEC_SCRIPT` with the same path and `HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256` as `sha256:<digest>`; the wrapper records the digest in its durable command evidence, makes the file mode `0500`, and removes it when the runner job exits.
+
+`--script-file -` reads stdin verbatim on the controller with the same bounded capture and materialization behavior; it does not stream stdin through `bash -s`. Zero-byte stdin is a validation error before Homeboy builds or submits a runner execution plan. Whitespace-only stdin is valid and is materialized verbatim, including newlines.
 
 Place Homeboy options before the runner ID and use `--` before the remote command. Without the separator, Homeboy diagnoses known exec options that appear after a remote command; the separator preserves remote flags with names such as `--cwd`, `--raw`, and `--run-id`.
 


### PR DESCRIPTION
## Summary
- Materialize runner exec --script-file sources as private content-addressed runner files and execute Bash against the file.
- Expose HOMEBOY_RUNNER_EXEC_SCRIPT and HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256, preserve - controller-stdin capture semantics, and clean files on process exit.
- Cover path, digest, cleanup, and exit-status behavior; document the contract.

Closes #11769

## Verification
- cargo fmt --check
- cargo test -p homeboy-cli commands::runner::tests::exec --lib
- cargo clippy -p homeboy-cli --lib --tests -- -D warnings (blocked by existing clippy::manual_inspect findings in crates/homeboy-lab-runner/src/execution/broker.rs:440 and crates/homeboy-lab-runner/src/execution/daemon.rs:395)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect the runner execution flow, implement the materialized script lifecycle, add focused tests, and update documentation. Chris Huber remains responsible for every line.