### PR TITLE
test(cook): use real paths for finalization fixtures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6912,6 +6912,14 @@ fn promotion(run_id: &str) -> AgentTaskPromotionReport {
         })).unwrap()
 }
 
+fn promotion_with_existing_path(run_id: &str, path: &std::path::Path) -> AgentTaskPromotionReport {
+    let mut promotion = promotion(run_id);
+    let path = path.display().to_string();
+    promotion.target.path = Some(path.clone());
+    promotion.provenance["worktree_path"] = serde_json::json!(path);
+    promotion
+}
+
 fn tracked_promotion_continuation_options(
     cook_id: &str,
     run_id: &str,
@@ -8052,6 +8060,7 @@ fn persisted_promotion_from_another_attempt_is_rejected() {
 fn cook_successful_concrete_attempt_publishes_reviewer_body() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "cook-8058-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
         let mut fixture_options =
             batch_cook_options("cook-8058", Arc::new(AcceptedDetachedAttemptDispatcher));
         fixture_options.initial_plan.tasks[0].executor.backend = "fixture-provider".to_string();
@@ -8092,8 +8101,12 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
         persist_initial_recipe(&options).unwrap();
         agent_task_lifecycle::record_cook_attempt("cook-8058", 1, run_id).unwrap();
         seed_review_form_aggregate(run_id, &plan);
-        let mut backend = CaptureBackend::default();
-        finalize_cook_pr_with_backend(&options, run_id, &promotion(run_id), &mut backend).unwrap();
+        let promotion = promotion_with_existing_path(run_id, target.path());
+        let mut backend = CaptureBackend {
+            synthetic_gate_proof: Some(promotion.clone()),
+            ..Default::default()
+        };
+        finalize_cook_pr_with_backend(&options, run_id, &promotion, &mut backend).unwrap();
         for section in [
                 "## Summary",
                 "## What changed",
@@ -8182,6 +8195,7 @@ fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980-normal";
         let run_id = "cook-10980-normal-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.initial_run_id = run_id.to_string();
         options.head = Some("fix/8058".to_string());
@@ -8193,10 +8207,10 @@ fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
         persist_initial_recipe(&options).expect("persist recipe");
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
         seed_review_form_aggregate(run_id, &options.initial_plan);
+        let promotion = promotion_with_existing_path(run_id, target.path());
 
-        let mut manual =
-            cook_finalization_options(&options, run_id, &promotion(run_id), Vec::new())
-                .expect("manual options");
+        let mut manual = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("manual options");
         manual.manual_finalization = true;
         let mut preflight_backend = CaptureBackend {
             candidate_state: Some(
@@ -8218,11 +8232,14 @@ fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
             .metadata["cook_finalization"]
             .is_null());
 
-        let mut normal_backend = CaptureBackend::default();
+        let mut normal_backend = CaptureBackend {
+            synthetic_gate_proof: Some(promotion.clone()),
+            ..Default::default()
+        };
         let receipt = finalize_or_load_cook_pr_with_backend(
             &options,
             run_id,
-            &promotion(run_id),
+            &promotion,
             &mut normal_backend,
         )
         .expect("normal Cook finalization continues");
@@ -8247,6 +8264,7 @@ fn manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980";
         let run_id = "cook-10980-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.initial_run_id = run_id.to_string();
         options.head = Some("fix/8058".to_string());
@@ -8258,10 +8276,10 @@ fn manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering
         persist_initial_recipe(&options).expect("persist recipe");
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
         seed_review_form_aggregate(run_id, &options.initial_plan);
+        let promotion = promotion_with_existing_path(run_id, target.path());
 
-        let mut finalization =
-            cook_finalization_options(&options, run_id, &promotion(run_id), Vec::new())
-                .expect("manual finalization options");
+        let mut finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("manual finalization options");
         finalization.manual_finalization = true;
         let clean_candidate =
             crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
@@ -8556,6 +8574,7 @@ fn recovered_cook_finalization_uses_latest_resumed_gate_contract() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-8307";
         let run_id = "cook-8307-attempt-2";
+        let target = tempfile::tempdir().expect("fixture target");
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.initial_run_id = run_id.to_string();
         options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
@@ -8568,19 +8587,26 @@ fn recovered_cook_finalization_uses_latest_resumed_gate_contract() {
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
         seed_review_form_aggregate(run_id, &options.initial_plan);
 
-        let mut resumed = promotion(run_id);
+        let mut resumed = promotion_with_existing_path(run_id, target.path());
         resumed.deterministic_gates[0].command = vec![
             "sh".to_string(),
             "-lc".to_string(),
             "cargo test resumed-gate-contract".to_string(),
         ];
         resumed.gate_results[0].name = "cargo test resumed-gate-contract".to_string();
-        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(resumed).unwrap())
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&resumed).unwrap())
             .expect("record latest applied promotion");
 
-        let report =
-            recover_cook_pr_with_backend(cook_id, Vec::new(), true, &mut CaptureBackend::default())
-                .expect("recovered preflight");
+        let report = recover_cook_pr_with_backend(
+            cook_id,
+            Vec::new(),
+            true,
+            &mut CaptureBackend {
+                synthetic_gate_proof: Some(resumed),
+                ..Default::default()
+            },
+        )
+        .expect("recovered preflight");
         assert_eq!(
             report["review_dossier"]["how_to_test"][0]["command"],
             "cargo test resumed-gate-contract"
@@ -8599,6 +8625,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-11290";
         let run_id = "cook-11290-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.initial_run_id = run_id.to_string();
         options.head = Some("fix/8058".to_string());
@@ -8607,7 +8634,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
         seed_review_form_aggregate(run_id, &options.initial_plan);
 
-        let mut failed = promotion(run_id);
+        let mut failed = promotion_with_existing_path(run_id, target.path());
         failed.status = crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed;
         failed.deterministic_gates[0].status = crate::agent_task_gate::AgentTaskGateStatus::Failed;
         failed.deterministic_gates[0].exit_code = 1;
@@ -8665,6 +8692,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             .message
             .contains("matching zero-exit command evidence"));
 
+        let replacement_for_finalization = replacement.clone();
         let replacement_for_replay = replacement.clone();
         record_replacement_gate_proof(
             run_id,
@@ -8714,7 +8742,10 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             "inherit"
         );
 
-        let mut backend = CaptureBackend::default();
+        let mut backend = CaptureBackend {
+            synthetic_gate_proof: Some(replacement_for_finalization),
+            ..Default::default()
+        };
         let published = recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut backend)
             .expect("replacement proof finalizes existing candidate");
         assert_eq!(published["status"], "review_ready");


### PR DESCRIPTION
## Summary

Fixes #11888.

Finalization-focused Cook fixtures now replace their synthetic `/repo` target and provenance paths with a real temporary directory. Production release-path validation remains fail-closed.

## Verification

- The five regression tests pass twice.
- `cargo fmt --check` passes.
- The full focused Cook suite reaches 131 passed, 6 ignored, with one unrelated flaky failure in `re_materialize_follow_up_baseline_recovers_after_worktree_deletion`; that test passes in isolation on current `origin/main`.
- `cargo clippy -p homeboy-agents --lib --tests -- -D warnings` is already blocked on current main by unrelated lint findings in `homeboy-core/src/notify_outbox.rs` and `homeboy-agents/src/agent_task_controller_service/mod.rs`.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode resumed the existing issue/worktree, reproduced the fixture failure, implemented the test-support repair, and ran focused verification. Chris Huber remains responsible for every line.