### PR TITLE
fix(daemon): converge when stop ownership disappears

### DIFF
--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -104,7 +104,19 @@ fn force_stop_for_lease_unlocked(expected_lease_id: &str) -> Result<DaemonStopRe
         });
     }
 
-    let termination = terminate_exact_supervised_daemon(&path, &identity, &state)?;
+    let termination = match terminate_exact_supervised_daemon(&path, &identity, &state)? {
+        SupervisedDaemonTerminationOutcome::Stopped(termination) => termination,
+        SupervisedDaemonTerminationOutcome::AlreadyAbsent => {
+            remove_lease_if_identity_matches(&path, &identity)?;
+            return Ok(DaemonStopResult {
+                stopped: false,
+                already_absent: true,
+                pid: Some(state.pid),
+                state_path: state_path_display,
+                termination_evidence: None,
+            });
+        }
+    };
     let evidence = DaemonTerminationEvidence {
         classification: DaemonTerminationClassification::CleanStop,
         observed_at: chrono::Utc::now().to_rfc3339(),
@@ -142,6 +154,18 @@ struct SupervisedDaemonTermination {
     supervisor_signal: Option<i32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupervisedDaemonTerminationOutcome {
+    Stopped(SupervisedDaemonTermination),
+    AlreadyAbsent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExactTerminationTarget {
+    Owned,
+    Absent,
+}
+
 impl SupervisedDaemonTermination {
     fn os_evidence(self, child_pid: u32) -> String {
         let child_signal = signal_name(self.child_signal);
@@ -168,14 +192,26 @@ fn terminate_exact_supervised_daemon(
     path: &std::path::Path,
     identity: &DaemonLeaseIdentity,
     state: &DaemonState,
-) -> Result<SupervisedDaemonTermination> {
+) -> Result<SupervisedDaemonTerminationOutcome> {
     let supervisor = supervised_parent_pid(state.pid, &state.startup_token)?;
-    revalidate_exact_termination_target(path, identity, state)?;
+    if revalidate_exact_termination_target(path, identity, state)? == ExactTerminationTarget::Absent
+    {
+        return Ok(SupervisedDaemonTerminationOutcome::AlreadyAbsent);
+    }
     signal_pid(state.pid, SIGNAL_TERMINATE)?;
     let child_signal = if wait_for_pid_exit(state.pid, TERM_GRACE) {
         Some(SIGNAL_TERMINATE)
     } else {
-        revalidate_exact_termination_target(path, identity, state)?;
+        if revalidate_exact_termination_target(path, identity, state)?
+            == ExactTerminationTarget::Absent
+        {
+            return Ok(SupervisedDaemonTerminationOutcome::Stopped(
+                SupervisedDaemonTermination {
+                    child_signal: Some(SIGNAL_TERMINATE),
+                    supervisor_signal: None,
+                },
+            ));
+        }
         signal_pid(state.pid, SIGNAL_KILL)?;
         if !wait_for_pid_exit(state.pid, KILL_GRACE) {
             return Err(Error::internal_unexpected(format!(
@@ -192,12 +228,30 @@ fn terminate_exact_supervised_daemon(
     let supervisor_signal = match supervisor {
         Some(pid) if wait_for_pid_exit(pid, TERM_GRACE) => None,
         Some(pid) => {
-            revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
+            if revalidate_exact_supervisor_termination_target(path, identity, state, pid)?
+                == ExactTerminationTarget::Absent
+            {
+                return Ok(SupervisedDaemonTerminationOutcome::Stopped(
+                    SupervisedDaemonTermination {
+                        child_signal,
+                        supervisor_signal: None,
+                    },
+                ));
+            }
             signal_pid(pid, SIGNAL_TERMINATE)?;
             if wait_for_pid_exit(pid, TERM_GRACE) {
                 Some(SIGNAL_TERMINATE)
             } else {
-                revalidate_exact_supervisor_termination_target(path, identity, state, pid)?;
+                if revalidate_exact_supervisor_termination_target(path, identity, state, pid)?
+                    == ExactTerminationTarget::Absent
+                {
+                    return Ok(SupervisedDaemonTerminationOutcome::Stopped(
+                        SupervisedDaemonTermination {
+                            child_signal,
+                            supervisor_signal: Some(SIGNAL_TERMINATE),
+                        },
+                    ));
+                }
                 signal_pid(pid, SIGNAL_KILL)?;
                 if !wait_for_pid_exit(pid, KILL_GRACE) {
                     return Err(Error::internal_unexpected(format!(
@@ -209,17 +263,19 @@ fn terminate_exact_supervised_daemon(
         }
         None => None,
     };
-    Ok(SupervisedDaemonTermination {
-        child_signal,
-        supervisor_signal,
-    })
+    Ok(SupervisedDaemonTerminationOutcome::Stopped(
+        SupervisedDaemonTermination {
+            child_signal,
+            supervisor_signal,
+        },
+    ))
 }
 
-fn revalidate_exact_termination_target(
+pub(super) fn revalidate_exact_termination_target(
     path: &std::path::Path,
     identity: &DaemonLeaseIdentity,
     state: &DaemonState,
-) -> Result<()> {
+) -> Result<ExactTerminationTarget> {
     let current = read_lease_if_identity_matches(path, identity)?;
     if current.pid != state.pid || !active_daemon_job_ids()?.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -229,18 +285,12 @@ fn revalidate_exact_termination_target(
             None,
         ));
     }
-    if !pid_has_ownership_token(state.pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)? {
-        return Err(Error::validation_invalid_argument(
-            "daemon_lease",
-            format!(
-                "daemon pid {} no longer owns the persisted startup token",
-                state.pid
-            ),
-            Some(state.pid.to_string()),
-            None,
-        ));
+    if !pid_is_running(state.pid)
+        || !pid_has_ownership_token(state.pid, DAEMON_STARTUP_TOKEN_ENV, &state.startup_token)?
+    {
+        return Ok(ExactTerminationTarget::Absent);
     }
-    Ok(())
+    Ok(ExactTerminationTarget::Owned)
 }
 
 /// The child is already absent when this runs, so the supervisor's token is the
@@ -252,7 +302,7 @@ fn revalidate_exact_supervisor_termination_target(
     identity: &DaemonLeaseIdentity,
     state: &DaemonState,
     supervisor_pid: u32,
-) -> Result<()> {
+) -> Result<ExactTerminationTarget> {
     let current = read_lease_if_identity_matches(path, identity)?;
     if current.pid != state.pid || !active_daemon_job_ids()?.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -267,14 +317,9 @@ fn revalidate_exact_supervisor_termination_target(
         DAEMON_STARTUP_TOKEN_ENV,
         &state.startup_token,
     )? {
-        return Err(Error::validation_invalid_argument(
-            "daemon_lease",
-            format!("supervisor pid {supervisor_pid} no longer owns the daemon startup token"),
-            Some(supervisor_pid.to_string()),
-            None,
-        ));
+        return Ok(ExactTerminationTarget::Absent);
     }
-    Ok(())
+    Ok(ExactTerminationTarget::Owned)
 }
 
 /// `ps` is the portable evidence adapter for the supervisor relationship. The
@@ -484,7 +529,19 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
             return Err(active_jobs_block_daemon_stop_error(state, &active_job_ids));
         }
         if !force {
-            let termination = terminate_exact_supervised_daemon(&path, &identity, state)?;
+            let termination = match terminate_exact_supervised_daemon(&path, &identity, state)? {
+                SupervisedDaemonTerminationOutcome::Stopped(termination) => termination,
+                SupervisedDaemonTerminationOutcome::AlreadyAbsent => {
+                    remove_lease_if_identity_matches(&path, &identity)?;
+                    return Ok(DaemonStopResult {
+                        stopped: false,
+                        already_absent: true,
+                        pid: Some(pid),
+                        state_path: state_path_display,
+                        termination_evidence: None,
+                    });
+                }
+            };
             let evidence = DaemonTerminationEvidence {
                 classification: DaemonTerminationClassification::CleanStop,
                 observed_at: chrono::Utc::now().to_rfc3339(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2437,6 +2437,29 @@ fn force_stop_matching_idle_lease_retires_a_reused_pid_without_signaling() {
     child.wait().expect("reap test process");
 }
 
+#[cfg(unix)]
+#[test]
+fn termination_revalidation_classifies_lost_ownership_as_absent_without_signaling() {
+    let _home = HomeGuard::new();
+    let mut child = spawn_force_stop_test_process(None);
+    let mut state = daemon_state_for_test(child.id(), "127.0.0.1:1");
+    state.startup_token = "ownership-that-disappeared".to_string();
+    write_daemon_state_for_test(&state);
+    let path = state_path().expect("state path");
+    let identity = DaemonLeaseIdentity::from_state(&state);
+
+    let target = stop::revalidate_exact_termination_target(&path, &identity, &state)
+        .expect("lost ownership is a safe terminal classification");
+
+    assert_eq!(target, stop::ExactTerminationTarget::Absent);
+    assert!(
+        pid_is_running(child.id()),
+        "the unowned PID must not be signaled"
+    );
+    child.kill().expect("cleanup test process");
+    child.wait().expect("reap test process");
+}
+
 #[test]
 fn ordinary_stop_retires_a_live_unowned_stale_lease_without_signaling() {
     let _home = HomeGuard::new();


### PR DESCRIPTION
## Summary
- classify vanished daemon ownership during exact termination revalidation as an already-converged state
- preserve hard failures for lease identity changes and active jobs
- avoid escalating signals to a child or supervisor after ownership disappears
- retire the matching stale lease when ownership vanishes before the first signal

## Verification
- `homeboy review lint --path . --changed-only --placement local --summary` (0 findings; run `0529198c-9636-4027-862b-4982b3aec677`)
- `cargo test -p homeboy-core force_stop_ -- --nocapture`
- `cargo test -p homeboy-core ordinary_stop_ -- --nocapture`
- `cargo test -p homeboy-core supervised_daemon -- --nocapture`
- `cargo test -p homeboy --test cleanup_next_actions aggregate_repo_artifact_next_action_runs_outside_a_checkout -- --nocapture` (3 consecutive passes on macOS)
- `cargo fmt --all --check`
- `git diff --check`

Closes #11721.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the ownership-race handling, added the regression test, and ran verification. Chris Huber reviewed and remains responsible for the change.