### PR TITLE
fix(agent-task): type the fanout portfolio wire format and surface truncation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
+++ b/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
@@ -19,6 +19,10 @@ pub const PORTFOLIO_INACTIVE_FINDING_FINGERPRINT_LIMIT: usize = 128;
 /// Maximum inactive historical findings retained per child. Every finding in
 /// the current child observation is retained regardless of this limit.
 pub const CHILD_INACTIVE_FINDING_FINGERPRINT_LIMIT: usize = 32;
+/// Child rows projected by the default [`AgentTaskFanoutPortfolio::status`]
+/// page. Deliberately unchanged from the previous hard-coded `take(10)`: the
+/// fix makes truncation *visible*, it does not widen the default page.
+pub const PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT: usize = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskFanoutPortfolio {
@@ -200,10 +204,29 @@ pub struct AgentTaskFanoutPortfolioStatus {
     pub schema: &'static str,
     pub fanout_id: String,
     pub revision: u64,
+    /// Total children in the portfolio, before any page limit was applied.
+    /// `ready`/`blocked`/`merged` are likewise whole-portfolio counts, never
+    /// page-scoped.
     pub total: usize,
     pub ready: usize,
     pub blocked: usize,
     pub merged: usize,
+    /// Number of child rows in `children` on this page. Mirrors
+    /// [`AgentTaskDiscoveryReport::count`] so a consumer never has to infer a
+    /// page size from the array length.
+    pub count: usize,
+    /// The applied page limit, echoed back so consumers can tell a capped
+    /// projection from a complete one. `None` when every child was projected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    /// `true` when the page limit left children unprojected. Previously the
+    /// projection silently `take(10)`-ed, so a 25-child wave reported 10 rows
+    /// with no way for a consumer to know rows were missing.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+    /// Offset to pass as the next page's cursor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<usize>,
     pub children: Vec<AgentTaskFanoutPortfolioChildStatus>,
     pub drill_down_ref: String,
 }
@@ -314,10 +337,24 @@ impl AgentTaskFanoutPortfolio {
         self.status(&observations)
     }
 
-    /// The default projection remains bounded even for much larger portfolios.
+    /// The default projection remains bounded even for much larger portfolios,
+    /// and reports the bound so truncation is visible rather than silent.
     pub fn status(
         &self,
         observations: &BTreeMap<String, AgentTaskFanoutPortfolioObservation>,
+    ) -> AgentTaskFanoutPortfolioStatus {
+        self.status_page(observations, Some(PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT), 0)
+    }
+
+    /// Paged projection. `limit: None` projects every child; `cursor` is a
+    /// zero-based offset into the portfolio's child order. Aggregate counts
+    /// (`total`, `ready`, `blocked`, `merged`) always describe the whole
+    /// portfolio, not the returned page.
+    pub fn status_page(
+        &self,
+        observations: &BTreeMap<String, AgentTaskFanoutPortfolioObservation>,
+        limit: Option<usize>,
+        cursor: usize,
     ) -> AgentTaskFanoutPortfolioStatus {
         let (ready, blocked, merged) =
             self.children.iter().fold((0, 0, 0), |totals, (id, child)| {
@@ -335,10 +372,17 @@ impl AgentTaskFanoutPortfolio {
                     totals.2 + usize::from(observation.pr == AgentTaskFanoutPrState::Merged),
                 )
             });
-        let children = self
+        let total = self.children.len();
+        let cursor = cursor.min(total);
+        let end = limit
+            .map(|limit| cursor.saturating_add(limit).min(total))
+            .unwrap_or(total);
+        let truncated = end < total;
+        let children: Vec<_> = self
             .children
             .iter()
-            .take(10)
+            .skip(cursor)
+            .take(end - cursor)
             .map(|(id, child)| {
                 let observation = observations.get(id).cloned().unwrap_or_default();
                 AgentTaskFanoutPortfolioChildStatus {
@@ -366,10 +410,14 @@ impl AgentTaskFanoutPortfolio {
             schema: AGENT_TASK_FANOUT_PORTFOLIO_STATUS_SCHEMA,
             fanout_id: self.fanout_id.clone(),
             revision: self.revision,
-            total: self.children.len(),
+            total,
             ready,
             blocked,
             merged,
+            count: children.len(),
+            limit,
+            truncated,
+            next_cursor: truncated.then_some(end),
             children,
             drill_down_ref: format!("homeboy://fanout/{}", self.fanout_id),
         }
@@ -1173,5 +1221,90 @@ mod tests {
         assert_eq!(row["worktree"], "clean");
         assert_eq!(row["gates"], "current");
         assert_eq!(row["acceptance"], "current");
+    }
+
+    /// A wave larger than the default page used to report ten rows with no
+    /// signal that any were withheld.
+    #[test]
+    fn oversized_portfolio_reports_visible_truncation_with_whole_portfolio_totals() {
+        let ids = (0..25)
+            .map(|index| format!("child-{index:02}"))
+            .collect::<Vec<_>>();
+        let mut portfolio =
+            AgentTaskFanoutPortfolio::new("oversized", ids.iter().map(|id| child(id)));
+        let states = ids.iter().map(|id| observation(id)).collect::<Vec<_>>();
+
+        let status = portfolio.reconcile(states, &IndependentFanoutDependencies);
+
+        // The default page size is unchanged; only its visibility is new.
+        assert_eq!(status.children.len(), PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT);
+        assert_eq!(status.count, PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT);
+        assert_eq!(status.total, 25);
+        assert_eq!(status.limit, Some(PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT));
+        assert!(status.truncated);
+        assert_eq!(status.next_cursor, Some(10));
+
+        let encoded = serde_json::to_value(&status).unwrap();
+        assert_eq!(encoded["truncated"], true);
+        assert_eq!(encoded["total"], 25);
+        assert_eq!(encoded["count"], 10);
+        assert_eq!(encoded["next_cursor"], 10);
+    }
+
+    /// A portfolio that fits the page is not truncated, and the truncation
+    /// fields stay out of the serialized payload entirely.
+    #[test]
+    fn portfolio_within_the_page_limit_is_not_marked_truncated() {
+        let ids = ["a", "b", "c"];
+        let mut portfolio = AgentTaskFanoutPortfolio::new("small", ids.into_iter().map(child));
+        let status = portfolio.reconcile(
+            ids.into_iter().map(observation).collect::<Vec<_>>(),
+            &IndependentFanoutDependencies,
+        );
+
+        assert_eq!(status.count, 3);
+        assert_eq!(status.total, 3);
+        assert!(!status.truncated);
+        assert_eq!(status.next_cursor, None);
+
+        let encoded = serde_json::to_value(&status).unwrap();
+        assert!(encoded.get("truncated").is_none());
+        assert!(encoded.get("next_cursor").is_none());
+    }
+
+    /// `next_cursor` is a real offset: following it yields the next distinct
+    /// rows, and an unlimited page projects every child.
+    #[test]
+    fn status_pages_walk_the_portfolio_without_repeating_or_dropping_children() {
+        let ids = (0..25)
+            .map(|index| format!("child-{index:02}"))
+            .collect::<Vec<_>>();
+        let mut portfolio = AgentTaskFanoutPortfolio::new("paged", ids.iter().map(|id| child(id)));
+        let states = ids.iter().map(|id| observation(id)).collect::<Vec<_>>();
+        portfolio.reconcile(states.clone(), &IndependentFanoutDependencies);
+        let observations = states
+            .into_iter()
+            .map(|state| (state.child_id.clone(), state))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut walked = Vec::new();
+        let mut cursor = Some(0);
+        while let Some(offset) = cursor {
+            let page = portfolio.status_page(
+                &observations,
+                Some(PORTFOLIO_STATUS_DEFAULT_PAGE_LIMIT),
+                offset,
+            );
+            assert_eq!(page.total, 25);
+            walked.extend(page.children.iter().map(|row| row.child_id.clone()));
+            cursor = page.next_cursor;
+        }
+        assert_eq!(walked, ids);
+
+        let everything = portfolio.status_page(&observations, None, 0);
+        assert_eq!(everything.count, 25);
+        assert_eq!(everything.limit, None);
+        assert!(!everything.truncated);
+        assert_eq!(everything.next_cursor, None);
     }
 }

--- a/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
+++ b/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
@@ -96,7 +96,8 @@ pub struct AgentTaskFanoutPortfolioObservation {
     pub findings: Vec<AgentTaskFanoutReviewFinding>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentTaskFanoutTrackerState {
     Open,
     Closed,
@@ -104,7 +105,8 @@ pub enum AgentTaskFanoutTrackerState {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentTaskFanoutProviderState {
     #[default]
     Pending,
@@ -113,7 +115,8 @@ pub enum AgentTaskFanoutProviderState {
     Failed,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentTaskFanoutWorktreeState {
     #[default]
     Clean,
@@ -136,7 +139,8 @@ pub struct AgentTaskFanoutCandidateState {
     pub can_recreate: bool,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentTaskFanoutEvidenceState {
     #[default]
     Missing,
@@ -146,7 +150,12 @@ pub enum AgentTaskFanoutEvidenceState {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Serialized snake_case, not via `Debug`. `OpenChecksPassing` is the wire
+/// string `open_checks_passing`; before #11821 the `Debug`-lowercasing
+/// projection shipped `opencheckspassing`, which was neither snake_case nor
+/// stable across a Rust-side variant rename.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentTaskFanoutPrState {
     #[default]
     Missing,
@@ -203,15 +212,15 @@ pub struct AgentTaskFanoutPortfolioStatus {
 pub struct AgentTaskFanoutPortfolioChildStatus {
     pub child_id: String,
     pub tracker_ref: String,
-    pub tracker: String,
+    pub tracker: AgentTaskFanoutTrackerState,
     pub source_sha: Option<String>,
     pub base_sha: Option<String>,
     pub head_sha: Option<String>,
-    pub provider: String,
-    pub worktree: String,
-    pub gates: String,
-    pub acceptance: String,
-    pub pr: String,
+    pub provider: AgentTaskFanoutProviderState,
+    pub worktree: AgentTaskFanoutWorktreeState,
+    pub gates: AgentTaskFanoutEvidenceState,
+    pub acceptance: AgentTaskFanoutEvidenceState,
+    pub pr: AgentTaskFanoutPrState,
     pub blocker: Option<AgentTaskFanoutPortfolioBlocker>,
     pub next_action: AgentTaskFanoutPortfolioAction,
     pub drill_down_ref: String,
@@ -335,15 +344,15 @@ impl AgentTaskFanoutPortfolio {
                 AgentTaskFanoutPortfolioChildStatus {
                     child_id: id.clone(),
                     tracker_ref: child.tracker_ref.clone(),
-                    tracker: format!("{:?}", observation.tracker).to_lowercase(),
+                    tracker: observation.tracker,
                     source_sha: child.source_sha.clone(),
                     base_sha: child.base_sha.clone(),
                     head_sha: child.head_sha.clone(),
-                    provider: format!("{:?}", observation.provider).to_lowercase(),
-                    worktree: format!("{:?}", observation.worktree).to_lowercase(),
-                    gates: format!("{:?}", observation.gates).to_lowercase(),
-                    acceptance: format!("{:?}", observation.acceptance).to_lowercase(),
-                    pr: format!("{:?}", observation.pr).to_lowercase(),
+                    provider: observation.provider,
+                    worktree: observation.worktree,
+                    gates: observation.gates,
+                    acceptance: observation.acceptance,
+                    pr: observation.pr,
                     blocker: child.blocker.clone(),
                     next_action: child
                         .next_action
@@ -1065,5 +1074,104 @@ mod tests {
                 "adapter_observe_failed"
             );
         });
+    }
+
+    /// The status projection is a wire contract, not a `Debug` dump. Every
+    /// observation enum must serialize as snake_case so a Rust-side variant
+    /// rename cannot silently change the emitted string.
+    #[test]
+    fn observation_states_serialize_as_snake_case_strings() {
+        fn wire<T: Serialize>(value: T) -> String {
+            serde_json::to_value(value)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .into()
+        }
+
+        assert_eq!(wire(AgentTaskFanoutTrackerState::Open), "open");
+        assert_eq!(wire(AgentTaskFanoutTrackerState::Closed), "closed");
+        assert_eq!(wire(AgentTaskFanoutTrackerState::Unknown), "unknown");
+
+        assert_eq!(wire(AgentTaskFanoutProviderState::Pending), "pending");
+        assert_eq!(wire(AgentTaskFanoutProviderState::Running), "running");
+        assert_eq!(wire(AgentTaskFanoutProviderState::Succeeded), "succeeded");
+        assert_eq!(wire(AgentTaskFanoutProviderState::Failed), "failed");
+
+        assert_eq!(wire(AgentTaskFanoutWorktreeState::Clean), "clean");
+        assert_eq!(wire(AgentTaskFanoutWorktreeState::Dirty), "dirty");
+        assert_eq!(wire(AgentTaskFanoutWorktreeState::Conflicted), "conflicted");
+        assert_eq!(wire(AgentTaskFanoutWorktreeState::Missing), "missing");
+
+        assert_eq!(wire(AgentTaskFanoutEvidenceState::Missing), "missing");
+        assert_eq!(wire(AgentTaskFanoutEvidenceState::Current), "current");
+        assert_eq!(wire(AgentTaskFanoutEvidenceState::Failed), "failed");
+        assert_eq!(wire(AgentTaskFanoutEvidenceState::Rejected), "rejected");
+        assert_eq!(wire(AgentTaskFanoutEvidenceState::Unknown), "unknown");
+
+        assert_eq!(wire(AgentTaskFanoutPrState::Missing), "missing");
+        assert_eq!(
+            wire(AgentTaskFanoutPrState::OpenChecksPending),
+            "open_checks_pending"
+        );
+        assert_eq!(
+            wire(AgentTaskFanoutPrState::OpenChecksFailed),
+            "open_checks_failed"
+        );
+        // The regression this contract exists for: the former
+        // `format!("{:?}", ..).to_lowercase()` projection emitted
+        // `opencheckspassing`.
+        assert_eq!(
+            wire(AgentTaskFanoutPrState::OpenChecksPassing),
+            "open_checks_passing"
+        );
+        assert_eq!(wire(AgentTaskFanoutPrState::Merged), "merged");
+        assert_eq!(wire(AgentTaskFanoutPrState::Unknown), "unknown");
+    }
+
+    /// The multi-word PR states are the only variants whose wire string the
+    /// typed projection changed, so they are pinned round-trip in both
+    /// directions rather than serialize-only.
+    #[test]
+    fn pr_state_round_trips_through_its_snake_case_wire_string() {
+        for state in [
+            AgentTaskFanoutPrState::Missing,
+            AgentTaskFanoutPrState::OpenChecksPending,
+            AgentTaskFanoutPrState::OpenChecksFailed,
+            AgentTaskFanoutPrState::OpenChecksPassing,
+            AgentTaskFanoutPrState::Merged,
+            AgentTaskFanoutPrState::Unknown,
+        ] {
+            let encoded = serde_json::to_string(&state).unwrap();
+            let decoded: AgentTaskFanoutPrState = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, state);
+        }
+        assert_eq!(
+            serde_json::from_str::<AgentTaskFanoutPrState>("\"open_checks_passing\"").unwrap(),
+            AgentTaskFanoutPrState::OpenChecksPassing
+        );
+    }
+
+    /// The status projection carries typed states, so a serialized child row
+    /// exposes them as snake_case strings rather than `Debug` output.
+    #[test]
+    fn child_status_rows_serialize_observation_states_as_snake_case() {
+        let mut portfolio = AgentTaskFanoutPortfolio::new("typed-status", [child("child")]);
+        let mut state = observation("child");
+        state.pr = AgentTaskFanoutPrState::OpenChecksPassing;
+        let status = portfolio.reconcile([state], &IndependentFanoutDependencies);
+
+        assert_eq!(
+            status.children[0].pr,
+            AgentTaskFanoutPrState::OpenChecksPassing
+        );
+        let encoded = serde_json::to_value(&status).unwrap();
+        let row = &encoded["children"][0];
+        assert_eq!(row["pr"], "open_checks_passing");
+        assert_eq!(row["tracker"], "open");
+        assert_eq!(row["provider"], "succeeded");
+        assert_eq!(row["worktree"], "clean");
+        assert_eq!(row["gates"], "current");
+        assert_eq!(row["acceptance"], "current");
     }
 }


### PR DESCRIPTION
The fanout supervisor computes genuinely good per-child typed next actions with typed blockers and evidence refs — exactly the actionable data an orchestrator needs. Two defects sat at the wire boundary.

## (a) `Debug` used as a serialization format

Five observation enums derived only `Debug`, so `status()` degraded them:
```rust
tracker: format!("{:?}", observation.tracker).to_lowercase(),
provider: format!("{:?}", observation.provider).to_lowercase(),
... pr: format!("{:?}", observation.pr).to_lowercase(),
```
Meanwhile `next_action` in the **same struct** stayed typed, because it does derive `Serialize`.

### Exact wire change — three strings, one enum

| Enum | Variant | Before | After |
|---|---|---|---|
| **PrState** | `OpenChecksPending` | `opencheckspending` | **`open_checks_pending`** |
| **PrState** | `OpenChecksFailed` | `openchecksfailed` | **`open_checks_failed`** |
| **PrState** | `OpenChecksPassing` | `opencheckspassing` | **`open_checks_passing`** |
| PrState | `Missing`/`Merged`/`Unknown` | unchanged | unchanged |
| TrackerState / ProviderState / WorktreeState / EvidenceState | all | unchanged | unchanged |

The other four enums were *accidentally* correct because every variant is single-word. Only multi-word variants were broken — and they broke silently, and would have changed again on any Rust-side rename.

*(My original finding said `openchecksspassing` with a doubled `s`. The real value is `opencheckspassing`. Defect identical in kind.)*

All five now carry `#[derive(Serialize, Deserialize)] #[serde(rename_all = "snake_case")]`, copied verbatim from `AgentTaskFanoutPortfolioAction` in the same file.

**Consumer sweep:** nothing in-repo consumes the old strings. Every `OpenChecks*` reference is the Rust *variant* (supervisor internals, plus `fanout.rs:974` mapping `ci_state` → enum). No docs, fixtures, or snapshot tests.

**⚠️ Schema not bumped.** Still `homeboy/agent-task-fanout-portfolio-status/v1`. An out-of-repo consumer matching `"opencheckspassing"` breaks silently on an unchanged version string. **Bump to `/v2` if you want that to be loud.**

## (b) Silent truncation at 10

```rust
let children = self.children.iter().take(10)
```
No flag, no count. **A 25-child wave reported 10 rows and the consumer could not tell.**

Mirrors `AgentTaskDiscoveryReport` exactly — `count`, `limit`, `truncated`, `next_cursor`, with the same `skip_serializing_if` attributes. `status()` keeps its signature (so `fanout.rs` is untouched) and delegates to `status_page(observations, limit, cursor)`.

**Default output is byte-identical when not truncated** — same ten rows, and the new fields are omitted from JSON unless they apply. The point is that truncation becomes *visible*, not that more rows ship.

One inherited quirk kept rather than diverged: discovery computes `truncated = end < total`, ignoring rows skipped by a non-zero cursor.

## Notes

- `Deserialize` was added alongside `Serialize` to mirror `next_action`'s attribute set exactly; five-line revert if you want serialize-only.
- `count` is one field beyond the strict need, added for discovery parity.
- Tests: per-enum snake_case sweep, `PrState` round-trip both directions, 25-child truncation with `total: 25` / `next_cursor: 10`, a 3-child case asserting the fields are *absent* from JSON, and a cursor walk proving no repeats or drops.

## Verification

`cargo check --workspace --tests -j2` clean.