### PR TITLE
Infer Cook repository identity from explicit workspaces

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -492,7 +492,9 @@ pub struct AgentTaskCookArgs {
     /// provider with a `commands.ensure` argv template, and without one you must
     /// create the destination first with `homeboy worktree create`. When
     /// omitted, --repo plus --task-url derives an issue-owned destination
-    /// through that same configured provider.
+    /// through that same configured provider. An explicit --workspace or --cwd
+    /// Git checkout can infer --repo when its remote maps to exactly one
+    /// configured component; an explicit --repo must match that checkout.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
     #[arg(
@@ -578,6 +580,10 @@ pub struct AgentTaskCookArgs {
     /// Policy the acceptance authority applies.
     #[arg(long, requires = "require_acceptance")]
     pub acceptance_policy: Option<String>,
+    /// Controller-resolved repository identity for a supplied checkout. This is
+    /// not caller input: Cook persists it with the compiled plan.
+    #[arg(skip)]
+    pub repository_identity: Option<serde_json::Value>,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2,6 +2,7 @@
 //! resume, and retry.
 
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -716,6 +717,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
 pub(crate) fn resolve_cook_destination(
     mut args: AgentTaskCookArgs,
 ) -> homeboy::core::Result<AgentTaskCookArgs> {
+    normalize_cook_repository_identity(&mut args)?;
     if args.to_worktree.is_some() {
         return Ok(args);
     }
@@ -747,6 +749,285 @@ pub(crate) fn resolve_cook_destination(
         args.head = Some(derived_cook_branch(task_url)?);
     }
     Ok(args)
+}
+
+#[derive(Debug, Clone)]
+struct CookRepositoryIdentity {
+    slug: String,
+    remote_identity: String,
+    workspace_path: PathBuf,
+    provenance: String,
+}
+
+fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    let mut identities = Vec::new();
+    let mut source_identities = Vec::new();
+    for (flag, value) in [
+        ("--workspace", args.dispatch.workspace.as_deref()),
+        ("--cwd", args.dispatch.cwd.as_deref()),
+    ] {
+        let Some(value) = value else {
+            continue;
+        };
+        let resolved = cook_repository_identities_for_workspace(flag, value)?;
+        source_identities.push((flag, resolved.clone()));
+        identities.extend(resolved);
+    }
+    if identities.is_empty() {
+        if args.dispatch.workspace.is_some() || args.dispatch.cwd.is_some() {
+            return require_explicit_cook_repo(
+                args,
+                "the supplied workspace is not a Git checkout with a configured repository remote",
+            );
+        }
+        return Ok(());
+    }
+
+    let source_remotes = source_identities
+        .iter()
+        .flat_map(|(_, identities)| {
+            identities
+                .iter()
+                .map(|identity| identity.remote_identity.clone())
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    if source_remotes.len() != 1
+        || source_identities
+            .iter()
+            .any(|(_, identities)| identities.is_empty())
+    {
+        return Err(repository_identity_conflict_error(&source_identities));
+    }
+
+    let candidates: BTreeMap<_, _> =
+        identities
+            .into_iter()
+            .fold(BTreeMap::new(), |mut candidates, identity| {
+                candidates.entry(identity.slug.clone()).or_insert(identity);
+                candidates
+            });
+    let selected = match args.dispatch.repo.as_deref() {
+        Some(repo) => candidates.get(repo).cloned().ok_or_else(|| {
+            repository_identity_error(
+                format!("--repo `{repo}` does not match the supplied workspace repository"),
+                &candidates,
+            )
+        })?,
+        None if candidates.len() == 1 => {
+            candidates.values().next().cloned().expect("one candidate")
+        }
+        None => {
+            return Err(repository_identity_error(
+                "the supplied workspace maps to multiple configured repositories".to_string(),
+                &candidates,
+            ));
+        }
+    };
+    args.dispatch.repo = Some(selected.slug.clone());
+    args.repository_identity = Some(serde_json::json!({
+        "slug": selected.slug,
+        "remote_identity": selected.remote_identity,
+        "workspace_path": selected.workspace_path,
+        "provenance": selected.provenance,
+    }));
+    Ok(())
+}
+
+fn require_explicit_cook_repo(args: &AgentTaskCookArgs, reason: &str) -> homeboy::core::Result<()> {
+    if args.dispatch.repo.is_some() {
+        return Ok(());
+    }
+    Err(homeboy::core::Error::validation_missing_argument(vec![
+        format!(
+            "--repo <repo> is required because {reason}; provide --repo <configured-component>"
+        ),
+    ]))
+}
+
+fn cook_repository_identities_for_workspace(
+    flag: &str,
+    value: &str,
+) -> homeboy::core::Result<Vec<CookRepositoryIdentity>> {
+    let path = Path::new(value);
+    let workspace_path = if path.is_dir() {
+        std::fs::canonicalize(path).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?
+    } else if let Some(record) = homeboy::core::worktree::resolve_workspace_ref_if_present(value)? {
+        PathBuf::from(record.path())
+    } else {
+        return Ok(Vec::new());
+    };
+    let Some(git_root) = homeboy::core::git::repo_root(&workspace_path) else {
+        return Ok(Vec::new());
+    };
+    let remotes = homeboy::core::git::output_optional(&git_root, &["remote"])
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|remote| !remote.is_empty())
+        .filter_map(|remote| {
+            homeboy::core::git::remote_url(&git_root, remote).map(|url| (remote.to_string(), url))
+        })
+        .collect::<Vec<_>>();
+    let configured = homeboy::core::component::registered()?;
+    let mut identities = Vec::new();
+    for (remote_name, remote_url) in remotes {
+        let Some(remote_identity) = canonical_remote_identity(&remote_url) else {
+            continue;
+        };
+        for component in &configured {
+            let Some(component_identity) = component
+                .remote_url
+                .as_deref()
+                .and_then(canonical_remote_identity)
+            else {
+                continue;
+            };
+            if component_identity == remote_identity {
+                identities.push(CookRepositoryIdentity {
+                    slug: component.id.clone(),
+                    remote_identity: remote_identity.clone(),
+                    workspace_path: git_root.clone(),
+                    provenance: format!("{flag}:git-remote:{remote_name}"),
+                });
+            }
+        }
+    }
+    Ok(identities)
+}
+
+pub(crate) fn canonical_remote_identity(remote_url: &str) -> Option<String> {
+    let remote_url = remote_url.trim();
+    let (host, path) = if let Some((_, rest)) = remote_url.split_once("://") {
+        let (authority, path) = rest.split_once('/')?;
+        (authority.rsplit('@').next()?, path)
+    } else {
+        let (authority, path) = remote_url.split_once(':')?;
+        (authority.rsplit('@').next()?, path)
+    };
+    let path = path.trim_matches('/').trim_end_matches(".git");
+    (!host.is_empty()
+        && path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .count()
+            >= 2)
+        .then(|| {
+            format!(
+                "git://{}/{}",
+                host.to_ascii_lowercase(),
+                path.to_ascii_lowercase()
+            )
+        })
+}
+
+fn repository_identity_conflict_error(
+    sources: &[(&str, Vec<CookRepositoryIdentity>)],
+) -> homeboy::core::Error {
+    let candidates = sources
+        .iter()
+        .map(|(flag, identities)| {
+            let identities = identities
+                .iter()
+                .map(|identity| identity.remote_identity.as_str())
+                .collect::<Vec<_>>();
+            format!(
+                "{flag}: {}",
+                if identities.is_empty() {
+                    "unresolved".to_string()
+                } else {
+                    identities.join(", ")
+                }
+            )
+        })
+        .collect::<Vec<_>>();
+    homeboy::core::Error::validation_invalid_argument(
+        "workspace",
+        format!(
+            "--workspace and --cwd must resolve to the same configured repository identity; --repo cannot select one conflicting checkout: {}",
+            candidates.join("; ")
+        ),
+        None,
+        None,
+    )
+}
+
+fn validate_cook_destination_identity(
+    args: &AgentTaskCookArgs,
+    destination: &Path,
+) -> homeboy::core::Result<()> {
+    let Some(expected) = args
+        .repository_identity
+        .as_ref()
+        .and_then(|identity| identity.get("remote_identity"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+    let Some(git_root) = homeboy::core::git::repo_root(destination) else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "to_worktree",
+            "Cook destination is not a Git checkout bound to the resolved repository identity",
+            Some(destination.display().to_string()),
+            None,
+        ));
+    };
+    let identities = homeboy::core::git::output_optional(&git_root, &["remote"])
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|remote| homeboy::core::git::remote_url(&git_root, remote))
+        .filter_map(|remote| canonical_remote_identity(&remote))
+        .collect::<std::collections::BTreeSet<_>>();
+    if identities.len() == 1 && identities.contains(expected) {
+        return Ok(());
+    }
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "to_worktree",
+        format!(
+            "Cook destination repository identity does not match resolved `{expected}`; destination identities: {}",
+            if identities.is_empty() {
+                "unresolved".to_string()
+            } else {
+                identities.into_iter().collect::<Vec<_>>().join(", ")
+            }
+        ),
+        Some(destination.display().to_string()),
+        None,
+    ))
+}
+
+fn repository_identity_error(
+    message: String,
+    candidates: &BTreeMap<String, CookRepositoryIdentity>,
+) -> homeboy::core::Error {
+    let candidates = candidates
+        .values()
+        .map(|candidate| {
+            format!(
+                "{} ({}, {})",
+                candidate.slug,
+                candidate.remote_identity,
+                candidate.workspace_path.display()
+            )
+        })
+        .collect::<Vec<_>>();
+    let recovery = candidates
+        .iter()
+        .map(|candidate| {
+            let slug = candidate
+                .split_whitespace()
+                .next()
+                .expect("candidate has slug");
+            format!("homeboy agent-task cook --repo {slug} ...")
+        })
+        .collect::<Vec<_>>();
+    homeboy::core::Error::validation_invalid_argument(
+        "repo",
+        format!("{message}; candidates: {}", candidates.join(", ")),
+        None,
+        Some(recovery),
+    )
 }
 
 fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
