### PR TITLE
fix(ci): admit test shards within capacity budget

### DIFF
--- a/.github/ci-capacity-admission.sh
+++ b/.github/ci-capacity-admission.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+config="${CI_CAPACITY_CONFIG:-.github/ci-capacity.json}"
+jq -e '
+  . as $config
+  | .schema == "homeboy/ci-capacity/v1"
+  and (.test_shards | type == "number" and floor == . and . >= 1)
+  and (.queue_delay_slo_seconds.window_days | type == "number" and . >= 1)
+  and (.queue_delay_slo_seconds.p95 | type == "number" and . > 0)
+  and ($config.queue_delay_slo_seconds.p99 | type == "number" and . >= $config.queue_delay_slo_seconds.p95)
+  and (.execution_slo_seconds.test_shard_p95 | type == "number" and . > 0)
+  and ($config.execution_slo_seconds.required_critical_path_p95 | type == "number" and . >= $config.execution_slo_seconds.test_shard_p95)
+' "${config}" >/dev/null
+
+shards="$(jq -r '.test_shards' "${config}")"
+queue_p95="$(jq -r '.queue_delay_slo_seconds.p95' "${config}")"
+queue_p99="$(jq -r '.queue_delay_slo_seconds.p99' "${config}")"
+window_days="$(jq -r '.queue_delay_slo_seconds.window_days' "${config}")"
+shard_p95="$(jq -r '.execution_slo_seconds.test_shard_p95' "${config}")"
+critical_p95="$(jq -r '.execution_slo_seconds.required_critical_path_p95' "${config}")"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "test-shards=${shards}"
+    echo "queue-delay-p95-seconds=${queue_p95}"
+    echo "queue-delay-p99-seconds=${queue_p99}"
+    echo "test-shard-p95-seconds=${shard_p95}"
+    echo "required-critical-path-p95-seconds=${critical_p95}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+cat <<EOF >> "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+## CI capacity admission
+
+| Field | Value |
+| --- | --- |
+| State | admitted |
+| Requested deterministic Test shards | ${shards} |
+| Admitted Test shards | ${shards} |
+| Deferred Test shards | 0 |
+| Capacity budget | ${shards} concurrent Test shards per run |
+| Queue-delay SLO | ${window_days}-day p95 <= ${queue_p95}s; p99 <= ${queue_p99}s |
+| Execution SLO | Test shard p95 <= ${shard_p95}s; required-check critical path p95 <= ${critical_p95}s |
+
+This repository admits only the configured shard budget. GitHub-hosted runner availability remains separately visible in the timing evidence job.
+EOF

--- a/.github/ci-capacity-evidence.sh
+++ b/.github/ci-capacity-evidence.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+config="${CI_CAPACITY_CONFIG:-.github/ci-capacity.json}"
+run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")"
+jobs="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" | jq -s '{jobs: map(.jobs[]) }')"
+required='["homeboy / Required Gates Declaration","homeboy / Workspace Tests Compile","homeboy / Windows Compile","homeboy / Rustfmt","homeboy / Audit","homeboy / Lint","homeboy / Test"]'
+
+jq -n --argjson run "${run}" --argjson jobs "${jobs}" --argjson required "${required}" --slurpfile config "${config}" '
+  def seconds($from; $to): (($to | fromdateiso8601) - ($from | fromdateiso8601));
+  ($jobs.jobs | map(select(.started_at != null and .completed_at != null))) as $completed
+  | ($completed | map({name, queue_delay_seconds: seconds(.created_at; .started_at), execution_seconds: seconds(.started_at; .completed_at)})) as $timings
+  | ($completed | map(select(.name as $name | $required | index($name))) | max_by(.completed_at)) as $critical
+  | {
+      schema: "homeboy/ci-capacity-evidence/v1",
+      run_id: $run.id,
+      workflow_created_at: $run.created_at,
+      admission: {state: "admitted", configured_test_shards: $config[0].test_shards, deferred_test_shards: 0},
+      jobs: $timings,
+      required_critical_path: (if $critical == null then null else {
+        terminal_job: $critical.name,
+        terminal_at: $critical.completed_at,
+        created_to_terminal_seconds: seconds($run.created_at; $critical.completed_at)
+      } end),
+      slo: $config[0]
+    }
+' > ci-capacity-evidence.json
+
+{
+  echo "## CI queue and execution evidence"
+  echo
+  echo "The admission decision is configuration-backed. GitHub exposes no separate scheduler admission timestamp, so each job's \\`created -> runner started\\` value is the observed hosted-runner queue delay."
+  echo
+  echo '| Job | Queue delay (s) | Execution (s) |'
+  echo '| --- | ---: | ---: |'
+  jq -r '.jobs[] | "| \(.name) | \(.queue_delay_seconds) | \(.execution_seconds) |"' ci-capacity-evidence.json
+  echo
+  jq -r 'if .required_critical_path == null then "Required critical path was not terminal; see job states above." else "Required critical path: \(.required_critical_path.terminal_job), created -> terminal \(.required_critical_path.created_to_terminal_seconds)s." end' ci-capacity-evidence.json
+  echo
+  echo "Rolling SLO evaluation requires seven days of retained run evidence; this run publishes its raw timing record for that aggregation."
+} >> "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"

