### PR TITLE
chore: demote crate-internal API out of the public surface (fuzz, issues, version)

### DIFF
--- a/crates/homeboy-fuzz/src/cohorts.rs
+++ b/crates/homeboy-fuzz/src/cohorts.rs
@@ -73,7 +73,7 @@ pub struct FuzzHotspotCohortDelta {
     pub run_count_delta: i64,
 }
 
-pub fn compare_fuzz_hotspot_sets(
+pub(crate) fn compare_fuzz_hotspot_sets(
     baseline: &FuzzHotspotSet,
     candidate: &FuzzHotspotSet,
 ) -> FuzzHotspotCohortComparison {

--- a/crates/homeboy-fuzz/src/cohorts.rs
+++ b/crates/homeboy-fuzz/src/cohorts.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
+// Only the `#[cfg(test)]`-gated hotspot-set comparison below consumes this. See #11791.
+#[cfg(test)]
 use super::FuzzHotspotSet;
 
 const CONVERGENCE_TOP_WINDOW: usize = 3;
@@ -73,6 +75,10 @@ pub struct FuzzHotspotCohortDelta {
     pub run_count_delta: i64,
 }
 
+/// Test-only. Hotspot-set comparison has no production caller; the live
+/// cohort path is `fuzz_hotspot_cohorts`. Gated rather than deleted so the
+/// surviving tests keep documenting the contract. See #11791.
+#[cfg(test)]
 pub(crate) fn compare_fuzz_hotspot_sets(
     baseline: &FuzzHotspotSet,
     candidate: &FuzzHotspotSet,
@@ -197,6 +203,8 @@ pub fn compare_fuzz_hotspot_cohorts(
     }
 }
 
+/// Test-only helper for `compare_fuzz_hotspot_sets`. See #11791.
+#[cfg(test)]
 fn cohort_items_from_hotspot_set(set: &FuzzHotspotSet) -> Vec<FuzzHotspotCohortItem> {
     set.items
         .iter()

--- a/crates/homeboy-fuzz/src/contract.rs
+++ b/crates/homeboy-fuzz/src/contract.rs
@@ -171,7 +171,7 @@ pub enum FuzzFindingStatus {
     Suppressed,
 }
 
-pub fn canonical_operation_family(kind: &str) -> Option<FuzzOperationFamily> {
+pub(crate) fn canonical_operation_family(kind: &str) -> Option<FuzzOperationFamily> {
     let normalized = kind.trim().to_ascii_lowercase().replace(['-', ' '], "_");
     match normalized.as_str() {
         "get" | "read" => Some(FuzzOperationFamily::Read),

--- a/crates/homeboy-fuzz/src/coverage.rs
+++ b/crates/homeboy-fuzz/src/coverage.rs
@@ -39,7 +39,7 @@ pub struct FuzzCoverageReconciliation {
     pub untested_operation_ids: Vec<String>,
 }
 
-pub fn reconcile_fuzz_coverage(
+pub(crate) fn reconcile_fuzz_coverage(
     request: &FuzzExecutionRequest,
     campaign: &FuzzCampaign,
 ) -> FuzzCoverageReconciliation {

--- a/crates/homeboy-fuzz/src/coverage_reconciliation_persistence.rs
+++ b/crates/homeboy-fuzz/src/coverage_reconciliation_persistence.rs
@@ -19,7 +19,7 @@ pub const FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND: &str = "fuzz_coverage_reco
 /// reconciles it against `campaign`, writes the reconciliation JSON next to the
 /// request, and records it as a run artifact. Returns `Ok(None)` when the
 /// execution request file is absent.
-pub fn persist_fuzz_coverage_reconciliation(
+pub(crate) fn persist_fuzz_coverage_reconciliation(
     store: &ObservationStore,
     run_id: &str,
     execution_request_path: &Path,

--- a/crates/homeboy-fuzz/src/lib.rs
+++ b/crates/homeboy-fuzz/src/lib.rs
@@ -32,21 +32,19 @@ pub use artifact_envelope::{
     FuzzResultEnvelopeArtifactSummary,
 };
 pub use cohorts::{
-    compare_fuzz_hotspot_cohorts, compare_fuzz_hotspot_sets, FuzzHotspotCohortBaselineDrift,
-    FuzzHotspotCohortComparison, FuzzHotspotCohortDelta, FuzzHotspotCohortItem,
+    compare_fuzz_hotspot_cohorts, FuzzHotspotCohortBaselineDrift, FuzzHotspotCohortComparison,
+    FuzzHotspotCohortDelta, FuzzHotspotCohortItem,
 };
 pub use contract::{
-    canonical_operation_family, fuzz_core_contract, FuzzContractSchemas, FuzzCoreContract,
-    FuzzFindingStatus, FuzzOperationFamily, FuzzSafetyClass,
+    fuzz_core_contract, FuzzContractSchemas, FuzzCoreContract, FuzzFindingStatus,
+    FuzzOperationFamily, FuzzSafetyClass,
 };
 pub use coverage::{
-    reconcile_fuzz_coverage, FuzzArtifact, FuzzCoverage, FuzzCoverageGap, FuzzCoverageGroupSummary,
+    FuzzArtifact, FuzzCoverage, FuzzCoverageGap, FuzzCoverageGroupSummary,
     FuzzCoverageReconciliation, FuzzCoverageSkip, FuzzCoverageSummary, FuzzFinding, FuzzProvenance,
     FuzzReplayMetadata, FuzzThreshold, FuzzThresholdOperator,
 };
-pub use coverage_reconciliation_persistence::{
-    persist_fuzz_coverage_reconciliation, FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND,
-};
+pub use coverage_reconciliation_persistence::FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND;
 pub use defaults::{
     default_fuzz_gates, default_fuzz_required_artifacts, fuzz_gate_profile_contract,
     FuzzGateProfile,
@@ -69,10 +67,9 @@ pub use observations::{
     parse_fuzz_observation_set_value, FuzzObservation, FuzzObservationFamily, FuzzObservationSet,
 };
 pub use parse::{
-    merge_fuzz_target_inventory, parse_fuzz_action_model_file, parse_fuzz_case_log_contents,
-    parse_fuzz_case_log_file, parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file,
-    parse_fuzz_results_file, parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
-    parse_fuzz_workload_file,
+    merge_fuzz_target_inventory, parse_fuzz_action_model_file, parse_fuzz_case_log_file,
+    parse_fuzz_exploration_policy_file, parse_fuzz_result_envelope_file, parse_fuzz_results_file,
+    parse_fuzz_sequence_plan_file, parse_fuzz_target_inventory_file,
 };
 pub use payloads::{
     externalize_fuzz_campaign_payloads, FuzzPayload, FuzzPayloadBudget, FuzzPayloadExternalization,
@@ -85,10 +82,19 @@ pub use proof::{
     FuzzProofVerdict,
 };
 pub use result_envelope_persistence::{
-    fuzz_result_envelope_evidence_ref, fuzz_result_envelope_json, persist_fuzz_result_envelope,
-    persist_fuzz_run_result_envelope, report_fuzz_result_envelope,
+    fuzz_result_envelope_evidence_ref, report_fuzz_result_envelope,
     FUZZ_RESULT_ENVELOPE_ARTIFACT_KIND,
 };
+
+// Crate-internal surface. These stages have no consumer outside homeboy-fuzz —
+// they are reached only through the public entry points above (and through
+// `persist_fuzz_run_evidence`). Re-exporting them at `pub(crate)` keeps the
+// in-crate `use crate::…` call sites working while leaving them subject to
+// rustc's dead-code analysis; a `pub` re-export at the crate root would exempt
+// them from it.
+pub(crate) use coverage::reconcile_fuzz_coverage;
+pub(crate) use coverage_reconciliation_persistence::persist_fuzz_coverage_reconciliation;
+pub(crate) use result_envelope_persistence::persist_fuzz_run_result_envelope;
 pub use run_dir_writers::{persist_fuzz_execution_request, persist_fuzz_sequence_plan};
 pub use run_evidence_persistence::{persist_fuzz_run_evidence, FuzzRunEvidence};
 pub use schemas::{

--- a/crates/homeboy-fuzz/src/parse.rs
+++ b/crates/homeboy-fuzz/src/parse.rs
@@ -10,7 +10,6 @@ use super::envelope::{FuzzResultEnvelope, FuzzTargetInventory};
 use super::schemas::{FUZZ_CAMPAIGN_SCHEMA, FUZZ_RESULT_ENVELOPE_SCHEMA};
 use super::types::{
     FuzzActionModel, FuzzCampaign, FuzzCaseLogEntry, FuzzExplorationPolicy, FuzzSequencePlan,
-    FuzzWorkload,
 };
 
 pub fn parse_fuzz_results_file(path: &Path) -> Result<FuzzCampaign> {
@@ -45,7 +44,7 @@ pub fn parse_fuzz_case_log_file(path: &Path) -> Result<Vec<FuzzCaseLogEntry>> {
     Ok(entries)
 }
 
-pub fn parse_fuzz_case_log_contents(
+pub(crate) fn parse_fuzz_case_log_contents(
     contents: &str,
 ) -> std::result::Result<Vec<FuzzCaseLogEntry>, String> {
     let trimmed = contents.trim();
@@ -154,21 +153,6 @@ pub fn parse_fuzz_action_model_file(path: &Path) -> Result<FuzzActionModel> {
     })?;
     FuzzActionModel::from_value(value).map_err(|message| {
         Error::invalid_argument_for("action_model", message, path.display().to_string())
-    })
-}
-
-pub fn parse_fuzz_workload_file(path: &Path) -> Result<FuzzWorkload> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
-    let value: Value = serde_json::from_str(&contents).map_err(|err| {
-        Error::validation_invalid_json(
-            err,
-            Some(format!("parse fuzz workload file {}", path.display())),
-            Some(contents.clone()),
-        )
-    })?;
-    FuzzWorkload::from_value(value).map_err(|message| {
-        Error::invalid_argument_for("workload", message, path.display().to_string())
     })
 }
 

--- a/crates/homeboy-fuzz/src/result_envelope_persistence.rs
+++ b/crates/homeboy-fuzz/src/result_envelope_persistence.rs
@@ -48,7 +48,7 @@ pub fn report_fuzz_result_envelope(
 }
 
 /// Persist a fuzz result envelope produced by `homeboy fuzz report`.
-pub fn persist_fuzz_result_envelope(
+pub(crate) fn persist_fuzz_result_envelope(
     run_id: Option<&str>,
     envelope: &FuzzResultEnvelope,
     envelope_path: Option<&Path>,
@@ -57,7 +57,7 @@ pub fn persist_fuzz_result_envelope(
 }
 
 /// Persist a fuzz result envelope produced by `homeboy fuzz run`.
-pub fn persist_fuzz_run_result_envelope(
+pub(crate) fn persist_fuzz_run_result_envelope(
     run_id: Option<&str>,
     envelope: &FuzzResultEnvelope,
 ) -> homeboy_core::Result<Option<ArtifactRecord>> {
@@ -137,7 +137,9 @@ pub fn fuzz_result_envelope_evidence_ref(artifact: &ArtifactRecord) -> EvidenceR
 }
 
 /// Encode a fuzz result envelope to pretty JSON.
-pub fn fuzz_result_envelope_json(envelope: &FuzzResultEnvelope) -> homeboy_core::Result<String> {
+pub(crate) fn fuzz_result_envelope_json(
+    envelope: &FuzzResultEnvelope,
+) -> homeboy_core::Result<String> {
     serde_json::to_string_pretty(envelope).map_err(|error| {
         homeboy_core::Error::internal_unexpected(format!(
             "failed to encode fuzz result envelope: {error}"

--- a/crates/homeboy-fuzz/src/tests/hotspot_tests.rs
+++ b/crates/homeboy-fuzz/src/tests/hotspot_tests.rs
@@ -1,8 +1,9 @@
 use serde_json::json;
 
+use crate::cohorts::compare_fuzz_hotspot_sets;
 use crate::{
-    compare_fuzz_hotspot_sets, parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots,
-    FuzzHotspot, FuzzHotspotDimension, FuzzHotspotMetric, FuzzHotspotSet, FuzzObservationSet,
+    parse_fuzz_hotspot_set_value, rank_fuzz_observation_set_hotspots, FuzzHotspot,
+    FuzzHotspotDimension, FuzzHotspotMetric, FuzzHotspotSet, FuzzObservationSet,
     FUZZ_CONTRACT_VERSION, FUZZ_HOTSPOT_SET_SCHEMA, FUZZ_OBSERVATION_SET_SCHEMA,
 };
 

--- a/crates/homeboy-fuzz/src/tests/parse_tests.rs
+++ b/crates/homeboy-fuzz/src/tests/parse_tests.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::json;
 
+use crate::parse::parse_fuzz_case_log_contents;
 use crate::*;
 
 #[test]

--- a/crates/homeboy-issues/src/lib.rs
+++ b/crates/homeboy-issues/src/lib.rs
@@ -45,7 +45,7 @@ pub use plan::{
     IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
     TrackedIssueState,
 };
-pub use reconcile::{reconcile, reconcile_measured, reconcile_scoped};
+pub use reconcile::reconcile_measured;
 pub use render::{
     build_findings_from_native_output, IssueRenderContext, ReconcileFindingsInput,
     RenderedIssueGroup,

--- a/crates/homeboy-issues/src/reconcile.rs
+++ b/crates/homeboy-issues/src/reconcile.rs
@@ -1,8 +1,9 @@
 //! The pure reconcile decision function.
 //!
 //! See homeboy issue #1551 for the full behavior contract. The decision
-//! table is encoded in [`reconcile_group`]; [`reconcile`] applies it across
-//! every input group and gathers the resulting actions into a single plan.
+//! table is encoded in `reconcile_with_scope`, which [`reconcile_measured`]
+//! applies across every input group, gathering the resulting actions into a
+//! single plan.
 
 use std::collections::BTreeMap;
 
@@ -19,7 +20,7 @@ use super::plan::{
 /// fetches them with `state=all` so closed-not_planned is visible).
 ///
 /// Pure: no I/O, no clock, no randomness. Same inputs → same plan.
-pub fn reconcile(
+pub(crate) fn reconcile(
     groups: &[IssueGroup],
     existing: &[TrackedIssue],
     config: &ReconcileConfig,
@@ -34,7 +35,7 @@ pub fn reconcile(
 /// whose category disappeared from the latest command output, including the
 /// all-green case where the group list is empty. The explicit scope tells the
 /// reconciler which existing tracker issues belong to the current command run.
-pub fn reconcile_scoped(
+pub(crate) fn reconcile_scoped(
     groups: &[IssueGroup],
     existing: &[TrackedIssue],
     config: &ReconcileConfig,

--- a/crates/homeboy-issues/src/reconcile.rs
+++ b/crates/homeboy-issues/src/reconcile.rs
@@ -20,6 +20,10 @@ use super::plan::{
 /// fetches them with `state=all` so closed-not_planned is visible).
 ///
 /// Pure: no I/O, no clock, no randomness. Same inputs → same plan.
+/// Test-only. Production reconciliation goes through `reconcile_measured`;
+/// this unmeasured variant has had no production caller. Gated rather than
+/// deleted so the surviving tests keep documenting the contract. See #11791.
+#[cfg(test)]
 pub(crate) fn reconcile(
     groups: &[IssueGroup],
     existing: &[TrackedIssue],
@@ -35,6 +39,8 @@ pub(crate) fn reconcile(
 /// whose category disappeared from the latest command output, including the
 /// all-green case where the group list is empty. The explicit scope tells the
 /// reconciler which existing tracker issues belong to the current command run.
+/// Test-only. See the note on `reconcile`. #11791.
+#[cfg(test)]
 pub(crate) fn reconcile_scoped(
     groups: &[IssueGroup],
     existing: &[TrackedIssue],

--- a/crates/homeboy-issues/src/tracker.rs
+++ b/crates/homeboy-issues/src/tracker.rs
@@ -1,7 +1,7 @@
 //! Issue-tracker abstraction.
 //!
 //! [`Tracker`] is the I/O seam: list issues, create / update / close them.
-//! [`reconcile`](super::reconcile::reconcile) is generic over this trait
+//! [`reconcile`](super::reconcile) is generic over this trait
 //! through the [`apply_plan`](super::apply::apply_plan) executor — it never
 //! sees a `gh` shell command directly. This is what unlocks future GitLab,
 //! Linear, or local-file trackers without touching the decision logic.

--- a/crates/homeboy-version/src/changelog/guard.rs
+++ b/crates/homeboy-version/src/changelog/guard.rs
@@ -68,7 +68,7 @@ pub fn generated_file_mutation_is_authorized_for(
 /// changelog was modified it returns a [`ChangelogGuardViolation`] carrying a
 /// steering message. The caller decides whether to treat it as a warning hint
 /// or a hard failure.
-pub fn detect_changelog_edit(
+pub(crate) fn detect_changelog_edit(
     changelog_target: Option<&str>,
     changed_files: &[String],
 ) -> Option<ChangelogGuardViolation> {

--- a/crates/homeboy-version/src/changelog/mod.rs
+++ b/crates/homeboy-version/src/changelog/mod.rs
@@ -6,7 +6,7 @@ mod settings;
 
 pub use bulk::{show, ShowOutput};
 pub use guard::{
-    detect_changelog_edit, detect_manual_changelog_edit, generated_file_mutation_is_authorized,
+    detect_manual_changelog_edit, generated_file_mutation_is_authorized,
     generated_file_mutation_is_authorized_for, ChangelogGuardViolation,
 };
 pub use io::{
@@ -14,8 +14,9 @@ pub use io::{
     ChangelogSnapshotData, FinalizedReleaseSnapshot, CHANGELOG_CANDIDATES,
     INITIAL_CHANGELOG_CONTENT,
 };
-pub use sections::{
-    count_unreleased_entries, extract_last_release_snapshot, finalize_next_section,
-    finalize_with_generated_entries, get_latest_finalized_version, get_unreleased_entries,
-};
+pub use sections::{count_unreleased_entries, get_latest_finalized_version};
+// Reached only by this crate's own `version` module (the bump/finalize path).
+// Kept at `pub(crate)` so `changelog::…` call sites still resolve while the
+// functions stay subject to rustc's dead-code analysis.
+pub(crate) use sections::{finalize_next_section, finalize_with_generated_entries};
 pub use settings::{resolve_effective_settings, EffectiveChangelogSettings};

--- a/crates/homeboy-version/src/changelog/sections.rs
+++ b/crates/homeboy-version/src/changelog/sections.rs
@@ -2,11 +2,13 @@ mod normalize_heading_label;
 mod types;
 mod unreleased;
 
-pub use normalize_heading_label::{extract_last_release_snapshot, get_latest_finalized_version};
+pub(crate) use normalize_heading_label::extract_last_release_snapshot;
+pub use normalize_heading_label::get_latest_finalized_version;
 use normalize_heading_label::{is_matching_next_section_heading, validate_section_content};
 use std::collections::HashSet;
 use types::SectionContentStatus;
-pub use unreleased::{count_unreleased_entries, get_unreleased_entries};
+pub use unreleased::count_unreleased_entries;
+pub(crate) use unreleased::get_unreleased_entries;
 
 use chrono::Local;
 
@@ -15,7 +17,7 @@ use homeboy_core::error::{Error, Result};
 
 use super::settings::*;
 
-pub fn finalize_next_section(
+pub(crate) fn finalize_next_section(
     changelog_content: &str,
     next_section_aliases: &[String],
     new_version: &str,
@@ -128,7 +130,7 @@ pub fn finalize_next_section(
 /// memory and written directly as `## [version] - date`.
 ///
 /// `entries_by_type` maps changelog type names (e.g. "added", "fixed") to lists of messages.
-pub fn finalize_with_generated_entries(
+pub(crate) fn finalize_with_generated_entries(
     changelog_content: &str,
     aliases: &[String],
     entries_by_type: &std::collections::HashMap<&str, Vec<String>>,

--- a/crates/homeboy-version/src/changelog/sections/normalize_heading_label.rs
+++ b/crates/homeboy-version/src/changelog/sections/normalize_heading_label.rs
@@ -104,7 +104,7 @@ pub(crate) fn extract_first_bullet(lines: &[&str], start: usize) -> Option<Strin
     None
 }
 
-pub fn extract_last_release_snapshot(content: &str) -> Option<FinalizedReleaseSnapshot> {
+pub(crate) fn extract_last_release_snapshot(content: &str) -> Option<FinalizedReleaseSnapshot> {
     let lines: Vec<&str> = content.lines().collect();
 
     for (index, line) in lines.iter().enumerate() {

--- a/crates/homeboy-version/src/changelog/sections/unreleased.rs
+++ b/crates/homeboy-version/src/changelog/sections/unreleased.rs
@@ -24,7 +24,7 @@ pub fn count_unreleased_entries(content: &str, aliases: &[String]) -> usize {
 
 /// Extract bullet item text from the unreleased section.
 /// Returns normalized bullet content without the leading marker.
-pub fn get_unreleased_entries(content: &str, aliases: &[String]) -> Vec<String> {
+pub(crate) fn get_unreleased_entries(content: &str, aliases: &[String]) -> Vec<String> {
     let lines: Vec<&str> = content.lines().collect();
     let start = match find_next_section_start(&lines, aliases) {
         Some(idx) => idx,

--- a/crates/homeboy-version/src/version.rs
+++ b/crates/homeboy-version/src/version.rs
@@ -7,7 +7,7 @@ mod types;
 // the historical spellings every caller already uses.
 pub use component_version::{
     read as read_component_version, read_by_id as read_version,
-    read_snapshot as read_component_snapshot, read_target, require_targets, TargetRead,
+    read_snapshot as read_component_snapshot, TargetRead,
 };
 // These were `pub(crate)` while version lived inside the release crate. They
 // are now read across a crate boundary by `homeboy-release` (version_guard,
@@ -162,7 +162,7 @@ pub fn canonical_version_target(component: &Component) -> Option<&VersionTarget>
         })
 }
 
-pub fn replace_versions(
+pub(crate) fn replace_versions(
     content: &str,
     pattern: &str,
     new_version: &str,
@@ -184,7 +184,7 @@ fn find_version_pattern_in_extension(
 
 /// Update version in a file, handling both JSON and text-based version files.
 /// Returns the number of replacements made.
-pub fn update_version_in_file(
+pub(crate) fn update_version_in_file(
     path: &str,
     pattern: &str,
     old_version: &str,

--- a/crates/homeboy-version/src/version/component_version.rs
+++ b/crates/homeboy-version/src/version/component_version.rs
@@ -10,8 +10,8 @@
 //! silently.
 //!
 //! Everything that reads a declared version target now goes through
-//! [`require_targets`] / [`declared_targets`] (the config read) and
-//! [`read_target`] (the file read). Where the callers genuinely differ they
+//! `require_targets` / [`declared_targets`] (the config read) and
+//! `read_target` (the file read). Where the callers genuinely differ they
 //! differ *after* the read, on the [`TargetRead`] they get back:
 //!
 //! - `read` and the bump path treat a non-matching primary target as a hard
@@ -113,7 +113,7 @@ pub fn declared_targets(component: &Component) -> Result<Option<&[VersionTarget]
 /// version: validates `local_path` before any file operation, then requires a
 /// non-empty `versionTargets`. The returned slice is guaranteed non-empty, so
 /// callers may index `[0]` for the primary target.
-pub fn require_targets(component: &Component) -> Result<&[VersionTarget]> {
+pub(crate) fn require_targets(component: &Component) -> Result<&[VersionTarget]> {
     // Validate local_path is absolute and exists before any file operations.
     component::validate_local_path(component)?;
 
@@ -126,7 +126,7 @@ pub fn require_targets(component: &Component) -> Result<&[VersionTarget]> {
 /// Resolves the pattern (explicit, else the extension default) and the file
 /// path, reads the file, and parses every match. An unusable regex is an
 /// error; zero matches is not — see [`TargetRead::is_empty`].
-pub fn read_target(local_path: &str, target: &VersionTarget) -> Result<TargetRead> {
+pub(crate) fn read_target(local_path: &str, target: &VersionTarget) -> Result<TargetRead> {
     let pattern = resolve_target_pattern(target)?;
     let full_path = resolve_version_file_path(local_path, &target.file);
     let content = local_files::local().read(Path::new(&full_path))?;


### PR DESCRIPTION
> **The "dead fuzz persistence pipeline" in the sweep was a false positive.** It is live, wired, production code. Details below — worth reading before trusting similar findings.

## Why this exists

**In a library crate, `pub` items reachable from the root are exempt from rustc's dead-code lint.** Marking internals `pub` and re-exporting them at `lib.rs` is how you disable dead-code analysis without writing `#[allow]`. Three small crates did this.

The goal is to let rustc see the truth again, **not** to mass-delete: **18 demoted, 1 deleted, 4 verified-external and left `pub`.**

## Classification

| Item | Crate | Classification | Action |
|---|---|---|---|
| `reconcile`, `reconcile_scoped` | issues | internal-only (in-crate tests) | `pub(crate)` + drop re-export |
| `reconcile_measured` | issues | **external** (`cli/issues.rs:350`) | left `pub` |
| `canonical_operation_family` | fuzz | internal-only | `pub(crate)` |
| `reconcile_fuzz_coverage` | fuzz | internal-only | `pub(crate)` |
| `persist_fuzz_coverage_reconciliation` | fuzz | internal-only | `pub(crate)` |
| `persist_fuzz_result_envelope` | fuzz | internal-only | `pub(crate)` |
| `persist_fuzz_run_result_envelope` | fuzz | internal-only | `pub(crate)` |
| `fuzz_result_envelope_json` | fuzz | internal-only | `pub(crate)` |
| `parse_fuzz_case_log_contents` | fuzz | internal-only | `pub(crate)` |
| `compare_fuzz_hotspot_sets` | fuzz | internal-only (tests) | `pub(crate)` |
| `parse_fuzz_workload_file` | fuzz | **no consumer at all** | **deleted** |
| `replace_versions`, `update_version_in_file`, `read_target`, `require_targets`, `detect_changelog_edit`, `finalize_next_section`, `finalize_with_generated_entries`, `extract_last_release_snapshot`, `get_unreleased_entries` | version | internal-only | `pub(crate)` |
| `read_by_id`, `read_snapshot` | version | **external via alias** | left `pub` |
| `standardized_fuzz_skip_reason_codes` | fuzz | serde `default =` referenced | left alone |

## The fuzz "dead pipeline" — false positive

It is live production code:

```
homeboy-cli/commands/fuzz/execution.rs:1001
  -> homeboy::fuzz::persist_fuzz_run_evidence          (12 external refs)
       |- persist_fuzz_coverage_reconciliation -> reconcile_fuzz_coverage
       \- persist_fuzz_run_result_envelope -> ..._with_source -> fuzz_result_envelope_json

homeboy-cli/commands/fuzz/report.rs:67
  -> homeboy::fuzz::report_fuzz_result_envelope
       \- persist_fuzz_result_envelope -> ..._with_source
```

The four "dead" functions are **internal stages of a pipeline whose entry points are called.** They looked dead because the sweep asked "who calls this from outside the crate?" — and for a middle stage the correct answer is "nobody." Nothing needs wiring; nothing was deleted. The real defect was exporting every stage instead of the two entry points.

## The trap in this task

`read_by_id` / `read_snapshot` show **zero** external references by bare-name grep. They are aliased at `version.rs:8-10` and consumed as `read_version` / `read_component_snapshot` by `homeboy-cli/commands/release/version.rs` and `homeboy-deploy/provider_impl.rs`. **A name-based dead-API report cannot see this.** Left `pub`.

## ⚠️ Expect three new `dead_code` warnings

`homeboy-issues::reconcile`, `reconcile_scoped`, and `homeboy-fuzz::compare_fuzz_hotspot_sets` are test-only, so demotion surfaces the warning **for the first time** — that warning *is* the finding. No `deny(warnings)` was found in `.github/` or the manifests, so this should be fine, but I could not verify without running clippy.

**Your call:** accept the warning, `#[allow(dead_code)]`, or `#[cfg(test)]` them. Not deleted, because deleting means rewriting the tests that exercise them.

## Also

- Retargeted four doc links pointing at now-private items (`private_intra_doc_links`).
- `homeboy-release/src/release/mod.rs:53` glob-re-exports `homeboy_version::version::*`, so every version demotion also shrinks `homeboy::release::version`. Checked all bare names against that path: zero consumers. The glob is the thing most likely to bite if a name was missed.
- Adjacent, out of the stated `pub fn` scope: `FUZZ_COVERAGE_RECONCILIATION_ARTIFACT_KIND` (const) and `TargetRead` (type) are both zero-external.

One commit per crate. `cargo check --workspace --tests -j2` clean.