### PR TITLE
refactor(core): define the two running-staleness thresholds once each

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -686,6 +686,13 @@ impl AgentTaskRunRecord {
         RunExecutionState::from(self.state) == self.lifecycle.execution.state
     }
 
+    /// Whether this record reported an `updated_at` heartbeat recently enough
+    /// to count as live.
+    ///
+    /// The exact inverse of the staleness rule discovery applies, against the
+    /// same shared threshold — this predicate carried its own bare `30` until
+    /// the threshold was unified, which is precisely the drift the shared
+    /// constant exists to prevent.
     pub(crate) fn has_fresh_update(&self) -> bool {
         self.updated_at
             .as_deref()
@@ -694,7 +701,7 @@ impl AgentTaskRunRecord {
                 chrono::Utc::now()
                     .signed_duration_since(updated_at.with_timezone(&chrono::Utc))
                     .num_minutes()
-                    < 30
+                    < homeboy_core::observation::RUNNING_HEARTBEAT_STALE_MINUTES
             })
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -4,6 +4,11 @@
 use crate::agent_task::{AgentTaskRequest, AgentTaskSourceRef};
 use crate::agent_task_lifecycle::{self, AgentTaskRecordHealthSummary, AgentTaskRunRecord};
 use crate::agent_task_scheduler::AgentTaskState;
+// `agent-task active` treats a `Running` record that has gone this long without
+// an `updated_at` heartbeat as suspect even when its owner process/runner-job
+// liveness cannot be disproven (#5682). Shared with `activity` so the two
+// surfaces cannot disagree about what "stale" means.
+use homeboy_core::observation::RUNNING_HEARTBEAT_STALE_MINUTES;
 use homeboy_core::{Error, Result};
 use serde_json::Value;
 
@@ -34,13 +39,6 @@ pub struct AgentTaskDiscoveryOptions {
     pub placement: Option<String>,
     pub parent_id: Option<String>,
 }
