### PR TITLE
fix(status): surface global health from unattached contexts

### DIFF
--- a/crates/homeboy-cli/src/commands/status/context_paths.rs
+++ b/crates/homeboy-cli/src/commands/status/context_paths.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use homeboy::core::{component, git};
 
-use super::types::UnregisteredContextStatusOutput;
+use super::types::{UnregisteredContextStatusOutput, UnregisteredControlPlaneStatus};
 
 pub(super) fn unregistered_cwd_status_output() -> Option<UnregisteredContextStatusOutput> {
     let cwd = std::env::current_dir().ok()?;
@@ -46,7 +46,11 @@ pub(super) fn unregistered_cwd_status_output() -> Option<UnregisteredContextStat
         cwd: cwd.to_string_lossy().to_string(),
         git_root: git_root_string,
         suggestion,
-        action: "Run `homeboy status --all` to inspect every configured component, or attach this checkout to a project/component first.",
+        action: "Run `homeboy status --global` for bounded local runner/control-plane health, `homeboy status --all` to inspect every configured component, or attach this checkout to a project/component first.",
+        control_plane: UnregisteredControlPlaneStatus {
+            status: "not_checked",
+            command: "homeboy status --global",
+        },
     })
 }
 

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -36,7 +36,8 @@ pub use types::{
     GlobalActivityStatus, GlobalDaemonStatus, GlobalInventoryStatus, GlobalRunnerStatus,
     GlobalStatusOutput, ProjectComponentDashboardStatus, ProjectDashboardOutput,
     ProjectDashboardSummary, ProjectStatusRow, StatusArgs, StatusOutput, StatusResult,
-    StatusTiming, UnregisteredContextStatusOutput, UnreleasedMerge, UpstreamDrift,
+    StatusTiming, UnregisteredContextStatusOutput, UnregisteredControlPlaneStatus, UnreleasedMerge,
+    UpstreamDrift,
 };
 use types::{StatusProgress, StatusTimer, READY_TO_DEPLOY_NOTE, UNRELEASED_MERGES_NOTE};
 
@@ -117,7 +118,11 @@ pub fn run(args: StatusArgs) -> CmdResult<StatusResult> {
                     "Repo not attached. Prefer: `homeboy project components attach-path <project-id> <path>`"
                         .to_string()
                 }),
-                action: "Run `homeboy status --all` to inspect every configured component, or attach this checkout to a project/component first.",
+                action: "Run `homeboy status --global` for bounded local runner/control-plane health, `homeboy status --all` to inspect every configured component, or attach this checkout to a project/component first.",
+                control_plane: UnregisteredControlPlaneStatus {
+                    status: "not_checked",
+                    command: "homeboy status --global",
+                },
             }),
             0,
         ));
@@ -820,6 +825,10 @@ mod tests {
     fn global_status_from_an_unregistered_cwd_is_local_and_bounded() {
         let _guard = CWD_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
         crate::test_support::with_isolated_home(|_| {
+            // A configured runner with no session is disconnected. The global
+            // follow-up must expose that persisted fact without contacting it.
+            runner::create(r#"{"id":"disconnected","kind":"local"}"#, false)
+                .expect("register disconnected runner");
             let original_cwd = env::current_dir().expect("current dir");
             let dir = TempDir::new().expect("tempdir");
             env::set_current_dir(dir.path()).expect("set unregistered cwd");
@@ -842,6 +851,8 @@ mod tests {
             assert_eq!(output.inventory.projects, 0);
             assert_eq!(output.inventory.components, 0);
             assert_eq!(output.runners.inspected, output.runners.registered);
+            assert!(output.runners.registered >= 1);
+            assert!(output.runners.disconnected >= 1);
             assert_eq!(output.activity.active, 0);
             assert!(output.drill_down.contains(&"homeboy daemon status"));
         });
@@ -1182,6 +1193,9 @@ mod tests {
                         dir.path().canonicalize().ok()
                     );
                     assert!(output.suggestion.contains("attach"));
+                    assert_eq!(output.control_plane.status, "not_checked");
+                    assert_eq!(output.control_plane.command, "homeboy status --global");
+                    assert!(output.action.contains("homeboy status --global"));
                     assert!(output.action.contains("homeboy status --all"));
                 }
                 _ => panic!("expected unregistered context output"),

--- a/crates/homeboy-cli/src/commands/status/types.rs
+++ b/crates/homeboy-cli/src/commands/status/types.rs
@@ -196,6 +196,16 @@ pub struct UnregisteredContextStatusOutput {
     pub git_root: Option<String>,
     pub suggestion: String,
     pub action: &'static str,
+    /// The default unregistered-context path intentionally avoids even local
+    /// control-plane inventory reads. This makes that omission explicit and
+    /// gives callers the bounded, local-only follow-up command.
+    pub control_plane: UnregisteredControlPlaneStatus,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UnregisteredControlPlaneStatus {
+    pub status: &'static str,
+    pub command: &'static str,
 }
 
 /// Bounded, local-only control-plane status. This intentionally contains counts


### PR DESCRIPTION
Fixes #11910

Unregistered `homeboy status` responses now include a structured `control_plane` section that explicitly says its health is `not_checked` and provides the bounded local follow-up command: `homeboy status --global`. This preserves the default fast path and avoids remote probes while making runner/control-plane health discoverable.

Tests cover the unregistered response contract and a disconnected configured runner reported through the bounded global status path.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli default_status_from_unregistered_cwd_returns_actionable_context_without_global_scan --lib`
- `cargo test -p homeboy-cli global_status_from_an_unregistered_cwd_is_local_and_bounded --lib`
- `git diff --check`
- `cargo clippy -p homeboy-cli --lib -- -D warnings` remains blocked by three pre-existing `homeboy-core` warnings in `http_api.rs` and `notify_outbox.rs`; this change introduces no clippy findings.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode inspected the status contract, implemented the structured global-health discovery, and added deterministic coverage. Chris Huber remains responsible for every line.