### PR TITLE
feat(release): bind readiness evidence to source

### DIFF
--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -26,6 +26,9 @@ pub struct AuditArgs {
     #[command(flatten)]
     pub comp: PositionalComponentArgs,
 
+    #[arg(long, hide = true)]
+    pub release_readiness_source: Option<String>,
+
     #[command(flatten)]
     pub extension_override: ExtensionOverrideArgs,
 
@@ -549,6 +552,7 @@ mod tests {
                 component: Some("homeboy".to_string()),
                 path: None,
             },
+            release_readiness_source: None,
             extension_override: ExtensionOverrideArgs::default(),
             conventions: false,
             only: vec![],
@@ -977,6 +981,7 @@ mod tests {
                     component: Some(root.to_string_lossy().to_string()),
                     path: None,
                 },
+                release_readiness_source: None,
                 extension_override: ExtensionOverrideArgs {
                     extensions: vec!["source-fixture".to_string()],
                 },

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -45,6 +45,9 @@ pub struct LintArgs {
     #[command(flatten)]
     pub comp: PositionalComponentArgs,
 
+    #[arg(long, hide = true)]
+    pub release_readiness_source: Option<String>,
+
     #[command(flatten)]
     pub extension_override: ExtensionOverrideArgs,
 

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -632,17 +632,33 @@ fn run_portable_preflight_with(
             path: &component.local_path,
             requested_runner_id: runner_id,
             placement: args.preflight_placement,
-        })?;
-        resolved_runner_id = child.runner_id.clone().or(resolved_runner_id);
-        evidence_refs.extend(child.evidence_refs.iter().cloned());
-        gate_results.push(ReleaseReadinessGateResult {
-            gate: gate.to_string(),
-            status: if child.passed { "passed" } else { "failed" }.to_string(),
-            reason: None,
-            source_sha: Some(commit.clone()),
-            runner_id: child.runner_id,
-            evidence_refs: child.evidence_refs,
         });
+        match child {
+            Ok(child) => {
+                resolved_runner_id = child.runner_id.clone().or(resolved_runner_id);
+                evidence_refs.extend(child.evidence_refs.iter().cloned());
+                gate_results.push(ReleaseReadinessGateResult {
+                    gate: gate.to_string(),
+                    status: if child.passed { "passed" } else { "failed" }.to_string(),
+                    reason: None,
+                    source_sha: Some(commit.clone()),
+                    runner_id: child.runner_id,
+                    evidence_refs: child.evidence_refs,
+                });
+            }
+            Err(error) => {
+                // Keep dispatch failures alongside other gate outcomes. The
+                // retained readiness operation makes this error durable.
+                gate_results.push(ReleaseReadinessGateResult {
+                    gate: gate.to_string(),
+                    status: "failed".to_string(),
+                    reason: Some(format!("portable dispatch failed: {error}")),
+                    source_sha: Some(commit.clone()),
+                    runner_id: runner_id.map(str::to_string),
+                    evidence_refs: Vec::new(),
+                });
+            }
+        }
     }
     // Package preflight owns release-specific lockfile and local-dependency
     // guards. No portable review command exposes that contract yet, so retain
@@ -1258,6 +1274,7 @@ fn resolve_component_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
 
     fn args(components: &[&str]) -> ReleaseExecuteArgs {
         ReleaseExecuteArgs {
@@ -1695,5 +1712,121 @@ jobs:
                 "runner-artifact://lab-runner-7/review.json".to_string(),
             ]
         );
+    }
+
+    struct RecordingPortableDispatcher {
+        calls: RefCell<Vec<String>>,
+        failing_gate: Option<&'static str>,
+    }
+
+    impl PortableStageDispatcher for RecordingPortableDispatcher {
+        fn dispatch(
+            &self,
+            request: PortableStageRequest<'_>,
+        ) -> homeboy::core::Result<PortableStageChildResult> {
+            self.calls.borrow_mut().push(request.gate.to_string());
+            if self.failing_gate == Some(request.gate) {
+                return Err(homeboy::core::Error::internal_unexpected(format!(
+                    "{} dispatcher unavailable",
+                    request.gate
+                )));
+            }
+            Ok(PortableStageChildResult {
+                passed: true,
+                runner_id: Some("test-runner".to_string()),
+                evidence_refs: vec![format!("evidence://{}", request.gate)],
+            })
+        }
+    }
+
+    fn portable_preflight_fixture() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(temp.path())
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        run(&["init", "-q", "--initial-branch", "main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(
+            temp.path().join("homeboy.json"),
+            r#"{
+                "id": "fixture",
+                "components": { "fixture": { "type": "fixture", "path": "." } }
+            }"#,
+        )
+        .expect("write config");
+        std::fs::write(temp.path().join("README.md"), "fixture\n").expect("write fixture");
+        run(&["add", "."]);
+        run(&["commit", "-qm", "initial"]);
+        temp
+    }
+
+    fn portable_preflight_args(path: &std::path::Path) -> ReleaseExecuteArgs {
+        let mut args = args(&["fixture"]);
+        args.path = Some(path.to_string_lossy().to_string());
+        args.preflight_placement = ReleasePreflightPlacementArg::Lab;
+        args
+    }
+
+    #[test]
+    fn portable_preflight_does_not_dispatch_skipped_stages() {
+        let temp = portable_preflight_fixture();
+        let dispatcher = RecordingPortableDispatcher {
+            calls: RefCell::new(Vec::new()),
+            failing_gate: None,
+        };
+
+        let readiness = run_portable_preflight_with(
+            &dispatcher,
+            &portable_preflight_args(temp.path()),
+            "fixture",
+            &["lint".to_string()],
+        )
+        .expect("preflight should complete")
+        .expect("lab preflight is enabled");
+
+        assert_eq!(*dispatcher.calls.borrow(), vec!["audit", "test"]);
+        assert_eq!(readiness.gate_results[1].gate, "lint");
+        assert_eq!(readiness.gate_results[1].status, "skipped");
+    }
+
+    #[test]
+    fn portable_dispatch_error_is_a_failed_gate_and_later_gates_run() {
+        let temp = portable_preflight_fixture();
+        let dispatcher = RecordingPortableDispatcher {
+            calls: RefCell::new(Vec::new()),
+            failing_gate: Some("lint"),
+        };
+
+        let readiness = run_portable_preflight_with(
+            &dispatcher,
+            &portable_preflight_args(temp.path()),
+            "fixture",
+            &[],
+        )
+        .expect("dispatch failure is retained as a gate result")
+        .expect("lab preflight is enabled");
+
+        assert_eq!(*dispatcher.calls.borrow(), vec!["audit", "lint", "test"]);
+        let lint = readiness
+            .gate_results
+            .iter()
+            .find(|gate| gate.gate == "lint")
+            .expect("lint result");
+        assert_eq!(lint.status, "failed");
+        assert!(lint
+            .reason
+            .as_deref()
+            .expect("failure reason")
+            .contains("dispatcher unavailable"));
+        assert!(readiness
+            .gate_results
+            .iter()
+            .any(|gate| gate.gate == "test" && gate.status == "passed"));
     }
 }

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -891,6 +891,17 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
     guard_no_github_release(&args, &component_ids)?;
 
     if args.package_only {
+        if readiness
+            .as_ref()
+            .is_some_and(|value| !release::readiness_is_valid(value))
+        {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "release.preflight",
+                "Portable release preflight has invalid selected gate evidence",
+                None,
+                None,
+            ));
+        }
         return run_package_only(args, &component_ids);
     }
 

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -441,6 +441,7 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
 fn run_portable_preflight(
     args: &ReleaseExecuteArgs,
     component_id: &str,
+    skipped: &[String],
 ) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
     let runner_id = args.preflight_runner.as_deref();
     if runner_id.is_none() && !matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
@@ -457,6 +458,12 @@ fn run_portable_preflight(
     })?;
     let mut gate_results = Vec::new();
     for gate in ["audit", "lint", "test"] {
+        if skipped.iter().any(|skip| skip == gate) {
+            gate_results.push(
+                serde_json::json!({ "gate": gate, "status": "skipped", "reason": "--skip-checks" }),
+            );
+            continue;
+        }
         let mut command = Command::new(&executable);
         if let Some(runner_id) = runner_id {
             command.args(["--runner", runner_id]);
@@ -483,21 +490,25 @@ fn run_portable_preflight(
                 "stderr": String::from_utf8_lossy(&output.stderr),
             })
         });
-        if !output.status.success() {
-            return Err(homeboy::core::Error::validation_invalid_argument(
-                "release.preflight",
-                format!(
-                    "Portable release {gate} gate failed with exit status {:?}",
-                    output.status.code()
-                ),
-                Some(component.local_path.clone()),
-                Some(vec![format!(
-                    "Inspect the returned {gate} evidence before retrying release."
-                )]),
-            ));
-        }
-        gate_results.push(result);
+        gate_results.push(serde_json::json!({
+            "gate": gate,
+            "status": if output.status.success() { "passed" } else { "failed" },
+            "command": command.get_args().map(|arg| arg.to_string_lossy()).collect::<Vec<_>>(),
+            "source_sha": commit,
+            "runner_id": runner_id,
+            "exit_code": output.status.code(),
+            "result": result,
+        }));
     }
+    // Package preflight owns release-specific lockfile and local-dependency
+    // guards. No portable review command exposes that contract yet, so retain
+    // the explicit controller placement while other gates still offload.
+    gate_results.push(serde_json::json!({
+        "gate": "package_preflight",
+        "status": "local_only",
+        "reason": "release package guards have no portable command contract",
+        "source_sha": commit,
+    }));
     let placement = ReleasePreflightPlacement {
         policy: if runner_id.is_some()
             || matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
@@ -534,7 +545,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         ));
     }
     let readiness = if component_ids.len() == 1 {
-        run_portable_preflight(&args, &component_ids[0])?
+        run_portable_preflight(&args, &component_ids[0], &skip_checks_granular)?
     } else {
         None
     };

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -863,6 +863,9 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
     let execution = args.execution_plan(skip_checks);
     validate_apply_boundary(&execution)?;
     let component_ids = resolve_component_ids(&args, &args.components)?;
+    if args.package_only {
+        validate_package_only_intent(&args, &component_ids)?;
+    }
     if component_ids.len() > 1
         && (args.preflight_runner.is_some()
             || matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab))
@@ -895,12 +898,18 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
             .as_ref()
             .is_some_and(|value| !release::readiness_is_valid(value))
         {
-            return Err(homeboy::core::Error::validation_invalid_argument(
-                "release.preflight",
-                "Portable release preflight has invalid selected gate evidence",
-                None,
-                None,
-            ));
+            let input = ReleaseCommandInput {
+                component_id: component_ids[0].clone(),
+                path_override: args.path.clone(),
+                readiness,
+                ..Default::default()
+            };
+            return match release::run_command_with_workspace(input, args.owner_run_ref.as_deref()) {
+                Ok(_) => Err(homeboy::core::Error::internal_unexpected(
+                    "invalid readiness unexpectedly passed",
+                )),
+                Err(error) => Err(error),
+            };
         }
         return run_package_only(args, &component_ids, readiness.as_ref());
     }
@@ -1102,6 +1111,7 @@ fn run_package_only(
     component_ids: &[String],
     readiness: Option<&ReleaseReadinessEnvelope>,
 ) -> CmdResult<ReleaseCommandOutput> {
+    validate_package_only_intent(&args, component_ids)?;
     if component_ids.len() != 1 {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "components",
@@ -1168,6 +1178,54 @@ fn run_package_only(
         })),
         0,
     ))
+}
+
+fn validate_package_only_intent(
+    args: &ReleaseExecuteArgs,
+    component_ids: &[String],
+) -> homeboy::core::Result<()> {
+    if component_ids.len() != 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "components",
+            "--package-only supports exactly one component",
+            None,
+            None,
+        ));
+    }
+    if args.project.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "project",
+            "--package-only does not support --project",
+            args.project.clone(),
+            None,
+        ));
+    }
+    validate_package_only_args(args)?;
+    if args.from_artifacts.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument("from-artifacts", "--from-artifacts is for --head publish recovery; --package-only regenerates artifacts instead", args.from_artifacts.clone(), None));
+    }
+    if args.dry_run_args.dry_run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "dry-run",
+            "--package-only writes release artifacts and does not support --dry-run",
+            None,
+            None,
+        ));
+    }
+    if args.bump.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "bump",
+            "--package-only packages an existing tag and cannot be combined with --bump",
+            args.bump.clone(),
+            None,
+        ));
+    }
+    if args.tag.is_none() {
+        return Err(homeboy::core::Error::validation_missing_argument(vec![
+            "--tag <existing-release-tag>".to_string(),
+        ]));
+    }
+    Ok(())
 }
 
 fn validate_package_only_args(args: &ReleaseExecuteArgs) -> homeboy::core::Result<()> {

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -11,6 +11,7 @@ use homeboy_release::release::{
     ReleaseCommandResult, ReleaseExecutionPlan, ReleasePackageResult, ReleasePhase,
     ReleasePipelineOptions, ReleasePreflightPlacement, ReleasePreflightPlacementPolicy,
     ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
+    ReleaseReadinessProvenance,
 };
 
 use super::utils::args::DryRunArgs;
@@ -441,9 +442,16 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
 fn run_portable_preflight(
     args: &ReleaseExecuteArgs,
     component_id: &str,
+    skip_all: bool,
     skipped: &[String],
 ) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
-    run_portable_preflight_with(&CliPortableStageDispatcher, args, component_id, skipped)
+    run_portable_preflight_with(
+        &CliPortableStageDispatcher,
+        args,
+        component_id,
+        skip_all,
+        skipped,
+    )
 }
 
 struct PortableStageRequest<'a> {
@@ -459,6 +467,7 @@ struct PortableStageChildResult {
     passed: bool,
     runner_id: Option<String>,
     evidence_refs: Vec<String>,
+    provenance: ReleaseReadinessProvenance,
 }
 
 trait PortableStageDispatcher {
@@ -555,6 +564,8 @@ struct PortableChildArtifactRef {
 struct PortableReviewChildData {
     #[serde(default)]
     execution_provenance: Option<PortableExecutionProvenance>,
+    #[serde(default)]
+    release_readiness_provenance: ReleaseReadinessProvenance,
 }
 #[derive(Deserialize)]
 struct PortableExecutionProvenance {
@@ -585,6 +596,11 @@ impl PortableReviewChildEnvelope {
         );
         evidence_refs.sort();
         evidence_refs.dedup();
+        let provenance = self
+            .data
+            .as_ref()
+            .map(|data| data.release_readiness_provenance.clone())
+            .unwrap_or_default();
         let runner_id = self
             .data
             .and_then(|data| data.execution_provenance)
@@ -594,6 +610,7 @@ impl PortableReviewChildEnvelope {
             passed: process_passed && self.success,
             runner_id,
             evidence_refs,
+            provenance,
         }
     }
 }
@@ -602,6 +619,7 @@ fn run_portable_preflight_with(
     dispatcher: &dyn PortableStageDispatcher,
     args: &ReleaseExecuteArgs,
     component_id: &str,
+    skip_all: bool,
     skipped: &[String],
 ) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
     let runner_id = args.preflight_runner.as_deref();
@@ -615,7 +633,7 @@ fn run_portable_preflight_with(
     let mut evidence_refs = Vec::new();
     let mut resolved_runner_id = None;
     for gate in ["audit", "lint", "test"] {
-        if skipped.iter().any(|skip| skip == gate) {
+        if skip_all || skipped.iter().any(|skip| skip == gate) {
             gate_results.push(ReleaseReadinessGateResult {
                 gate: gate.to_string(),
                 status: "skipped".to_string(),
@@ -623,6 +641,7 @@ fn run_portable_preflight_with(
                 source_sha: Some(commit.clone()),
                 runner_id: None,
                 evidence_refs: Vec::new(),
+                provenance: None,
             });
             continue;
         }
@@ -644,6 +663,7 @@ fn run_portable_preflight_with(
                     source_sha: Some(commit.clone()),
                     runner_id: child.runner_id,
                     evidence_refs: child.evidence_refs,
+                    provenance: Some(child.provenance),
                 });
             }
             Err(error) => {
@@ -656,6 +676,7 @@ fn run_portable_preflight_with(
                     source_sha: Some(commit.clone()),
                     runner_id: runner_id.map(str::to_string),
                     evidence_refs: Vec::new(),
+                    provenance: None,
                 });
             }
         }
@@ -670,6 +691,7 @@ fn run_portable_preflight_with(
         source_sha: Some(commit.clone()),
         runner_id: None,
         evidence_refs: Vec::new(),
+        provenance: None,
     });
     let placement = ReleasePreflightPlacement {
         policy: if runner_id.is_some()
@@ -688,7 +710,17 @@ fn run_portable_preflight_with(
         placement,
         runner_id: resolved_runner_id.or_else(|| runner_id.map(str::to_string)),
         evidence_refs,
-        provenance: release::readiness_provenance(&component)?,
+        provenance: gate_results
+            .iter()
+            .filter_map(|gate| gate.provenance.as_ref())
+            .fold(
+                ReleaseReadinessProvenance::default(),
+                |mut all, provenance| {
+                    all.dependencies.extend(provenance.dependencies.clone());
+                    all.extensions.extend(provenance.extensions.clone());
+                    all
+                },
+            ),
         gate_results,
     }))
 }
