### PR TITLE
Diagnose provider failures behind malformed evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/status_support.rs
+++ b/crates/homeboy-agents/src/agent_task_service/status_support.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
@@ -594,11 +595,11 @@ pub fn hydrate_evidence_summary(task_id: &str, evidence: &AgentTaskEvidenceRef) 
         "kind": evidence.kind,
         "label": evidence.label,
         "uri": evidence.uri,
-        "summary": evidence_json_summary(&redacted),
+        "summary": evidence_json_summary(&redacted, Path::new(path).parent()),
     }))
 }
 
-fn evidence_json_summary(value: &Value) -> Value {
+fn evidence_json_summary(value: &Value, stream_root: Option<&Path>) -> Value {
     json!({
         "status": find_string_field(value, &["status", "state"]),
         "failure_classification": find_string_field(value, &["failure_classification", "failure_class", "classification", "class", "code", "kind"]),
@@ -608,6 +609,142 @@ fn evidence_json_summary(value: &Value) -> Value {
         "stderr_excerpt": find_string_field(value, &["stderr", "stderr_excerpt"]).map(|text| excerpt(&text)),
         "stdout_excerpt": find_string_field(value, &["stdout", "stdout_excerpt"]).map(|text| excerpt(&text)),
         "diagnostics": first_diagnostics(value),
+        "process_streams": process_stream_summaries(value, stream_root),
+    })
+}
+
+/// Project executor process output without requiring a provider-specific wrapper
+/// schema. The compact preview keeps malformed wrapper evidence actionable while
+/// preserving a stable, bounded default diagnose payload.
+fn process_stream_summaries(value: &Value, stream_root: Option<&Path>) -> Value {
+    const LIMIT: usize = 600;
+    let mut streams = Vec::new();
+    collect_process_stream_summaries(value, &mut streams, LIMIT, stream_root);
+    Value::Array(streams)
+}
+
+fn collect_process_stream_summaries(
+    value: &Value,
+    streams: &mut Vec<Value>,
+    limit: usize,
+    stream_root: Option<&Path>,
+) {
+    if streams.len() >= 2 {
+        return;
+    }
+    match value {
+        Value::Object(map) => {
+            for name in ["stdout", "stderr"] {
+                if streams.len() >= 2 {
+                    return;
+                }
+                if let Some(text) = map.get(name).and_then(Value::as_str) {
+                    streams.push(json!({
+                        "name": name,
+                        "source": "inline",
+                        "status": "available",
+                        "excerpt": excerpt_with_limit(text, limit),
+                    }));
+                } else if let Some(uri) = map.get(&format!("{name}_uri")).and_then(Value::as_str) {
+                    streams.push(process_stream_file_summary(
+                        name,
+                        "uri",
+                        uri,
+                        limit,
+                        stream_root,
+                    ));
+                } else if let Some(path) = map.get(&format!("{name}_path")).and_then(Value::as_str)
+                {
+                    streams.push(process_stream_file_summary(
+                        name,
+                        "path",
+                        path,
+                        limit,
+                        stream_root,
+                    ));
+                }
+            }
+            for nested in map.values() {
+                collect_process_stream_summaries(nested, streams, limit, stream_root);
+            }
+        }
+        Value::Array(items) => {
+            for nested in items {
+                collect_process_stream_summaries(nested, streams, limit, stream_root);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn process_stream_file_summary(
+    name: &str,
+    source: &str,
+    reference: &str,
+    limit: usize,
+    stream_root: Option<&Path>,
+) -> Value {
+    let unavailable = |error: &str| {
+        json!({
+            "name": name,
+            "source": source,
+            "reference": reference,
+            "status": "unavailable",
+            "error": error,
+        })
+    };
+    let path = if source == "uri" {
+        let Some(path) = reference.strip_prefix("file://") else {
+            return unavailable("unsupported_uri");
+        };
+        PathBuf::from(path)
+    } else {
+        if reference.contains("://") {
+            return unavailable("unsupported_uri");
+        }
+        PathBuf::from(reference)
+    };
+    if reference.contains('\0') || !path.is_absolute() {
+        return unavailable("invalid_path");
+    }
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => metadata,
+        Ok(_) => return unavailable("not_regular_file"),
+        Err(error) => return unavailable(&error.kind().to_string()),
+    };
+    if metadata.file_type().is_symlink() {
+        return unavailable("not_regular_file");
+    }
+    let Some(stream_root) = stream_root else {
+        return unavailable("untrusted_path");
+    };
+    let root = match stream_root.canonicalize() {
+        Ok(root) => root,
+        Err(_) => return unavailable("untrusted_path"),
+    };
+    let path = match path.canonicalize() {
+        Ok(path) if path.starts_with(&root) => path,
+        Ok(_) => return unavailable("untrusted_path"),
+        Err(error) => return unavailable(&error.kind().to_string()),
+    };
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) => return unavailable(&error.kind().to_string()),
+    };
+    let mut bytes = Vec::with_capacity(limit + 1);
+    if let Err(error) = file.take((limit + 1) as u64).read_to_end(&mut bytes) {
+        return unavailable(&error.kind().to_string());
+    }
+    let truncated = bytes.len() > limit;
+    bytes.truncate(limit);
+    let excerpt = RedactionPolicy::default().redact_string(&String::from_utf8_lossy(&bytes));
+    json!({
+        "name": name,
+        "source": source,
+        "reference": reference,
+        "status": "available",
+        "excerpt": excerpt,
+        "truncated": truncated,
     })
 }
 
@@ -675,12 +812,15 @@ fn first_diagnostics(value: &Value) -> Value {
 }
 
 fn excerpt(text: &str) -> String {
-    const LIMIT: usize = 600;
+    excerpt_with_limit(text, 600)
+}
+
+fn excerpt_with_limit(text: &str, limit: usize) -> String {
     let trimmed = text.trim();
-    if trimmed.chars().count() <= LIMIT {
+    if trimmed.chars().count() <= limit {
         trimmed.to_string()
     } else {
-        let prefix: String = trimmed.chars().take(LIMIT).collect();
+        let prefix: String = trimmed.chars().take(limit).collect();
         format!("{prefix}...")
     }
 }
@@ -753,6 +893,64 @@ mod tests {
             error.details["context"],
             "agent_task.evidence.hydrate.read: evidence.json"
         );
+    }
+
+    #[test]
+    fn process_stream_summaries_hydrate_file_uris_with_redaction_and_a_byte_limit() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let stream = directory.path().join("provider.stderr");
+        fs::write(&stream, format!("token=raw-secret\n{}", "x".repeat(700))).expect("write stream");
+
+        let streams = process_stream_summaries(
+            &json!({ "stderr_uri": format!("file://{}", stream.display()) }),
+            Some(directory.path()),
+        );
+        let stream = &streams.as_array().expect("stream array")[0];
+
+        assert_eq!(stream["source"], "uri");
+        assert_eq!(stream["status"], "available");
+        assert_eq!(stream["truncated"], true);
+        assert!(stream["excerpt"]
+            .as_str()
+            .expect("stream excerpt")
+            .contains("token=[REDACTED]"));
+        assert!(!stream["excerpt"]
+            .as_str()
+            .expect("stream excerpt")
+            .contains("raw-secret"));
+    }
+
+    #[test]
+    fn process_stream_summaries_reject_unsafe_or_unreadable_references() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let streams = process_stream_summaries(
+            &json!({
+                "stdout_uri": "https://example.test/provider.stdout",
+                "stderr_path": directory.path(),
+            }),
+            Some(directory.path()),
+        );
+        let streams = streams.as_array().expect("stream array");
+
+        assert_eq!(streams[0]["error"], "unsupported_uri");
+        assert_eq!(streams[1]["error"], "not_regular_file");
+    }
+
+    #[test]
+    fn process_stream_summaries_do_not_follow_paths_outside_the_evidence_directory() {
+        let evidence_directory = tempfile::tempdir().expect("evidence directory");
+        let stream_directory = tempfile::tempdir().expect("stream directory");
+        let stream = stream_directory.path().join("provider.stderr");
+        fs::write(&stream, "private stream").expect("write stream");
+
+        let streams = process_stream_summaries(
+            &json!({ "stderr_path": stream }),
+            Some(evidence_directory.path()),
+        );
+
+        assert_eq!(streams[0]["status"], "unavailable");
+        assert_eq!(streams[0]["error"], "untrusted_path");
+        assert!(streams[0].get("excerpt").is_none());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1249,21 +1249,34 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
                         "hydrated_evidence",
                         &mut nested_reasons,
                     );
+                    collect_process_stream_diagnostics(
+                        &outcome.task_id,
+                        summary
+                            .pointer("/summary/process_streams")
+                            .unwrap_or(&Value::Null),
+                        &mut nested_reasons,
+                    );
                     hydrated_evidence.push(summary);
                 }
             }
         }
     }
 
