### PR TITLE
Let notification extensions resolve routes from caller context

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -100,7 +100,11 @@ pub mod manifest_test_config;
 pub mod manifest_toolchain_config;
 pub mod notification_transport_config;
 pub use notification_transport_config::{
-    NotificationTransportConfig, NotificationTransportDescriptor, NOTIFICATION_TRANSPORT_SCHEMA,
+    NotificationRouteResolverConfig, NotificationRouteResolverRequest,
+    NotificationRouteResolverResponse, NotificationRouteResolverStatus,
+    NotificationTransportConfig, NotificationTransportDescriptor,
+    NOTIFICATION_ROUTE_RESOLVER_REQUEST_SCHEMA, NOTIFICATION_ROUTE_RESOLVER_SCHEMA,
+    NOTIFICATION_TRANSPORT_SCHEMA,
 };
 pub mod runner_contract;
 pub mod runtime_helper;

--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -607,6 +607,7 @@ mod tests {
             schema: NOTIFICATION_TRANSPORT_SCHEMA.to_string(),
             id: id.to_string(),
             command: vec!["notify".to_string()],
+            route_resolver: None,
         }
     }
 

--- a/crates/contracts/homeboy-extension-contract/src/notification_transport_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/notification_transport_config.rs
@@ -9,6 +9,36 @@ use homeboy_error::{Error, Result};
 use serde::{Deserialize, Serialize};
 
 pub const NOTIFICATION_TRANSPORT_SCHEMA: &str = "homeboy/notification-transport/v1";
+pub const NOTIFICATION_ROUTE_RESOLVER_SCHEMA: &str = "homeboy/notification-route-resolver/v1";
+pub const NOTIFICATION_ROUTE_RESOLVER_REQUEST_SCHEMA: &str =
+    "homeboy/notification-route-resolver-request/v1";
+
+/// The complete, transport-neutral request sent to a declared route resolver
+/// over stdin. Context remains extension-owned and is never serialized here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationRouteResolverRequest {
+    pub schema: String,
+    pub transport: String,
+}
+
+/// A resolver's explicit selection state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationRouteResolverStatus {
+    Matched,
+    Unmatched,
+}
+
+/// The one JSON response a declared resolver writes to stdout.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationRouteResolverResponse {
+    pub schema: String,
+    pub status: NotificationRouteResolverStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+}
 
 /// Safe, read-only transport metadata exposed by extension discovery surfaces.
 /// Invocation argv stays confined to the installed manifest and dispatch path.
@@ -16,6 +46,18 @@ pub const NOTIFICATION_TRANSPORT_SCHEMA: &str = "homeboy/notification-transport/
 pub struct NotificationTransportDescriptor {
     pub schema: String,
     pub id: String,
+    pub has_route_resolver: bool,
+}
+
+/// An extension-owned, bounded literal argv command that may derive a route
+/// from the caller context it understands. Homeboy passes a versioned request
+/// on stdin and reads one versioned response from stdout.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationRouteResolverConfig {
+    #[serde(default = "default_notification_route_resolver_schema")]
+    pub schema: String,
+    pub command: Vec<String>,
 }
 
 /// An installed extension-owned notification command. `command` is a literal
@@ -28,10 +70,16 @@ pub struct NotificationTransportConfig {
     pub schema: String,
     pub id: String,
     pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_resolver: Option<NotificationRouteResolverConfig>,
 }
 
 fn default_notification_transport_schema() -> String {
     NOTIFICATION_TRANSPORT_SCHEMA.to_string()
+}
+
+fn default_notification_route_resolver_schema() -> String {
+    NOTIFICATION_ROUTE_RESOLVER_SCHEMA.to_string()
 }
 
 impl NotificationTransportConfig {
@@ -39,6 +87,7 @@ impl NotificationTransportConfig {
         NotificationTransportDescriptor {
             schema: self.schema.clone(),
             id: self.id.clone(),
+            has_route_resolver: self.route_resolver.is_some(),
         }
     }
 
@@ -78,6 +127,36 @@ impl NotificationTransportConfig {
                 None,
             ));
         }
