### PR TITLE
fix(release): verify Linux consumers resolve published release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1454,6 +1454,50 @@ jobs:
           fi
           echo "::notice::Release ${RELEASE_TAG} contains every planned asset."
 
+  # A complete remote inventory proves that every archive was uploaded. It does
+  # not prove that the consumer resolver selects this release rather than
+  # falling back to an older installable one. Exercise the public action on
+  # Linux with no source or binary override, which is the same resolution path
+  # used by downstream CI consumers.
+  verify-linux-consumer:
+    name: Verify Linux consumer
+    needs:
+      - prepare
+      - verify-published
+    if: ${{ always() && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.verify-published.result == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs['release-tag'] }}
+          persist-credentials: false
+
+      - name: Resolve latest release and run Homeboy Action
+        uses: Extra-Chill/homeboy-action@v2
+        with:
+          # Deliberately omit local-build and supplied-executable inputs: the
+          # action must install the Linux archive a downstream consumer
+          # resolves from latest.
+          commands: review lint
+          expected-commands: review lint
+
+      - name: Verify Homeboy Action installed the published version
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
+        run: |
+          set -euo pipefail
+          EXPECTED_VERSION="${RELEASE_TAG#v}"
+          ACTUAL_VERSION="$(homeboy --version)"
+          case "${ACTUAL_VERSION}" in
+            *"${EXPECTED_VERSION}"*)
+              echo "::notice::Linux consumer resolved ${ACTUAL_VERSION} for ${RELEASE_TAG}"
+              ;;
+            *)
+              echo "::error::Linux consumer resolved '${ACTUAL_VERSION}', not the release just published (${RELEASE_TAG}). The action must not fall back to an older release." >&2
+              exit 1
+              ;;
+          esac
+
   announce:
     needs:
       - plan
@@ -1482,6 +1526,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - host
+      - verify-linux-consumer
       - verify-published
       - announce
     if: ${{ always() && github.event_name == 'push' && needs.check.outputs.should-release == 'true' && contains(toJson(needs), '"result":"failure"') }}
@@ -1553,6 +1598,7 @@ jobs:
       - build-local-artifacts
       - build-global-artifacts
       - host
