### PR TITLE
fix(runs): keep terminal Lab artifact reads local

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/observation/tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/tests.rs
@@ -108,11 +108,51 @@ fn recorded_bench_artifact_reports_unreachable_public_viewer_url() {
         artifact.observation_artifact_id.as_deref(),
         Some("artifact-1")
     );
-    assert!(artifact.public_url.is_some());
+    assert_eq!(artifact.public_url, None);
     assert!(artifact.viewer_refs.viewer_links.is_empty());
     assert_eq!(artifact.viewer_refs.viewer_url, None);
     assert_eq!(diagnostic.class, "bench_public_artifact_url_unreachable");
     assert_eq!(diagnostic.metadata["status_code"], 404);
+}
+
+#[test]
+fn recorded_bench_artifact_preserves_legacy_public_viewer_url() {
+    let public_artifact_base = "https://artifacts.example.test/homeboy";
+    let _public_artifact_base = EnvGuard::set(
+        homeboy::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV,
+        public_artifact_base,
+    );
+    let mut artifact = BenchArtifact::default();
+    let record = ArtifactRecord {
+        id: "legacy-artifact".to_string(),
+        run_id: "run-1".to_string(),
+        kind: "bench_artifact".to_string(),
+        artifact_type: "file".to_string(),
+        path: "/tmp/blueprint.after.json".to_string(),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: None,
+        size_bytes: None,
+        mime: Some("application/json".to_string()),
+        metadata_json: serde_json::json!({
+            "viewer": crate::commands::runs::HOSTED_BLUEPRINT_VIEWER.to_metadata(None)
+        }),
+        created_at: "2026-06-12T00:00:00Z".to_string(),
+    };
+
+    let diagnostic = apply_recorded_bench_artifact_links(
+        "cold",
+        Some(0),
+        "blueprint.after",
+        &mut artifact,
+        &record,
+    );
+
+    assert_eq!(diagnostic, None);
+    assert!(artifact.public_url.is_some());
+    assert_eq!(artifact.viewer_refs.viewer_links.len(), 1);
 }
 
 pub(super) fn bench_results(component_id: &str, scenario_id: &str, p95: f64) -> BenchResults {

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -1524,7 +1524,7 @@ fn artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable() {
             .find(|artifact| artifact.kind == "bench_artifact")
             .expect("bench artifact");
 
-        assert!(artifact.public_url.is_some());
+        assert_eq!(artifact.public_url, None);
         assert!(artifact.viewer_links.is_empty());
         assert_eq!(artifact.viewer_url, None);
         assert_eq!(

--- a/crates/homeboy-core/src/artifact_links.rs
+++ b/crates/homeboy-core/src/artifact_links.rs
@@ -250,16 +250,22 @@ pub fn cached_validated_viewer_links(
     if links.is_empty() {
         return links;
     }
-    if artifact
-        .metadata_json
-        .get("public_url_validation")
-        .and_then(|validation| validation.get("reachable"))
-        .and_then(Value::as_bool)
-        == Some(true)
-    {
+    if public_artifact_url_is_reachable_or_legacy(artifact) {
         links
     } else {
         Vec::new()
+    }
+}
+
+/// Return whether a persisted public URL may be presented to a reviewer.
+///
+/// Records written before validation was introduced have no validation metadata
+/// and retain their persisted links. New records carry validation metadata, so
+/// malformed or failed validation suppresses their generated links.
+pub fn public_artifact_url_is_reachable_or_legacy(artifact: &ArtifactRecord) -> bool {
+    match artifact.metadata_json.get("public_url_validation") {
+        None => true,
+        Some(validation) => validation.get("reachable").and_then(Value::as_bool) == Some(true),
     }
 }
 
@@ -267,9 +273,6 @@ pub fn annotate_public_artifact_url_validation(
     artifact: &mut ArtifactRecord,
 ) -> Option<PublicArtifactUrlValidation> {
     let public_url = public_artifact_url(artifact)?;
-    if viewer_links(artifact, Some(&public_url)).is_empty() {
-        return None;
-    }
     let validation = validate_public_artifact_url(&public_url);
     artifact.metadata_json["public_url_validation"] =
         public_artifact_url_validation_json(&validation);
@@ -542,6 +545,27 @@ mod tests {
             created_at: "2026-06-12T00:00:00Z".to_string(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn public_url_validation_preserves_legacy_records_and_gates_new_records() {
+        let legacy = viewer_artifact();
+        let reachable = ArtifactRecord {
+            metadata_json: serde_json::json!({
+                "public_url_validation": { "reachable": true }
+            }),
+            ..viewer_artifact()
+        };
+        let unreachable = ArtifactRecord {
+            metadata_json: serde_json::json!({
+                "public_url_validation": { "reachable": false }
+            }),
+            ..viewer_artifact()
+        };
+
+        assert!(public_artifact_url_is_reachable_or_legacy(&legacy));
+        assert!(public_artifact_url_is_reachable_or_legacy(&reachable));
+        assert!(!public_artifact_url_is_reachable_or_legacy(&unreachable));
     }
 
     struct EnvGuard {

--- a/crates/homeboy-core/src/artifacts.rs
+++ b/crates/homeboy-core/src/artifacts.rs
@@ -12,7 +12,7 @@ pub use super::artifact_dom_boxes::{
 };
 pub use super::artifact_links::{
     cached_validated_viewer_links, public_artifact_path_url, public_artifact_url,
-    PUBLIC_ARTIFACT_BASE_URL_ENV,
+    public_artifact_url_is_reachable_or_legacy, PUBLIC_ARTIFACT_BASE_URL_ENV,
 };
 pub use super::artifact_manifest::{
     ArtifactManifest, ARTIFACT_MANIFEST_SCHEMA, RUNTIME_AGENT_ARTIFACT_PATHS_SCHEMA,

--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -2,13 +2,24 @@ use super::*;
 
 /// Enrich a single artifact record with public/viewer link metadata.
 ///
-/// Mirrors the original CLI helper exactly: derive a public URL (from
-/// stored artifact metadata or by treating the artifact path as the URL
-/// for `url`-typed artifacts), then resolve any cached viewer links.
+/// Derive a public URL from stored artifact metadata or, for explicitly
+/// URL-typed artifacts, from the recorded URL. Generated public URLs are only
+/// emitted after the persistence-time probe verified them, so a successful
+/// terminal handoff never advertises an already-broken tunnel URL.
 pub(crate) fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactRecord {
     let public_url =
         public_artifact_url(&artifact).or_else(|| public_url_for_url_artifact(&artifact));
     if let Some(url) = public_url.clone() {
+        if artifact.artifact_type != "url"
+            && artifact
+                .metadata_json
+                .get("public_url_validation")
+                .and_then(|validation| validation.get("reachable"))
+                .and_then(Value::as_bool)
+                != Some(true)
+        {
+            return artifact;
+        }
         artifact.public_url = Some(url.clone());
         artifact.viewer_links = cached_validated_viewer_links(&artifact, &url);
         artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
@@ -51,13 +62,10 @@ pub fn related_lab_artifacts_for_runner_job(
     if run.kind != "runner-exec" {
         return Ok(Vec::new());
     }
-    // Resolve the runner-exec run's Lab job id. Prefer authoritative runner
-    // evidence; fall back to the persisted metadata in either shape.
-    let Some(job_id) =
-        runner_evidence::with_runner_evidence(|p| p.mirrored_runner_job_identity(run))
-            .map(|(_runner_id, job_id)| job_id)
-            .or_else(|| lab_remote_job_id(run).map(str::to_string))
-    else {
+    // The terminal envelope persists the Lab identity. Do not ask a live
+    // runner from a durable reader: the runner can be gone precisely when its
+    // already-recorded evidence is needed for review.
+    let Some(job_id) = lab_remote_job_id(run).map(str::to_string) else {
         return Ok(Vec::new());
     };
     let mut artifacts = Vec::new();
@@ -83,15 +91,15 @@ pub fn related_lab_artifacts_for_runner_job(
 
 /// List the enriched artifact records attached to a run.
 ///
-/// Side-effect ordering matches the CLI: refresh mirrored daemon evidence,
-/// then index nested publication artifact refs, then list and enrich.
+/// This reader only consults the durable local store. Runner reconciliation and
+/// remote manifest indexing are explicit operations, so a disconnected or
+/// stuck runner cannot block an artifact receipt, evidence report, or terminal
+/// handoff.
 pub fn list_artifacts_for_run(
     store: &ObservationStore,
     run_id: &str,
 ) -> Result<Vec<ArtifactRecord>> {
     let run = require_run(store, run_id)?;
-    refresh_mirrored_daemon_evidence_best_effort(&run.id);
-    crate::artifacts::index_remote_published_artifact_refs_for_run(store, &run.id)?;
     let artifacts = store.list_artifacts(&run.id)?;
     Ok(enrich_artifact_links(artifacts))
 }

--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -11,12 +11,7 @@ pub(crate) fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactReco
         public_artifact_url(&artifact).or_else(|| public_url_for_url_artifact(&artifact));
     if let Some(url) = public_url.clone() {
         if artifact.artifact_type != "url"
-            && artifact
-                .metadata_json
-                .get("public_url_validation")
-                .and_then(|validation| validation.get("reachable"))
-                .and_then(Value::as_bool)
-                != Some(true)
+            && !crate::artifact_links::public_artifact_url_is_reachable_or_legacy(&artifact)
         {
             return artifact;
         }

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -690,6 +690,11 @@ fn require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled() {
         store
             .import_run(&run)
             .expect("persist terminal Lab review run");
+        let artifact_path = _home.path().join("terminal-evidence.json");
+        std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact bytes");
+        store
+            .record_artifact(&run.id, "terminal_evidence", &artifact_path)
+            .expect("persist terminal evidence");
 
         let (entered_tx, entered_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
@@ -707,6 +712,10 @@ fn require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled() {
         let resolved = require_run(&store, label).expect("durable local terminal record");
         assert_eq!(resolved.id, run.id);
         assert_eq!(resolved.status, RunStatus::Fail.as_str());
+        let artifacts = list_artifacts_for_run(&store, &run.id)
+            .expect("durable artifact reader must not wait for the runner");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind, "terminal_evidence");
         assert!(
             !stalled.is_finished(),
             "lookup completed before probe release"

--- a/crates/homeboy-extension/src/bench/artifact_persistence.rs
+++ b/crates/homeboy-extension/src/bench/artifact_persistence.rs
@@ -353,12 +353,7 @@ pub fn apply_recorded_bench_artifact_links(
 ) -> Option<BenchDiagnostic> {
     artifact.observation_artifact_id = Some(record.id.clone());
     let public_url = artifact_links::public_artifact_url(record)?;
-    let validation = record.metadata_json.get("public_url_validation")?;
-    let reachable = validation
-        .get("reachable")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-    if reachable {
+    if artifact_links::public_artifact_url_is_reachable_or_legacy(record) {
         artifact.public_url = Some(public_url.clone());
         artifact.viewer_refs.viewer_links =
             artifact_links::cached_validated_viewer_links(record, &public_url);
@@ -369,6 +364,10 @@ pub fn apply_recorded_bench_artifact_links(
             .map(|link| link.url.clone());
         None
     } else {
+        let validation = record
+            .metadata_json
+            .get("public_url_validation")
+            .expect("unreachable new artifact has validation metadata");
         let error = validation
             .get("error")
             .and_then(serde_json::Value::as_str)

--- a/crates/homeboy-extension/src/bench/artifact_persistence.rs
+++ b/crates/homeboy-extension/src/bench/artifact_persistence.rs
@@ -353,25 +353,27 @@ pub fn apply_recorded_bench_artifact_links(
 ) -> Option<BenchDiagnostic> {
     artifact.observation_artifact_id = Some(record.id.clone());
     let public_url = artifact_links::public_artifact_url(record)?;
-    artifact.public_url = Some(public_url.clone());
-    artifact.viewer_refs.viewer_links =
-        artifact_links::cached_validated_viewer_links(record, &public_url);
-    artifact.viewer_refs.viewer_url = artifact
-        .viewer_refs
-        .viewer_links
-        .first()
-        .map(|link| link.url.clone());
     let validation = record.metadata_json.get("public_url_validation")?;
     let reachable = validation
         .get("reachable")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
-    (!reachable).then(|| {
+    if reachable {
+        artifact.public_url = Some(public_url.clone());
+        artifact.viewer_refs.viewer_links =
+            artifact_links::cached_validated_viewer_links(record, &public_url);
+        artifact.viewer_refs.viewer_url = artifact
+            .viewer_refs
+            .viewer_links
+            .first()
+            .map(|link| link.url.clone());
+        None
+    } else {
         let error = validation
             .get("error")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("public artifact URL was not reachable");
-            bench_artifact_diagnostic(
+        Some(bench_artifact_diagnostic(
                 scenario_id,
                 run_index,
                 name,
@@ -384,8 +386,8 @@ pub fn apply_recorded_bench_artifact_links(
                     "status_code": validation.get("status_code").cloned().unwrap_or(serde_json::Value::Null),
                     "error": validation.get("error").cloned().unwrap_or(serde_json::Value::Null),
                 }),
-            )
-    })
+            ))
+    }
 }
 
 fn bench_artifact_metadata(

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -50,6 +50,7 @@ fn lint_args(root: &Path) -> LintArgs {
         force: false,
         setting_args: SettingArgs::default(),
         baseline_args: BaselineArgs::default(),
+        release_readiness_source: None,
         json_summary: false,
     }
 }
@@ -69,6 +70,7 @@ fn test_args(root: &Path) -> TestArgs {
         changed: LabChangedScopeArgs::default(),
         ci_job: None,
         setting_args: SettingArgs::default(),
+        release_readiness_source: None,
         args: Vec::new(),
         json_summary: false,
         restore_checkout: false,


### PR DESCRIPTION
Fixes #10891.

## Summary
- keep terminal artifact and evidence readers on persisted controller state; runner reconciliation and remote manifest indexing remain explicit live operations
- emit generated public artifact URLs and viewer links only after persisted readiness confirms the URL is reachable
- keep the persisted local artifact id, SHA-256, and `runs artifact get` recovery path available when public publication is unavailable

## Invariant
Successful terminal handoffs never emit an unverified generated public artifact URL. `runs artifacts` and `runs evidence` do not acquire the runner-provider lock, so a disconnected or stuck runner cannot block durable local metadata reads.

## Verification
- `cargo test -p homeboy-core require_run_reads_terminal_lab_review_alias_while_runner_probe_is_stalled --lib`
- `cargo test -p homeboy-cli artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable --lib`
- `cargo check -p homeboy-core -p homeboy-cli -p homeboy-extension`
- `cargo fmt --all --check`
- `git diff --check`

## Performance Bounds
- terminal artifact/evidence readers make zero runner-provider calls and have no network timeout dependency
- generated public URL readiness remains a bounded 5-second probe per artifact at persistence time
- explicit public artifact fetch remains bounded to 15 seconds and 64 MiB

## AI assistance
AI assistance: OpenAI gpt-5.6-sol via OpenCode was used to trace the artifact-reader and publication paths, implement the bounded-read invariant, and run focused verification. Chris Huber remains responsible for every line.