+        if let Some(resolver) = &self.route_resolver {
+            resolver.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl NotificationRouteResolverConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != NOTIFICATION_ROUTE_RESOLVER_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "notification_transports.route_resolver.schema",
+                format!("must be {NOTIFICATION_ROUTE_RESOLVER_SCHEMA}"),
+                Some(self.schema.clone()),
+                None,
+            ));
+        }
+        if self.command.is_empty()
+            || self
+                .command
+                .iter()
+                .any(|arg| arg.is_empty() || arg.contains('\0'))
+        {
+            return Err(Error::validation_invalid_argument(
+                "notification_transports.route_resolver.command",
+                "must be a non-empty literal argv array without empty or NUL values",
+                None,
+                None,
+            ));
+        }
         Ok(())
     }
 }
@@ -91,6 +170,7 @@ mod tests {
             schema: NOTIFICATION_TRANSPORT_SCHEMA.to_string(),
             id: id.to_string(),
             command: vec!["notify".to_string()],
+            route_resolver: None,
         }
     }
 
@@ -104,9 +184,24 @@ mod tests {
             serde_json::to_value(descriptor).expect("serialize descriptor"),
             serde_json::json!({
                 "schema": NOTIFICATION_TRANSPORT_SCHEMA,
-                "id": "example.completed"
+                "id": "example.completed",
+                "has_route_resolver": false
             })
         );