-
-/// Number of minutes a `Running` record may go without an `updated_at`
-/// heartbeat before `agent-task active` treats it as suspect even when its
-/// owner process/runner-job liveness cannot be disproven. Lab/offloaded runs
-/// whose runner process died silently surface here so operators can reconcile
-/// them instead of trusting a frozen `running` record indefinitely (#5682).
-const STALE_UPDATE_THRESHOLD_MINUTES: i64 = 30;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AgentTaskDiscoveryReport {
@@ -433,7 +431,7 @@ fn classify_liveness(
         let heartbeat_age =
             last_update_age_minutes.or_else(|| age_minutes(Some(&record.submitted_at), now));
         let has_fresh_heartbeat =
-            heartbeat_age.is_some_and(|age| age < STALE_UPDATE_THRESHOLD_MINUTES);
+            heartbeat_age.is_some_and(|age| age < RUNNING_HEARTBEAT_STALE_MINUTES);
         let has_live_owner = record.owner_process_is_running();
         let has_live_submission_intent =
             agent_task_lifecycle::has_live_pending_runner_submission_intent(record, now);
@@ -461,7 +459,7 @@ fn classify_liveness(
     }
 
     let stale_by_age =
-        last_update_age_minutes.is_some_and(|age| age >= STALE_UPDATE_THRESHOLD_MINUTES);
+        last_update_age_minutes.is_some_and(|age| age >= RUNNING_HEARTBEAT_STALE_MINUTES);
 
     let has_owner_signal =
         record.metadata.get("runner_pid").is_some() || record.runner_id().is_some();

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -6,14 +6,12 @@ use std::path::{Path, PathBuf};
 use homeboy::core::engine::run_dir;
 use homeboy::core::observation::{
     run_has_active_remote_job, run_owner_pid, runs_service, ObservationStore, RunListFilter,
-    RunRecord, RunStatus,
+    RunRecord, RunStatus, OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES,
 };
 use homeboy::core::process::pid_is_running;
 
 use crate::commands::runs::RunsOutput;
 use crate::commands::CmdResult;
-
-const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
 
 /// Upper bound on how long a runner-backed running record stays exempt from
 /// reconciliation.

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -12,6 +12,9 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
+// `crate::observation` is the crate-root module, not this module's own
+// `observation` submodule declared below.
+use crate::observation::RUNNING_HEARTBEAT_STALE_MINUTES;
 use crate::{Error, Result};
 
 pub mod agent_task_provider;
@@ -31,13 +34,6 @@ pub(crate) use action_helpers::{action, metadata_string, ms_to_rfc3339, parse_ts
 pub(crate) use collector::ActivityCollector;
 
 pub const ACTIVITY_REPORT_SCHEMA: &str = "homeboy/activity-report/v1";
-
-/// A `Running` activity row whose last heartbeat/update is older than this many
-/// minutes is treated as an unverified stale projection rather than active
-/// running work. Old observation rows (runner executions and Cooks from hours or
-/// days earlier) whose processes are gone must not inflate the `active`/`running`
-/// totals that operators rely on for cleanup and workload decisions (#9743).
-const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;
 
 pub fn activity_report(scope: ActivityScope, limit: usize) -> Result<ActivityReport> {
     let mut collector = ActivityCollector::default();

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -13,11 +13,9 @@ use crate::api_jobs::{self, ActiveRunnerJobSummary, JobStore, RunnerJobProjectio
 use crate::error::{Error, Result};
 use crate::observation::{
     run_owner_pid, running_status_note, FindingListFilter, ObservationStore, RunListFilter,
-    RunRecord, RunStatus, MAX_RUN_PAGE_LIMIT,
+    RunRecord, RunStatus, MAX_RUN_PAGE_LIMIT, OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES,
 };
 use crate::{activity, component, git, paths};
-
-const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
 
 mod analysis_job_runner;
 mod sandbox_tools;

--- a/crates/homeboy-core/src/observation/mod.rs
+++ b/crates/homeboy-core/src/observation/mod.rs
@@ -56,7 +56,8 @@ pub use records::{
     NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder,
     NewTriageItemRecord, RecordedHomeboyFinding, RunCursor, RunEvidenceCommands, RunListFilter,
     RunPage, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
-    TriagePullRequestSignals,
+    TriagePullRequestSignals, OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES,
+    RUNNING_HEARTBEAT_STALE_MINUTES,
 };
 pub use run_failure_causes::{nested_failure_causes_from_run_detail, RunFailureCause};
 pub use store::{

--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -13,7 +13,9 @@ mod triage_items;
 
 pub use finding_records::*;
 pub use run_builder::NewRunRecordBuilder;
-pub use run_status::RunStatus;
+pub use run_status::{
+    RunStatus, OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES, RUNNING_HEARTBEAT_STALE_MINUTES,
+};
 pub use trace_run_builder::NewTraceRunRecordBuilder;
 pub use trace_span_builder::NewTraceSpanRecordBuilder;
 pub use triage_items::{NewTriageItemRecord, TriageItemRecord, TriagePullRequestSignals};

--- a/crates/homeboy-core/src/observation/records/run_staleness_guard_test.rs
+++ b/crates/homeboy-core/src/observation/records/run_staleness_guard_test.rs
@@ -1,0 +1,358 @@
+//! Source guard: each running-staleness threshold is defined exactly once.
+//!
+//! Four independent definitions of "when is a `Running` record stale" existed
+//! in this workspace, all holding 30 minutes and none pinned equal by any test:
+//!
+//! * `activity.rs::RUNNING_HEARTBEAT_STALE_MINUTES` (#9743)
+//! * `http_api.rs::OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES`
+//! * `commands/runs/reconcile.rs::OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES`
+//! * `agent_task_service/discovery.rs::STALE_UPDATE_THRESHOLD_MINUTES` (#5682)
+//!
+//! A fifth copy was worse: `AgentTaskRunRecord::has_fresh_update` compared
+//! against a bare `30` with no name at all, so it could never have been found
+//! by searching for the constant. That is the shape this guard exists to catch —
+//! the divergence that is invisible to a name-based search.
+//!
+//! They resolved to **two** concepts, not one, and the split is by which
+//! timestamp is measured. See [`super::RUNNING_HEARTBEAT_STALE_MINUTES`] and
+//! [`super::OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES`] for the reasoning. This
+//! guard pins the resulting structure so a third home cannot quietly appear.
+//!
+//! Following the `owned_args_guard_test` and `core-agnostic-source` precedent,
+//! this reads source text, so it is deliberately shape-based rather than
+//! semantic. Comment lines are skipped so prose describing the shape — this
+//! module header included — is not a finding.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Every constant in this workspace that names a running-staleness threshold in
+/// minutes, mapped to the reason it is allowed its own definition.
+///
+/// Two entries are the shared vocabulary; the third is a genuinely different
+/// concept that merely lives in the same family. Anything else is a
+/// re-divergence and fails the guard.
+const SANCTIONED_STALENESS_THRESHOLDS: &[(&str, &str)] = &[
+    (
+        "crates/homeboy-core/src/observation/records/run_status.rs::RUNNING_HEARTBEAT_STALE_MINUTES",
+        "canonical: heartbeat liveness, measured from `updated_at` (#9743, #5682)",
+    ),
+    (
+        "crates/homeboy-core/src/observation/records/run_status.rs::OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES",
+        "canonical: ownerless grace period, measured from `started_at`",
+    ),
+    (
+        "crates/homeboy-cli/src/commands/runs/reconcile.rs::RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES",
+        "different concept: the 24h ceiling on a runner-backed record's reconciliation exemption, \
+         where a live remote job is authoritative and the bound exists only so the exemption ends (#11107)",
+    ),
+];
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is `<workspace>/crates/homeboy-core`.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// The source subtrees this guard walks: every workspace crate, plus the thin
+/// root `homeboy` crate. Workspace-root `tests/` is excluded as test source.
+const SCANNED_SUBTREES: &[&str] = &["crates", "src"];
+
+fn is_test_source(relative_path: &str) -> bool {
+    relative_path.contains("/tests/")
+        || relative_path.ends_with("_test.rs")
+        || relative_path.ends_with("_tests.rs")
+        || relative_path.ends_with("/tests.rs")
+}
+
+fn collect_rust_sources(directory: &Path, root: &Path, collected: &mut Vec<(String, String)>) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+
+    for entry in entries {
+        let entry = entry.expect("readable directory entry");
+        let path = entry.path();
+        if path.is_dir() {
+            // `target/` under a crate is build output, not source.
+            if path.file_name().and_then(|name| name.to_str()) == Some("target") {
+                continue;
+            }
+            collect_rust_sources(&path, root, collected);
+            continue;
+        }
+        if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+            continue;
+        }
+        let relative_path = path
+            .strip_prefix(root)
+            .expect("collected path is under the workspace root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_test_source(&relative_path) {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {relative_path}: {error}"));
+        collected.push((relative_path, content));
+    }
+}
+
+fn is_comment_line(line: &str) -> bool {
+    line.trim_start().starts_with("//")
+}
+
+/// The name of the staleness-threshold constant this line declares, if it
+/// declares one.
+///
+/// The shape is a `const` whose name mentions both staleness and a minute unit,
+/// which is what every one of the original four spelled.
+fn declared_staleness_threshold(line: &str) -> Option<&str> {
+    let mut rest = line.trim_start();
+    for visibility in ["pub(crate) ", "pub(super) ", "pub(self) ", "pub "] {
+        if let Some(stripped) = rest.strip_prefix(visibility) {
+            rest = stripped.trim_start();
+            break;
+        }
+    }
+    let rest = rest.strip_prefix("const ")?;
+    let name_end = rest.find(':')?;
+    let name = rest[..name_end].trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    {
+        return None;
+    }
+    (name.contains("STALE") && name.contains("MINUTES")).then_some(name)
+}
+
+/// Whether a `num_minutes()` result on this line is compared against a bare
+/// integer literal rather than a named threshold.
+///
+/// The comparison may wrap onto the next line, which is exactly how the
+/// `has_fresh_update` copy hid: `.num_minutes()` ended one line and `< 30`
+/// began the next.
+fn compares_minutes_to_a_bare_literal(lines: &[&str], index: usize) -> bool {
+    const CALL: &str = "num_minutes()";
+    let line = lines[index];
+    let Some(offset) = line.find(CALL) else {
+        return false;
+    };
+
+    let mut tail = line[offset + CALL.len()..].trim().to_string();
+    if tail.is_empty() {
+        let Some(next) = lines.get(index + 1) else {
+            return false;
+        };
+        if is_comment_line(next) {
+            return false;
+        }
+        tail = next.trim().to_string();
+    }
+
+    let stripped = tail.trim_start_matches(['<', '>', '=']);
+    if stripped.len() == tail.len() {
+        // No comparison operator followed the call.
+        return false;
+    }
+    stripped
+        .trim_start()
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit())
+}
+
+fn workspace_sources() -> Vec<(String, String)> {
+    let root = workspace_root();
+    let mut sources = Vec::new();
+    for subtree in SCANNED_SUBTREES {
+        collect_rust_sources(&root.join(subtree), &root, &mut sources);
+    }
+    assert!(
+        !sources.is_empty(),
+        "no rust sources found under {}",
+        root.display()
+    );
+    sources
+}
+
+/// Every staleness-threshold constant declared in the workspace, by site.
+fn declared_staleness_thresholds() -> BTreeSet<String> {
+    let mut declarations = BTreeSet::new();
+    for (relative_path, content) in &workspace_sources() {
+        for line in content.lines() {
+            if is_comment_line(line) {
+                continue;
+            }
+            if let Some(name) = declared_staleness_threshold(line) {
+                declarations.insert(format!("{relative_path}::{name}"));
+            }
+        }
+    }
+    declarations
+}
+
+#[test]
+fn a_new_running_staleness_threshold_is_a_failure() {
+    let declarations = declared_staleness_thresholds();
+    let unsanctioned: Vec<&String> = declarations
+        .iter()
+        .filter(|site| {
+            !SANCTIONED_STALENESS_THRESHOLDS
+                .iter()
+                .any(|(sanctioned, _)| *sanctioned == site.as_str())
+        })
+        .collect();
+
+    assert!(
+        unsanctioned.is_empty(),
+        "these sites define their own running-staleness threshold: {unsanctioned:?}. \
+         Four such definitions already drifted apart unpinned once. Import \
+         `RUNNING_HEARTBEAT_STALE_MINUTES` (heartbeat age, from `updated_at`) or \
+         `OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES` (ownerless grace, from `started_at`) \
+         from `homeboy_core::observation`, or add the site to \
+         SANCTIONED_STALENESS_THRESHOLDS with the reason it is a distinct concept."
+    );
+}
+
+#[test]
+fn a_sanctioned_threshold_that_no_longer_exists_is_a_failure() {
+    // A stale entry is how an inventory stops describing the tree it guards.
+    let declarations = declared_staleness_thresholds();
+    let missing: Vec<&str> = SANCTIONED_STALENESS_THRESHOLDS
+        .iter()
+        .filter(|(site, _)| !declarations.contains(*site))
+        .map(|(site, _)| *site)
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "SANCTIONED_STALENESS_THRESHOLDS names thresholds that no longer exist: {missing:?}. \
+         Remove the stale rows."
+    );
+}
+
+#[test]
+fn every_sanctioned_threshold_states_a_reason() {
+    for (site, reason) in SANCTIONED_STALENESS_THRESHOLDS {
+        assert!(
+            reason.len() > 20,
+            "{site} is sanctioned without a usable reason"
+        );
+    }
+}
+
+#[test]
+fn no_minute_age_is_compared_against_a_bare_literal() {
+    let mut findings = Vec::new();
+    for (relative_path, content) in &workspace_sources() {
+        let lines: Vec<&str> = content.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if is_comment_line(line) {
+                continue;
+            }
+            if compares_minutes_to_a_bare_literal(&lines, index) {
+                findings.push(format!("{relative_path}:{}", index + 1));
+            }
+        }
+    }
+
+    assert!(
+        findings.is_empty(),
+        "these sites compare a minute age against a bare integer literal: {findings:?}. \
+         `AgentTaskRunRecord::has_fresh_update` was a fifth copy of the 30-minute \
+         staleness rule written exactly this way, invisible to any search for the \
+         constant's name. Name the threshold instead."
+    );
+}
+
+#[test]
+fn the_guard_recognizes_the_declaration_shape_it_is_written_to_catch() {
+    // The four original definitions, as they were written.
+    assert_eq!(
+        declared_staleness_threshold("const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;"),
+        Some("RUNNING_HEARTBEAT_STALE_MINUTES")
+    );
+    assert_eq!(
+        declared_staleness_threshold("const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;"),
+        Some("OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES")
+    );
+    assert_eq!(
+        declared_staleness_threshold("const STALE_UPDATE_THRESHOLD_MINUTES: i64 = 30;"),
+        Some("STALE_UPDATE_THRESHOLD_MINUTES")
+    );
+    assert_eq!(
+        declared_staleness_threshold("pub const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;"),
+        Some("RUNNING_HEARTBEAT_STALE_MINUTES")
+    );
+
+    // A staleness threshold in another unit is a different question.
+    assert_eq!(
+        declared_staleness_threshold("pub const STALE_RUN_RECLAIM_SECS: i64 = 6 * 60 * 60;"),
+        None
+    );
+    assert_eq!(
+        declared_staleness_threshold("const STALE_PENDING_ACTION_SECONDS: i64 = 24 * 60 * 60;"),
+        None
+    );
+    // Not a constant, and not a threshold.
+    assert_eq!(
+        declared_staleness_threshold("    let stale_minutes = 30;"),
+        None
+    );
+    assert_eq!(
+        declared_staleness_threshold("const STALE_DAEMON_RECOVERY: &str = \"stale\";"),
+        None
+    );
+}
+
+#[test]
+fn the_guard_recognizes_the_bare_literal_shape_it_is_written_to_catch() {
+    // The `has_fresh_update` copy, as it was written: the operator wrapped.
+    let wrapped = [
+        "                    .signed_duration_since(updated_at.with_timezone(&chrono::Utc))",
+        "                    .num_minutes()",
+        "                    < 30",
+    ];
+    assert!(compares_minutes_to_a_bare_literal(&wrapped, 1));
+
+    // The same shape inline.
+    let inline = ["let stale = age.num_minutes() >= 30;"];
+    assert!(compares_minutes_to_a_bare_literal(&inline, 0));
+
+    // A named threshold is the whole point and must not be a finding.
+    let named = [
+        "                    .num_minutes()",
+        "                    < RUNNING_HEARTBEAT_STALE_MINUTES",
+    ];
+    assert!(!compares_minutes_to_a_bare_literal(&named, 0));
+
+    let named_inline = ["age.num_minutes() >= OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES"];
+    assert!(!compares_minutes_to_a_bare_literal(&named_inline, 0));
+
+    // Binding the age without comparing it is not a finding.
+    let bound = ["let age_minutes = (now - heartbeat).num_minutes();"];
+    assert!(!compares_minutes_to_a_bare_literal(&bound, 0));
+}
+
+#[test]
+fn test_sources_are_out_of_scope() {
+    // Paths are workspace-relative, as `collect_rust_sources` produces them.
+    assert!(is_test_source(
+        "crates/homeboy-cli/src/commands/runner/tests/status.rs"
+    ));
+    assert!(is_test_source("crates/homeboy-core/src/paths_tests.rs"));
+    assert!(is_test_source(
+        "crates/homeboy-core/src/observation/records/run_staleness_guard_test.rs"
+    ));
+    assert!(!is_test_source(
+        "crates/homeboy-core/src/observation/records/run_status.rs"
+    ));
+    assert!(!is_test_source(
+        "crates/homeboy-cli/src/commands/runs/reconcile.rs"
+    ));
+    assert!(!is_test_source("src/lib.rs"));
+}

