### PR TITLE
fix(test): unbreak the observation store suite and main's test build

### DIFF
--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -899,6 +899,15 @@ mod tests {
     }
 
     fn seed_owned_and_orphaned_children(connection: &Connection) {
+        // These rows model state written *while FK enforcement was off* -- the
+        // exact scenario migration 13 exists to clean up, and what
+        // `migration_13_reaps_rows_orphaned_while_enforcement_was_off` is named
+        // for. `enforce_foreign_keys` now turns enforcement on at open, so the
+        // seed must turn it off to create the orphans whose reaping is under
+        // test. (It also lets `trace_spans` be inserted before `trace_runs`.)
+        connection
+            .pragma_update(None, "foreign_keys", false)
+            .expect("relax foreign keys to seed orphaned children");
         connection
             .execute_batch(
                 r#"
@@ -931,6 +940,9 @@ mod tests {
                 "#,
             )
             .unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .expect("restore foreign key enforcement after seeding");
     }
 
     fn surviving_run_ids(connection: &Connection, table: &str) -> Vec<String> {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -29,12 +29,6 @@ impl XdgGuard {
         std::env::remove_var("XDG_DATA_HOME");
         Self { prior }
     }
-
-    fn set(value: &std::path::Path) -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::set_var("XDG_DATA_HOME", value);
-        Self { prior }
-    }
 }
 
 impl Drop for XdgGuard {
@@ -50,6 +44,18 @@ impl EnvGuard {
     fn set(key: &'static str, value: String) -> Self {
         let prior = std::env::var(key).ok();
         std::env::set_var(key, value);
+        Self { key, prior }
+    }
+
+    /// Clear a variable for the guard's lifetime.
+    ///
+    /// Needed for the XDG-layout assertions below: `with_isolated_home` sets
+    /// `HOMEBOY_DATA_DIR`, and `homeboy_data()` checks it *before* consulting
+    /// `XDG_DATA_HOME` -- so an `XdgGuard` alone cannot reach the path it is
+    /// setting up. Same drift documented in #11919.
+    fn unset(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::remove_var(key);
         Self { key, prior }
     }
 }
@@ -70,6 +76,7 @@ mod store_init_tests {
     fn test_status() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
+            let _data_dir = EnvGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
 
             let status = store::status().expect("status");
 
@@ -90,15 +97,29 @@ mod store_init_tests {
         });
     }
 
+    /// Pins the resolved database path under an isolated home.
+    ///
+    /// This deliberately does **not** set `XDG_DATA_HOME`. `homeboy_data()`
+    /// consults the registered home-root override *before* XDG -- the override
+    /// "outranks `XDG_DATA_HOME` deliberately" per its own comment -- and
+    /// `with_isolated_home` always registers one. So an `XdgGuard::set` here
+    /// could never take effect, and asserting an XDG-derived path was pinning
+    /// a resolution order that does not exist. It failed for that reason.
+    ///
+    /// `HOMEBOY_DATA_DIR` is cleared because the harness sets it and it
+    /// short-circuits ahead of everything; clearing it is what makes this the
+    /// production default rather than a test artifact (#11919).
     #[test]
     fn test_database_path() {
         with_isolated_home(|home| {
-            let data_home = home.path().join("xdg-data");
-            let _xdg = XdgGuard::set(&data_home);
+            let _data_dir = EnvGuard::unset(crate::paths::HOMEBOY_DATA_DIR_ENV);
 
             let path = store::database_path().expect("db path");
 
-            assert_eq!(path, data_home.join("homeboy/homeboy.sqlite"));
+            assert_eq!(
+                path,
+                home.path().join(".local/share/homeboy/homeboy.sqlite")
+            );
         });
     }
 
@@ -1099,8 +1120,14 @@ mod store_artifact_tests {
                 std::fs::read_to_string(persisted.join("nested/detail.txt")).expect("read nested"),
                 "detail"
             );
