### PR TITLE
fix(runner): reconcile disconnected generation state

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1809,9 +1809,12 @@ pub fn reconcile_status(runner_id: &str) -> Result<RunnerStatusReport> {
     if report.connected {
         reconcile_session_metadata_with_observed_daemon(&runner, &mut report.session, true)?;
     }
-    // Terminal-job settlement was formerly coupled to status. Keep it under
-    // this explicit lifecycle owner so status remains safe to parallelize.
-    reconcile_terminal_jobs(runner_id)?;
+    // Terminal-job settlement needs a live session transport. Generation
+    // reconciliation below can instead inspect a disconnected SSH runner, so
+    // do not let the terminal-job preflight block its advertised recovery path.
+    if report.connected {
+        reconcile_terminal_jobs(runner_id)?;
+    }
     if let Ok(Some((_, _, client))) = remote_daemon::resolve_ssh_runner(&runner) {
         super::generation_store::reconcile_with_ssh(runner_id, report.session.as_ref(), &client)?;
     } else {

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -1931,6 +1931,40 @@ fn full_status_projection_leaves_large_legacy_shared_state_and_observation_db_un
     });
 }
 
+#[test]
+fn disconnected_generation_reconcile_action_passes_reconcile_preflight() {
+    test_support::with_isolated_home(|_| {
+        crate::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false).expect("create runner");
+        let mut session = direct_ssh_session("lease-stale");
+        // The persisted stale generation has no local tunnel to probe. This
+        // keeps the fixture focused on disconnected recovery preflight.
+        session.local_url = None;
+        session.local_port = None;
+        write_session(&session).expect("write disconnected direct session");
+        let mut generations = crate::RollingGenerations::new("lease-stale", session);
+        generations.admit();
+        crate::generation_store::write("homeboy-lab", &generations)
+            .expect("persist stale generation evidence");
+
+        let status = status("homeboy-lab").expect("read disconnected status");
+        assert!(!status.connected);
+        let inventory =
+            crate::generation_store::status_projection("homeboy-lab", status.session.as_ref())
+                .expect("read persisted generation evidence");
+        assert_eq!(
+            status
+                .admission_summary_with_generations(&inventory, &[], inventory.len())
+                .next_action
+                .as_deref(),
+            Some("homeboy runner reconcile homeboy-lab")
+        );
+
+        let reconciled = reconcile_status("homeboy-lab")
+            .expect("status-recommended reconciliation accepts a disconnected runner");
+        assert!(!reconciled.connected);
+    });
+}
+
 fn snapshot_directory(
     root: &std::path::Path,
 ) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {


### PR DESCRIPTION
## Summary
- skip live terminal-job settlement when a runner is disconnected, allowing the existing bounded generation reconciliation path to run
- add a persisted disconnected-generation fixture that verifies the emitted reconcile action passes command preflight

## Tests
- cargo fmt --check
- cargo check -p homeboy-lab-runner
- cargo test -p homeboy-lab-runner disconnected_generation_reconcile_action_passes_reconcile_preflight --lib

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the runner recovery flow, implemented the guarded terminal settlement, and added deterministic command-contract coverage. Chris Huber remains responsible for every line.