### PR TITLE
Fix runtime tool readiness command prefixes

### DIFF
--- a/crates/homeboy-agents/src/agent_task.rs
+++ b/crates/homeboy-agents/src/agent_task.rs
@@ -68,6 +68,7 @@ pub use request::{
 pub use runtime_tools::{
     AgentTaskRuntimeTool, AgentTaskRuntimeToolCapabilityProbe, AgentTaskRuntimeToolLifecycle,
     AgentTaskRuntimeToolProbeEvidence, AgentTaskRuntimeToolReadiness, ResolvedAgentTaskRuntimeTool,
+    ResolvedAgentTaskRuntimeToolReadiness, ResolvedAgentTaskRuntimeToolReadinessEvidence,
     AGENT_TASK_RUNTIME_TOOL_SCHEMA, RESOLVED_AGENT_TASK_RUNTIME_TOOL_SCHEMA,
 };
 pub use schema::{

--- a/crates/homeboy-agents/src/agent_task/runtime_tools.rs
+++ b/crates/homeboy-agents/src/agent_task/runtime_tools.rs
@@ -32,6 +32,10 @@ pub struct AgentTaskRuntimeTool {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AgentTaskRuntimeToolReadiness {
+    /// Arguments after the executable that identify the tool for readiness
+    /// probes. When omitted, probes retain all declared launch arguments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command_prefix: Option<Vec<String>>,
     /// Arguments used to collect a stable executable version before dispatch.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub version_command: Vec<String>,

--- a/crates/homeboy-agents/src/agent_task/runtime_tools.rs
+++ b/crates/homeboy-agents/src/agent_task/runtime_tools.rs
@@ -83,8 +83,21 @@ pub struct ResolvedAgentTaskRuntimeTool {
     pub env_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_env_names: Vec<String>,
-    pub readiness: String,
+    pub readiness: ResolvedAgentTaskRuntimeToolReadiness,
     pub lifecycle: AgentTaskRuntimeToolLifecycle,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentTaskRuntimeToolReadiness {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<ResolvedAgentTaskRuntimeToolReadinessEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedAgentTaskRuntimeToolReadinessEvidence {
+    pub kind: String,
+    pub success: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -417,7 +417,15 @@ mod tests {
             }),
             env_names: vec!["FIXTURE_MODE".to_string()],
             secret_env_names: Vec::new(),
-            readiness: "ready".to_string(),
+            readiness: crate::agent_task::ResolvedAgentTaskRuntimeToolReadiness {
+                status: "ready".to_string(),
+                evidence: Some(
+                    crate::agent_task::ResolvedAgentTaskRuntimeToolReadinessEvidence {
+                        kind: "declared_probe".to_string(),
+                        success: true,
+                    },
+                ),
+            },
             lifecycle: Default::default(),
         }];
 

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -175,7 +175,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
                     json!({
                         "tool_id": required.id,
                         "missing_capabilities": missing,
-                        "readiness": resolved.map_or("missing", |tool| tool.readiness.as_str()),
+                        "readiness": resolved.map_or("missing", |tool| tool.readiness.status.as_str()),
                     })
                 })
             })

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
@@ -2,8 +2,9 @@ use super::runner_readiness::resolve_executable_candidate;
 use super::*;
 use crate::agent_task::{
     AgentCommandDecision, AgentTaskRuntimeTool, AgentTaskRuntimeToolProbeEvidence,
-    AgentToolExecutionLocation, ResolvedAgentTaskRuntimeTool, AGENT_TASK_RUNTIME_TOOL_SCHEMA,
-    RESOLVED_AGENT_TASK_RUNTIME_TOOL_SCHEMA,
+    AgentToolExecutionLocation, ResolvedAgentTaskRuntimeTool,
+    ResolvedAgentTaskRuntimeToolReadiness, ResolvedAgentTaskRuntimeToolReadinessEvidence,
+    AGENT_TASK_RUNTIME_TOOL_SCHEMA, RESOLVED_AGENT_TASK_RUNTIME_TOOL_SCHEMA,
 };
 use crate::agent_task_process_containment::AgentTaskProcessContainment;
 use std::process::{Command, Stdio};
@@ -76,6 +77,19 @@ pub(crate) fn resolve_runtime_tools(
                 request.request.executor.secret_env.push(secret.clone());
             }
         }
+        let readiness_evidence = if capability_probe.is_some() {
+            Some(ResolvedAgentTaskRuntimeToolReadinessEvidence {
+                kind: "declared_probe".to_string(),
+                success: true,
+            })
+        } else {
+            version
+                .as_ref()
+                .map(|_| ResolvedAgentTaskRuntimeToolReadinessEvidence {
+                    kind: "version_command".to_string(),
+                    success: true,
+                })
+        };
         resolved.push(ResolvedAgentTaskRuntimeTool {
             schema: RESOLVED_AGENT_TASK_RUNTIME_TOOL_SCHEMA.to_string(),
             id: tool.id.clone(),
@@ -93,7 +107,10 @@ pub(crate) fn resolve_runtime_tools(
             capability_probe,
             env_names: tool.env.keys().cloned().collect(),
             secret_env_names: tool.secret_env.clone(),
-            readiness: "ready".to_string(),
+            readiness: ResolvedAgentTaskRuntimeToolReadiness {
+                status: "ready".to_string(),
+                evidence: readiness_evidence,
+            },
             lifecycle: tool.lifecycle,
         });
     }

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_tool_resolution.rs
@@ -51,7 +51,7 @@ pub(crate) fn resolve_runtime_tools(
             }
         })?;
         let readiness_command = std::iter::once(executable.as_str())
