### PR TITLE
fix(lint): route absolute finding paths through fixers

### DIFF
--- a/crates/homeboy-refactor/src/plan/sources/lint_scope.rs
+++ b/crates/homeboy-refactor/src/plan/sources/lint_scope.rs
@@ -293,6 +293,7 @@ fn looks_like_signature_line(line: &str) -> bool {
 }
 
 pub(super) fn lint_finding_scope_files(
+    root: &Path,
     findings: &[homeboy_core::finding::HomeboyFinding],
 ) -> Vec<String> {
     let mut files = BTreeSet::new();
@@ -300,7 +301,16 @@ pub(super) fn lint_finding_scope_files(
         let Some(file) = finding.location.file.as_deref() else {
             continue;
         };
-        if let Some(normalized) = normalize_relative_release_path(file) {
+        let path = Path::new(file);
+        let path = if path.is_absolute() {
+            let Ok(path) = path.strip_prefix(root) else {
+                continue;
+            };
+            path
+        } else {
+            path
+        };
+        if let Some(normalized) = normalize_relative_release_path(&path.to_string_lossy()) {
             files.insert(normalized);
         }
     }
@@ -607,20 +617,27 @@ diff --git a/src/lib.php b/src/lib.php
                 .file("src/b.php")
                 .build(),
             homeboy_core::finding::HomeboyFinding::builder("lint", "message")
+                .file("/repo/src/c.php")
+                .build(),
+            homeboy_core::finding::HomeboyFinding::builder("lint", "message")
                 .file("./src/a.php")
                 .build(),
             homeboy_core::finding::HomeboyFinding::builder("lint", "message")
                 .file("src/b.php")
                 .build(),
             homeboy_core::finding::HomeboyFinding::builder("lint", "message")
-                .file("../outside.php")
+                .file("/outside.php")
                 .build(),
             homeboy_core::finding::HomeboyFinding::builder("lint", "message").build(),
         ];
 
         assert_eq!(
-            lint_finding_scope_files(&findings),
-            vec!["src/a.php".to_string(), "src/b.php".to_string()]
+            lint_finding_scope_files(Path::new("/repo"), &findings),
+            vec![
+                "src/a.php".to_string(),
+                "src/b.php".to_string(),
+                "src/c.php".to_string()
+            ]
         );
     }
 }

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -418,7 +418,7 @@ pub(super) fn run_lint_stage(
     // Diagnostics are the authoritative fallback scope for every invocation
     // shape. A glob identifies the diagnostic pass; its reported files select
     // the extension-declared fixer route. Explicit selected files still win.
-    let finding_scope_files = lint_finding_scope_files(&lint_findings);
+    let finding_scope_files = lint_finding_scope_files(root, &lint_findings);
     let fix_scope_files = requested_scope_files
         .or((!finding_scope_files.is_empty()).then_some(finding_scope_files.as_slice()));
     let (stage_changed_files, fix_results, stage_warnings) = if write && !lint_findings.is_empty() {
@@ -998,7 +998,7 @@ mod tests {
         fs::write(
             extension.join("lint.sh"),
             format!(
-                "#!/bin/sh\nset -eu\nfile=\"$HOMEBOY_COMPONENT_PATH/src/example.fixture\"\necho \"${{HOMEBOY_FIX_ONLY:-diagnose}}:${{HOMEBOY_STEP:-all}}:${{HOMEBOY_SUMMARY_MODE:-0}}\" >> \"$HOMEBOY_COMPONENT_PATH/runner.log\"\nif [ \"${{HOMEBOY_FIX_ONLY:-}}\" = 1 ]; then\n  [ \"${{HOMEBOY_STEP:-}}\" = fixture-fixer ] || exit 91\n  {}\n  exit 0\nfi\nif grep -q unresolved \"$file\"; then\n  printf '%s\\n' '[{{\"tool\":\"fixture\",\"file\":\"src/example.fixture\",\"message\":\"unresolved fixture finding\",\"rule\":\"fixture.rule\",\"fixable\":true}}]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nelse\n  printf '%s\\n' '[]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nfi\n",
+                "#!/bin/sh\nset -eu\nfile=\"$HOMEBOY_COMPONENT_PATH/src/example.fixture\"\necho \"${{HOMEBOY_FIX_ONLY:-diagnose}}:${{HOMEBOY_STEP:-all}}:${{HOMEBOY_SUMMARY_MODE:-0}}\" >> \"$HOMEBOY_COMPONENT_PATH/runner.log\"\nif [ \"${{HOMEBOY_FIX_ONLY:-}}\" = 1 ]; then\n  [ \"${{HOMEBOY_STEP:-}}\" = fixture-fixer ] || exit 91\n  {}\n  exit 0\nfi\nif grep -q unresolved \"$file\"; then\n  printf '%s\\n' \"[{{\\\"tool\\\":\\\"fixture\\\",\\\"file\\\":\\\"$file\\\",\\\"message\\\":\\\"unresolved fixture finding\\\",\\\"rule\\\":\\\"fixture.rule\\\",\\\"fixable\\\":true}}]\" > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nelse\n  printf '%s\\n' '[]' > \"$HOMEBOY_LINT_FINDINGS_FILE\"\nfi\n",
                 if mutates { "printf 'resolved\\n' > \"$file\"" } else { ":" }
             ),
         )
@@ -1067,7 +1067,7 @@ mod tests {
     }
 
     #[test]
-    fn local_lint_write_applies_routed_fixer_once_and_reports_changed_file() {
+    fn local_lint_write_routes_absolute_finding_path_to_declared_fixer() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let root = tmp_dir("glob-routed-fix");
             init_routed_lint_repo(&root);


### PR DESCRIPTION
## Summary

Closes #11841.

PHPCS emits absolute file paths, while the lint fixer route accepted only component-relative finding paths. Normalize an absolute finding path only when it is under the component root, then resolve it through the extension-declared fixer route. Paths outside the component root remain excluded.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-refactor -- --test-threads=1` (345 passed)
- Regression fixture emits an absolute lint finding path, invokes its extension-declared fixer, applies the edit, and verifies the clean follow-up diagnostic.

AI assistance: OpenAI GPT-5.6 Sol via OpenCode investigated the source, reproduced the defect, implemented the root-bounded routing fix, and ran the tests; Chris Huber remains responsible.