### PR TITLE
fix(agent-task): retain failed provider artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ git clone https://github.com/Extra-Chill/homeboy.git
 cd homeboy && cargo install --path .
 ```
 
+## Development Build
+
+```bash
+./scripts/dev-build
+```
+
+This builds the root package's runnable `homeboy` binary and verifies that its
+embedded commit matches `HEAD`. It respects `CARGO_TARGET_DIR`, including from
+linked worktrees. `homeboy-cli` is the command-layer library; `cargo build -p
+homeboy-cli` does not produce `target/debug/homeboy`.
+
 ## Documentation
 
 Documentation is checked into this repo and embedded in the binary:

--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -18,6 +18,7 @@
 //! the redaction pass because [`RedactionPolicy`] only rewrites known-sensitive
 //! keys and leaves the rest of the JSON intact.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -34,11 +35,22 @@ pub const EXECUTOR_INPUT_EVIDENCE_KIND: &str = "executor-input";
 /// outcome). Surfaced as a first-class run evidence ref.
 pub const EXECUTOR_RESULT_EVIDENCE_KIND: &str = "executor-result";
 
+/// Evidence kinds for Homeboy-owned provider runtime evidence.
+pub const EXECUTOR_ARTIFACT_ROOT_EVIDENCE_KIND: &str = "executor-artifact-root";
+pub const PROVIDER_SESSION_EVIDENCE_KIND: &str = "provider-session";
+pub const RUNTIME_STDOUT_EVIDENCE_KIND: &str = "provider-runtime-stdout";
+pub const RUNTIME_STDERR_EVIDENCE_KIND: &str = "provider-runtime-stderr";
+pub const RUNTIME_PROGRESS_EVIDENCE_KIND: &str = "provider-runtime-progress";
+pub const RUNTIME_EVIDENCE_KIND: &str = "executor-runtime-evidence";
+
 /// File name for the persisted latest raw executor request.
 pub const EXECUTOR_INPUT_FILE: &str = "executor-input.json";
 
 /// File name for the persisted latest raw executor result.
 pub const EXECUTOR_RESULT_FILE: &str = "executor-result.json";
+
+/// File name for the redacted runtime evidence index.
+pub const RUNTIME_EVIDENCE_FILE: &str = "executor-runtime-evidence.json";
 
 /// Persist the latest raw executor request and result for `request`/`outcome`
 /// and append linking evidence refs onto the outcome.
@@ -87,6 +99,137 @@ pub(crate) fn link_latest_executor_evidence(
             },
         );
     }
+
+    link_runtime_evidence(request, outcome, &dir, &policy);
+}
+
+/// Link provider-neutral runtime evidence retained under the executor's owned
+/// artifact root. The index records absent optional streams explicitly, while
+/// individual file refs remain directly hydratable when they exist.
+fn link_runtime_evidence(
+    request: &AgentTaskExecutorRequest,
+    outcome: &mut AgentTaskOutcome,
+    evidence_dir: &Path,
+    policy: &RedactionPolicy,
+) {
+    let artifact_root = request.artifacts_path.canonicalize().ok();
+    let runtime_files = artifact_root
+        .as_deref()
+        .map(discover_runtime_files)
+        .unwrap_or_default();
+    let sessions = provider_session_metadata(outcome);
+    let index = json!({
+        "artifact_root": artifact_root.as_ref().map(|path| format!("file://{}", path.display())),
+        "provider_runtime_identities": sessions,
+        "runtime_stdout": runtime_files.get(RUNTIME_STDOUT_EVIDENCE_KIND),
+        "runtime_stderr": runtime_files.get(RUNTIME_STDERR_EVIDENCE_KIND),
+        "runtime_progress": runtime_files.get(RUNTIME_PROGRESS_EVIDENCE_KIND),
+    });
+    let Some(index_uri) = persist_evidence_file(
+        &evidence_dir.join(RUNTIME_EVIDENCE_FILE),
+        &policy.redact_json(&index),
+    ) else {
+        return;
+    };
+
+    push_unique_evidence_ref(
+        outcome,
+        AgentTaskEvidenceRef {
+            kind: RUNTIME_EVIDENCE_KIND.to_string(),
+            uri: index_uri.clone(),
+            label: Some("provider runtime evidence index".to_string()),
+        },
+    );
+    if let Some(root) = artifact_root {
+        push_unique_evidence_ref(
+            outcome,
+            AgentTaskEvidenceRef {
+                kind: EXECUTOR_ARTIFACT_ROOT_EVIDENCE_KIND.to_string(),
+                uri: format!("file://{}", root.display()),
+                label: Some("executor artifact root".to_string()),
+            },
+        );
+    }
+    if !sessions.is_empty() {
+        push_unique_evidence_ref(
+            outcome,
+            AgentTaskEvidenceRef {
+                kind: PROVIDER_SESSION_EVIDENCE_KIND.to_string(),
+                uri: index_uri,
+                label: Some("provider-native session metadata".to_string()),
+            },
+        );
+    }
+    for (kind, paths) in runtime_files {
+        for path in paths {
+            push_unique_evidence_ref(
+                outcome,
+                AgentTaskEvidenceRef {
+                    kind: kind.clone(),
+                    uri: format!("file://{}", path.display()),
+                    label: Some(kind.replace("provider-", "").replace('-', " ")),
+                },
+            );
+        }
+    }
+}
+
+fn provider_session_metadata(outcome: &AgentTaskOutcome) -> Vec<Value> {
+    outcome
+        .metadata
+        .as_object()
+        .into_iter()
+        .flatten()
+        .filter(|(key, value)| key.to_ascii_lowercase().contains("session") && !value.is_null())
+        .map(|(key, value)| {
+            let id = value
+                .as_object()
+                .and_then(|session| {
+                    ["id", "session_id", "sessionId"]
+                        .iter()
+                        .find_map(|key| session.get(*key).and_then(Value::as_str))
+                })
+                .filter(|id| !id.trim().is_empty());
+            json!({
+                "source": key,
+                "id": id,
+                "details": value,
+            })
+        })
+        .collect()
+}
+
+fn discover_runtime_files(root: &Path) -> BTreeMap<String, Vec<PathBuf>> {
+    let mut files = BTreeMap::new();
+    let Ok(entries) = fs::read_dir(root) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(path) = path.canonicalize() else {
+            continue;
+        };
+        if !path.starts_with(root) || !path.is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+        let kind = if name.contains("runtime") && name.contains("stdout") {
+            Some(RUNTIME_STDOUT_EVIDENCE_KIND)
+        } else if name.contains("runtime") && name.contains("stderr") {
+            Some(RUNTIME_STDERR_EVIDENCE_KIND)
+        } else if name.contains("progress") {
+            Some(RUNTIME_PROGRESS_EVIDENCE_KIND)
+        } else {
+            None
+        };
+        if let Some(kind) = kind {
+            files
+                .entry(kind.to_string())
+                .or_insert_with(Vec::new)
+                .push(path);
+        }
+    }
+    files
 }
 
 fn executor_evidence_dir(run_id: Option<&str>, task_id: &str) -> PathBuf {
@@ -321,7 +464,7 @@ mod tests {
                     .uri
                     .strip_prefix("file://")
                     .expect("file uri prefix");
-                assert!(Path::new(path).is_file(), "evidence file should exist");
+                assert!(Path::new(path).exists(), "evidence path should exist");
             }
         });
     }
@@ -392,6 +535,86 @@ mod tests {
     }
 
     #[test]
+    fn links_retained_runtime_files_and_redacted_provider_session_metadata() {
+        with_artifact_root(|_| {
+            let request = executor_test_request();
+            fs::write(
+                request.artifacts_path.join("provider-runtime-stdout.log"),
+                "runtime stdout",
+            )
+            .expect("write stdout");
+            fs::write(
+                request.artifacts_path.join("provider-runtime-stderr.log"),
+                "runtime stderr",
+            )
+            .expect("write stderr");
+            fs::write(
+                request.artifacts_path.join("provider-progress.jsonl"),
+                "{}\n",
+            )
+            .expect("write progress");
+            let mut outcome = test_outcome();
+            outcome.status = AgentTaskOutcomeStatus::Failed;
+            outcome.metadata = json!({
+                "provider_session": { "id": "session-123", "token": "secret-session-token" }
+            });
+
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
+
+            for kind in [
+                EXECUTOR_ARTIFACT_ROOT_EVIDENCE_KIND,
+                PROVIDER_SESSION_EVIDENCE_KIND,
+                RUNTIME_STDOUT_EVIDENCE_KIND,
+                RUNTIME_STDERR_EVIDENCE_KIND,
+                RUNTIME_PROGRESS_EVIDENCE_KIND,
+            ] {
+                assert!(
+                    outcome
+                        .evidence_refs
+                        .iter()
+                        .any(|evidence| evidence.kind == kind),
+                    "missing {kind} evidence ref"
+                );
+            }
+            let index = outcome
+                .evidence_refs
+                .iter()
+                .find(|evidence| evidence.kind == RUNTIME_EVIDENCE_KIND)
+                .expect("runtime evidence index");
+            let raw = fs::read_to_string(index.uri.strip_prefix("file://").expect("file uri"))
+                .expect("read runtime evidence index");
+            assert!(raw.contains("session-123"));
+            assert!(!raw.contains("secret-session-token"));
+            assert!(raw.contains("[REDACTED]"));
+        });
+    }
+
+    #[test]
+    fn runtime_evidence_index_records_absent_optional_streams() {
+        with_artifact_root(|_| {
+            let request = executor_test_request();
+            let mut outcome = test_outcome();
+
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
+
+            let index = outcome
+                .evidence_refs
+                .iter()
+                .find(|evidence| evidence.kind == RUNTIME_EVIDENCE_KIND)
+                .expect("runtime evidence index");
+            let value: Value = serde_json::from_slice(
+                &fs::read(index.uri.strip_prefix("file://").expect("file uri"))
+                    .expect("read runtime evidence index"),
+            )
+            .expect("parse runtime evidence index");
+            assert_eq!(value["provider_runtime_identities"], json!([]));
+            assert_eq!(value["runtime_stdout"], Value::Null);
+            assert_eq!(value["runtime_stderr"], Value::Null);
+            assert_eq!(value["runtime_progress"], Value::Null);
+        });
+    }
+
+    #[test]
     fn persisted_input_redacts_runtime_tool_literal_environment_values() {
         let mut request = executor_test_request();
         request.request.runtime_tools = vec![serde_json::from_value(json!({
@@ -453,12 +676,14 @@ mod tests {
 
     #[test]
     fn evidence_dir_is_stable_for_a_run_and_task_id() {
-        let first = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
-        let second = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
-        assert_eq!(first, second);
-        assert!(first
-            .to_string_lossy()
-            .contains("agent-task/executor-evidence"));
+        with_artifact_root(|_| {
+            let first = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
+            let second = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
+            assert_eq!(first, second);
+            assert!(first
+                .to_string_lossy()
+                .contains("agent-task/executor-evidence"));
+        });
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
-use crate::agent_task::{AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskOutcome};
+use crate::agent_task::{
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskExecutorRequest, AgentTaskOutcome,
+    AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
+};
 use homeboy_core::{Error, Result};
 
 /// Identity captured after Homeboy creates the executor root and before the
@@ -210,6 +213,206 @@ pub(crate) fn finalize_provider_file_artifacts(
         }
         Ok(())
     }
+}
+
+/// Preserves declared regular files from an attested Cook attempt workspace when
+/// a provider fails before it can serialize its own outcome. Sources remain
+/// provider-owned only until they are copied into the executor root; the normal
+/// finalizer then moves the copied bytes into Homeboy-owned storage.
+pub(crate) fn retain_failed_workspace_artifacts(
+    outcome: &mut AgentTaskOutcome,
+    request: &AgentTaskExecutorRequest,
+) -> Result<()> {
+    if matches!(
+        outcome.status,
+        AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp
+    ) || !outcome.artifacts.is_empty()
+    {
+        return Ok(());
+    }
+    request.artifacts_root_identity.verify()?;
+    let Some(workspace) = request.request.workspace.root.as_deref() else {
+        return Ok(());
+    };
+    let Some(attestation) = request
+        .request
+        .metadata
+        .get("cook_attempt_workspace_identity")
+    else {
+        return Ok(());
+    };
+    let workspace = Path::new(workspace);
+    if !crate::agent_task_workspace_identity::workspace_matches_attestation(workspace, attestation)
+    {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "Cook attempt workspace no longer matches its identity attestation",
+            Some(workspace.display().to_string()),
+            None,
+        ));
+    }
+    let workspace = workspace.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "canonicalize Cook attempt workspace {}",
+                workspace.display()
+            )),
+        )
+    })?;
+
+    for declaration in request.request.canonical_artifact_declarations() {
+        let Some(path) = declaration.path else {
+            continue;
+        };
+        let declared = Path::new(&path);
+        let candidate = if declared.is_absolute() {
+            declared.to_path_buf()
+        } else {
+            workspace.join(declared)
+        };
+        if declared
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+            || (declared.is_absolute() && !candidate.starts_with(&workspace))
+        {
+            retain_failure_diagnostic(outcome, &path, "path is outside the attempt workspace");
+            continue;
+        }
+        let Ok(metadata) = fs::symlink_metadata(&candidate) else {
+            continue;
+        };
+        if is_link_or_reparse_point(&metadata) || !metadata.is_file() {
+            retain_failure_diagnostic(outcome, &path, "path is not a regular file");
+            continue;
+        }
+        if reject_symlink_path_components(&workspace, &candidate).is_err() {
+            retain_failure_diagnostic(outcome, &path, "path traverses a symlink");
+            continue;
+        }
+        let Ok(canonical) = candidate.canonicalize() else {
+            retain_failure_diagnostic(outcome, &path, "path could not be canonicalized");
+            continue;
+        };
+        if !canonical.starts_with(&workspace) {
+            retain_failure_diagnostic(
+                outcome,
+                &path,
+                "path resolves outside the attempt workspace",
+            );
+            continue;
+        }
+
+        let mut input = match open_regular_file_no_follow(&candidate) {
+            Ok(input) => input,
+            Err(_) => {
+                retain_failure_diagnostic(
+                    outcome,
+                    &path,
+                    "path could not be opened as a regular file",
+                );
+                continue;
+            }
+        };
+        if !opened_file_matches_path(&input, &canonical) {
+            retain_failure_diagnostic(
+                outcome,
+                &path,
+                "opened file no longer matches its canonical path",
+            );
+            continue;
+        }
+        let token = declaration_token(&declaration.name);
+        let extension = canonical
+            .extension()
+            .filter(|extension| !extension.is_empty())
+            .map(|extension| format!(".{}", extension.to_string_lossy()))
+            .unwrap_or_default();
+        let staged_name = format!("recovered-{token}-{}{extension}", uuid::Uuid::new_v4());
+        let staged = request.artifacts_path.join(&staged_name);
+        let mut output = File::create(&staged).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "stage recovered workspace artifact {}",
+                    staged.display()
+                )),
+            )
+        })?;
+        std::io::copy(&mut input, &mut output).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("copy recovered workspace artifact".to_string()),
+            )
+        })?;
+        output.sync_all().map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("sync recovered workspace artifact".to_string()),
+            )
+        })?;
+        outcome.artifacts.push(AgentTaskArtifact {
+            schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: format!("recovered-{token}"),
+            kind: declaration
+                .artifact_type
+                .filter(|kind| validate_token("artifact.kind", kind).is_ok())
+                .unwrap_or_else(|| "declared_artifact".to_string()),
+            name: Some(declaration.name),
+            path: Some(staged_name),
+            metadata: json!({ "recovered_from": "attested_attempt_workspace" }),
+            ..Default::default()
+        });
+    }
+    if !crate::agent_task_workspace_identity::workspace_matches_attestation(&workspace, attestation)
+    {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "Cook attempt workspace changed while recovering declared artifacts",
+            Some(workspace.display().to_string()),
+            None,
+        ));
+    }
+    finalize_provider_file_artifacts(outcome, &request.artifacts_root_identity)
+}
+
+fn declaration_token(name: &str) -> String {
+    let mut hash = Sha256::new();
+    hash.update(name.as_bytes());
+    format!("{:x}", hash.finalize())
+}
+
+fn retain_failure_diagnostic(outcome: &mut AgentTaskOutcome, path: &str, reason: &str) {
+    outcome.diagnostics.push(AgentTaskDiagnostic {
+        class: "agent_task.failed_workspace_artifact_rejected".to_string(),
+        message: format!("declared failed-attempt artifact '{path}' was not retained: {reason}"),
+        data: json!({ "path": path, "reason": reason }),
+    });
+}
+
+#[cfg(unix)]
+fn opened_file_matches_path(file: &File, canonical: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(opened) = file.metadata() else {
+        return false;
+    };
+    let Ok(current) = fs::metadata(canonical) else {
+        return false;
+    };
+    opened.is_file()
+        && current.is_file()
+        && opened.dev() == current.dev()
+        && opened.ino() == current.ino()
+}
+
+#[cfg(windows)]
+fn opened_file_matches_path(file: &File, canonical: &Path) -> bool {
+    windows_file_identity(file).ok() == windows_file_identity_from_path(canonical, false).ok()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn opened_file_matches_path(_file: &File, _canonical: &Path) -> bool {
+    false
 }
 
 fn staged_file(

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -16,7 +16,7 @@ use crate::agent_task_process_containment::{
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
@@ -560,22 +560,27 @@ fn run_materialized_provider_command_once_contained(
         );
     }
 
+    let started = Instant::now();
     let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     let stderr_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let last_progress: Arc<AtomicU64> = Arc::new(AtomicU64::new(now_unix_ms()));
+    // Progress and the wall timeout must share a monotonic clock. A system-clock
+    // adjustment must never turn a stale provider into a live one.
+    let last_progress_ms: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
 
     let stdout_reader = child.stdout.take().map(|stdout| {
         spawn_output_reader(
             stdout,
             Arc::clone(&stdout_buffer),
-            Arc::clone(&last_progress),
+            Arc::clone(&last_progress_ms),
+            started,
         )
     });
     let stderr_reader = child.stderr.take().map(|stderr| {
         spawn_output_reader(
             stderr,
             Arc::clone(&stderr_buffer),
-            Arc::clone(&last_progress),
+            Arc::clone(&last_progress_ms),
+            started,
         )
     });
 
@@ -583,7 +588,6 @@ fn run_materialized_provider_command_once_contained(
         let _ = Write::write_all(&mut stdin, &input);
     }
 
-    let started = Instant::now();
     let liveness_timeout = request
         .limits
         .liveness_timeout_ms
@@ -597,9 +601,9 @@ fn run_materialized_provider_command_once_contained(
                     break (None, false, true);
                 }
                 if let Some(liveness) = liveness_timeout {
-                    let progress_age = Duration::from_millis(
-                        now_unix_ms().saturating_sub(last_progress.load(Ordering::SeqCst)),
-                    );
+                    let progress_age = started.elapsed().saturating_sub(Duration::from_millis(
+                        last_progress_ms.load(Ordering::SeqCst),
+                    ));
                     if progress_age >= liveness {
                         break (None, true, false);
                     }
@@ -648,8 +652,14 @@ fn run_materialized_provider_command_once_contained(
     let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_string();
 
     if killed_for_liveness {
-        let (status, classification, message) =
-            classify_stall_or_rate_limit(&stdout, &stderr, &provider.id, requested_timeout_ms);
+        let (status, classification, message) = classify_stall_or_rate_limit(
+            &stdout,
+            &stderr,
+            &provider.id,
+            liveness_timeout
+                .expect("liveness kill requires a configured liveness deadline")
+                .as_millis(),
+        );
         return failure_outcome(
             request,
             status,
@@ -659,6 +669,7 @@ fn run_materialized_provider_command_once_contained(
             json!({
                 "provider": provider.id,
                 "command": command,
+                "deadline": "liveness",
                 "timeout_ms": requested_timeout_ms,
                 "process_timeout_ms": process_timeout.as_millis(),
                 "liveness_timeout_ms": request.limits.liveness_timeout_ms,
@@ -685,7 +696,14 @@ fn run_materialized_provider_command_once_contained(
                 "provider '{}' exceeded timeout_ms={}",
                 provider.id, requested_timeout_ms
             ),
-            json!({ "provider": provider.id, "command": command, "timeout_ms": requested_timeout_ms, "process_timeout_ms": process_timeout.as_millis() }),
+            json!({
+                "provider": provider.id,
+                "command": command,
+                "deadline": "wall_clock",
+                "timeout_ms": requested_timeout_ms,
+                "process_timeout_ms": process_timeout.as_millis(),
+                "liveness_timeout_ms": request.limits.liveness_timeout_ms,
+            }),
         );
     }
     let Some(status) = status else {
@@ -1102,7 +1120,8 @@ fn now_unix_ms() -> u64 {
 fn spawn_output_reader<R>(
     mut reader: R,
     buffer: Arc<Mutex<Vec<u8>>>,
-    last_progress: Arc<AtomicU64>,
+    last_progress_ms: Arc<AtomicU64>,
+    started: Instant,
 ) -> std::thread::JoinHandle<()>
 where
     R: Read + Send + 'static,
@@ -1114,7 +1133,10 @@ where
                 break;
             }
             buffer.lock().expect("output buffer").extend(&chunk[..read]);
-            last_progress.store(now_unix_ms(), Ordering::SeqCst);
+            last_progress_ms.store(
+                u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
         }
     })
 }
@@ -1123,7 +1145,7 @@ fn classify_stall_or_rate_limit(
     stdout: &str,
     stderr: &str,
     provider_id: &str,
-    requested_timeout_ms: u64,
+    liveness_timeout_ms: u128,
 ) -> (
     AgentTaskOutcomeStatus,
     AgentTaskFailureClassification,
@@ -1141,7 +1163,7 @@ fn classify_stall_or_rate_limit(
         AgentTaskOutcomeStatus::ProviderError,
         AgentTaskFailureClassification::Stalled,
         format!(
-            "provider '{provider_id}' produced no stdout/stderr progress before timeout_ms={requested_timeout_ms}"
+            "provider '{provider_id}' produced no stdout/stderr progress before liveness_timeout_ms={liveness_timeout_ms}"
         ),
     )
 }
@@ -1745,12 +1767,11 @@ pub fn run_provider_readiness_invocation(
     }
 
     let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let last_progress = Arc::new(AtomicU64::new(now_unix_ms()));
-    let stdout_reader = child
-        .stdout
-        .take()
-        .map(|stdout| spawn_output_reader(stdout, Arc::clone(&stdout_buffer), last_progress));
+    let last_progress = Arc::new(AtomicU64::new(0));
     let started = Instant::now();
+    let stdout_reader = child.stdout.take().map(|stdout| {
+        spawn_output_reader(stdout, Arc::clone(&stdout_buffer), last_progress, started)
+    });
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1,4 +1,6 @@
-use super::artifact_finalization::finalize_provider_file_artifacts;
+use super::artifact_finalization::{
+    finalize_provider_file_artifacts, retain_failed_workspace_artifacts,
+};
 use super::outcome_normalization::{
     normalize_homeboy_local_artifact_sizes, normalize_provider_outcome_roles,
     push_unique_diagnostic,
@@ -321,6 +323,15 @@ pub(super) fn run_materialized_provider_command_once(
         &mut containment_report,
     );
     containment_report.annotate(&mut outcome);
+    if let Err(error) = retain_failed_workspace_artifacts(&mut outcome, request) {
+        push_unique_diagnostic(
+            &mut outcome.diagnostics,
+            "agent_task.failed_workspace_artifact_retention_failed".to_string(),
+            "Homeboy could not retain declared artifacts from the failed attempt workspace"
+                .to_string(),
+            json!({ "details": error.message }),
+        );
+    }
     outcome
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1,5 +1,6 @@
 use super::common::{request, script};
 use super::*;
+use crate::agent_task::AgentTaskArtifactDeclaration;
 use crate::agent_task_scheduler::{
     AgentTaskAggregateStatus, AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy,
 };
@@ -791,6 +792,48 @@ fn parent_visible_progress_keeps_provider_alive_until_wall_deadline() {
         json!(300)
     );
     assert_eq!(outcome.diagnostics[0].data["timeout_ms"], json!(500));
+}
+
+#[test]
+fn stalled_provider_retains_declared_attempt_workspace_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = linked_cook_source(&temp);
+    let command = format!(
+        "node {}",
+        script("let fs=require('fs'); fs.writeFileSync('partial.patch','retained partial patch\\n'); process.stderr.write('artifact written\\n'); setInterval(() => {}, 1000);")
+    );
+    let (mut request, provider) = request("task-stalled-artifact", command);
+    request.workspace.root = Some(workspace.display().to_string());
+    request.metadata = serde_json::json!({
+        "cook_attempt_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&workspace)
+            .expect("attest workspace"),
+    });
+    request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
+        name: "partial_patch".to_string(),
+        artifact_type: Some("patch".to_string()),
+        artifact_schema: None,
+        path: Some("partial.patch".to_string()),
+        required: true,
+        description: None,
+        metadata: Value::Null,
+    }];
+    request.limits.liveness_timeout_ms = Some(5_000);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    let artifact = outcome.artifacts.first().expect("retained artifact");
+    let path = std::path::Path::new(artifact.path.as_deref().expect("finalized path"));
+    assert_eq!(
+        std::fs::read(path).expect("retained bytes"),
+        b"retained partial patch\n"
+    );
+    assert_eq!(artifact.size_bytes, Some(23));
+    assert_eq!(
+        artifact.sha256,
+        Some(homeboy_core::artifact_metadata::sha256_file(path).expect("retained hash"))
+    );
+    assert_eq!(artifact.metadata["executor_artifact_finalized"], true);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1,5 +1,6 @@
 use super::common::{request, script};
 use super::*;
+use crate::agent_task::AgentTaskArtifactDeclaration;
 use crate::agent_task_scheduler::{
     AgentTaskAggregateStatus, AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy,
 };
@@ -743,6 +744,48 @@ fn stalled_provider_is_killed_and_rotates_to_configured_fallback() {
         "liveness timeout must reap the provider child"
     );
     let _ = fs::remove_file(&pid_path);
+}
+
+#[test]
+fn stalled_provider_retains_declared_attempt_workspace_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = linked_cook_source(&temp);
+    let command = format!(
+        "node {}",
+        script("let fs=require('fs'); fs.writeFileSync('partial.patch','retained partial patch\\n'); process.stderr.write('artifact written\\n'); setInterval(() => {}, 1000);")
+    );
+    let (mut request, provider) = request("task-stalled-artifact", command);
+    request.workspace.root = Some(workspace.display().to_string());
+    request.metadata = serde_json::json!({
+        "cook_attempt_workspace_identity": crate::agent_task_workspace_identity::attest_workspace(&workspace)
+            .expect("attest workspace"),
+    });
+    request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
+        name: "partial_patch".to_string(),
+        artifact_type: Some("patch".to_string()),
+        artifact_schema: None,
+        path: Some("partial.patch".to_string()),
+        required: true,
+        description: None,
+        metadata: Value::Null,
+    }];
+    request.limits.liveness_timeout_ms = Some(5_000);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    let artifact = outcome.artifacts.first().expect("retained artifact");
+    let path = std::path::Path::new(artifact.path.as_deref().expect("finalized path"));
+    assert_eq!(
+        std::fs::read(path).expect("retained bytes"),
+        b"retained partial patch\n"
+    );
+    assert_eq!(artifact.size_bytes, Some(23));
+    assert_eq!(
+        artifact.sha256,
+        Some(homeboy_core::artifact_metadata::sha256_file(path).expect("retained hash"))
+    );
+    assert_eq!(artifact.metadata["executor_artifact_finalized"], true);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -746,6 +746,54 @@ fn stalled_provider_is_killed_and_rotates_to_configured_fallback() {
 }
 
 #[test]
+fn silent_provider_hits_liveness_deadline_before_wall_timeout() {
+    let command = format!("node {}", script("setInterval(() => {}, 1_000);"));
+    let (mut request, provider) = request("task-liveness-silent", command);
+    request.limits.timeout_ms = Some(500);
+    request.limits.liveness_timeout_ms = Some(50);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::Stalled)
+    );
+    assert_eq!(
+        outcome.diagnostics[0].class,
+        "agent_task.provider_liveness_timeout"
+    );
+    assert_eq!(outcome.diagnostics[0].data["deadline"], json!("liveness"));
+    assert_eq!(
+        outcome.diagnostics[0].data["liveness_timeout_ms"],
+        json!(50)
+    );
+    assert_eq!(outcome.diagnostics[0].data["timeout_ms"], json!(500));
+}
+
+#[test]
+fn parent_visible_progress_keeps_provider_alive_until_wall_deadline() {
+    let command = format!(
+        "node {}",
+        script("setInterval(() => process.stderr.write('.'), 10);")
+    );
+    let (mut request, provider) = request("task-liveness-progress", command);
+    request.limits.timeout_ms = Some(500);
+    request.limits.liveness_timeout_ms = Some(300);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Timeout);
+    assert_eq!(outcome.diagnostics[0].class, "agent_task.provider_timeout");
+    assert_eq!(outcome.diagnostics[0].data["deadline"], json!("wall_clock"));
+    assert_eq!(
+        outcome.diagnostics[0].data["liveness_timeout_ms"],
+        json!(300)
+    );
+    assert_eq!(outcome.diagnostics[0].data["timeout_ms"], json!(500));
+}
+
+#[test]
 fn provider_can_return_timeout_payload_during_wrapper_grace() {
     let command = format!(
         "node {}",

--- a/crates/homeboy-agents/src/agent_task_service/status_support.rs
+++ b/crates/homeboy-agents/src/agent_task_service/status_support.rs
@@ -430,6 +430,21 @@ fn hydrate_file_evidence_ref(uri: &str) -> Result<HydratedContent> {
 fn hydrate_local_path_evidence_ref(path: &Path) -> Result<HydratedContent> {
     let metadata =
         fs::metadata(path).map_err(|error| file_evidence_io_error("metadata", path, error))?;
+    if metadata.is_dir() {
+        let mut entries = fs::read_dir(path)
+            .map_err(|error| file_evidence_io_error("read_dir", path, error))?
+            .flatten()
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .collect::<Vec<_>>();
+        entries.sort();
+        return Ok(HydratedContent {
+            source: "directory".to_string(),
+            truncated: false,
+            bytes_read: None,
+            omitted_bytes: None,
+            content: json!({ "path": path, "entries": entries }),
+        });
+    }
     if !metadata.is_file() {
         return Err(homeboy_core::Error::validation_invalid_argument(
             "evidence_ref",
@@ -1023,6 +1038,22 @@ mod tests {
         assert_eq!(
             error.details["context"],
             format!("agent_task.evidence.hydrate.metadata: {}", path.display())
+        );
+    }
+
+    #[test]
+    fn directory_evidence_lists_artifact_root_entries() {
+        let directory = tempfile::tempdir().expect("artifact directory");
+        fs::write(directory.path().join("runtime.log"), "runtime").expect("write runtime log");
+        fs::create_dir(directory.path().join("nested")).expect("create nested directory");
+
+        let hydrated =
+            hydrate_local_path_evidence_ref(directory.path()).expect("hydrate directory");
+
+        assert_eq!(hydrated.source, "directory");
+        assert_eq!(
+            hydrated.content["entries"],
+            json!(["nested", "runtime.log"])
         );
     }
 

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -1043,6 +1043,8 @@ pub(crate) fn filter_component_conventional_bench_workloads(
 }
 
 fn is_component_conventional_bench_workload(path: &Path, component_root: &Path) -> bool {
+    let path = homeboy::core::paths::canonical_or_normalized_local_path(path);
+    let component_root = homeboy::core::paths::canonical_or_normalized_local_path(component_root);
     let Ok(relative) = path.strip_prefix(component_root) else {
         return false;
     };

--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -426,6 +426,30 @@ fn first_warmup_metric(output: BenchOutput) -> f64 {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn conventional_workloads_under_a_symlinked_component_root_are_filtered() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temp root");
+    let component = root.path().join("component");
+    let workload = component.join("bench/fixture.bench.mjs");
+    fs::create_dir_all(workload.parent().expect("bench parent")).expect("create bench directory");
+    fs::write(&workload, "// fixture\n").expect("write workload");
+    let alias = root.path().join("component-alias");
+    symlink(&component, &alias).expect("symlink component");
+
+    let filtered = filter_component_conventional_bench_workloads(
+        vec![workload],
+        Some(alias.to_string_lossy().as_ref()),
+    );
+
+    assert!(
+        filtered.is_empty(),
+        "aliased component roots share an identity"
+    );
+}
+
 fn list_args(component: Option<&str>, rig: Vec<String>) -> BenchListArgs {
     BenchListArgs {
         comp: PositionalComponentArgs {

--- a/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
@@ -113,6 +113,70 @@ fn run_list_serializes_installed_rig_package_evidence() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn run_list_filters_installed_rig_workloads_discovered_under_a_component_alias() {
+    use std::os::unix::fs::symlink;
+
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let fixture_root = tempfile::tempdir().expect("fixture root");
+        let component = fixture_root.path().join("component");
+        let conventional_workload = component.join("bench/fixture.bench.js");
+        fs::create_dir_all(conventional_workload.parent().expect("bench directory"))
+            .expect("create bench directory");
+        fs::write(&conventional_workload, "// fixture\n").expect("write workload");
+
+        let package_root = home.path().join("installed-rig-package");
+        let rig_dir = package_root.join("rigs/installed-alias-rig");
+        fs::create_dir_all(&rig_dir).expect("create rig directory");
+        fs::write(
+            rig_dir.join("rig.json"),
+            format!(
+                r#"{{
+                    "components": {{
+                        "studio": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "studio" }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "path": "${{components.studio.path}}/bench/fixture.bench.js" }}
+                    ] }}
+                }}"#,
+                component.display()
+            ),
+        )
+        .expect("write rig");
+        homeboy::rig::install(
+            package_root.to_string_lossy().as_ref(),
+            Some("installed-alias-rig"),
+            false,
+        )
+        .expect("install rig");
+
+        let alias = fixture_root.path().join("component-alias");
+        symlink(&component, &alias).expect("symlink component");
+        let mut args = list_args(None, vec!["installed-alias-rig".to_string()]);
+        args.comp.path = Some(alias.to_string_lossy().into_owned());
+
+        let (output, exit_code) = run_list(&args).expect("list installed rig through alias");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 3);
+                assert!(result
+                    .scenarios
+                    .iter()
+                    .all(|scenario| scenario.id != "fixture"));
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
 #[test]
 fn run_list_prefers_enclosing_local_rig_package_over_installed_package() {
     let _guard = current_dir_lock().lock().expect("lock current dir");

--- a/crates/homeboy-core/src/paths_tests.rs
+++ b/crates/homeboy-core/src/paths_tests.rs
@@ -16,6 +16,40 @@ use crate::paths::{
 use crate::test_support::with_isolated_home;
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+#[test]
+fn canonical_or_normalized_local_path_resolves_symlink_identity() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temp root");
+    let target = root.path().join("target");
+    std::fs::create_dir(&target).expect("create target");
+    let alias = root.path().join("alias");
+    symlink(&target, &alias).expect("symlink target");
+
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path(&target),
+        crate::paths::canonical_or_normalized_local_path(&alias)
+    );
+}
+
+#[test]
+fn canonical_or_normalized_local_path_preserves_nonexistent_path_normalization() {
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path("/missing/root/../workload.bench.mjs"),
+        PathBuf::from("/missing/workload.bench.mjs")
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn canonical_or_normalized_local_path_resolves_the_var_alias() {
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path("/var"),
+        crate::paths::canonical_or_normalized_local_path("/private/var")
+    );
+}
+
 #[test]
 fn join_remote_path_allows_absolute_paths_without_base() {
     assert_eq!(

--- a/crates/homeboy-extension/src/bench/parsing/mod.rs
+++ b/crates/homeboy-extension/src/bench/parsing/mod.rs
@@ -65,7 +65,7 @@ mod normalize;
 mod validate;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::structured_sidecar;
@@ -218,7 +218,8 @@ fn resolve_duplicate_scenario_ids(
         return Ok(());
     };
 
-    let preferred_workspace_path = preferred_workspace_path.map(lexical_normalize_path);
+    let preferred_workspace_path =
+        preferred_workspace_path.map(homeboy_core::paths::canonical_or_normalized_local_path);
     let mut seen_id_paths = BTreeSet::new();
     scenarios.retain(|scenario| {
         let Some(id) = scenario.get("id").and_then(serde_json::Value::as_str) else {
@@ -351,26 +352,12 @@ fn display_path_key(path: &str, base_path: Option<&Path>) -> String {
 fn path_with_base(path: &str, base_path: Option<&Path>) -> PathBuf {
     let path = PathBuf::from(path);
     if path.is_absolute() {
-        lexical_normalize_path(&path)
+        homeboy_core::paths::canonical_or_normalized_local_path(path)
     } else if let Some(base_path) = base_path {
-        lexical_normalize_path(&base_path.join(path))
+        homeboy_core::paths::canonical_or_normalized_local_path(base_path.join(path))
     } else {
-        lexical_normalize_path(&path)
+        homeboy_core::paths::canonical_or_normalized_local_path(path)
     }
-}
-
-fn lexical_normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
 }
 
 #[cfg(test)]
@@ -450,6 +437,67 @@ mod tests {
         assert_eq!(parsed.scenarios.len(), 1);
         assert_eq!(parsed.scenarios[0].id, "static-site-fixture-matrix");
         assert_eq!(parsed.scenarios[0].metrics.get("p95_ms"), Some(1.0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn duplicate_scenario_ids_from_symlinked_workspace_are_deduped() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace = root.path().join("workspace");
+        let bench = workspace.join("bench");
+        std::fs::create_dir_all(&bench).expect("create bench directory");
+        let workload = bench.join("fixture.bench.mjs");
+        std::fs::write(&workload, "// fixture\n").expect("write workload");
+        let alias = root.path().join("workspace-alias");
+        symlink(&workspace, &alias).expect("symlink workspace");
+
+        let raw = format!(
+            r#"{{
+                "component_id": "example",
+                "iterations": 0,
+                "scenarios": [
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }},
+                    {{ "id": "fixture", "file": "bench/fixture.bench.mjs", "iterations": 0, "metrics": {{}} }}
+                ]
+            }}"#,
+            alias.join("bench/fixture.bench.mjs").display(),
+        );
+
+        let parsed = parse_bench_results_str_with_artifact_context_scenarios_and_workspace(
+            &raw,
+            None,
+            &["fixture".to_string()],
+            Some(&workspace),
+        )
+        .expect("filesystem aliases should identify one scenario source");
+
+        assert_eq!(parsed.scenarios.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_scenario_ids_from_distinct_existing_files_are_diagnostic() {
+        let root = tempfile::tempdir().expect("temp root");
+        let first = root.path().join("one.bench.mjs");
+        let second = root.path().join("two.bench.mjs");
+        std::fs::write(&first, "// first\n").expect("write first workload");
+        std::fs::write(&second, "// second\n").expect("write second workload");
+        let raw = format!(
+            r#"{{
+                "component_id": "example",
+                "iterations": 0,
+                "scenarios": [
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }},
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }}
+                ]
+            }}"#,
+            first.display(),
+            second.display(),
+        );
+
+        let err = parse_bench_results_str(&raw).expect_err("distinct files must remain distinct");
+        assert!(err.to_string().contains("duplicate_scenario_id"));
     }
 
     #[test]

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -331,6 +331,17 @@ pub fn normalize_local_path(path: impl AsRef<Path>) -> PathBuf {
     }
 }
 
+/// Resolve an existing local path to its filesystem identity, falling back to
+/// lexical normalization when the path does not exist yet.
+///
+/// This makes aliases such as symlinked roots and macOS's `/var` ->
+/// `/private/var` resolve to one identity without conflating distinct paths
+/// that cannot be canonicalized.
+pub fn canonical_or_normalized_local_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    std::fs::canonicalize(path).unwrap_or_else(|_| normalize_local_path(path))
+}
+
 /// Render each path component as a lossy UTF-8 string, in order.
 ///
 /// Centralizes the `path.components()` + `as_os_str().to_string_lossy()`

--- a/scripts/dev-build
+++ b/scripts/dev-build
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+cargo build --bin homeboy
+
+target_dir="${CARGO_TARGET_DIR:-$root/target}"
+if [[ "$target_dir" != /* ]]; then
+    target_dir="$root/$target_dir"
+fi
+binary="$target_dir/debug/homeboy"
+expected_commit="$(git rev-parse --short=12 HEAD)"
+
+if [[ ! -x "$binary" ]]; then
+    printf 'expected development binary was not produced: %s\n' "$binary" >&2
+    exit 1
+fi
+
+actual_commit="$($binary self identity | jq -r '.data.git_commit // empty')"
+if [[ "$actual_commit" != "$expected_commit" ]]; then
+    printf 'development binary identity mismatch: expected %s, got %s\n' \
+        "$expected_commit" "${actual_commit:-missing}" >&2
+    exit 1
+fi
+
+printf 'built %s at %s\n' "$binary" "$expected_commit"


### PR DESCRIPTION
## Summary
- retain declared regular files from attested failed Cook attempt workspaces before scheduler cleanup
- stage bytes under the Homeboy executor root and finalize through the existing artifact contract
- cover a provider that writes a patch then stalls, asserting retained bytes, hash, and finalized reference

Closes #11866

## Verification
- cargo test -p homeboy-agents stalled_provider_retains_declared_attempt_workspace_artifact --lib
- cargo test -p homeboy-agents artifact_finalization --lib
- cargo fmt --check

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the failed-attempt artifact retention path and tests. Chris Huber remains responsible for every line.