-            .chain(tool.command.iter().skip(1).map(String::as_str))
+            .chain(readiness_command_prefix(tool).iter().map(String::as_str))
             .chain(tool.readiness.version_command.iter().map(String::as_str))
             .collect::<Vec<_>>()
             .join(" ");
@@ -166,7 +166,7 @@ fn probe_capabilities(
         return Ok(None);
     };
     let command = std::iter::once(executable)
-        .chain(tool.command.iter().skip(1).map(String::as_str))
+        .chain(readiness_command_prefix(tool).iter().map(String::as_str))
         .chain(probe.argv.iter().map(String::as_str))
         .collect::<Vec<_>>()
         .join(" ");
@@ -180,7 +180,7 @@ fn probe_capabilities(
     }
     let mut command = Command::new(executable);
     command
-        .args(tool.command.iter().skip(1))
+        .args(readiness_command_prefix(tool))
         .args(&probe.argv)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -262,7 +262,7 @@ fn probe_version(
     }
     let mut command = Command::new(executable);
     command
-        .args(tool.command.iter().skip(1))
+        .args(readiness_command_prefix(tool))
         .args(&tool.readiness.version_command)
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -339,6 +339,13 @@ fn probe_version(
 
 fn apply_probe_environment(command: &mut Command, tool: &AgentTaskRuntimeTool) {
     command.env_clear().envs(&tool.env);
+}
+
+fn readiness_command_prefix(tool: &AgentTaskRuntimeTool) -> &[String] {
+    tool.readiness
+        .command_prefix
+        .as_deref()
+        .unwrap_or(&tool.command[1..])
 }
 
 fn valid_identifier(value: &str) -> bool {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -374,6 +374,10 @@ process.stdin.once('data', input => {
         "fixture 1.0"
     );
     assert_eq!(
+        outcome.metadata["resolved_runtime_tools"][0]["readiness"],
+        json!({ "status": "ready", "evidence": { "kind": "declared_probe", "success": true } })
+    );
+    assert_eq!(
         outcome.metadata["capability_evidence"]["tool_contributed"][0]["capabilities"][0],
         "browser"
     );

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -309,7 +309,7 @@ process.stdin.on('end', () => {
 #[test]
 fn provider_adapter_receives_and_consumes_resolved_stdio_runtime_tool() {
     let tool = script(
-        "if (process.env.FIXTURE_MODE !== 'isolated') process.exit(17); if (process.argv[2] !== undefined && (process.env.PROBE_HOME !== 'declared' || process.env.PATH !== undefined || process.env.HOME !== undefined)) process.exit(19); if (process.argv[2] === '--version') { process.stdout.write('fixture 1.0'); process.exit(0); } if (process.argv[2] === '--capability-probe') process.exit(0); if (process.argv[2] !== undefined) process.exit(18); process.stdout.write(process.env.FIXTURE_MODE + ':ping'); process.exit(0);",
+        "if (process.env.FIXTURE_MODE !== 'isolated') process.exit(17); if (process.argv[2] !== '--launch-only' && (process.env.PROBE_HOME !== 'declared' || process.env.PATH !== undefined || process.env.HOME !== undefined)) process.exit(19); if (process.argv[2] === '--version') { process.stdout.write('fixture 1.0'); process.exit(0); } if (process.argv[2] === '--capability-probe') process.exit(0); if (process.argv[2] !== '--launch-only') process.exit(18); process.stdout.write(process.env.FIXTURE_MODE + ':ping'); process.exit(0);",
     );
     let provider_script = script(
         r#"const { spawnSync } = require('child_process');
@@ -325,11 +325,11 @@ process.stdin.once('data', input => {
         request("runtime-tool-projection", format!("node {provider_script}"));
     request.runtime_tools = vec![serde_json::from_value(json!({
         "id": "fixture.mcp",
-        "command": ["node", tool],
+        "command": ["node", tool, "--launch-only"],
         "env": { "FIXTURE_MODE": "isolated", "PROBE_HOME": "declared" },
         "secret_env": ["HOME"],
         "required_capabilities": ["browser"],
-        "readiness": { "version_command": ["--version"], "capability_probe": { "argv": ["--capability-probe"] } }
+        "readiness": { "command_prefix": [tool], "version_command": ["--version"], "capability_probe": { "argv": ["--capability-probe"] } }
     }))
     .expect("runtime tool")];
     request.policy.tools.tools.insert(


### PR DESCRIPTION
## Summary

- add an explicit readiness command prefix for runtime tools
- keep launch-only arguments out of version and capability probes
- project structured readiness status and probe evidence compatible with runtime adapters
- preserve the existing full-launch-argv default and adapter projection
- cover interpreter-backed launch/probe separation and the serialized producer contract

Fixes #11828.
Fixes #11840.

## Verification

- `cargo test -p homeboy-agents runtime_tool_`
- `cargo test -p homeboy-agents provider_adapter_receives_and_consumes_resolved_stdio_runtime_tool`
- `cargo clippy -p homeboy-agents -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Use: Identified the readiness/launch argv and producer/consumer schema mismatches, implemented the generic contracts, and added focused coverage under Chris Huber's direction. Chris remains responsible for every line.