### PR TITLE
fix(agent-task): cap batch concurrency and add a wall-clock deadline

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
@@ -66,4 +66,8 @@ use resources::{
     active_resource_units, adaptive_concurrency_decision, executor_key, model_key,
     task_resource_units,
 };
+pub use resources::{
+    resolve_batch_concurrency, BatchConcurrencyDecision, BatchConcurrencyInputs,
+    BatchConcurrencySource,
+};
 pub(crate) use scheduling::AgentTaskScheduleSupport;

--- a/crates/homeboy-agents/src/agent_task_scheduler/resources.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/resources.rs
@@ -173,6 +173,145 @@ pub(super) fn resource_capacity_available(
         <= max_active_units
 }
 
+/// How many whole tasks the resource budget still has room for, or `None` when
+/// the budget declares no ceiling.
+///
+/// This is the one place the "available units divided by per-task units"
+/// arithmetic lives. Both the scheduler's adaptive concurrency loop and the
+/// batch-cook fanout ceiling read it, so a host that tightens
+/// `max_active_units` tightens both by the same rule instead of by two
+/// hand-maintained copies that can disagree.
+pub(super) fn resource_budget_slots(
+    budget: &AgentTaskResourceBudget,
+    active_units: u32,
+) -> Option<usize> {
+    let max_active_units = budget.max_active_units?;
+    let default_task_units = budget.default_task_units.max(1);
+    let available_units = max_active_units.saturating_sub(active_units);
+    Some((available_units / default_task_units) as usize)
+}
+
+/// Why the batch fanout chose the concurrency it chose.
+///
+/// Reported alongside the limit so an operator reading a batch result can tell
+/// a deliberate `--max-concurrency 1` from a host config ceiling from a
+/// resource budget that quietly scaled the batch down, without re-deriving the
+/// decision from inputs that are no longer on hand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchConcurrencySource {
+    /// An explicit `--max-concurrency` flag.
+    Flag,
+    /// The host's `/agent_task/max_batch_concurrency` setting.
+    Config,
+    /// The plan's resource budget had fewer whole task slots than the ceiling.
+    ResourceBudget,
+    /// Fewer children than any ceiling: the batch is its own limit.
+    ChildCount,
+}
+
+impl BatchConcurrencySource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Flag => "flag",
+            Self::Config => "config",
+            Self::ResourceBudget => "resource_budget",
+            Self::ChildCount => "child_count",
+        }
+    }
+}
+
+/// The inputs a batch concurrency ceiling is resolved from.
+#[derive(Debug, Clone)]
+pub struct BatchConcurrencyInputs<'a> {
+    /// Explicit operator override, if one was given.
+    pub requested: Option<usize>,
+    /// Host config ceiling, if one is set.
+    pub configured: Option<usize>,
+    /// Fallback ceiling when neither of the above is set.
+    pub default_limit: usize,
+    /// The batch's resource budget, consulted for whole task slots.
+    pub resource_budget: &'a AgentTaskResourceBudget,
+    /// Units already committed. A batch coordinator starts at zero.
+    pub active_units: u32,
+    /// How many children the batch actually has.
+    pub child_count: usize,
+}
+
+/// The resolved ceiling and the reason for it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BatchConcurrencyDecision {
+    pub limit: usize,
+    pub source: BatchConcurrencySource,
+    pub reason: String,
+}
+
+/// Resolve how many child cooks a batch may run at once.
+///
+/// An explicit flag is operator authority and is taken as the ceiling. With no
+/// flag, the host config ceiling (or the caller's default) applies. Either way
+/// the resource budget and the child count can only lower the result, never
+/// raise it, so declaring a budget can never be made less protective by a
+/// larger ceiling somewhere else.
+///
+/// The floor is 1: a batch with work to do always makes progress.
+pub fn resolve_batch_concurrency(inputs: BatchConcurrencyInputs<'_>) -> BatchConcurrencyDecision {
+    let (ceiling, source) = match inputs.requested {
+        Some(requested) => (requested.max(1), BatchConcurrencySource::Flag),
+        None => (
+            inputs.configured.unwrap_or(inputs.default_limit).max(1),
+            BatchConcurrencySource::Config,
+        ),
+    };
+    let mut limit = ceiling;
+    let mut source = source;
+    let mut reason = match source {
+        BatchConcurrencySource::Flag => {
+            format!("--max-concurrency {ceiling} requested by the caller")
+        }
+        _ => match inputs.configured {
+            Some(configured) => {
+                format!("host config /agent_task/max_batch_concurrency {configured}")
+            }
+            None => format!(
+                "built-in default ceiling {} with no --max-concurrency flag or host config",
+                inputs.default_limit
+            ),
+        },
+    };
+
+    // A resource budget is a statement about what the host can physically
+    // sustain, so it lowers even an explicit flag.
+    if let Some(slots) = resource_budget_slots(inputs.resource_budget, inputs.active_units) {
+        let slots = slots.max(1);
+        if slots < limit {
+            limit = slots;
+            source = BatchConcurrencySource::ResourceBudget;
+            reason = format!(
+                "resource budget allows {slots} concurrent tasks (max_active_units={:?} active_units={} default_task_units={}), below the {ceiling} ceiling",
+                inputs.resource_budget.max_active_units,
+                inputs.active_units,
+                inputs.resource_budget.default_task_units.max(1),
+            );
+        }
+    }
+
+    if inputs.child_count > 0 && inputs.child_count < limit {
+        reason = format!(
+            "batch has {} children, fewer than the effective ceiling {limit}",
+            inputs.child_count,
+        );
+        limit = inputs.child_count;
+        source = BatchConcurrencySource::ChildCount;
+    }
+
+    BatchConcurrencyDecision {
+        limit: limit.max(1),
+        source,
+        reason,
+    }
+}
+
 pub(super) fn adaptive_concurrency_decision(
     policy: Option<&AgentTaskAdaptiveConcurrencyPolicy>,
     configured_max_concurrency: usize,
@@ -217,10 +356,11 @@ pub(super) fn adaptive_concurrency_decision(
         }
     }
 