--- a/crates/homeboy-core/src/observation/records/run_status.rs
+++ b/crates/homeboy-core/src/observation/records/run_status.rs
@@ -1,5 +1,45 @@
 use serde::Serialize;
 
+/// Minutes a `Running` record may go without a heartbeat (`updated_at`) before
+/// readers stop counting it as active work.
+///
+/// This is the *heartbeat liveness* threshold: it measures the age of the last
+/// update a record reported, so it answers "has this run checked in recently?".
+/// Old observation rows — runner executions and Cooks from hours or days
+/// earlier — whose processes are gone must not inflate the `active`/`running`
+/// totals operators rely on for cleanup and workload decisions (#9743). It also
+/// catches Lab/offloaded runs whose runner process died silently, which would
+/// otherwise leave a frozen `running` record trusted indefinitely (#5682).
+///
+/// A record with **no** `updated_at` at all is deliberately not stale by this
+/// rule: absence of a timestamp is not evidence of death, and every reader here
+/// leaves such a record for a liveness signal (owner pid, runner job) to judge.
+///
+/// Deliberately **separate** from [`OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES`]
+/// despite sharing a value today. That one measures `started_at`, not
+/// `updated_at`, and answers a different question. See its docs.
+pub const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;
+
+/// Minutes an *ownerless* `Running` run record stays credible, measured from
+/// its `started_at`, before reconciliation may settle it to
+/// [`RunStatus::Stale`].
+///
+/// This is a *grace period for missing provenance*, not a heartbeat measure.
+/// It is only ever consulted after a record has been shown to carry no owner
+/// pid at all, so a long-lived run with a live owner never reaches it. The
+/// conjunction is the point: "ownerless" alone would strike down a run that has
+/// only just started and not yet recorded its owner, and "old" alone would
+/// strike down healthy long jobs.
+///
+/// Deliberately **separate** from [`RUNNING_HEARTBEAT_STALE_MINUTES`] despite
+/// sharing a value today: a record can be freshly heartbeating and still
+/// ownerless, or owned and silent. Tuning one must not move the other.
+///
+/// Runner-backed ownerless records get a far longer window instead of this one,
+/// because a live remote job is authoritative; that exemption and its 24h
+/// ceiling are documented at the reconcile call site (#11107).
+pub const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum RunStatus {
     Running,
@@ -71,9 +111,27 @@ impl RunStatus {
     }
 }
 
