### PR TITLE
fix(agents): keep fixture name out of executor tests

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -492,12 +492,12 @@ mod tests {
     fn workspace_permission_root_is_emitted_only_for_the_versioned_capability() {
         let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
             "id": "permission-aware",
-            "backend": "fixture",
+            "backend": "permission-aware",
             "capabilities": [AGENT_TASK_PROVIDER_CAPABILITY_WORKSPACE_PERMISSION_ROOT_V1]
         }))
         .expect("provider declaration");
         let mut executor = AgentTaskExecutor {
-            backend: "fixture".to_string(),
+            backend: "permission-aware".to_string(),
             selector: None,
             runtime_selection: None,
             required_capabilities: Vec::new(),
@@ -513,7 +513,7 @@ mod tests {
         let provider_without_capability: AgentTaskExecutorProvider =
             serde_json::from_value(json!({
                 "id": "unaware",
-                "backend": "fixture"
+                "backend": "permission-aware"
             }))
             .expect("provider declaration");
         let mut unaffected = executor.clone();


### PR DESCRIPTION
Closes #11885.

The fixture gate correctly protects the production executor from literal reserved-backend branches. Its source scan was failing because an unrelated `#[cfg(test)]` capability unit test used the reserved `fixture` value. This replaces those values with `permission-aware`, keeping the full-file architecture guard strict and the executor dispatch through `fixture_provider_outcome`.

Verification:
- `cargo test -p homeboy-agents agent_task_provider::fixture_gate::tests::the_provider_executor_never_branches_on_the_backend_name_by_string -- --exact`
- `cargo test -p homeboy-agents agent_task_provider::` ran 172 tests; 169 passed and three pre-existing parallel-suite isolation failures were confirmed passing individually on unchanged `origin/main`.
- `cargo fmt --check` passed.
- `cargo clippy -p homeboy-agents --all-targets -- -D warnings` is baseline-blocked identically on `origin/main` by `crates/homeboy-core/src/notify_outbox.rs:378` (`clippy::unnecessary_sort_by`).

AI assistance: OpenAI gpt-5.6-terra via OpenCode reproduced the regression, traced the test-only literal, implemented the minimal correction, and ran verification. Chris Huber remains responsible for every line.