### PR TITLE
Admit reverse runners with unavailable compatibility verification

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1712,6 +1712,18 @@ fn handle_reverse_broker_request(
     use serde_json::json;
 
     let ok = |body| json!({ "success": true, "data": { "body": body } });
+    if request.method == "GET" && request.path == "/jobs" {
+        let active_runner_jobs = store.active_runner_jobs();
+        let stale_runner_jobs = store.stale_runner_jobs();
+        return ok(json!({
+            "command": "api.jobs.list",
+            "jobs": store.list(),
+            "active_runner_job_count": active_runner_jobs.len(),
+            "active_runner_jobs": active_runner_jobs,
+            "stale_runner_job_count": stale_runner_jobs.len(),
+            "stale_runner_jobs": stale_runner_jobs,
+        }));
+    }
     if request.method == "POST" && request.path == "/runner/sessions" {
         return ok(json!({ "registered": true }));
     }
@@ -1929,6 +1941,73 @@ mod tests {
             assert_eq!(command_env(&command, source), Some(None));
             assert_eq!(command_env(&command, lab), Some(None));
         }
+    }
+
+    #[test]
+    fn reverse_broker_fixture_projects_active_and_stale_runner_jobs() {
+        let store = JobStore::default();
+        let active = store
+            .submit_remote_runner_job(
+                serde_json::from_value(serde_json::json!({
+                    "runner_id": "lab",
+                    "command": ["true"],
+                }))
+                .expect("active runner request"),
+            )
+            .expect("queue active runner job");
+        let response = handle_reverse_broker_request(
+            &store,
+            "lab",
+            ReverseBrokerRequest {
+                method: "GET".to_string(),
+                path: "/jobs".to_string(),
+                body: serde_json::Value::Null,
+            },
+        );
+
+        assert_eq!(response["success"], true);
+        assert_eq!(
+            response["data"]["body"]["jobs"][0]["id"],
+            active.id.to_string()
+        );
+        assert_eq!(response["data"]["body"]["active_runner_job_count"], 1);
+        assert_eq!(
+            response["data"]["body"]["active_runner_jobs"][0]["job_id"],
+            active.id.to_string()
+        );
+        assert_eq!(response["data"]["body"]["stale_runner_job_count"], 0);
+
+        let temp = tempfile::tempdir().expect("job store directory");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("open durable store");
+        let stale = store
+            .submit_remote_runner_job(
+                serde_json::from_value(serde_json::json!({
+                    "runner_id": "lab",
+                    "command": ["true"],
+                }))
+                .expect("stale runner request"),
+            )
+            .expect("queue stale runner job");
+        store
+            .claim_remote_runner_job("lab", None, 30_000, None)
+            .expect("claim stale runner job");
+        let recovered = JobStore::open(&path).expect("recover stale runner job");
+        let response = handle_reverse_broker_request(
+            &recovered,
+            "lab",
+            ReverseBrokerRequest {
+                method: "GET".to_string(),
+                path: "/jobs".to_string(),
+                body: serde_json::Value::Null,
+            },
+        );
+
+        assert_eq!(response["data"]["body"]["stale_runner_job_count"], 1);
+        assert_eq!(
+            response["data"]["body"]["stale_runner_jobs"][0]["job_id"],
+            stale.id.to_string()
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -175,6 +175,88 @@ fn lab_runner_preparation_uses_already_connected_runner() {
 }
 
 #[test]
+fn lab_runner_preparation_accepts_explicit_connected_reverse_runner_with_unavailable_verification()
+{
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: RunnerTunnelMode::Reverse,
+    };
+
+    let prepared = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(connected_reverse_status(
+                runner_id,
+                Some(RunnerStaleDaemonWarning::verification_unavailable(
+                    runner_id,
+                    "homeboy 0.0.0".to_string(),
+                    Some("homeboy 0.0.0+test".to_string()),
+                    "reverse_runner_identity_unavailable",
+                    "reverse runner identity cannot be verified".to_string(),
+                )),
+            ))
+        },
+        |_| panic!("connected reverse runner should not reconnect"),
+    )
+    .expect("prepared");
+
+    assert_eq!(prepared, LabRunnerPreparation::Ready);
+}
+
+#[test]
+fn lab_runner_preparation_accepts_default_connected_reverse_runner_with_unavailable_verification() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Default,
+        mode: RunnerTunnelMode::Reverse,
+    };
+
+    let prepared = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(connected_reverse_status(
+                runner_id,
+                Some(RunnerStaleDaemonWarning::verification_unavailable(
+                    runner_id,
+                    "homeboy 0.0.0".to_string(),
+                    Some("homeboy 0.0.0+test".to_string()),
+                    "reverse_runner_identity_unavailable",
+                    "reverse runner identity cannot be verified".to_string(),
+                )),
+            ))
+        },
+        |_| panic!("connected reverse runner should not reconnect"),
+    )
+    .expect("prepared");
+
+    assert_eq!(prepared, LabRunnerPreparation::Ready);
+}
+
+#[test]
+fn lab_runner_preparation_blocks_connected_reverse_runner_with_compared_mismatch() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: RunnerTunnelMode::Reverse,
+    };
+
+    let error = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(connected_reverse_status(
+                runner_id,
+                Some(stale_daemon_warning(runner_id)),
+            ))
+        },
+        |_| panic!("stale reverse runner should not reconnect"),
+    )
+    .expect_err("compared daemon mismatch should remain blocked");
+
+    assert!(error.message.contains("daemon is stale"));
+}
+
+#[test]
 fn lab_runner_preparation_falls_back_for_stale_default_daemon_version_without_reconnecting() {
     let selection = LabRunnerSelection {
         runner_id: "lab".to_string(),
@@ -784,6 +866,52 @@ fn connected_direct_session(
         worker_pid: None,
         last_seen_at: None,
         leaseless_recovery_evidence: None,
+    }
+}
+
+fn connected_reverse_status(
+    runner_id: &str,
+    stale_daemon: Option<RunnerStaleDaemonWarning>,
+) -> RunnerStatusReport {
+    RunnerStatusReport {
+        runner_id: runner_id.to_string(),
+        connected: true,
+        state: super::super::RunnerSessionState::Connected,
+        session: Some(super::super::RunnerSession {
+            runner_id: runner_id.to_string(),
+            mode: RunnerTunnelMode::Reverse,
+            role: super::super::RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: Some("controller".to_string()),
+            broker_url: Some("http://127.0.0.1:9876".to_string()),
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: None,
+            tunnel_pid: None,
+            tunnel_process_start_identity: None,
+            proxy_forward: None,
+            remote_daemon_pid: None,
+            remote_daemon_lease_id: None,
+            homeboy_version: "homeboy 0.0.0".to_string(),
+            homeboy_build_identity: Some("homeboy 0.0.0+test".to_string()),
+            connected_at: "2026-06-03T00:00:00Z".to_string(),
+            worker_identity: Some("worker-1".to_string()),
+            worker_pid: Some(1234),
+            last_seen_at: Some(chrono::Utc::now().to_rfc3339()),
+            leaseless_recovery_evidence: None,
+        }),
+        stale_daemon,
+        daemon_freshness: None,
+        active_jobs: Vec::new(),
+        active_runner_jobs: Vec::new(),
+        active_job_count: 0,
+        stale_runner_jobs: Vec::new(),
+        stale_runner_job_count: 0,
+        active_job_state: RunnerActiveJobState::Available,
+        active_job_source: None,
+        active_job_error: None,
+        active_job_recovery_evidence: None,
+        session_path: "/tmp/lab.json".to_string(),
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -457,7 +457,7 @@ fn placement_readiness_from_status_with_catalog(
     let availability = RunnerAvailability::from_status_parts(
         request.runner_id.clone(),
         status.connected,
-        status.stale_daemon.is_some(),
+        status.admission_blocking_stale_daemon().is_some(),
         status.active_jobs.len(),
         &status.active_job_state,
         capacity,
@@ -535,7 +535,7 @@ fn placement_readiness_from_status_with_catalog(
             },
             PlacementReadinessPredicate {
                 id: "daemon_fresh".to_string(),
-                satisfied: status.stale_daemon.is_none(),
+                satisfied: status.admission_blocking_stale_daemon().is_none(),
             },
             PlacementReadinessPredicate {
                 id: "active_jobs_authoritative".to_string(),
@@ -748,14 +748,23 @@ fn preflight_lab_runner_availability_with(
     selection: &LabRunnerSelection,
     status_fn: impl Fn(&str) -> Result<RunnerStatusReport>,
 ) -> Result<(RunnerAvailability, RunnerStatusReport)> {
+    let capacity = load(&selection.runner_id)?.settings.concurrency_limit;
+    preflight_lab_runner_availability_from_status(selection, status_fn, capacity)
+}
+
+fn preflight_lab_runner_availability_from_status(
+    selection: &LabRunnerSelection,
+    status_fn: impl Fn(&str) -> Result<RunnerStatusReport>,
+    capacity: Option<usize>,
+) -> Result<(RunnerAvailability, RunnerStatusReport)> {
     let status = status_fn(&selection.runner_id)?;
     let availability = RunnerAvailability::from_status_parts(
         selection.runner_id.clone(),
         status.connected,
-        status.stale_daemon.is_some(),
+        status.admission_blocking_stale_daemon().is_some(),
         status.active_jobs.len(),
         &status.active_job_state,
-        load(&selection.runner_id)?.settings.concurrency_limit,
+        capacity,
     );
     Ok((availability, status))
 }
@@ -1251,7 +1260,7 @@ fn connected_runner_not_ready_reason(
     runner_id: &str,
     status: &RunnerStatusReport,
 ) -> Option<String> {
-    if let Some(warning) = status.stale_daemon.as_ref() {
+    if let Some(warning) = status.admission_blocking_stale_daemon() {
         let restart = daemon_repair_command(runner_id, status);
         if !warning.stale_runtime_paths.is_empty() || !warning.changed_runtime_paths.is_empty() {
             return Some(format!(
@@ -2178,6 +2187,107 @@ mod placement_readiness_tests {
         );
         assert_eq!(result.state, PlacementReadinessState::Blocked);
         assert!(!result.recovery_actions.is_empty());
+    }
+
+    #[test]
+    fn placement_readiness_accepts_reverse_runner_with_unavailable_verification() {
+        let mut observed = status();
+        observed.stale_daemon = Some(RunnerStaleDaemonWarning::verification_unavailable(
+            "lab",
+            "homeboy 0.0.0".to_string(),
+            Some("homeboy 0.0.0+test".to_string()),
+            "reverse_runner_identity_unavailable",
+            "reverse runner identity cannot be verified".to_string(),
+        ));
+
+        let result = decide(
+            &request(),
+            &observed,
+            Some(1),
+            RunnerTunnelMode::Reverse,
+            super::super::LabRunnerGateDecision::Eligible,
+        );
+
+        assert_eq!(result.state, PlacementReadinessState::Ready);
+        assert!(result
+            .predicates
+            .iter()
+            .any(|predicate| predicate.id == "daemon_fresh" && predicate.satisfied));
+    }
+
+    #[test]
+    fn placement_readiness_rejects_reverse_runner_with_compared_mismatch() {
+        let mut observed = status();
+        observed.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+            "lab",
+            "homeboy 0.0.0".to_string(),
+            "homeboy 0.0.1".to_string(),
+            Some("homeboy 0.0.0+old".to_string()),
+            Some("homeboy 0.0.1+new".to_string()),
+        ));
+
+        let result = decide(
+            &request(),
+            &observed,
+            Some(1),
+            RunnerTunnelMode::Reverse,
+            super::super::LabRunnerGateDecision::Eligible,
+        );
+
+        assert_eq!(result.state, PlacementReadinessState::Blocked);
+    }
+
+    #[test]
+    fn preflight_accepts_reverse_runner_with_unavailable_verification() {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: RunnerTunnelMode::Reverse,
+        };
+        let mut observed = status();
+        observed.stale_daemon = Some(RunnerStaleDaemonWarning::verification_unavailable(
+            "lab",
+            "homeboy 0.0.0".to_string(),
+            Some("homeboy 0.0.0+test".to_string()),
+            "reverse_runner_identity_unavailable",
+            "reverse runner identity cannot be verified".to_string(),
+        ));
+
+        let (availability, _) = preflight_lab_runner_availability_from_status(
+            &selection,
+            |_| Ok(observed.clone()),
+            Some(1),
+        )
+        .expect("preflight");
+
+        assert!(availability.accepts_jobs);
+    }
+
+    #[test]
+    fn preflight_rejects_reverse_runner_with_compared_mismatch() {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: RunnerTunnelMode::Reverse,
+        };
+        let mut observed = status();
+        observed.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+            "lab",
+            "homeboy 0.0.0".to_string(),
+            "homeboy 0.0.1".to_string(),
+            Some("homeboy 0.0.0+old".to_string()),
+            Some("homeboy 0.0.1+new".to_string()),
+        ));
+
+        let (availability, _) = preflight_lab_runner_availability_from_status(
+            &selection,
+            |_| Ok(observed.clone()),
+            Some(1),
+        )
+        .expect("preflight");
+
+        assert!(!availability.accepts_jobs);
+        assert_eq!(availability.reasons, ["stale_daemon"]);
     }
 
     #[test]

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -190,6 +190,8 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
         "HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY",
         homeboy_core::build_identity::current().display,
     );
+    let runtime_identity = std::env::var("HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY")
+        .expect("fixture controller runtime identity");
     // The daemon, submitting CLI, and detached worker all pin the same
     // immutable controller binary while retaining independent mutable state.
     std::env::set_var(
@@ -230,11 +232,19 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
     let ssh = context.root().join("ssh");
     std::fs::write(
         &ssh,
-        "#!/bin/sh\nfor argument do command=$argument; done\ncase \"$command\" in\n  p=*'df -Pk'*) printf '%s\\n' '10485760 5242880' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
+        "#!/bin/sh\nfor argument do command=$argument; done\ncase \"$command\" in\n  *'self identity'*) identity=\"${HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY:?}\"; version=\"${identity#homeboy }\"; version=\"${version%%+*}\"; printf '{\"version\":\"%s\",\"display\":\"%s\"}\\n' \"$version\" \"$identity\" ;;\n  *'daemon status'*) printf '%s\\n' '{\"success\":true,\"data\":{\"running\":false,\"fresh\":true,\"reachable\":true,\"active_jobs\":0}}' ;;\n  *'df -Pk'*) printf '%s\\n' 'fixture-device 5242880 1048576' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
     )
     .expect("write capability probe SSH shim");
     std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755))
         .expect("make capability probe SSH shim executable");
+    let setsid = context.root().join("setsid");
+    std::fs::write(
+        &setsid,
+        "#!/usr/bin/env perl\nuse POSIX qw(setsid);\nsetsid() or die \"setsid: $!\\n\";\nexec @ARGV or die \"exec: $!\\n\";\n",
+    )
+    .expect("write setsid shim");
+    std::fs::set_permissions(&setsid, std::fs::Permissions::from_mode(0o755))
+        .expect("make setsid shim executable");
     let path = format!(
         "{}:{}",
         context.root().display(),
@@ -319,7 +329,7 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
             "remote_daemon_pid": daemon_pid,
             "remote_daemon_lease_id": daemon_lease_id,
             "homeboy_version": env!("CARGO_PKG_VERSION"),
-            "homeboy_build_identity": null,
+            "homeboy_build_identity": runtime_identity,
             "connected_at": "2026-01-01T00:00:00Z",
             "worker_identity": "fixture-worker",
             "worker_pid": 1,


### PR DESCRIPTION
## Summary
- route Lab readiness, preflight, and preparation through the canonical admission-blocking compatibility policy
- keep compared daemon mismatches fenced while allowing reverse-only unavailable verification
- complete reverse acceptance identity, capacity, process-group, and broker-job fixtures with production-shaped behavior

## Verification
- reverse Cook acceptance passed three consecutive runs
- Lab readiness tests: 19 passed
- Lab preparation tests: 12 passed
- compared mismatch handoff tests passed
- stateful reverse broker active/stale jobs test passed
- formatting and diff checks passed

Closes #11863.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode diagnosed, implemented, repeatedly tested, and independently reviewed the admission and fixture repair. Chris Huber reviewed and remains responsible for every line.