-    if let Some(max_active_units) = resource_budget.max_active_units {
+    if let Some(resource_slots) = resource_budget_slots(resource_budget, active_units) {
+        let max_active_units = resource_budget
+            .max_active_units
+            .expect("resource slots are only produced by a budget with a ceiling");
         let default_task_units = resource_budget.default_task_units.max(1);
-        let available_units = max_active_units.saturating_sub(active_units);
-        let resource_slots = (available_units / default_task_units) as usize;
         if resource_slots == 0 {
             effective_concurrency = 0;
             reason = format!(
@@ -345,5 +485,153 @@ pub(super) fn render_value_templates(value: &mut Value, bindings: &HashMap<Strin
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod batch_concurrency_tests {
+    use super::*;
+
+    fn inputs<'a>(
+        budget: &'a AgentTaskResourceBudget,
+        child_count: usize,
+    ) -> BatchConcurrencyInputs<'a> {
+        BatchConcurrencyInputs {
+            requested: None,
+            configured: None,
+            default_limit: 4,
+            resource_budget: budget,
+            active_units: 0,
+            child_count,
+        }
+    }
+
+    /// The regression this whole path exists for: a large batch on a host with
+    /// no flag and no config must not fan out to the core count.
+    #[test]
+    fn an_unconfigured_batch_is_capped_by_the_built_in_default() {
+        let budget = AgentTaskResourceBudget::default();
+        let decision = resolve_batch_concurrency(inputs(&budget, 32));
+        assert_eq!(decision.limit, 4);
+        assert_eq!(decision.source, BatchConcurrencySource::Config);
+    }
+
+    #[test]
+    fn an_explicit_flag_is_the_ceiling_and_is_reported_as_the_source() {
+        let budget = AgentTaskResourceBudget::default();
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            requested: Some(2),
+            configured: Some(8),
+            ..inputs(&budget, 32)
+        });
+        assert_eq!(decision.limit, 2);
+        assert_eq!(decision.source, BatchConcurrencySource::Flag);
+    }
+
+    #[test]
+    fn host_config_applies_when_no_flag_is_given() {
+        let budget = AgentTaskResourceBudget::default();
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            configured: Some(1),
+            ..inputs(&budget, 32)
+        });
+        assert_eq!(decision.limit, 1);
+        assert_eq!(decision.source, BatchConcurrencySource::Config);
+    }
+
+    /// A budget is a statement about the host, so it lowers even an explicit
+    /// flag. Getting this backwards is how a declared budget stops protecting.
+    #[test]
+    fn a_resource_budget_lowers_even_an_explicit_flag() {
+        let budget = AgentTaskResourceBudget {
+            max_active_units: Some(2),
+            default_task_units: 1,
+            ..AgentTaskResourceBudget::default()
+        };
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            requested: Some(8),
+            ..inputs(&budget, 32)
+        });
+        assert_eq!(decision.limit, 2);
+        assert_eq!(decision.source, BatchConcurrencySource::ResourceBudget);
+        assert!(
+            decision.reason.contains("resource budget"),
+            "{}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn a_budget_larger_than_the_ceiling_does_not_raise_it() {
+        let budget = AgentTaskResourceBudget {
+            max_active_units: Some(64),
+            default_task_units: 1,
+            ..AgentTaskResourceBudget::default()
+        };
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            requested: Some(2),
+            ..inputs(&budget, 32)
+        });
+        assert_eq!(decision.limit, 2);
+        assert_eq!(decision.source, BatchConcurrencySource::Flag);
+    }
+
+    #[test]
+    fn a_small_batch_is_limited_by_its_own_child_count() {
+        let budget = AgentTaskResourceBudget::default();
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            requested: Some(8),
+            ..inputs(&budget, 2)
+        });
+        assert_eq!(decision.limit, 2);
+        assert_eq!(decision.source, BatchConcurrencySource::ChildCount);
+    }
+
+    /// A batch with work to do always makes progress, however tight the budget.
+    #[test]
+    fn the_floor_is_one_worker() {
+        let budget = AgentTaskResourceBudget {
+            max_active_units: Some(0),
+            default_task_units: 8,
+            ..AgentTaskResourceBudget::default()
+        };
+        let decision = resolve_batch_concurrency(BatchConcurrencyInputs {
+            requested: Some(0),
+            ..inputs(&budget, 32)
+        });
+        assert_eq!(decision.limit, 1);
+    }
+
+    #[test]
+    fn the_source_serializes_as_the_documented_vocabulary() {
+        for (source, expected) in [
+            (BatchConcurrencySource::Flag, "flag"),
+            (BatchConcurrencySource::Config, "config"),
+            (BatchConcurrencySource::ResourceBudget, "resource_budget"),
+            (BatchConcurrencySource::ChildCount, "child_count"),
+        ] {
+            assert_eq!(source.as_str(), expected);
+            assert_eq!(
+                serde_json::to_value(source).expect("source serializes"),
+                serde_json::Value::String(expected.to_string()),
+            );
+        }
+    }
+
+    /// The scheduler's adaptive loop and the batch ceiling must divide units
+    /// the same way, which is the point of sharing this helper.
+    #[test]
+    fn budget_slots_are_absent_without_a_ceiling_and_floor_at_zero_when_full() {
+        let unbounded = AgentTaskResourceBudget::default();
+        assert_eq!(resource_budget_slots(&unbounded, 0), None);
+
+        let bounded = AgentTaskResourceBudget {
+            max_active_units: Some(10),
+            default_task_units: 4,
+            ..AgentTaskResourceBudget::default()
+        };
+        assert_eq!(resource_budget_slots(&bounded, 0), Some(2));
+        assert_eq!(resource_budget_slots(&bounded, 8), Some(0));
+        assert_eq!(resource_budget_slots(&bounded, 999), Some(0));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -19,6 +19,7 @@ use crate::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionSt
 use crate::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
+use crate::agent_task_timeout::{capture_cook_deadline, expired_cook_deadline, CookDeadline};
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::{Error, Result};
@@ -160,6 +161,41 @@ fn pre_artifact_interruption_report(
     });
     report.value.terminal_phase = Some(phase.name().to_string());
     report.value.terminal_failure_classification = Some("pre_artifact_interruption".to_string());
+    report
+}
+
+/// Terminalize a Cook that ran out of wall-clock budget.
+///
+/// Reported as [`CookStatus::TimedOut`] — the existing vocabulary entry for
+/// "exceeded its wall-clock budget" — rather than a new status, so the batch
+/// totals, exit-code classification, and terminality rules that already
+/// understand `timed_out` need no teaching. Exit code is 1: the Cook did not
+/// finish the work it was asked to do, and an operator has something to act on.
+///
+/// [`CookDisposition::Terminal`] is declared explicitly: nothing is left
+/// carrying this Cook forward, so the orchestrator's completion is due now.
+fn cook_deadline_report(
+    cook_id: String,
+    attempts: Vec<AgentTaskCookAttemptReport>,
+    run_id: &str,
+    deadline: &CookDeadline,
+    boundary: &str,
+) -> AgentTaskRunResult<AgentTaskCookReport> {
+    let mut report = cook_report(CookReportInput {
+        cook_id,
+        // The existing vocabulary entry for "exceeded its wall-clock budget"
+        // ([`CookStatus::TimedOut`]). Written as the literal every other exit
+        // in this file uses; the linkage is pinned by test.
+        status: "timed_out",
+        disposition: CookDisposition::Terminal,
+        attempts,
+        finalization: None,
+        stop_reason: Some(deadline.stop_reason(boundary)),
+        exit_code: 1,
+        invocation_latest_run_id: Some(run_id),
+    });
+    report.value.terminal_phase = Some("cook_deadline".to_string());
+    report.value.terminal_failure_classification = Some("timed_out".to_string());
     report
 }
 
@@ -1054,6 +1090,11 @@ where
     // The caller's route is thread-local, so each worker must re-bind it or its
     // children submit unrouted and never notify the originating destination.
     let notification_route = homeboy_core::notification_route::capture();