+    }
+
+    #[test]
+    fn resolver_requires_a_versioned_literal_argv_contract() {
+        let mut config = transport("example.completed");
+        config.route_resolver = Some(NotificationRouteResolverConfig {
+            schema: NOTIFICATION_ROUTE_RESOLVER_SCHEMA.to_string(),
+            command: vec!["resolve-route".to_string()],
+        });
+        config.validate().expect("valid resolver");
+        assert!(config.descriptor().has_route_resolver);
+
+        config.route_resolver.as_mut().unwrap().command.clear();
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -539,21 +539,28 @@ impl CliRuntime {
         };
         let mut cli = compiled.value;
         let command_provenance = compiled.provenance;
-        let notification_route = match crate::core::notification_route::from_cli_or_env(
-            cli.notification_transport.as_deref(),
-            cli.notification_route.as_deref(),
-        ) {
-            Ok(route) => route,
-            Err(err) => {
-                output_runtime::emit_json_result_for_identity(
-                    Err(err),
-                    output_file.as_deref(),
-                    2,
-                    &command_identity,
-                );
-                return std::process::ExitCode::from(2);
-            }
-        };
+        let notification_route =
+            match crate::core::notification_route_resolver::resolve_from_cli_or_env(
+                cli.notification_transport.as_deref(),
+                cli.notification_route.as_deref(),
+            ) {
+                Ok(route) => route,
+                Err(err) => {
+                    output_runtime::emit_json_result_for_identity(
+                        Err(err),
+                        output_file.as_deref(),
+                        2,
+                        &command_identity,
+                    );
+                    return std::process::ExitCode::from(2);
+                }
+            };
+        if let Some(route) = &notification_route {
+            // Placement routing happens before the thread-local command scope.
+            // Mirror the selected route into its existing durable handoff input.
+            cli.notification_transport = Some(route.transport.clone());
+            cli.notification_route = Some(route.route.clone());
+        }
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
         normalize_cook_runner_option(&mut cli, &normalized);

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -140,6 +140,7 @@ pub use homeboy_lab_contract::materialization_currency;
 pub mod matrix_artifact_summary;
 pub use homeboy_lab_contract::notification_payload;
 pub use homeboy_lab_contract::notification_route;
+pub mod notification_route_resolver;
 pub mod notify;
 pub mod observation;
 pub mod output;

--- a/crates/homeboy-core/src/notification_route_resolver.rs
+++ b/crates/homeboy-core/src/notification_route_resolver.rs
@@ -1,0 +1,274 @@
+//! Extension-owned notification route resolution.
+//!
+//! Core supplies only the transport identity. Resolvers own all interpretation
+//! of their inherited caller context and return a small, versioned JSON result.
+
+use std::{
+    io::{Read, Write},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use homeboy_error::{Error, Result};
+use homeboy_extension_contract::{
+    NotificationRouteResolverConfig, NotificationRouteResolverRequest,
+    NotificationRouteResolverResponse, NotificationRouteResolverStatus,
+    NOTIFICATION_ROUTE_RESOLVER_REQUEST_SCHEMA, NOTIFICATION_ROUTE_RESOLVER_SCHEMA,
+};
+
+use crate::{extension_store::load_all_extensions, notification_route::NotificationRoute};
+
+const RESOLVER_TIMEOUT: Duration = Duration::from_secs(2);
+const RESOLVER_OUTPUT_LIMIT: usize = 16 * 1024;
+
+/// Ask installed transport resolvers for a route. One match is selected; zero
+/// matches retains route-less behavior. Any invalid declaration or outcome is a
+/// hard error so caller context can never select an unintended destination.
+pub fn resolve_installed() -> Result<Option<NotificationRoute>> {
+    let extensions = load_all_extensions()?;
+    let mut matches = Vec::new();
+    for extension in extensions {
+        for transport in &extension.notification_transports {
+            let Some(resolver) = &transport.route_resolver else {
+                continue;
+            };
+            if let Some(route) = invoke(
+                resolver,
+                &transport.id,
+                extension.extension_path.as_deref().unwrap_or_default(),
+            )? {
+                matches.push(route);
+            }
+        }
+    }
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => Err(resolver_error(
+            "more than one installed notification route resolver matched",
+        )),
+    }
+}
+
+/// Apply the route precedence contract without making resolver execution a
+/// fallback for an explicit caller choice.
+pub fn resolve_from_cli_or_env(
+    cli_transport: Option<&str>,
+    cli_route: Option<&str>,
+) -> Result<Option<NotificationRoute>> {
+    match crate::notification_route::from_cli_or_env(cli_transport, cli_route)? {
+        Some(route) => Ok(Some(route)),
+        None => resolve_installed(),
+    }
+}
+
+fn invoke(
+    resolver: &NotificationRouteResolverConfig,
+    transport: &str,
+    extension_path: &str,
+) -> Result<Option<NotificationRoute>> {
+    let argv: Vec<String> = resolver
+        .command
+        .iter()
+        .map(|arg| arg.replace("{extension_path}", extension_path))
+        .collect();
+    let program = argv.first().expect("validated resolver command");
+    let request = serde_json::to_vec(&NotificationRouteResolverRequest {
+        schema: NOTIFICATION_ROUTE_RESOLVER_REQUEST_SCHEMA.to_string(),
+        transport: transport.to_string(),
+    })
+    .expect("resolver request is serializable");
+    let mut child = Command::new(program)
+        .args(&argv[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| resolver_error("could not start an installed notification route resolver"))?;
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(&request)
+        .map_err(|_| resolver_error("could not send the resolver request"))?;
+    let stdout = child.stdout.take().expect("piped stdout");
+    let reader = thread::spawn(move || read_bounded(stdout));
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|_| resolver_error("could not wait for a notification route resolver"))?
+        {
+            break status;
+        }
+        if started.elapsed() >= RESOLVER_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(resolver_error("notification route resolver timed out"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    let (stdout, oversized) = reader
+        .join()
+        .map_err(|_| resolver_error("notification route resolver output reader failed"))?;
+    if oversized {
+        return Err(resolver_error(
+            "notification route resolver output exceeded its limit",
+        ));
+    }
+    if !status.success() {
+        return Err(resolver_error(
+            "notification route resolver exited unsuccessfully",
+        ));
+    }
+    let response: NotificationRouteResolverResponse = serde_json::from_slice(&stdout)
+        .map_err(|_| resolver_error("notification route resolver returned malformed output"))?;
+    if response.schema != NOTIFICATION_ROUTE_RESOLVER_SCHEMA {
+        return Err(resolver_error(
+            "notification route resolver returned an unsupported schema",
+        ));
+    }
+    match (response.status, response.route) {
+        (NotificationRouteResolverStatus::Unmatched, None) => Ok(None),
+        (NotificationRouteResolverStatus::Matched, Some(route)) => {
+            NotificationRoute::new(transport, route)
+                .map(Some)
+                .map_err(|_| {
+                    resolver_error("notification route resolver returned an invalid route")
+                })
+        }
+        _ => Err(resolver_error(
+            "notification route resolver returned an invalid result shape",
+        )),
+    }
+}
+
+fn read_bounded(mut reader: impl Read) -> (Vec<u8>, bool) {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let mut oversized = false;
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) | Err(_) => break,
+            Ok(count) => {
+                let remaining = RESOLVER_OUTPUT_LIMIT
+                    .saturating_add(1)
+                    .saturating_sub(output.len());
+                output.extend_from_slice(&buffer[..count.min(remaining)]);
+                oversized |= output.len() > RESOLVER_OUTPUT_LIMIT || count > remaining;
+            }
+        }
+    }
+    (output, oversized)
+}
+
+fn resolver_error(message: &str) -> Error {
+    Error::validation_invalid_argument("notification_route_resolver", message, None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn install_resolver(id: &str, command: &str) {
+        let mut manifest: homeboy_extension_contract::ExtensionManifest =
+            serde_json::from_value(serde_json::json!({
+                "name": "Resolver test",
+                "version": "1.0.0",
+                "notification_transports": [{
+                    "id": "synthetic.completed",
+                    "command": ["true"],
+                    "route_resolver": { "command": ["sh", "-c", command] }
+                }]
+            }))
+            .unwrap();
+        manifest.id = id.to_string();
+        crate::extension_store::save_manifest(&manifest).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selects_one_transport_neutral_resolver_match() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "request=$(cat); [ \"$request\" = '{\"schema\":\"homeboy/notification-route-resolver-request/v1\",\"transport\":\"synthetic.completed\"}' ] || exit 9; printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"matched\",\"route\":\"opaque-thread\"}'");
+            assert_eq!(
+                resolve_installed().unwrap(),
+                Some(NotificationRoute::new("synthetic.completed", "opaque-thread").unwrap())
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unmatched_resolver_preserves_route_less_behavior() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"unmatched\"}'");
+            assert_eq!(resolve_installed().unwrap(), None);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn malformed_and_oversized_results_fail_closed() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "printf not-json");
+            assert!(resolve_installed()
+                .unwrap_err()
+                .to_string()
+                .contains("malformed"));
+        });
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "yes x | head -c 20000");
+            assert!(resolve_installed()
+                .unwrap_err()
+                .to_string()
+                .contains("exceeded"));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ambiguity_invalid_routes_and_timeouts_fail_closed() {
+        crate::test_support::with_isolated_home(|_| {
+            let matched = "printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"matched\",\"route\":\"route\"}'";
+            install_resolver("resolver-one", matched);
+            install_resolver("resolver-two", matched);
+            assert!(resolve_installed()
+                .unwrap_err()
+                .to_string()
+                .contains("more than one"));
+        });
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"matched\",\"route\":\"token=secret\"}'");
+            assert!(resolve_installed()
+                .unwrap_err()
+                .to_string()
+                .contains("invalid route"));
+        });
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "sleep 3");
+            assert!(resolve_installed()
+                .unwrap_err()
+                .to_string()
+                .contains("timed out"));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_route_wins_without_invoking_a_resolver() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver("resolver-test", "sleep 3");
+            let started = Instant::now();
+            let route = resolve_from_cli_or_env(Some("chosen.transport"), Some("chosen-route"))
+                .expect("explicit route is valid");
+            assert!(started.elapsed() < Duration::from_secs(1));
+            assert_eq!(
+                route,
+                Some(NotificationRoute::new("chosen.transport", "chosen-route").unwrap())
+            );
+        });
+    }
+}

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -205,18 +205,21 @@ mod tests {
             schema: "wrong".to_string(),
             id: "test.run-completion".to_string(),
             command: vec!["true".to_string()],
+            route_resolver: None,
         };
         assert!(invalid.validate().is_err());
         let invalid = NotificationTransportConfig {
             schema: NOTIFICATION_TRANSPORT_SCHEMA.to_string(),
             id: "bad id".to_string(),
             command: vec!["true".to_string()],
+            route_resolver: None,
         };
         assert!(invalid.validate().is_err());
         let invalid = NotificationTransportConfig {
             schema: NOTIFICATION_TRANSPORT_SCHEMA.to_string(),
             id: "test.run-completion".to_string(),
             command: vec![],
+            route_resolver: None,
         };
         assert!(invalid.validate().is_err());
     }

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -209,7 +209,11 @@ prefix, never a shell command or template.
   "notification_transports": [{
     "schema": "homeboy/notification-transport/v1",
     "id": "discord.run-completion",
-    "command": ["bin/notify-discord"]
+    "command": ["bin/notify"],
+    "route_resolver": {
+      "schema": "homeboy/notification-route-resolver/v1",
+      "command": ["bin/resolve-notification-route"]
+    }
   }]
 }
 ```
@@ -250,6 +254,47 @@ text-only transport receives the same information as bounded prose.
 Transports that print a JSON object on stdout have it retained verbatim in
 homeboy's `NotifyOutcome.result`, so delivery mode, attempt counts, truncation,
 and classified error kinds survive instead of collapsing to an exit code.
+
+#### Route resolver (optional)
+
+`notification_transports[].route_resolver` lets a transport derive its own
+opaque destination from caller context it owns. The declaration is a versioned,
+non-empty literal argv array. Homeboy does not inspect caller environment names,
+values, or ambient context keys; extensions alone choose what inherited context
+to read. Extension list and show output expose only `has_route_resolver`, never
+resolver argv or caller context.
+
+Homeboy invokes declared resolvers only after neither `--notification-transport`
+plus `--notification-route` nor the paired `HOMEBOY_NOTIFICATION_TRANSPORT` and
+`HOMEBOY_NOTIFICATION_ROUTE` values selected a route. Explicit CLI values win,
+then the environment pair, then exactly one resolver match. No match preserves
+the route-less policy.
+
+The resolver receives this JSON object on stdin:
+
+```json
+{"schema":"homeboy/notification-route-resolver-request/v1","transport":"example.completed"}
+```
+
+It must write exactly one JSON result to stdout:
+
+```json
+{"schema":"homeboy/notification-route-resolver/v1","status":"unmatched"}
+```
+
+or:
+
+```json
+{"schema":"homeboy/notification-route-resolver/v1","status":"matched","route":"opaque-destination"}
+```
+
+Resolvers have a two-second execution limit and a 16 KiB stdout limit. Their
+stderr is not retained. Multiple matches, a non-zero exit, malformed or
+oversized output, a timeout, an unsupported schema, an invalid result shape, or
+an invalid/secret-bearing route fail closed with a typed
+`notification_route_resolver` diagnostic. A selected route is validated and
+bound before durable submission, so detached, fanout, resume, daemon, and
+delivery paths reuse their existing route persistence.
 
 Known sidecar names default to these run-directory paths when `path` is omitted:
 


### PR DESCRIPTION
## Summary

- add a generic extension-owned notification route resolver manifest contract
- resolve bounded typed outputs only after explicit CLI and environment routes
- bind automatic routes through the existing durable detached/fanout/resume lifecycle
- expose resolver availability without command argv or caller context

Closes #11864

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-extension-contract notification_transport_config`
- `cargo test -p homeboy-core notification_route_resolver`
- `cargo check -p homeboy-cli`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented, reviewed, and verified the generic extension-owned route resolver contract under Chris Huber's direction. Chris remains responsible for every line.