### PR TITLE
Require complete supported-platform release assets

### DIFF
--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -21,9 +21,11 @@
 #      fires no matter WHO published — including a local `homeboy release` from
 #      a laptop, which is what a 7-asset macOS-only inventory looks like.
 #
-# The required set is derived from `dist-workspace.toml`, so adding a target
-# there automatically widens the contract. It cannot drift from what the repo
-# declares it ships.
+# The release workflow passes cargo-dist's planned asset inventory directly.
+# That plan is the authoritative contract: it includes the configured platform
+# archives, their checksums, and installer assets without reconstructing names
+# from a particular product. The config-derived fallback keeps the independent
+# integrity sweeper able to audit releases outside the workflow.
 #
 # Environment:
 #   RELEASE_TAG              (required) tag whose inventory is checked
@@ -32,6 +34,9 @@
 #   RELEASE_INVENTORY_JSON   (optional) pre-fetched `{"assets":[...]}` JSON.
 #                            When set, no `gh` call is made. This is the seam
 #                            the Rust tests drive the contract through.
+#   EXPECTED_ASSETS          (optional) JSON array emitted by cargo-dist's
+#                            release plan. When set, this is the required
+#                            inventory contract.
 #   REQUIRE_ANNOUNCE_ASSETS  (optional, default true) require assets cargo-dist
 #                            attaches during announce (`dist-manifest.json`).
 #                            Set false for the pre-publication gate, where the
@@ -62,40 +67,71 @@ if [ -z "${RELEASE_TAG}" ]; then
   fail "RELEASE_TAG is required to check release asset completeness"
 fi
 
-# ── Required inventory, derived from what the repo declares it ships ──
-if [ ! -f "${DIST_WORKSPACE}" ]; then
-  fail "Cannot derive the release asset contract: ${DIST_WORKSPACE} is missing. Refusing to treat an underivable contract as a satisfied one."
-fi
-
-TARGETS_LINE="$(grep -E '^[[:space:]]*targets[[:space:]]*=' "${DIST_WORKSPACE}" | head -n 1)"
-TARGETS=()
-if [ -n "${TARGETS_LINE}" ]; then
-  while IFS= read -r target; do
-    [ -n "${target}" ] && TARGETS+=("${target}")
-  done < <(printf '%s\n' "${TARGETS_LINE}" | grep -oE '"[^"]+"' | tr -d '"')
-fi
-
-if [ "${#TARGETS[@]}" -eq 0 ]; then
-  fail "Cannot derive the release asset contract: no \`targets\` declared in ${DIST_WORKSPACE}. An empty platform contract would silently pass every incomplete release."
-fi
-
 REQUIRED=()
-for target in "${TARGETS[@]}"; do
-  REQUIRED+=("homeboy-${target}.tar.xz" "homeboy-${target}.tar.xz.sha256")
-done
-REQUIRED+=("source.tar.gz" "source.tar.gz.sha256" "sha256.sum")
+CONTRACT_SOURCE="cargo-dist release plan"
+if [ -n "${EXPECTED_ASSETS:-}" ]; then
+  if ! jq -e 'type == "array" and length > 0 and all(.[]; type == "string" and length > 0)' >/dev/null 2>&1 <<< "${EXPECTED_ASSETS}"; then
+    fail "The cargo-dist expected asset contract is not a non-empty JSON array of names. Refusing to treat an underivable contract as satisfied."
+  fi
+  while IFS= read -r asset; do
+    REQUIRED+=("${asset}")
+  done < <(jq -r '.[]' <<< "${EXPECTED_ASSETS}")
+else
+  # The sweeper has no plan-job output, so derive the portable cargo-dist
+  # fallback from the declared target matrix.
+  CONTRACT_SOURCE="${DIST_WORKSPACE}"
+  if [ ! -f "${DIST_WORKSPACE}" ]; then
+    fail "Cannot derive the release asset contract: ${DIST_WORKSPACE} is missing. Refusing to treat an underivable contract as a satisfied one."
+  fi
 