@@ -710,7 +742,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         ));
     }
     let readiness = if component_ids.len() == 1 {
-        run_portable_preflight(&args, &component_ids[0], &skip_checks_granular)?
+        run_portable_preflight(&args, &component_ids[0], skip_checks, &skip_checks_granular)?
     } else {
         None
     };
@@ -1697,7 +1729,13 @@ jobs:
             "run": { "id": "review-run-7", "location": "lab-runner-7" },
             "refs": { "runs": [{ "id": "review-run-7" }] },
             "evidence": [{ "uri": "runner-artifact://lab-runner-7/review.json" }],
-            "data": { "execution_provenance": { "resolved_execution": { "runner_id": "lab-runner-7" } } }
+            "data": {
+                "execution_provenance": { "resolved_execution": { "runner_id": "lab-runner-7" } },
+                "release_readiness_provenance": {
+                    "dependencies": { "fixture-dependency": "child-locked-sha" },
+                    "extensions": { "fixture-extension": "sha256:child-manifest" }
+                }
+            }
         }))
         .expect("stable child result");
 
@@ -1705,6 +1743,14 @@ jobs:
 
         assert!(projected.passed);
         assert_eq!(projected.runner_id.as_deref(), Some("lab-runner-7"));
+        assert_eq!(
+            projected.provenance.dependencies["fixture-dependency"],
+            "child-locked-sha"
+        );
+        assert_eq!(
+            projected.provenance.extensions["fixture-extension"],
+            "sha256:child-manifest"
+        );
         assert_eq!(
             projected.evidence_refs,
             vec![
@@ -1735,6 +1781,7 @@ jobs:
                 passed: true,
                 runner_id: Some("test-runner".to_string()),
                 evidence_refs: vec![format!("evidence://{}", request.gate)],
+                provenance: ReleaseReadinessProvenance::default(),
             })
         }
     }
@@ -1785,6 +1832,7 @@ jobs:
             &dispatcher,
             &portable_preflight_args(temp.path()),
             "fixture",
+            false,
             &["lint".to_string()],
         )
         .expect("preflight should complete")
@@ -1807,6 +1855,7 @@ jobs:
             &dispatcher,
             &portable_preflight_args(temp.path()),
             "fixture",
+            false,
             &[],
         )
         .expect("dispatch failure is retained as a gate result")
@@ -1828,5 +1877,86 @@ jobs:
             .gate_results
             .iter()
             .any(|gate| gate.gate == "test" && gate.status == "passed"));
+    }
+
+    #[test]
+    fn portable_preflight_bare_skip_checks_dispatches_no_remote_gates() {
+        let temp = portable_preflight_fixture();
+        let dispatcher = RecordingPortableDispatcher {
+            calls: RefCell::new(Vec::new()),
+            failing_gate: None,
+        };
+
+        let readiness = run_portable_preflight_with(
+            &dispatcher,
+            &portable_preflight_args(temp.path()),
+            "fixture",
+            true,
+            &[],
+        )
+        .expect("preflight should complete")
+        .expect("lab preflight is enabled");
+
+        assert!(dispatcher.calls.borrow().is_empty());
+        assert!(readiness
+            .gate_results
+            .iter()
+            .filter(|gate| ["audit", "lint", "test"].contains(&gate.gate.as_str()))
+            .all(|gate| gate.status == "skipped"));
+    }
+
+    #[test]
+    fn portable_preflight_retains_child_provenance_not_controller_state() {
+        let temp = portable_preflight_fixture();
+        let child_provenance = ReleaseReadinessProvenance {
+            dependencies: std::collections::BTreeMap::from([(
+                "fixture-dependency".to_string(),
+                "child-locked-sha".to_string(),
+            )]),
+            extensions: std::collections::BTreeMap::from([(
+                "fixture-extension".to_string(),
+                "sha256:child-manifest".to_string(),
+            )]),
+        };
+        struct ProvenanceDispatcher(ReleaseReadinessProvenance);
+        impl PortableStageDispatcher for ProvenanceDispatcher {
+            fn dispatch(
+                &self,
+                _request: PortableStageRequest<'_>,
+            ) -> homeboy::core::Result<PortableStageChildResult> {
+                Ok(PortableStageChildResult {
+                    passed: true,
+                    runner_id: Some("lab".to_string()),
+                    evidence_refs: Vec::new(),
+                    provenance: self.0.clone(),
+                })
+            }
+        }
+
+        let readiness = run_portable_preflight_with(
+            &ProvenanceDispatcher(child_provenance.clone()),
+            &portable_preflight_args(temp.path()),
+            "fixture",
+            false,
+            &[],
+        )
+        .expect("preflight should complete")
+        .expect("lab preflight is enabled");
+
+        let controller_component = component::resolve_effective(
+            Some("fixture"),
+            Some(temp.path().to_string_lossy().as_ref()),
+            None,
+        )
+        .expect("controller component");
+        let controller_provenance =
+            release::readiness_provenance(&controller_component).expect("controller provenance");
+        assert_ne!(controller_provenance, child_provenance);
+        assert_eq!(readiness.provenance, child_provenance);
+        assert!(readiness
+            .gate_results
+            .iter()
+            .filter(|gate| ["audit", "lint", "test"].contains(&gate.gate.as_str()))
+            .all(|gate| gate.provenance.as_ref() == Some(&child_provenance)));
     }
 }

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -471,10 +471,18 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
                         homeboy::core::Error::validation_invalid_argument(
                             "reference",
                             "release readiness operation does not exist",
-                            Some(reference),
+                            Some(reference.clone()),
                             None,
                         )
                     })?;
+                if record.operation != "release_readiness" {
+                    return Err(homeboy::core::Error::validation_invalid_argument(
+                        "reference",
+                        "operation reference is not a release readiness record",
+                        Some(reference),
+                        None,
+                    ));
+                }
                 return Ok((
                     ReleaseCommandOutput::ReadinessShow(ReleaseReadinessShowOutput {
                         variant: "readiness-show",
@@ -1989,6 +1997,43 @@ jobs:
                 panic!("expected readiness show output");
             };
             assert_eq!(output.record.owner_run_ref, record.owner_run_ref);
+        });
+    }
+
+    #[test]
+    fn readiness_show_rejects_non_readiness_operation_records() {
+        homeboy::core::test_support::with_isolated_home(|_| {
+            let record = release::operation_record::OperationRecord {
+                owner_run_ref: "not-readiness".to_string(),
+                operation: "provider_workspace".to_string(),
+                subject: "fixture".to_string(),
+                provider: "lab".to_string(),
+                handle: "commit".to_string(),
+                path: None,
+                source_sha: "commit".to_string(),
+                cleanup_policy: "retain".to_string(),
+                lifecycle_state: "finalized".to_string(),
+                terminal_disposition: Some("succeeded".to_string()),
+                finalization_status: "completed".to_string(),
+                finalization_lease: None,
+                finalization_lease_started_ms: None,
+                attempt_count: 1,
+                continuation_evidence: Vec::new(),
+                attributes: Default::default(),
+            };
+            release::operation_record::OperationRecordStore::create(&record).expect("record");
+            let error = match run(ReleaseArgs {
+                command: Some(ReleaseSubcommand::Readiness(ReleaseReadinessArgs {
+                    command: ReleaseReadinessCommand::Show {
+                        reference: record.owner_run_ref,
+                    },
+                })),
+                execute: args(&[]),
+            }) {
+                Ok(_) => panic!("non-readiness records are rejected"),
+                Err(error) => error,
+            };
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
         });
     }
 

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -11,7 +11,7 @@ use homeboy_release::release::{
     ReleaseCommandResult, ReleaseExecutionPlan, ReleasePackageResult, ReleasePhase,
     ReleasePipelineOptions, ReleasePreflightPlacement, ReleasePreflightPlacementPolicy,
     ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
-    ReleaseReadinessProvenance,
+    ReleaseReadinessLocalOnly, ReleaseReadinessProvenance,
 };
 
 use super::utils::args::DryRunArgs;
@@ -767,6 +767,7 @@ fn run_portable_preflight_with(
                 runner_id: None,
                 evidence_refs: Vec::new(),
                 provenance: None,
+                local_only: None,
             });
             continue;
         }
@@ -790,6 +791,7 @@ fn run_portable_preflight_with(
                     runner_id: child.runner_id,
                     evidence_refs: child.evidence_refs,
                     provenance: Some(child.provenance),
+                    local_only: None,
                 });
             }
             Err(error) => {
@@ -803,6 +805,7 @@ fn run_portable_preflight_with(
                     runner_id: runner_id.map(str::to_string),
                     evidence_refs: Vec::new(),
                     provenance: None,
+                    local_only: None,
                 });
             }
         }
@@ -818,6 +821,10 @@ fn run_portable_preflight_with(
         runner_id: None,
         evidence_refs: Vec::new(),
         provenance: None,
+        local_only: Some(ReleaseReadinessLocalOnly {
+            reason: "release package guards have no portable command contract".to_string(),
+            continuation: "preflight.package".to_string(),
+        }),
     });
     let placement = ReleasePreflightPlacement {
         policy: if runner_id.is_some()
@@ -2058,7 +2065,13 @@ jobs:
                 passed: true,
                 runner_id: Some("test-runner".to_string()),
                 evidence_refs: vec![format!("evidence://{}", request.gate)],
-                provenance: ReleaseReadinessProvenance::default(),
+                provenance: ReleaseReadinessProvenance {
+                    dependencies: std::collections::BTreeMap::from([(
+                        "fixture".to_string(),
+                        "locked".to_string(),
+                    )]),
+                    extensions: Default::default(),
+                },
             })
         }
     }
@@ -2118,6 +2131,7 @@ jobs:
         assert_eq!(*dispatcher.calls.borrow(), vec!["audit", "test"]);
         assert_eq!(readiness.gate_results[1].gate, "lint");
         assert_eq!(readiness.gate_results[1].status, "skipped");
+        assert!(release::readiness_is_valid(&readiness));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -64,6 +64,22 @@ enum ReleaseSubcommand {
     Contains(contains::ContainsArgs),
     /// Report how far the installed build is behind the newest release
     Gap(contains::GapArgs),
+    /// Inspect retained portable release-readiness evidence
+    Readiness(ReleaseReadinessArgs),
+}
+
+#[derive(Args)]
+struct ReleaseReadinessArgs {
+    #[command(subcommand)]
+    command: ReleaseReadinessCommand,
+}
+
+#[derive(Subcommand)]
+enum ReleaseReadinessCommand {
+    /// Show one retained readiness operation by operation:// reference or ID
+    Show { reference: String },
+    /// List retained readiness operations for a component
+    List { component_id: String },
 }
 
 #[derive(Args)]
@@ -285,6 +301,18 @@ pub struct ArtifactSourceAuthorityOutput {
 }
 
 #[derive(Serialize)]
+pub struct ReleaseReadinessShowOutput {
+    pub variant: &'static str,
+    pub record: release::operation_record::OperationRecord,
+}
+
+#[derive(Serialize)]
+pub struct ReleaseReadinessListOutput {
+    pub variant: &'static str,
+    pub records: Vec<release::operation_record::OperationRecord>,
+}
+
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum ReleaseCommandOutput {
     Single(Box<ReleaseOutput>),
@@ -296,6 +324,8 @@ pub enum ReleaseCommandOutput {
     Version(version::VersionOutput),
     Contains(Box<release::ReleaseContainsReport>),
     Gap(Box<release::ReleaseGapReport>),
+    ReadinessShow(ReleaseReadinessShowOutput),
+    ReadinessList(ReleaseReadinessListOutput),
 }
 
 fn map_nested<T>(
@@ -433,6 +463,41 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
                 0,
             ));
         }
+        Some(ReleaseSubcommand::Readiness(args)) => match args.command {
+            ReleaseReadinessCommand::Show { reference } => {
+                let owner_run_ref = reference.strip_prefix("operation://").unwrap_or(&reference);
+                let record = release::operation_record::OperationRecordStore::load(owner_run_ref)?
+                    .ok_or_else(|| {
+                        homeboy::core::Error::validation_invalid_argument(
+                            "reference",
+                            "release readiness operation does not exist",
+                            Some(reference),
+                            None,
+                        )
+                    })?;
+                return Ok((
+                    ReleaseCommandOutput::ReadinessShow(ReleaseReadinessShowOutput {
+                        variant: "readiness-show",
+                        record,
+                    }),
+                    0,
+                ));
+            }
+            ReleaseReadinessCommand::List { component_id } => {
+                let records = release::operation_record::OperationRecordStore::for_subject(
+                    "release_readiness",
+                    &component_id,
+                    false,
+                )?;
+                return Ok((
+                    ReleaseCommandOutput::ReadinessList(ReleaseReadinessListOutput {
+                        variant: "readiness-list",
+                        records,
+                    }),
+                    0,
+                ));
+            }
+        },
         None => {}
     }
 
@@ -458,6 +523,7 @@ struct PortableStageRequest<'a> {
     gate: &'a str,
     component_id: &'a str,
     path: &'a str,
+    source_commit: &'a str,
     requested_runner_id: Option<&'a str>,
     placement: ReleasePreflightPlacementArg,
 }
@@ -502,6 +568,8 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
             request.component_id,
             "--path",
             request.path,
+            "--release-readiness-source",
+            request.source_commit,
         ]);
         let output = command.output().map_err(|error| {
             homeboy::core::Error::internal_io(
@@ -521,7 +589,7 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
                     None,
                 )
             })?;
-        Ok(envelope.project(output.status.success()))
+        envelope.project(output.status.success(), request.source_commit)
     }
 }
 
