### PR TITLE
fix(runner): guide disconnected status recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -1484,7 +1484,7 @@ pub(super) fn runner_status_operator_commands(
         }
     }
 
-    if session.mode == RunnerTunnelMode::DirectSsh {
+    if session.mode == RunnerTunnelMode::DirectSsh && report.connected {
         commands.push(RunnerOperatorCommand {
             scope: "generation_reconcile",
             runner_id: report.runner_id.clone(),

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -330,6 +330,9 @@ fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
     assert!(runner_status_operator_commands(&report)
         .iter()
         .all(|command| command.scope != "daemon_reconcile_split_view"));
+    assert!(runner_status_operator_commands(&report)
+        .iter()
+        .all(|command| command.scope != "generation_reconcile"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -241,7 +241,7 @@ fn record_partial_peer_projection(runner_id: &str, reason_code: &'static str, de
         reason_code,
         timeout_seconds: 0,
         detail: format!(
-            "{detail}; status is partial. Run `homeboy runner reconcile {runner_id}` to select or repair the authoritative session."
+            "{detail}; status is partial. Run `homeboy runner connect {runner_id}` to re-establish and validate the authoritative session."
         ),
     });
 }
@@ -1274,6 +1274,33 @@ mod tests {
             .expect("project bounded peers"),
             StatusPeerSession::Truncated
         ));
+    }
+
+    #[test]
+    fn partial_peer_session_recovery_guidance_reconnects_instead_of_reconciling() {
+        let _ = crate::readonly_probe::take_degradations();
+        let root = TempDir::new().expect("session directory");
+        for index in 0..9 {
+            let peer = session(&format!("peer-{index}"), "lease-live");
+            write_session_at(&root.path().join(format!("peer-{index}.json")), &peer)
+                .expect("write peer session");
+        }
+
+        assert!(matches!(
+            status_peer_session_in_with(&root.path().to_path_buf(), "current", |_| true)
+                .expect("project bounded peers"),
+            StatusPeerSession::Truncated
+        ));
+
+        record_partial_peer_projection("runner-a", "probe_truncated", "nine peers".to_string());
+        let guidance = crate::readonly_probe::take_degradations()
+            .into_iter()
+            .find(|degradation| degradation.runner_id.as_deref() == Some("runner-a"))
+            .expect("partial peer guidance");
+        assert!(guidance.detail.contains("homeboy runner connect runner-a"));
+        assert!(!guidance
+            .detail
+            .contains("homeboy runner reconcile runner-a"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -881,13 +881,18 @@ impl RunnerStatusReport {
             .as_ref()
             .and_then(|session| session.homeboy_build_identity.clone());
 
-        // A retained active count has to receive a bounded authoritative
-        // observation before a reconnect can be considered. Otherwise status
-        // advertises connect while connect correctly returns to reconcile.
-        let next_action = unresolved_generation
-            .as_ref()
-            .map(|_| reconcile_action(&self.runner_id))
-            .or_else(|| self.admission_action())
+        // Retained generations still need a bounded authoritative observation,
+        // but only after the disconnected runner restores its daemon transport.
+        // Reconciliation settles terminal jobs through the connected daemon.
+        // A disconnected report must first select its reconnect, refresh, or
+        // ownership-recovery action rather than advertising that unavailable path.
+        let next_action = self
+            .admission_action()
+            .or_else(|| {
+                unresolved_generation
+                    .as_ref()
+                    .map(|_| reconcile_action(&self.runner_id))
+            })
             .map(|action| action.render_command());
 
         RunnerAdmissionSummary {
@@ -1514,7 +1519,7 @@ mod status_serialization_tests {
     }
 
     #[test]
-    fn retained_admission_count_projects_each_durable_owner_before_reconnect() {
+    fn disconnected_retained_admission_count_points_to_connect_before_reconcile() {
         let mut report = base_report();
         report.connected = false;
         report.state = RunnerSessionState::Disconnected;
@@ -1550,7 +1555,64 @@ mod status_serialization_tests {
         );
         assert_eq!(
             summary.next_action.as_deref(),
-            Some("homeboy runner reconcile homeboy-lab")
+            Some("homeboy runner connect homeboy-lab")
+        );
+    }
+
+    #[test]
+    fn disconnected_stale_daemon_with_retained_projections_points_to_refresh() {
+        let mut report = base_report();
+        report.connected = false;
+        report.state = RunnerSessionState::Disconnected;
+        report.active_job_state = RunnerActiveJobState::Available;
+        report.stale_daemon = Some(RunnerStaleDaemonWarning {
+            severity: "error",
+            verification: RunnerDaemonVerification::Compared,
+            probe_error: None,
+            mismatch_predicate: "active_daemon_control_plane_version != job_command_binary_version",
+            session_homeboy_version: "0.299.0".to_string(),
+            current_homeboy_version: "0.299.2".to_string(),
+            session_homeboy_build_identity: None,
+            current_homeboy_build_identity: None,
+            controller_homeboy_version: None,
+            controller_homeboy_build_identity: None,
+            compatibility_reason: None,
+            active_daemon_control_plane_version: "0.299.0".to_string(),
+            job_command_binary_version: "0.299.0".to_string(),
+            active_daemon_control_plane_build_identity: None,
+            job_command_binary_build_identity: None,
+            refresh_command:
+                "homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect"
+                    .to_string(),
+            stale_runtime_paths: Vec::new(),
+            changed_runtime_paths: Vec::new(),
+            message: "stale".to_string(),
+            recovery_commands: Vec::new(),
+            recovery_actions: Vec::new(),
+        });
+        let generations = vec![RunnerDaemonGenerationStatus {
+            generation: "lease-old".to_string(),
+            admission_owner: false,
+            drain_state: crate::RollingDrainState::Draining,
+            active_job_count: 2,
+            observed_active_job_count: None,
+            active_job_count_authoritative: false,
+            job_owner_count: 2,
+            run_owner_count: 0,
+            artifact_owner_count: 0,
+            homeboy_build_identity: None,
+            remote_daemon_lease_id: Some("lease-old".to_string()),
+            remote_daemon_address: None,
+            local_url: None,
+        }];
+
+        let summary = report.admission_summary_with_generations(&generations, &[], 1);
+
+        assert_eq!(summary.active_job_count, 0);
+        assert_eq!(summary.unresolved_retained_projection_count, 2);
+        assert_eq!(
+            summary.next_action.as_deref(),
+            Some("homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect")
         );
     }
 }


### PR DESCRIPTION
## Summary
- prioritize a disconnected runner's executable recovery action over generation reconciliation in structured status output
- omit direct-SSH `runner reconcile` guidance until the runner is connected
- direct truncated peer-session recovery to `runner connect`, with coverage for nine persisted peers, stale daemon evidence, retained projections, and zero active jobs

Fixes #11898

## Validation
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner disconnected_retained_admission_count_points_to_connect_before_reconcile`
- `cargo test -p homeboy-lab-runner disconnected_stale_daemon_with_retained_projections_points_to_refresh`
- `cargo test -p homeboy-lab-runner partial_peer_session_recovery_guidance_reconnects_instead_of_reconciling`
- `cargo test -p homeboy-cli disconnected_split_view_status_exposes_bounded_reconciliation_command`
- `git diff --check`

## Lint
`cargo clippy -p homeboy-lab-runner -p homeboy-cli --tests -- -D warnings` remains blocked by three existing `homeboy-core` warnings in untouched `http_api.rs` and `notify_outbox.rs` (`needless_update`, `unnecessary_sort_by`).

## AI assistance
Model: OpenAI `gpt-5.6-terra`. Tool: OpenCode. Used to inspect the runner recovery state machine, implement deterministic disconnected guidance, add regression coverage, and run validation. Chris Huber remains responsible for every line.