### PR TITLE
Refresh build identity after linked-worktree commits

### DIFF
--- a/crates/homeboy-product-identity/build.rs
+++ b/crates/homeboy-product-identity/build.rs
@@ -3,6 +3,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[path = "src/git_watch_paths.rs"]
+mod git_watch_paths;
+
 fn main() {
     let manifest_dir =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR missing"));
@@ -13,6 +16,7 @@ fn main() {
     let manifest = root.join("Cargo.toml");
 
     println!("cargo:rerun-if-changed={}", manifest.display());
+    println!("cargo:rerun-if-changed=src/git_watch_paths.rs");
     println!(
         "cargo:rustc-env=HOMEBOY_PRODUCT_VERSION={}",
         root_package_version(&manifest)
@@ -56,12 +60,14 @@ fn rerun_if_changed_when_present(path: &Path) {
 fn emit_git_identity(root: &Path) {
     let git_dir = resolve_git_dir(root).unwrap_or_else(|| root.join(".git"));
     let common_dir = git_common_dir(root, &git_dir).unwrap_or_else(|| git_dir.clone());
-    rerun_if_changed_when_present(&git_dir.join("HEAD"));
-    rerun_if_changed_when_present(&common_dir.join("packed-refs"));
-    if let Ok(head) = fs::read_to_string(git_dir.join("HEAD")) {
-        if let Some(reference) = head.trim().strip_prefix("ref: ") {
-            rerun_if_changed_when_present(&git_dir.join(reference));
-        }
+    let head = fs::read_to_string(git_dir.join("HEAD")).ok();
+    for path in git_watch_paths::git_watch_paths(
+        &git_dir,
+        &common_dir,
+        head.as_deref(),
+        "refs/notes/homeboy-snapshot",
+    ) {
+        rerun_if_changed_when_present(&path);
     }
 
     // `.git/index` is deliberately NOT declared. This build script runs

--- a/crates/homeboy-product-identity/src/git_watch_paths.rs
+++ b/crates/homeboy-product-identity/src/git_watch_paths.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn git_watch_paths(
+    git_dir: &Path,
+    common_dir: &Path,
+    head: Option<&str>,
+    snapshot_note_ref: &str,
+) -> Vec<PathBuf> {
+    let mut paths = vec![
+        git_dir.join("HEAD"),
+        common_dir.join("packed-refs"),
+        common_dir.join(snapshot_note_ref),
+    ];
+    if let Some(reference) = head.and_then(|head| head.trim().strip_prefix("ref: ")) {
+        let ref_dir =
+            if reference.starts_with("refs/bisect/") || reference.starts_with("refs/worktree/") {
+                git_dir
+            } else {
+                common_dir
+            };
+        paths.push(ref_dir.join(reference));
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watches_symbolic_ref_in_common_git_directory_for_linked_worktree() {
+        let paths = git_watch_paths(
+            Path::new("/repo/.git/worktrees/feature"),
+            Path::new("/repo/.git"),
+            Some("ref: refs/heads/feature\n"),
+            "refs/notes/homeboy-snapshot",
+        );
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/repo/.git/worktrees/feature/HEAD"),
+                PathBuf::from("/repo/.git/packed-refs"),
+                PathBuf::from("/repo/.git/refs/notes/homeboy-snapshot"),
+                PathBuf::from("/repo/.git/refs/heads/feature"),
+            ]
+        );
+    }
+
+    #[test]
+    fn watches_primary_worktree_ref_and_packed_refs() {
+        let paths = git_watch_paths(
+            Path::new("/repo/.git"),
+            Path::new("/repo/.git"),
+            Some("ref: refs/heads/main\n"),
+            "refs/notes/homeboy-snapshot",
+        );
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/repo/.git/HEAD"),
+                PathBuf::from("/repo/.git/packed-refs"),
+                PathBuf::from("/repo/.git/refs/notes/homeboy-snapshot"),
+                PathBuf::from("/repo/.git/refs/heads/main"),
+            ]
+        );
+    }
+
+    #[test]
+    fn detached_head_watches_git_metadata_without_a_symbolic_ref() {
+        let paths = git_watch_paths(
+            Path::new("/repo/.git/worktrees/detached"),
+            Path::new("/repo/.git"),
+            Some("9e102eb708131db18e55e100cc47262694148056\n"),
+            "refs/notes/homeboy-snapshot",
+        );
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/repo/.git/worktrees/detached/HEAD"),
+                PathBuf::from("/repo/.git/packed-refs"),
+                PathBuf::from("/repo/.git/refs/notes/homeboy-snapshot"),
+            ]
+        );
+    }
+
+    #[test]
+    fn watches_per_worktree_refs_in_the_linked_git_directory() {
+        let git_dir = Path::new("/repo/.git/worktrees/feature");
+        let common_dir = Path::new("/repo/.git");
+
+        for reference in ["refs/bisect/good", "refs/worktree/operation"] {
+            let paths = git_watch_paths(
+                git_dir,
+                common_dir,
+                Some(&format!("ref: {reference}\n")),
+                "refs/notes/homeboy-snapshot",
+            );
+
+            assert_eq!(paths.last(), Some(&git_dir.join(reference)));
+        }
+    }
+}

--- a/crates/homeboy-product-identity/src/lib.rs
+++ b/crates/homeboy-product-identity/src/lib.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+#[cfg(test)]
+mod git_watch_paths;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuildIdentity {
     pub version: String,


### PR DESCRIPTION
## Summary

- resolve linked-worktree symbolic branch refs through Git's common directory
- continue watching worktree-local HEAD, packed refs, snapshot notes, and per-worktree refs
- keep `.git/index` excluded so dirty file edits do not cause rebuild loops
- share the build-script path resolver with focused primary, linked, detached, bisect, and worktree-ref tests

Fixes #11821.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-product-identity` (5 passed)
- `cargo check -p homeboy-product-identity`
- `git diff --check`

## Evidence Boundary

The deterministic resolver tests cover the incorrect linked-worktree path selection. The live reproduction showed a `9e102eb` commit rebuilding as `4f79f65`; a full post-merge incremental-build proof remains pending while this PR is draft.

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding subagents
- Use: Traced stale local candidate provenance to linked-worktree Git metadata, implemented and reviewed ref-watch resolution, and added focused tests under Chris Huber's direction. Chris remains responsible for every line.