+    // The wall-clock budget is thread-local for the same reason and must cross
+    // the same boundary. A budget bound only on the coordinator would leave
+    // every child it started unbounded, which is the fanout multiplication this
+    // budget exists to stop.
+    let cook_deadline = capture_cook_deadline();
     std::thread::scope(|scope| {
         for _ in 0..workers {
             let cooks = Arc::clone(&cooks);
@@ -1062,36 +1103,38 @@ where
             let executor = executor.clone();
             let notification_route = notification_route.clone();
             scope.spawn(move || {
-                notification_route.bind(|| loop {
-                    let index = {
-                        let mut next = next.lock().expect("cook batch work queue");
-                        if *next == cooks.len() {
-                            return;
-                        }
-                        let index = *next;
-                        *next += 1;
-                        index
-                    };
-                    let cook = cooks[index].clone();
-                    let cell = match run_cook(cook.clone(), executor.clone()) {
-                        Ok(result) => AgentTaskCookBatchCellReport {
-                            cook_id: cook.cook_id,
-                            initial_run_id: cook.initial_run_id,
-                            status: result.value.status.clone(),
-                            exit_code: result.exit_code,
-                            result: Some(result.value),
-                            error: None,
-                        },
-                        Err(error) => AgentTaskCookBatchCellReport {
-                            cook_id: cook.cook_id,
-                            initial_run_id: cook.initial_run_id,
-                            status: "failed".to_string(),
-                            exit_code: 1,
-                            result: None,
-                            error: Some(error.to_string()),
-                        },
-                    };
-                    let _ = tx.send((index, cell));
+                cook_deadline.bind(|| {
+                    notification_route.bind(|| loop {
+                        let index = {
+                            let mut next = next.lock().expect("cook batch work queue");
+                            if *next == cooks.len() {
+                                return;
+                            }
+                            let index = *next;
+                            *next += 1;
+                            index
+                        };
+                        let cook = cooks[index].clone();
+                        let cell = match run_cook(cook.clone(), executor.clone()) {
+                            Ok(result) => AgentTaskCookBatchCellReport {
+                                cook_id: cook.cook_id,
+                                initial_run_id: cook.initial_run_id,
+                                status: result.value.status.clone(),
+                                exit_code: result.exit_code,
+                                result: Some(result.value),
+                                error: None,
+                            },
+                            Err(error) => AgentTaskCookBatchCellReport {
+                                cook_id: cook.cook_id,
+                                initial_run_id: cook.initial_run_id,
+                                status: "failed".to_string(),
+                                exit_code: 1,
+                                result: None,
+                                error: Some(error.to_string()),
+                            },
+                        };
+                        let _ = tx.send((index, cell));
+                    })
                 })
             });
         }
@@ -2587,6 +2630,18 @@ where
         max_attempts
     };
     for attempt in first_attempt..=attempt_limit {
+        // Attempt boundary. Checked before any provider work is dispatched, so
+        // an expired budget costs nothing further and the attempt that would
+        // have run is never started rather than started and killed.
+        if let Some(deadline) = expired_cook_deadline() {
+            return Ok(cook_deadline_report(
+                cook_id,
+                attempts,
+                &run_id,
+                &deadline,
+                &format!("attempt {attempt} could be started"),
+            ));
+        }
         let plan = match next_plan.take() {
             Some(plan) => plan,
             None => agent_task_lifecycle::load_plan(&run_id)?,
@@ -2783,10 +2838,15 @@ where
                         .tasks
                         .first()
                         .map(|task| task.executor.backend.clone());
+                    // Captured before the spawn: the budget lives in a
+                    // thread-local, and the heartbeat runs on a thread of its
+                    // own that would otherwise start unbudgeted.
+                    let heartbeat_deadline = capture_cook_deadline();
                     std::thread::scope(|scope| {
                         scope.spawn(move || {
                             let mut supervisor =
                                 CookSupervisor::new(supervision_policy, supervision_backend);
+                            let mut deadline_stop_issued = false;
                             while let Err(mpsc::RecvTimeoutError::Timeout) =
                                 heartbeat_wait.recv_timeout(COOK_HEARTBEAT_INTERVAL)
                             {
@@ -2844,6 +2904,56 @@ where
                                         // reader conclude the run was stopped.
                                         Err(error) => serde_json::json!({
                                             "status": "termination_failed",
+                                            "error": error.to_string(),
+                                            "recovery_commands":
+                                                homeboy_core::process::process_tree_recovery_commands(
+                                                    heartbeat_owner_pid,
+                                                ),
+                                        }),
+                                    };
+                                    let _ = agent_task_lifecycle::record_cook_supervision_stop(
+                                        &heartbeat_run_id,
+                                        attempt,
+                                        outcome,
+                                    );
+                                }
+                                // A deadline that only fired at attempt and
+                                // gate boundaries would not bound a single
+                                // provider execution that runs past it, so the
+                                // budget would be advisory for exactly the case
+                                // it exists to bound. Expiry therefore takes
+                                // the same route a supervision stop does:
+                                // terminate the provider's process tree, from
+                                // the same thread, recorded through the same
+                                // durable evidence. Issued once — a second
+                                // SIGKILL adds nothing and would overwrite the
+                                // first outcome record.
+                                if !deadline_stop_issued
+                                    && heartbeat_deadline
+                                        .deadline()
+                                        .is_some_and(|deadline| deadline.is_expired())
+                                {
+                                    deadline_stop_issued = true;
+                                    let outcome = match homeboy_core::process::terminate_process_tree(
+                                        heartbeat_owner_pid,
+                                    ) {
+                                        Ok(termination) => serde_json::json!({
+                                            "status": "terminated",
+                                            "cause": "cook_deadline",
+                                            "signal": termination.signal,
+                                            "signalled_pids": termination.signalled_pids,
+                                            "killed_pids": termination.killed_pids,
+                                            "surviving_pids": termination.surviving_pids,
+                                            "recovery_commands": termination.recovery_commands,
+                                        }),
+                                        // Same reasoning as the supervision
+                                        // stop above: a host that cannot
+                                        // terminate the tree must say so rather
+                                        // than let a reader conclude the
+                                        // provider was stopped.
+                                        Err(error) => serde_json::json!({
+                                            "status": "termination_failed",
+                                            "cause": "cook_deadline",
                                             "error": error.to_string(),
                                             "recovery_commands":
                                                 homeboy_core::process::process_tree_recovery_commands(
@@ -3163,6 +3273,32 @@ where
             }));
         }
 
+        // Gate dispatch boundary. Promotion is where the deterministic gates
+        // run, and gates are the expensive half of the budget: five gates at
+        // the default 30-minute timeout outlast the provider execution that
+        // produced the candidate. Checked before dispatch so an expired budget
+        // does not start a fresh multi-hour gate sweep.
+        //
+        // The provider's candidate is already durable at this point, so this
+        // stops without discarding work: the Cook is recoverable by the normal
+        // continuation route once the operator grants more budget.
+        if let Some(deadline) = expired_cook_deadline() {
+            attempts.push(AgentTaskCookAttemptReport {
+                attempt,
+                run_id: run_id.clone(),
+                run_state: format!("{:?}", record.state),
+                aggregate_path: record.aggregate_path.clone(),
+                promotion: None,
+                feedback: None,
+            });
+            return Ok(cook_deadline_report(
+                cook_id,
+                attempts,
+                &run_id,
+                &deadline,
+                &format!("attempt {attempt} could enter promotion and run its gates"),
+            ));
+        }
         report_cook_progress(
             durable_observer,
             &cook_id,
@@ -4205,3 +4341,107 @@ fn rebind_baseline_continuation_workspace(
 #[cfg(test)]
 #[path = "cook_tests.rs"]
 mod tests;
+
+/// Wall-clock budget behaviour at the boundaries the Cook loop checks.
+///
+/// These cover the decision and the contract it produces. The loop plumbing
+/// that calls them is exercised by the integration cases in `cook_tests.rs`.
+#[cfg(test)]
+mod cook_deadline_tests {
+    use super::*;
+    use crate::agent_task_timeout::{
+        current_cook_deadline, now_unix_ms, with_current_cook_deadline,
+    };
+
+    fn expired() -> CookDeadline {
+        CookDeadline::from_unix_ms(now_unix_ms().saturating_sub(1))
+    }
+
+    /// The default has to remain "no budget": every caller that never set one
+    /// must reach its attempt boundary exactly as before.
+    #[test]
+    fn an_unbudgeted_cook_never_reports_an_expired_boundary() {
+        assert_eq!(current_cook_deadline(), None);
+        assert_eq!(expired_cook_deadline(), None);
+    }
+
+    /// A live budget must not stop a Cook that still has time. Firing early is
+    /// the failure mode that kills real work.
+    #[test]
+    fn a_live_budget_does_not_trip_a_boundary() {
+        with_current_cook_deadline(Some(CookDeadline::from_duration_seconds(3_600)), || {
+            assert_eq!(expired_cook_deadline(), None);
+        });
+    }
+
+    #[test]
+    fn an_expired_budget_trips_the_boundary() {
+        let deadline = expired();
+        with_current_cook_deadline(Some(deadline), || {
+            assert_eq!(expired_cook_deadline(), Some(deadline));
+        });
+    }
+
+    /// Expiry must terminalize cleanly and inspectably: a known status, a
+    /// declared terminal disposition, a non-zero exit, and a stop reason that
+    /// names the boundary and the remedy.
+    #[test]
+    fn deadline_expiry_at_an_attempt_boundary_terminalizes_as_timed_out() {
+        let deadline = expired();
+        let result = cook_deadline_report(
+            "cook-1".to_string(),
+            Vec::new(),
+            "run-1",
+            &deadline,
+            "attempt 2 could be started",
+        );
+
+        assert_eq!(result.exit_code, 1, "expiry is not a success");
+        assert_eq!(result.value.status, "timed_out");
+        assert_eq!(result.value.disposition, CookDisposition::Terminal);
+        assert_eq!(
+            result.value.terminal_phase.as_deref(),
+            Some("cook_deadline"),
+            "the phase must distinguish a budget stop from any other timeout"
+        );
+        assert_eq!(
+            result.value.terminal_failure_classification.as_deref(),
+            Some("timed_out")
+        );
+
+        let reason = result.value.stop_reason.clone().expect("a stop reason");
+        assert!(reason.contains("--max-duration"), "{reason}");
+        assert!(reason.contains("attempt 2 could be started"), "{reason}");
+    }
+
+    /// The status must classify the same way every other terminal Cook status
+    /// does, or batch totals and exit codes disagree with the report.
+    ///
+    /// Also pins the literal written by `cook_deadline_report` to the enum
+    /// entry it is meant to be, so the two cannot drift apart.
+    #[test]
+    fn the_reported_status_reads_as_terminal_and_not_as_success() {
+        assert_eq!(CookStatus::TimedOut.as_str(), "timed_out");
+        let status = CookStatus::from_status("timed_out");
+        assert_eq!(status, CookStatus::TimedOut);
+        assert!(!status.is_in_flight());
+        assert!(!status.is_success_exit());
+    }
+
+    /// A gate-boundary stop names the gates, because "out of time" and "out of
+    /// time before the gates could run" call for different follow-ups.
+    #[test]
+    fn a_gate_boundary_stop_names_the_gate_phase() {
+        let reason = cook_deadline_report(
+            "cook-1".to_string(),
+            Vec::new(),
+            "run-1",
+            &expired(),
+            "attempt 1 could enter promotion and run its gates",
+        )
+        .value
+        .stop_reason
+        .expect("a stop reason");
+        assert!(reason.contains("run its gates"), "{reason}");
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_timeout.rs
+++ b/crates/homeboy-agents/src/agent_task_timeout.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const MAX_TIMEOUT_GRACE_MS: u64 = 30_000;
@@ -36,6 +37,131 @@ fn default_provider_timeout_ms() -> u64 {
     DEFAULT_PROVIDER_TIMEOUT_MS
 }
 
+thread_local! {
+    static CURRENT_COOK_DEADLINE: RefCell<Option<CookDeadline>> = const { RefCell::new(None) };
+}
+
+/// An absolute wall-clock budget for a whole Cook, spanning every attempt and
+/// every gate rather than any single provider execution or gate command.
+///
+/// # Why this is separate from the existing timeouts
+///
+/// Before this existed the only bounds were per-provider-execution
+/// ([`DEFAULT_PROVIDER_TIMEOUT_MS`], 20 minutes) and per-gate
+/// (`--gate-timeout-seconds`, 30 minutes). Those bound the *parts*, and the
+/// parts multiply: a Cook with `--max-attempts 3` and five gates has a legal
+/// upper bound near `3 x (20min + 5 x 30min)`, roughly eight and a half hours,
+/// with nothing that stops it — multiplied again by the children of a fanout.
+/// A budget over the whole is not derivable from budgets over the parts, so it
+/// has to be stated.
+///
+/// # Absolute, not relative
+///
+/// The budget is stored as an absolute instant, resolved once by whoever set
+/// it. A duration re-based at each attempt would grant the full budget again
+/// on every retry, which is the bound this exists to remove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CookDeadline {
+    deadline_unix_ms: u64,
+}
+
+impl CookDeadline {
+    /// A budget expiring `max_duration_seconds` from now.
+    pub fn from_duration_seconds(max_duration_seconds: u64) -> Self {
+        Self {
+            deadline_unix_ms: now_unix_ms().saturating_add(max_duration_seconds * 1_000),
+        }
+    }
+
+    pub fn from_unix_ms(deadline_unix_ms: u64) -> Self {
+        Self { deadline_unix_ms }
+    }
+
+    pub fn deadline_unix_ms(&self) -> u64 {
+        self.deadline_unix_ms
+    }
+
+    /// Milliseconds left, saturating at zero.
+    pub fn remaining_ms(&self) -> u64 {
+        self.deadline_unix_ms.saturating_sub(now_unix_ms())
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.remaining_ms() == 0
+    }
+
+    /// The operator-facing explanation recorded as a Cook's stop reason.
+    ///
+    /// Names the boundary the budget was noticed at, because "the Cook ran out
+    /// of time" and "the Cook ran out of time before its gates could run" call
+    /// for different follow-ups.
+    pub fn stop_reason(&self, boundary: &str) -> String {
+        format!(
+            "Cook exceeded its wall-clock budget (--max-duration): the deadline at unix_ms {} \
+             passed before {boundary}. No further attempt or gate was started. Re-run with a \
+             larger --max-duration, or reduce --max-attempts or the number of gates.",
+            self.deadline_unix_ms,
+        )
+    }
+}
+
+/// A deadline captured for propagation onto worker threads.
+///
+/// Batch workers are separate threads, and a thread-local does not cross that
+/// boundary on its own. This mirrors how the notification route is captured
+/// and re-bound per worker in the same batch runner.
+#[derive(Debug, Clone, Copy)]
+pub struct PropagatedCookDeadline(Option<CookDeadline>);
+
+impl PropagatedCookDeadline {
+    pub fn bind<T>(&self, operation: impl FnOnce() -> T) -> T {
+        with_current_cook_deadline(self.0, operation)
+    }
+
+    pub fn deadline(&self) -> Option<CookDeadline> {
+        self.0
+    }
+}
+
+/// Capture the calling thread's deadline for propagation onto worker threads.
+pub fn capture_cook_deadline() -> PropagatedCookDeadline {
+    PropagatedCookDeadline(current_cook_deadline())
+}
+
+/// The deadline governing the calling thread, if any.
+///
+/// `None` means unbudgeted, which is the pre-existing behaviour and remains
+/// the default for every caller that does not set one.
+pub fn current_cook_deadline() -> Option<CookDeadline> {
+    CURRENT_COOK_DEADLINE.with(|current| *current.borrow())
+}
+
+/// Run `operation` with `deadline` governing this thread, restoring the
+/// previous value afterwards even on unwind.
+pub fn with_current_cook_deadline<T>(
+    deadline: Option<CookDeadline>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    struct Restore(Option<CookDeadline>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            CURRENT_COOK_DEADLINE.with(|current| *current.borrow_mut() = self.0);
+        }
+    }
+
+    let previous = CURRENT_COOK_DEADLINE.with(|current| current.replace(deadline));
+    let _restore = Restore(previous);
+    operation()
+}
+
+/// The expired deadline governing this thread, if it has already passed.
+///
+/// Callers at a boundary use this to decide whether to stop: `Some` means the
+/// budget is spent and no further work may be started.
+pub fn expired_cook_deadline() -> Option<CookDeadline> {
+    current_cook_deadline().filter(CookDeadline::is_expired)
+}
+
 pub(crate) fn timeout_with_grace(timeout_ms: u64) -> Duration {
     Duration::from_millis(timeout_ms.saturating_add(timeout_grace_ms(timeout_ms)))
 }
@@ -49,6 +175,75 @@ fn timeout_grace_ms(timeout_ms: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The default has to stay "no budget", or every existing caller that
+    /// never asked for one silently acquires a way to be killed.
+    #[test]
+    fn no_deadline_is_bound_by_default() {
+        assert_eq!(current_cook_deadline(), None);
+        assert_eq!(expired_cook_deadline(), None);
+    }
+
+    #[test]
+    fn a_past_deadline_is_expired_and_a_future_one_is_not() {
+        let past = CookDeadline::from_unix_ms(now_unix_ms().saturating_sub(1));
+        assert!(past.is_expired());
+        assert_eq!(past.remaining_ms(), 0);
+
+        let future = CookDeadline::from_duration_seconds(3_600);
+        assert!(!future.is_expired());
+        assert!(future.remaining_ms() > 0);
+    }
+
+    #[test]
+    fn a_bound_deadline_is_visible_and_is_restored_after_the_scope() {
+        let deadline = CookDeadline::from_duration_seconds(3_600);
+        with_current_cook_deadline(Some(deadline), || {
+            assert_eq!(current_cook_deadline(), Some(deadline));
+            // An expired check must not fire on a live budget.
+            assert_eq!(expired_cook_deadline(), None);
+        });
+        assert_eq!(current_cook_deadline(), None, "scope must not leak");
+    }
+
+    #[test]
+    fn an_expired_deadline_is_reported_only_once_it_has_passed() {
+        let expired = CookDeadline::from_unix_ms(now_unix_ms().saturating_sub(1));
+        with_current_cook_deadline(Some(expired), || {
+            assert_eq!(expired_cook_deadline(), Some(expired));
+        });
+    }
+
+    /// Batch children run on worker threads, so a budget that does not cross
+    /// the thread boundary bounds only the coordinator and nothing it started.
+    #[test]
+    fn a_captured_deadline_crosses_a_thread_boundary() {
+        let deadline = CookDeadline::from_duration_seconds(3_600);
+        with_current_cook_deadline(Some(deadline), || {
+            let propagated = capture_cook_deadline();
+            assert_eq!(propagated.deadline(), Some(deadline));
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    assert_eq!(
+                        current_cook_deadline(),
+                        None,
+                        "a fresh thread starts unbudgeted"
+                    );
+                    propagated.bind(|| {
+                        assert_eq!(current_cook_deadline(), Some(deadline));
+                    });
+                });
+            });
+        });
+    }
+
+    #[test]
+    fn the_stop_reason_names_the_boundary_and_the_flag() {
+        let reason = CookDeadline::from_unix_ms(1_234).stop_reason("attempt 2 started");
+        assert!(reason.contains("--max-duration"), "{reason}");
+        assert!(reason.contains("attempt 2 started"), "{reason}");
+        assert!(reason.contains("1234"), "{reason}");
+    }
 
     #[test]
     fn timeout_grace_is_bounded() {

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -84,6 +84,19 @@ pub struct AgentTaskFanoutCookBatchArgs {
     /// append to or replace shared --verify/--private-verify gates per issue.
     #[arg(long = "verification-profiles", value_name = "JSON")]
     pub verification_profiles: Option<String>,
+    /// Maximum number of child cooks to run at once.
+    ///
+    /// Without this, the ceiling is the host's
+    /// `/agent_task/max_batch_concurrency` config or a built-in default. A
+    /// declared resource budget and the number of children can lower the
+    /// result further, never raise it. The effective limit and the reason for
+    /// it are reported as `concurrency` in the batch result.
+    #[arg(
+        long = "max-concurrency",
+        value_parser = clap::value_parser!(usize).range(1..),
+        value_name = "N"
+    )]
+    pub max_concurrency: Option<usize>,
     #[arg(long = "dry-run")]
     pub dry_run: bool,
     #[arg(long = "run-plan")]
@@ -145,4 +158,12 @@ pub struct AgentTaskFanoutRunPlanArgs {
     /// Overrides the persisted plan value for this execution.
     #[arg(long = "ai-tool", value_name = "TEXT")]
     pub ai_tool: Option<String>,
+    /// Maximum number of child cooks to run at once. See
+    /// `fanout cook-batch --max-concurrency`.
+    #[arg(
+        long = "max-concurrency",
+        value_parser = clap::value_parser!(usize).range(1..),
+        value_name = "N"
+    )]
+    pub max_concurrency: Option<usize>,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -93,10 +93,10 @@ pub struct AgentTaskFanoutCookBatchArgs {
     /// it are reported as `concurrency` in the batch result.
     #[arg(
         long = "max-concurrency",
-        value_parser = clap::value_parser!(usize).range(1..),
+        value_parser = clap::value_parser!(u32).range(1..),
         value_name = "N"
     )]
-    pub max_concurrency: Option<usize>,
+    pub max_concurrency: Option<u32>,
     /// Wall-clock budget, in seconds, for the whole batch — every child, every
     /// attempt, and every gate.
     ///
@@ -177,10 +177,10 @@ pub struct AgentTaskFanoutRunPlanArgs {
     /// `fanout cook-batch --max-concurrency`.
     #[arg(
         long = "max-concurrency",
-        value_parser = clap::value_parser!(usize).range(1..),
+        value_parser = clap::value_parser!(u32).range(1..),
         value_name = "N"
     )]
-    pub max_concurrency: Option<usize>,
+    pub max_concurrency: Option<u32>,
     /// Wall-clock budget, in seconds, for the whole batch. See
     /// `fanout cook-batch --max-duration`.
     #[arg(

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -97,6 +97,21 @@ pub struct AgentTaskFanoutCookBatchArgs {
         value_name = "N"
     )]
     pub max_concurrency: Option<usize>,
+    /// Wall-clock budget, in seconds, for the whole batch — every child, every
+    /// attempt, and every gate.
+    ///
+    /// The per-provider and per-gate timeouts bound only the parts, and the
+    /// parts multiply: with `--max-attempts 3` and five gates a single child
+    /// can legally run for hours. On expiry each child terminalizes as
+    /// `timed_out` at its next attempt or gate boundary, and a provider still
+    /// running has its process tree terminated. Unset means no budget, which
+    /// is the existing behaviour.
+    #[arg(
+        long = "max-duration",
+        value_parser = clap::value_parser!(u64).range(1..),
+        value_name = "SECONDS"
+    )]
+    pub max_duration: Option<u64>,
     #[arg(long = "dry-run")]
     pub dry_run: bool,
     #[arg(long = "run-plan")]
@@ -166,4 +181,12 @@ pub struct AgentTaskFanoutRunPlanArgs {
         value_name = "N"
     )]
     pub max_concurrency: Option<usize>,
+    /// Wall-clock budget, in seconds, for the whole batch. See
+    /// `fanout cook-batch --max-duration`.
+    #[arg(
+        long = "max-duration",
+        value_parser = clap::value_parser!(u64).range(1..),
+        value_name = "SECONDS"
+    )]
+    pub max_duration: Option<u64>,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -7,6 +7,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::process::Command;
 
 use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
