### PR TITLE
Stop candidate CI after pull request closure

### DIFF
--- a/.github/ci-pr-state.sh
+++ b/.github/ci-pr-state.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Emits whether this CI run may admit candidate work. A pull_request.closed run
+# exists solely to cancel the previous run in the same concurrency group.
+
+set -euo pipefail
+
+active=true
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] \
+  && [ "${GITHUB_EVENT_ACTION:-}" = "closed" ]; then
+  active=false
+fi
+
+echo "active=${active}" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # A closed PR starts one lightweight run in the existing concurrency group.
+    # That cancels an in-flight candidate DAG, while pr-state keeps this run from
+    # admitting the reusable workflow's binary, inventory, and shard jobs.
+    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +25,25 @@ permissions:
   issues: write
 
 jobs:
+  # The event payload is authoritative for a closure run. Non-PR invocations
+  # remain active so manual CI and future push CI behavior are unchanged. Check
+  # out the default branch: the closure decision must not come from PR code.
+  pr-state:
+    name: homeboy / PR State
+    runs-on: ubuntu-latest
+    outputs:
+      active: ${{ steps.state.outputs.active }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Determine whether candidate work may start
+        id: state
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+        run: bash .github/ci-pr-state.sh
+
   # Named for what a green tick here actually proves: the DECLARATION is intact.
   # It used to be called "Required Gates Policy" and run `--local`, which reads
   # as "GitHub requires these checks" while only proving "ci.yml emits these
@@ -32,6 +55,8 @@ jobs:
   # this stays reporting and no PR is newly blocked by it.
   required-gates-declaration:
     name: homeboy / Required Gates Declaration
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -50,6 +75,8 @@ jobs:
   # (codegen-free, so it's cheap) and fails closed if any of them break.
   workspace-tests-compile:
     name: homeboy / Workspace Tests Compile
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -61,6 +88,8 @@ jobs:
 
   warning-clean:
     name: homeboy / Warning Clean
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,6 +108,8 @@ jobs:
   # Unix-only test helpers rely on that boundary.
   windows-compile:
     name: homeboy / Windows Compile
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -96,6 +127,8 @@ jobs:
   # non-differential whole-workspace check, so it catches drift anywhere.
   rustfmt:
     name: homeboy / Rustfmt
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -109,6 +142,8 @@ jobs:
 
   homeboy-fast:
     name: homeboy / ${{ matrix.title }}
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -167,6 +202,8 @@ jobs:
   # ambiguous source changes fail closed or use Homeboy's full-scope fallback.
   homeboy:
     name: homeboy
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
       commands: review test

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -1,0 +1,120 @@
+use std::process::Command;
+
+fn ci_workflow() -> &'static str {
+    include_str!("../.github/workflows/ci.yml")
+}
+
+fn pr_state(event_name: &str, event_action: &str) -> String {
+    let output = std::env::temp_dir().join(format!(
+        "homeboy-pr-ci-state-{}-{event_name}-{event_action}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&output);
+
+    let status = Command::new("bash")
+        .arg(".github/ci-pr-state.sh")
+        .env("GITHUB_EVENT_NAME", event_name)
+        .env("GITHUB_EVENT_ACTION", event_action)
+        .env("GITHUB_OUTPUT", &output)
+        .status()
+        .expect("PR-state guard should run");
+    assert!(status.success());
+
+    let state = std::fs::read_to_string(&output).expect("PR-state guard output");
+    let _ = std::fs::remove_file(output);
+    state
+}
+
+fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
+    let marker = format!("  {job}:\n");
+    let start = workflow
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing {job} job"));
+    let rest = &workflow[start + marker.len()..];
+    let end = rest
+        .lines()
+        .scan(0usize, |offset, line| {
+            let current = *offset;
+            *offset += line.len() + 1;
+            Some((current, line))
+        })
+        .find_map(|(offset, line)| {
+            (line.starts_with("  ") && !line.starts_with("    ") && line.ends_with(':'))
+                .then_some(offset.saturating_sub(1))
+        })
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
+    // These model closure arriving before candidate build, inventory planning,
+    // or shard fanout. The closure run cancels the prior concurrency-group
+    // member and every candidate boundary waits for its false output.
+    for phase in ["candidate-build", "inventory", "shard-fanout"] {
+        assert_eq!(
+            pr_state("pull_request", "closed"),
+            "active=false\n",
+            "a closure before {phase} must not admit more candidate work"
+        );
+    }
+
+    let workflow = ci_workflow();
+    assert!(workflow.contains(
+        "pull_request:\n    branches: [main]\n    # A closed PR starts one lightweight run in the existing concurrency group.\n    # That cancels an in-flight candidate DAG, while pr-state keeps this run from\n    # admitting the reusable workflow's binary, inventory, and shard jobs.\n    types: [opened, synchronize, reopened, closed]"
+    ));
+    assert!(workflow.contains("group: ci-${{ github.event.pull_request.number || github.ref }}"));
+    assert!(workflow.contains("cancel-in-progress: true"));
+
+    let state = job_section(workflow, "pr-state");
+    assert!(state.contains("active: ${{ steps.state.outputs.active }}"));
+    assert!(state.contains("ref: ${{ github.event.repository.default_branch }}"));
+    assert!(state.contains("bash .github/ci-pr-state.sh"));
+
+    for (phase, job) in [
+        ("candidate build", "homeboy-fast"),
+        ("inventory planning", "homeboy"),
+        ("shard fanout", "homeboy"),
+    ] {
+        let candidate = job_section(workflow, job);
+        assert!(
+            candidate.contains("needs: pr-state"),
+            "{phase} must await PR state"
+        );
+        assert!(
+            candidate.contains("if: ${{ needs.pr-state.outputs.active == 'true' }}"),
+            "{phase} must be skipped after closure"
+        );
+    }
+
+    for job in [
+        "required-gates-declaration",
+        "workspace-tests-compile",
+        "warning-clean",
+        "windows-compile",
+        "rustfmt",
+        "homeboy-fast",
+        "homeboy",
+    ] {
+        let section = job_section(workflow, job);
+        assert!(
+            section.contains("needs: pr-state"),
+            "{job} must await PR state"
+        );
+        assert!(
+            section.contains("if: ${{ needs.pr-state.outputs.active == 'true' }}"),
+            "{job} must be skipped after closure"
+        );
+    }
+
+    let test = job_section(workflow, "homeboy");
+    assert!(test.contains("uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2"));
+    assert!(test.contains("test-shards: '16'"));
+}
+
+#[test]
+fn non_pr_ci_invocations_remain_admitted() {
+    assert_eq!(pr_state("pull_request", "synchronize"), "active=true\n");
+    assert_eq!(pr_state("workflow_dispatch", ""), "active=true\n");
+    assert_eq!(pr_state("push", ""), "active=true\n");
+}


### PR DESCRIPTION
## Summary
- trigger a lightweight closure run in the existing PR concurrency group
- evaluate PR state from trusted default-branch code
- gate every downstream candidate and shard job on active PR state

## Verification
- `cargo test --test pr_ci_lifecycle_test` (2 passed)
- `actionlint .github/workflows/ci.yml`
- `shellcheck .github/ci-pr-state.sh`
- formatting and diff checks

Closes #11826.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding and review agents implemented and reviewed the workflow guard and tests. Chris Huber reviewed and remains responsible for every line.