@@ -1432,6 +1713,15 @@ pub(crate) fn compile_cook_plan(
     // dispatch input, never authority to replace the writable Cook workspace.
     dispatch.cwd = None;
     dispatch.workspace = Some(workspace);
+    validate_cook_destination_identity(
+        args,
+        Path::new(
+            dispatch
+                .workspace
+                .as_deref()
+                .expect("Cook workspace is set"),
+        ),
+    )?;
     let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
     let mut plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
         Ok(plan) => plan,
@@ -1451,6 +1741,9 @@ pub(crate) fn compile_cook_plan(
     };
     plan.options.candidate_completion = args.candidate_completion;
     record_cook_provision(&mut plan, provision);
+    if let Some(identity) = &args.repository_identity {
+        plan.metadata["cook_repository_identity"] = identity.clone();
+    }
     for task in &mut plan.tasks {
         let root = task.workspace.root.as_deref().ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -40,6 +40,27 @@ fn cook_args_from_cli(args: Vec<String>) -> AgentTaskCookArgs {
     *cook
 }
 
+fn register_component(id: &str, path: &std::path::Path, remote_url: &str) {
+    homeboy::core::component::write_standalone_component_config(
+        &homeboy::core::component::Component {
+            id: id.to_string(),
+            local_path: path.display().to_string(),
+            remote_url: Some(remote_url.to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("register component");
+}
+
+fn add_remote(path: &std::path::Path, name: &str, remote_url: &str) {
+    let status = Command::new("git")
+        .args(["remote", "add", name, remote_url])
+        .current_dir(path)
+        .status()
+        .expect("add fixture remote");
+    assert!(status.success(), "git remote add {name} failed");
+}
+
 #[test]
 fn cook_derives_issue_destination_and_preserves_explicit_override() {
     with_isolated_home(|_| {
@@ -94,6 +115,349 @@ fn cook_derives_issue_destination_and_preserves_explicit_override() {
             Some("homeboy@caller-selected")
         );
         assert_eq!(explicit.head, None);
+    });
+}
+
+#[test]
+fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance() {
+    with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source checkout");
+        init_runtime_component_checkout(source.path());
+        let remote = "https://github.com/example/inferred.git";
+        add_remote(source.path(), "origin", remote);
+        register_component("inferred", source.path(), remote);
+        let destination_root = tempfile::tempdir().expect("destination root");
+        let destination = destination_root.path().join("task");
+        let status = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/inferred",
+                destination.to_str().expect("destination path"),
+                "HEAD",
+            ])
+            .current_dir(source.path())
+            .status()
+            .expect("create linked worktree");
+        assert!(status.success(), "create linked worktree");
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--workspace".to_string(),
+            source.path().display().to_string(),
+            "--to-worktree".to_string(),
+            destination.display().to_string(),
+            "--backend".to_string(),
+            "fixture".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("infer repository from workspace");
+        assert_eq!(args.dispatch.repo.as_deref(), Some("inferred"));
+        assert_eq!(
+            args.repository_identity.as_ref().expect("identity")["remote_identity"],
+            "git://github.com/example/inferred"
+        );
+        assert_eq!(
+            args.repository_identity.as_ref().expect("identity")["provenance"],
+            "--workspace:git-remote:origin"
+        );
+
+        let plan = super::super::run::compile_cook_plan(&args, json!({ "path": destination }))
+            .expect("compile Cook plan");
+        assert_eq!(
+            plan.metadata["cook_repository_identity"],
+            args.repository_identity.expect("identity")
+        );
+    });
+}
+
+#[test]
+fn cook_rejects_ambiguous_or_mismatching_workspace_repository_identity() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://github.com/example/one.git",
+        );
+        add_remote(
+            workspace.path(),
+            "upstream",
+            "https://github.com/example/two.git",
+        );
+        register_component(
+            "one",
+            workspace.path(),
+            "https://github.com/example/one.git",
+        );
+        register_component(
+            "two",
+            workspace.path(),
+            "https://github.com/example/two.git",
+        );
+
+        let ambiguous = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--workspace".to_string(),
+            workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            workspace.path().display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("multiple configured remotes are ambiguous");
+        assert!(
+            ambiguous
+                .message
+                .contains("cannot select one conflicting checkout"),
+            "{}",
+            ambiguous.message
+        );
+        assert!(
+            ambiguous.message.contains("git://github.com/example/one"),
+            "{}",
+            ambiguous.message
+        );
+        assert_eq!(ambiguous.details["field"], "workspace");
+
+        let mismatch_workspace = tempfile::tempdir().expect("mismatch workspace");
+        init_runtime_component_checkout(mismatch_workspace.path());
+        add_remote(
+            mismatch_workspace.path(),
+            "origin",
+            "https://github.com/example/one.git",
+        );
+        let mismatch = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--workspace".to_string(),
+            mismatch_workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            mismatch_workspace.path().display().to_string(),
+            "--repo".to_string(),
+            "other".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("explicit repo must match workspace identity");
+        assert!(
+            mismatch.message.contains("does not match"),
+            "{}",
+            mismatch.message
+        );
+        assert!(
+            mismatch
+                .message
+                .contains("one (git://github.com/example/one"),
+            "{}",
+            mismatch.message
+        );
+    });
+}
+
+#[test]
+fn cook_requires_repo_for_an_explicit_non_git_workspace() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--cwd".to_string(),
+            workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            workspace.path().display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("non-Git workspace cannot infer a repository");
+        assert_eq!(
+            error.details["args"][0],
+            "--repo <repo> is required because the supplied workspace is not a Git checkout with a configured repository remote; provide --repo <configured-component>"
+        );
+    });
+}
+
+#[test]
+fn cook_rejects_conflicting_workspace_and_cwd_even_with_an_explicit_repo() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let cwd = tempfile::tempdir().expect("cwd");
+        init_runtime_component_checkout(workspace.path());
+        init_runtime_component_checkout(cwd.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://github.com/example/one.git",
+        );
+        add_remote(cwd.path(), "origin", "https://github.com/example/two.git");
+        register_component(
+            "one",
+            workspace.path(),
+            "https://github.com/example/one.git",
+        );
+        register_component("two", cwd.path(), "https://github.com/example/two.git");
+
+        for repo in ["one", "two"] {
+            let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "implement the fix".to_string(),
+                "--workspace".to_string(),
+                workspace.path().display().to_string(),
+                "--cwd".to_string(),
+                cwd.path().display().to_string(),
+                "--to-worktree".to_string(),
+                workspace.path().display().to_string(),
+                "--repo".to_string(),
+                repo.to_string(),
+                "--no-finalize".to_string(),
+            ]))
+            .expect_err("explicit repo cannot select a conflicting checkout");
+            assert!(error
+                .message
+                .contains("cannot select one conflicting checkout"));
+            assert!(error.message.contains("git://github.com/example/one"));
+            assert!(error.message.contains("git://github.com/example/two"));
+        }
+    });
+}
+
+#[test]
+fn cook_rejects_destination_with_a_different_repository_identity() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let destination = tempfile::tempdir().expect("destination");
+        init_runtime_component_checkout(workspace.path());
+        init_runtime_component_checkout(destination.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://github.com/example/one.git",
+        );
+        add_remote(
+            destination.path(),
+            "origin",
+            "https://github.com/example/two.git",
+        );
+        register_component(
+            "one",
+            workspace.path(),
+            "https://github.com/example/one.git",
+        );
+        register_component(
+            "two",
+            destination.path(),
+            "https://github.com/example/two.git",
+        );
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--workspace".to_string(),
+            workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            destination.path().display().to_string(),
+            "--backend".to_string(),
+            "fixture".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("resolve source identity");
+
+        let error =
+            super::super::run::compile_cook_plan(&args, json!({ "path": destination.path() }))
+                .expect_err("destination remote must match Cook repository identity");
+        assert!(error
+            .message
+            .contains("does not match resolved `git://github.com/example/one`"));
+        assert!(error.message.contains("git://github.com/example/two"));
+    });
+}
+
+#[test]
+fn cook_infers_an_ssh_scheme_remote_and_redacts_credentials_from_provenance() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "ssh://git@github.com/example/secure.git",
+        );
+        register_component(
+            "secure",
+            workspace.path(),
+            "https://github.com/example/secure.git",
+        );
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--cwd".to_string(),
+            workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            workspace.path().display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("infer ssh remote");
+        assert_eq!(args.dispatch.repo.as_deref(), Some("secure"));
+        assert_eq!(
+            args.repository_identity.expect("identity")["remote_identity"],
+            "git://github.com/example/secure"
+        );
+
+        let credentialed = "https://token:secret@github.com/example/secure.git";
+        let status = Command::new("git")
+            .args(["remote", "set-url", "origin", credentialed])
+            .current_dir(workspace.path())
+            .status()
+            .expect("set credentialed fixture remote");
+        assert!(status.success(), "set credentialed fixture remote");
+        let credentialed_args =
+            super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "implement the fix".to_string(),
+                "--cwd".to_string(),
+                workspace.path().display().to_string(),
+                "--to-worktree".to_string(),
+                workspace.path().display().to_string(),
+                "--no-finalize".to_string(),
+            ]))
+            .expect("infer credentialed remote without persisting its credential");
+        assert!(!credentialed_args
+            .repository_identity
+            .expect("identity")
+            .to_string()
+            .contains("secret"));
+        assert_eq!(
+            super::super::run::canonical_remote_identity(credentialed).as_deref(),
+            Some("git://github.com/example/secure")
+        );
+        assert!(!super::super::run::canonical_remote_identity(credentialed)
+            .expect("canonical identity")
+            .contains("secret"));
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -566,6 +566,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 require_acceptance: false,
                 acceptance_authority: None,
                 acceptance_policy: None,