-    let root_cause = ranked_diagnostics(nested_reasons)
-        .into_iter()
+    let ranked_reasons = ranked_diagnostics(nested_reasons);
+    let root_cause = ranked_reasons
+        .first()
+        .cloned()
         .map(collected_diagnostic_value)
-        .next()
         .or_else(|| {
             aggregate
                 .as_ref()
                 .and_then(|aggregate| failure_reasons_from_aggregate(aggregate).into_iter().next())
         });
+    let diagnostic_chain = ranked_reasons
+        .into_iter()
+        .take(FAILURE_REASON_LIMIT)
+        .map(collected_diagnostic_value)
+        .collect::<Vec<_>>();
 
     let missing_artifacts = aggregate
         .as_ref()
@@ -1281,6 +1294,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         "run_id": record.run_id.clone(),
         "state": record.state,
         "root_cause": root_cause,
+        "diagnostic_chain": diagnostic_chain,
         "causal_chain": causal_chain,
         "missing_artifacts": missing_artifacts.clone(),
         "hydrated_evidence": hydrated_evidence,
@@ -2708,10 +2722,11 @@ fn ranked_diagnostics(collected: Vec<CollectedDiagnostic>) -> Vec<CollectedDiagn
         deduped.push(item);
     }
 
-    deduped.sort_by_key(|item| diagnostic_priority(&item.class, &item.message));
+    deduped.sort_by_key(diagnostic_priority);
     deduped
 }
 
