### PR TITLE
Fix Cook gate-feedback declaration and recovery budgets

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -6,8 +6,9 @@ use crate::agent_task::{
     AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::agent_task_gate::{
-    text_tail, AgentTaskGateDiagnosticProducer, AgentTaskGateDiagnosticRecord, AgentTaskGateReport,
-    AgentTaskGateRevealPolicy, AgentTaskGateStatus, AgentTaskGateVisibility,
+    text_tail, AgentTaskGateDiagnosticProducer, AgentTaskGateDiagnosticRecord,
+    AgentTaskGateFailureClassification, AgentTaskGateReport, AgentTaskGateRevealPolicy,
+    AgentTaskGateStatus, AgentTaskGateVisibility,
 };
 use crate::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use crate::agent_task_review_dossier::AiFilledReviewForm;
@@ -175,6 +176,8 @@ pub struct AgentTaskCookLoopGateFailure {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub command: String,
     pub exit_code: i32,
+    #[serde(default)]
+    pub classification: AgentTaskGateFailureClassification,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub stdout_tail: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -249,6 +252,9 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     apply_failure_progression_to_quality(&mut quality, &failure_progression);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
         && !failed_gates.is_empty()
+        && failed_gates
+            .iter()
+            .all(|gate| gate.classification == AgentTaskGateFailureClassification::CandidateCode)
         && !baseline_red
         && retry_budget_remaining > 0;
     // Deterministic gates take precedence: a red gate must be fixed before the
@@ -608,6 +614,11 @@ fn gate_failure(
         reveal_policy: gate.reveal_policy,
         command,
         exit_code: gate.exit_code,
+        classification: gate
+            .failure_evidence
+            .as_ref()
+            .map(|evidence| evidence.classification)
+            .unwrap_or_default(),
         stdout_tail,
         stderr_tail,
         summary,
@@ -641,6 +652,7 @@ fn agent_visible_gate_failure(
             reveal_policy: failure.reveal_policy,
             command: String::new(),
             exit_code: failure.exit_code,
+            classification: failure.classification,
             stdout_tail: String::new(),
             stderr_tail: String::new(),
             summary: format!(
@@ -657,6 +669,7 @@ fn agent_visible_gate_failure(
             reveal_policy: failure.reveal_policy,
             command: String::new(),
             exit_code: failure.exit_code,
+            classification: failure.classification,
             stdout_tail: String::new(),
             stderr_tail: String::new(),
             summary: "private deterministic gate failed; evidence redacted".to_string(),
@@ -670,6 +683,7 @@ fn agent_visible_gate_failure(
             reveal_policy: failure.reveal_policy,
             command: String::new(),
             exit_code: failure.exit_code,
+            classification: failure.classification,
             stdout_tail: String::new(),
             stderr_tail: String::new(),
             summary: "private deterministic gate failed".to_string(),
@@ -979,6 +993,33 @@ mod tests {
             AgentToolExecutionLocation::Runner
         );
         assert_eq!(request.policy.write, "artifacts_only");
+    }
+
+    #[test]
+    fn gate_declaration_failure_never_creates_code_remediation() {
+        let mut gate = failed_gate();
+        gate.failure_evidence
+            .as_mut()
+            .expect("failure evidence")
+            .classification = AgentTaskGateFailureClassification::GateDeclaration;
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(AgentTaskPromotionStatus::GateFailed, vec![gate]),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-declaration".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        assert!(report.follow_up_request.is_none());
+        assert_eq!(
+            report.failed_gates[0].classification,
+            AgentTaskGateFailureClassification::GateDeclaration
+        );
     }
 
     #[test]
@@ -1381,6 +1422,7 @@ mod tests {
             "producer output is opaque",
             String::new(),
             Some(AgentTaskGateFailureEvidence {
+                classification: AgentTaskGateFailureClassification::CandidateCode,
                 summary: "producer reported a failure".to_string(),
                 command: "opaque-gate".to_string(),
                 exit_code: 1,
@@ -1451,6 +1493,7 @@ mod tests {
             reveal_policy: AgentTaskGateRevealPolicy::FullEvidence,
             command: "opaque-gate".to_string(),
             exit_code: 101,
+            classification: AgentTaskGateFailureClassification::CandidateCode,
             stdout_tail: String::new(),
             stderr_tail: String::new(),
             summary: String::new(),
@@ -1898,6 +1941,7 @@ mod tests {
             "running tests",
             "boom",
             Some(AgentTaskGateFailureEvidence {
+                classification: AgentTaskGateFailureClassification::CandidateCode,
                 summary: "opaque gate failed".to_string(),
                 command: "opaque-gate".to_string(),
                 exit_code: 101,
@@ -1942,6 +1986,7 @@ mod tests {
             "secret fixture mismatch",
             "private evaluator stack trace",
             Some(AgentTaskGateFailureEvidence {
+                classification: AgentTaskGateFailureClassification::CandidateCode,
                 summary: "secret fixture mismatch on randomized private corpus".to_string(),
                 command: "./hidden-heldout-check --fixture secret".to_string(),
                 exit_code: 7,

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -254,6 +254,75 @@ impl VerifyGateOptions {
     pub(crate) fn required_toolchains(&self) -> Vec<AgentTaskGateToolchainRequirement> {
         self.gate_toolchains.clone()
     }
+
+    /// Reject repository-owned npm gate declarations that no candidate patch can
+    /// repair before a provider is admitted.
+    pub(crate) fn preflight_declarations(&self, workspace: &Path) -> Result<()> {
+        for command in self.verify.iter().chain(&self.private_verify) {
+            let Some(script) = npm_run_script(command) else {
+                continue;
+            };
+            let manifest_path = workspace.join("package.json");
+            let manifest = fs::read_to_string(&manifest_path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(manifest_path.display().to_string()))
+            })?;
+            let manifest: serde_json::Value = serde_json::from_str(&manifest).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "gate declaration",
+                    format!("invalid package manifest: {error}"),
+                    Some(manifest_path.display().to_string()),
+                    None,
+                )
+            })?;
+            if manifest.pointer(&format!("/scripts/{script}")).is_some() {
+                continue;
+            }
+            let package = manifest
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unnamed package");
+            let remediation = format!(
+                "Add \"{script}\": \"<command>\" to {}/scripts for package `{package}`, or change/remove the declared Cook gate `{command}`.",
+                manifest_path.display(),
+            );
+            let mut error = Error::validation_invalid_argument(
+                "gate declaration",
+                format!(
+                    "declared npm gate `{command}` is invalid for package `{package}`: {} has no `scripts.{script}`. {remediation}",
+                    manifest_path.display(),
+                ),
+                Some(manifest_path.display().to_string()),
+                None,
+            );
+            error.details = json!({
+                "failure_classification": "gate_declaration",
+                "command": command,
+                "package": package,
+                "manifest": manifest_path,
+                "missing_script": script,
+                "remediation": remediation,
+            });
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn has_npm_run_declaration(&self) -> bool {
+        self.verify
+            .iter()
+            .chain(&self.private_verify)
+            .any(|command| npm_run_script(command).is_some())
+    }
+}
+
+fn npm_run_script(command: &str) -> Option<&str> {
+    let tokens: Vec<_> = command.split_whitespace().collect();
+    if tokens.len() == 3 && tokens[0] == "npm" && tokens[1] == "run" && !tokens[2].starts_with('-')
+    {
+        Some(tokens[2])
+    } else {
+        None
+    }
 }
 
 impl Default for VerifyGateOptions {
@@ -726,6 +795,8 @@ impl From<AgentTaskGateStatus> for HomeboyGateStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateFailureEvidence {
+    #[serde(default)]
+    pub classification: AgentTaskGateFailureClassification,
     pub summary: String,
     pub command: String,
     pub exit_code: i32,
@@ -738,6 +809,14 @@ pub struct AgentTaskGateFailureEvidence {
     /// Homeboy treats their locations and suggested actions as opaque data.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<AgentTaskGateDiagnosticRecord>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskGateFailureClassification {
+    #[default]
+    CandidateCode,
+    GateDeclaration,
 }
 
 pub const AGENT_TASK_GATE_DIAGNOSTIC_RECORD_SCHEMA: &str = "homeboy/gate-diagnostic-record/v1";
@@ -2098,12 +2177,29 @@ fn gate_failure_evidence(
 ) -> AgentTaskGateFailureEvidence {
     let stdout_tail = text_tail(stdout, 20);
     let stderr_tail = text_tail(stderr, 20);
-    let summary = format!("deterministic gate failed with exit code {exit_code}: {command}");
-    let agent_feedback = format!(
-        "A deterministic verification gate failed after the candidate patch was applied. Fix the code so `{command}` passes, using the captured stdout/stderr tails as the primary failure evidence."
-    );
+    let missing_script = npm_run_script(command).filter(|script| {
+        stderr.contains(&format!("Missing script: \"{script}\""))
+            || stderr.contains(&format!("Missing script: {script}"))
+    });
+    let classification = missing_script
+        .is_some()
+        .then_some(AgentTaskGateFailureClassification::GateDeclaration)
+        .unwrap_or(AgentTaskGateFailureClassification::CandidateCode);
+    let summary = match missing_script {
+        Some(script) => format!("declared npm gate is missing script `{script}`: {command}"),
+        None => format!("deterministic gate failed with exit code {exit_code}: {command}"),
+    };
+    let agent_feedback = match missing_script {
+        Some(script) => format!(
+            "The declared gate is invalid, not candidate-code feedback. Add `scripts.{script}` to the relevant package.json or change/remove `{command}` before rerunning Cook."
+        ),
+        None => format!(
+            "A deterministic verification gate failed after the candidate patch was applied. Fix the code so `{command}` passes, using the captured stdout/stderr tails as the primary failure evidence."
+        ),
+    };
 
     AgentTaskGateFailureEvidence {
+        classification,
         summary,
         command: command.to_string(),
         exit_code,
@@ -3753,6 +3849,32 @@ mod tests {
                 "{name} must resolve to the invocation temp dir"
             );
         }
+    }
+
+    #[test]
+    fn npm_missing_script_is_a_non_retryable_gate_declaration_failure() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        fs::write(
+            workspace.path().join("package.json"),
+            r#"{"name":"fixture-package","scripts":{"test":"true"}}"#,
+        )
+        .expect("manifest");
+        let gates = VerifyGateOptions {
+            verify: vec!["npm run typecheck".to_string()],
+            ..Default::default()
+        };
+
+        let error = gates
+            .preflight_declarations(workspace.path())
+            .expect_err("missing script is a declaration failure");
+
+        assert_eq!(error.details["failure_classification"], "gate_declaration");
+        assert_eq!(error.details["package"], "fixture-package");
+        assert_eq!(error.details["missing_script"], "typecheck");
+        assert!(error.details["remediation"]
+            .as_str()
+            .expect("remediation")
+            .contains("scripts"));
     }
 
     /// A symlinked invocation temp alias must yield sandbox paths that are

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2454,6 +2454,19 @@ fn review_budget_authority(
     })
 }
 
+fn child_execution_budget(
+    scope: CookFollowUpBudgetScope,
+    budget_limit: &AgentTaskExecutionBudget,
+) -> AgentTaskExecutionBudget {
+    match scope {
+        CookFollowUpBudgetScope::Cook => budget_limit.clone(),
+        CookFollowUpBudgetScope::FreshCookReview
+        | CookFollowUpBudgetScope::CandidateAdoptionReview => {
+            AgentTaskExecutionBudget::new(1, 0, 0)
+        }
+    }
+}
+
 /// Append and dispatch one remediation attempt from an authenticated promoted
 /// candidate. Both ordinary Cook feedback and external candidate adoption use
 /// this boundary so their budget, provenance, and baseline authority match.
@@ -2638,8 +2651,13 @@ where
                 vec![follow_up_request],
             );
             follow_up_plan.options = plan.options.clone();
-            follow_up_plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
-            follow_up_plan.options.retry.max_attempts = 1;
+            // Gate-feedback is a child execution, not a fresh one-shot policy.
+            // Review-only continuations retain their separately bounded plan.
+            follow_up_plan.options.execution_budget =
+                child_execution_budget(budget_scope, &budget_limit);
+            if budget_scope != CookFollowUpBudgetScope::Cook {
+                follow_up_plan.options.retry.max_attempts = 1;
+            }
             (next_attempt, next_run_id, follow_up_plan, None)
         }
     };
@@ -3335,6 +3353,40 @@ where
         options.max_attempts,
         &options.ai_tool,
     );
+    if options.gates.has_npm_run_declaration() {
+        let gate_workspace = options.source_worktree_path.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "workspace",
+                "Cook requires a workspace before gate declaration preflight",
+                Some(options.to_worktree.clone()),
+                None,
+            )
+        })?;
+        if let Err(error) = options
+            .gates
+            .preflight_declarations(std::path::Path::new(gate_workspace))
+        {
+            let error = with_pre_execution_phase(error, "gate_declaration_preflight");
+            record_pre_execution_failure(
+                &options.initial_plan,
+                &options.initial_run_id,
+                &error,
+                "gate_declaration_preflight",
+            )?;
+            return Ok(pre_execution_failure_report(
+                options.cook_id.clone(),
+                Vec::new(),
+                pre_execution_failure_details(
+                    agent_task_lifecycle::exact_record(&options.initial_run_id)
+                        .ok()
+                        .as_ref(),
+                    &error,
+                ),
+                error,
+                Some(&options.initial_run_id),
+            ));
+        }
+    }
     let required_toolchains = options.gates.required_toolchains();
     let preflight = if required_toolchains.is_empty()
         && options.gates.gate_package_artifacts.is_empty()

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -807,6 +807,16 @@ fn fresh_cook_review_form_has_bounded_budget_independent_of_code_execution() {
 }
 
 #[test]
+fn gate_feedback_child_budget_preserves_declared_retry_and_rotation_capacity() {
+    let declared = crate::agent_task_scheduler::AgentTaskExecutionBudget::new(3, 1, 1);
+
+    assert_eq!(
+        child_execution_budget(CookFollowUpBudgetScope::Cook, &declared),
+        declared
+    );
+}
+
+#[test]
 fn persisted_review_budget_authority_preserves_lower_bounds_and_caps_larger_values() {
     let scope = CookFollowUpBudgetScope::FreshCookReview;
     let cook_budget = crate::agent_task_scheduler::AgentTaskExecutionBudget::new(9, 9, 9);
@@ -5328,7 +5338,7 @@ fn pre_provider_adoption_retries_only_the_missing_form_binds_model_and_reaches_r
 }
 
 #[test]
-fn adoption_review_uses_one_bounded_execution_after_the_source_budget_is_consumed() {
+fn adoption_review_child_plan_remains_one_bounded_execution() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let fixture = CandidateAdoptionFixture::new_with_execution_budget(
             "cook-9575-consumed-source-budget",

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -38,6 +38,7 @@ fn lint_args(root: &Path) -> LintArgs {
     LintArgs {
         comp: component_args(root),
         extension_override: ExtensionOverrideArgs::default(),
+        release_readiness_source: None,
         summary: false,
         file: None,
         glob: None,
@@ -58,6 +59,7 @@ fn test_args(root: &Path) -> TestArgs {
     TestArgs {
         comp: component_args(root),
         extension_override: ExtensionOverrideArgs::default(),
+        release_readiness_source: None,
         skip_lint: false,
         coverage: false,
         coverage_min: None,


### PR DESCRIPTION
## Summary
- classify declared npm run script gates with missing package scripts before provider admission and record exact operator remediation
- preserve the declared Cook gate-feedback execution, same-provider retry, and rotation budget in child plans
- retain separate bounded review-form child plans and cover declaration feedback plus recovery budget behavior

Closes #11934
Closes #11937

## Verification
- cargo fmt --check
- focused cargo test -p homeboy-agents coverage for missing npm scripts, declaration no-remediation behavior, gate-feedback budget retention, provider failure then recovery, and #10572-adjacent continuation
- cargo test -p homeboy-agents --lib was run: 1626 passed, 25 failed in unrelated existing parallel test/environment cases; the affected Cook continuation case was re-run and passed after the parser correction
- cargo clippy -p homeboy-agents --all-targets -- -D warnings is blocked by three existing homeboy-core warnings in http_api.rs and notify_outbox.rs

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect related issues and implementation paths, implement the change, run focused verification, and review the diff. Chris Huber reviewed and remains responsible for every line.