+      - verify-linux-consumer
       - verify-published
       - announce
     if: ${{ always() && github.event_name == 'push' && needs.check.outputs.should-release == 'true' && !contains(toJson(needs), '"result":"failure"') && !contains(toJson(needs), '"result":"cancelled"') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1466,6 +1466,8 @@ jobs:
       - verify-published
     if: ${{ always() && needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs['release-tag'] != '' && needs.verify-published.result == 'success' }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -107,6 +107,13 @@ Release execution:
 4. Stops on failure and returns structured step results.
 5. Leaves plan-only steps visible for review without executing them.
 
+For Homeboy's own binary release, the CI pipeline owns cross-platform
+publication. Before the run can succeed, it verifies the declared asset
+inventory and then runs `Extra-Chill/homeboy-action@v2` on Linux with its normal
+`latest` resolver. The action runs `review lint` and its installed version must
+match the release tag, proving downstream Linux CI consumes the newly published
+archive rather than falling back to an older release.
+
 Release requires a clean working tree except for files the release process owns,
 such as version targets and changelog targets.
 

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -735,6 +735,7 @@ fn release_proves_latest_is_consumable_by_the_linux_homeboy_action() {
     let clear_failure = job_section(workflow, "clear-failure");
 
     assert!(consumer.contains("runs-on: ubuntu-22.04"));
+    assert!(consumer.contains("permissions:\n      contents: read"));
     assert!(consumer.contains("needs.verify-published.result == 'success'"));
     assert!(consumer.contains("uses: Extra-Chill/homeboy-action@v2"));
     assert!(consumer.contains("commands: review lint"));
@@ -748,6 +749,7 @@ fn release_proves_latest_is_consumable_by_the_linux_homeboy_action() {
     // Linux archive downstream CI downloads.
     assert!(!consumer.contains("source:"));
     assert!(!consumer.contains("binary-path:"));
+    assert!(!consumer.contains("write"));
 
     // Consumer failure is release failure; it cannot be hidden by the cleanup
     // bookkeeping jobs that otherwise turn a failed publish chain into green.

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -728,6 +728,35 @@ fn release_fails_loudly_when_prepared_release_does_not_publish() {
 }
 
 #[test]
+fn release_proves_latest_is_consumable_by_the_linux_homeboy_action() {
+    let workflow = release_workflow();
+    let consumer = job_section(workflow, "verify-linux-consumer");
+    let record_failure = job_section(workflow, "record-failure");
+    let clear_failure = job_section(workflow, "clear-failure");
+
+    assert!(consumer.contains("runs-on: ubuntu-22.04"));
+    assert!(consumer.contains("needs.verify-published.result == 'success'"));
+    assert!(consumer.contains("uses: Extra-Chill/homeboy-action@v2"));
+    assert!(consumer.contains("commands: review lint"));
+    assert!(consumer.contains("expected-commands: review lint"));
+    assert!(consumer.contains("ACTUAL_VERSION=\"$(homeboy --version)\""));
+    assert!(consumer.contains("Linux consumer resolved"));
+    assert!(consumer.contains("must not fall back to an older release"));
+
+    // The consumer action must use its ordinary latest-release resolver. A
+    // source build or injected binary would only test this checkout, not the
+    // Linux archive downstream CI downloads.
+    assert!(!consumer.contains("source:"));
+    assert!(!consumer.contains("binary-path:"));
+
+    // Consumer failure is release failure; it cannot be hidden by the cleanup
+    // bookkeeping jobs that otherwise turn a failed publish chain into green.
+    for section in [record_failure, clear_failure] {
+        assert!(section.contains("- verify-linux-consumer"));
+    }
+}
+
+#[test]
 fn release_artifact_builds_survive_recovery_skips_but_fail_closed_on_required_builds() {
     let workflow = release_workflow();
     let local = job_section(workflow, "build-local-artifacts");

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -37,6 +37,7 @@ fn component_args(root: &Path) -> PositionalComponentArgs {
 fn lint_args(root: &Path) -> LintArgs {
     LintArgs {
         comp: component_args(root),
+        release_readiness_source: None,
         extension_override: ExtensionOverrideArgs::default(),
         summary: false,
         file: None,
@@ -57,6 +58,7 @@ fn lint_args(root: &Path) -> LintArgs {
 fn test_args(root: &Path) -> TestArgs {
     TestArgs {
         comp: component_args(root),
+        release_readiness_source: None,
         extension_override: ExtensionOverrideArgs::default(),
         skip_lint: false,
         coverage: false,


### PR DESCRIPTION
## Summary

- add a post-publication `ubuntu-22.04` consumer gate that invokes `Extra-Chill/homeboy-action@v2` without a source or binary override
- run `review lint` through the action and require its installed `homeboy --version` to match the release tag, proving `latest` resolves the newly published Linux archive rather than falling back
- make consumer-gate failure part of release failure bookkeeping and document the contract

Fixes #11811.

## Artifact Contract

A successful release must contain cargo-dist's declared supported-platform archives and checksums plus `dist-manifest.json`. After publication, the Linux consumer gate resolves `latest`, executes Homeboy Action's `review lint`, and rejects any binary whose version does not match the just-published tag.

## Verification

- `cargo fmt --all --check`
- `cargo test --test release_workflow_test` (56 passed)
- `actionlint -ignore SC2129 -ignore SC2086 .github/workflows/release.yml`
- `git diff --check`

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode inspected the issue, release assets, related PRs, and workflow runs; implemented the Linux consumer gate, tests, and documentation; and ran focused verification. Chris Huber remains responsible for every line.