+                repository_identity: None,
             },
             ExtensionProviderAgentTaskExecutor::default(),
         )
@@ -941,6 +942,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 require_acceptance: false,
                 acceptance_authority: None,
                 acceptance_policy: None,
+                repository_identity: None,
             },
             executor.clone(),
             Some(Arc::new(MirroredAttemptDispatcher {

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -147,15 +147,22 @@ pub struct DispatchArgs {
     #[arg(long = "task", value_name = "PROMPT", hide = true)]
     pub tasks: Vec<String>,
 
-    /// Existing local repo checkout or worktree path to cook in.
+    /// Existing local repo checkout or worktree path to cook in. For Cook,
+    /// omitting --repo infers its configured component when the Git remote maps
+    /// unambiguously to one registered component.
     #[arg(long, value_name = "PATH")]
     pub cwd: Option<String>,
 
-    /// Homeboy workspace ID or existing local workspace path to cook in.
+    /// Homeboy workspace ID or existing local workspace path to cook in. For
+    /// Cook, omitting --repo infers its configured component when the workspace
+    /// Git remote maps unambiguously to one registered component.
     #[arg(long, value_name = "ID_OR_PATH")]
     pub workspace: Option<String>,
 
     /// Repo/component slug for metadata and task grouping, e.g. sample-plugin.
+    /// Cook infers this from an explicit --workspace or --cwd Git checkout when
+    /// its configured remote mapping is unambiguous; an explicit value must
+    /// match the checkout.
     #[arg(long, value_name = "REPO")]
     pub repo: Option<String>,
 


### PR DESCRIPTION
## Summary
- infer credential-safe canonical repository identity from explicit Git workspace or cwd inputs
- reject conflicting workspace/cwd identities and bind the selected component to the actual destination checkout
- support HTTPS, SCP-style SSH, and `ssh://` remotes while persisting provenance without credentials

## Verification
- focused inferred, ambiguous, non-Git, conflicting-input, destination-mismatch, SSH, and redaction tests
- `cargo test -p homeboy-cli cook_rejects_conflicting_workspace_and_cwd_even_with_an_explicit_repo --lib`
- `cargo fmt --check`

Closes #11979

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the fix, a separate OpenCode general agent identified execution-destination binding and remote grammar gaps that were corrected, and Chris Huber remains responsible for every line.