### PR TITLE
fix(dev): add deterministic development build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ git clone https://github.com/Extra-Chill/homeboy.git
 cd homeboy && cargo install --path .
 ```
 
+## Development Build
+
+```bash
+./scripts/dev-build
+```
+
+This builds the root package's runnable `homeboy` binary and verifies that its
+embedded commit matches `HEAD`. It respects `CARGO_TARGET_DIR`, including from
+linked worktrees. `homeboy-cli` is the command-layer library; `cargo build -p
+homeboy-cli` does not produce `target/debug/homeboy`.
+
 ## Documentation
 
 Documentation is checked into this repo and embedded in the binary:

--- a/scripts/dev-build
+++ b/scripts/dev-build
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+cargo build --bin homeboy
+
+target_dir="${CARGO_TARGET_DIR:-$root/target}"
+if [[ "$target_dir" != /* ]]; then
+    target_dir="$root/$target_dir"
+fi
+binary="$target_dir/debug/homeboy"
+expected_commit="$(git rev-parse --short=12 HEAD)"
+
+if [[ ! -x "$binary" ]]; then
+    printf 'expected development binary was not produced: %s\n' "$binary" >&2
+    exit 1
+fi
+
+actual_commit="$($binary self identity | jq -r '.data.git_commit // empty')"
+if [[ "$actual_commit" != "$expected_commit" ]]; then
+    printf 'development binary identity mismatch: expected %s, got %s\n' \
+        "$expected_commit" "${actual_commit:-missing}" >&2
+    exit 1
+fi
+
+printf 'built %s at %s\n' "$binary" "$expected_commit"


### PR DESCRIPTION
Closes #11874

Adds `./scripts/dev-build`, which builds the root package `homeboy` binary, honors `CARGO_TARGET_DIR`, and verifies the binary reports the current 12-character HEAD commit through `self identity`. Documents that `homeboy-cli` is a library and does not produce the runnable binary.

Tests:
- `bash -n scripts/dev-build`
- `cargo fmt --all --check`
- `cargo test --locked -p homeboy-product-identity`
- `CARGO_TARGET_DIR=/Users/chubes/Developer/homeboy/target ./scripts/dev-build`
- `CARGO_TARGET_DIR=../homeboy/target ./scripts/dev-build`

AI-assisted: OpenAI GPT-5.6 Sol via OpenCode implemented the root-binary build and identity validation. Chris Huber reviewed and is responsible for every line.