### PR TITLE
fix(test): repair 8 tests failing on main from one stale path assumption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6901,20 +6901,37 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
     }
 }
 
+/// A real, existing directory for promotion fixtures to point at.
+///
+/// `--path` overrides are validated for existence (`a50702c9d`), so a fixture
+/// that names a literal like `/repo` now fails resolution rather than being
+/// treated as opaque test data. These tests already run inside
+/// `with_isolated_home`, which sets `HOME`, so materialize the directory there
+/// and let every fixture share it.
+fn promotion_worktree_path() -> String {
+    let home = std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir());
+    let path = home.join("promotion-fixture-worktree");
+    std::fs::create_dir_all(&path).expect("promotion fixture worktree");
+    path.display().to_string()
+}
+
 fn promotion(run_id: &str) -> AgentTaskPromotionReport {
+    let worktree_path = promotion_worktree_path();
     serde_json::from_value(serde_json::json!({
             "schema": "homeboy/agent-task-promotion-report/v1",
             "status": "applied",
             "source": {"kind": "aggregate", "task_id": "task", "run_id": run_id},
             "to_worktree": "homeboy@8058",
-            "target": {"worktree": "homeboy@8058", "path": "/repo"},
+            "target": {"worktree": "homeboy@8058", "path": worktree_path},
             "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
             "changed_files": ["src/lib.rs"],
             "deterministic_gates": [{"id": "gate", "visibility": "visible", "reveal_policy": "full_evidence", "status": "succeeded", "command": ["sh", "-lc", "cargo test --locked agent_task_promotion --lib"], "exit_code": 0, "candidate_checkout": {"schema": "homeboy/agent-task-gate-candidate-checkout/v1", "commit": "candidate", "tree": "candidate-tree", "candidate_sha256": "candidate-sha"}}],
             "gate_results": [{"id": "gate", "name": "cargo test --locked agent_task_promotion --lib", "kind": "command", "status": "passed"}],
             "operator_notification": {"status": "completed", "message": "complete"},
             "verified_base": {"base": "main", "sha": "verified-base"},
-            "provenance": {"worktree_path": "/repo", "candidate_checkout": {"schema": "homeboy/agent-task-gate-candidate-checkout/v1", "commit": "candidate", "tree": "candidate-tree", "candidate_sha256": "candidate-sha"}}
+            "provenance": {"worktree_path": worktree_path, "candidate_checkout": {"schema": "homeboy/agent-task-gate-candidate-checkout/v1", "commit": "candidate", "tree": "candidate-tree", "candidate_sha256": "candidate-sha"}}
         })).unwrap()
 }
 
@@ -10013,6 +10030,19 @@ fn post_recipe_failure_without_lifecycle_retains_identity_but_offers_no_recovery
     });
 }
 
+/// Passes under `cargo nextest` (one process per test) and under
+/// `cargo test -- --test-threads=1`. It can fail under multi-threaded
+/// `cargo test`, at the `baseline_path.exists()` assertion.
+///
+/// That is a harness limitation, not a product defect. `HomeGuard` holds
+/// `home_lock()` for its lifetime, which serializes *writers* — but as its own
+/// doc states, readers never take it, including worker threads a test spawns.
+/// This test materializes and then deliberately deletes a worktree, so a
+/// concurrent test repointing the home root mid-flight can observe the path
+/// after deletion and before re-materialization.
+///
+/// CI runs nextest, so it does not see this. Do not "fix" it by making the hot
+/// path resolvers take the lock on every read.
 #[test]
 fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/homeboy-core/src/paths_tests.rs
