### PR TITLE
chore(lab): delete the unreachable source-CLI dependency bootstrap

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -11,9 +11,9 @@ use homeboy_core::{component, Error, Result};
 
 use super::lab_workspaces_deps::{
     accepted_extra_lab_workspaces, add_candidate_extra_workspace, bare_module_imports,
-    bootstrap_source_cli_dependencies, canonical_existing_dir, component_contract_candidate_paths,
-    containing_checkout_or_parent, discovered_validation_dependency_workspaces,
-    provider_config_candidate_paths, provider_config_source_cli_files,
+    canonical_existing_dir, component_contract_candidate_paths, containing_checkout_or_parent,
+    discovered_validation_dependency_workspaces, provider_config_candidate_paths,
+    provider_config_source_cli_files,
 };
 use super::{
     sync_workspace, RunnerGitDependencyMaterializationOutput, RunnerValidationDependencySyncOutput,
@@ -72,8 +72,6 @@ pub(super) struct ExtraLabWorkspace {
     pub(super) role: String,
     pub(super) path: PathBuf,
     pub(super) snapshot_includes: Vec<String>,
-    pub(super) bootstrap_node_dependencies: bool,
-    pub(super) bootstrap_command: Option<Vec<String>>,
     pub(super) allow_dirty_lab_workspace: bool,
     pub(super) source_provenance: Option<serde_json::Value>,
 }
@@ -191,14 +189,6 @@ pub(super) fn sync_extra_lab_workspaces(
         .0;
         let mut entry = workspace_mapping_entry(&extra.role, &synced);
         entry.source_provenance = extra.source_provenance.clone();
-        if let Some(command) = &extra.bootstrap_command {
-            bootstrap_source_cli_dependencies(
-                runner_id,
-                command,
-                &synced.local_path,
-                &synced.remote_path,
-            )?;
-        }
         workspace_mapping.push(entry.clone());
         synced_entries.push(entry);
     }
@@ -443,8 +433,6 @@ pub(super) fn parse_runtime_overlays(
                 role,
                 path,
                 snapshot_includes: spec.snapshot_includes,
-                bootstrap_node_dependencies: false,
-                bootstrap_command: None,
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             },
@@ -740,8 +728,6 @@ pub(super) fn agent_task_plan_extra_workspaces(
                         role: "agent_task_plan".to_string(),
                         path: canon,
                         snapshot_includes: Vec::new(),
-                        bootstrap_node_dependencies: false,
-                        bootstrap_command: None,
                         allow_dirty_lab_workspace: false,
                         source_provenance: None,
                     });
