### PR TITLE
fix(tunnel): bind preview host claims to the ingress host authority

### DIFF
--- a/crates/homeboy-tunnel/src/preview_ingress/http.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress/http.rs
@@ -273,7 +273,10 @@ pub(crate) fn reason_for_status(status: u16) -> &'static str {
     match status {
         204 => "No Content",
         302 => "Found",
+        401 => "Unauthorized",
+        403 => "Forbidden",
         404 => "Not Found",
+        405 => "Method Not Allowed",
         410 => "Gone",
         502 => "Bad Gateway",
         504 => "Gateway Timeout",

--- a/crates/homeboy-tunnel/src/preview_ingress/serve.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress/serve.rs
@@ -44,6 +44,7 @@ pub(crate) fn serve_listener(
     let auth = Arc::new(PreviewIngressAuth {
         token_sha256_env: spec.token_sha256_env.clone(),
         token_sha256: preview_token_sha256(&spec.token_sha256_env),
+        public_host_pattern: spec.public_host_pattern.trim().to_ascii_lowercase(),
     });
     eprintln!(
         "homeboy preview ingress listening on {} for {} ({})",
@@ -316,6 +317,29 @@ fn handle_client_api(
             let body: PreviewRegisterRequest = parse_json_body(&request.body, "register")?;
             let public_host = normalize_public_host(&body.public_host);
             validate_client_public_host(&public_host)?;
+            if let Err(error) = validate_public_host_authority(&public_host, auth) {
+                let failure = PreviewIngressFailure {
+                    request_id: uuid::Uuid::new_v4().to_string(),
+                    host: request.host.clone().unwrap_or_default(),
+                    path: request.target.clone(),
+                    status: 403,
+                    classification: "host_claim_rejected".to_string(),
+                    message: error.message.clone(),
+                };
+                record_failure(recent_failures, failure);
+                return write_json_response(
+                    stream,
+                    403,
+                    json!({
+                        "error": "forbidden",
+                        "classification": "host_claim_rejected",
+                        "message": error.message,
+                        "public_host": public_host,
+                        "public_host_pattern": auth.public_host_pattern,
+                        "hint": "A preview client may only register a public host matching the pattern this ingress was started with."
+                    }),
+                );
+            }
             validate_client_local_origin(&body.local_origin)?;
             let _session_id = body.session_id.unwrap_or_else(|| public_host.clone());
             let mut sessions_guard = sessions
@@ -643,9 +667,11 @@ fn preview_token_sha256(env_name: &str) -> Option<String> {
 }
 
 fn authorized_preview_client(request: &IngressHttpRequest, auth: &PreviewIngressAuth) -> bool {
+    // Fail CLOSED: with no configured digest there is nothing to authenticate
+    // against, so every client request is denied rather than admitted.
     let Some(expected) = auth.token_sha256.as_deref() else {
         eprintln!(
-            "homeboy preview ingress client auth disabled: {} is not set",
+            "homeboy preview ingress denying all client requests: {} is not set, so no client token can be verified",
             auth.token_sha256_env
         );
         return false;
@@ -682,7 +708,58 @@ fn validate_client_public_host(public_host: &str) -> Result<()> {
             None,
         ));
     }
+    // A registered host becomes a routing key matched against inbound Host
+    // headers, so restrict it to the DNS hostname charset. Without this, a
+    // claim like `attacker.example#x-tunnel.operator.example` still satisfies a
+    // `*-tunnel.operator.example` pattern while never being a host real traffic
+    // can arrive on.
+    if !public_host
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    {
+        return Err(Error::validation_invalid_argument(
+            "public_host",
+            "preview client public host must contain only DNS hostname characters",
+            Some(public_host.to_string()),
+            None,
+        ));
+    }
     Ok(())
+}
+
+/// Bind a claimed public host to the host authority this ingress was started with.
+///
+/// The shared bearer token is a single secret held by every client of an
+/// ingress, so on its own it cannot distinguish one client from another. Session
+/// state is keyed by public host, and registration overwrites unconditionally,
+/// so an unbound `public_host` lets any token holder claim any host -- including
+/// one already owned by another client -- and intercept its traffic.
+///
+/// `public_host_pattern` is the same value the operator puts in the reverse
+/// proxy `server_name`, so a host outside it can never legitimately reach this
+/// ingress anyway. Enforcing it here closes the takeover path without
+/// constraining any host that real traffic can arrive on.
+fn validate_public_host_authority(public_host: &str, auth: &PreviewIngressAuth) -> Result<()> {
+    let pattern = auth.public_host_pattern.trim();
+    if pattern.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "public_host",
+            "preview ingress has no public host pattern configured, so no host claim can be authorized",
+            Some(public_host.to_string()),
+            Some(vec![
+                "restart the ingress with --public-host-pattern '*-tunnel.<domain>'".to_string(),
+            ]),
+        ));
+    }
+    if pattern == public_host || glob_match::glob_match(pattern, public_host) {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "public_host",
+        "preview client is not authorized to claim a public host outside this ingress's host pattern",
+        Some(public_host.to_string()),
+        Some(vec![pattern.to_string()]),
+    ))
 }
 
 fn query_value(target: &str, key: &str) -> Option<String> {

--- a/crates/homeboy-tunnel/src/preview_ingress/types.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress/types.rs
@@ -193,6 +193,13 @@ pub(crate) struct PreviewClientSessions {
 pub(crate) struct PreviewIngressAuth {
     pub(crate) token_sha256_env: String,
     pub(crate) token_sha256: Option<String>,
+    /// The operator-declared host authority for this ingress, lowercased.
+    ///
+    /// The bearer token proves *a* client is allowed to talk to this ingress; it
+    /// does not say which public host that client may claim. Without this bound,
+    /// any token holder can register any host and take over another client's
+    /// route, because sessions are keyed by public host.
+    pub(crate) public_host_pattern: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/homeboy-tunnel/src/preview_ingress_tests.rs
+++ b/crates/homeboy-tunnel/src/preview_ingress_tests.rs
@@ -205,6 +205,174 @@ fn reverse_channel_client_serves_public_request() {
     });
 }
 
+/// Boot an ingress on an ephemeral port and return that port.
+///
+/// Each caller passes its own env var name so tests never share auth state.
+fn spawn_ingress(token_sha256_env: &str, public_host_pattern: &str) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+    let port = listener.local_addr().expect("local addr").port();
+    let token_sha256_env = token_sha256_env.to_string();
+    let public_host_pattern = public_host_pattern.to_string();
+    thread::spawn(move || {
+        serve_listener(
+            PreviewIngressServeSpec {
+                bind: format!("127.0.0.1:{port}"),
+                domain: "example.com".to_string(),
+                public_host_pattern,
+                token_sha256_env,
+            },
+            listener,
+        )
+        .expect("serve ingress");
+    });
+    thread::sleep(Duration::from_millis(100));
+    port
+}
+
+fn register_body(public_host: &str) -> String {
+    json!({
+        "public_host": public_host,
+        "local_origin": "http://127.0.0.1:49999",
+        "session_id": "run-1"
+    })
+    .to_string()
+}
+
+#[test]
+fn client_auth_denies_every_request_when_token_env_is_unset() {
+    test_support::with_isolated_home(|_| {
+        // Deliberately never set this env var: an ingress with no configured
+        // digest must reject clients, not admit them.
+        std::env::remove_var("HOMEBOY_TEST_UNSET_TOKEN_SHA256");
+        let port = spawn_ingress("HOMEBOY_TEST_UNSET_TOKEN_SHA256", "*-tunnel.example.com");
+
+        let with_token = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            Some("any-token-at-all"),
+            register_body("run-1-tunnel.example.com"),
+        );
+        assert!(
+            with_token.contains("401 Unauthorized"),
+            "unset token env must fail closed, got: {with_token}"
+        );
+
+        let without_token = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            None,
+            register_body("run-1-tunnel.example.com"),
+        );
+        assert!(
+            without_token.contains("401 Unauthorized"),
+            "unset token env must fail closed, got: {without_token}"
+        );
+    });
+}
+
+#[test]
+fn client_auth_denies_wrong_bearer_token() {
+    test_support::with_isolated_home(|_| {
+        std::env::set_var(
+            "HOMEBOY_TEST_WRONG_TOKEN_SHA256",
+            native_preview_token_sha256("correct-token"),
+        );
+        let port = spawn_ingress("HOMEBOY_TEST_WRONG_TOKEN_SHA256", "*-tunnel.example.com");
+
+        let response = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            Some("wrong-token"),
+            register_body("run-1-tunnel.example.com"),
+        );
+        assert!(response.contains("401 Unauthorized"), "{response}");
+    });
+}
+
+#[test]
+fn client_with_valid_token_cannot_claim_host_outside_ingress_pattern() {
+    test_support::with_isolated_home(|_| {
+        let token = "host-claim-token";
+        std::env::set_var(
+            "HOMEBOY_TEST_HOST_CLAIM_TOKEN_SHA256",
+            native_preview_token_sha256(token),
+        );
+        let port = spawn_ingress(
+            "HOMEBOY_TEST_HOST_CLAIM_TOKEN_SHA256",
+            "*-tunnel.example.com",
+        );
+
+        // A valid token holder attempting to claim a host this ingress has no
+        // authority over: the takeover primitive the bearer check alone allowed.
+        for hijack in [
+            "victim.other-tenant.com",
+            "run-1-tunnel.evil.com",
+            "example.com",
+        ] {
+            let response = http_request(
+                port,
+                "POST",
+                "/preview/client/register",
+                "homeboy-health-tunnel.example.com",
+                Some(token),
+                register_body(hijack),
+            );
+            assert!(
+                response.contains("403 Forbidden"),
+                "claiming {hijack} must be rejected, got: {response}"
+            );
+            assert!(
+                response.contains("host_claim_rejected"),
+                "claiming {hijack} must be classified, got: {response}"
+            );
+        }
+
+        // The in-pattern host still registers: only added terms, nothing weakened.
+        let allowed = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            register_body("run-1-tunnel.example.com"),
+        );
+        assert!(allowed.contains("200 OK"), "{allowed}");
+    });
+}
+
+#[test]
+fn host_claim_is_authorized_case_insensitively_and_ignores_port() {
+    test_support::with_isolated_home(|_| {
+        let token = "host-normalize-token";
+        std::env::set_var(
+            "HOMEBOY_TEST_HOST_NORMALIZE_TOKEN_SHA256",
+            native_preview_token_sha256(token),
+        );
+        let port = spawn_ingress(
+            "HOMEBOY_TEST_HOST_NORMALIZE_TOKEN_SHA256",
+            "*-tunnel.example.com",
+        );
+
+        // normalize_public_host lowercases and strips the port before the
+        // authority check, so this must be treated as the in-pattern host.
+        let response = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            register_body("RUN-1-TUNNEL.EXAMPLE.COM:443"),
+        );
+        assert!(response.contains("200 OK"), "{response}");
+    });
+}
+
 #[test]
 fn durable_reverse_client_reregisters_after_session_disconnect() {
     test_support::with_isolated_home(|_| {


### PR DESCRIPTION
> **Correction first: the reported fail-open vulnerability does not exist.** The sweep claimed `authorized_preview_client` fails open when its env var is unset. It does not.

## The premise was wrong — it fails CLOSED

`serve.rs:669`:
```rust
let Some(expected) = auth.token_sha256.as_deref() else {
    eprintln!("homeboy preview ingress client auth disabled: {} is not set", auth.token_sha256_env);
    return false;
};
```

`return false` — not `true`. There is exactly one caller, `serve.rs:292`:
```rust
if !authorized_preview_client(&request, auth) {
    ... return write_json_response(stream, 401, json!({ "error": "unauthorized", ... }));
}
```

Unset env var → `false` → **401**. No caller re-admits it. **Not a vulnerability.**

What misled the report is the log text: `"client auth disabled"` reads as *auth is off* while the code denies everything. This PR corrects the message only — the behaviour was already right.

## The validator was not wireable, and I did not fake it

`validate_native_preview_claim` is genuinely dead (only caller is `tunnel_tests.rs`), but wiring it is blocked twice over:

1. **No `ServiceTunnel` in the process.** The validator reads `tunnel.policy.native_preview_auth` — token registry, `allowed_clients`, `allowed_public_hosts`, expiry, revocation. The ingress is a standalone edge daemon (systemd unit, `install.rs:509`) holding only `PreviewIngressAuth { token_sha256_env, token_sha256 }`: one digest from one env var. Deliberate — install.rs calls it "generic non-secret operator config."
2. **`client_id` does not exist on the wire.** `PreviewRegisterRequest` is `{public_host, local_origin, session_id}`.

Inventing values to make the types line up would create the appearance of validation without the substance — strictly worse than the current state. Deferred; it needs a control-plane change (ship resolved policy to the edge, add `client_id` to the protocol).

## The real gap, found while looking

**`public_host` was completely unbound at registration.** `spec.public_host_pattern` was used only for a startup `eprintln!` and status output — never at request time; `handle_client_api` never even received it. Sessions are keyed by public host and `sessions_guard.insert(...)` overwrites unconditionally.

**Any bearer-token holder could register any host — including one already owned by another client — and intercept its traffic.** That is precisely the substance of the dead validator's `host_claim_allowed`, and unlike the rest of the policy, the ingress *does* have the data to enforce it.

Also checked and cleared: `local_origin` is **not** an SSRF sink here — `serve.rs:481` is `let _local_origin = ...`, unused. Only the client fetches it, and it validates its own spec.

## Posture

| Check at register | Before | After |
|---|---|---|
| Missing token env var | Denied (401) — already correct | Denied (401), log no longer says "disabled" |
| Wrong/missing bearer token | Denied (401) | Denied (401) — untouched, still runs first |
| Host outside ingress pattern | **Allowed → route takeover** | **Denied (403 `host_claim_rejected`)** |
| Non-hostname chars in host | Allowed | Denied |
| Empty pattern configured | n/a | Denied |
| Per-client host binding | None | Still none — needs control plane |
| `client_id` / policy tokens | Unenforced | Still unenforced — deferred |

No existing check was weakened; the token check still runs first.

## Flagging

- **Commit subject deviates from the task.** Enforcing "the native preview claim policy" is not what this does and could not be — putting that claim in auth-code history would be false.
- **Behaviour change:** enforcing the pattern could break a deployment whose clients register out-of-pattern hosts. Judged safe because the pattern is what goes into nginx `server_name`, so such traffic could never reach the ingress anyway — the registration was already useless. All 6 existing test registrations match their patterns.
- `reason_for_status` now returns 401/403/405 phrases where everything previously rendered `"OK"`. No tests asserted the old strings; `homeboy-core` already maps 405 the same way.

## Verification

`cargo check --workspace --tests -j2` clean. Tests added for each new denial path.