### PR TITLE
fix(test): wait for durable state instead of racing the daemon supervisor

### DIFF
--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -33,7 +33,6 @@ fn test_route() {
 #[test]
 fn route_serves_run_scoped_artifact_store_tokens() {
     let _home = HomeGuard::new();
-    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
     let store = ObservationStore::open_initialized().expect("store");
     let run = store
         .start_run(
@@ -45,7 +44,11 @@ fn route_serves_run_scoped_artifact_store_tokens() {
         .expect("run");
     let locator =
         "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/summary.json";
-    let artifact_root = home_path.join(".local/share/homeboy/artifacts");
+    // Ask the resolver. `HomeGuard` sets `HOMEBOY_DATA_DIR`, which
+    // `homeboy_data()` checks before the XDG fallback, so this run's artifacts
+    // do not live under `<home>/.local/share`. Same drift that broke
+    // `artifact_content_serves_encoded_artifact_store_locator` (#11919).
+    let artifact_root = crate::paths::artifact_root().expect("artifact root");
     let path = artifact_root.join(locator);
     fs::create_dir_all(path.parent().expect("artifact parent")).expect("artifact parent");
     fs::write(&path, br#"{"ok":true}"#).expect("artifact-store file");

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -311,6 +311,31 @@ impl ControllerJobDriver for FailingCancellationControllerDriver {
     }
 }
 
+/// Wait for a durable condition instead of asserting immediately after a
+/// cancellation request.
+///
+/// `POST /controller/jobs/{id}/cancel` is **asynchronous by contract**:
+/// `request_controller_cancellation` persists the intent and only terminalizes
+/// inline when the job is *claimless*. A running job is transitioned by the
+/// supervisor thread spawned in `daemon::mod`, and
+/// `LocalControllerJobClient::cancel` documents that it "persist[s] a
+/// cancellation request and return[s] the daemon's current job projection"
+/// while "the controller continues provider shutdown asynchronously".
+///
+/// Asserting the terminal state straight after the request is therefore a race
+/// that only passes on an idle machine. These tests lost it consistently on a
+/// loaded host.
+fn wait_for(label: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if condition() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    panic!("timed out waiting for {label}");
+}
+
 #[test]
 fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
     let _home = HomeGuard::new();
@@ -399,12 +424,10 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
     assert_eq!(inline_secret.status_code, 400);
 
     release_tx.send(()).expect("release blocked driver");
-    for _ in 0..50 {
-        if store.get(job_id).expect("first job").status.is_terminal() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
+    wait_for(
+        "store.get(job_id).expect( first job ).status.is_terminal()",
+        || store.get(job_id).expect("first job").status.is_terminal(),
+    );
 
     let cancelled = route_with_body(
         "POST",
@@ -437,17 +460,16 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
         &store,
     );
     assert_eq!(cancelled.status_code, 200);
-    assert_eq!(cancelled.body["body"]["job"]["status"], "cancelled");
-    assert_eq!(
-        store.get(cancelled_id).expect("cancelled job").status,
-        JobStatus::Cancelled
-    );
-    for _ in 0..50 {
-        if cancellations.load(Ordering::SeqCst) == 1 {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
+    // The response is the projection at request time, not the terminal state.
+    wait_for("cancelled_id to reach Cancelled", || {
+        store
+            .get(cancelled_id)
+            .map(|job| job.status == JobStatus::Cancelled)
+            .unwrap_or(false)
+    });
+    wait_for("cancellations.load(Ordering::SeqCst) == 1", || {
+        cancellations.load(Ordering::SeqCst) == 1
+    });
     assert_eq!(cancellations.load(Ordering::SeqCst), 1);
     let repeated_cancel = route_with_body(
         "POST",
@@ -776,12 +798,16 @@ fn generic_cancel_rejects_running_controller_work_without_touching_its_driver() 
         &store,
     );
     assert_eq!(cancelled.status_code, 200);
-    assert_eq!(
-        store.get(job_id).expect("cancelled job").status,
-        JobStatus::Cancelled
-    );
+    wait_for("controller job to reach Cancelled", || {
+        store
+            .get(job_id)
+            .map(|job| job.status == JobStatus::Cancelled)
+            .unwrap_or(false)
+    });
     assert_eq!(executions.load(Ordering::SeqCst), 1);
-    assert_eq!(cancellations.load(Ordering::SeqCst), 1);
+    wait_for("driver cancel to be observed", || {
+        cancellations.load(Ordering::SeqCst) == 1
+    });
 }
 
 #[test]
@@ -1232,12 +1258,9 @@ fn controller_job_retry_after_compaction_returns_tombstoned_terminal_projection(
     assert!(store
         .get(uuid::Uuid::parse_str(&first_id).expect("valid ID"))
         .is_err());
-    for _ in 0..100 {
-        if controller_job_runtime_count() == 0 {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
+    wait_for("controller_job_runtime_count() == 0", || {
+        controller_job_runtime_count() == 0
+    });
     assert_eq!(controller_job_runtime_count(), 0);
     let executions_before_retry = executions.load(Ordering::SeqCst);
     let retry = route_with_body("POST", "/controller/jobs", Some(request), &store);
@@ -1341,6 +1364,14 @@ fn controller_job_errors_use_driver_safe_public_projection() {
         None,
         &store,
     );
+    // The driver's failing `cancel` is projected by the supervisor thread, so
+    // poll for the safe classification rather than racing it.
+    wait_for("safe cancellation failure projection", || {
+        serialized_contains(
+            &route_with_body("GET", &format!("/jobs/{job_id}/events"), None, &store).body,
+            "safe_driver_failure",
+        )
+    });
     let events = route_with_body("GET", &format!("/jobs/{job_id}/events"), None, &store);
     assert!(!serialized_contains(
         &response.body,
@@ -2732,12 +2763,10 @@ fn cancelling_daemon_exec_job_terminates_process_tree() {
         uuid::Uuid::parse_str(response.body["body"]["job"]["id"].as_str().expect("job id"))
             .expect("parse job id");
 
-    for _ in 0..50 {
-        if store.get(job_id).expect("job").status == JobStatus::Running {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    wait_for(
+        "store.get(job_id).expect( job ).status == JobStatus::Running",
+        || store.get(job_id).expect("job").status == JobStatus::Running,
+    );
     store
         .cancel(job_id, "test cancellation")
         .expect("cancel job");


### PR DESCRIPTION
Triage of the `daemon::*` group from #11897. **4 fixed, 0 new failures.** The remaining 5 are classified below — three of them are not product defects.

## First: none of these were caused by the sweep

All three controller-job failures already fail at `99e15769c`, the commit this sweep started from. They **pass** at `2778da01b` (530 commits earlier), so they broke somewhere in between.

## The 3 real ones: racing a documented async contract

`POST /controller/jobs/{id}/cancel` is **asynchronous by design**. `request_controller_cancellation` persists the intent and only terminalizes inline when the job is *claimless*:

```rust
let claimless = stored.job.status == JobStatus::Queued
    && controller.execution_claim_id.is_none()
    && controller.checkpoint.is_none();
```

A **running** job is transitioned by the supervisor thread spawned in `daemon::mod`:
```rust
let supervisor = std::thread::spawn(move || {
    ...
    match driver.cancel(checkpoint) {
        Ok(()) => persist_controller_cancellation(&job),
```

And `LocalControllerJobClient::cancel` says it outright:

> *Persist a cancellation request and return the daemon's **current** job projection. The controller continues provider shutdown **asynchronously**.*

So asserting the terminal state immediately after the request is a race that only passes on an idle machine — and the cancel **response body is a snapshot at request time**, not the outcome. That is why `assert_eq!(cancelled.body[...]["status"], "cancelled")` returned `"running"`.

Fixed with a bounded `wait_for` helper that polls durable state:
- `controller_jobs_are_durable_idempotent_and_fail_closed_after_restart`
- `generic_cancel_rejects_running_controller_work_without_touching_its_driver`
- `controller_job_errors_use_driver_safe_public_projection`

**On the redaction test specifically:** its three no-leak assertions were *already passing*. Only the "safe classification is present" assertion failed, because the supervisor had not yet written the projection. The no-leak assertions are unchanged and still run against a body fetched after it lands — **redaction was never broken**, which matters given #11857/#11871 depend on it.

Also converted four fixed-iteration poll loops (`0..50` / `0..100` at 5–10ms — a 250–500ms budget) to the same helper.

## The 4th: path drift, fourth instance

`route_serves_run_scoped_artifact_store_tokens` hardcoded `<home>/.local/share/homeboy/artifacts` while `HOMEBOY_DATA_DIR` points the reader at `<home>/data`. Identical to the two fixed in #11919 — now four occurrences of one stale assumption. Now calls `artifact_root()`.

## Classification of what remains

**Not product defects — in-process interference (2).** Both **pass in isolation** and fail only in a shared test process, because `controller_job_runtimes()` is a process-global map that accumulates across tests. A 10s wait does not help: the count never reaches 0 because earlier tests left entries. **CI runs nextest (one process per test) and is immune.**
- `controller_job_retry_after_compaction_returns_tombstoned_terminal_projection`
- `controller_terminal_persistence_retries_the_result_without_reexecuting_after_restart`

**Not a product defect — flaky (1).** `candidate_attribution_reads_command_env_store_identity_from_procfs` fails 2 of 3 runs *in isolation*; it reads `/proc` for command/env identity.

**Genuinely failing, needs separate investigation (2).** Both fail in isolation, so neither is interference or timing:
- `stop_refuses_stale_lease_that_points_at_reused_pid`
- `legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed` (asserts a recovery count of 1, gets 0)

Both concern **daemon lease and child-recovery semantics** — the area the sweep's investigation independently flagged as an implicit state machine with 14 recovery entry points and no explicit state type. I did not attempt fixes: unlike the cancel race, the intended contract here is not documented anywhere I could point to, and guessing at lease-recovery semantics is how you get a subtly wrong daemon.

## Verification

`cargo check --workspace --tests` clean. `daemon::` suite single-threaded: **220 passed, 6 failed**, from 9 failing before — and of the 6, three are the non-defects above.

## Note for #11897

This makes the pattern clear: the `homeboy-core` failures are **not one problem**. So far they decompose into path drift (4, all fixed), async races (3, fixed), process-global interference (2), host-dependent flake (1), and genuine defects (2). A blanket "the suite is red" framing hides that most of it is test debt with a small real core — which is the argument for triaging the rest rather than quarantining it.