+            // The immutable tree digest lives in `sha256`, not `url`.
+            // `record_directory_artifact_with_id_and_metadata` computes
+            // `directory_tree_sha256` and stores it there -- it is also what the
+            // idempotent-reuse check compares (`existing.sha256.as_deref()`).
+            // This assertion had the two fields swapped and failed for that
+            // reason.
             assert_eq!(
-                artifact.url,
+                artifact.sha256,
                 Some(
                     crate::observation::directory_tree_sha256(&persisted)
                         .expect("directory digest")
@@ -1108,7 +1135,7 @@ mod store_artifact_tests {
             );
             assert_eq!(artifact.size_bytes, None);
             assert_eq!(artifact.mime, None);
-            assert_eq!(artifact.sha256, None);
+            assert_eq!(artifact.url, None);
         });
     }
 

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -38,6 +38,7 @@ fn lint_args(root: &Path) -> LintArgs {
     LintArgs {
         comp: component_args(root),
         extension_override: ExtensionOverrideArgs::default(),
+        release_readiness_source: None,
         summary: false,
         file: None,
         glob: None,
@@ -59,6 +60,7 @@ fn test_args(root: &Path) -> TestArgs {
         comp: component_args(root),
         extension_override: ExtensionOverrideArgs::default(),
         skip_lint: false,
+        release_readiness_source: None,
         coverage: false,
         coverage_min: None,
         baseline_args: BaselineArgs::default(),


### PR DESCRIPTION
Continues the #11897 triage into `observation::store` and `cleanup`. **7 fixed, 0 new failures** (`homeboy-core --lib`: 30 → 23, diffed against `origin/main`).

## ⚠️ main did not compile

`release_readiness_source` was added to **both** `TestArgs` and `LintArgs` without updating `tests/self_checks_test.rs`, so `cargo check --workspace --tests` failed outright:

```
error[E0063]: missing field `release_readiness_source` in initializer of `homeboy::commands::test::TestArgs`
error[E0063]: missing field `release_readiness_source` in initializer of `homeboy::commands::lint::LintArgs`
```

Same class as #11767, and **the second time this session**. This is exactly what the `cargo check --workspace --tests` pre-push gate exists to catch: a struct gains a field and an initializer in a *different* package goes unupdated.

## The store failures were three different bugs

**`schema::tests` (3)** — `seed_owned_and_orphaned_children` inserts rows referencing a run that does not exist, *because that is the point*: migration 13 exists to reap them, and one test is literally named `migration_13_reaps_rows_orphaned_while_enforcement_was_off`. `enforce_foreign_keys` now enables enforcement at open, so the seed could no longer create the orphans under test and died with `FOREIGN KEY constraint failed` while setting up. The seed now relaxes the pragma and restores it — which is precisely the "enforcement was off" state the tests model.

**`store_init_tests` (2)** — `test_status` and `test_database_path` asserted the XDG layout while `with_isolated_home` sets `HOMEBOY_DATA_DIR`, which `homeboy_data()` checks first. Added `EnvGuard::unset` beside the existing `EnvGuard::set`.

`test_database_path` had a second, more interesting problem: it set `XDG_DATA_HOME` and asserted an XDG-derived path, but **that assertion could never pass**. The registered home-root override outranks XDG *deliberately* (its own comment says so) and `with_isolated_home` always registers one. The test was pinning a resolution order that does not exist. It now pins the one that does.

**`store_artifact_tests` (1)** — `test_record_directory_artifact` had two fields **swapped**. `record_directory_artifact_with_id_and_metadata` writes the tree digest to `sha256` — it is what the idempotent-reuse check compares (`existing.sha256.as_deref() == Some(tree_sha256)`) — while the test asserted the digest in `url` and expected `sha256` to be `None`.

## Classification of what remains

**`cleanup::self_artifacts` (5) — environment-dependent, not defects.** They require a *managed Homeboy source checkout* to own the running test binary. I tested the obvious hypothesis by building `target/debug/homeboy` (816 MB, incidentally corroborating the "~700 MB" figure #11775 relies on) — **it did not help.** They need real host state that an isolated home lacks by construction, so they cannot pass in a hermetic run.

**`publication_manifest_*` (2) — genuinely failing, needs investigation.** `record_artifact` on a `publication_manifest` is expected to index the artifacts its manifest references; only the source artifact appears. That is real behaviour worth understanding, not a fixture problem, and I did not guess at it.

**`migration_from_version_8_...` (1) — genuinely failing.** `apply migration 13: no such table: findings`. Migration 13 assumes `findings` exists; a database legitimately at v8 may not have it. **This one may be a real migration bug rather than a test bug** — it is the same migration whose test fixtures are fixed above, so it deserves a look from someone who knows the intended v8 shape.

## Verification

`cargo check --workspace --tests` clean, **0 warnings** (also removed a now-unused `XdgGuard::set` that `-Dwarnings` would have rejected). `-Dwarnings` binary build clean.

Full `homeboy-core --lib` single-threaded, diffed against `origin/main`:

| | count |
|---|---|
| main | 30 |
| branch | 23 |
| **new** | **0** |
| fixed | 7 (6 targeted + `controller_runtime::publication_is_no_clobber_and_idempotent`, which is flaky) |

## Running total for #11897

19 tests fixed across #11919, #11927 and this PR. The decomposition continues to hold: **path drift (6), async races (3), FK-enforcement drift (3), swapped assertions (1), unreachable premises (2), plus compile breaks** — versus a small core of genuine defects (2 daemon lease/recovery, 2 publication-manifest, 1 possible migration bug).