--- a/.github/ci-capacity.json
+++ b/.github/ci-capacity.json
@@ -1,0 +1,13 @@
+{
+  "schema": "homeboy/ci-capacity/v1",
+  "test_shards": 4,
+  "queue_delay_slo_seconds": {
+    "window_days": 7,
+    "p95": 300,
+    "p99": 600
+  },
+  "execution_slo_seconds": {
+    "test_shard_p95": 1800,
+    "required_critical_path_p95": 2100
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Publish queue, execution, and critical-path timing evidence
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,24 @@ jobs:
           GITHUB_EVENT_ACTION: ${{ github.event.action }}
         run: bash .github/ci-pr-state.sh
 
+  # This repository owns how much work it asks the reusable workflow to admit.
+  # The action owns deterministic shard planning and aggregation, not this
+  # repository's GitHub-hosted runner budget.
+  ci-capacity-admission:
+    name: homeboy / CI Capacity Admission
+    needs: pr-state
+    if: ${{ needs.pr-state.outputs.active == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      test-shards: ${{ steps.admit.outputs.test-shards }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - id: admit
+        name: Admit configured Test capacity
+        run: bash .github/ci-capacity-admission.sh
+
   # Named for what a green tick here actually proves: the DECLARATION is intact.
   # It used to be called "Required Gates Policy" and run `--local`, which reads
   # as "GitHub requires these checks" while only proving "ci.yml emits these
@@ -202,7 +220,7 @@ jobs:
   # ambiguous source changes fail closed or use Homeboy's full-scope fallback.
   homeboy:
     name: homeboy
-    needs: pr-state
+    needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
@@ -223,9 +241,29 @@ jobs:
       scope: auto
       differential-gating: 'false'
       baseline-commands: none
-      test-shards: '16'
+      test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}
       execution-timeout-seconds: '1800'
       test-timeout-seconds: '1500'
       comment-section-key: test
       comment-section-title: Test
     secrets: inherit
+
+  ci-capacity-evidence:
+    name: homeboy / CI Capacity Evidence
+    needs: [required-gates-declaration, workspace-tests-compile, warning-clean, windows-compile, rustfmt, homeboy-fast, homeboy]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Publish queue, execution, and critical-path timing evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/ci-capacity-evidence.sh
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: homeboy-ci-capacity-evidence-${{ github.run_attempt }}
+          path: ci-capacity-evidence.json
+          if-no-files-found: warn

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -137,6 +137,7 @@ fn ci_admits_only_the_configured_shard_budget_and_publishes_timing_evidence() {
     let admission = job_section(workflow, "ci-capacity-admission");
     assert!(admission.contains("bash .github/ci-capacity-admission.sh"));
     let evidence = job_section(workflow, "ci-capacity-evidence");
+    assert!(evidence.contains("ref: ${{ github.event.pull_request.head.sha || github.sha }}"));
     assert!(evidence.contains("bash .github/ci-capacity-evidence.sh"));
     assert!(evidence.contains("homeboy-ci-capacity-evidence-"));
 }

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -78,7 +78,8 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
     ] {
         let candidate = job_section(workflow, job);
         assert!(
-            candidate.contains("needs: pr-state"),
+            candidate.contains("needs: pr-state")
+                || candidate.contains("needs: [pr-state, ci-capacity-admission]"),
             "{phase} must await PR state"
         );
         assert!(
@@ -88,6 +89,7 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
     }
 
     for job in [
+        "ci-capacity-admission",
         "required-gates-declaration",
         "workspace-tests-compile",
         "warning-clean",
@@ -98,7 +100,8 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
     ] {
         let section = job_section(workflow, job);
         assert!(
-            section.contains("needs: pr-state"),
+            section.contains("needs: pr-state")
+                || section.contains("needs: [pr-state, ci-capacity-admission]"),
             "{job} must await PR state"
         );
         assert!(
@@ -109,7 +112,8 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
 
     let test = job_section(workflow, "homeboy");
     assert!(test.contains("uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2"));
-    assert!(test.contains("test-shards: '16'"));
+    assert!(test.contains("needs: [pr-state, ci-capacity-admission]"));
+    assert!(test.contains("test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
 }
 
 #[test]
@@ -117,4 +121,22 @@ fn non_pr_ci_invocations_remain_admitted() {
     assert_eq!(pr_state("pull_request", "synchronize"), "active=true\n");
     assert_eq!(pr_state("workflow_dispatch", ""), "active=true\n");
     assert_eq!(pr_state("push", ""), "active=true\n");
+}
+
+#[test]
+fn ci_admits_only_the_configured_shard_budget_and_publishes_timing_evidence() {
+    let config: serde_json::Value =
+        serde_json::from_str(include_str!("../.github/ci-capacity.json")).expect("capacity config");
+    assert_eq!(config["schema"], "homeboy/ci-capacity/v1");
+    assert_eq!(config["test_shards"], 4);
+    assert_eq!(config["queue_delay_slo_seconds"]["window_days"], 7);
+    assert_eq!(config["queue_delay_slo_seconds"]["p95"], 300);
+    assert_eq!(config["queue_delay_slo_seconds"]["p99"], 600);
+
+    let workflow = ci_workflow();
+    let admission = job_section(workflow, "ci-capacity-admission");
+    assert!(admission.contains("bash .github/ci-capacity-admission.sh"));
+    let evidence = job_section(workflow, "ci-capacity-evidence");
+    assert!(evidence.contains("bash .github/ci-capacity-evidence.sh"));
+    assert!(evidence.contains("homeboy-ci-capacity-evidence-"));
 }

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -189,7 +189,8 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
     assert!(test_gate.contains("      scope: auto"));
     assert!(test_gate.contains("      differential-gating: 'false'"));
     assert!(test_gate.contains("      baseline-commands: none"));
-    assert!(test_gate.contains("      test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
+    assert!(test_gate
+        .contains("      test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
     assert!(test_gate.contains("      execution-timeout-seconds: '1800'"));
     assert!(test_gate.contains("      test-timeout-seconds: '1500'"));
     assert!(

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -189,7 +189,7 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
     assert!(test_gate.contains("      scope: auto"));
     assert!(test_gate.contains("      differential-gating: 'false'"));
     assert!(test_gate.contains("      baseline-commands: none"));
-    assert!(test_gate.contains("      test-shards: '16'"));
+    assert!(test_gate.contains("      test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
     assert!(test_gate.contains("      execution-timeout-seconds: '1800'"));
     assert!(test_gate.contains("      test-timeout-seconds: '1500'"));
     assert!(


### PR DESCRIPTION
Closes #11949.

## Root cause
Homeboy CI requested all 16 deterministic Test shards without a repository-level capacity budget, so GitHub-hosted runner queues became an invisible part of the required-check critical path.

## Design
- Adds versioned generic CI-capacity configuration: four admitted Test shards, seven-day queue-delay SLO (p95 <= 300s, p99 <= 600s), and execution/required-critical-path objectives.
- Gates the reusable Test workflow behind a visible admission job and passes the configured shard budget instead of requesting 16 shards.
- Keeps `cancel-in-progress: true` unchanged.
- Publishes an artifact-backed per-run record with job queue delay (`created -> runner started`), execution time, and required-check critical-path terminal timing.

## Boundaries
`homeboy-action` owns reusable deterministic shard planning, execution, and aggregation. This Homeboy-only change owns the repository CI topology and its hosted-runner admission budget. It deliberately does not change the test-scope work owned by #11037 or interruption classification owned by #10997.

## Validation
`cargo test --locked --test pr_ci_lifecycle_test --test required_gates_policy_test`
`bash -n .github/ci-capacity-admission.sh`
`bash -n .github/ci-capacity-evidence.sh`
Admission-script output contract check.

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode inspected the workflow and ownership boundary, implemented the capacity admission and timing evidence, and ran the listed validation. Chris Huber remains responsible for every line.