### PR TITLE
fix(bench): canonicalize scenario paths

### DIFF
--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -1043,6 +1043,8 @@ pub(crate) fn filter_component_conventional_bench_workloads(
 }
 
 fn is_component_conventional_bench_workload(path: &Path, component_root: &Path) -> bool {
+    let path = homeboy::core::paths::canonical_or_normalized_local_path(path);
+    let component_root = homeboy::core::paths::canonical_or_normalized_local_path(component_root);
     let Ok(relative) = path.strip_prefix(component_root) else {
         return false;
     };

--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -426,6 +426,30 @@ fn first_warmup_metric(output: BenchOutput) -> f64 {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn conventional_workloads_under_a_symlinked_component_root_are_filtered() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temp root");
+    let component = root.path().join("component");
+    let workload = component.join("bench/fixture.bench.mjs");
+    fs::create_dir_all(workload.parent().expect("bench parent")).expect("create bench directory");
+    fs::write(&workload, "// fixture\n").expect("write workload");
+    let alias = root.path().join("component-alias");
+    symlink(&component, &alias).expect("symlink component");
+
+    let filtered = filter_component_conventional_bench_workloads(
+        vec![workload],
+        Some(alias.to_string_lossy().as_ref()),
+    );
+
+    assert!(
+        filtered.is_empty(),
+        "aliased component roots share an identity"
+    );
+}
+
 fn list_args(component: Option<&str>, rig: Vec<String>) -> BenchListArgs {
     BenchListArgs {
         comp: PositionalComponentArgs {

--- a/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
@@ -113,6 +113,70 @@ fn run_list_serializes_installed_rig_package_evidence() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn run_list_filters_installed_rig_workloads_discovered_under_a_component_alias() {
+    use std::os::unix::fs::symlink;
+
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let fixture_root = tempfile::tempdir().expect("fixture root");
+        let component = fixture_root.path().join("component");
+        let conventional_workload = component.join("bench/fixture.bench.js");
+        fs::create_dir_all(conventional_workload.parent().expect("bench directory"))
+            .expect("create bench directory");
+        fs::write(&conventional_workload, "// fixture\n").expect("write workload");
+
+        let package_root = home.path().join("installed-rig-package");
+        let rig_dir = package_root.join("rigs/installed-alias-rig");
+        fs::create_dir_all(&rig_dir).expect("create rig directory");
+        fs::write(
+            rig_dir.join("rig.json"),
+            format!(
+                r#"{{
+                    "components": {{
+                        "studio": {{
+                            "path": "{}",
+                            "extensions": {{ "fixture-bench": {{}} }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "studio" }},
+                    "bench_workloads": {{ "fixture-bench": [
+                        {{ "path": "${{components.studio.path}}/bench/fixture.bench.js" }}
+                    ] }}
+                }}"#,
+                component.display()
+            ),
+        )
+        .expect("write rig");
+        homeboy::rig::install(
+            package_root.to_string_lossy().as_ref(),
+            Some("installed-alias-rig"),
+            false,
+        )
+        .expect("install rig");
+
+        let alias = fixture_root.path().join("component-alias");
+        symlink(&component, &alias).expect("symlink component");
+        let mut args = list_args(None, vec!["installed-alias-rig".to_string()]);
+        args.comp.path = Some(alias.to_string_lossy().into_owned());
+
+        let (output, exit_code) = run_list(&args).expect("list installed rig through alias");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 3);
+                assert!(result
+                    .scenarios
+                    .iter()
+                    .all(|scenario| scenario.id != "fixture"));
+            }
+            _ => panic!("expected list output"),
+        }
+    });
+}
+
 #[test]
 fn run_list_prefers_enclosing_local_rig_package_over_installed_package() {
     let _guard = current_dir_lock().lock().expect("lock current dir");

--- a/crates/homeboy-core/src/paths_tests.rs
+++ b/crates/homeboy-core/src/paths_tests.rs
@@ -16,6 +16,40 @@ use crate::paths::{
 use crate::test_support::with_isolated_home;
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+#[test]
+fn canonical_or_normalized_local_path_resolves_symlink_identity() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("temp root");
+    let target = root.path().join("target");
+    std::fs::create_dir(&target).expect("create target");
+    let alias = root.path().join("alias");
+    symlink(&target, &alias).expect("symlink target");
+
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path(&target),
+        crate::paths::canonical_or_normalized_local_path(&alias)
+    );
+}
+
+#[test]
+fn canonical_or_normalized_local_path_preserves_nonexistent_path_normalization() {
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path("/missing/root/../workload.bench.mjs"),
+        PathBuf::from("/missing/workload.bench.mjs")
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn canonical_or_normalized_local_path_resolves_the_var_alias() {
+    assert_eq!(
+        crate::paths::canonical_or_normalized_local_path("/var"),
+        crate::paths::canonical_or_normalized_local_path("/private/var")
+    );
+}
+
 #[test]
 fn join_remote_path_allows_absolute_paths_without_base() {
     assert_eq!(

--- a/crates/homeboy-extension/src/bench/parsing/mod.rs
+++ b/crates/homeboy-extension/src/bench/parsing/mod.rs
@@ -65,7 +65,7 @@ mod normalize;
 mod validate;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::structured_sidecar;
@@ -218,7 +218,8 @@ fn resolve_duplicate_scenario_ids(
         return Ok(());
     };
 
-    let preferred_workspace_path = preferred_workspace_path.map(lexical_normalize_path);
+    let preferred_workspace_path =
+        preferred_workspace_path.map(homeboy_core::paths::canonical_or_normalized_local_path);
     let mut seen_id_paths = BTreeSet::new();
     scenarios.retain(|scenario| {
         let Some(id) = scenario.get("id").and_then(serde_json::Value::as_str) else {
@@ -351,26 +352,12 @@ fn display_path_key(path: &str, base_path: Option<&Path>) -> String {
 fn path_with_base(path: &str, base_path: Option<&Path>) -> PathBuf {
     let path = PathBuf::from(path);
     if path.is_absolute() {
-        lexical_normalize_path(&path)
+        homeboy_core::paths::canonical_or_normalized_local_path(path)
     } else if let Some(base_path) = base_path {
-        lexical_normalize_path(&base_path.join(path))
+        homeboy_core::paths::canonical_or_normalized_local_path(base_path.join(path))
     } else {
-        lexical_normalize_path(&path)
+        homeboy_core::paths::canonical_or_normalized_local_path(path)
     }
-}
-
-fn lexical_normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
 }
 
 #[cfg(test)]
@@ -450,6 +437,67 @@ mod tests {
         assert_eq!(parsed.scenarios.len(), 1);
         assert_eq!(parsed.scenarios[0].id, "static-site-fixture-matrix");
         assert_eq!(parsed.scenarios[0].metrics.get("p95_ms"), Some(1.0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn duplicate_scenario_ids_from_symlinked_workspace_are_deduped() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("temp root");
+        let workspace = root.path().join("workspace");
+        let bench = workspace.join("bench");
+        std::fs::create_dir_all(&bench).expect("create bench directory");
+        let workload = bench.join("fixture.bench.mjs");
+        std::fs::write(&workload, "// fixture\n").expect("write workload");
+        let alias = root.path().join("workspace-alias");
+        symlink(&workspace, &alias).expect("symlink workspace");
+
+        let raw = format!(
+            r#"{{
+                "component_id": "example",
+                "iterations": 0,
+                "scenarios": [
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }},
+                    {{ "id": "fixture", "file": "bench/fixture.bench.mjs", "iterations": 0, "metrics": {{}} }}
+                ]
+            }}"#,
+            alias.join("bench/fixture.bench.mjs").display(),
+        );
+
+        let parsed = parse_bench_results_str_with_artifact_context_scenarios_and_workspace(
+            &raw,
+            None,
+            &["fixture".to_string()],
+            Some(&workspace),
+        )
+        .expect("filesystem aliases should identify one scenario source");
+
+        assert_eq!(parsed.scenarios.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_scenario_ids_from_distinct_existing_files_are_diagnostic() {
+        let root = tempfile::tempdir().expect("temp root");
+        let first = root.path().join("one.bench.mjs");
+        let second = root.path().join("two.bench.mjs");
+        std::fs::write(&first, "// first\n").expect("write first workload");
+        std::fs::write(&second, "// second\n").expect("write second workload");
+        let raw = format!(
+            r#"{{
+                "component_id": "example",
+                "iterations": 0,
+                "scenarios": [
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }},
+                    {{ "id": "fixture", "file": "{}", "iterations": 0, "metrics": {{}} }}
+                ]
+            }}"#,
+            first.display(),
+            second.display(),
+        );
+
+        let err = parse_bench_results_str(&raw).expect_err("distinct files must remain distinct");
+        assert!(err.to_string().contains("duplicate_scenario_id"));
     }
 
     #[test]

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -331,6 +331,17 @@ pub fn normalize_local_path(path: impl AsRef<Path>) -> PathBuf {
     }
 }
 
+/// Resolve an existing local path to its filesystem identity, falling back to
+/// lexical normalization when the path does not exist yet.
+///
+/// This makes aliases such as symlinked roots and macOS's `/var` ->
+/// `/private/var` resolve to one identity without conflating distinct paths
+/// that cannot be canonicalized.
+pub fn canonical_or_normalized_local_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    std::fs::canonicalize(path).unwrap_or_else(|_| normalize_local_path(path))
+}
+
 /// Render each path component as a lossy UTF-8 string, in order.
 ///
 /// Centralizes the `path.components()` + `as_os_str().to_string_lossy()`


### PR DESCRIPTION
Closes #10903

## Summary
- resolve existing local paths to canonical filesystem identities while retaining lexical normalization for paths that do not exist
- apply identity comparison to conventional workload filtering and duplicate scenario source resolution
- cover symlink and macOS `/var` aliases, repo-relative discovery, installed rig filtering, nonexistent paths, and distinct real files

## Verification
- `cargo fmt --all`
- `cargo test -p homeboy-extension duplicate_scenario_ids -- --nocapture`
- `cargo test -p homeboy-cli run_list_filters_installed_rig_workloads_discovered_under_a_component_alias -- --nocapture`
- `cargo test -p homeboy-core canonical_or_normalized_local_path -- --nocapture`
- `cargo clippy -p homeboy-paths -- -D warnings`
- Multi-crate clippy remains blocked by pre-existing `clippy::unnecessary_sort_by` in `crates/homeboy-core/src/notify_outbox.rs:378`; this PR does not modify that file.

## AI assistance
AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented the filesystem identity handling and regression coverage. Chris Huber reviewed the change.