### PR TITLE
fix(tests): prove local cancellation reaps owned tree

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -15,6 +15,10 @@ use crate::agent_task_scheduler::{
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
+#[cfg(unix)]
+use std::io::{BufRead, BufReader};
+#[cfg(unix)]
+use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 
 #[test]
@@ -1941,6 +1945,7 @@ fn mark_running_reclaims_stale_running_record() {
     });
 }
 
+#[cfg(unix)]
 #[test]
 fn cancel_run_signals_live_running_record() {
     with_isolated_home(|_| {
@@ -1948,18 +1953,48 @@ fn cancel_run_signals_live_running_record() {
         submit_plan(&plan, Some("run-cancel-live")).expect("submitted");
         mark_running("run-cancel-live").expect("marked running");
 
+        // The test binary cannot be a cancellation target: process cleanup
+        // correctly excludes the current PID. Use a separate owner with a
+        // descendant that ignores SIGTERM, proving the SIGKILL path reaps both.
+        let mut child = std::process::Command::new("sh")
+            .args([
+                "-c",
+                "trap '' TERM; (trap '' TERM; exec sleep 30) & echo $!; wait",
+            ])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn live owned process tree");
+        let stdout = child.stdout.take().expect("child stdout");
+        let mut stdout = BufReader::new(stdout);
+        let mut descendant_pid = String::new();
+        stdout
+            .read_line(&mut descendant_pid)
+            .expect("read descendant pid");
+        let descendant_pid: u32 = descendant_pid.trim().parse().expect("descendant pid");
+        let owner_pid = child.id();
+        let mut running = store::read_record("run-cancel-live").expect("running record");
+        running.metadata["runner_pid"] = json!(owner_pid);
+        store::write_record(&running).expect("persist owned process identity");
+
         let cancelled = cancel_run("run-cancel-live", None).expect("live run cancelled");
 
         assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
         assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
         assert_eq!(
             cancelled.metadata["live_cancellation"]["owner_pid"],
-            json!(std::process::id())
+            json!(owner_pid)
         );
         assert_eq!(
             cancelled.metadata["live_cancellation"]["signal"],
-            json!("SIGTERM")
+            json!("SIGKILL")
         );
+        assert!(cancelled.metadata["live_cancellation"]["killed_pids"]
+            .as_array()
+            .expect("SIGKILL targets")
+            .iter()
+            .any(|pid| pid == &json!(descendant_pid)));
+        assert!(!homeboy_core::process::pid_is_running(owner_pid));
+        assert!(!homeboy_core::process::pid_is_running(descendant_pid));
     });
 }
 


### PR DESCRIPTION
Closes #11887

## Summary

Replaces the self-PID fixture in `cancel_run_signals_live_running_record` with an independently spawned owner and descendant that both ignore SIGTERM. The test now verifies generic lifecycle cancellation escalates to SIGKILL, records the actual owner, and proves both processes are gone.

No termination grace period changed. Existing generic process cleanup remains fail-closed when SIGKILL survivors are observed.

## Evidence

Current `origin/main` was `0cad5a5421a26eab1f322339bc65c0b08b958b50`. The old focused test passed 20/20 but was structurally vacuous because its owner was `std::process::id()`, which cancellation intentionally excludes.

Passed:

```sh
# 10 consecutive runs
for run in {1..10}; do
  cargo test -p homeboy-agents \
    agent_task_lifecycle::tests::status_and_recovery::cancel_run_signals_live_running_record \
    -- --exact --nocapture
done

cargo test -p homeboy-core terminate_process_tree -- --nocapture
cargo fmt --check
```

`cargo clippy -p homeboy-agents --tests -- -D warnings` is blocked by an unrelated baseline lint in `crates/homeboy-core/src/notify_outbox.rs:378`: `clippy::unnecessary_sort_by`. This PR does not modify that file.

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Used for: refreshed `origin/main`, searched existing issues and PRs, reproduced the lifecycle test repeatedly, inspected process ownership and cleanup behavior, implemented the deterministic fixture, and ran focused verification under Chris Huber's direction.