+use homeboy::agents::agent_task_scheduler::{
+    resolve_batch_concurrency, BatchConcurrencyDecision, BatchConcurrencyInputs,
+};
 use homeboy::agents::agent_tasks::batch;
 use homeboy::agents::agent_tasks::dependency_actions::{
     execute_resolved_dependency_actions, DependencyAction, DependencyActionExecutor,
@@ -1070,6 +1073,7 @@ fn batch_artifacts(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
 fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
+    plan.apply_max_concurrency_override(args.max_concurrency);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1084,6 +1088,7 @@ pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
 ) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
+    plan.apply_max_concurrency_override(args.max_concurrency);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1124,18 +1129,20 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
     persist_fanout_run_batch_record(&plan)?;
     persist_batch_cook_recipes(&plan)?;
     let ready_plan = plan.ready_plan()?;
+    let cooks = compile_batch_cooks(&ready_plan, |options| {
+        options.attempt_dispatcher = Some(attempt_dispatcher(options));
+    })?;
+    let concurrency = batch_concurrency(&plan, &cooks);
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
-            cooks: compile_batch_cooks(&ready_plan, |options| {
-                options.attempt_dispatcher = Some(attempt_dispatcher(options));
-            })?,
-            max_concurrency: batch_worker_limit(&plan),
+            cooks,
+            max_concurrency: concurrency.limit,
         },
         provider::ExtensionProviderAgentTaskExecutor::discover(),
     )?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
