### PR TITLE
fix(lint): scope baseline drift comparison

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/lint_results.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lint_results.rs
@@ -33,6 +33,8 @@ pub struct LintCommandOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline_comparison: Option<BaselineComparison>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_provenance: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub formatting_findings: Option<crate::lint_result::FormattingFindings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub findings: Option<Vec<HomeboyFinding>>,

--- a/crates/homeboy-extension/src/lint/baseline.rs
+++ b/crates/homeboy-extension/src/lint/baseline.rs
@@ -22,6 +22,70 @@ pub struct LintBaselineMetadata {
     pub findings_count: usize,
 }
 
+/// The exact lint population a baseline is allowed to describe.
+///
+/// A changed-file run must never compare itself with an unscoped run: the
+/// latter contains findings the former deliberately did not ask producers to
+/// inspect. The digest is used as the persisted key while this full value is
+/// returned as provenance for humans and automation.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintBaselineProvenance {
+    pub baseline_key: String,
+    pub compared: bool,
+    pub files: Vec<String>,
+    pub tools: Vec<String>,
+    pub scope: String,
+    pub category: Option<String>,
+    pub errors_only: bool,
+    pub sniffs: Option<String>,
+    pub exclude_sniffs: Option<String>,
+}
+
+impl LintBaselineProvenance {
+    pub fn new(
+        files: Vec<String>,
+        tools: Vec<String>,
+        scope: impl Into<String>,
+        category: Option<String>,
+        errors_only: bool,
+        sniffs: Option<String>,
+        exclude_sniffs: Option<String>,
+    ) -> Self {
+        let mut files = files;
+        files.sort();
+        files.dedup();
+        let mut tools = tools;
+        tools.sort();
+        tools.dedup();
+        let scope = scope.into();
+        let identity = serde_json::json!({
+            "files": files,
+            "tools": tools,
+            "scope": scope,
+            "category": category,
+            "errors_only": errors_only,
+            "sniffs": sniffs,
+            "exclude_sniffs": exclude_sniffs,
+        });
+        let digest = homeboy_engine_primitives::content_hash::sha256_hex(
+            serde_json::to_string(&identity)
+                .expect("lint baseline provenance is serializable")
+                .as_bytes(),
+        );
+        Self {
+            baseline_key: format!("{BASELINE_KEY}:{digest}"),
+            compared: false,
+            files,
+            tools,
+            scope,
+            category,
+            errors_only,
+            sniffs,
+            exclude_sniffs,
+        }
+    }
+}
+
 struct LintFingerprint<'a>(&'a HomeboyFinding);
 
 impl Fingerprintable for LintFingerprint<'_> {
@@ -46,6 +110,15 @@ impl Fingerprintable for LintFingerprint<'_> {
 
 pub type LintBaseline = generic::Baseline<LintBaselineMetadata>;
 pub type BaselineComparison = generic::Comparison;