@@ -560,25 +628,24 @@ struct PortableChildRunRef {
 struct PortableChildArtifactRef {
     uri: String,
 }
-#[derive(Default, Deserialize)]
+#[derive(Deserialize)]
 struct PortableReviewChildData {
-    #[serde(default)]
-    execution_provenance: Option<PortableExecutionProvenance>,
-    #[serde(default)]
-    release_readiness_provenance: ReleaseReadinessProvenance,
-}
-#[derive(Deserialize)]
-struct PortableExecutionProvenance {
-    resolved_execution: PortableResolvedExecution,
-}
-#[derive(Deserialize)]
-struct PortableResolvedExecution {
-    #[serde(default)]
-    runner_id: Option<String>,
+    release_readiness: PortableChildReadinessEvidence,
 }
 
+#[derive(Deserialize)]
+struct PortableChildReadinessEvidence {
+    requested_source_commit: String,
+    source_commit: String,
+    runner_id: Option<String>,
+    provenance: ReleaseReadinessProvenance,
+}
 impl PortableReviewChildEnvelope {
-    fn project(self, process_passed: bool) -> PortableStageChildResult {
+    fn project(
+        self,
+        process_passed: bool,
+        requested_source_commit: &str,
+    ) -> homeboy::core::Result<PortableStageChildResult> {
         let mut evidence_refs = self
             .evidence
             .into_iter()
@@ -596,23 +663,73 @@ impl PortableReviewChildEnvelope {
         );
         evidence_refs.sort();
         evidence_refs.dedup();
-        let provenance = self
-            .data
-            .as_ref()
-            .map(|data| data.release_readiness_provenance.clone())
-            .unwrap_or_default();
-        let runner_id = self
-            .data
-            .and_then(|data| data.execution_provenance)
-            .and_then(|provenance| provenance.resolved_execution.runner_id)
-            .or_else(|| self.run.and_then(|run| run.location));
-        PortableStageChildResult {
-            passed: process_passed && self.success,
-            runner_id,
-            evidence_refs,
-            provenance,
+        let child = self.data.ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "release.preflight",
+                "portable child omitted typed readiness evidence",
+                None,
+                None,
+            )
+        })?;
+        let readiness = child.release_readiness;
+        if process_passed && self.success {
+            validate_portable_child_success(&readiness, requested_source_commit, &evidence_refs)?;
         }
+        Ok(PortableStageChildResult {
+            passed: process_passed && self.success,
+            runner_id: readiness.runner_id,
+            evidence_refs,
+            provenance: readiness.provenance,
+        })
     }
+}
+
+fn validate_portable_child_success(
+    child: &PortableChildReadinessEvidence,
+    requested_source_commit: &str,
+    evidence_refs: &[String],
+) -> homeboy::core::Result<()> {
+    if child.source_commit != requested_source_commit {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            "portable child source commit does not match frozen release source",
+            Some(child.source_commit.clone()),
+            None,
+        ));
+    }
+    if child.requested_source_commit != requested_source_commit {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            "portable child did not retain the frozen release source request",
+            Some(child.requested_source_commit.clone()),
+            None,
+        ));
+    }
+    if child.runner_id.is_none() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            "portable child omitted its resolved runner ID",
+            None,
+            None,
+        ));
+    }
+    if evidence_refs.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            "portable child omitted durable run, artifact, or evidence references",
+            None,
+            None,
+        ));
+    }
+    if ReleaseReadinessProvenance::is_empty(&child.provenance) {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            "portable child omitted immutable dependency and extension provenance",
+            None,
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn run_portable_preflight_with(
@@ -649,6 +766,7 @@ fn run_portable_preflight_with(
             gate,
             component_id,
             path: &component.local_path,
+            source_commit: &commit,
             requested_runner_id: runner_id,
             placement: args.preflight_placement,
         });
@@ -791,7 +909,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         return Ok((
             ReleaseCommandOutput::Single(Box::new(ReleaseOutput {
                 variant: "single",
-                actionable: recovery_actionable_metadata(&result),
+                actionable: release_actionable_metadata(&result),
                 result,
                 workspace: workspace_result.workspace,
                 cascade,
@@ -889,15 +1007,29 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
     ))
 }
 
-fn recovery_actionable_metadata(
-    result: &ReleaseCommandResult,
-) -> Option<CommandActionableMetadata> {
-    result.continuation_command.as_ref().map(|command| {
-        CommandActionableMetadata::default().with_next_action(
+fn release_actionable_metadata(result: &ReleaseCommandResult) -> Option<CommandActionableMetadata> {
+    let mut metadata = CommandActionableMetadata::default();
+    if let Some(command) = result.continuation_command.as_ref() {
+        metadata = metadata.with_next_action(
             CommandNextAction::new("finish release publication", command)
                 .with_kind(CommandNextActionKind::Repair),
-        )
-    })
+        );
+    }
+    if let Some(reference) = result.readiness.as_ref().and_then(|readiness| {
+        readiness
+            .evidence_refs
+            .iter()
+            .find_map(|reference| reference.strip_prefix("operation://"))
+    }) {
+        metadata = metadata.with_next_action(
+            CommandNextAction::new(
+                "inspect release readiness",
+                format!("homeboy release readiness show {reference}"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        );
+    }
+    (!metadata.is_empty()).then_some(metadata)
 }
 
 /// Run the dependency-aware cascade after a single-component release, when
@@ -1703,7 +1835,7 @@ jobs:
         };
         let output = ReleaseOutput {
             variant: "single",
-            actionable: recovery_actionable_metadata(&result),
+            actionable: release_actionable_metadata(&result),
             result,
             workspace: None,
             cascade: None,
@@ -1730,16 +1862,20 @@ jobs:
             "refs": { "runs": [{ "id": "review-run-7" }] },
             "evidence": [{ "uri": "runner-artifact://lab-runner-7/review.json" }],
             "data": {
-                "execution_provenance": { "resolved_execution": { "runner_id": "lab-runner-7" } },
-                "release_readiness_provenance": {
-                    "dependencies": { "fixture-dependency": "child-locked-sha" },
-                    "extensions": { "fixture-extension": "sha256:child-manifest" }
+                "release_readiness": {
+                    "requested_source_commit": "frozen-source",
+                    "source_commit": "frozen-source",
+                    "runner_id": "lab-runner-7",
+                    "provenance": {
+                        "dependencies": { "fixture-dependency": "child-locked-sha" },
+                        "extensions": { "fixture-extension": "sha256:child-manifest" }
+                    }
                 }
             }
         }))
         .expect("stable child result");
 
-        let projected = child.project(true);
+        let projected = child.project(true, "frozen-source").expect("valid child");
 
         assert!(projected.passed);
         assert_eq!(projected.runner_id.as_deref(), Some("lab-runner-7"));
@@ -1758,6 +1894,102 @@ jobs:
                 "runner-artifact://lab-runner-7/review.json".to_string(),
             ]
         );
+    }
+
+    fn valid_child_evidence() -> PortableChildReadinessEvidence {
+        PortableChildReadinessEvidence {
+            requested_source_commit: "frozen-source".to_string(),
+            source_commit: "frozen-source".to_string(),
+            runner_id: Some("lab-runner".to_string()),
+            provenance: ReleaseReadinessProvenance {
+                dependencies: std::collections::BTreeMap::from([(
+                    "dependency".to_string(),
+                    "locked-sha".to_string(),
+                )]),
+                extensions: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn portable_child_success_rejects_missing_source_commit() {
+        let mut child = valid_child_evidence();
+        child.source_commit.clear();
+        assert!(
+            validate_portable_child_success(&child, "frozen-source", &["run://1".to_string()])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn portable_child_success_rejects_mismatched_source_commit() {
+        let mut child = valid_child_evidence();
+        child.source_commit = "other-source".to_string();
+        assert!(
+            validate_portable_child_success(&child, "frozen-source", &["run://1".to_string()])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn portable_child_success_rejects_missing_runner_or_durable_evidence() {
+        let mut child = valid_child_evidence();
+        child.runner_id = None;
+        assert!(
+            validate_portable_child_success(&child, "frozen-source", &["run://1".to_string()])
+                .is_err()
+        );
+        let child = valid_child_evidence();
+        assert!(validate_portable_child_success(&child, "frozen-source", &[]).is_err());
+    }
+
+    #[test]
+    fn portable_child_success_rejects_empty_provenance() {
+        let mut child = valid_child_evidence();
+        child.provenance = Default::default();
+        assert!(
+            validate_portable_child_success(&child, "frozen-source", &["run://1".to_string()])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn readiness_show_resolves_operation_reference_for_operators() {
+        homeboy::core::test_support::with_isolated_home(|_| {
+            let record = release::operation_record::OperationRecord {
+                owner_run_ref: "release-readiness-operator-test".to_string(),
+                operation: "release_readiness".to_string(),
+                subject: "fixture".to_string(),
+                provider: "lab".to_string(),
+                handle: "commit".to_string(),
+                path: None,
+                source_sha: "commit".to_string(),
+                cleanup_policy: "retain".to_string(),
+                lifecycle_state: "finalized".to_string(),
+                terminal_disposition: Some("succeeded".to_string()),
+                finalization_status: "completed".to_string(),
+                finalization_lease: None,
+                finalization_lease_started_ms: None,
+                attempt_count: 1,
+                continuation_evidence: Vec::new(),
+                attributes: Default::default(),
+            };
+            release::operation_record::OperationRecordStore::create(&record).expect("record");
+            let (output, exit_code) = run(ReleaseArgs {
+                command: Some(ReleaseSubcommand::Readiness(ReleaseReadinessArgs {
+                    command: ReleaseReadinessCommand::Show {
+                        reference: format!("operation://{}", record.owner_run_ref),
+                    },
+                })),
+                execute: args(&[]),
+            })
+            .expect("show readiness");
+            assert_eq!(exit_code, 0);
+            let ReleaseCommandOutput::ReadinessShow(output) = output else {
+                panic!("expected readiness show output");
+            };
+            assert_eq!(output.record.owner_run_ref, record.owner_run_ref);
+        });
     }
 
     struct RecordingPortableDispatcher {

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -456,7 +456,7 @@ fn run_portable_preflight(
         )
     })?;
     let mut gate_results = Vec::new();
-    for gate in ["lint", "test"] {
+    for gate in ["audit", "lint", "test"] {
         let mut command = Command::new(&executable);
         if let Some(runner_id) = runner_id {
             command.args(["--runner", runner_id]);
@@ -539,7 +539,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         None
     };
     if readiness.is_some() {
-        for gate in ["lint", "test"] {
+        for gate in ["audit", "lint", "test"] {
             if !skip_checks_granular.iter().any(|existing| existing == gate) {
                 skip_checks_granular.push(gate.to_string());
             }
@@ -1105,6 +1105,8 @@ mod tests {
             project: None,
             outdated: false,
             path: None,
+            preflight_runner: None,
+            preflight_placement: ReleasePreflightPlacementArg::Local,
             dry_run_args: DryRunArgs { dry_run: true },
             apply: false,
             deploy: false,
@@ -1161,6 +1163,8 @@ mod tests {
             project: None,
             outdated: false,
             path: None,
+            preflight_runner: None,
+            preflight_placement: ReleasePreflightPlacementArg::Local,
             dry_run_args: DryRunArgs { dry_run: true },
             apply: false,
             deploy: false,

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand, ValueEnum};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::{fs, path::Path};
 
@@ -10,7 +10,7 @@ use homeboy_release::release::{
     self, ArtifactSourceAuthorityManifest, BatchReleaseResult, ReleaseCommandInput,
     ReleaseCommandResult, ReleaseExecutionPlan, ReleasePackageResult, ReleasePhase,
     ReleasePipelineOptions, ReleasePreflightPlacement, ReleasePreflightPlacementPolicy,
-    ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
+    ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
 };
 
 use super::utils::args::DryRunArgs;
@@ -443,6 +443,167 @@ fn run_portable_preflight(
     component_id: &str,
     skipped: &[String],
 ) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
+    run_portable_preflight_with(&CliPortableStageDispatcher, args, component_id, skipped)
+}
+
+struct PortableStageRequest<'a> {
+    gate: &'a str,
+    component_id: &'a str,
+    path: &'a str,
+    requested_runner_id: Option<&'a str>,
+    placement: ReleasePreflightPlacementArg,
+}
+
+#[derive(Debug, Clone)]
+struct PortableStageChildResult {
+    passed: bool,
+    runner_id: Option<String>,
+    evidence_refs: Vec<String>,
+}
+
+trait PortableStageDispatcher {
+    fn dispatch(
+        &self,
+        request: PortableStageRequest<'_>,
+    ) -> homeboy::core::Result<PortableStageChildResult>;
+}
+
+struct CliPortableStageDispatcher;
+
+impl PortableStageDispatcher for CliPortableStageDispatcher {
+    fn dispatch(
+        &self,
+        request: PortableStageRequest<'_>,
+    ) -> homeboy::core::Result<PortableStageChildResult> {
+        let executable = std::env::current_exe().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some("release preflight executable".to_string()),
+            )
+        })?;
+        let mut command = Command::new(executable);
+        if let Some(runner_id) = request.requested_runner_id {
+            command.args(["--runner", runner_id]);
+        } else if matches!(request.placement, ReleasePreflightPlacementArg::Lab) {
+            command.args(["--placement", "lab"]);
+        }
+        command.args([
+            "review",
+            request.gate,
+            request.component_id,
+            "--path",
+            request.path,
+        ]);
+        let output = command.output().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                format!("start portable release {} preflight: {error}", request.gate),
+                Some(request.path.to_string()),
+            )
+        })?;
+        let envelope: PortableReviewChildEnvelope = serde_json::from_slice(&output.stdout)
+            .map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "release.preflight",
+                    format!(
+                        "portable {} preflight returned no stable command-result JSON: {error}",
+                        request.gate
+                    ),
+                    Some(String::from_utf8_lossy(&output.stderr).to_string()),
+                    None,
+                )
+            })?;
+        Ok(envelope.project(output.status.success()))
+    }
+}
+
+/// Stable subset of a child command-result envelope consumed by release.
+/// Release deliberately retains only durable references and resolved placement,
+/// never an opaque copy of child JSON.
+#[derive(Deserialize)]
+struct PortableReviewChildEnvelope {
+    #[serde(default)]
+    success: bool,
+    #[serde(default)]
+    run: Option<PortableChildRunRef>,
+    #[serde(default)]
+    refs: PortableChildRefs,
+    #[serde(default)]
+    artifacts: Vec<PortableChildArtifactRef>,
+    #[serde(default)]
+    evidence: Vec<PortableChildArtifactRef>,
+    #[serde(default)]
+    data: Option<PortableReviewChildData>,
+}
+
+#[derive(Default, Deserialize)]
+struct PortableChildRefs {
+    #[serde(default)]
+    runs: Vec<PortableChildRunRef>,
+}
+
+#[derive(Deserialize)]
+struct PortableChildRunRef {
+    id: String,
+    #[serde(default)]
+    location: Option<String>,
+}
+#[derive(Deserialize)]
+struct PortableChildArtifactRef {
+    uri: String,
+}
+#[derive(Default, Deserialize)]
+struct PortableReviewChildData {
+    #[serde(default)]
+    execution_provenance: Option<PortableExecutionProvenance>,
+}
+#[derive(Deserialize)]
+struct PortableExecutionProvenance {
+    resolved_execution: PortableResolvedExecution,
+}
+#[derive(Deserialize)]
+struct PortableResolvedExecution {
+    #[serde(default)]
+    runner_id: Option<String>,
+}
+
+impl PortableReviewChildEnvelope {
+    fn project(self, process_passed: bool) -> PortableStageChildResult {
+        let mut evidence_refs = self
+            .evidence
+            .into_iter()
+            .map(|reference| reference.uri)
+            .collect::<Vec<_>>();
+        evidence_refs.extend(self.artifacts.into_iter().map(|reference| reference.uri));
+        if let Some(run) = self.run.as_ref() {
+            evidence_refs.push(format!("run://{}", run.id));
+        }
+        evidence_refs.extend(
+            self.refs
+                .runs
+                .into_iter()
+                .map(|run| format!("run://{}", run.id)),
+        );
+        evidence_refs.sort();
+        evidence_refs.dedup();
+        let runner_id = self
+            .data
+            .and_then(|data| data.execution_provenance)
+            .and_then(|provenance| provenance.resolved_execution.runner_id)
+            .or_else(|| self.run.and_then(|run| run.location));
+        PortableStageChildResult {
+            passed: process_passed && self.success,
+            runner_id,
+            evidence_refs,
+        }
+    }
+}
+
+fn run_portable_preflight_with(
+    dispatcher: &dyn PortableStageDispatcher,
+    args: &ReleaseExecuteArgs,
+    component_id: &str,
+    skipped: &[String],
+) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
     let runner_id = args.preflight_runner.as_deref();
     if runner_id.is_none() && !matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
     {
@@ -450,65 +611,50 @@ fn run_portable_preflight(
     }
     let component = component::resolve_effective(Some(component_id), args.path.as_deref(), None)?;
     let commit = homeboy::core::git::get_head_commit(&component.local_path)?;
-    let executable = std::env::current_exe().map_err(|error| {
-        homeboy::core::Error::internal_io(
-            error.to_string(),
-            Some("release preflight executable".to_string()),
-        )
-    })?;
     let mut gate_results = Vec::new();
+    let mut evidence_refs = Vec::new();
+    let mut resolved_runner_id = None;
     for gate in ["audit", "lint", "test"] {
         if skipped.iter().any(|skip| skip == gate) {
-            gate_results.push(
-                serde_json::json!({ "gate": gate, "status": "skipped", "reason": "--skip-checks" }),
-            );
+            gate_results.push(ReleaseReadinessGateResult {
+                gate: gate.to_string(),
+                status: "skipped".to_string(),
+                reason: Some("--skip-checks".to_string()),
+                source_sha: Some(commit.clone()),
+                runner_id: None,
+                evidence_refs: Vec::new(),
+            });
             continue;
         }
-        let mut command = Command::new(&executable);
-        if let Some(runner_id) = runner_id {
-            command.args(["--runner", runner_id]);
-        } else {
-            command.args(["--placement", "lab"]);
-        }
-        command.args([
-            "review",
+        let child = dispatcher.dispatch(PortableStageRequest {
             gate,
             component_id,
-            "--path",
-            &component.local_path,
-        ]);
-        let output = command.output().map_err(|error| {
-            homeboy::core::Error::internal_io(
-                format!("start portable release {gate} preflight: {error}"),
-                Some(component.local_path.clone()),
-            )
+            path: &component.local_path,
+            requested_runner_id: runner_id,
+            placement: args.preflight_placement,
         })?;
-        let result = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
-            serde_json::json!({
-                "gate": gate,
-                "stdout": String::from_utf8_lossy(&output.stdout),
-                "stderr": String::from_utf8_lossy(&output.stderr),
-            })
+        resolved_runner_id = child.runner_id.clone().or(resolved_runner_id);
+        evidence_refs.extend(child.evidence_refs.iter().cloned());
+        gate_results.push(ReleaseReadinessGateResult {
+            gate: gate.to_string(),
+            status: if child.passed { "passed" } else { "failed" }.to_string(),
+            reason: None,
+            source_sha: Some(commit.clone()),
+            runner_id: child.runner_id,
+            evidence_refs: child.evidence_refs,
         });
-        gate_results.push(serde_json::json!({
-            "gate": gate,
-            "status": if output.status.success() { "passed" } else { "failed" },
-            "command": command.get_args().map(|arg| arg.to_string_lossy()).collect::<Vec<_>>(),
-            "source_sha": commit,
-            "runner_id": runner_id,
-            "exit_code": output.status.code(),
-            "result": result,
-        }));
     }
     // Package preflight owns release-specific lockfile and local-dependency
     // guards. No portable review command exposes that contract yet, so retain
     // the explicit controller placement while other gates still offload.
-    gate_results.push(serde_json::json!({
-        "gate": "package_preflight",
-        "status": "local_only",
-        "reason": "release package guards have no portable command contract",
-        "source_sha": commit,
-    }));
+    gate_results.push(ReleaseReadinessGateResult {
+        gate: "package_preflight".to_string(),
+        status: "local_only".to_string(),
+        reason: Some("release package guards have no portable command contract".to_string()),
+        source_sha: Some(commit.clone()),
+        runner_id: None,
+        evidence_refs: Vec::new(),
+    });
     let placement = ReleasePreflightPlacement {
         policy: if runner_id.is_some()
             || matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
@@ -517,13 +663,16 @@ fn run_portable_preflight(
         } else {
             ReleasePreflightPlacementPolicy::Local
         },
-        runner_id: runner_id.map(str::to_string),
+        runner_id: resolved_runner_id
+            .clone()
+            .or_else(|| runner_id.map(str::to_string)),
     };
     Ok(Some(ReleaseReadinessEnvelope {
         source: ReleasePreflightSourceIdentity { commit },
         placement,
-        runner_id: runner_id.map(str::to_string),
-        evidence_refs: Vec::new(),
+        runner_id: resolved_runner_id.or_else(|| runner_id.map(str::to_string)),
+        evidence_refs,
+        provenance: release::readiness_provenance(&component)?,
         gate_results,
     }))
 }
@@ -1501,6 +1650,7 @@ jobs:
             deployment: None,
             continuation_command: Some(continuation.clone()),
             release_summary: vec!["Git state recovered; publication is incomplete".to_string()],
+            readiness: None,
         };
         let output = ReleaseOutput {
             variant: "single",
@@ -1521,5 +1671,29 @@ jobs:
         assert!(!value["success"].as_bool().expect("success boolean"));
         assert_eq!(value["data"]["result"]["status"], "git_recovered");
         assert_eq!(value["next_actions"][0]["command"], continuation);
+    }
+
+    #[test]
+    fn portable_child_projection_retains_remote_runner_and_durable_evidence() {
+        let child: PortableReviewChildEnvelope = serde_json::from_value(serde_json::json!({
+            "success": true,
+            "run": { "id": "review-run-7", "location": "lab-runner-7" },
+            "refs": { "runs": [{ "id": "review-run-7" }] },
+            "evidence": [{ "uri": "runner-artifact://lab-runner-7/review.json" }],
+            "data": { "execution_provenance": { "resolved_execution": { "runner_id": "lab-runner-7" } } }
+        }))
+        .expect("stable child result");
+
+        let projected = child.project(true);
+
+        assert!(projected.passed);
+        assert_eq!(projected.runner_id.as_deref(), Some("lab-runner-7"));
+        assert_eq!(
+            projected.evidence_refs,
+            vec![
+                "run://review-run-7".to_string(),
+                "runner-artifact://lab-runner-7/review.json".to_string(),
+            ]
+        );
     }
 }

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -902,7 +902,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
                 None,
             ));
         }
-        return run_package_only(args, &component_ids);
+        return run_package_only(args, &component_ids, readiness.as_ref());
     }
 
     // Single component: use the original single-release flow