-    Ok(batch_cook_result(&plan, result))
+    Ok(batch_cook_result(&plan, result, &concurrency))
 }
 
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
@@ -1155,16 +1162,18 @@ where
     persist_fanout_run_batch_record(&plan)?;
     persist_batch_cook_recipes(&plan)?;
     let ready_plan = plan.ready_plan()?;
+    let cooks = compile_batch_cooks(&ready_plan, |_| {})?;
+    let concurrency = batch_concurrency(&plan, &cooks);
     let result = agent_task_service::run_cook_batch(
         agent_task_service::AgentTaskCookBatchOptions {
             batch_id: plan.fanout_id.clone(),
-            cooks: compile_batch_cooks(&ready_plan, |_| {})?,
-            max_concurrency: batch_worker_limit(&plan),
+            cooks,
+            max_concurrency: concurrency.limit,
         },
         executor,
     )?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
-    Ok(batch_cook_result(&plan, result))
+    Ok(batch_cook_result(&plan, result, &concurrency))
 }
 
 /// Recipes are the durable restart boundary. Persist blocked dependents before
@@ -1223,15 +1232,43 @@ fn compile_batch_cooks(
         .collect()
 }
 
-fn batch_worker_limit(plan: &BatchCookFanoutPlan) -> usize {
-    plan.cooks
-        .len()
-        .min(std::thread::available_parallelism().map_or(1, usize::from))
+/// Resolve how many children this batch may run at once.
+///
+/// This used to be `min(children, available_parallelism())`, which is not a
+/// limit: an eight-core host started eight concurrent cooks regardless of what
+/// those cooks did. A cook whose gate compiles can consume tens of gigabytes of
+/// disk, so the core count is the wrong quantity entirely. The ceiling now
+/// comes from the operator, the host config, or the plan's resource budget —
+/// resolved by the scheduler's own resource module so the batch path and the
+/// scheduler apply one rule rather than two.
+fn batch_concurrency(
+    plan: &BatchCookFanoutPlan,
+    cooks: &[AgentTaskCookServiceOptions],
+) -> BatchConcurrencyDecision {
+    // A batch coordinator commits nothing before it starts, so the budget is
+    // read at zero active units. The budget itself is the children's own, taken
+    // from the first compiled plan: every child in a batch is compiled from the
+    // same host policy.
+    let resource_budget = cooks
+        .first()
+        .map(|cook| cook.initial_plan.options.resource_budget.clone())
+        .unwrap_or_default();
+    resolve_batch_concurrency(BatchConcurrencyInputs {
+        requested: plan.max_concurrency,
+        configured: homeboy_core::defaults::load_config()
+            .agent_task
+            .max_batch_concurrency,
+        default_limit: homeboy_core::defaults::DEFAULT_AGENT_TASK_MAX_BATCH_CONCURRENCY,
+        resource_budget: &resource_budget,
+        active_units: 0,
+        child_count: cooks.len(),
+    })
 }
 
 fn batch_cook_result(
     plan: &BatchCookFanoutPlan,
     result: agent_task_service::AgentTaskRunResult<agent_task_service::AgentTaskCookBatchReport>,
+    concurrency: &BatchConcurrencyDecision,
 ) -> (Value, i32) {
     let report = result.value;
     let cooks = report
@@ -1260,6 +1297,14 @@ fn batch_cook_result(
             "schema": AGENT_TASK_BATCH_COOK_FANOUT_RUN_SCHEMA,
             "fanout_id": plan.fanout_id,
             "status": report.status,
+            // Reported so an operator can tell a deliberate ceiling from one a
+            // resource budget imposed, without re-deriving it from inputs that
+            // are no longer on hand.
+            "concurrency": {
+                "limit": concurrency.limit,
+                "source": concurrency.source.as_str(),
+                "reason": concurrency.reason,
+            },
             "summary": {
                 "total": report.total,
                 "queued": report.queued,
@@ -1568,6 +1613,11 @@ struct BatchCookFanoutPlan {
     schema: String,
     fanout_id: String,
     cooks: Vec<BatchCookSpec>,
+    /// Operator ceiling on how many children run at once, carried on the plan
+    /// so a plan built by `cook-batch` keeps its limit when it is persisted and
+    /// later executed by `run-plan`. `None` defers to host config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_concurrency: Option<usize>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     metadata: Value,
 }
@@ -1636,6 +1686,14 @@ impl BatchCookFanoutPlan {
         let Some(ai_tool) = ai_tool else { return };
         for cook in &mut self.cooks {
             cook.ai_tool = ai_tool.to_string();
+        }
+    }
+
+    /// An execution-time `--max-concurrency` replaces the ceiling the plan was
+    /// built with. Absent, the persisted plan value stands.
+    fn apply_max_concurrency_override(&mut self, max_concurrency: Option<usize>) {
+        if max_concurrency.is_some() {
+            self.max_concurrency = max_concurrency;
         }
     }
 
@@ -2144,6 +2202,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         schema: batch_cook_fanout_plan_schema(),
         fanout_id,
         cooks,
+        max_concurrency: args.max_concurrency,
         metadata: serde_json::json!({
             "source": "agent-task fanout cook-batch",
             "issue_count": args.issues.len(),
@@ -2697,6 +2756,14 @@ mod tests {
     use serde_json::json;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+
+    fn test_concurrency_decision() -> BatchConcurrencyDecision {
+        BatchConcurrencyDecision {
+            limit: 2,
+            source: homeboy::agents::agent_task_scheduler::BatchConcurrencySource::ChildCount,
+            reason: "batch has 2 children".to_string(),
+        }
+    }
 
     fn test_batch_plan() -> BatchCookFanoutPlan {
         BatchCookFanoutPlan::from_value(
@@ -3432,6 +3499,7 @@ fi
                 isolate_gate_xdg: true,
             },
             verification_profiles: None,
+            max_concurrency: None,
             dry_run: true,
             run_plan: false,
         }
@@ -3935,6 +4003,7 @@ fi
         let mut legacy = BatchCookFanoutPlan {
             schema: batch_cook_fanout_plan_schema(),
             fanout_id: "legacy".to_string(),
+            max_concurrency: None,
             cooks: vec![BatchCookSpec {
                 cook_id: "issue-6453".to_string(),
                 ..plan.cooks[0].clone()
@@ -4108,7 +4177,7 @@ fi
         active_failed_report.succeeded = 0;
         active_failed_report.failed = 1;
         active_failed_report.cooks[0].status = "in_flight".to_string();
-        let (data, exit_code) = batch_cook_result(&plan, result);
+        let (data, exit_code) = batch_cook_result(&plan, result, &test_concurrency_decision());
         let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
             &Ok(data),
             exit_code,
@@ -4131,6 +4200,7 @@ fi
                 exit_code: 1,
                 value: all_failed_report,
             },
+            &test_concurrency_decision(),
         );
         let envelope = crate::commands::utils::response::cli_response_for_json_result_for_command(
             &Ok(data),
@@ -4148,6 +4218,7 @@ fi
                 exit_code: 0,
                 value: active_failed_report.clone(),
             },
+            &test_concurrency_decision(),
         );
         let (resumed, resume_exit_code) =
             batch_resume_result(active_failed_report, 0, "test-batch", None);
@@ -4324,6 +4395,114 @@ fi
         assert_eq!(
             args.ai_tool.as_deref(),
             Some("OpenAI GPT-5.6 Sol via OpenCode")
+        );
+    }
+
+    #[test]
+    fn run_plan_cli_parses_max_concurrency() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@plan.json",
+            "--max-concurrency",
+            "2",
+        ])
+        .expect("run-plan parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Fanout(fanout) = agent_task.command else {
+            panic!("fanout command");
+        };
+        let AgentTaskFanoutCommand::RunPlan(args) = fanout.command else {
+            panic!("run-plan command");
+        };
+        assert_eq!(args.max_concurrency, Some(2));
+    }
+
+    /// Zero workers would deadlock a batch that has work to do, so the flag
+    /// refuses it at parse time rather than silently clamping later.
+    #[test]
+    fn max_concurrency_rejects_zero() {
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@plan.json",
+            "--max-concurrency",
+            "0",
+        ])
+        .is_err());
+    }
+
+    /// A ceiling declared at plan time has to survive persistence, or a batch
+    /// planned with `--max-concurrency 1` fans out unbounded when `run-plan`
+    /// executes it later.
+    #[test]
+    fn a_persisted_plan_carries_its_concurrency_ceiling() {
+        let mut plan = test_batch_plan();
+        assert_eq!(plan.max_concurrency, None);
+        plan.max_concurrency = Some(1);
+
+        let encoded = serde_json::to_value(&plan).expect("plan serializes");
+        assert_eq!(encoded["max_concurrency"], 1);
+
+        let reloaded = BatchCookFanoutPlan::from_value(encoded, &args()).expect("plan reloads");
+        assert_eq!(reloaded.max_concurrency, Some(1));
+    }
+
+    #[test]
+    fn an_execution_time_flag_overrides_the_persisted_ceiling() {
+        let mut plan = test_batch_plan();
+        plan.max_concurrency = Some(4);
+
+        plan.apply_max_concurrency_override(None);
+        assert_eq!(plan.max_concurrency, Some(4), "absent flag must not clear");
+
+        plan.apply_max_concurrency_override(Some(1));
+        assert_eq!(plan.max_concurrency, Some(1));
+    }
+
+    /// The operator-facing half of the fix: the limit and why it was chosen
+    /// have to be readable off the result.
+    #[test]
+    fn the_batch_result_reports_the_effective_limit_and_its_source() {
+        let plan = test_batch_plan();
+        let report = agent_task_service::AgentTaskCookBatchReport {
+            schema: "homeboy/agent-task-cook-batch/v1",
+            batch_id: "test-batch".to_string(),
+            status: "succeeded".to_string(),
+            total: 2,
+            queued: 0,
+            running: 0,
+            succeeded: 2,
+            failed: 0,
+            cancelled: 0,
+            timed_out: 0,
+            cooks: Vec::new(),
+        };
+        let (data, _exit_code) = batch_cook_result(
+            &plan,
+            agent_task_service::AgentTaskRunResult {
+                exit_code: 0,
+                value: report,
+            },
+            &BatchConcurrencyDecision {
+                limit: 1,
+                source: homeboy::agents::agent_task_scheduler::BatchConcurrencySource::Flag,
+                reason: "--max-concurrency 1 requested by the caller".to_string(),
+            },
+        );
+        assert_eq!(data["concurrency"]["limit"], 1);
+        assert_eq!(data["concurrency"]["source"], "flag");
+        assert_eq!(
+            data["concurrency"]["reason"],
+            "--max-concurrency 1 requested by the caller"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -10,6 +10,7 @@ use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::agents::agent_task_scheduler::{
     resolve_batch_concurrency, BatchConcurrencyDecision, BatchConcurrencyInputs,
 };
+use homeboy::agents::agent_task_timeout::{with_current_cook_deadline, CookDeadline};
 use homeboy::agents::agent_tasks::batch;
 use homeboy::agents::agent_tasks::dependency_actions::{
     execute_resolved_dependency_actions, DependencyAction, DependencyActionExecutor,
@@ -1074,6 +1075,7 @@ fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
     plan.apply_max_concurrency_override(args.max_concurrency);
+    plan.apply_max_duration_override(args.max_duration);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1089,6 +1091,7 @@ pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
     plan.apply_max_concurrency_override(args.max_concurrency);
+    plan.apply_max_duration_override(args.max_duration);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
     }
@@ -1133,14 +1136,19 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
         options.attempt_dispatcher = Some(attempt_dispatcher(options));
     })?;
     let concurrency = batch_concurrency(&plan, &cooks);