+/// Pins that each running-staleness threshold is defined exactly once, so the
+/// four-way drift that produced these constants cannot re-form.
+#[cfg(test)]
+#[path = "run_staleness_guard_test.rs"]
+mod run_staleness_guard_test;
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two thresholds are asserted **separately and never against each
+    /// other**. They share a value today and are still two concepts: one
+    /// measures `updated_at`, the other `started_at`. Asserting them equal
+    /// would re-couple exactly what splitting them was meant to free, so this
+    /// pins each value on its own — enough to catch an accidental change during
+    /// a refactor, without making a deliberate tune of one a failure.
+    #[test]
+    fn the_shared_thresholds_hold_their_reconciled_values() {
+        assert_eq!(RUNNING_HEARTBEAT_STALE_MINUTES, 30);
+        assert_eq!(OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES, 30);
+    }
 
     #[test]
     fn test_as_str() {


### PR DESCRIPTION
> The finding said "four copies of one constant." It is **two concepts, not one** — and there was a **fifth** copy. Merging all four would have been a bug.

## The split

Four sites, all `= 30`, but they measure **different timestamps**:

**Group A — heartbeat liveness, measured from `updated_at`:**
- `activity.rs:151` — `(now - heartbeat).num_minutes() >= N`, `heartbeat = item.updated_at`. Missing `updated_at` explicitly skipped ("liveness cannot be disproven from a timestamp alone").
- `discovery.rs:435,463` — age of `record.updated_at`. Missing → not stale.

Same basis, same direction, same treatment of a missing timestamp. The differing labels (`Stale` vs `Suspect`) are the consuming classification, not the threshold.

**Group B — ownerless grace, measured from `started_at`:**
- `http_api.rs:744` — `api_stale_running_reason` returns early if `run_owner_pid(run)` is `Some`; the threshold is reached only on the `owner_metadata_missing` branch, and measures `run.started_at`.
- `reconcile.rs:196` — identical structure via `run_started_at_least_minutes_ago`.

**This is exactly the conjunction to watch for.** `started_at` age is total elapsed wall time, not a heartbeat. A healthy 45-minute run with a fresh heartbeat crosses B's threshold and is saved only by having owner metadata. A record can be freshly heartbeating and still ownerless, or owned and silent. **A and B must move independently.**

## The fifth copy

`AgentTaskRunRecord::has_fresh_update` (`agent_task_lifecycle/records.rs:689`) compared against a bare, unnamed `30`. It is Group A's exact inverse and is used *in the same function* as `discovery.rs`'s constant. **No name-based search would ever have found it.**

## What landed

| | Action |
|---|---|
| `activity.rs`, `discovery.rs`, `has_fresh_update` | → `RUNNING_HEARTBEAT_STALE_MINUTES` |
| `http_api.rs`, `reconcile.rs` | → `OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES` |
| `RUNNER_BACKED_..._MINUTES` (24×60) | **left alone — confirmed different.** A ceiling on a runner-backed record's reconciliation exemption, only used in `reconcile.rs`, documented at #11107. |

**No value changed.** Both constants are 30, as before. They live in `observation/records/run_status.rs` next to `RunStatus`; each doc comment cites its issues and states why it is *not* the other.

## The actual durable fix

A source guard test (`run_staleness_guard_test.rs`) walking all 1,561 non-test sources under `crates/` + `src/`, failing on:
1. any staleness threshold defined outside a 3-entry sanctioned inventory
2. **any minute age compared to a bare integer literal** — the shape that hid copy #5

Constant consolidation is the smaller half; nothing previously pinned these equal, so they would silently re-diverge the moment anyone tuned one.

**Deliberate non-assertion:** the two constants are *not* asserted equal to each other. That would re-couple exactly what splitting them frees. Each value is pinned separately.

## Verification

`cargo check --workspace --tests -j2` clean.

Note for the record: this branch initially appeared to fail with `unresolved import ... OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES`. That was a stale-artifact artefact of reusing one `CARGO_TARGET_DIR` across branches with divergent `homeboy-core`; an isolated target dir compiles clean.