### PR TITLE
Run release recovery helpers from control revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1364,8 +1364,15 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
           REQUIRE_ANNOUNCE_ASSETS: 'false'
+          CONTROL_SHA: ${{ github.sha }}
         run: |
-          bash .github/release-asset-completeness.sh
+          set -euo pipefail
+          if ! git cat-file -e "${CONTROL_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "${CONTROL_SHA}"
+          fi
+          CONTROL_HELPER="${RUNNER_TEMP}/release-asset-completeness.sh"
+          git show "${CONTROL_SHA}:.github/release-asset-completeness.sh" > "${CONTROL_HELPER}"
+          bash "${CONTROL_HELPER}"
 
       - name: Finish Homeboy release pipeline at tag
         uses: Extra-Chill/homeboy-action@v2

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1186,6 +1186,29 @@ fn release_fast_path_keeps_every_publication_verification() {
     );
 }
 
+#[test]
+fn release_recovery_runs_publication_gate_from_the_control_revision() {
+    let workflow = release_workflow();
+    let host = job_section(workflow, "host");
+    let gate = release_step_block(host, "name: Gate publication on the declared asset set");
+
+    assert!(
+        gate.contains("CONTROL_SHA: ${{ github.sha }}"),
+        "the publication helper must be pinned to the workflow control revision"
+    );
+    assert!(
+        gate.contains(
+            "git show \"${CONTROL_SHA}:.github/release-asset-completeness.sh\" > \"${CONTROL_HELPER}\""
+        ),
+        "a stranded target tag may predate the helper, so recovery must materialize it from the control revision"
+    );
+    assert!(gate.contains("bash \"${CONTROL_HELPER}\""));
+    assert!(
+        !gate.contains("bash .github/release-asset-completeness.sh"),
+        "the target-tag checkout must not own recovery control helpers"
+    );
+}
+
 /// Recovery is allowed — required — to run a control binary NEWER than the tag
 /// it repairs; that is the bootstrap #10519 asks for, and #10560 built it by
 /// pinning `gate-build` to `github.sha`. The inverse was never bounded: a


### PR DESCRIPTION
Closes #11952.

## Summary
- materialize the asset-completeness helper from the workflow control SHA
- keep the release target checkout pinned to the stranded tag
- execute the helper from runner temporary storage so target provenance and cleanliness remain intact
- cover tags that predate the recovery helper with deterministic workflow assertions

## Verification
- `cargo test --locked --test release_workflow_test --test release_expected_assets_test` (62 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint` and standalone `shellcheck` retain only pre-existing warnings outside this change

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode diagnosed the stranded-tag checkout boundary, implemented the control-revision helper materialization, and added deterministic workflow coverage. Chris Huber remains responsible for every line.