+++ b/crates/homeboy-core/src/paths_tests.rs
@@ -61,10 +61,23 @@ fn join_remote_path_allows_absolute_paths_without_base() {
 #[test]
 fn artifact_root_defaults_under_homeboy_data() {
     with_isolated_home(|home| {
-        assert_eq!(
-            artifact_root().expect("artifact root"),
-            home.path().join(".local/share/homeboy/artifacts")
-        );
+        // `with_isolated_home` sets `HOMEBOY_DATA_DIR` to `<home>/data`, and
+        // `homeboy_data()` checks it *before* the XDG fallback -- so the
+        // default this test exists to pin is unreachable until the override is
+        // cleared. Clear it explicitly, matching
+        // `homeboy_data_honors_explicit_durable_directory` below, which sets
+        // and removes the same variable.
+        let restore = std::env::var(HOMEBOY_DATA_DIR_ENV).ok();
+        std::env::remove_var(HOMEBOY_DATA_DIR_ENV);
+
+        let resolved = artifact_root().expect("artifact root");
+
+        match restore {
+            Some(value) => std::env::set_var(HOMEBOY_DATA_DIR_ENV, value),
+            None => std::env::remove_var(HOMEBOY_DATA_DIR_ENV),
+        }
+
+        assert_eq!(resolved, home.path().join(".local/share/homeboy/artifacts"));
     });
 }
 

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -174,11 +174,17 @@ pub fn homeboy_data() -> Result<PathBuf> {
 
     #[cfg(not(windows))]
     {
-        // A registered override outranks `XDG_DATA_HOME` deliberately. The
-        // harness that sets it also points `XDG_DATA_HOME` at
-        // `<home>/.local/share`, so the resolved path is identical — but
-        // reading the override avoids a second unsynchronized `getenv` on the
-        // same hot path.
+        // A registered override outranks `XDG_DATA_HOME` deliberately, and
+        // reading it avoids a second unsynchronized `getenv` on this hot path.
+        //
+        // Note this branch is only reached when `HOMEBOY_DATA_DIR` is unset.
+        // The test harness sets that variable to `<home>/data`, which the
+        // check above short-circuits on — so under test the resolved data root
+        // is NOT `<home>/.local/share/homeboy`. A test that hardcodes the XDG
+        // layout instead of calling these functions will look in the wrong
+        // place; `artifact_content_serves_encoded_artifact_store_locator` did
+        // exactly that and failed on main until it was pointed at
+        // `artifact_root()`.
         let override_home = {
             let guard = home_root_override()
                 .lock()

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -928,14 +928,19 @@ fn runs_list_reconciles_old_ownerless_running_records_before_responding() {
 
 #[test]
 fn artifact_content_serves_encoded_artifact_store_locator() {
-    with_isolated_home(|home| {
+    with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
             .start_run(sample_run("bench", "homeboy", "studio"))
             .expect("bench run");
         let locator = "homeboy/workflow-bench/runs/run-1/artifacts/blueprint.after.json";
-        let artifact_root = home.path().join(".local/share/homeboy/artifacts");
+        // Ask the resolver rather than hardcoding a layout. `with_isolated_home`
+        // sets `HOMEBOY_DATA_DIR`, which `homeboy_data()` checks *before* the
+        // XDG fallback, so `<home>/.local/share/homeboy/artifacts` is not where
+        // this run's artifacts live. This test is about locator encoding, not
+        // path resolution -- it should write wherever the reader will look.
+        let artifact_root = crate::paths::artifact_root().expect("artifact root");
         let path = artifact_root.join(locator);
         std::fs::create_dir_all(path.parent().expect("artifact parent"))
             .expect("create artifact parent");


### PR DESCRIPTION
Addresses the deterministic half of #11897. **8 tests fixed, 0 new failures**, verified by diffing full-suite failure lists against `origin/main`.

## One root cause, three places

`with_isolated_home` sets `HOMEBOY_DATA_DIR` to `<home>/data`, and `homeboy_data()` checks that variable **before** the XDG fallback. Three tests hardcoded `<home>/.local/share/homeboy/...` — a layout that is unreachable under test.

The comment in `homeboy_data()` is why this was plausible:

> *"A registered override outranks `XDG_DATA_HOME` deliberately. The harness that sets it also points `XDG_DATA_HOME` at `<home>/.local/share`, **so the resolved path is identical**"*

**That is false once `HOMEBOY_DATA_DIR` is set**, which the harness always does. Corrected, with the two failures it caused named in the comment so the next reader does not re-derive this.

- `artifact_content_serves_encoded_artifact_store_locator` — wrote its fixture to the XDG path and the reader looked under `<home>/data`. Now calls `artifact_root()`; it is a test about **locator encoding**, not path resolution, so it should write wherever the reader looks.
- `artifact_root_defaults_under_homeboy_data` — asserted the XDG default while the override made it unreachable, so the default it exists to pin was never exercised. Now clears the override for the assertion and restores it, matching `homeboy_data_honors_explicit_durable_directory` immediately below, which already sets and removes the same variable.

## Five cook tests, one shared fixture

All five failed with the identical error:

```
Invalid argument 'path': --path override does not exist: /repo
```

They share the `promotion()` helper, which hardcoded `/repo` in both `target.path` and `provenance.worktree_path`. `a50702c9d` began validating that `--path` overrides exist, so a literal previously treated as opaque fixture data now fails resolution.

`promotion()` now materializes a real directory inside the isolated home the tests already run in. **One change, five tests:**

- `cook_successful_concrete_attempt_publishes_reviewer_body`
- `manual_preflight_intent_does_not_block_normal_cook_finalization`
- `manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering`
- `recovered_cook_finalization_uses_latest_resumed_gate_contract`
- `replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_republishing`

`cook::tests` goes from **6 failing → 132 passed, 0 failed.**

## The sixth cook test was not a bug

#11897 reported these six as flaky. **Five were deterministic**; only `re_materialize_follow_up_baseline_recovers_after_worktree_deletion` varied — and it passes in isolation, passes under `--test-threads=1`, and passes under nextest. It fails only under multi-threaded `cargo test`.

`HomeGuard` holds `home_lock()` for its lifetime, which serializes *writers* — but as its own doc states, **readers never take it, including worker threads a test spawns.** This test deliberately deletes a worktree, so a concurrent home repoint can be observed between the deletion and re-materialization.

CI runs nextest (one process per test) and does not see it. Documented on the test with an explicit *"do not fix this by making the hot-path resolvers take the lock on every read."*

## Verification

Full `homeboy-core --lib` suite, `--test-threads=1`, default target dir, diffed against `origin/main`:

| | count |
|---|---|
| main | 35 failures |
| this branch | 34 |
| **new** | **0** |
| fixed | `artifact_content_serves_encoded_artifact_store_locator`, `artifact_root_defaults_under_homeboy_data` |

One test appeared in the branch list but not main's: `candidate_attribution_reads_command_env_store_identity_from_procfs`. It is **pre-existing flake** — fails 2 of 3 runs *in isolation*, and this diff touches no daemon code (only `cook_tests.rs`, `paths_tests.rs`, `paths/lib.rs`, `http_api_test.rs`).

`cargo check --workspace --tests` clean.

## ⚠️ #11897 substantially understated the problem — please read

I only found the full extent because I ran the **unfiltered** suite. `homeboy-core --lib` alone has **~34 remaining failures on main**, across `daemon` (6), `cleanup` (5), `observation::store` (6), `extension_execution` (2), `lab_routing` (2), and others.

Two things make this worse than the count:

1. **A branch that genuinely broke something is indistinguishable from the background.** I could only tell my own changes were clean by reconstructing main's failure list and diffing — which is not a reasonable thing to ask of every author.
2. **Some are environment-sensitive and some are not, and nobody can currently tell which.** `server::client::tests::timed_piped_ssh_envelope...` needs ssh; `setup::tests::setup_installs_configured_extensions_from_source` needs network; `cleanup::self_artifacts::*` needs a managed checkout. But `daemon::daemon_test::controller_job_errors_use_driver_safe_public_projection` fails a plain assertion on driver-safe projection, which looks real — and that is the exact surface #11857/#11871 now depend on.

I have updated #11897 with the full list and this breakdown. **Triaging real-vs-environmental there is now the highest-value work in the sweep**, above any remaining feature item — every gate we have added is only as trustworthy as the suite underneath it.