@@ -1100,6 +1100,7 @@ fn run_cascade_if_requested(
 fn run_package_only(
     args: ReleaseExecuteArgs,
     component_ids: &[String],
+    readiness: Option<&ReleaseReadinessEnvelope>,
 ) -> CmdResult<ReleaseCommandOutput> {
     if component_ids.len() != 1 {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -1157,6 +1158,7 @@ fn run_package_only(
         args.path.clone(),
         &tag,
         args.skip_build_validation,
+        readiness.map(|value| value.source.commit.as_str()),
     )?;
 
     Ok((
@@ -1626,7 +1628,7 @@ mod tests {
         args.package_only = true;
         args.apply = true;
 
-        let err = match run_package_only(args, &["fixture".to_string()]) {
+        let err = match run_package_only(args, &["fixture".to_string()], None) {
             Ok(_) => panic!("package-only requires an explicit tag"),
             Err(err) => err,
         };

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -1,5 +1,6 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
+use std::process::Command;
 use std::{fs, path::Path};
 
 use homeboy::core::component;
@@ -8,7 +9,8 @@ use homeboy_deploy::{self as deploy, ReleaseStateStatus};
 use homeboy_release::release::{
     self, ArtifactSourceAuthorityManifest, BatchReleaseResult, ReleaseCommandInput,
     ReleaseCommandResult, ReleaseExecutionPlan, ReleasePackageResult, ReleasePhase,
-    ReleasePipelineOptions,
+    ReleasePipelineOptions, ReleasePreflightPlacement, ReleasePreflightPlacementPolicy,
+    ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
 };
 
 use super::utils::args::DryRunArgs;
@@ -103,6 +105,15 @@ pub struct ReleaseExecuteArgs {
     /// Override local_path for version file lookup (single component only)
     #[arg(long)]
     pub path: Option<String>,
+
+    /// Run portable lint and test release gates through the existing Lab review
+    /// commands before controller-owned release mutation.
+    #[arg(long, value_name = "RUNNER_ID", conflicts_with = "preflight_placement")]
+    preflight_runner: Option<String>,
+
+    /// Placement policy for portable release preflight gates.
+    #[arg(long, value_enum, default_value_t = ReleasePreflightPlacementArg::Local)]
+    preflight_placement: ReleasePreflightPlacementArg,
 
     #[command(flatten)]
     dry_run_args: DryRunArgs,
@@ -224,6 +235,13 @@ pub struct ReleaseExecuteArgs {
     /// releases only.
     #[arg(long)]
     cascade: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum ReleasePreflightPlacementArg {
+    #[default]
+    Local,
+    Lab,
 }
 
 #[derive(Serialize)]
@@ -420,11 +438,113 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
     run_execute(args.execute)
 }
 
+fn run_portable_preflight(
+    args: &ReleaseExecuteArgs,
+    component_id: &str,
+) -> homeboy::core::Result<Option<ReleaseReadinessEnvelope>> {
+    let runner_id = args.preflight_runner.as_deref();
+    if runner_id.is_none() && !matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
+    {
+        return Ok(None);
+    }
+    let component = component::resolve_effective(Some(component_id), args.path.as_deref(), None)?;
+    let commit = homeboy::core::git::get_head_commit(&component.local_path)?;
+    let executable = std::env::current_exe().map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("release preflight executable".to_string()),
+        )
+    })?;
+    let mut gate_results = Vec::new();
+    for gate in ["lint", "test"] {
+        let mut command = Command::new(&executable);
+        if let Some(runner_id) = runner_id {
+            command.args(["--runner", runner_id]);
+        } else {
+            command.args(["--placement", "lab"]);
+        }
+        command.args([
+            "review",
+            gate,
+            component_id,
+            "--path",
+            &component.local_path,
+        ]);
+        let output = command.output().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                format!("start portable release {gate} preflight: {error}"),
+                Some(component.local_path.clone()),
+            )
+        })?;
+        let result = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+            serde_json::json!({
+                "gate": gate,
+                "stdout": String::from_utf8_lossy(&output.stdout),
+                "stderr": String::from_utf8_lossy(&output.stderr),
+            })
+        });
+        if !output.status.success() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "release.preflight",
+                format!(
+                    "Portable release {gate} gate failed with exit status {:?}",
+                    output.status.code()
+                ),
+                Some(component.local_path.clone()),
+                Some(vec![format!(
+                    "Inspect the returned {gate} evidence before retrying release."
+                )]),
+            ));
+        }
+        gate_results.push(result);
+    }
+    let placement = ReleasePreflightPlacement {
+        policy: if runner_id.is_some()
+            || matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab)
+        {
+            ReleasePreflightPlacementPolicy::Lab
+        } else {
+            ReleasePreflightPlacementPolicy::Local
+        },
+        runner_id: runner_id.map(str::to_string),
+    };
+    Ok(Some(ReleaseReadinessEnvelope {
+        source: ReleasePreflightSourceIdentity { commit },
+        placement,
+        runner_id: runner_id.map(str::to_string),
+        evidence_refs: Vec::new(),
+        gate_results,
+    }))
+}
+
 fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
-    let (skip_checks, skip_checks_granular) = args.resolve_skip_checks()?;
+    let (skip_checks, mut skip_checks_granular) = args.resolve_skip_checks()?;
     let execution = args.execution_plan(skip_checks);
     validate_apply_boundary(&execution)?;
     let component_ids = resolve_component_ids(&args, &args.components)?;
+    if component_ids.len() > 1
+        && (args.preflight_runner.is_some()
+            || matches!(args.preflight_placement, ReleasePreflightPlacementArg::Lab))
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "preflight-runner",
+            "portable release preflight currently requires one component",
+            None,
+            None,
+        ));
+    }
+    let readiness = if component_ids.len() == 1 {
+        run_portable_preflight(&args, &component_ids[0])?
+    } else {
+        None
+    };
+    if readiness.is_some() {
+        for gate in ["lint", "test"] {
+            if !skip_checks_granular.iter().any(|existing| existing == gate) {
+                skip_checks_granular.push(gate.to_string());
+            }
+        }
+    }
     let bump_override = args.bump.clone();
 
     guard_no_github_release(&args, &component_ids)?;
@@ -452,6 +572,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
             skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
             execution: Some(execution.clone()),
+            readiness,
         };
         let (workspace_result, exit_code) =
             release::run_command_with_workspace(input.clone(), args.owner_run_ref.as_deref())?;
@@ -535,6 +656,7 @@ fn run_execute(args: ReleaseExecuteArgs) -> CmdResult<ReleaseCommandOutput> {
         skip_github_release: args.no_github_release,
         git_identity: args.git_identity.clone(),
         execution: Some(execution),
+        readiness: None,
     };
 
     let batch_result = release::run_batch(&component_ids, &input_template);

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -327,14 +327,50 @@ fn dispatch_review_plan_step(
 
 pub fn run(args: ReviewArgs) -> CmdResult<Value> {
     match args.command {
-        Some(ReviewCommand::Audit(args)) => to_value(audit::run(args.audit)),
+        Some(ReviewCommand::Audit(args)) => {
+            let component = args.audit.comp.load()?;
+            to_value_with_readiness_provenance(audit::run(args.audit), &component)
+        }
         Some(ReviewCommand::AuditBaseline(args)) => to_value(audit_baseline::run(args)),
-        Some(ReviewCommand::Lint(args)) => to_value(lint::run(review_lint_args(args))),
-        Some(ReviewCommand::Test(args)) => to_value(test::run(args)),
+        Some(ReviewCommand::Lint(args)) => {
+            let component = args.comp.load()?;
+            to_value_with_readiness_provenance(lint::run(review_lint_args(args)), &component)
+        }
+        Some(ReviewCommand::Test(args)) => {
+            let component = args.comp.load()?;
+            to_value_with_readiness_provenance(test::run(args), &component)
+        }
         Some(ReviewCommand::Build(args)) => to_value(build::run(args)),
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args)),
         None => to_value(run_umbrella(args)),
     }
