### PR TITLE
Fix candidate daemon freshness verification

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -305,10 +305,9 @@ pub(crate) fn rotate_daemon_generation(
         };
     if let Some(expected_binary_sha256) = candidate_binary_sha256 {
         let freshness = daemon_http_freshness(runner_id, &local_url, "", candidate_identity);
-        let hash_matches = freshness.as_ref().is_ok_and(|report| {
-            report.fresh && report.binary_hash.as_deref() == Some(expected_binary_sha256)
-        });
-        if !hash_matches {
+        if let Err(error) =
+            verify_candidate_daemon_freshness(runner_id, expected_binary_sha256, freshness)
+        {
             if let Some(lease_id) = daemon.lease_id.as_deref() {
                 let command = format!(
                     "{} daemon stop --force --lease-id {}",
@@ -320,18 +319,11 @@ pub(crate) fn rotate_daemon_generation(
             if let Some(pid) = tunnel_pid {
                 terminate_pid(pid);
             }
-            return Err(Error::validation_invalid_argument(
-                "reconnect",
-                freshness.err().map_or_else(
-                    || {
-                        "candidate daemon did not report the validated binary SHA-256 as fresh"
-                            .to_string()
-                    },
-                    |error| format!("candidate daemon freshness verification failed: {error}"),
-                ),
-                Some(runner_id.to_string()),
-                None,
-            ));
+            // The candidate was never activated. Remove any retained entry for
+            // this generation just as the preceding startup-validation path
+            // does, leaving the current admission owner untouched.
+            let _ = super::generation_store::rollback_candidate(runner_id, &current, &generation);
+            return Err(error);
         }
     }
     let candidate = RunnerSession {
@@ -386,6 +378,39 @@ pub(crate) fn rotate_daemon_generation(
         return Err(error);
     }
     Ok(())
+}
+
+/// Candidate startup is admitted only when the daemon's own freshness report
+/// proves it is serving the exact immutable binary selected by refresh.
+fn verify_candidate_daemon_freshness(
+    runner_id: &str,
+    expected_binary_sha256: &str,
+    freshness: std::result::Result<DaemonFreshnessReport, String>,
+) -> Result<()> {
+    match freshness {
+        Ok(report)
+            if report.fresh && report.binary_hash.as_deref() == Some(expected_binary_sha256) =>
+        {
+            Ok(())
+        }
+        Ok(report) => Err(Error::validation_invalid_argument(
+            "reconnect",
+            format!(
+                "candidate daemon freshness did not match the immutable binary SHA-256 (expected {expected_binary_sha256}, observed {}, fresh={}, stale_reason_code={:?})",
+                report.binary_hash.as_deref().unwrap_or("<missing>"),
+                report.fresh,
+                report.stale_reason_code,
+            ),
+            Some(runner_id.to_string()),
+            None,
+        )),
+        Err(error) => Err(Error::validation_invalid_argument(
+            "reconnect",
+            format!("candidate daemon freshness verification failed: {error}"),
+            Some(runner_id.to_string()),
+            None,
+        )),
+    }
 }
 
 fn rollback_rotated_candidate(

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -103,6 +103,61 @@ fn failed_generation_cleanup_kills_the_exact_daemon_and_tunnel() {
 }
 
 #[test]
+fn candidate_daemon_freshness_accepts_the_materialized_immutable_binary_hash() {
+    let expected = "a".repeat(64);
+    let report = DaemonFreshnessReport {
+        fresh: true,
+        stale_reason_code: None,
+        restartable: false,
+        lease_id: Some("lease-candidate".to_string()),
+        pid: Some(4242),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: Some(expected.clone()),
+        daemon_version: Some("test".to_string()),
+        daemon_build_identity: Some("homeboy test+candidate".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    };
+
+    verify_candidate_daemon_freshness("homeboy-lab", &expected, Ok(report))
+        .expect("candidate rotates");
+}
+
+#[test]
+fn candidate_daemon_freshness_mismatch_reports_expected_and_observed_hashes() {
+    let expected = "a".repeat(64);
+    let observed = "b".repeat(64);
+    let report = DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(DaemonStaleReasonCode::BinaryHashMismatch),
+        restartable: true,
+        lease_id: Some("lease-candidate".to_string()),
+        pid: Some(4242),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: Some(observed.clone()),
+        daemon_version: Some("test".to_string()),
+        daemon_build_identity: Some("homeboy test+candidate".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    };
+
+    let error = verify_candidate_daemon_freshness("homeboy-lab", &expected, Ok(report))
+        .expect_err("mismatch");
+    assert!(error.message.contains(&format!("expected {expected}")));
+    assert!(error.message.contains(&format!("observed {observed}")));
+    assert!(error.message.contains("fresh=false"));
+    assert!(error.message.contains("BinaryHashMismatch"));
+}
+
+#[test]
 fn generation_data_root_preserves_home_scoped_config_and_auth() {
     let command = super::remote_daemon::generation_daemon_ensure_command(
         "/opt/homeboy",

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -523,7 +523,9 @@ fn daemon_freshness_report(
     expected_version: &str,
     expected_identity: &str,
 ) -> std::result::Result<DaemonFreshnessReport, String> {
-    let DaemonVersionResponse { body, raw_body } = daemon_http_body(local_url)?;
+    // Freshness, including the immutable executable hash, is a daemon health
+    // contract. A version response is only an identity compatibility fallback.
+    let DaemonVersionResponse { body, raw_body } = daemon_http_body_at(local_url, "health")?;
     if let Some(report) = daemon_freshness_from_body(&body) {
         if report.fresh
             && daemon_version_identity_mismatch(
@@ -672,6 +674,51 @@ mod tests {
             build_identity: None,
             inspected_freshness: None,
         }
+    }
+
+    #[test]
+    fn freshness_reads_the_hash_bearing_health_contract() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let expected_hash = "a".repeat(64);
+        let mut freshness = report("lease-candidate", 4242).freshness;
+        freshness.fresh = true;
+        freshness.binary_hash = Some(expected_hash.clone());
+        let body = serde_json::json!({
+            "version": "test",
+            "build_identity": { "display": "homeboy test+candidate" },
+            "lease": { "lease_id": "lease-candidate" },
+            "freshness": freshness,
+        })
+        .to_string();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("health request");
+            let mut request = [0; 1024];
+            let read = stream.read(&mut request).expect("read request");
+            assert!(std::str::from_utf8(&request[..read])
+                .expect("request text")
+                .starts_with("GET /health HTTP/1.1"));
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(), body
+                    )
+                    .as_bytes(),
+                )
+                .expect("health response");
+        });
+
+        let report = daemon_http_freshness(
+            "homeboy-lab",
+            &format!("http://{address}"),
+            "test",
+            "homeboy test+candidate",
+        )
+        .expect("freshness report");
+        assert!(report.fresh);
+        assert_eq!(report.binary_hash.as_deref(), Some(expected_hash.as_str()));
+        server.join().expect("server");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -593,7 +593,7 @@ fn daemon_version_identity_mismatch(
                 response_body_excerpt(raw_body)
             )
         })?;
-    if !versions_match(&running_version, expected_version) {
+    if !expected_version.trim().is_empty() && !versions_match(&running_version, expected_version) {
         return Ok(Some(format!(
             "version {running_version} != configured runner version {expected_version}"
         )));
@@ -677,7 +677,7 @@ mod tests {
     }
 
     #[test]
-    fn freshness_reads_the_hash_bearing_health_contract() {
+    fn freshness_allows_an_unspecified_version_with_matching_identity_and_hash() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
         let address = listener.local_addr().expect("address");
         let expected_hash = "a".repeat(64);
@@ -712,13 +712,35 @@ mod tests {
         let report = daemon_http_freshness(
             "homeboy-lab",
             &format!("http://{address}"),
-            "test",
+            "",
             "homeboy test+candidate",
         )
         .expect("freshness report");
         assert!(report.fresh);
         assert_eq!(report.binary_hash.as_deref(), Some(expected_hash.as_str()));
         server.join().expect("server");
+    }
+
+    #[test]
+    fn freshness_rejects_a_nonempty_wrong_expected_version() {
+        let body = serde_json::json!({
+            "version": "test",
+            "build_identity": { "display": "homeboy test+candidate" },
+            "lease": { "lease_id": "lease-candidate" },
+        });
+
+        let mismatch = daemon_version_identity_mismatch(
+            &body,
+            "fixture body",
+            "wrong-version",
+            "homeboy test+candidate",
+        )
+        .expect("version mismatch result");
+
+        assert_eq!(
+            mismatch.as_deref(),
+            Some("version test != configured runner version wrong-version")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- read candidate-daemon binary freshness from the canonical `/health` contract
- require the exact immutable SHA selected during refresh materialization
- include expected and observed hash evidence on mismatch
- roll back an unactivated retained generation after failed hash verification

Fixes #11794.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner freshness --lib` (15 passed)
- `cargo check -p homeboy-lab-runner`
- `git diff --check origin/main...HEAD`

## Evidence Boundary

Live SSH refresh with candidate `9e102eb70813` completed materialization, identity verification, bootstrap promotion, configuration promotion, and generation rotation. The daemon reported the exact expected SHA and the corrected rotation admitted it.

Admission then stopped at a separate stale local controller provenance mismatch tracked in #11821 and draft PR #11822. This PR stays draft while CI completes and that independent identity fix is reviewed.

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding subagents
- Use: Traced the refresh and daemon-freshness contracts, implemented the repair, reviewed rollback behavior, and added focused regression coverage under Chris Huber's direction. Chris remains responsible for every line.