+#[derive(Clone)]
 struct CollectedDiagnostic {
     task_id: String,
     class: String,
@@ -2723,9 +2738,14 @@ struct CollectedDiagnostic {
 /// (validation/fatal/registration/missing-path) are surfaced before generic or
 /// transient noise so the first reason an operator sees is the one worth acting
 /// on.
-fn diagnostic_priority(class: &str, message: &str) -> u8 {
-    let text = format!("{} {}", class, message).to_ascii_lowercase();
-    if text.contains("typed_artifacts_missing")
+fn diagnostic_priority(item: &CollectedDiagnostic) -> (u8, u8) {
+    let text = format!("{} {}", item.class, item.message).to_ascii_lowercase();
+    let priority = if text.contains("provider_malformed_json")
+        || text.contains("malformed executor")
+        || text.contains("outcome-normalization")
+    {
+        8
+    } else if text.contains("typed_artifacts_missing")
         || text.contains("required_typed_artifacts_missing")
         || text.contains("required typed artifacts")
         || text.contains("declared artifact result envelope")
@@ -2747,8 +2767,40 @@ fn diagnostic_priority(class: &str, message: &str) -> u8 {
         || text.contains("io")
     {
         3
+    } else if item.source == "hydrated_process_stream" {
+        4
     } else {
         9
+    };
+    // Stream provenance is causal only among equally actionable diagnostics;
+    // it must not hide a stronger typed validation or fatal failure.
+    (priority, u8::from(item.source != "hydrated_process_stream"))
+}
+
+/// Process streams are untrusted wrapper output. When a stream is JSON, its
+/// diagnostics are the execution-layer cause and therefore rank ahead of the
+/// wrapper's outcome-normalization consequence.
+fn collect_process_stream_diagnostics(
+    task_id: &str,
+    streams: &Value,
+    out: &mut Vec<CollectedDiagnostic>,
+) {
+    for stream in streams.as_array().into_iter().flatten() {
+        let Some(excerpt) = stream.get("excerpt").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Ok(value) = serde_json::from_str(excerpt) {
+            collect_nested_diagnostics(task_id, &value, "hydrated_process_stream", out);
+            continue;
+        }
+        if !excerpt.trim().is_empty() {
+            out.push(CollectedDiagnostic {
+                task_id: task_id.to_string(),
+                class: "provider.process_stream".to_string(),
+                message: excerpt.to_string(),
+                source: "hydrated_process_stream".to_string(),
+            });
+        }
     }
 }
 
@@ -3794,12 +3846,27 @@ fn evidence_is_test(kind: &str, uri: &str) -> bool {
 }
 
 fn collected_diagnostic_value(item: CollectedDiagnostic) -> Value {
+    let owner = diagnostic_owner(&item.class, &item.source);
     json!({
         "task_id": item.task_id,
         "class": item.class,
         "message": item.message,
         "source": item.source,
+        "owner": owner,
     })
+}
+
+fn diagnostic_owner(class: &str, source: &str) -> &'static str {
+    let class = class.to_ascii_lowercase();
+    if source == "hydrated_process_stream" {
+        "provider_runtime"
+    } else if class.contains("malformed") || class.contains("normalization") {
+        "executor_wrapper"
+    } else if class.contains("provider") || class.contains("runtime") {
+        "provider_runtime"
+    } else {
+        "agent_task"
+    }
 }
 
 fn missing_artifact_summaries(aggregate: &AgentTaskAggregate) -> Vec<Value> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -843,6 +843,184 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn diagnose_prioritizes_provider_stream_cause_over_malformed_wrapper() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({
+                "diagnostics": [{
+                    "class": "agent_task.provider_malformed_json",
+                    "message": "executor wrapper returned malformed JSON",
+                    "data": {
+                        "stdout": serde_json::to_string(&json!({
+                            "diagnostics": [{
+                                "class": "provider.runtime_unavailable",
+                                "message": "runtime executable is unavailable"
+                            }]
+                        })).expect("stream json"),
+                        "stderr": "token=raw-secret"
+                    }
+                }, {
+                    "class": "agent_task.required_typed_artifacts_missing",
+                    "message": "agent task did not produce required typed artifacts: concept_packet"
+                }]
+            }))
+            .expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        let run_id = "run-cli-diagnose-provider-stream";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            },
+        )
+        .expect("run completed with failed outcome");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["root_cause"]["class"], "provider.runtime_unavailable");
+        assert_eq!(value["root_cause"]["source"], "hydrated_process_stream");
+        assert_eq!(value["root_cause"]["owner"], "provider_runtime");
+        assert!(value["diagnostic_chain"]
+            .as_array()
+            .expect("diagnostic chain")
+            .iter()
+            .any(|diagnostic| diagnostic["owner"] == "executor_wrapper"));
+        assert_eq!(
+            value["hydrated_evidence"][0]["summary"]["diagnostics"][0]["class"],
+            "agent_task.provider_malformed_json"
+        );
+        assert!(value["hydrated_evidence"][0]["summary"]["process_streams"]
+            .as_array()
+            .expect("process streams")
+            .iter()
+            .any(|stream| stream["excerpt"] == "token=[REDACTED]"));
+    });
+}
+
+#[test]
+fn diagnose_surfaces_a_raw_provider_cause_from_a_bounded_stream_uri() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let stream_path = evidence_dir.path().join("executor.stderr");
+        std::fs::write(
+            &stream_path,
+            "The 'gpt-5.6-terra' model requires a newer version of Codex. token=raw-secret",
+        )
+        .expect("write stream");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({
+                "diagnostics": [{
+                    "class": "agent_task.provider_malformed_json",
+                    "message": "executor wrapper returned malformed JSON",
+                    "data": { "stderr_uri": format!("file://{}", stream_path.display()) }
+                }]
+            }))
+            .expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        let run_id = "run-cli-diagnose-provider-stream-uri";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            },
+        )
+        .expect("run completed with failed outcome");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["root_cause"]["class"], "provider.process_stream");
+        assert_eq!(value["root_cause"]["owner"], "provider_runtime");
+        assert!(value["root_cause"]["message"]
+            .as_str()
+            .expect("root cause message")
+            .contains("requires a newer version of Codex"));
+        assert!(!value["root_cause"]["message"]
+            .as_str()
+            .expect("root cause message")
+            .contains("raw-secret"));
+        assert_eq!(
+            value["hydrated_evidence"][0]["summary"]["process_streams"][0]["source"],
+            "uri"
+        );
+    });
+}
+
+#[test]
+fn diagnose_reports_unavailable_process_streams_without_failing() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        let missing_stream = evidence_dir.path().join("missing.stderr");
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({
+                "diagnostics": [{
+                    "class": "agent_task.provider_malformed_json",
+                    "message": "executor wrapper returned malformed JSON",
+                    "data": {
+                        "stdout_path": missing_stream,
+                        "stderr_path": evidence_dir.path()
+                    }
+                }]
+            }))
+            .expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        let run_id = "run-cli-diagnose-missing-stream";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            },
+        )
+        .expect("run completed with failed outcome");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            value["root_cause"]["class"],
+            "agent_task.provider_malformed_json"
+        );
+        assert_eq!(
+            value["hydrated_evidence"][0]["summary"]["process_streams"][0]["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            value["hydrated_evidence"][0]["summary"]["process_streams"][1]["status"],
+            "unavailable"
+        );
+    });
+}
+
+#[test]
 fn diagnose_derives_next_actions_from_the_failure_classification() {
     with_temp_home(|| {
         let run_id = "run-cli-diagnose-actionable-timeout";


### PR DESCRIPTION
## Summary

- hydrate bounded redacted provider process streams during `agent-task diagnose`
- reject remote, symlinked, non-file, and out-of-evidence-tree stream references
- rank actionable provider/runtime causes ahead of secondary malformed-wrapper failures
- retain both causes with owning-layer attribution in a bounded diagnostic chain

Fixes #11796.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents process_stream_summaries --lib` (3 passed)
- focused raw-stream, malformed-wrapper, and unavailable-stream CLI tests (3 passed)
- `cargo check -p homeboy-cli`
- `git diff --check origin/main...HEAD`

## Compatibility

The change is additive to diagnose output. Existing evidence remains durable; default hydration is limited to two 600-byte redacted excerpts.

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding subagents
- Use: Implemented and reviewed safe stream hydration, causal ranking, ownership attribution, and regression coverage under Chris Huber's direction. Chris remains responsible for every line.
