### PR TITLE
Bind provider workspace permission roots exactly

### DIFF
--- a/crates/homeboy-agents/src/agent_task/executor.rs
+++ b/crates/homeboy-agents/src/agent_task/executor.rs
@@ -146,6 +146,7 @@ mod tests {
 
         assert_eq!(executor.config["workspace"]["root"], "/candidate");
         assert_eq!(executor.config["workspace_root"], "/candidate");
+        assert!(executor.config.get("workspace_permission_root").is_none());
         assert_eq!(executor.config["unrelated_root"], "/original");
     }
 

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -117,6 +117,12 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
                 )
             }
         };
+        let workspace_root = request.request.workspace.root.clone();
+        bind_workspace_permission_root(
+            &mut request.request.executor,
+            workspace_root.as_deref(),
+            &provider,
+        );
 
         if let Err(error) = resolve_runtime_tools(&mut request, &provider) {
             return failure_outcome(
@@ -207,6 +213,37 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
 
         run_materialized_provider_command(&request, &provider, context.run_id.as_deref())
     }
+}
+
+/// Pass the scheduler-selected workspace without deriving a path from runtime
+/// identifiers. The explicit capability keeps this provider-owned config field
+/// out of executors that do not consume it.
+fn bind_workspace_permission_root(
+    executor: &mut crate::agent_task::AgentTaskExecutor,
+    workspace_root: Option<&str>,
+    provider: &AgentTaskExecutorProvider,
+) {
+    if !provider
+        .capabilities
+        .iter()
+        .any(|capability| capability == AGENT_TASK_PROVIDER_CAPABILITY_WORKSPACE_PERMISSION_ROOT_V1)
+    {
+        return;
+    }
+    let Some(root) = workspace_root else {
+        return;
+    };
+    if !executor.config.is_object() {
+        executor.config = Value::Object(Default::default());
+    }
+    executor
+        .config
+        .as_object_mut()
+        .expect("executor config object")
+        .insert(
+            "workspace_permission_root".to_string(),
+            Value::String(root.to_string()),
+        );
 }
 
 fn resolved_provider_from_request(
@@ -449,5 +486,50 @@ mod tests {
 
         assert!(path.starts_with(blocked_root.path()));
         assert!(!error.to_string().is_empty());
+    }
+
+    #[test]
+    fn workspace_permission_root_is_emitted_only_for_the_versioned_capability() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "permission-aware",
+            "backend": "fixture",
+            "capabilities": [AGENT_TASK_PROVIDER_CAPABILITY_WORKSPACE_PERMISSION_ROOT_V1]
+        }))
+        .expect("provider declaration");
+        let mut executor = AgentTaskExecutor {
+            backend: "fixture".to_string(),
+            selector: None,
+            runtime_selection: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+            model: None,
+            config: json!({ "preserve": true }),
+        };
+        let workspace = "/scratch/cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874/workspace";
+
+        bind_workspace_permission_root(&mut executor, Some(workspace), &provider);
+
+        assert_eq!(executor.config["workspace_permission_root"], workspace);
+        let provider_without_capability: AgentTaskExecutorProvider =
+            serde_json::from_value(json!({
+                "id": "unaware",
+                "backend": "fixture"
+            }))
+            .expect("provider declaration");
+        let mut unaffected = executor.clone();
+        unaffected
+            .config
+            .as_object_mut()
+            .expect("config object")
+            .remove("workspace_permission_root");
+
+        bind_workspace_permission_root(
+            &mut unaffected,
+            Some("/different-materialized-workspace"),
+            &provider_without_capability,
+        );
+
+        assert!(unaffected.config.get("workspace_permission_root").is_none());
+        assert_eq!(unaffected.config["preserve"], true);
     }
 }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -238,7 +238,7 @@ fn provider_readiness_invocation_receives_effective_config_and_fails_closed() {
 }
 
 #[test]