-    let result = agent_task_service::run_cook_batch(
-        agent_task_service::AgentTaskCookBatchOptions {
-            batch_id: plan.fanout_id.clone(),
-            cooks,
-            max_concurrency: concurrency.limit,
-        },
-        provider::ExtensionProviderAgentTaskExecutor::discover(),
-    )?;
+    // Resolved once, here, and bound for the whole batch: every worker thread
+    // re-binds this same absolute instant, so the budget covers the batch
+    // rather than restarting per child.
+    let result = with_current_cook_deadline(plan.cook_deadline(), || {
+        agent_task_service::run_cook_batch(
+            agent_task_service::AgentTaskCookBatchOptions {
+                batch_id: plan.fanout_id.clone(),
+                cooks,
+                max_concurrency: concurrency.limit,
+            },
+            provider::ExtensionProviderAgentTaskExecutor::discover(),
+        )
+    })?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
     Ok(batch_cook_result(&plan, result, &concurrency))
 }
@@ -1164,14 +1172,18 @@ where
     let ready_plan = plan.ready_plan()?;
     let cooks = compile_batch_cooks(&ready_plan, |_| {})?;
     let concurrency = batch_concurrency(&plan, &cooks);
-    let result = agent_task_service::run_cook_batch(
-        agent_task_service::AgentTaskCookBatchOptions {
-            batch_id: plan.fanout_id.clone(),
-            cooks,
-            max_concurrency: concurrency.limit,
-        },
-        executor,
-    )?;
+    // See the sibling runner: the budget is resolved once and bound for the
+    // whole batch so it does not restart per child.
+    let result = with_current_cook_deadline(plan.cook_deadline(), || {
+        agent_task_service::run_cook_batch(
+            agent_task_service::AgentTaskCookBatchOptions {
+                batch_id: plan.fanout_id.clone(),
+                cooks,
+                max_concurrency: concurrency.limit,
+            },
+            executor,
+        )
+    })?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
     Ok(batch_cook_result(&plan, result, &concurrency))
 }