+}
+
+/// Portable release preflight consumes this child-produced provenance from the
+/// command result. Capture it after execution on the runner that tested it.
+fn to_value_with_readiness_provenance<T: Serialize>(
+    result: CmdResult<T>,
+    component: &homeboy::core::component::Component,
+) -> CmdResult<Value> {
+    let (output, exit_code) = result?;
+    let mut value = serde_json::to_value(output).map_err(|error| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "failed to serialize review command output: {error}"
+        ))
+    })?;
+    let object = value.as_object_mut().ok_or_else(|| {
+        homeboy::core::Error::internal_unexpected("review command output was not an object")
+    })?;
+    let provenance = homeboy_release::release::readiness_provenance(component)?;
+    object.insert(
+        "release_readiness_provenance".to_string(),
+        serde_json::to_value(provenance).map_err(|error| {
+            homeboy::core::Error::internal_unexpected(format!(
+                "failed to serialize review readiness provenance: {error}"
+            ))
+        })?,
+    );
+    Ok((value, exit_code))
 }
 
 fn to_value<T: Serialize>(result: CmdResult<T>) -> CmdResult<Value> {

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -116,6 +116,16 @@ pub enum ReviewCommand {
     Ci(ci::CiArgs),
 }
 
+/// Typed portable-release evidence emitted by a review child after its stage
+/// executes in the selected checkout.
+#[derive(Serialize)]
+struct ReviewChildReadinessEvidence {
+    requested_source_commit: String,
+    source_commit: String,
+    runner_id: Option<String>,
+    provenance: homeboy_release::release::ReleaseReadinessProvenance,
+}
+
 impl ReviewCommand {
     fn lab_label(&self) -> &'static str {
         match self {
@@ -328,17 +338,32 @@ fn dispatch_review_plan_step(
 pub fn run(args: ReviewArgs) -> CmdResult<Value> {
     match args.command {
         Some(ReviewCommand::Audit(args)) => {
+            let requested_source = args.audit.release_readiness_source.clone();
             let component = args.audit.comp.load()?;
-            to_value_with_readiness_provenance(audit::run(args.audit), &component)
+            to_value_with_readiness_provenance(
+                audit::run(args.audit),
+                &component,
+                requested_source.as_deref(),
+            )
         }
         Some(ReviewCommand::AuditBaseline(args)) => to_value(audit_baseline::run(args)),
         Some(ReviewCommand::Lint(args)) => {
+            let requested_source = args.release_readiness_source.clone();
             let component = args.comp.load()?;
-            to_value_with_readiness_provenance(lint::run(review_lint_args(args)), &component)
+            to_value_with_readiness_provenance(
+                lint::run(review_lint_args(args)),
+                &component,
+                requested_source.as_deref(),
+            )
         }
         Some(ReviewCommand::Test(args)) => {
+            let requested_source = args.release_readiness_source.clone();
             let component = args.comp.load()?;
-            to_value_with_readiness_provenance(test::run(args), &component)
+            to_value_with_readiness_provenance(
+                test::run(args),
+                &component,
+                requested_source.as_deref(),
+            )
         }
         Some(ReviewCommand::Build(args)) => to_value(build::run(args)),
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args)),
@@ -351,6 +376,7 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
 fn to_value_with_readiness_provenance<T: Serialize>(
     result: CmdResult<T>,
     component: &homeboy::core::component::Component,
+    requested_source: Option<&str>,
 ) -> CmdResult<Value> {
     let (output, exit_code) = result?;
     let mut value = serde_json::to_value(output).map_err(|error| {
@@ -361,15 +387,31 @@ fn to_value_with_readiness_provenance<T: Serialize>(
     let object = value.as_object_mut().ok_or_else(|| {
         homeboy::core::Error::internal_unexpected("review command output was not an object")
     })?;
-    let provenance = homeboy_release::release::readiness_provenance(component)?;
-    object.insert(
-        "release_readiness_provenance".to_string(),
-        serde_json::to_value(provenance).map_err(|error| {
-            homeboy::core::Error::internal_unexpected(format!(
-                "failed to serialize review readiness provenance: {error}"
-            ))
-        })?,
-    );
+    if let Some(requested_source) = requested_source {
+        let provenance = homeboy_release::release::readiness_provenance(component)?;
+        let source_commit = homeboy::core::git::get_head_commit(&component.local_path)?;
+        let runner_id =
+            crate::commands::utils::execution_provenance::captured().and_then(|value| {
+                value
+                    .pointer("/resolved_execution/runner_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            });
+        object.insert(
+            "release_readiness".to_string(),
+            serde_json::to_value(ReviewChildReadinessEvidence {
+                requested_source_commit: requested_source.to_string(),
+                source_commit,
+                runner_id,
+                provenance,
+            })
+            .map_err(|error| {
+                homeboy::core::Error::internal_unexpected(format!(
+                    "failed to serialize review readiness evidence: {error}"
+                ))
+            })?,
+        );
+    }
     Ok((value, exit_code))
 }
 
@@ -854,6 +896,7 @@ fn build_audit_args(
 ) -> audit::AuditArgs {
     audit::AuditArgs {
         comp: args.effective_component_args().clone(),
+        release_readiness_source: None,
         extension_override: args.extension_override.clone(),
         conventions: false,
         only: Vec::new(),
@@ -886,6 +929,7 @@ fn selected_audit_profile(args: &ReviewArgs, review_context: &ReviewExecutionCon
 fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> lint::LintArgs {
     lint::LintArgs {
         comp: args.effective_component_args().clone(),
+        release_readiness_source: None,
         summary: args.summary,
         file: None,
         glob: None,
@@ -917,6 +961,7 @@ fn build_lint_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -
 fn build_test_args(args: &ReviewArgs, review_context: &ReviewExecutionContext) -> test::TestArgs {
     test::TestArgs {
         comp: args.effective_component_args().clone(),
+        release_readiness_source: None,
         extension_override: args.extension_override.clone(),
         skip_lint: true,
         coverage: false,

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -42,6 +42,9 @@ pub struct TestArgs {
     #[command(flatten)]
     pub comp: PositionalComponentArgs,
 
+    #[arg(long, hide = true)]
+    pub release_readiness_source: Option<String>,
+
     #[command(flatten)]
     pub extension_override: ExtensionOverrideArgs,
 

--- a/crates/homeboy-release/src/release/context.rs
+++ b/crates/homeboy-release/src/release/context.rs
@@ -1,5 +1,6 @@
 use homeboy_core::component::{self, Component};
 use homeboy_core::error::{Error, Result};
+use homeboy_core::git;
 use homeboy_extension as extension;
 use homeboy_extension::{self, ExtensionManifest};
 
@@ -28,20 +29,32 @@ pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionM
     Ok(extensions)
 }
 
-/// Capture configuration and resolved extension revisions before portable work.
+/// Capture immutable identities for the dependency and extension resolutions
+/// that release will consume before portable work begins.
 pub fn readiness_provenance(component: &Component) -> Result<ReleaseReadinessProvenance> {
     let mut provenance = ReleaseReadinessProvenance::default();
     for dependency in &component.dependency_stack {
-        if let Some(revision) = &dependency.update {
-            provenance
-                .dependencies
-                .insert(dependency.package.clone(), revision.clone());
-        }
+        let upstream = component::resolve_effective(Some(&dependency.upstream), None, None)?;
+        let revision = git::get_head_commit(&upstream.local_path)?;
+        provenance
+            .dependencies
+            .insert(dependency.package.clone(), revision);
     }
     for extension in resolve_extensions(component)? {
+        let path = extension.extension_path.as_deref().ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "resolved extension '{}' has no materialized path",
+                extension.id
+            ))
+        })?;
+        let manifest = std::path::Path::new(path).join(format!("{}.json", extension.id));
+        let revision =
+            homeboy_engine_primitives::content_hash::sha256_file(&manifest).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(manifest.display().to_string()))
+            })?;
         provenance
             .extensions
-            .insert(extension.id, extension.version);
+            .insert(extension.id, format!("sha256:{revision}"));
     }
     Ok(provenance)
 }

--- a/crates/homeboy-release/src/release/context.rs
+++ b/crates/homeboy-release/src/release/context.rs
@@ -3,7 +3,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_extension as extension;
 use homeboy_extension::{self, ExtensionManifest};
 
-use super::types::ReleaseOptions;
+use super::types::{ReleaseOptions, ReleaseReadinessProvenance};
 
 /// Load a component with portable config fallback when path_override is set.
 /// In CI environments, the component may not be registered — only homeboy.json exists.
@@ -26,6 +26,24 @@ pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionM
         }
     }
     Ok(extensions)
+}
+
+/// Capture configuration and resolved extension revisions before portable work.
+pub fn readiness_provenance(component: &Component) -> Result<ReleaseReadinessProvenance> {
+    let mut provenance = ReleaseReadinessProvenance::default();
+    for dependency in &component.dependency_stack {
+        if let Some(revision) = &dependency.update {
+            provenance
+                .dependencies
+                .insert(dependency.package.clone(), revision.clone());
+        }
+    }
+    for extension in resolve_extensions(component)? {
+        provenance
+            .extensions
+            .insert(extension.id, extension.version);
+    }
+    Ok(provenance)
 }
 
 #[cfg(test)]

--- a/crates/homeboy-release/src/release/context.rs
+++ b/crates/homeboy-release/src/release/context.rs
@@ -1,6 +1,5 @@
 use homeboy_core::component::{self, Component};
-use homeboy_core::error::{Error, Result};
-use homeboy_core::git;
+use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_extension as extension;
 use homeboy_extension::{self, ExtensionManifest};
 
@@ -29,16 +28,28 @@ pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionM
     Ok(extensions)
 }
 
-/// Capture immutable identities for the dependency and extension resolutions
-/// that release will consume before portable work begins.
+/// Capture immutable identities from the dependency adapters and materialized
+/// extension manifests in the process that executed a portable review gate.
 pub fn readiness_provenance(component: &Component) -> Result<ReleaseReadinessProvenance> {
     let mut provenance = ReleaseReadinessProvenance::default();
-    for dependency in &component.dependency_stack {
-        let upstream = component::resolve_effective(Some(&dependency.upstream), None, None)?;
-        let revision = git::get_head_commit(&upstream.local_path)?;
-        provenance
-            .dependencies
-            .insert(dependency.package.clone(), revision);
+    let dependencies =
+        match homeboy_core::deps::status(Some(&component.id), Some(&component.local_path), None) {
+            Ok(status) => status.packages,
+            // Dependency hydration treats a component with no declared provider as
+            // a no-op; provenance must preserve that same contract.
+            Err(error)
+                if error.code == ErrorCode::ValidationInvalidArgument
+                    && error.details.get("field").and_then(|value| value.as_str())
+                        == Some("dependency_provider") =>
+            {
+                Vec::new()
+            }
+            Err(error) => return Err(error),
+        };
+    for dependency in dependencies {
+        if let Some(revision) = dependency.locked_reference.or(dependency.locked_version) {
+            provenance.dependencies.insert(dependency.name, revision);
+        }
     }
     for extension in resolve_extensions(component)? {
         let path = extension.extension_path.as_deref().ok_or_else(|| {

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -59,6 +59,7 @@ pub use containment::{
     ContainmentAssessment, ContainmentStatus, ContainsQuery, GapStatus, ReleaseContainsReport,
     ReleaseGapAssessment, ReleaseGapReport,
 };
+pub use context::readiness_provenance;
 pub use executor::artifacts::{
     write_artifact_source_authority_manifest, ArtifactSourceAuthorityManifest,
 };
@@ -70,9 +71,10 @@ pub use types::{
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
     ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
     ReleasePreflightPlacement, ReleasePreflightPlacementPolicy, ReleasePreflightSourceIdentity,
-    ReleaseProjectDeployResult, ReleaseReadinessEnvelope, ReleaseRollbackEvidence, ReleaseRun,
-    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
-    ReleaseStepResult, ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
+    ReleaseProjectDeployResult, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
+    ReleaseReadinessProvenance, ReleaseRollbackEvidence, ReleaseRun, ReleaseRunResult,
+    ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
+    ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -27,6 +27,7 @@ mod planning_policy;
 mod planning_quality;
 mod planning_semver;
 mod planning_worktree;
+mod preflight_identity;
 pub use homeboy_deploy::provider_impl;
 mod types;
 mod utils;
@@ -68,9 +69,10 @@ pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
     ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
-    ReleaseProjectDeployResult, ReleaseRollbackEvidence, ReleaseRun, ReleaseRunResult,
-    ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
-    ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
+    ReleasePreflightPlacement, ReleasePreflightPlacementPolicy, ReleasePreflightSourceIdentity,
+    ReleaseProjectDeployResult, ReleaseReadinessEnvelope, ReleaseRollbackEvidence, ReleaseRun,
+    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
+    ReleaseStepResult, ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -66,15 +66,16 @@ pub use executor::artifacts::{
 pub use package_recovery::{package_existing_tag, ReleasePackageResult};
 pub use pipeline::run;
 pub use planner::plan;
+pub use types::readiness_is_valid;
 pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
     ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
     ReleasePreflightPlacement, ReleasePreflightPlacementPolicy, ReleasePreflightSourceIdentity,
     ReleaseProjectDeployResult, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
-    ReleaseReadinessProvenance, ReleaseRollbackEvidence, ReleaseRun, ReleaseRunResult,
-    ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
-    ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
+    ReleaseReadinessLocalOnly, ReleaseReadinessProvenance, ReleaseRollbackEvidence, ReleaseRun,
+    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
+    ReleaseStepResult, ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -120,6 +120,12 @@ fn run_with_plan_inner(
         return Ok((initial_plan, run));
     }
 
+    // The portable portion of preflight is now complete. Freeze its source
+    // identity before building the mutation plan; any later checkout movement
+    // invalidates its evidence and must block controller-owned mutation.
+    let preflight_component = super::context::load_component(component_id, options)?;
+    let preflight_source = super::preflight_identity::capture(&preflight_component)?;
+
     // Rebuild the full plan after executable preflights. `preflight.remote_sync`
     // may fast-forward HEAD and `preflight.changelog_bootstrap` may create the
     // first changelog file; changelog/version planning must observe those
@@ -127,6 +133,8 @@ fn run_with_plan_inner(
     let release_plan = plan(component_id, options)?;
     let completed_preflights: HashSet<&'static str> =
         initial_executable_preflight_ids().iter().copied().collect();
+
+    super::preflight_identity::revalidate(&preflight_component, &preflight_source)?;
 
     timer.time("package", || {
         super::execution_plan::execute_plan_steps_at_source(

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -100,6 +100,7 @@ fn run_with_plan_inner(
     staging_source_sha: Option<&str>,
 ) -> Result<(ReleasePlan, ReleaseRun)> {
     let mut results: Vec<ReleaseStepResult> = Vec::new();
+    ensure_readiness_passed(options)?;
 
     let initial_plan = build_initial_preflight_plan(component_id, options);
     let mut timer = PhaseTimer::new();
@@ -139,32 +140,6 @@ fn run_with_plan_inner(
         initial_executable_preflight_ids().iter().copied().collect();
 
     super::preflight_identity::revalidate(&preflight_component, &preflight_source)?;
-    if let Some(readiness) = options.readiness.as_ref() {
-        let failed = readiness
-            .gate_results
-            .iter()
-            .filter(|gate| gate.status == "failed")
-            .map(|gate| gate.gate.as_str())
-            .collect::<Vec<_>>();
-        if !failed.is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "release.preflight",
-                format!(
-                    "Portable release preflight failed for: {}",
-                    failed.join(", ")
-                ),
-                Some(readiness.source.commit.clone()),
-                Some(
-                    readiness
-                        .evidence_refs
-                        .iter()
-                        .map(|reference| format!("Inspect durable readiness evidence: {reference}"))
-                        .collect(),
-                ),
-            ));
-        }
-    }
-
     timer.time("package", || {
         super::execution_plan::execute_plan_steps_at_source(
             &release_plan.plan.steps,
@@ -180,6 +155,36 @@ fn run_with_plan_inner(
     restore_checkout_after_failed_run(checkout_guard, &mut run)?;
 
     Ok((release_plan, run))
+}
+
+fn ensure_readiness_passed(options: &ReleaseOptions) -> Result<()> {
+    let Some(readiness) = options.readiness.as_ref() else {
+        return Ok(());
+    };
+    let failed = readiness
+        .gate_results
+        .iter()
+        .filter(|gate| gate.status == "failed")
+        .map(|gate| gate.gate.as_str())
+        .collect::<Vec<_>>();
+    if failed.is_empty() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "release.preflight",
+        format!(
+            "Portable release preflight failed for: {}",
+            failed.join(", ")
+        ),
+        Some(readiness.source.commit.clone()),
+        Some(
+            readiness
+                .evidence_refs
+                .iter()
+                .map(|reference| format!("Inspect durable readiness evidence: {reference}"))
+                .collect(),
+        ),
+    ))
 }
 
 /// Wrap the accumulated step results into a `ReleaseRun` with an overall

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -124,7 +124,11 @@ fn run_with_plan_inner(
     // identity before building the mutation plan; any later checkout movement
     // invalidates its evidence and must block controller-owned mutation.
     let preflight_component = super::context::load_component(component_id, options)?;
-    let preflight_source = super::preflight_identity::capture(&preflight_component)?;
+    let preflight_source = options
+        .readiness
+        .as_ref()
+        .map(|readiness| readiness.source.clone())
+        .unwrap_or(super::preflight_identity::capture(&preflight_component)?);
 
     // Rebuild the full plan after executable preflights. `preflight.remote_sync`
     // may fast-forward HEAD and `preflight.changelog_bootstrap` may create the

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -143,15 +143,8 @@ fn run_with_plan_inner(
         let failed = readiness
             .gate_results
             .iter()
-            .filter_map(|gate| {
-                (gate.get("status").and_then(serde_json::Value::as_str) == Some("failed")).then(
-                    || {
-                        gate.get("gate")
-                            .and_then(serde_json::Value::as_str)
-                            .unwrap_or("unknown")
-                    },
-                )
-            })
+            .filter(|gate| gate.status == "failed")
+            .map(|gate| gate.gate.as_str())
             .collect::<Vec<_>>();
         if !failed.is_empty() {
             return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -139,6 +139,38 @@ fn run_with_plan_inner(
         initial_executable_preflight_ids().iter().copied().collect();
 
     super::preflight_identity::revalidate(&preflight_component, &preflight_source)?;
+    if let Some(readiness) = options.readiness.as_ref() {
+        let failed = readiness
+            .gate_results
+            .iter()
+            .filter_map(|gate| {
+                (gate.get("status").and_then(serde_json::Value::as_str) == Some("failed")).then(
+                    || {
+                        gate.get("gate")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown")
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        if !failed.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "release.preflight",
+                format!(
+                    "Portable release preflight failed for: {}",
+                    failed.join(", ")
+                ),
+                Some(readiness.source.commit.clone()),
+                Some(
+                    readiness
+                        .evidence_refs
+                        .iter()
+                        .map(|reference| format!("Inspect durable readiness evidence: {reference}"))
+                        .collect(),
+                ),
+            ));
+        }
+    }
 
     timer.time("package", || {
         super::execution_plan::execute_plan_steps_at_source(

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -161,21 +161,12 @@ fn ensure_readiness_passed(options: &ReleaseOptions) -> Result<()> {
     let Some(readiness) = options.readiness.as_ref() else {
         return Ok(());
     };
-    let failed = readiness
-        .gate_results
-        .iter()
-        .filter(|gate| gate.status == "failed")
-        .map(|gate| gate.gate.as_str())
-        .collect::<Vec<_>>();
-    if failed.is_empty() {
+    if super::types::readiness_is_valid(readiness) {
         return Ok(());
     }
     Err(Error::validation_invalid_argument(
         "release.preflight",
-        format!(
-            "Portable release preflight failed for: {}",
-            failed.join(", ")
-        ),
+        format!("Portable release preflight has invalid selected gate evidence"),
         Some(readiness.source.commit.clone()),
         Some(
             readiness

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -32,6 +32,7 @@ pub fn package_existing_tag(
     path_override: Option<String>,
     tag: &str,
     skip_build_validation: bool,
+    expected_source: Option<&str>,
 ) -> Result<ReleasePackageResult> {
     let component = load_component(
         component_id,
@@ -41,6 +42,14 @@ pub fn package_existing_tag(
         },
     )?;
     let head_commit = git::get_head_commit(&component.local_path)?;
+    if expected_source.is_some_and(|source| source != head_commit) {
+        return Err(Error::validation_invalid_argument(
+            "release.preflight",
+            "Package recovery source drifted from portable readiness",
+            Some(head_commit),
+            None,
+        ));
+    }
     validate_existing_tag_at_head(&component.local_path, tag, &head_commit)?;
     super::executor::package_preflight::run_package_preflight(&component.local_path)?;
 

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -42,6 +42,7 @@ pub fn package_existing_tag(
     )?;
     let head_commit = git::get_head_commit(&component.local_path)?;
     validate_existing_tag_at_head(&component.local_path, tag, &head_commit)?;
+    super::executor::package_preflight::run_package_preflight(&component.local_path)?;
 
     let version = super::version::read_component_version(&component)?.version;
     let extensions = resolve_extensions(&component)?;

--- a/crates/homeboy-release/src/release/preflight_identity.rs
+++ b/crates/homeboy-release/src/release/preflight_identity.rs
@@ -1,0 +1,80 @@
+use homeboy_core::component::Component;
+use homeboy_core::error::{Error, Result};
+use homeboy_core::git;
+
+use super::types::ReleasePreflightSourceIdentity;
+
+/// Freeze the commit whose portable quality evidence may authorize a release.
+pub(super) fn capture(component: &Component) -> Result<ReleasePreflightSourceIdentity> {
+    Ok(ReleasePreflightSourceIdentity {
+        commit: git::get_head_commit(&component.local_path)?,
+    })
+}
+
+/// Refuse controller mutation when the source inspected by readiness gates moved.
+pub(super) fn revalidate(
+    component: &Component,
+    expected: &ReleasePreflightSourceIdentity,
+) -> Result<()> {
+    let actual = git::get_head_commit(&component.local_path)?;
+    if actual == expected.commit {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release.preflight_source",
+        format!(
+            "Release preflight source drift: portable gates validated commit {} but controller mutation would run at {}",
+            expected.commit, actual
+        ),
+        Some(actual.clone()),
+        Some(vec![format!(
+            "Rerun release preflight so its evidence is bound to the current commit {actual}."
+        )]),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn revalidation_fails_closed_when_the_source_moves_after_preflight() {
+        let repo = tempfile::tempdir().expect("repo");
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+        run_git(repo.path(), &["config", "user.name", "Test"]);
+        std::fs::write(repo.path().join("file"), "one\n").expect("write source");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-q", "-m", "first"]);
+        let component = Component {
+            local_path: repo.path().display().to_string(),
+            ..Component::default()
+        };
+        let identity = capture(&component).expect("capture identity");
+
+        std::fs::write(repo.path().join("file"), "two\n").expect("move source");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-q", "-m", "second"]);
+
+        let error =
+            revalidate(&component, &identity).expect_err("source drift must block mutation");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("Release preflight source drift"));
+    }
+
+    fn run_git(path: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git");
+        assert!(
+            output.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -541,6 +541,12 @@ pub fn readiness_is_valid(readiness: &ReleaseReadinessEnvelope) -> bool {
                         })
                 }
                 "skipped" => gate.source_sha.as_deref() == Some(readiness.source.commit.as_str()),
+                "local_only" => {
+                    gate.gate == "package_preflight"
+                        && gate.local_only.as_ref().is_some_and(|local_only| {
+                            !local_only.reason.is_empty() && !local_only.continuation.is_empty()
+                        })
+                }
                 _ => false,
             })
 }
@@ -560,6 +566,14 @@ pub struct ReleaseReadinessGateResult {
     /// Immutable identities emitted by the child that executed this gate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ReleaseReadinessProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_only: Option<ReleaseReadinessLocalOnly>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseReadinessLocalOnly {
+    pub reason: String,
+    pub continuation: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -895,6 +909,7 @@ mod tests {
                 runner_id: Some("homeboy-lab".to_string()),
                 evidence_refs: Vec::new(),
                 provenance: None,
+                local_only: None,
             }],
         };
 

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -537,6 +537,9 @@ pub struct ReleaseReadinessGateResult {
     pub runner_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence_refs: Vec<String>,
+    /// Immutable identities emitted by the child that executed this gate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ReleaseReadinessProvenance>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -871,6 +874,7 @@ mod tests {
                 source_sha: None,
                 runner_id: Some("homeboy-lab".to_string()),
                 evidence_refs: Vec::new(),
+                provenance: None,
             }],
         };
 

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -454,6 +454,8 @@ pub struct ReleaseOptions {
     /// always remains controller-owned; a runner is evidence provenance only.
     #[serde(default, skip_serializing_if = "ReleasePreflightPlacement::is_default")]
     pub preflight_placement: ReleasePreflightPlacement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<ReleaseReadinessEnvelope>,
 }
 
 /// Typed placement policy for the portable portion of release preflight.
@@ -503,6 +505,8 @@ pub struct ReleaseReadinessEnvelope {
     pub placement: ReleasePreflightPlacement,
     pub runner_id: Option<String>,
     pub evidence_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gate_results: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -571,6 +575,8 @@ pub struct ReleaseCommandInput {
     /// Internal execution contract resolved before the workflow runs.
     #[serde(skip_serializing)]
     pub execution: Option<ReleaseExecutionPlan>,
+    #[serde(skip_serializing)]
+    pub readiness: Option<ReleaseReadinessEnvelope>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -825,6 +831,7 @@ mod tests {
             },
             runner_id: Some("homeboy-lab".to_string()),
             evidence_refs: vec!["runner-artifact://homeboy-lab/release/lint.json".to_string()],
+            gate_results: vec![serde_json::json!({ "gate": "lint", "status": "passed" })],
         };
 
         let value = serde_json::to_value(envelope).expect("serialize readiness envelope");

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -536,6 +536,11 @@ pub fn readiness_is_valid(readiness: &ReleaseReadinessEnvelope) -> bool {
             .all(|gate| match gate.status.as_str() {
                 "passed" => {
                     gate.source_sha.as_deref() == Some(readiness.source.commit.as_str())
+                        && gate
+                            .runner_id
+                            .as_deref()
+                            .is_some_and(|runner| !runner.is_empty())
+                        && !gate.evidence_refs.is_empty()
                         && gate.provenance.as_ref().is_some_and(|provenance| {
                             !ReleaseReadinessProvenance::is_empty(provenance)
                         })

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -525,6 +525,26 @@ impl ReleaseReadinessProvenance {
     }
 }
 
+/// A readiness envelope authorizes release planning only when it has an
+/// explicit selected-gate outcome. Bare `--skip-checks` remains authorized
+/// because it records every selected portable gate as `skipped`.
+pub fn readiness_is_valid(readiness: &ReleaseReadinessEnvelope) -> bool {
+    !readiness.gate_results.is_empty()
+        && readiness
+            .gate_results
+            .iter()
+            .all(|gate| match gate.status.as_str() {
+                "passed" => {
+                    gate.source_sha.as_deref() == Some(readiness.source.commit.as_str())
+                        && gate.provenance.as_ref().is_some_and(|provenance| {
+                            !ReleaseReadinessProvenance::is_empty(provenance)
+                        })
+                }
+                "skipped" => gate.source_sha.as_deref() == Some(readiness.source.commit.as_str()),
+                _ => false,
+            })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReleaseReadinessGateResult {
     pub gate: String,

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -450,6 +450,59 @@ pub struct ReleaseOptions {
     /// Bump policy controls that affect release plan validation.
     #[serde(default, skip_serializing_if = "ReleaseBumpPolicyOptions::is_default")]
     pub bump_policy: ReleaseBumpPolicyOptions,
+    /// Placement selected for portable release-readiness gates. Release mutation
+    /// always remains controller-owned; a runner is evidence provenance only.
+    #[serde(default, skip_serializing_if = "ReleasePreflightPlacement::is_default")]
+    pub preflight_placement: ReleasePreflightPlacement,
+}
+
+/// Typed placement policy for the portable portion of release preflight.
+///
+/// This deliberately does not describe versioning, tagging, pushing, or
+/// publication. Those operations mutate controller-owned state and are never
+/// authorized by readiness evidence from a runner.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleasePreflightPlacement {
+    #[serde(default)]
+    pub policy: ReleasePreflightPlacementPolicy,
+    /// Runner selected for portable gate execution, when policy pinning is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleasePreflightPlacementPolicy {
+    #[default]
+    Auto,
+    Local,
+    Lab,
+    LabOrLocal,
+}
+
+impl ReleasePreflightPlacement {
+    fn is_default(value: &Self) -> bool {
+        value == &Self::default()
+    }
+}
+
+/// Immutable source identity bound to release-readiness evidence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleasePreflightSourceIdentity {
+    pub commit: String,
+}
+
+/// Portable gate evidence that the controller may consume before mutation.
+///
+/// The envelope is intentionally data-only: Lab dispatch owns runner execution
+/// and artifact persistence, while release owns the decision to mutate only
+/// after this identity is revalidated locally.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseReadinessEnvelope {
+    pub source: ReleasePreflightSourceIdentity,
+    pub placement: ReleasePreflightPlacement,
+    pub runner_id: Option<String>,
+    pub evidence_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -758,6 +811,27 @@ mod tests {
         let input = ReleaseCommandInput::default();
 
         assert!(!input.force_lower_bump);
+    }
+
+    #[test]
+    fn readiness_envelope_keeps_runner_provenance_separate_from_mutation_policy() {
+        let envelope = ReleaseReadinessEnvelope {
+            source: ReleasePreflightSourceIdentity {
+                commit: "abc123".to_string(),
+            },
+            placement: ReleasePreflightPlacement {
+                policy: ReleasePreflightPlacementPolicy::Lab,
+                runner_id: Some("homeboy-lab".to_string()),
+            },
+            runner_id: Some("homeboy-lab".to_string()),
+            evidence_refs: vec!["runner-artifact://homeboy-lab/release/lint.json".to_string()],
+        };
+
+        let value = serde_json::to_value(envelope).expect("serialize readiness envelope");
+
+        assert_eq!(value["source"]["commit"], "abc123");
+        assert_eq!(value["runner_id"], "homeboy-lab");
+        assert!(value.get("mutation_runner_id").is_none());
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -1,6 +1,6 @@
 use serde::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize, Serializer};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use homeboy_core::is_zero_u32;
 use homeboy_core::phase_timing::PhaseTimingReport;
@@ -505,8 +505,38 @@ pub struct ReleaseReadinessEnvelope {
     pub placement: ReleasePreflightPlacement,
     pub runner_id: Option<String>,
     pub evidence_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "ReleaseReadinessProvenance::is_empty")]
+    pub provenance: ReleaseReadinessProvenance,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub gate_results: Vec<serde_json::Value>,
+    pub gate_results: Vec<ReleaseReadinessGateResult>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseReadinessProvenance {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dependencies: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extensions: BTreeMap<String, String>,
+}
+
+impl ReleaseReadinessProvenance {
+    pub fn is_empty(value: &Self) -> bool {
+        value.dependencies.is_empty() && value.extensions.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseReadinessGateResult {
+    pub gate: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -676,6 +706,8 @@ pub struct ReleaseCommandResult {
     pub continuation_command: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub release_summary: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<ReleaseReadinessEnvelope>,
 }
 
 /// Result of a batch release across multiple components.
@@ -831,7 +863,15 @@ mod tests {
             },
             runner_id: Some("homeboy-lab".to_string()),
             evidence_refs: vec!["runner-artifact://homeboy-lab/release/lint.json".to_string()],
-            gate_results: vec![serde_json::json!({ "gate": "lint", "status": "passed" })],
+            provenance: ReleaseReadinessProvenance::default(),
+            gate_results: vec![ReleaseReadinessGateResult {
+                gate: "lint".to_string(),
+                status: "passed".to_string(),
+                reason: None,
+                source_sha: None,
+                runner_id: Some("homeboy-lab".to_string()),
+                evidence_refs: Vec::new(),
+            }],
         };
 
         let value = serde_json::to_value(envelope).expect("serialize readiness envelope");

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -52,10 +52,7 @@ pub fn run_command_with_workspace(
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
     let readiness_owner_run_ref = if let Some(readiness) = input.readiness.as_mut() {
-        let owner_run_ref = format!(
-            "release-readiness-{}-{}",
-            input.component_id, readiness.source.commit
-        );
+        let owner_run_ref = format!("release-readiness-{}", uuid::Uuid::new_v4());
         let operation_ref = format!("operation://{owner_run_ref}");
         if !readiness.evidence_refs.contains(&operation_ref) {
             readiness.evidence_refs.push(operation_ref.clone());
@@ -1074,6 +1071,27 @@ mod tests {
     use homeboy_core::plan::{PlanStep, PlanStepStatus, PlanValues};
     use homeboy_core::test_support::with_isolated_home;
 
+    fn failed_readiness(source: &str) -> ReleaseReadinessEnvelope {
+        ReleaseReadinessEnvelope {
+            source: ReleasePreflightSourceIdentity {
+                commit: source.to_string(),
+            },
+            placement: ReleasePreflightPlacement::default(),
+            runner_id: Some("lab-test".to_string()),
+            evidence_refs: vec!["evidence://lint".to_string()],
+            provenance: Default::default(),
+            gate_results: vec![ReleaseReadinessGateResult {
+                gate: "lint".to_string(),
+                status: "failed".to_string(),
+                reason: Some("portable dispatch failed".to_string()),
+                source_sha: Some(source.to_string()),
+                runner_id: Some("lab-test".to_string()),
+                evidence_refs: Vec::new(),
+                provenance: None,
+            }],
+        }
+    }
+
     #[test]
     fn batch_status_bucket_rolls_up_non_released_outcomes_as_failed() {
         // Issue #6916: a failed component must not be counted as released.
@@ -1111,6 +1129,7 @@ mod tests {
                     source_sha: Some(source.clone()),
                     runner_id: Some("lab-test".to_string()),
                     evidence_refs: Vec::new(),
+                    provenance: None,
                 }],
             };
 
@@ -1125,12 +1144,18 @@ mod tests {
             )
             .expect_err("failed readiness must stop release before controller mutation");
 
-            let owner = format!("release-readiness-fixture-{source}");
+            let record = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "fixture",
+                false,
+            )
+            .expect("list readiness records")
+            .into_iter()
+            .find(|record| record.source_sha == source)
+            .expect("readiness record is retained");
+            let owner = record.owner_run_ref.clone();
             assert!(error.hints.iter().any(|hint| hint.message
                 == format!("Readiness evidence retained at operation://{owner}")));
-            let record = super::super::operation_record::OperationRecordStore::load(&owner)
-                .expect("load operation record")
-                .expect("readiness record is retained");
             assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             assert_eq!(record.finalization_status, "completed");
             assert_eq!(
@@ -1146,6 +1171,79 @@ mod tests {
                     .trim(),
                 source
             );
+        });
+    }
+
+    #[test]
+    fn sequential_same_commit_readiness_invocations_retain_distinct_records() {
+        with_isolated_home(|_| {
+            let source = "same-commit";
+            for _ in 0..2 {
+                run_command_with_workspace(
+                    ReleaseCommandInput {
+                        component_id: "fixture".to_string(),
+                        readiness: Some(failed_readiness(source)),
+                        ..Default::default()
+                    },
+                    None,
+                )
+                .expect_err("failed readiness blocks before component resolution");
+            }
+
+            let records = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "fixture",
+                false,
+            )
+            .expect("list records");
+            assert_eq!(records.len(), 2);
+            assert_ne!(records[0].owner_run_ref, records[1].owner_run_ref);
+            assert!(records.iter().all(|record| {
+                record.source_sha == source
+                    && record.terminal_disposition.as_deref() == Some("failed")
+                    && record.finalization_status == "completed"
+            }));
+        });
+    }
+
+    #[test]
+    fn concurrent_same_commit_readiness_invocations_retain_distinct_records() {
+        with_isolated_home(|_| {
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let workers = (0..2)
+                .map(|_| {
+                    let barrier = std::sync::Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        run_command_with_workspace(
+                            ReleaseCommandInput {
+                                component_id: "fixture".to_string(),
+                                readiness: Some(failed_readiness("concurrent-commit")),
+                                ..Default::default()
+                            },
+                            None,
+                        )
+                        .expect_err("failed readiness blocks before component resolution");
+                    })
+                })
+                .collect::<Vec<_>>();
+            for worker in workers {
+                worker.join().expect("worker succeeds");
+            }
+
+            let records = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "fixture",
+                false,
+            )
+            .expect("list records");
+            assert_eq!(records.len(), 2);
+            assert_ne!(records[0].owner_run_ref, records[1].owner_run_ref);
+            assert!(records.iter().all(|record| {
+                record.source_sha == "concurrent-commit"
+                    && record.terminal_disposition.as_deref() == Some("failed")
+                    && record.finalization_status == "completed"
+            }));
         });
     }
 

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -201,6 +201,7 @@ pub fn run_command_with_workspace(
             require_explicit_major,
         },
         preflight_placement: Default::default(),
+        readiness: input.readiness.clone(),
     };
 
     if options.dry_run {
@@ -888,6 +889,7 @@ pub fn run_batch(
             skip_github_release: input_template.skip_github_release,
             git_identity: input_template.git_identity.clone(),
             execution: input_template.execution.clone(),
+            readiness: None,
         };
 
         match run_command(input) {
@@ -1936,6 +1938,7 @@ fn legacy_release_command_input_struct_literal_remains_source_compatible() {
         skip_github_release: false,
         git_identity: None,
         execution: None,
+        readiness: None,
     };
     let _ = ReleaseOptions {
         bump_type: "patch".to_string(),
@@ -1950,5 +1953,6 @@ fn legacy_release_command_input_struct_literal_remains_source_compatible() {
         git_identity: None,
         bump_policy: Default::default(),
         preflight_placement: Default::default(),
+        readiness: None,
     };
 }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -186,6 +186,17 @@ fn run_command_with_workspace_inner(
     let execution = release_execution_plan(&input);
 
     if input.recover {
+        if let Some(readiness) = input.readiness.as_ref() {
+            let component = load_component(
+                &input.component_id,
+                &ReleaseOptions {
+                    path_override: input.path_override.clone(),
+                    ..Default::default()
+                },
+            )?;
+            super::preflight_identity::revalidate(&component, &readiness.source)?;
+            super::executor::package_preflight::run_package_preflight(&component.local_path)?;
+        }
         return run_recover(&input, recovery_owner_run_ref).map(
             |(result, workspace, exit_code)| {
                 (

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -102,12 +102,13 @@ pub fn run_command_with_workspace(
         None
     };
     let readiness = input.readiness.clone();
+    let readiness_succeeded = readiness.as_ref().map(readiness_is_valid).unwrap_or(false);
     match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
         Ok((mut output, exit_code)) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
                 complete_readiness_operation(
                     owner_run_ref,
-                    true,
+                    readiness_succeeded,
                     serde_json::json!({
                         "exit_code": exit_code,
                         "status": output.result.status,
@@ -121,7 +122,7 @@ pub fn run_command_with_workspace(
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
                 complete_readiness_operation(
                     owner_run_ref,
-                    false,
+                    readiness_succeeded,
                     serde_json::json!({ "error": error.to_string() }),
                 )?;
                 return Err(error.with_hint(format!(
@@ -131,6 +132,20 @@ pub fn run_command_with_workspace(
             Err(error)
         }
     }
+}
+
+fn readiness_is_valid(readiness: &super::types::ReleaseReadinessEnvelope) -> bool {
+    readiness
+        .gate_results
+        .iter()
+        .filter(|gate| matches!(gate.status.as_str(), "passed" | "failed"))
+        .all(|gate| {
+            gate.status == "passed"
+                && gate.source_sha.as_deref() == Some(readiness.source.commit.as_str())
+                && gate.provenance.as_ref().is_some_and(|provenance| {
+                    !super::types::ReleaseReadinessProvenance::is_empty(provenance)
+                })
+        })
 }
 
 fn complete_readiness_operation(
@@ -1103,6 +1118,21 @@ mod tests {
         }
     }
 
+    fn successful_readiness(source: &str) -> ReleaseReadinessEnvelope {
+        let mut readiness = failed_readiness(source);
+        let gate = &mut readiness.gate_results[0];
+        gate.status = "passed".to_string();
+        gate.reason = None;
+        gate.provenance = Some(super::super::types::ReleaseReadinessProvenance {
+            dependencies: std::collections::BTreeMap::from([(
+                "dependency".to_string(),
+                "locked-sha".to_string(),
+            )]),
+            extensions: Default::default(),
+        });
+        readiness
+    }
+
     #[test]
     fn batch_status_bucket_rolls_up_non_released_outcomes_as_failed() {
         // Issue #6916: a failed component must not be counted as released.
@@ -1300,6 +1330,57 @@ mod tests {
                 SKIPPED_RELEASE_EXIT_CODE
             );
             assert_eq!(record.attributes["downstream_release"]["status"], "skipped");
+        });
+    }
+
+    #[test]
+    fn failed_readiness_remains_failed_for_dry_run() {
+        with_isolated_home(|_| {
+            run_command_with_workspace(
+                ReleaseCommandInput {
+                    component_id: "fixture".to_string(),
+                    dry_run: true,
+                    readiness: Some(failed_readiness("dry-run-source")),
+                    ..Default::default()
+                },
+                None,
+            )
+            .expect_err("failed readiness blocks dry-run planning");
+            let record = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "fixture",
+                false,
+            )
+            .expect("records")
+            .pop()
+            .expect("record");
+            assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
+            assert!(record.attributes["downstream_release"]["error"].is_string());
+        });
+    }
+
+    #[test]
+    fn successful_readiness_remains_succeeded_after_downstream_error() {
+        with_isolated_home(|_| {
+            run_command_with_workspace(
+                ReleaseCommandInput {
+                    component_id: "missing-component".to_string(),
+                    readiness: Some(successful_readiness("success-source")),
+                    ..Default::default()
+                },
+                None,
+            )
+            .expect_err("missing component is downstream of validated readiness");
+            let record = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "missing-component",
+                false,
+            )
+            .expect("records")
+            .pop()
+            .expect("record");
+            assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
+            assert!(record.attributes["downstream_release"]["error"].is_string());
         });
     }
 

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -200,6 +200,7 @@ pub fn run_command_with_workspace(
             force_empty_release: input.bump_override.is_some(),
             require_explicit_major,
         },
+        preflight_placement: Default::default(),
     };
 
     if options.dry_run {
@@ -1948,5 +1949,6 @@ fn legacy_release_command_input_struct_literal_remains_source_compatible() {
         skip_github_release: false,
         git_identity: None,
         bump_policy: Default::default(),
+        preflight_placement: Default::default(),
     };
 }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -91,6 +91,16 @@ pub fn run_command_with_workspace(
             .evidence_refs
             .push(format!("operation://{owner_run_ref}"));
     }
+    let readiness = input.readiness.clone();
+    let (mut output, exit_code) = run_command_with_workspace_inner(input, recovery_owner_run_ref)?;
+    output.result.readiness = readiness;
+    Ok((output, exit_code))
+}
+
+fn run_command_with_workspace_inner(
+    input: ReleaseCommandInput,
+    recovery_owner_run_ref: Option<&str>,
+) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
     let execution = release_execution_plan(&input);
 
     if input.recover {
@@ -290,6 +300,7 @@ pub fn run_command_with_workspace(
                         deployment: None,
                         continuation_command: None,
                         release_summary: release_summary_for_skipped_plan(),
+                        readiness: None,
                     },
                     workspace: None,
                 },
@@ -318,6 +329,7 @@ pub fn run_command_with_workspace(
                         deployment: None,
                         continuation_command: None,
                         release_summary,
+                        readiness: None,
                     },
                     workspace: None,
                 },
@@ -356,6 +368,7 @@ pub fn run_command_with_workspace(
                     deployment,
                     continuation_command: None,
                     release_summary: release_summary_for_skipped_plan(),
+                    readiness: None,
                 },
                 workspace: None,
             },
@@ -433,6 +446,7 @@ pub fn run_command_with_workspace(
                 deployment,
                 continuation_command: None,
                 release_summary,
+                readiness: None,
             },
             workspace,
         },
@@ -511,6 +525,7 @@ fn prepared_tag_publish_recovery_decision(
             release_summary: vec![format!(
                 "Prepared tag {tag} exists at HEAD; GitHub Release is missing and should be published"
             )],
+            readiness: None,
         }),
         Some(true) | None => None,
     }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -106,6 +106,22 @@ pub fn run_command_with_workspace(
         .as_ref()
         .map(super::types::readiness_is_valid)
         .unwrap_or(false);
+    if readiness.is_some() && !readiness_succeeded {
+        let error = Error::validation_invalid_argument(
+            "release.preflight",
+            "Portable release preflight has invalid selected gate evidence",
+            None,
+            None,
+        );
+        if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
+            complete_readiness_operation(
+                owner_run_ref,
+                false,
+                serde_json::json!({ "error": error.to_string() }),
+            )?;
+        }
+        return Err(error);
+    }
     match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
         Ok((mut output, exit_code)) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -48,9 +48,49 @@ pub fn run_command_with_recovery_owner(
 /// Additive staging-aware command entry point. CLI callers use the workspace
 /// envelope when provider staging or recovery reconciliation produced metadata.
 pub fn run_command_with_workspace(
-    input: ReleaseCommandInput,
+    mut input: ReleaseCommandInput,
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
+    if let Some(readiness) = input.readiness.as_mut() {
+        let owner_run_ref = format!(
+            "release-readiness-{}-{}",
+            input.component_id, readiness.source.commit
+        );
+        super::operation_record::OperationRecordStore::create(
+            &super::operation_record::OperationRecord {
+                owner_run_ref: owner_run_ref.clone(),
+                operation: "release_readiness".to_string(),
+                subject: input.component_id.clone(),
+                provider: readiness
+                    .runner_id
+                    .clone()
+                    .unwrap_or_else(|| "controller".to_string()),
+                handle: readiness.source.commit.clone(),
+                path: None,
+                source_sha: readiness.source.commit.clone(),
+                cleanup_policy: "retain".to_string(),
+                lifecycle_state: "validated".to_string(),
+                terminal_disposition: Some("succeeded".to_string()),
+                finalization_status: "completed".to_string(),
+                finalization_lease: None,
+                finalization_lease_started_ms: None,
+                attempt_count: 1,
+                continuation_evidence: readiness.evidence_refs.clone(),
+                attributes: serde_json::Map::from_iter([(
+                    "readiness".to_string(),
+                    serde_json::to_value(&*readiness).map_err(|error| {
+                        Error::internal_json(
+                            error.to_string(),
+                            Some("release readiness".to_string()),
+                        )
+                    })?,
+                )]),
+            },
+        )?;
+        readiness
+            .evidence_refs
+            .push(format!("operation://{owner_run_ref}"));
+    }
     let execution = release_execution_plan(&input);
 
     if input.recover {

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -51,11 +51,24 @@ pub fn run_command_with_workspace(
     mut input: ReleaseCommandInput,
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
-    if let Some(readiness) = input.readiness.as_mut() {
+    let readiness_owner_run_ref = if let Some(readiness) = input.readiness.as_mut() {
         let owner_run_ref = format!(
             "release-readiness-{}-{}",
             input.component_id, readiness.source.commit
         );
+        let operation_ref = format!("operation://{owner_run_ref}");
+        if !readiness.evidence_refs.contains(&operation_ref) {
+            readiness.evidence_refs.push(operation_ref.clone());
+        }
+        for gate in readiness
+            .gate_results
+            .iter_mut()
+            .filter(|gate| gate.status == "failed")
+        {
+            if !gate.evidence_refs.contains(&operation_ref) {
+                gate.evidence_refs.push(operation_ref.clone());
+            }
+        }
         super::operation_record::OperationRecordStore::create(
             &super::operation_record::OperationRecord {
                 owner_run_ref: owner_run_ref.clone(),
@@ -69,9 +82,9 @@ pub fn run_command_with_workspace(
                 path: None,
                 source_sha: readiness.source.commit.clone(),
                 cleanup_policy: "retain".to_string(),
-                lifecycle_state: "validated".to_string(),
-                terminal_disposition: Some("succeeded".to_string()),
-                finalization_status: "completed".to_string(),
+                lifecycle_state: "running".to_string(),
+                terminal_disposition: None,
+                finalization_status: "pending".to_string(),
                 finalization_lease: None,
                 finalization_lease_started_ms: None,
                 attempt_count: 1,
@@ -87,14 +100,55 @@ pub fn run_command_with_workspace(
                 )]),
             },
         )?;
-        readiness
-            .evidence_refs
-            .push(format!("operation://{owner_run_ref}"));
-    }
+        Some(owner_run_ref)
+    } else {
+        None
+    };
     let readiness = input.readiness.clone();
-    let (mut output, exit_code) = run_command_with_workspace_inner(input, recovery_owner_run_ref)?;
-    output.result.readiness = readiness;
-    Ok((output, exit_code))
+    match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
+        Ok((mut output, exit_code)) => {
+            if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
+                complete_readiness_operation(owner_run_ref, exit_code == 0, None)?;
+            }
+            output.result.readiness = readiness;
+            Ok((output, exit_code))
+        }
+        Err(error) => {
+            if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
+                complete_readiness_operation(owner_run_ref, false, Some(error.to_string()))?;
+                return Err(error.with_hint(format!(
+                    "Readiness evidence retained at operation://{owner_run_ref}"
+                )));
+            }
+            Err(error)
+        }
+    }
+}
+
+fn complete_readiness_operation(
+    owner_run_ref: &str,
+    succeeded: bool,
+    error: Option<String>,
+) -> Result<()> {
+    super::operation_record::OperationRecordStore::update(owner_run_ref, |record| {
+        let mut record = record.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "owner_run_ref",
+                "release readiness operation record does not exist",
+                Some(owner_run_ref.to_string()),
+                None,
+            )
+        })?;
+        record.lifecycle_state = "finalized".to_string();
+        record.terminal_disposition =
+            Some(if succeeded { "succeeded" } else { "failed" }.to_string());
+        record.finalization_status = "completed".to_string();
+        if let Some(error) = error {
+            record.continuation_evidence.push(error);
+        }
+        Ok(record)
+    })?;
+    Ok(())
 }
 
 fn run_command_with_workspace_inner(
@@ -1013,9 +1067,12 @@ mod tests {
     use super::*;
     use crate::release::types::ReleasePhase;
     use crate::release::{
-        ReleaseRollbackEvidence, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+        ReleasePreflightPlacement, ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
+        ReleaseReadinessGateResult, ReleaseRollbackEvidence, ReleaseRunResult, ReleaseStepResult,
+        ReleaseStepStatus,
     };
     use homeboy_core::plan::{PlanStep, PlanStepStatus, PlanValues};
+    use homeboy_core::test_support::with_isolated_home;
 
     #[test]
     fn batch_status_bucket_rolls_up_non_released_outcomes_as_failed() {
@@ -1026,6 +1083,70 @@ mod tests {
         assert_eq!(batch_status_bucket("missing"), BatchStatusBucket::Failed);
         assert_eq!(batch_status_bucket("partial"), BatchStatusBucket::Failed);
         assert_eq!(batch_status_bucket("unknown"), BatchStatusBucket::Failed);
+    }
+
+    #[test]
+    fn failed_readiness_is_durable_and_blocks_controller_mutation() {
+        with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            setup_release_range_fixture(temp.path(), "1.2.3", 1);
+            let source =
+                String::from_utf8_lossy(&run_in(temp.path(), &["git", "rev-parse", "HEAD"]).stdout)
+                    .trim()
+                    .to_string();
+            let version_before = std::fs::read_to_string(temp.path().join("VERSION"))
+                .expect("read version before release");
+            let readiness = ReleaseReadinessEnvelope {
+                source: ReleasePreflightSourceIdentity {
+                    commit: source.clone(),
+                },
+                placement: ReleasePreflightPlacement::default(),
+                runner_id: Some("lab-test".to_string()),
+                evidence_refs: vec!["evidence://lint".to_string()],
+                provenance: Default::default(),
+                gate_results: vec![ReleaseReadinessGateResult {
+                    gate: "lint".to_string(),
+                    status: "failed".to_string(),
+                    reason: Some("portable dispatch failed".to_string()),
+                    source_sha: Some(source.clone()),
+                    runner_id: Some("lab-test".to_string()),
+                    evidence_refs: Vec::new(),
+                }],
+            };
+
+            let error = run_command_with_workspace(
+                ReleaseCommandInput {
+                    component_id: "fixture".to_string(),
+                    path_override: Some(temp.path().to_string_lossy().to_string()),
+                    readiness: Some(readiness),
+                    ..Default::default()
+                },
+                None,
+            )
+            .expect_err("failed readiness must stop release before controller mutation");
+
+            let owner = format!("release-readiness-fixture-{source}");
+            assert!(error.hints.iter().any(|hint| hint.message
+                == format!("Readiness evidence retained at operation://{owner}")));
+            let record = super::super::operation_record::OperationRecordStore::load(&owner)
+                .expect("load operation record")
+                .expect("readiness record is retained");
+            assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
+            assert_eq!(record.finalization_status, "completed");
+            assert_eq!(
+                record.attributes["readiness"]["gate_results"][0]["evidence_refs"][0],
+                format!("operation://{owner}")
+            );
+            assert_eq!(
+                std::fs::read_to_string(temp.path().join("VERSION")).expect("read version after"),
+                version_before
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&run_in(temp.path(), &["git", "rev-parse", "HEAD"]).stdout)
+                    .trim(),
+                source
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -1103,6 +1103,7 @@ mod tests {
                 runner_id: Some("lab-test".to_string()),
                 evidence_refs: Vec::new(),
                 provenance: None,
+                local_only: None,
             }],
         }
     }
@@ -1160,6 +1161,7 @@ mod tests {
                     runner_id: Some("lab-test".to_string()),
                     evidence_refs: Vec::new(),
                     provenance: None,
+                    local_only: None,
                 }],
             };
 

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -102,7 +102,10 @@ pub fn run_command_with_workspace(
         None
     };
     let readiness = input.readiness.clone();
-    let readiness_succeeded = readiness.as_ref().map(readiness_is_valid).unwrap_or(false);
+    let readiness_succeeded = readiness
+        .as_ref()
+        .map(super::types::readiness_is_valid)
+        .unwrap_or(false);
     match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
         Ok((mut output, exit_code)) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
@@ -132,20 +135,6 @@ pub fn run_command_with_workspace(
             Err(error)
         }
     }
-}
-
-fn readiness_is_valid(readiness: &super::types::ReleaseReadinessEnvelope) -> bool {
-    readiness
-        .gate_results
-        .iter()
-        .filter(|gate| matches!(gate.status.as_str(), "passed" | "failed"))
-        .all(|gate| {
-            gate.status == "passed"
-                && gate.source_sha.as_deref() == Some(readiness.source.commit.as_str())
-                && gate.provenance.as_ref().is_some_and(|provenance| {
-                    !super::types::ReleaseReadinessProvenance::is_empty(provenance)
-                })
-        })
 }
 
 fn complete_readiness_operation(
@@ -1381,6 +1370,66 @@ mod tests {
             .expect("record");
             assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
             assert!(record.attributes["downstream_release"]["error"].is_string());
+        });
+    }
+
+    #[test]
+    fn empty_and_unknown_readiness_gates_fail_durably_and_block_mutation() {
+        with_isolated_home(|_| {
+            for (source, mutate) in [("empty-gates", None), ("unknown-gate", Some("unknown"))] {
+                let mut readiness = successful_readiness(source);
+                if let Some(status) = mutate {
+                    readiness.gate_results[0].status = status.to_string();
+                } else {
+                    readiness.gate_results.clear();
+                }
+                run_command_with_workspace(
+                    ReleaseCommandInput {
+                        component_id: source.to_string(),
+                        readiness: Some(readiness),
+                        ..Default::default()
+                    },
+                    None,
+                )
+                .expect_err("invalid readiness blocks before component mutation");
+                let record = super::super::operation_record::OperationRecordStore::for_subject(
+                    "release_readiness",
+                    source,
+                    false,
+                )
+                .expect("records")
+                .pop()
+                .expect("record");
+                assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
+            }
+        });
+    }
+
+    #[test]
+    fn explicitly_skipped_gates_authorize_readiness() {
+        with_isolated_home(|_| {
+            let mut readiness = successful_readiness("skipped-gates");
+            let gate = &mut readiness.gate_results[0];
+            gate.status = "skipped".to_string();
+            gate.provenance = None;
+            run_command_with_workspace(
+                ReleaseCommandInput {
+                    component_id: "missing-component".to_string(),
+                    readiness: Some(readiness),
+                    ..Default::default()
+                },
+                None,
+            )
+            .expect_err("downstream component error follows authorized skipped readiness");
+            let record = super::super::operation_record::OperationRecordStore::for_subject(
+                "release_readiness",
+                "missing-component",
+                false,
+            )
+            .expect("records")
+            .pop()
+            .expect("record");
+            assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
         });
     }
 

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -105,16 +105,27 @@ pub fn run_command_with_workspace(
     match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
         Ok((mut output, exit_code)) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
-                complete_readiness_operation(owner_run_ref, exit_code == 0, None)?;
+                complete_readiness_operation(
+                    owner_run_ref,
+                    true,
+                    serde_json::json!({
+                        "exit_code": exit_code,
+                        "status": output.result.status,
+                    }),
+                )?;
             }
             output.result.readiness = readiness;
             Ok((output, exit_code))
         }
         Err(error) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
-                complete_readiness_operation(owner_run_ref, false, Some(error.to_string()))?;
+                complete_readiness_operation(
+                    owner_run_ref,
+                    false,
+                    serde_json::json!({ "error": error.to_string() }),
+                )?;
                 return Err(error.with_hint(format!(
-                    "Readiness evidence retained at operation://{owner_run_ref}"
+                    "Inspect readiness evidence: homeboy release readiness show {owner_run_ref}"
                 )));
             }
             Err(error)
@@ -125,7 +136,7 @@ pub fn run_command_with_workspace(
 fn complete_readiness_operation(
     owner_run_ref: &str,
     succeeded: bool,
-    error: Option<String>,
+    downstream_release: serde_json::Value,
 ) -> Result<()> {
     super::operation_record::OperationRecordStore::update(owner_run_ref, |record| {
         let mut record = record.ok_or_else(|| {
@@ -140,9 +151,9 @@ fn complete_readiness_operation(
         record.terminal_disposition =
             Some(if succeeded { "succeeded" } else { "failed" }.to_string());
         record.finalization_status = "completed".to_string();
-        if let Some(error) = error {
-            record.continuation_evidence.push(error);
-        }
+        record
+            .attributes
+            .insert("downstream_release".to_string(), downstream_release);
         Ok(record)
     })?;
     Ok(())
@@ -1155,7 +1166,7 @@ mod tests {
             .expect("readiness record is retained");
             let owner = record.owner_run_ref.clone();
             assert!(error.hints.iter().any(|hint| hint.message
-                == format!("Readiness evidence retained at operation://{owner}")));
+                == format!("Inspect readiness evidence: homeboy release readiness show {owner}")));
             assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             assert_eq!(record.finalization_status, "completed");
             assert_eq!(
@@ -1244,6 +1255,51 @@ mod tests {
                     && record.terminal_disposition.as_deref() == Some("failed")
                     && record.finalization_status == "completed"
             }));
+        });
+    }
+
+    #[test]
+    fn readiness_succeeds_when_downstream_release_is_intentionally_skipped() {
+        with_isolated_home(|_| {
+            let owner = "release-readiness-skip";
+            super::super::operation_record::OperationRecordStore::create(
+                &super::super::operation_record::OperationRecord {
+                    owner_run_ref: owner.to_string(),
+                    operation: "release_readiness".to_string(),
+                    subject: "fixture".to_string(),
+                    provider: "lab".to_string(),
+                    handle: "commit".to_string(),
+                    path: None,
+                    source_sha: "commit".to_string(),
+                    cleanup_policy: "retain".to_string(),
+                    lifecycle_state: "running".to_string(),
+                    terminal_disposition: None,
+                    finalization_status: "pending".to_string(),
+                    finalization_lease: None,
+                    finalization_lease_started_ms: None,
+                    attempt_count: 1,
+                    continuation_evidence: Vec::new(),
+                    attributes: Default::default(),
+                },
+            )
+            .expect("create readiness");
+
+            complete_readiness_operation(
+                owner,
+                true,
+                serde_json::json!({ "exit_code": SKIPPED_RELEASE_EXIT_CODE, "status": "skipped" }),
+            )
+            .expect("complete readiness");
+
+            let record = super::super::operation_record::OperationRecordStore::load(owner)
+                .expect("load")
+                .expect("record");
+            assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
+            assert_eq!(
+                record.attributes["downstream_release"]["exit_code"],
+                SKIPPED_RELEASE_EXIT_CODE
+            );
+            assert_eq!(record.attributes["downstream_release"]["status"], "skipped");
         });
     }
 

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -64,6 +64,7 @@ pub(super) fn run_recover(
             releasable_commits: 0, new_version: None, tag: None, skipped_reason: None, plan: None, run: None,
             deployment: None, continuation_command: None,
             release_summary: vec![format!("Reconciled provider workspace `{}` without replaying release mutation or push.", record.owner_run_ref)],
+            readiness: None,
         }, Some(super::workspace::output_from_record(&record)), 0));
     }
     if let Some(deployment) = super::deployment::resume_deployment(&input.component_id)? {
@@ -84,6 +85,7 @@ pub(super) fn run_recover(
                 deployment: Some(deployment),
                 continuation_command: None,
                 release_summary: vec!["Resumed only incomplete release deployment targets; publication steps were not replayed.".to_string()],
+                readiness: None,
             },
             None,
             if failed { 1 } else { 0 },
@@ -373,6 +375,7 @@ pub(super) fn run_recover(
                     )],
                 ]
                 .concat(),
+                readiness: None,
             },
             None,
             RECOVERY_INCOMPLETE_EXIT_CODE,
@@ -554,6 +557,7 @@ pub(super) fn run_recover(
                 )],
             ]
             .concat(),
+            readiness: None,
         },
         None,
         RECOVERY_INCOMPLETE_EXIT_CODE,
@@ -592,6 +596,7 @@ fn recovery_dry_run_result(
         deployment: None,
         continuation_command: None,
         release_summary: actions,
+        readiness: None,
     }
 }
 

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -27,6 +27,7 @@ fn component_script_args(root: &Path) -> PositionalComponentArgs {
 fn test_command_args(root: &Path) -> TestArgs {
     TestArgs {
         comp: component_script_args(root),
+        release_readiness_source: None,
         extension_override: ExtensionOverrideArgs::default(),
         skip_lint: false,
         coverage: false,


### PR DESCRIPTION
Refs #10112.

## Package Dispatch Validation
- Package-only intent now validates before portable source freezing or runner dispatch.
- Invalid package-only readiness is routed through the durable workflow readiness record path.
- Passed portable gates require matching source, immutable provenance, non-empty runner ID, and durable evidence references.

## Verification
- `cargo fmt`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli --no-run`

AI assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode added pre-dispatch package validation and gate evidence requirements. Chris Huber remains responsible for every line.