@@ -1173,8 +1159,6 @@ fn add_candidate_workspace_ref_extra_workspace(
         role: "path_setting_workspace_ref".to_string(),
         path: canon,
         snapshot_includes: Vec::new(),
-        bootstrap_node_dependencies: false,
-        bootstrap_command: None,
         allow_dirty_lab_workspace: false,
         source_provenance: Some(serde_json::json!({
             "source_provenance": "workspace_ref",

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -98,7 +98,6 @@ fn provider_config_file_path_syncs_containing_checkout() {
     std::fs::create_dir_all(&source).expect("source dir");
     std::fs::create_dir_all(cli.parent().unwrap()).expect("cli dist dir");
     std::fs::write(&cli, "#!/usr/bin/env node\n").expect("cli file");
-    std::fs::write(provider.join("package-lock.json"), "{}\n").expect("package lock");
     git(&provider, &["init", "-b", "main"]);
     git(&provider, &["config", "user.email", "test@example.com"]);
     git(&provider, &["config", "user.name", "Homeboy Test"]);
@@ -120,7 +119,6 @@ fn provider_config_file_path_syncs_containing_checkout() {
     assert!(workspaces[0]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
-    assert!(workspaces[0].bootstrap_node_dependencies);
 }
 
 #[test]
@@ -211,7 +209,6 @@ fn provider_config_file_path_merges_snapshot_includes_for_duplicate_checkout() {
     std::fs::create_dir_all(&source).expect("source dir");
     std::fs::create_dir_all(cli.parent().unwrap()).expect("cli dist dir");
     std::fs::write(&cli, "#!/usr/bin/env node\n").expect("cli file");
-    std::fs::write(provider.join("package-lock.json"), "{}\n").expect("package lock");
     git(&provider, &["init", "-b", "main"]);
     git(&provider, &["config", "user.email", "test@example.com"]);
     git(&provider, &["config", "user.name", "Homeboy Test"]);
@@ -236,7 +233,6 @@ fn provider_config_file_path_merges_snapshot_includes_for_duplicate_checkout() {
     assert!(workspaces[0]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
-    assert!(workspaces[0].bootstrap_node_dependencies);
 }
 
 #[test]
@@ -290,7 +286,6 @@ fn agent_task_run_plan_file_path_syncs_containing_checkout() {
     std::fs::create_dir_all(plan.parent().unwrap()).expect("plan dir");
     std::fs::create_dir_all(tool_bin.parent().unwrap()).expect("tool cli dir");
     std::fs::write(&tool_bin, "#!/usr/bin/env node\n").expect("tool bin");
-    std::fs::write(tool.join("package-lock.json"), "{}\n").expect("package lock");
     std::fs::write(
         &plan,
         serde_json::json!({
@@ -336,13 +331,11 @@ fn agent_task_run_plan_file_path_syncs_containing_checkout() {
     assert_eq!(workspaces[0].role, "agent_task_plan");
     assert_eq!(workspaces[0].path, planner.canonicalize().unwrap());
     assert!(workspaces[0].snapshot_includes.is_empty());
-    assert!(!workspaces[0].bootstrap_node_dependencies);
     assert_eq!(workspaces[1].role, "agent_task_plan_config");
     assert_eq!(workspaces[1].path, tool.canonicalize().unwrap());
     assert!(workspaces[1]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
-    assert!(workspaces[1].bootstrap_node_dependencies);
 }
 
 #[test]
@@ -460,7 +453,6 @@ fn agent_task_run_plan_relative_file_reads_from_primary_workspace() {
     std::fs::create_dir_all(plan.parent().unwrap()).expect("plan dir");
     std::fs::create_dir_all(tool_bin.parent().unwrap()).expect("tool cli dir");
     std::fs::write(&tool_bin, "#!/usr/bin/env node\n").expect("tool bin");
-    std::fs::write(tool.join("package-lock.json"), "{}\n").expect("package lock");
     std::fs::write(
         &plan,
         serde_json::json!({
@@ -507,7 +499,6 @@ fn path_setting_local_file_syncs_containing_checkout() {
     std::fs::create_dir_all(&source).expect("source dir");
     std::fs::create_dir_all(tool_bin.parent().unwrap()).expect("tool cli dir");
     std::fs::write(&tool_bin, "#!/usr/bin/env node\n").expect("tool bin");
-    std::fs::write(tool.join("package-lock.json"), "{}\n").expect("package lock");
     git(&tool, &["init", "-b", "main"]);
     git(&tool, &["config", "user.email", "test@example.com"]);
     git(&tool, &["config", "user.name", "Homeboy Test"]);
@@ -531,7 +522,6 @@ fn path_setting_local_file_syncs_containing_checkout() {
     assert!(workspaces[0]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
-    assert!(workspaces[0].bootstrap_node_dependencies);
 }
 
 #[test]
@@ -874,8 +864,6 @@ fn workspace_ref_provenance_is_recorded_on_mapping_entry() {
         role: "path_setting_workspace_ref".to_string(),
         path: PathBuf::from("/local/repo@cook"),
         snapshot_includes: Vec::new(),
-        bootstrap_node_dependencies: false,
-        bootstrap_command: None,
         allow_dirty_lab_workspace: false,
         source_provenance: Some(serde_json::json!({
             "source_provenance": "workspace_ref",
@@ -946,7 +934,6 @@ fn agent_task_run_plan_syncs_symlinked_dependency_target_inside_primary_workspac
     std::fs::create_dir_all(symlink.parent().unwrap()).expect("ci dir");
     std::fs::create_dir_all(tool_bin.parent().unwrap()).expect("tool cli dir");
     std::fs::write(&tool_bin, "#!/usr/bin/env node\n").expect("tool bin");
-    std::fs::write(tool.join("package-lock.json"), "{}\n").expect("package lock");
     std::os::unix::fs::symlink(&tool, &symlink).expect("tool symlink");
     std::fs::write(
         &plan,
@@ -989,7 +976,6 @@ fn agent_task_run_plan_syncs_symlinked_dependency_target_inside_primary_workspac
     assert!(workspaces[0]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
-    assert!(workspaces[0].bootstrap_node_dependencies);
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/runtime_overlay.rs
@@ -42,7 +42,6 @@ fn parses_artifact_only_overlay_without_install_step() {
     assert_eq!(overlay.workspace.snapshot_includes, vec!["cli".to_string()]);
     assert!(overlay.install.is_none());
     assert!(overlay.expose_remote_path_env.is_none());
-    assert!(!overlay.workspace.bootstrap_node_dependencies);
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
@@ -1,8 +1,8 @@
-//! Source-built CLI dependency discovery and bootstrap for lab workspaces.
+//! Source-built CLI dependency discovery for lab workspaces.
 //!
 //! Collects candidate workspace paths from provider configs and component
-//! contracts, resolves source-built CLI dependencies by parsing bare module
-//! imports, and bootstraps their production dependencies on the runner.
+//! contracts, and resolves source-built CLI dependencies by parsing bare module
+//! imports so an un-syncable dependency fails preflight instead of the runner.
 //!
 //! Split out of `lab_workspaces.rs` to keep the workspace-mapping entry points
 //! separate from the dependency-discovery internals.
@@ -16,10 +16,8 @@ use homeboy_core::{Error, Result};
 use super::lab_workspaces::{
     ExtraLabWorkspace, LAB_EXTRA_WORKSPACES_ENV, LAB_EXTRA_WORKSPACES_JSON_ENV,
 };
+use super::preflight_remote_argv_path_translation;
 use super::workspace::git_output;
-use super::{
-    exec, preflight_remote_argv_path_translation, RunnerCapabilityPreflight, RunnerExecOptions,
-};
 
 pub(super) fn provider_config_candidate_paths(value: &serde_json::Value) -> Vec<String> {
     let mut paths = Vec::new();
@@ -42,16 +40,12 @@ pub(super) fn add_candidate_extra_workspace(
 ) -> Result<()> {
     let expanded = shellexpand::tilde(candidate).to_string();
     let path = Path::new(&expanded);
-    let (workspace_path, snapshot_includes, bootstrap_node_dependencies) = if path.is_dir() {
-        (containing_checkout_or_dir(path)?, Vec::new(), false)
+    let (workspace_path, snapshot_includes) = if path.is_dir() {
+        (containing_checkout_or_dir(path)?, Vec::new())
     } else if path.is_file() {
         let workspace_path = containing_checkout_or_parent(path)?;
         let snapshot_includes = provider_config_file_snapshot_includes(&workspace_path, path);
-        (
-            workspace_path,
-            snapshot_includes,
-            is_node_cli_file(path) && source_cli_workspace_has_package_lock(path),
-        )
+        (workspace_path, snapshot_includes)
     } else {
         return Ok(());
     };
@@ -73,7 +67,6 @@ pub(super) fn add_candidate_extra_workspace(
                     existing.snapshot_includes.push(include);
                 }
             }
-            existing.bootstrap_node_dependencies |= bootstrap_node_dependencies;
         }
         return Ok(());
     }
@@ -81,8 +74,6 @@ pub(super) fn add_candidate_extra_workspace(
         role: role.to_string(),
         path: canon,
         snapshot_includes,
-        bootstrap_node_dependencies,
-        bootstrap_command: None,
         allow_dirty_lab_workspace: false,
         source_provenance: None,
     });
@@ -282,8 +273,6 @@ pub(super) fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> 
                 role: "extra".to_string(),
                 path: canonical_existing_dir(&path, "extra_workspace")?,
                 snapshot_includes: Vec::new(),
-                bootstrap_node_dependencies: false,
-                bootstrap_command: None,
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             })
@@ -324,8 +313,6 @@ pub(super) fn discovered_validation_dependency_workspaces(
                 role: "dependency".to_string(),
                 path,
                 snapshot_includes: Vec::new(),
-                bootstrap_node_dependencies: false,
-                bootstrap_command: None,
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             });
@@ -399,28 +386,6 @@ pub(super) fn provider_config_file_snapshot_includes(
     vec![parent.clone(), format!("{parent}/**")]
 }
 
-pub(super) fn source_cli_workspace_has_package_lock(file_path: &Path) -> bool {
-    containing_checkout_or_parent(file_path)
-        .ok()
-        .is_some_and(|workspace| workspace.join("package-lock.json").is_file())
-}
-
-/// Capability-parity contract for the runner-side source-CLI dependency
-/// bootstrap. The clean dependency install is executed by an external command,
-/// so the runner must expose the declared commands before remote dispatch.
-pub(super) fn source_cli_bootstrap_capability_preflight() -> RunnerCapabilityPreflight {
-    RunnerCapabilityPreflight {
-        required_toolchain_probes: Vec::new(),
-        command: "lab.source_cli_bootstrap".to_string(),
-        required_tools: Vec::new(),
-        required_commands: Vec::new(),
-        required_tool_capabilities: Vec::new(),
-        required_components: Vec::new(),
-        required_env: Vec::new(),
-        timeout: None,
-    }
-}
-
 /// Path-translation preflight for a runtime-overlay install step. The overlay
 /// artifact has already been synced to a runner-side remote path and the opaque
 /// install command runs with the resolved remote workdir as cwd. Assert that no
@@ -441,53 +406,4 @@ pub(super) fn preflight_runtime_overlay_install_argv(
         local_path,
         remote_workdir,
     )
-}
-
-pub(super) fn bootstrap_source_cli_dependencies(
-    runner_id: &str,
-    command: &[String],
-    local_path: &str,
-    remote_path: &str,
-) -> Result<()> {
-    if command.is_empty() {
-        return Ok(());
-    }
-
-    // Path-translation preflight: the source-built CLI workspace has already been
-    // synced to a runner-side remote path; the dependency install runs with the
-    // remote workspace as cwd. Assert that no controller-local workspace path
-    // survived un-translated into the dispatched argv before handing it to the
-    // remote runner, so a missed remap fails loudly here instead of installing
-    // against a non-existent local path (#5422).
-    preflight_remote_argv_path_translation(
-        "Lab source-CLI dependency bootstrap",
-        runner_id,
-        command,
-        Path::new(local_path),
-        remote_path,
-    )?;
-
-    let (output, exit_code) = exec(
-        runner_id,
-        // Validate remote capability parity before dispatch. Concrete command
-        // requirements are supplied declaratively by the workspace provider.
-        RunnerExecOptions::raw_command(command.to_vec())
-            .with_cwd(remote_path)
-            .with_capability_preflight(source_cli_bootstrap_capability_preflight()),
-    )?;
-    if exit_code == 0 {
-        return Ok(());
-    }
-
-    Err(Error::validation_invalid_argument(
-        "provider_config",
-        format!(
-            "Lab offload could not install production dependencies for source-built CLI workspace `{remote_path}`"
-        ),
-        Some(remote_path.to_string()),
-        Some(vec![
-            format!("dependency install stderr: {}", output.stderr.trim()),
-            "Build or package the CLI as a self-contained artifact, or make the source-built workspace installable on the runner.".to_string(),
-        ]),
-    ))
 }


### PR DESCRIPTION
**−125 / +10, net −115.**

## The dead subsystem

`ExtraLabWorkspace` carried two mutually-redundant install hooks.

**`bootstrap_command` — no production `Some` setter anywhere:**
```
mod.rs:194          the ONLY read  (if let Some(command) = &extra.bootstrap_command)
mod.rs:447 744 1177 : None
deps.rs:85 286 328  : None
```
Six production construction sites, all literal `None`. Zero `Some(` writes. There is also **no config channel**: `ExtraLabWorkspace` derives only `Debug, Clone, PartialEq, Eq` — not `Deserialize` — and a repo-wide grep over `*.md *.json *.sh *.toml *.yml *.yaml` for these names returns nothing. **The consumer at `mod.rs:194-201` was statically unreachable.**

Tellingly, `parse_runtime_overlays` hardcodes `bootstrap_command: None` and routes its install through `RuntimeOverlay.install` instead — the live generic path, in the same function.

**`bootstrap_node_dependencies` — no production reader.** Every genuine read is a test assertion; the `|=` at `deps.rs:76` is a compound write into a value nothing downstream consumes.

Deleted: both fields and all 12 write sites, the unreachable consumer, `bootstrap_source_cli_dependencies` (48 lines), `source_cli_bootstrap_capability_preflight`, `source_cli_workspace_has_package_lock`, the now-unused imports, and 7 test assertions.

**`RuntimeOverlayInstallStep` already does a post-sync install step generically and IS wired** (`sync_lab_runtime_overlays`) — so this removes a dead specific mechanism that a live generic one supersedes.

## What I kept, correcting the original finding

**`bare_module_imports` and `is_node_cli_file` — KEPT.** The sweep listed both for deletion. `preflight_provider_config_source_cli_dependencies` **is reachable in production** (`lab/offload/workspace_stage.rs:530`, inside `stage_workspaces`, well above that file's `#[cfg(test)]`), and `is_node_cli_file` has a second caller — `provider_config_source_cli_files` — which is exactly what feeds that preflight. Deleting either would have broken a live path.

**So the Node hardcoding survives** in the preflight: `.js|.mjs|.cjs` matching, the `from '` / `require(` / `import(` scrape, and the hardcoded builtin-module list. That is a real remaining layering violation in a layer documented as ecosystem-agnostic — just not a dead one. Separate work.

**The `node_modules` exclude — KEPT.** It is not snapshot configuration. `mod.rs:1248-1251` is the **guard clause of that reachable preflight**: if `node_modules` is not in the caller's excludes, the preflight returns early. Deleting it would make the preflight fire unconditionally and turn a narrow warning into a broad false-positive hard error.

## One judgment call beyond the brief

Removed 6 `package-lock.json` fixture writes from tests; they existed solely to make the deleted `source_cli_workspace_has_package_lock` return true, and nothing reads `package-lock.json` any more. Revert those 6 lines if you want the diff minimal.

No test was deleted outright — every removed assertion lived in a test that still meaningfully asserts role/path/snapshot_includes. `source_cli_preflight_names_missing_workspace_package_and_importer` covers the surviving preflight and is untouched.

## Verification

`cargo check --workspace --tests -j2` clean.