### PR TITLE
Fix controller-owned runner convergence lease

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -100,6 +100,34 @@ thread_local! {
     // Direct reentrancy is deliberately capability-based. A matching PID alone
     // is not ownership evidence because PIDs are reusable after a restart.
     static LOCAL_LEASE_CAPABILITIES: RefCell<Vec<SubprocessLeaseCapability>> = const { RefCell::new(Vec::new()) };
+    // A primary owner can grant a nested in-process operation authority for one
+    // distinct target without exposing that authority to unrelated operations.
+    static LOCAL_LEASE_DELEGATIONS: RefCell<Vec<LocalLeaseDelegation>> = const { RefCell::new(Vec::new()) };
+}
+
+#[derive(Debug, Clone)]
+struct LocalLeaseDelegation {
+    capability: SubprocessLeaseCapability,
+    target: String,
+}
+
+struct LocalLeaseDelegationGuard(Vec<LocalLeaseDelegation>);
+
+impl Drop for LocalLeaseDelegationGuard {
+    fn drop(&mut self) {
+        LOCAL_LEASE_DELEGATIONS.with(|delegations| {
+            let mut delegations = delegations.borrow_mut();
+            for expected in self.0.iter().rev() {
+                if let Some(index) = delegations.iter().rposition(|delegation| {
+                    delegation.target == expected.target
+                        && delegation.capability.owner_pid == expected.capability.owner_pid
+                        && delegation.capability.capability == expected.capability.capability
+                }) {
+                    delegations.remove(index);
+                }
+            }
+        });
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -450,6 +478,53 @@ where
 }
 
 impl RuntimePromotionLease {
+    /// Run one nested local operation against a distinct target under this
+    /// lease. The authority is thread-local and scoped to `operation`.
+    pub fn with_local_targets<T>(
+        &self,
+        targets: &[String],
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        self.assert_generation()?;
+        let capability = SubprocessLeaseCapability {
+            owner_pid: self.owner_pid,
+            owner_linux_starttime_ticks: crate::process::linux_process_starttime_ticks(
+                self.owner_pid,
+            )
+            .ok()
+            .flatten(),
+            owner_process_start_identity: crate::process::process_start_identity(self.owner_pid)
+                .ok()
+                .flatten(),
+            target: self.target.clone(),
+            generation: self.generation.clone(),
+            capability: self.capability.clone(),
+        };
+        let delegations = targets
+            .iter()
+            .map(|target| LocalLeaseDelegation {
+                capability: capability.clone(),
+                target: target.clone(),
+            })
+            .collect::<Vec<_>>();
+        LOCAL_LEASE_DELEGATIONS.with(|active| active.borrow_mut().extend(delegations.clone()));
+        let _delegation = LocalLeaseDelegationGuard(delegations);
+        let result = operation();
+        self.assert_generation()?;
+        result
+    }
+
+    /// Run one nested local operation against a distinct target under this
+    /// lease. The authority is thread-local and scoped to `operation`.
+    pub fn with_local_target<T>(
+        &self,
+        target: impl Into<String>,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        let target = target.into();
+        self.with_local_targets(&[target], operation)
+    }
+
     /// Explicitly authorize one Homeboy subprocess to join this transaction.
     /// Callers must use this immediately before spawning the participating
     /// Homeboy command rather than relying on unrelated runtime environment.
@@ -742,15 +817,22 @@ fn authorizes_local_reentrancy(
     target: &str,
     generation: &str,
 ) -> bool {
+    let owns_held_lease = |capability: &SubprocessLeaseCapability| {
+        capability.owner_pid == held.pid
+            && capability.owner_linux_starttime_ticks == held.linux_starttime_ticks
+            && capability.owner_process_start_identity == held.process_start_identity
+            && capability.target == held.target
+            && capability.generation == held.generation
+            && capability.capability == held.capability
+    };
     LOCAL_LEASE_CAPABILITIES.with(|capabilities| {
         capabilities.borrow().iter().any(|capability| {
-            capability.owner_pid == held.pid
-                && capability.owner_linux_starttime_ticks == held.linux_starttime_ticks
-                && capability.owner_process_start_identity == held.process_start_identity
-                && capability.target == held.target
-                && capability.generation == held.generation
-                && capability.capability == held.capability
-                && target == held.target
+            owns_held_lease(capability) && target == held.target && generation == held.generation
+        })
+    }) || LOCAL_LEASE_DELEGATIONS.with(|delegations| {
+        delegations.borrow().iter().any(|delegation| {
+            owns_held_lease(&delegation.capability)
+                && delegation.target == target
                 && generation == held.generation
         })
     })
@@ -1523,6 +1605,26 @@ mod tests {
             ]);
             lease.authorize_subprocess(&mut child);
             assert!(child.status().expect("run authorized child").success());
+        });
+    }
+
+    #[test]
+    fn controller_lease_delegates_only_selected_runner_targets() {
+        crate::test_support::with_isolated_home(|_| {
+            let lease = acquire("controller upgrade", "active controller")
+                .expect("controller owns promotion lease");
+            assert!(acquire("runner daemon disconnect", "lab").is_err());
+
+            lease
+                .with_local_target("lab", || {
+                    acquire("runner daemon disconnect", "lab")?;
+                    acquire("runner daemon reconnect", "lab")?;
+                    assert!(acquire("runner daemon reconnect", "other").is_err());
+                    Ok(())
+                })
+                .expect("selected runner can reenter controller promotion");
+
+            assert!(acquire("runner daemon reconnect", "lab").is_err());
         });
     }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -1364,7 +1364,10 @@ fn build_identity_commit(identity: &str) -> Option<&str> {
 /// immediately releases an admission against the reconnected session's own
 /// lease, so success guarantees the next handoff converges onto the same
 /// endpoint.
-fn probe_reconnected_admission_readiness(runner_id: &str, identity_commit: &str) -> Result<()> {
+pub(crate) fn probe_reconnected_admission_readiness(
+    runner_id: &str,
+    identity_commit: &str,
+) -> Result<()> {
     let session = super::connection::status_for_admission(runner_id)?
         .session
         .filter(|session| session.mode == super::RunnerTunnelMode::DirectSsh);

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -44,6 +44,14 @@ pub fn reconnect_runner_daemon(runner_id: &str) -> Result<(String, Option<String
     let (report, exit_code) = runner::connect(runner_id)?;
     if exit_code == 0 && report.connected {
         let homeboy_version = report.homeboy_version;
+        crate::homeboy_refresh::probe_reconnected_admission_readiness(
+            runner_id,
+            report
+                .homeboy_build_identity
+                .as_deref()
+                .or(homeboy_version.as_deref())
+                .unwrap_or("the upgraded runner"),
+        )?;
         return Ok((
             format!(
                 "connected runner daemon restarted after upgrade; session reports {}",

--- a/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
@@ -63,6 +63,7 @@ impl RunnerUpgradeProvider for RunnerUpgrade {
         expected_controller_identity: Option<&str>,
         runner_targets: &[String],
         extension_updates: &[ExtensionUpgradeEntry],
+        promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
         upgrade_configured_runners_with_explicit_source_path(
             force,
@@ -72,6 +73,7 @@ impl RunnerUpgradeProvider for RunnerUpgrade {
             expected_controller_identity,
             runner_targets,
             extension_updates,
+            promotion_lease,
         )
     }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -79,6 +79,7 @@ pub fn upgrade_configured_runners(
     source_path: Option<&Path>,
     runner_targets: &[String],
     extension_updates: &[ExtensionUpgradeEntry],
+    promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
 ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
     let runners = runner_upgrade_targets(runner_targets)?;
     if runners.is_empty() {
@@ -90,17 +91,33 @@ pub fn upgrade_configured_runners(
         "Updating {} configured runner(s)...",
         runners.len()
     );
-    Ok(upgrade_runners_with_executor(
-        &runners,
-        force,
-        method_override,
-        source_path,
-        extension_updates,
-        runner::exec,
-        runner::status,
-    ))
+    let upgrade = || {
+        Ok(upgrade_runners_with_executor(
+            &runners,
+            force,
+            method_override,
+            source_path,
+            extension_updates,
+            runner::exec,
+            runner::status,
+        ))
+    };
+    match promotion_lease {
+        Some(lease) => lease.with_local_targets(
+            &runners
+                .iter()
+                .map(|runner| runner.id.clone())
+                .collect::<Vec<_>>(),
+            upgrade,
+        ),
+        None => upgrade(),
+    }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The runner-upgrade provider preserves its explicit controller identity and promotion authority inputs."
+)]
 pub fn upgrade_configured_runners_with_explicit_source_path(
     force: bool,
     method_override: Option<InstallMethod>,
@@ -109,6 +126,7 @@ pub fn upgrade_configured_runners_with_explicit_source_path(
     expected_controller_identity: Option<&str>,
     runner_targets: &[String],
     extension_updates: &[ExtensionUpgradeEntry],
+    promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
 ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
     if !explicit_source_path {
         return upgrade_configured_runners(
@@ -117,6 +135,7 @@ pub fn upgrade_configured_runners_with_explicit_source_path(
             source_path,
             runner_targets,
             extension_updates,
+            promotion_lease,
         );
     }
 
@@ -130,19 +149,31 @@ pub fn upgrade_configured_runners_with_explicit_source_path(
         "Updating {} configured runner(s)...",
         runners.len()
     );
-    Ok(
-        upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
-            &runners,
-            force,
-            method_override,
-            source_path,
-            extension_updates,
-            runner::exec,
-            runner::status,
-            materialize_explicit_runner_source_path,
-            expected_controller_identity,
+    let upgrade = || {
+        Ok(
+            upgrade_runners_with_executor_and_source_materializer_with_expected_controller_identity(
+                &runners,
+                force,
+                method_override,
+                source_path,
+                extension_updates,
+                runner::exec,
+                runner::status,
+                materialize_explicit_runner_source_path,
+                expected_controller_identity,
+            ),
+        )
+    };
+    match promotion_lease {
+        Some(lease) => lease.with_local_targets(
+            &runners
+                .iter()
+                .map(|runner| runner.id.clone())
+                .collect::<Vec<_>>(),
+            upgrade,
         ),
-    )
+        None => upgrade(),
+    }
 }
 
 pub fn runner_upgrade_targets(runner_targets: &[String]) -> Result<Vec<Runner>> {

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -254,6 +254,7 @@ pub fn run_upgrade_with_method(
                         None,
                         runner_targets,
                         &extensions_updated,
+                        Some(&promotion_lease),
                     )
                 })?
             };
@@ -394,6 +395,7 @@ pub fn run_upgrade_with_method(
                 new_build_identity.as_deref(),
                 runner_targets,
                 &extensions_updated,
+                Some(&promotion_lease),
             )
         })?
     } else {
@@ -626,6 +628,7 @@ fn run_targeted_runner_upgrade(
             Some(&previous_build_identity),
             runner_targets,
             &installed_extension_catalog(),
+            None,
         )
     })?;
 

--- a/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
+++ b/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
@@ -39,6 +39,7 @@ pub trait RunnerUpgradeProvider: Send + Sync {
         expected_controller_identity: Option<&str>,
         runner_targets: &[String],
         extension_updates: &[ExtensionUpgradeEntry],
+        promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)>;
 
     /// A short build-identity string for a source checkout (commit + dirty
@@ -70,6 +71,7 @@ impl RunnerUpgradeProvider for NoopRunnerUpgradeProvider {
         _expected_controller_identity: Option<&str>,
         _runner_targets: &[String],
         _extension_updates: &[ExtensionUpgradeEntry],
+        _promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
     ) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
         Ok((Vec::new(), Vec::new()))
     }


### PR DESCRIPTION
## Summary
- delegate the active controller promotion lease to only the selected runner targets during nested daemon convergence
- retain generation fencing and reject unrelated runner targets throughout the scoped delegation
- probe post-reconnect admission readiness before marking a runner converged

Closes #11771.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core controller_lease_delegates_only_selected_runner_targets --lib`
- `cargo test -p homeboy-lab-runner restarts_stale_connected_daemon_after_runner_upgrade --lib`
- `cargo test -p homeboy-upgrade successful_but_stale_child_is_partial_controller_convergence --lib`
- `cargo check -p homeboy-upgrade -p homeboy-lab-runner -p homeboy-core`

`cargo clippy -p homeboy-upgrade -p homeboy-lab-runner -p homeboy-core -- -D warnings` remains blocked by pre-existing `clippy::manual_inspect` findings in `crates/homeboy-lab-runner/src/execution/broker.rs:440` and `crates/homeboy-lab-runner/src/execution/daemon.rs:395`; this change adds no clippy findings.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent inspected the lease and runner convergence paths, implemented scoped selected-runner delegation and post-refresh admission verification, and ran focused checks. Chris Huber remains responsible for every line.