-# The Homebrew formula is a published asset whenever the tap installer is on.
-if grep -qE '^[[:space:]]*installers[[:space:]]*=.*homebrew' "${DIST_WORKSPACE}"; then
-  REQUIRED+=("homeboy.rb")
+  TARGETS_LINE="$(grep -E '^[[:space:]]*targets[[:space:]]*=' "${DIST_WORKSPACE}" | head -n 1)"
+  TARGETS=()
+  if [ -n "${TARGETS_LINE}" ]; then
+    while IFS= read -r target; do
+      [ -n "${target}" ] && TARGETS+=("${target}")
+    done < <(printf '%s\n' "${TARGETS_LINE}" | grep -oE '"[^"]+"' | tr -d '"')
+  fi
+
+  if [ "${#TARGETS[@]}" -eq 0 ]; then
+    fail "Cannot derive the release asset contract: no \`targets\` declared in ${DIST_WORKSPACE}. An empty platform contract would silently pass every incomplete release."
+  fi
+
+  PACKAGE_NAME="$(awk '
+    /^\[package\]$/ { in_package = 1; next }
+    /^\[/ { in_package = 0 }
+    in_package && /^[[:space:]]*name[[:space:]]*=/ {
+      sub(/^[^"]*"/, "")
+      sub(/".*$/, "")
+      print
+      exit
+    }
+  ' Cargo.toml)"
+  if [ -z "${PACKAGE_NAME}" ]; then
+    fail "Cannot derive the release asset contract: Cargo.toml has no package name."
+  fi
+
+  for target in "${TARGETS[@]}"; do
+    REQUIRED+=("${PACKAGE_NAME}-${target}.tar.xz" "${PACKAGE_NAME}-${target}.tar.xz.sha256")
+  done
+  REQUIRED+=("source.tar.gz" "source.tar.gz.sha256" "sha256.sum")
+
+  if grep -qE '^[[:space:]]*installers[[:space:]]*=.*homebrew' "${DIST_WORKSPACE}"; then
+    REQUIRED+=("${PACKAGE_NAME}.rb")
+  fi
+
+  if [ "${REQUIRE_ANNOUNCE_ASSETS}" = "true" ]; then
+    REQUIRED+=("dist-manifest.json")
+  fi
 fi
 
-# cargo-dist attaches `dist-manifest.json` to the release it announces, and it
-# is absent on exactly the broken releases (v0.288.0 inverted the set and had
-# ONLY this file; v0.323.1, v0.328.1 and v0.333.0 have everything but it). That
-# makes it the cheapest possible completeness signal — no download required.
-if [ "${REQUIRE_ANNOUNCE_ASSETS}" = "true" ]; then
-  REQUIRED+=("dist-manifest.json")
+# cargo-dist attaches this during announce, after the pre-publication upload
+# phase. It remains required at the final published/success boundary.
+if [ "${REQUIRE_ANNOUNCE_ASSETS}" != "true" ]; then
+  PRE_ANNOUNCE_REQUIRED=()
+  for asset in "${REQUIRED[@]}"; do
+    [ "${asset}" != "dist-manifest.json" ] && PRE_ANNOUNCE_REQUIRED+=("${asset}")
+  done
+  REQUIRED=("${PRE_ANNOUNCE_REQUIRED[@]}")
 fi
 
 # ── Observed inventory ──
@@ -131,9 +167,9 @@ done
 
 if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "::error::Release ${RELEASE_TAG} does not satisfy the declared asset contract. Missing or unusable: ${MISSING[*]}"
-  echo "::error::Derived from ${DIST_WORKSPACE}: ${#REQUIRED[@]} assets required across ${#TARGETS[@]} targets. A release that cannot satisfy its own platform matrix must not be published — consumers on the missing platforms get a 404 from \`homeboy upgrade\` (#11749)."
+  echo "::error::Derived from ${CONTRACT_SOURCE}: ${#REQUIRED[@]} assets required. A release that cannot satisfy its own platform matrix must not be published — consumers on the missing platforms get a 404 from \`homeboy upgrade\` (#11749)."
   exit 1
 fi
 
-echo "::notice::Release ${RELEASE_TAG} satisfies the declared asset contract (${#REQUIRED[@]} assets across ${#TARGETS[@]} targets)."
+echo "::notice::Release ${RELEASE_TAG} satisfies the declared asset contract (${#REQUIRED[@]} assets from ${CONTRACT_SOURCE})."
 exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1362,6 +1362,7 @@ jobs:
       - name: Gate publication on the declared asset set
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+          EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
           REQUIRE_ANNOUNCE_ASSETS: 'false'
         run: |
           bash .github/release-asset-completeness.sh

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1887,15 +1887,24 @@ fn release_inventory(names: &[&str]) -> String {
 
 /// Drive the asset contract the way both callers do, through a pre-fetched
 /// inventory so no network or `gh` is involved.
-fn asset_contract(inventory: &str, require_announce_assets: &str) -> (i32, String) {
-    let output = std::process::Command::new("bash")
+fn asset_contract_with_expected_assets(
+    inventory: &str,
+    expected_assets: Option<&str>,
+    require_announce_assets: &str,
+) -> (i32, String) {
+    let mut command = std::process::Command::new("bash");
+    command
         .arg(".github/release-asset-completeness.sh")
         .env("RELEASE_TAG", "v9.9.9")
         .env("RELEASE_INVENTORY_JSON", inventory)
         .env("REQUIRE_ANNOUNCE_ASSETS", require_announce_assets)
         // Never let a test append to the surrounding job's real step output.
         .env_remove("GITHUB_OUTPUT")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .current_dir(env!("CARGO_MANIFEST_DIR"));
+    if let Some(expected_assets) = expected_assets {
+        command.env("EXPECTED_ASSETS", expected_assets);
+    }
+    let output = command
         .output()
         .expect("release asset completeness script should run");
 
@@ -1905,6 +1914,10 @@ fn asset_contract(inventory: &str, require_announce_assets: &str) -> (i32, Strin
         String::from_utf8_lossy(&output.stderr)
     );
     (output.status.code().unwrap_or(-1), combined)
+}
+
+fn asset_contract(inventory: &str, require_announce_assets: &str) -> (i32, String) {
+    asset_contract_with_expected_assets(inventory, None, require_announce_assets)
 }
 
 fn declared_dist_targets() -> Vec<String> {
@@ -1944,6 +1957,43 @@ fn asset_contract_accepts_a_complete_release_and_rejects_the_one_that_shipped_br
         out.contains("dist-manifest.json"),
         "`dist-manifest.json` is absent on exactly the broken releases and must be \
          part of the published contract: {out}"
+    );
+}
+
+#[test]
+fn planned_contract_rejects_host_only_assets_and_accepts_every_supported_platform() {
+    let expected_assets = serde_json::to_string(HEALTHY_RELEASE_ASSETS).expect("asset contract");
+
+    let (code, out) = asset_contract_with_expected_assets(
+        &release_inventory(BROKEN_RELEASE_ASSETS),
+        Some(&expected_assets),
+        "true",
+    );
+    assert_ne!(
+        code, 0,
+        "host-only assets must not satisfy the cargo-dist plan: {out}"
+    );
+    assert!(
+        out.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz"),
+        "{out}"
+    );
+    assert!(
+        out.contains("homeboy-x86_64-unknown-linux-gnu.tar.xz.sha256"),
+        "the plan must require the matching checksum too: {out}"
+    );
+
+    let (code, out) = asset_contract_with_expected_assets(
+        &release_inventory(HEALTHY_RELEASE_ASSETS),
+        Some(&expected_assets),
+        "true",
+    );
+    assert_eq!(
+        code, 0,
+        "the complete supported-platform plan must pass: {out}"
+    );
+    assert!(
+        out.contains("13 assets from cargo-dist release plan"),
+        "the final contract must include every planned asset, including dist-manifest.json: {out}"
     );
 }
 
@@ -2060,6 +2110,10 @@ fn publication_is_gated_on_the_declared_asset_set_before_it_happens() {
     assert!(
         gate.contains("REQUIRE_ANNOUNCE_ASSETS: 'false'"),
         "the pre-publication gate runs before announce attaches dist-manifest.json; got:\n{gate}"
+    );
+    assert!(
+        gate.contains("EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}"),
+        "the pre-publication gate must consume cargo-dist's planned asset contract; got:\n{gate}"
     );
 
     let gate_at = host


### PR DESCRIPTION
## Summary
- derive the required publication inventory from the cargo-dist plan
- fail publication when any supported-platform archive, checksum, or distribution manifest is missing
- preserve host packaging as an intermediate phase

## Verification
- `cargo test --test release_workflow_test` (55 passed)
- `cargo test --test release_expected_assets_test` (5 passed)
- `cargo fmt --all --check`
- `actionlint` and shell syntax checks

Closes #11811.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding and review agents implemented and repeatedly reviewed the release contract and tests. Chris Huber reviewed and remains responsible for every line.