### PR TITLE
test(agents): assert controller-local placement stamp

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -845,7 +845,7 @@ mod execution_placement_tests {
     }
 
     #[test]
-    fn normalization_only_projects_an_explicit_plan_decision() {
+    fn normalization_preserves_submission_stamp_and_projects_explicit_plan_decision() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let plan = super::super::tests::test_plan();
             let record =
@@ -853,10 +853,19 @@ mod execution_placement_tests {
                     .expect("submit plan");
 
             let normalized = normalize_local_execution_placement(&record.run_id)
-                .expect("unclassified controller plan remains unchanged");
+                .expect("submission stamp remains authoritative");
+            let submission_decision: homeboy_lab_runner_contract::ExecutionPlacementDecision =
+                serde_json::from_value(normalized.metadata["execution_placement_decision"].clone())
+                    .expect("controller-local submission records a canonical decision");
+            assert!(submission_decision.is_submission_stamp());
+            assert_eq!(
+                submission_decision.selected,
+                EffectiveExecutionPlacement::Local
+            );
+            assert!(submission_decision.permits_local_execution());
             assert!(normalized
                 .metadata
-                .get("execution_placement_decision")
+                .get("execution_placement_normalization")
                 .is_none());
             assert_eq!(load_plan(&record.run_id).expect("durable plan"), plan);
 


### PR DESCRIPTION
## Summary

Updates the stale placement-normalization test expectation after #11666. A plan without a routed placement decision now produces a typed, submission-derived controller-local stamp; read-only normalization preserves that stamp. The explicit plan-decision restoration case remains covered.

Closes #11886.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents --lib agent_task_lifecycle::lifecycle_ops::execution_placement_tests -- --nocapture` (6 passed)
- `cargo clippy -p homeboy-agents --lib -- -D warnings` is blocked by pre-existing `clippy::unnecessary_sort_by` in `crates/homeboy-core/src/notify_outbox.rs:378` on the `origin/main` base.

AI assistance: OpenAI gpt-5.6-sol via OpenCode was used to reproduce the release failure, inspect the compatibility contract, implement the test repair, and run verification. Chris remains responsible for every line.