### PR TITLE
fix(notify): propagate the notification route to child processes

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/notification_route.rs
+++ b/crates/contracts/homeboy-lab-contract/src/notification_route.rs
@@ -110,6 +110,39 @@ pub fn from_cli_or_env(
     }
 }
 
+/// The environment pairs that carry a route across a process boundary.
+///
+/// This is the producer half of [`from_cli_or_env`]. Both variables were read
+/// from the start but nothing ever wrote them, so a route reached a child only
+/// when the child's argv happened to preserve it — which is why cook needed a
+/// durable-record fallback (#11115). That fallback stays; this is the direct
+/// path for the offloaded case it was invented for.
+///
+/// Emitted together or not at all. [`from_cli_or_env`] rejects a half-set pair
+/// as a hard validation error, so a producer that set only one variable would
+/// make every child fail to start.
+///
+/// # Credential safety
+///
+/// The propagated value is the transport-owned destination, documented as an
+/// opaque non-secret value and rejected by [`NotificationRoute::validate`] if it
+/// carries credential syntax. It is the same string `notify::dispatch` already
+/// passes to a transport as a `--route` argv element, and on Linux argv is the
+/// *more* exposed channel of the two (`/proc/<pid>/cmdline` is world-readable;
+/// `/proc/<pid>/environ` is readable only by the process owner). Propagating it
+/// through the environment therefore adds no exposure the delivery path did not
+/// already have.
+pub fn child_env(route: Option<&NotificationRoute>) -> Vec<(&'static str, String)> {
+    route
+        .map(|route| {
+            vec![
+                (NOTIFICATION_TRANSPORT_ENV, route.transport.clone()),
+                (NOTIFICATION_ROUTE_ENV, route.route.clone()),
+            ]
+        })
+        .unwrap_or_default()
+}
+
 fn contains_credential_syntax(route: &str) -> bool {
     let lowercase = route.to_ascii_lowercase();
     lowercase.contains("authorization=")
@@ -227,6 +260,89 @@ mod tests {
             .join()
             .unwrap();
         assert!(observed.is_none());
+    }
+
+    #[test]
+    fn child_env_carries_a_bound_route_as_both_variables() {
+        let route = NotificationRoute::new("extension", "opaque/thread 42").expect("route");
+        assert_eq!(
+            child_env(Some(&route)),
+            vec![
+                (NOTIFICATION_TRANSPORT_ENV, "extension".to_string()),
+                (NOTIFICATION_ROUTE_ENV, "opaque/thread 42".to_string()),
+            ]
+        );
+    }
+
+    /// A half-set pair is a hard error in `from_cli_or_env`, so an absent route
+    /// must leave both variables alone rather than emit one of them.
+    #[test]
+    fn child_env_without_a_route_sets_neither_variable() {
+        assert!(child_env(None).is_empty());
+    }
+
+    /// The producer and consumer halves are the same mechanism: what
+    /// `child_env` writes is exactly what a child's `from_cli_or_env` reads.
+    #[test]
+    fn child_env_round_trips_through_the_environment_reader() {
+        let _lock = env_lock().lock().unwrap();
+        let old_transport = std::env::var(NOTIFICATION_TRANSPORT_ENV).ok();
+        let old_route = std::env::var(NOTIFICATION_ROUTE_ENV).ok();
+        let route = NotificationRoute::new("extension", "opaque-destination").expect("route");
+        for (name, value) in child_env(Some(&route)) {
+            std::env::set_var(name, value);
+        }
+        assert_eq!(from_cli_or_env(None, None).unwrap(), Some(route));
+        match old_transport {
+            Some(value) => std::env::set_var(NOTIFICATION_TRANSPORT_ENV, value),
+            None => std::env::remove_var(NOTIFICATION_TRANSPORT_ENV),
+        }
+        match old_route {
+            Some(value) => std::env::set_var(NOTIFICATION_ROUTE_ENV, value),
+            None => std::env::remove_var(NOTIFICATION_ROUTE_ENV),
+        }
+    }
+
+    /// Precedence: explicit argv outranks a conflicting propagated environment.
+    #[test]
+    fn propagated_environment_loses_to_explicit_argv() {
+        let _lock = env_lock().lock().unwrap();
+        let old_transport = std::env::var(NOTIFICATION_TRANSPORT_ENV).ok();
+        let old_route = std::env::var(NOTIFICATION_ROUTE_ENV).ok();
+        let propagated =
+            NotificationRoute::new("propagated.transport", "propagated-route").expect("route");
+        for (name, value) in child_env(Some(&propagated)) {
+            std::env::set_var(name, value);
+        }
+        let resolved = from_cli_or_env(Some("argv.transport"), Some("argv-route"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.transport, "argv.transport");
+        assert_eq!(resolved.route, "argv-route");
+        match old_transport {
+            Some(value) => std::env::set_var(NOTIFICATION_TRANSPORT_ENV, value),
+            None => std::env::remove_var(NOTIFICATION_TRANSPORT_ENV),
+        }
+        match old_route {
+            Some(value) => std::env::set_var(NOTIFICATION_ROUTE_ENV, value),
+            None => std::env::remove_var(NOTIFICATION_ROUTE_ENV),
+        }
+    }
+
+    /// The credential-syntax guard applies to anything that could be
+    /// propagated, so a secret-bearing destination can never reach a child env.
+    #[test]
+    fn credential_bearing_routes_cannot_be_propagated() {
+        for destination in [
+            "https://example.invalid/hook?token=secret",
+            "https://user:pass@example.invalid/hook",
+            "channel?authorization=Bearer%20abc",
+        ] {
+            assert!(
+                NotificationRoute::new("extension", destination).is_err(),
+                "{destination} must be rejected before it can reach a child environment"
+            );
+        }
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -64,6 +64,26 @@ fn should_deliver(kind: NotifyEventKind, has_explicit_route: bool) -> bool {
 /// In-process thread hops are still covered by
 /// `notification_route::capture`/`bind`; the thread-local deliberately wins so
 /// an explicitly bound route is never overridden by durable metadata.
+///
+/// # Precedence
+///
+/// Resolution is ordered most-explicit first, and this function implements only
+/// the last two steps because the first two are already collapsed into the
+/// thread-local before any command runs:
+///
+/// 1. **Explicit argv** — `--notification-transport` / `--notification-route`.
+/// 2. **Propagated environment** — `HOMEBOY_NOTIFICATION_TRANSPORT` /
+///    `HOMEBOY_NOTIFICATION_ROUTE`, written onto child processes by
+///    `notification_route::child_env` and read back by
+///    `notification_route::from_cli_or_env`. Steps 1 and 2 are resolved once at
+///    process entry, where argv wins, and the winner is bound as the
+///    thread-local this function reads.
+/// 3. **Durable record** — the route persisted on the run, below.
+///
+/// The durable fallback is not made redundant by environment propagation. It
+/// covers resumption paths that inherit neither argv nor environment from the
+/// launching process — `cook --continue`, controller adoption, a claimed
+/// continuation — so both remain load-bearing.
 fn effective_route(run_id: &str) -> Option<NotificationRoute> {
     notification_route::current()
         .or_else(|| crate::agent_task_lifecycle::durable_notification_route(run_id))

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -333,9 +333,11 @@ fn dispatch_record(
         )
     })?;
     let args = child_args(record, runner_id);
+    let route = record_notification_route(record);
     let mut child = Command::new(executable)
         .args(&args[1..])
         .env("HOMEBOY_DEFERRED_WORKLOAD_REPLAY", "1")
+        .envs(homeboy::core::notification_route::child_env(route.as_ref()))
         .spawn()
         .map_err(|error| {
             homeboy::core::Error::internal_io(
@@ -365,6 +367,40 @@ fn dispatch_record(
         }
         thread::sleep(Duration::from_secs(1));
     }
+}
+
+/// The destination a deferred workload's notifications belong to.
+///
+/// Read from the record's own persisted argv, never from the worker's ambient
+/// route. The deferred-workload worker is a long-lived singleton that claims
+/// records deferred by unrelated callers; propagating the worker's own route
+/// would deliver every deferred workload's notifications to whoever happened to
+/// start the worker, which is a mis-attribution rather than a fix.
+///
+/// A record deferred by a caller who supplied the route through the environment
+/// rather than argv still cannot be recovered here, because the route is not
+/// persisted on the record. That gap belongs to the deferral producer.
+fn record_notification_route(
+    record: &deferred_workload::DeferredWorkload,
+) -> Option<homeboy::core::notification_route::NotificationRoute> {
+    let transport = argv_flag_value(&record.args, "--notification-transport")?;
+    let route = argv_flag_value(&record.args, "--notification-route")?;
+    // Observability must never fail a dispatch, so a malformed persisted pair
+    // is dropped rather than propagated or raised.
+    homeboy::core::notification_route::NotificationRoute::new(transport, route).ok()
+}
+
+/// The value of `flag` in an argv, covering both spellings clap accepts:
+/// a separated `--flag value` and an attached `--flag=value`.
+fn argv_flag_value<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+    let attached = format!("{flag}=");
+    args.iter().enumerate().find_map(|(index, arg)| {
+        if arg == flag {
+            args.get(index + 1).map(String::as_str)
+        } else {
+            arg.strip_prefix(attached.as_str())
+        }
+    })
 }
 
 fn child_args(record: &deferred_workload::DeferredWorkload, runner_id: &str) -> Vec<String> {
@@ -468,6 +504,88 @@ mod tests {
             },
             job_overrides: Default::default(),
         }
+    }
+
+    fn input_with_args(extra: &[&str]) -> deferred_workload::DeferredWorkloadInput {
+        let mut input = input();
+        input
+            .args
+            .extend(extra.iter().map(|value| value.to_string()));
+        input
+    }
+
+    /// A deferred workload is replayed by a separate worker process, so its
+    /// route reaches the dispatched child only through the child environment.
+    #[test]
+    fn a_deferred_workload_child_carries_the_recorded_route() {
+        crate::test_support::with_isolated_home(|_| {
+            let record = deferred_workload::defer(input_with_args(&[
+                "--notification-transport",
+                "extension.run-completion",
+                "--notification-route",
+                "opaque-destination",
+            ]))
+            .expect("defer routed workload");
+
+            let route = record_notification_route(&record).expect("recorded route resolves");
+
+            assert_eq!(
+                homeboy::core::notification_route::child_env(Some(&route)),
+                vec![
+                    (
+                        homeboy::core::notification_route::NOTIFICATION_TRANSPORT_ENV,
+                        "extension.run-completion".to_string()
+                    ),
+                    (
+                        homeboy::core::notification_route::NOTIFICATION_ROUTE_ENV,
+                        "opaque-destination".to_string()
+                    ),
+                ]
+            );
+        });
+    }
+
+    /// Half a pair is a hard validation error in the child, so a workload
+    /// deferred without a route must leave both variables untouched.
+    #[test]
+    fn a_deferred_workload_without_a_route_sets_neither_variable() {
+        crate::test_support::with_isolated_home(|_| {
+            let record = deferred_workload::defer(input()).expect("defer unrouted workload");
+
+            assert!(record_notification_route(&record).is_none());
+            assert!(homeboy::core::notification_route::child_env(None).is_empty());
+        });
+    }
+
+    /// An incomplete recorded pair cannot be completed, and a half-set child
+    /// environment would make the dispatched child fail to start.
+    #[test]
+    fn a_partially_recorded_route_propagates_nothing() {
+        crate::test_support::with_isolated_home(|_| {
+            let record = deferred_workload::defer(input_with_args(&[
+                "--notification-transport",
+                "extension.run-completion",
+            ]))
+            .expect("defer half-routed workload");
+
+            assert!(record_notification_route(&record).is_none());
+        });
+    }
+
+    #[test]
+    fn argv_flag_value_reads_both_spellings_clap_accepts() {
+        let separated = vec!["--notification-route".to_string(), "opaque".to_string()];
+        let attached = vec!["--notification-route=opaque".to_string()];
+
+        assert_eq!(
+            argv_flag_value(&separated, "--notification-route"),
+            Some("opaque")
+        );
+        assert_eq!(
+            argv_flag_value(&attached, "--notification-route"),
+            Some("opaque")
+        );
+        assert_eq!(argv_flag_value(&[], "--notification-route"), None);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -94,7 +94,7 @@ pub(super) fn intercept_local_detached_cook(
     materialize_stdin_prompt(&mut child_args, &session_root)?;
     let log_path = session_root.join("cook.log");
 
-    let mut child = spawn_detached_cook(&child_args, &log_path)?;
+    let mut child = spawn_detached_cook(&child_args, &log_path, detached_route(cli).as_ref())?;
     let pid = child.id();
     let handoff = await_durable_handoff(&cook_id, &mut child, handoff_timeout());
 
@@ -151,6 +151,26 @@ fn detached_cook_child_args(
         args.push(cook_id.to_string());
     }
     args
+}
+
+/// The destination the detached cook's notifications belong to.
+///
+/// Resolved from the launcher's own arguments rather than from
+/// `notification_route::current()`, because detachment is intercepted during
+/// argument routing — before the runtime binds the thread-local route — so the
+/// thread-local is still empty here.
+///
+/// A route this process could not resolve is `None` rather than an error. The
+/// runtime already validated this exact pair before routing, so a failure here
+/// is unreachable; and notification routing is observability, which must never
+/// take a cook down with it.
+fn detached_route(cli: &Cli) -> Option<homeboy::core::notification_route::NotificationRoute> {
+    homeboy::core::notification_route::from_cli_or_env(
+        cli.notification_transport.as_deref(),
+        cli.notification_route.as_deref(),
+    )
+    .ok()
+    .flatten()
 }
 
 /// Replace a `--prompt -` stdin request with a file the detached cook can read.
@@ -217,9 +237,17 @@ fn detached_session_root(cook_id: &str) -> homeboy::core::Result<PathBuf> {
     Ok(root)
 }
 
+/// Spawn the cook in its own session.
+///
+/// The route is set explicitly rather than left to environment inheritance so
+/// the detached cook is bound to the destination the launcher resolved, whether
+/// that came from argv or from the launcher's own environment. Setting both
+/// variables together also normalizes a half-set pair inherited from the
+/// launcher, which the child would otherwise reject as a validation error.
 fn spawn_detached_cook(
     args: &[String],
     log_path: &Path,
+    route: Option<&homeboy::core::notification_route::NotificationRoute>,
 ) -> homeboy::core::Result<std::process::Child> {
     let exe = std::env::current_exe().map_err(|error| {
         Error::internal_io(
@@ -237,6 +265,7 @@ fn spawn_detached_cook(
     let mut command = Command::new(exe);
     command
         .args(args)
+        .envs(homeboy::core::notification_route::child_env(route))
         .stdin(Stdio::null())
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));
@@ -386,6 +415,57 @@ mod tests {
         ]);
         let cli = Cli::try_parse_from(argv.clone()).expect("parse cook invocation");
         (cli, args(&argv))
+    }
+
+    /// A detached cook is a different process, so the launcher's route reaches
+    /// it only if something writes it onto the child environment.
+    #[test]
+    fn a_detached_cook_child_carries_an_explicit_route() {
+        let (cli, _) = cook_cli(&[
+            "--placement",
+            "local",
+            "--detach-after-handoff",
+            "--notification-transport",
+            "extension.run-completion",
+            "--notification-route",
+            "opaque-destination",
+        ]);
+
+        let route = detached_route(&cli).expect("an explicit route resolves");
+
+        assert_eq!(
+            homeboy::core::notification_route::child_env(Some(&route)),
+            vec![
+                (
+                    homeboy::core::notification_route::NOTIFICATION_TRANSPORT_ENV,
+                    "extension.run-completion".to_string()
+                ),
+                (
+                    homeboy::core::notification_route::NOTIFICATION_ROUTE_ENV,
+                    "opaque-destination".to_string()
+                ),
+            ]
+        );
+    }
+
+    /// Half a pair is a hard validation error in the child, so propagation is
+    /// all-or-nothing.
+    ///
+    /// A cook launched without CLI values can still legitimately inherit a
+    /// route from this test process's own environment, so the deterministic
+    /// assertion is the all-or-nothing rule rather than a fixed count.
+    #[test]
+    fn a_detached_cook_never_propagates_half_a_route() {
+        assert!(homeboy::core::notification_route::child_env(None).is_empty());
+
+        let (cli, _) = cook_cli(&["--placement", "local", "--detach-after-handoff"]);
+
+        let propagated =
+            homeboy::core::notification_route::child_env(detached_route(&cli).as_ref());
+        assert!(
+            propagated.is_empty() || propagated.len() == 2,
+            "propagated {propagated:?}"
+        );
     }
 
     /// The rejection this replaces was unconditional. Preserving it inside a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -45,9 +45,21 @@ the higher-level system model and core/extension boundary, see
 
 Notification caller context can be supplied per process with
 `HOMEBOY_NOTIFICATION_TRANSPORT` and `HOMEBOY_NOTIFICATION_ROUTE`; both are
-required together. Explicit `--notification-transport` and
-`--notification-route` CLI values take precedence over these environment
-variables.
+required together, and setting only one is an error.
+
+A run resolves its destination in this order, most explicit first:
+
+1. Explicit `--notification-transport` and `--notification-route` CLI values.
+2. `HOMEBOY_NOTIFICATION_TRANSPORT` and `HOMEBOY_NOTIFICATION_ROUTE`.
+3. The route persisted on the durable run record, which is what lets a run
+   resumed in another process — `cook --continue`, controller adoption, a
+   claimed continuation — keep reporting to the destination that launched it.
+
+Homeboy sets both environment variables on the child processes it spawns when a
+route is in scope, so a detached or deferred run inherits its caller's
+destination. They are always written as a pair or not at all. The route itself
+is an opaque, non-secret value owned by the transport; credentials belong to the
+transport extension, never to the route.
 
 ## Storage Locations
 


### PR DESCRIPTION
> The notification **transport** layer is already correct and is not touched here. `grep -i discord` across all crates returns 6 hits, all tests/fixtures, one asserting it does *not* leak. `NotificationRoute` is `{transport, route}` with an opaque destination and `notify::dispatch` resolves the transport from installed extension manifests. That design is right.

## The finding

`notification_route.rs` declares **and reads** two env vars:
```rust
pub const NOTIFICATION_TRANSPORT_ENV: &str = "HOMEBOY_NOTIFICATION_TRANSPORT";
pub const NOTIFICATION_ROUTE_ENV: &str = "HOMEBOY_NOTIFICATION_ROUTE";
```

**Nothing ever wrote them.** Grepping either constant returns only the defining file and its own tests. No child-process spawn set them.

So route propagation across a process boundary worked only via argv preservation or a durable-record fallback — and **that fallback exists precisely because the thread-local was lost** (#11115). Half the mechanism was built.

## Credential safety — the thing that had to be right

**Verdict: safe.** Five lines of evidence, one decisive:

1. Documented contract — `extension-manifest-schema.md:218`: *"Routes are opaque, non-secret transport-owned values."*
2. **Decisive: it is already on a command line.** `notify::dispatch` passes the route to the transport child as an **argv element** (`notify.rs:138`), pinned by `event_argv_keeps_opaque_route_as_one_value`. On Linux `/proc/<pid>/cmdline` is world-readable while `/proc/<pid>/environ` is readable only by the process owner. **Environment is strictly less exposed than the channel this exact string already travels** — this cannot be a regression.
3. `validate()` rejects `authorization=`, `password=`, `secret=`, `token=`, and `://…@` userinfo. Every propagated value passes through `NotificationRoute`.
4. Real route shape is an identifier, not a secret: `discord:v1:channel:123456789012345678`. The bot token lives in the transport extension.
5. `agent_task_dispatch_plan/mod.rs:1025` already asserts serialized plans leak no destination.

**⚠️ Caveat, stated plainly:** `contains_credential_syntax` would **not** reject a bare webhook URL like `https://…/webhooks/<id>/<token>` — no `=`, no `@`. Validation is a guard, not a proof. This proceeded on point 2, not on validation. **If routes ever stop being argv-delivered, that guard must be revisited.**

## Precedence

Unchanged in behaviour, now documented and actually reachable: **explicit argv > `HOMEBOY_NOTIFICATION_*` env > durable record.** Steps 1–2 collapse into the thread-local at process entry (`cli_runtime.rs:532`, argv wins). Purely additive; the durable fallback is untouched.

## Sites wired

| Site | Status |
|---|---|
| Detached cook (`local_detach.rs`) | wired |
| Deferred worker (`deferred_workload.rs`) | wired |
| **Lab job env** (`lab_offload.rs`) | **could not — reporting** |

`lab_offload.rs` has no env surface at all; the real `lab_job_overrides` is `commands/infra/route.rs:2686` with `LabJobOverrides` in `homeboy-core/src/lab_offload.rs`. Note for whoever takes it: `insert_lab_env_override` applies a `RedactionPolicy`, so the pair must be checked against it.

## Two judgement calls worth reviewing

**The deferred worker does NOT use its own ambient route.** It is a long-lived singleton claiming records deferred by unrelated callers — propagating its own route would deliver *every* deferred workload's notifications to whoever happened to start the worker. That is mis-attribution, not a fix. It reads the route from each record's own persisted argv instead.
*Residual gap:* a caller who supplied the route via **env** at defer time still loses it, because `DeferredWorkload` has no route field. Fixing that means persisting it in `route.rs:1911`, outside this change.

**`local_detach` resolves from `cli` fields, not the thread-local.** `route_after_parse` runs *before* `with_current`, so `notification_route::current()` is empty there. Reaching for it would have silently propagated nothing.

## Notes

- `docs/reference/configuration.md` updated — it documents the precedence order and was now inaccurate. Nothing `include_str!`s it.
- One test was made deterministic: `detached_route` falls through to ambient env, so asserting "sets neither var" could flake if the test process has them set. It now asserts the all-or-nothing rule.

## Verification

`cargo check --workspace --tests -j2` clean.

*(This branch initially showed phantom `cannot find function child_env` errors — a stale-artifact effect of reusing one `CARGO_TARGET_DIR` across branches with divergent contract crates. Clean in an isolated target dir. Second time this pattern has bitten in this sweep.)*