-fn opencode_provider_boundary_uses_task_workspace_for_cwd_and_config() {
+fn workspace_permission_root_capability_serializes_the_exact_task_workspace() {
     let temp = tempfile::tempdir().expect("tempdir");
     let original = temp.path().join("promotion-target");
     let candidate = temp.path().join("attempt-candidate");
@@ -251,10 +251,11 @@ process.stdin.on('data', (chunk) => input += chunk);
 process.stdin.on('end', () => {
   const request = JSON.parse(input);
   fs.writeFileSync('provider-observation.json', JSON.stringify({
-    cwd: process.cwd(),
-    workspace: request.workspace.root,
-    config_workspace: request.executor.config.workspace.root,
-    config_workspace_root: request.executor.config.workspace_root
+     cwd: process.cwd(),
+     workspace: request.workspace.root,
+     config_workspace: request.executor.config.workspace.root,
+     config_workspace_root: request.executor.config.workspace_root,
+     workspace_permission_root: request.executor.config.workspace_permission_root
   }));
   process.stderr.write('permission denied');
 });"#,
@@ -262,6 +263,9 @@ process.stdin.on('end', () => {
     let (mut request, mut provider) = request("opencode-boundary", format!("node {script}"));
     provider.id = "opencode.agent-task-executor".to_string();
     provider.backend = "opencode".to_string();
+    provider
+        .capabilities
+        .push(AGENT_TASK_PROVIDER_CAPABILITY_WORKSPACE_PERMISSION_ROOT_V1.to_string());
     request.executor.backend = "opencode".to_string();
     request.workspace.root = Some(candidate.display().to_string());
     request.executor.config = json!({
@@ -269,7 +273,18 @@ process.stdin.on('end', () => {
         "workspace_root": candidate.display().to_string(),
     });
 
-    let outcome = run_provider_command_once(&request, &provider);
+    let outcome = ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]).execute(
+        request,
+        AgentTaskExecutionContext {
+            plan_id: "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874"
+                .to_string(),
+            run_id: Some(
+                "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874".to_string(),
+            ),
+            attempt: 1,
+            cancellation: Default::default(),
+        },
+    );
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
     assert_eq!(
         outcome.diagnostics[0].class, "agent_task.provider_empty_stdout",
@@ -302,6 +317,11 @@ process.stdin.on('end', () => {
     assert_eq!(
         observation["config_workspace_root"],
         candidate.display().to_string()
+    );
+    assert_eq!(
+        observation["workspace_permission_root"],
+        candidate.display().to_string(),
+        "the versioned provider capability receives the scheduler-selected workspace without run-ID path reconstruction"
     );
     assert!(!original.join("provider-observation.json").exists());
 }

--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -3,6 +3,10 @@ use super::*;
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
 pub const AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA: &str =
     "homeboy/agent-task-provider-capability-contract/v1";
+/// Provider accepts `executor.config.workspace_permission_root` as the exact
+/// task workspace path used for runtime permission policy.
+pub const AGENT_TASK_PROVIDER_CAPABILITY_WORKSPACE_PERMISSION_ROOT_V1: &str =
+    "workspace_permission_root/v1";
 
 /// Shared request/outcome schema identifiers carried by provider capability
 /// contracts. Flattened into parents so the on-wire JSON keeps the

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -93,6 +93,14 @@ mod provider_rotation_tests {
                 root.display().to_string(),
                 "provider workspace config follows the isolated attempt root"
             );
+            assert!(
+                request
+                    .executor
+                    .config
+                    .get("workspace_permission_root")
+                    .is_none(),
+                "scheduler must not add provider-owned config without a capability declaration"
+            );
             assert_eq!(
                 request.executor.config["cwd"],
                 root.display().to_string(),
@@ -257,7 +265,7 @@ mod provider_rotation_tests {
             observed_roots: Arc::clone(&observed_roots),
             calls: AtomicUsize::new(0),
         })
-        .with_run_id("run-8081");
+        .with_run_id("cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874");
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
         plan.tasks[0].executor.model = Some("primary-model".to_string());
@@ -273,8 +281,15 @@ mod provider_rotation_tests {
         // `reserve_provider_execution` reads the record before it will let a
         // provider execute, so without this every task fails admission with
         // "agent-task run record not found" instead of rotating.
-        crate::agent_tasks::lifecycle::submit_plan(&plan, Some("run-8081")).expect("submit plan");
-        crate::agent_tasks::lifecycle::mark_running("run-8081").expect("mark running");
+        crate::agent_tasks::lifecycle::submit_plan(
+            &plan,
+            Some("cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874"),
+        )
+        .expect("submit plan");
+        crate::agent_tasks::lifecycle::mark_running(
+            "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874",
+        )
+        .expect("mark running");
 
         let aggregate = scheduler.run(plan);
 
@@ -306,7 +321,10 @@ mod provider_rotation_tests {
             .sha256
             .as_deref()
             .is_some_and(|sha256| sha256.len() == 64));
-        assert_eq!(candidate.metadata["run_id"], "run-8081");
+        assert_eq!(
+            candidate.metadata["run_id"],
+            "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874"
+        );
         assert_eq!(candidate.metadata["task_id"], "task-1");
         let patch = fs::read_to_string(candidate.path.as_deref().expect("candidate path"))
             .expect("candidate patch remains available");
@@ -314,7 +332,7 @@ mod provider_rotation_tests {
         assert!(candidate
             .path
             .as_deref()
-            .is_some_and(|path| path.contains("agent-task/attempt-patches/run-8081/task-1")));
+            .is_some_and(|path| path.contains("agent-task/attempt-patches/cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874/task-1")));
         // The first attempt left an uncommitted candidate (captured above as a
         // promoted patch artifact), so scheduler cleanup retains its checkout for
         // lifecycle cleanup rather than force-removing it (#8579). The second,


### PR DESCRIPTION
## Summary
- add versioned `workspace_permission_root/v1` provider capability
- emit the exact materialized workspace only for capable providers
- preserve non-capable provider configuration unchanged

## Verification
- focused capability serialization and scheduler rotation tests
- hyphen-heavy Cook identity request fixture
- `cargo fmt --all --check`

Consumer runtime: Extra-Chill/homeboy-extensions#2570.
Closes #11823.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding and review agents implemented and repeatedly reviewed the provider contract and tests. Chris Huber reviewed and remains responsible for every line.