@@ -1618,6 +1630,14 @@ struct BatchCookFanoutPlan {
     /// later executed by `run-plan`. `None` defers to host config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     max_concurrency: Option<usize>,
+    /// Wall-clock budget for the whole batch, in seconds.
+    ///
+    /// Stored as a duration rather than an absolute instant so a plan
+    /// persisted today and executed tomorrow gets the budget it asked for
+    /// instead of one that expired while it sat on disk. It is resolved to an
+    /// absolute deadline once, when the batch starts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_duration_seconds: Option<u64>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     metadata: Value,
 }
@@ -1695,6 +1715,20 @@ impl BatchCookFanoutPlan {
         if max_concurrency.is_some() {
             self.max_concurrency = max_concurrency;
         }
+    }
+
+    /// An execution-time `--max-duration` replaces the budget the plan was
+    /// built with. Absent, the persisted plan value stands.
+    fn apply_max_duration_override(&mut self, max_duration_seconds: Option<u64>) {
+        if max_duration_seconds.is_some() {
+            self.max_duration_seconds = max_duration_seconds;
+        }
+    }
+
+    /// Resolve this batch's wall-clock budget to an absolute deadline, now.
+    fn cook_deadline(&self) -> Option<CookDeadline> {
+        self.max_duration_seconds
+            .map(CookDeadline::from_duration_seconds)
     }
 
     fn dependency_nodes(&self) -> Vec<AgentTaskDependencyNode> {
@@ -2203,6 +2237,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         fanout_id,
         cooks,
         max_concurrency: args.max_concurrency,
+        max_duration_seconds: args.max_duration,
         metadata: serde_json::json!({
             "source": "agent-task fanout cook-batch",
             "issue_count": args.issues.len(),
@@ -3500,6 +3535,7 @@ fi
             },
             verification_profiles: None,
             max_concurrency: None,
+            max_duration: None,
             dry_run: true,
             run_plan: false,
         }
@@ -4004,6 +4040,7 @@ fi
             schema: batch_cook_fanout_plan_schema(),
             fanout_id: "legacy".to_string(),
             max_concurrency: None,
+            max_duration_seconds: None,
             cooks: vec![BatchCookSpec {
                 cook_id: "issue-6453".to_string(),
                 ..plan.cooks[0].clone()
@@ -4466,6 +4503,95 @@ fi
 
         plan.apply_max_concurrency_override(Some(1));
         assert_eq!(plan.max_concurrency, Some(1));
+    }
+
+    #[test]
+    fn run_plan_cli_parses_max_duration() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@plan.json",
+            "--max-duration",
+            "5400",
+        ])
+        .expect("run-plan parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Fanout(fanout) = agent_task.command else {
+            panic!("fanout command");
+        };
+        let AgentTaskFanoutCommand::RunPlan(args) = fanout.command else {
+            panic!("run-plan command");
+        };
+        assert_eq!(args.max_duration, Some(5400));
+    }
+
+    /// A zero-second budget would expire before the first attempt could start,
+    /// so it is refused at parse time rather than silently killing the batch.
+    #[test]
+    fn max_duration_rejects_zero() {
+        assert!(Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "run-plan",
+            "--input",
+            "@plan.json",
+            "--max-duration",
+            "0",
+        ])
+        .is_err());
+    }
+
+    /// Absent the flag, a batch must stay unbudgeted — the pre-existing
+    /// behaviour for every caller that never asked for a deadline.
+    #[test]
+    fn a_plan_without_a_budget_resolves_no_deadline() {
+        let plan = test_batch_plan();
+        assert_eq!(plan.max_duration_seconds, None);
+        assert!(plan.cook_deadline().is_none());
+    }
+
+    /// The budget is persisted as a duration and resolved to an absolute
+    /// instant only at execution, so a plan that sat on disk still gets the
+    /// budget it asked for instead of one that expired while it waited.
+    #[test]
+    fn a_budget_is_persisted_as_a_duration_and_resolved_at_run_time() {
+        let mut plan = test_batch_plan();
+        plan.max_duration_seconds = Some(3_600);
+
+        let encoded = serde_json::to_value(&plan).expect("plan serializes");
+        assert_eq!(encoded["max_duration_seconds"], 3_600);
+
+        let reloaded = BatchCookFanoutPlan::from_value(encoded, &args()).expect("plan reloads");
+        assert_eq!(reloaded.max_duration_seconds, Some(3_600));
+
+        let deadline = reloaded.cook_deadline().expect("a resolved deadline");
+        assert!(
+            !deadline.is_expired(),
+            "a fresh budget must not start spent"
+        );
+        assert!(deadline.remaining_ms() > 0);
+    }
+
+    #[test]
+    fn an_execution_time_flag_overrides_the_persisted_budget() {
+        let mut plan = test_batch_plan();
+        plan.max_duration_seconds = Some(7_200);
+
+        plan.apply_max_duration_override(None);
+        assert_eq!(
+            plan.max_duration_seconds,
+            Some(7_200),
+            "absent flag must not clear the persisted budget"
+        );
+
+        plan.apply_max_duration_override(Some(60));
+        assert_eq!(plan.max_duration_seconds, Some(60));
     }
 
     /// The operator-facing half of the fix: the limit and why it was chosen

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1074,7 +1074,7 @@ fn batch_artifacts(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
 fn run_batch_cook_fanout(args: AgentTaskFanoutRunPlanArgs) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
-    plan.apply_max_concurrency_override(args.max_concurrency);
+    plan.apply_max_concurrency_override(args.max_concurrency.map(|value| value as usize));
     plan.apply_max_duration_override(args.max_duration);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
@@ -1090,7 +1090,7 @@ pub(crate) fn run_batch_cook_fanout_with_attempt_dispatcher(
 ) -> CmdResult<Value> {
     let mut plan = load_batch_cook_fanout_plan(&args.input)?;
     plan.apply_ai_tool_override(args.ai_tool.as_deref());
-    plan.apply_max_concurrency_override(args.max_concurrency);
+    plan.apply_max_concurrency_override(args.max_concurrency.map(|value| value as usize));
     plan.apply_max_duration_override(args.max_duration);
     if let Some(record_run_id) = args.record_run_id {
         plan.rekey(record_run_id);
@@ -2236,7 +2236,7 @@ fn build_cook_batch_plan(args: &AgentTaskFanoutCookBatchArgs) -> Result<BatchCoo
         schema: batch_cook_fanout_plan_schema(),
         fanout_id,
         cooks,
-        max_concurrency: args.max_concurrency,
+        max_concurrency: args.max_concurrency.map(|value| value as usize),
         max_duration_seconds: args.max_duration,
         metadata: serde_json::json!({
             "source": "agent-task fanout cook-batch",

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -629,7 +629,32 @@ pub struct AgentTaskConfig {
     /// request on stdin and returns a signed verdict on stdout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceptance_verifier: Option<AgentTaskAcceptanceVerifierConfig>,
+    /// Host-level ceiling on how many child cooks a batch fanout may run at
+    /// once, settable via `homeboy config set /agent_task/max_batch_concurrency
+    /// <n>`.
+    ///
+    /// Batch fanout previously derived its worker count from
+    /// `available_parallelism()` alone, so an eight-core host started eight
+    /// concurrent cooks. Concurrency is a property of what those cooks *do*,
+    /// not of the core count: a cook whose gate is a compile consumes tens of
+    /// gigabytes of disk, and eight of those exhaust a volume that fits one.
+    /// The core count cannot express that, so the host has to.
+    ///
+    /// `None` falls back to [`DEFAULT_AGENT_TASK_MAX_BATCH_CONCURRENCY`]. An
+    /// explicit `--max-concurrency` flag overrides both.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_batch_concurrency: Option<usize>,
 }
+
+/// Fallback ceiling on concurrent child cooks in a batch fanout when neither
+/// `--max-concurrency` nor `/agent_task/max_batch_concurrency` is set.
+///
+/// Deliberately generous relative to what a resource-constrained host can
+/// actually sustain, because it applies to every host and cannot know what the
+/// gates do. It exists to make the limit *finite* — the previous behaviour had
+/// no ceiling at all beyond the core count. Hosts that need a tighter bound set
+/// the config value or a resource budget; both lower it from here.
+pub const DEFAULT_AGENT_TASK_MAX_BATCH_CONCURRENCY: usize = 4;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskAcceptanceVerifierConfig {


### PR DESCRIPTION
Two commits (plus a clap fixup), revertible independently.

## 1. Batch concurrency had no cap and no override

```rust
fn batch_worker_limit(plan: &BatchCookFanoutPlan) -> usize {
    plan.cooks.len().min(std::thread::available_parallelism().map_or(1, usize::from))
}
```

`AgentTaskFanoutCookBatchArgs` had **no concurrency flag at all**.

**On an 8-core box that starts 8 concurrent cooks, each of which may run `--verify 'cargo test'`.** This repo's own `RULES.md` records that one cargo test build is **28 GB** and "exactly ONE fits" on a 75 G volume — and names parallel cargo as the cause of a prior root-volume outage. This function would happily start eight.

### Was `agent_task_scheduler::resources` reusable?

**Not as-is, and this is worth knowing.** `adaptive_concurrency_decision` is `pub(super)` behind a private `mod resources;`, returns `None` unless an `AgentTaskAdaptiveConcurrencyPolicy` is set, and needs live scheduler queue state. Its one caller reads `plan.options.resource_budget` — per-plan state that only exists inside the scheduler engine, which `run_cook_batch` never enters (it is a raw `std::thread::scope` pool).

So rather than write a parallel calculation, the shared unit arithmetic was **extracted** into `resource_budget_slots(budget, active_units)`, now called by both the scheduler loop (behaviour preserved exactly — same `max_active_units` / `default_task_units` reason strings) and the new `resolve_batch_concurrency`. **One rule, two consumers.**

### Resolution

`--max-concurrency` flag → `/agent_task/max_batch_concurrency` config → built-in default **4**. Resource budget and child count can only **lower** the result, never raise it, so declaring a budget cannot be defeated by a larger ceiling elsewhere. Floor 1.

Reported as `concurrency: {limit, source, reason}` on the batch result, so an operator can see *why* it chose what it chose.

**This is the intended behaviour change:** `available_parallelism()` is gone from the batch path. A workflow that relied on scaling to core count now caps at 4 unless configured.

## 2. No wall-clock budget at cook or batch scope

The only timeouts were per-provider (20 min) and per-gate (30 min). `agent_task_cook_loop.rs` bounded only `max_attempts`. **A cook with `--max-attempts 3` and 5 gates had a legal upper bound of ~8.5 hours with nothing to stop it** — times children in a fanout.

`CookDeadline` is an **absolute instant**, resolved once at batch start. A per-attempt duration would re-grant the budget on every retry, which is the bound being removed. Persisted on the plan as a *duration* and resolved at execution, so a plan sitting on disk is not born expired.

Checked at the **attempt boundary**, at **gate dispatch** (before promotion — the candidate is already durable, so nothing is discarded and the cook stays recoverable), and on the **heartbeat** for in-flight expiry.

On expiry: `status: "timed_out"`, reusing the existing `CookStatus::TimedOut` — **no new variant**, so batch totals and exit-code classification need no teaching. `CookDisposition::Terminal`, exit 1, `terminal_phase: "cook_deadline"`.

**Cancellation path:** `cook.rs` has no cancellation plumbing of its own; the real in-flight stop is the supervisor's `tick.stop_now` → `terminate_process_tree(std::process::id())` (excludes the caller, so it reaps the provider subtree and leaves the controller alive to record why). Deadline expiry follows that exact path, same thread, same evidence sink, tagged `cause: "cook_deadline"`.

## ⚠️ Flagging

**The deadline is thread-local, not a struct field.** An explicit `deadline_unix_ms` on `AgentTaskCookServiceOptions` is better engineering, but that struct is built by **18 literals across 7 files**, 16 of them outside this change's scope. The ambient-scope pattern has direct precedent *in the same function* — `notification_route::capture()/bind()` crosses the identical worker boundary for the identical reason. **Say the word and I'll convert it to an explicit field; it is mechanical across 5 files.**

**Not covered:** a batch child handed to a **runner daemon** returns `in_flight` with a durable owner before the heartbeat exists, so `--max-duration` does not bound that path. Pre-existing gap, not introduced here, worth a follow-up.

**`--max-duration` is not on `agent-task cook`** — only on the batch commands. Wiring it needs `commands/agent_task/run.rs:1041`, outside this change. A flag that parses but is ignored is worse than an absent one on a safety limit, so it was left off.

## Fixup commit

`clap::value_parser!(usize)` resolves to `_AnonymousValueParser`, which has no `.range()`. `cook.rs:521` already uses `value_parser!(u32).range(1..)`; matched it and converted at the three consumption sites. (Caught by `cargo check`, not by review.)

## Verification

`cargo check --workspace --tests -j2` clean.