### PR TITLE
docs(contracts): correct the crossref and untyped-key notes after upstream removal

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -177,12 +177,24 @@ pub struct ExtensionManifest {
     /// (`lifecycle::source_metadata`) — and nothing else in here has a reader.
     ///
     /// Landing anything else here makes it inert *silently*, which is how
-    /// shipped manifests accumulated `dependency_materialization_recipes` (51
-    /// lines), `required_output_declarations` (26 lines), `testing`, and `docs`:
-    /// all parse, all survive a round-trip, none are ever consulted by anything
-    /// in this workspace. A key that core is meant to act on belongs on a typed
-    /// field, where its absence of a reader is a compile-time fact rather than
-    /// something a grep has to discover. (#11124)
+    /// shipped manifests accumulated `required_output_declarations` (26 lines),
+    /// `testing`, `docs`, `component_type`, and `homeboy_version_target`: all
+    /// parsed, all survived a round-trip, none were ever consulted by anything
+    /// in this workspace. Extra-Chill/homeboy-extensions#2565 removed that set
+    /// at the source.
+    ///
+    /// Two things deliberately stayed, and the distinction matters: no reader
+    /// *here* is not the same as no reader *anywhere*.
+    /// `dependency_materialization_recipes` (51 lines) is still inert to core
+    /// but is asserted on by the WordPress extension's own smoke tests.
+    /// managed-preview's `browser_trace_helpers` and `preview_backends` have no
+    /// reader in this workspace or in the extensions repo, which makes their
+    /// inertness an unprovable negative from here rather than a demonstrated
+    /// one — so they were left alone.
+    ///
+    /// A key that core is meant to act on belongs on a typed field, where its
+    /// absence of a reader is a compile-time fact rather than something a grep
+    /// has to discover. (#11124)
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
     pub extra: HashMap<String, serde_json::Value>,
 

--- a/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
@@ -72,12 +72,15 @@ pub struct DiscoveryMarkerConfig {
 /// Each key maps a capability name to a script path relative to the extension directory.
 ///
 /// Every field here must have a live consumer in core. A key with no reader is
-/// not a feature, it is a promise the manifest cannot keep: `crossref` is
-/// declared by the WordPress extension and has *never* existed on this struct,
-/// so serde has silently dropped it since the day it was added, leaving a
-/// ~185-line script and a README row wired to nothing. `topology` was the
-/// mirror image — it existed here, and nothing ever declared it — and was
-/// removed in #11124.
+/// not a feature, it is a promise the manifest cannot keep. `crossref` is the
+/// cautionary case: the WordPress extension declared it, but it *never* existed
+/// as a field on this struct, so serde silently dropped it on every parse for
+/// the entire life of the key — leaving a 573-line script and a README row
+/// wired to nothing. Nothing failed, nothing warned; the cost was only ever
+/// visible to someone who went looking. It was removed at the source in
+/// Extra-Chill/homeboy-extensions#2565 (key, script, and README row).
+/// `topology` was the mirror image — it existed here, and nothing ever
+/// declared it — and was removed in #11124.
 ///
 /// Unknown keys are dropped rather than rejected (no `deny_unknown_fields`),
 /// which is the right call for forward compatibility but means a typo or a

--- a/tests/fixtures/extension_manifests/wordpress.json
+++ b/tests/fixtures/extension_manifests/wordpress.json
@@ -3,7 +3,7 @@
   "version": "3.6.1",
   "provides": {
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
-    "capabilities": ["fingerprint", "refactor", "crossref", "validate"]
+    "capabilities": ["fingerprint", "refactor", "validate"]
   },
   "structured_sidecars": {
     "lint.findings": true,
@@ -24,7 +24,6 @@
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.py",
-    "crossref": "scripts/test/crossref.php",
     "validate": "scripts/validation/validate-syntax.sh",
     "format": "scripts/format.sh"
   },


### PR DESCRIPTION
Follow-up to `Extra-Chill/homeboy-extensions#2565`, which deleted the `crossref` manifest key and `wordpress/scripts/test/crossref.php`. Comments and one JSON fixture only — **no code paths touched.**

## 1. `ScriptsConfig` doc comment

Said `crossref` "is declared by the WordPress extension and has *never* existed on this struct... leaving a **~185-line** script and a README row wired to nothing."

Present tense, and the line count was wrong: the script was **573 lines** (verified against the sibling repo's deletion diff — exactly 573 deleted). Now past tense, correct count, and records that #2565 removed key + script + README row. The `deny_unknown_fields` lesson below it is untouched — it is the genuinely valuable part and explains why this failure mode matters.

## 2. `ExtensionManifest::extra` doc comment — my brief was wrong here

I told the agent to preserve a "keep" set. The list actually enumerated **only four** keys:

> `dependency_materialization_recipes` (51 lines), `required_output_declarations` (26 lines), `testing`, and `docs`

It never mentioned `component_type`, `homeboy_version_target`, `browser_trace_helpers`, or `preview_backends`. So `dependency_materialization_recipes` was the only survivor of a list of four. Added the two other removed keys for completeness, plus a "deliberately stayed" paragraph — without it the doc reads as though #2565 emptied the buffer.

Kept a precision the original had right: `dependency_materialization_recipes` has **no reader in this workspace** — its reader is a JS smoke test in the extensions repo. Writing "it has a reader" would have made the doc wrong in the other direction.

## 3. Test fixture — updated, after reading its consumers

`tests/fixtures/extension_manifests/wordpress.json` carried `crossref` twice. The only consumer is `crates/homeboy-extension/src/tests.rs`:

- `extension_manifest_accepts_real_extension_fixture_shapes` — asserts `parse` / `id` / `name`
- `shipped_manifests_do_not_yet_declare_every_exported_sidecar` — reads only `structured_sidecars`

Neither reads `scripts` or `provides.capabilities`, so removal cannot change an assertion.

On "is this a deliberate parse-tolerance fixture?" — **no.** Both tests are named for *shipped reality*, and the second asserts concrete facts about shipped manifests and is explicitly designed to retire itself when shipped reality changes. That only works if the fixtures track shipped manifests.

**Parse-tolerance coverage is not lost:** `ProvidesConfig` has no `capabilities` field and `ScriptsConfig` has no `validate` field, so the fixture still carries two untyped keys exercising silent-drop behaviour.

## Flagging

**The fixture is a far staler snapshot than just `crossref`.** It pins `"version": "3.6.1"`; the shipped manifest is **3.34.39**. Shipped `provides` has no `capabilities` key at all, and shipped `scripts` has no `validate`. Deliberately untouched — out of scope, and `shipped_manifests_do_not_yet_declare_every_exported_sidecar` asserts on `structured_sidecars` in ways not worth disturbing without running tests. Worth a separate task.

`crossref` (dead manifest key) vs `ActivityCrossRefs` (live struct, `homeboy-core/src/activity/model.rs:43`, used in 6 files) kept strictly distinct — the latter is untouched, as is ~18 hits of ordinary "cross-reference" prose.

`cargo check --workspace --tests -j2` clean.