### PR TITLE
fix(cli): enforce --runner/--placement exclusivity regardless of argument position

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -444,6 +444,12 @@ impl CliRuntime {
         }
 
         let matches = self.parse_matches(normalized.clone());
+        // Global-arg conflicts are only enforced by clap when the flags follow
+        // the subcommand, so this must be checked explicitly (#11826).
+        if let Err(error) = crate::cli_surface::reject_conflicting_placement_selection(&matches) {
+            eprintln!("{error}");
+            return std::process::ExitCode::from(2);
+        }
         self.run_matches(matches, normalized)
     }
 

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1522,5 +1522,33 @@ mod tests {
 mod global_flag_surface_tests;
 
 pub mod reference_docs;
+/// Reject `--runner` combined with an explicit `--placement`.
+///
+/// Both carry `conflicts_with`, but clap only enforces that when they are
+/// supplied *after* the subcommand. Given at the root — `homeboy --placement
+/// local --runner lab agent-task cook …` — the conflict silently does not fire,
+/// so a contradictory invocation parsed cleanly and resolved to some placement
+/// nobody asked for. `--runner` implies Lab, so pairing it with `--placement
+/// local` is not a preference, it is two different answers to one question.
+///
+/// `placement` carries a default, so presence is not enough to detect: this
+/// keys on argument provenance and fires only when both were actually typed.
+pub fn reject_conflicting_placement_selection(
+    matches: &clap::ArgMatches,
+) -> Result<(), clap::Error> {
+    use crate::cli_surface::argument_provenance::{ArgumentSource, CommandArgumentProvenance};
+
+    let provenance = CommandArgumentProvenance::from_matches(matches);
+    let typed = |name: &str| provenance.source(name) == Some(ArgumentSource::CommandLine);
+
+    if typed("placement") && typed("runner") {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ArgumentConflict,
+            "the argument '--placement <PLACEMENT>' cannot be used with '--runner <RUNNER_ID>'\n\n             '--runner' already selects Lab placement by pinning a runner. Use one or the other.\n",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod reference_docs_tests;


### PR DESCRIPTION
## The hole

`--placement` and `--runner` both declare `conflicts_with`, and the unit test `runner_and_placement_are_mutually_exclusive` passes. But clap only enforces a **global** arg's conflict when it is supplied *after* the subcommand:

| invocation | result |
|---|---|
| `homeboy --placement local --runner homeboy-lab bench example` | **silently accepted** |
| `homeboy bench example --runner homeboy-lab --placement local` | rejected |

`--runner` already selects Lab placement by pinning a runner, so pairing it with `--placement local` is two contradictory answers to one question. Accepting it resolved to some placement nobody asked for.

The unit test passes because it builds the command directly and puts both flags after the subcommand — exactly the position clap does enforce. So the guard looked covered while the root-position case went unchecked.

## Fix

An explicit post-parse check. `placement` carries `default_value_t`, so presence is not sufficient to detect — this keys on the argument provenance from #10945 and fires only when **both were actually typed**:

```rust
let typed = |name| provenance.source(name) == Some(ArgumentSource::CommandLine);
if typed("placement") && typed("runner") { ... }
```

## Verified against the built binary

| case | before | after |
|---|---|---|
| `--placement local --runner X bench example` (root) | accepted | **rejected, exit 2** |
| `bench example --runner X --placement local` (sub) | rejected | rejected |
| `--placement local runner status` alone | works | works |
| `--runner X runner status` alone | works | works |

The last two matter: the default value must not trip the guard.

## This unblocks releases

`cook_lab_handoff_test::cook_rejects_invalid_controller_transport_before_worktree_resolution` has been failing the release **Test gate**, which is why no release has published since v0.333.0 (2026-08-06T17:15Z). That file goes from **5 passed / 4 failed → 6 passed / 3 failed**.

The remaining 3 are a **separate pre-existing break**, confirmed identical on unmodified `main`: they invoke `agent-task cook` without `--backend` and now stop at `requires --backend because no default backend policy is configured` before reaching the behaviour under test. Filed separately — I did not guess at fixes for tests whose success path I could not reason about.

## Verification

`cargo check --workspace --tests` → 0 errors, 0 warnings. `runner_and_placement_are_mutually_exclusive` still passes.

🤖 Authored by chubes-bot