+
+fn config(source_path: &Path, provenance: Option<&LintBaselineProvenance>) -> BaselineConfig {
+    BaselineConfig::new(
+        source_path,
+        provenance
+            .map(|provenance| provenance.baseline_key.as_str())
+            .unwrap_or(BASELINE_KEY),
+    )
+}
 
 pub fn parse_findings_file(path: &Path) -> homeboy_core::error::Result<Vec<HomeboyFinding>> {
     if !path.exists() {
@@ -102,7 +175,16 @@ pub fn save_baseline(
     component_id: &str,
     findings: &[HomeboyFinding],
 ) -> homeboy_core::error::Result<std::path::PathBuf> {
-    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    save_baseline_for_scope(source_path, component_id, findings, None)
+}
+
+pub fn save_baseline_for_scope(
+    source_path: &Path,
+    component_id: &str,
+    findings: &[HomeboyFinding],
+    provenance: Option<&LintBaselineProvenance>,
+) -> homeboy_core::error::Result<std::path::PathBuf> {
+    let config = config(source_path, provenance);
     let metadata = LintBaselineMetadata {
         findings_count: findings.len(),
     };
@@ -111,7 +193,14 @@ pub fn save_baseline(
 }
 
 pub fn load_baseline(source_path: &Path) -> Option<LintBaseline> {
-    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    load_baseline_for_scope(source_path, None)
+}
+
+pub fn load_baseline_for_scope(
+    source_path: &Path,
+    provenance: Option<&LintBaselineProvenance>,
+) -> Option<LintBaseline> {
+    let config = config(source_path, provenance);
     generic::load::<LintBaselineMetadata>(&config).unwrap_or_default()
 }
 

--- a/crates/homeboy-extension/src/lint/report.rs
+++ b/crates/homeboy-extension/src/lint/report.rs
@@ -69,6 +69,9 @@ pub fn from_main_workflow_with_ci_context(
             autofix: result.autofix,
             hints: result.hints,
             baseline_comparison: result.baseline_comparison,
+            baseline_provenance: result.baseline_provenance.map(|provenance| {
+                serde_json::to_value(provenance).expect("lint provenance serializes")
+            }),
             formatting_findings: result.formatting_findings,
             findings: if json_summary { None } else { result.findings },
             producer_summaries: result.producer_summaries,
@@ -202,6 +205,7 @@ pub fn from_lint_fix(component_label: String, run: LintFixInput) -> (LintCommand
             autofix: Some(autofix),
             hints,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: None,
             producer_summaries: Vec::new(),
@@ -279,6 +283,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: Some(vec![
                 HomeboyFinding::builder("eslint", "eslint error").build(),
@@ -314,6 +319,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: Some(vec![HomeboyFinding::builder("phpcs", "phpcs warning")
                 .severity("warning")
@@ -347,6 +353,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: Some(Vec::new()),
             producer_summaries: vec![
@@ -374,6 +381,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: Some(FormattingFindings {
                 files: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
                 summary: Some("FMT SUMMARY: 2 files need formatting".to_string()),
@@ -409,6 +417,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: Some(Vec::new()),
             producer_summaries: vec![FindingProducerSummary::new(

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -162,7 +162,7 @@ exit 1
 }
 
 #[test]
-fn changed_scope_baseline_verdict_matches_an_identical_merge_tree() {
+fn scoped_zero_findings_do_not_compare_unrelated_legacy_baseline() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");
         let run_git = |args: &[&str]| {
@@ -191,7 +191,6 @@ fn changed_scope_baseline_verdict_matches_an_identical_merge_tree() {
             .expect("candidate source");
         run_git(&["add", "."]);
         run_git(&["commit", "-q", "-m", "candidate"]);
-        run_git(&["branch", "merge-candidate"]);
 
         let component = routed_lint_component(
             home.path(),
@@ -199,6 +198,7 @@ fn changed_scope_baseline_verdict_matches_an_identical_merge_tree() {
             r#"#!/bin/sh
 if [ -n "$HOMEBOY_LINT_GLOB" ]; then
   printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+  printf '[{"tool":"phpcs","status":"passed","finding_count":0},{"tool":"phpstan","status":"passed","finding_count":0}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
   exit 0
 else
   printf '[{"tool":"phpcs","message":"known","fingerprint":"known","file":"untouched.php"},{"tool":"phpstan","message":"relocated","fingerprint":"relocated","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
@@ -223,60 +223,50 @@ fi
         )
         .expect("PR workflow result");
 
-        let merge_tree = std::process::Command::new("git")
-            .args(["rev-parse", "merge-candidate^{tree}"])
-            .current_dir(source.path())
-            .output()
-            .expect("merge tree");
-        let head_tree = std::process::Command::new("git")
-            .args(["rev-parse", "HEAD^{tree}"])
-            .current_dir(source.path())
-            .output()
-            .expect("head tree");
-        assert_eq!(
-            head_tree.stdout, merge_tree.stdout,
-            "trees must be identical"
-        );
+        assert_eq!(pr_result.status, "passed");
+        assert_eq!(pr_result.exit_code, 0);
+        assert!(pr_result.findings.as_ref().is_some_and(Vec::is_empty));
+        assert!(pr_result.baseline_comparison.is_none());
+        let provenance = pr_result
+            .baseline_provenance
+            .as_ref()
+            .expect("scoped baseline provenance");
+        assert!(!provenance.compared);
+        assert_eq!(provenance.files, vec!["legacy.php"]);
+        assert_eq!(provenance.tools, vec!["phpcs", "phpstan"]);
+        assert_eq!(provenance.scope, "changed");
+        assert!(provenance.baseline_key.starts_with("lint:"));
+        assert_ne!(provenance.baseline_key, "lint");
 
-        let merge_result = run_main_lint_workflow(
+        let mut save_args = lint_args();
+        save_args.changed_since = Some("baseline".to_string());
+        save_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        save_args.baseline_flags.baseline = true;
+        run_main_lint_workflow(
             &component,
             source.path(),
-            lint_args(),
-            &RunDir::create().expect("merge run dir"),
+            save_args,
+            &RunDir::create().expect("scoped baseline run dir"),
         )
-        .expect("merge workflow result");
+        .expect("save scoped baseline");
 
-        assert_eq!(pr_result.status, "failed");
-        assert_eq!(merge_result.status, "failed");
-        assert_eq!(
-            pr_result
-                .baseline_comparison
-                .as_ref()
-                .expect("PR baseline comparison")
-                .new_items
-                .iter()
-                .map(|item| item.fingerprint.as_str())
-                .collect::<Vec<_>>(),
-            merge_result
-                .baseline_comparison
-                .as_ref()
-                .expect("merge baseline comparison")
-                .new_items
-                .iter()
-                .map(|item| item.fingerprint.as_str())
-                .collect::<Vec<_>>(),
-            "the PR gate must predict the full-scope verdict for the same tree"
-        );
-        assert_eq!(
-            pr_result
-                .baseline_comparison
-                .as_ref()
-                .expect("PR baseline comparison")
-                .new_items
-                .len(),
-            1,
-            "the untouched baseline finding remains accepted"
-        );
+        let mut compare_args = lint_args();
+        compare_args.changed_since = Some("baseline".to_string());
+        compare_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        let scoped_baseline_result = run_main_lint_workflow(
+            &component,
+            source.path(),
+            compare_args,
+            &RunDir::create().expect("scoped comparison run dir"),
+        )
+        .expect("compare scoped baseline");
+        assert!(scoped_baseline_result
+            .baseline_provenance
+            .as_ref()
+            .is_some_and(|provenance| provenance.compared));
+        assert!(scoped_baseline_result
+            .baseline_comparison
+            .is_some_and(|comparison| comparison.new_items.is_empty()));
     });
 }
 
@@ -473,13 +463,11 @@ exit 0
             .producer_summaries
             .iter()
             .any(|producer| producer.step.as_deref() == Some("js") && producer.status == "error"));
-        assert_eq!(
-            workflow
-                .baseline_comparison
-                .as_ref()
-                .map(|comparison| comparison.new_items.len()),
-            Some(0)
-        );
+        assert!(workflow.baseline_comparison.is_none());
+        assert!(workflow
+            .baseline_provenance
+            .as_ref()
+            .is_some_and(|provenance| !provenance.compared));
     });
 }
 

--- a/crates/homeboy-extension/src/lint/run/types.rs
+++ b/crates/homeboy-extension/src/lint/run/types.rs
@@ -69,6 +69,8 @@ pub struct LintRunWorkflowResult {
     pub hints: Option<Vec<String>>,
     pub baseline_comparison: Option<lint_baseline::BaselineComparison>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_provenance: Option<lint_baseline::LintBaselineProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub formatting_findings: Option<FormattingFindings>,
     pub findings: Option<Vec<HomeboyFinding>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -11,7 +11,7 @@ use super::findings::{
 use super::formatting::{extract_formatting_findings, self_check_output_is_harness_failure};
 use super::hints::build_autofix_hint;
 use super::scoping::resolve_scoped_lint_runs;
-use super::types::{LintRunWorkflowArgs, LintRunWorkflowResult, ScopedLintRun};
+use super::types::{LintRunWorkflowArgs, LintRunWorkflowResult, ScopedLintPlan, ScopedLintRun};
 use crate as extension;
 use crate::lint::baseline as lint_baseline;
 use crate::lint::build_lint_runner;
@@ -37,12 +37,6 @@ struct ScopedLintOutput {
     output: extension::RunnerOutput,
     evidence: Vec<LintRunEvidence>,
     child_run_dirs: Vec<RunDir>,
-}
-
-struct FullCandidateBaseline {
-    findings: Vec<HomeboyFinding>,
-    hard_error: bool,
-    exit_code: i32,
 }
 
 /// Run the main lint workflow.
@@ -85,39 +79,6 @@ pub fn run_main_lint_workflow(
     // read differently to an operator and to the PR comment.
     if let Some(ref plan) = scoped_plan {
         if plan.runs.is_empty() {
-            let full_candidate =
-                should_verify_full_candidate_baseline(source_path, &args, scoped_plan.as_ref())
-                    .then(|| run_full_candidate_baseline(component, &args))
-                    .transpose()?;
-            if let Some(candidate) = full_candidate {
-                let (baseline_comparison, baseline_exit_override) =
-                    process_baseline(source_path, &args, &candidate.findings)?;
-                let exit_code = if candidate.hard_error {
-                    candidate.exit_code
-                } else {
-                    baseline_exit_override.unwrap_or(0)
-                };
-                return Ok(LintRunWorkflowResult {
-                    status: if exit_code == 0 { "passed" } else { "failed" }.to_string(),
-                    component: args.component_label,
-                    exit_code,
-                    harness_error: false,
-                    infrastructure_failure: false,
-                    autofix: None,
-                    hints: None,
-                    baseline_comparison,
-                    formatting_findings: None,
-                    findings: None,
-                    producer_summaries: Vec::new(),
-                    summary: if args.json_summary {
-                        Some(build_lint_summary(&[], &[], exit_code))
-                    } else {
-                        None
-                    },
-                    self_check_capture: None,
-                    extension_phase_timings: Vec::new(),
-                });
-            }
             let hints = (plan.changed_files_considered > 0).then(|| {
                 vec![format!(
                     "Lint ran no scopes: {} changed file(s) were considered and none matched any \
@@ -138,6 +99,7 @@ pub fn run_main_lint_workflow(
                 autofix: None,
                 hints,
                 baseline_comparison: None,
+                baseline_provenance: None,
                 formatting_findings: None,
                 findings: None,
                 producer_summaries: Vec::new(),
@@ -249,14 +211,6 @@ pub fn run_main_lint_workflow(
         lint_findings.extend(route_findings);
         producer_summaries.extend(route_producers);
     }
-    // Changed-file routes intentionally omit untouched debt from their output.
-    // Before accepting that scoped result against a baseline, run the same
-    // candidate tree without a route so fingerprint changes remain predictable
-    // after a fast-forward or merge commit with the identical tree.
-    let full_candidate =
-        should_verify_full_candidate_baseline(source_path, &args, scoped_plan.as_ref())
-            .then(|| run_full_candidate_baseline(component, &args))
-            .transpose()?;
     let formatting_findings =
         extract_formatting_findings(&output.stdout, &output.stderr, source_path);
 
@@ -271,14 +225,9 @@ pub fn run_main_lint_workflow(
     let lint_exit_code = normalize_producer_exit_code(runner_exit_code, &producer_summaries);
 
     // Baseline lifecycle
-    let (baseline_comparison, baseline_exit_override) = process_baseline(
-        source_path,
-        &args,
-        full_candidate
-            .as_ref()
-            .map(|candidate| candidate.findings.as_slice())
-            .unwrap_or(&lint_findings),
-    )?;
+    let baseline_context = baseline_provenance(&args, scoped_plan.as_ref(), &producer_summaries);
+    let (baseline_comparison, baseline_exit_override, baseline_provenance) =
+        process_baseline(source_path, &args, &lint_findings, baseline_context)?;
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
@@ -288,9 +237,6 @@ pub fn run_main_lint_workflow(
             && producer.metadata.contains_key("failure")
     });
     let hard_error = output.exit_code >= 2
-        || full_candidate
-            .as_ref()
-            .is_some_and(|candidate| candidate.hard_error)
         || harness_error
         || producer_summaries
             .iter()
@@ -358,6 +304,7 @@ pub fn run_main_lint_workflow(
         autofix: None,
         hints,
         baseline_comparison,
+        baseline_provenance: Some(baseline_provenance),
         formatting_findings,
         summary: if args.json_summary {
             Some(build_lint_summary(
@@ -375,68 +322,38 @@ pub fn run_main_lint_workflow(
     })
 }
 
-fn should_verify_full_candidate_baseline(
-    source_path: &Path,
+fn baseline_provenance(
     args: &LintRunWorkflowArgs,
-    scoped_plan: Option<&super::types::ScopedLintPlan>,
-) -> bool {
-    scoped_plan.is_some()
-        && args.file.is_none()
-        && args.glob.is_none()
-        && args.category.is_none()
-        && !args.sniff_filters.errors_only
-        && args.sniff_filters.sniffs.is_none()
-        && args.sniff_filters.exclude_sniffs.is_none()
-        && !args.baseline_flags.baseline
-        && !args.baseline_flags.ignore_baseline
-        && lint_baseline::load_baseline(source_path).is_some()
-}
-
-fn run_full_candidate_baseline(
-    component: &Component,
-    args: &LintRunWorkflowArgs,
-) -> homeboy_core::Result<FullCandidateBaseline> {
-    let full_run_dir = RunDir::create()?;
-    let runner = build_lint_runner(crate::lint::LintRunnerRequest {
-        component,
-        path_override: args.path_override.clone(),
-        settings: &args.settings,
-        summary: true,
-        file: None,
-        glob: None,
-        errors_only: false,
-        sniffs: None,
-        exclude_sniffs: None,
-        category: None,
-        step: None,
-        changed_files: None,
-        run_dir: &full_run_dir,
-    })?;
-    let runner = args
-        .ci_env
-        .iter()
-        .fold(runner, |runner, (key, value)| runner.env(key, value));
-    let output = runner
-        .env_if(
-            args.changed_since.is_some(),
-            "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
-            "1",
+    scoped_plan: Option<&ScopedLintPlan>,
+    producer_summaries: &[homeboy_core::finding::FindingProducerSummary],
+) -> lint_baseline::LintBaselineProvenance {
+    let (scope, files) = if let Some(plan) = scoped_plan {
+        (
+            "changed".to_string(),
+            plan.runs
+                .iter()
+                .flat_map(|run| run.changed_files.iter().cloned())
+                .collect(),
         )
-        .passthrough(false)
-        .run()?;
-    let findings_file = full_run_dir.step_file(run_dir::files::LINT_FINDINGS);
-    if crate::lint::declares_lint_findings_sidecar(component) && !findings_file.is_file() {
-        full_run_dir.finish(false);
-        return Err(missing_findings_evidence_error(&findings_file));
-    }
-    let findings = lint_baseline::parse_findings_file(&findings_file)?;
-    full_run_dir.finish(output.success);
-
-    Ok(FullCandidateBaseline {
-        findings,
-        hard_error: output.exit_code >= 2,
-        exit_code: output.exit_code,
-    })
+    } else if let Some(file) = &args.file {
+        ("file".to_string(), vec![file.clone()])
+    } else if let Some(glob) = &args.glob {
+        ("glob".to_string(), vec![glob.clone()])
+    } else {
+        ("full".to_string(), Vec::new())
+    };
+    lint_baseline::LintBaselineProvenance::new(
+        files,
+        producer_summaries
+            .iter()
+            .map(|producer| producer.tool.clone())
+            .collect(),
+        scope,
+        args.category.clone(),
+        args.sniff_filters.errors_only,
+        args.sniff_filters.sniffs.clone(),
+        args.sniff_filters.exclude_sniffs.clone(),
+    )
 }
 
 fn run_scoped_lint_runs(
@@ -674,6 +591,7 @@ Re-run `homeboy review lint {}` or skip only this gate with `--skip-checks=lint`
         autofix: None,
         hints,
         baseline_comparison: None,
+        baseline_provenance: None,
         formatting_findings,
         findings: Some(Vec::new()),
         producer_summaries: producer_summaries.clone(),
@@ -696,12 +614,22 @@ fn process_baseline(
     source_path: &Path,
     args: &LintRunWorkflowArgs,
     lint_findings: &[HomeboyFinding],
-) -> homeboy_core::Result<(Option<lint_baseline::BaselineComparison>, Option<i32>)> {
+    mut provenance: lint_baseline::LintBaselineProvenance,
+) -> homeboy_core::Result<(
+    Option<lint_baseline::BaselineComparison>,
+    Option<i32>,
+    lint_baseline::LintBaselineProvenance,
+)> {
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
 
     if args.baseline_flags.baseline {
-        let saved = lint_baseline::save_baseline(source_path, &args.component_id, lint_findings)?;
+        let saved = lint_baseline::save_baseline_for_scope(
+            source_path,
+            &args.component_id,
+            lint_findings,
+            Some(&provenance),
+        )?;
         eprintln!(
             "[lint] Baseline saved to {} ({} findings)",
             saved.display(),
@@ -710,7 +638,10 @@ fn process_baseline(
     }
 
     if !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
-        if let Some(existing) = lint_baseline::load_baseline(source_path) {
+        if let Some(existing) =
+            lint_baseline::load_baseline_for_scope(source_path, Some(&provenance))
+        {
+            provenance.compared = true;
             let comparison = lint_baseline::compare(lint_findings, &existing);
 
             if comparison.drift_increased {
@@ -734,5 +665,5 @@ fn process_baseline(
         }
     }
 
-    Ok((baseline_comparison, baseline_exit_override))
+    Ok((baseline_comparison, baseline_exit_override, provenance))
 }

--- a/crates/homeboy-review/src/review/render.rs
+++ b/crates/homeboy-review/src/review/render.rs
@@ -685,6 +685,7 @@ mod tests {
             autofix: None,
             hints: None,
             baseline_comparison: None,
+            baseline_provenance: None,
             formatting_findings: None,
             findings: Some(findings),
             producer_summaries: Vec::new(),


### PR DESCRIPTION
## Summary
- derive lint baseline keys from the resolved files, producer tools, and lint filter context
- remove the hidden full-tree lint baseline pass from scoped runs
- expose baseline key, scope, files, tools, and comparison status in lint output
- cover a clean changed-file run against an unrelated legacy baseline

Fixes #11803

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-extension lint:: --lib --no-fail-fast`
- `cargo check --workspace`

`cargo test -p homeboy-extension --lib --no-fail-fast` has 18 unrelated environment-sensitive trace/lifecycle failures; the lint regression passes.

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the scoped baseline identity, provenance output, and regression coverage. Chris Huber remains responsible for every line.