### PR TITLE
Fix manual finalization preflight recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1501,14 +1501,17 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     let recipe = if super::cook_recipe::recipe_exists(run_or_cook_id)? {
         super::cook_recipe::load_recipe(run_or_cook_id)?
     } else {
-        super::cook_recipe::load_recipe_for_attempt(run_or_cook_id)?.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "run_or_cook_id",
-                "no durable Cook recipe contains this run or cook id",
-                Some(run_or_cook_id.to_string()),
-                None,
-            )
-        })?
+        match super::cook_recipe::load_recipe_for_attempt(run_or_cook_id)? {
+            Some(recipe) => recipe,
+            None => {
+                return recover_manual_finalization_pr(
+                    run_or_cook_id,
+                    overrides,
+                    preflight,
+                    backend,
+                )
+            }
+        }
     };
     if let Some(receipt) = completed_finalization_receipt_for_recovery(&recipe, run_or_cook_id)? {
         return Ok(receipt);
@@ -1616,6 +1619,48 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     Ok(value)
 }
 
+/// Recover a standalone manual-finalization record. Unlike Cook attempts, a
+/// manual identity can be reserved without a recipe, so it is its own durable
+/// recovery root.
+fn recover_manual_finalization_pr<B: AgentTaskPrFinalizationBackend>(
+    run_id: &str,
+    overrides: Vec<AgentTaskReviewOverride>,
+    preflight: bool,
+    backend: &mut B,
+) -> Result<Value> {
+    let record = agent_task_lifecycle::status(run_id).map_err(|_| {
+        Error::validation_invalid_argument(
+            "run_or_cook_id",
+            "no durable Cook recipe or manual finalization record contains this run or cook id",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    if let Some(receipt) = manual_finalization_receipt_for_run(&record, run_id)? {
+        return Ok(receipt);
+    }
+    if !overrides.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "review_overrides",
+            "recovered manual finalization must execute the preflight-validated dossier unchanged",
+            None,
+            None,
+        ));
+    }
+    let report = manual_finalization_intent_for_run(&record, run_id)?;
+    let finalization = manual_finalization_options(report)?;
+    let report = if preflight {
+        preflight_pr_with_backend(finalization, backend)?
+    } else {
+        finalize_pr_with_backend(finalization, backend)?
+    };
+    let value = serde_json::to_value(&report).unwrap_or(Value::Null);
+    if !preflight {
+        persist_manual_finalization_receipt(run_id, &report)?;
+    }
+    Ok(value)
+}
+
 fn manual_finalization_run_ids(recipe: &super::cook_recipe::AgentTaskCookRecipe) -> Vec<&str> {
     recipe
         .attempts
@@ -1653,28 +1698,46 @@ fn completed_finalization_receipt_for_recovery(
         // generic shape. Only the explicit manual receipt schema requires the
         // additional recovery integrity contract.
         if value["manual_finalization"] == true {
-            let report: AgentTaskPrFinalizationReport = serde_json::from_value(value.clone())
-                .map_err(|_| {
-                    Error::validation_invalid_argument(
-                        "cook_finalization",
-                        "persisted manual finalization receipt is invalid",
-                        Some(run_id.to_string()),
-                        None,
-                    )
-                })?;
-            let intent = manual_finalization_intent_for_run(&record, run_id)?;
-            if !valid_manual_finalization_receipt(&report, &intent, &record, run_id, true) {
-                return Err(Error::validation_invalid_argument(
-                    "cook_finalization",
-                    "persisted manual finalization receipt failed integrity validation",
-                    Some(run_id.to_string()),
-                    None,
-                ));
-            }
+            return manual_finalization_receipt_for_run(&record, run_id);
         }
         return Ok(Some(value.clone()));
     }
     Ok(None)
+}
+
+fn manual_finalization_receipt_for_run(
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+    run_id: &str,
+) -> Result<Option<Value>> {
+    let Some(value) = record.metadata.get("cook_finalization") else {
+        return Ok(None);
+    };
+    if !matches!(
+        value["status"].as_str(),
+        Some("review_ready" | "draft_published")
+    ) || value["manual_finalization"] != true
+    {
+        return Ok(None);
+    }
+    let report: AgentTaskPrFinalizationReport =
+        serde_json::from_value(value.clone()).map_err(|_| {
+            Error::validation_invalid_argument(
+                "cook_finalization",
+                "persisted manual finalization receipt is invalid",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let intent = manual_finalization_intent_for_run(record, run_id)?;
+    if !valid_manual_finalization_receipt(&report, &intent, record, run_id, true) {
+        return Err(Error::validation_invalid_argument(
+            "cook_finalization",
+            "persisted manual finalization receipt failed integrity validation",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(value.clone()))
 }
 
 fn manual_finalization_intent_for_recovery(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8408,6 +8408,84 @@ fn manual_finalization_identity_resolves_cook_and_failed_attempt_or_reserves_fre
 }
 
 #[test]
+fn standalone_manual_preflight_continuation_recovers_and_is_idempotent() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "manual-11974";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(
+            "cook-11974-fixture",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            ..Default::default()
+        };
+        // Reuse the Cook fixture builder to construct a valid dossier, then
+        // remove its recipe before recovery so this exercises the standalone
+        // durable manual-record route used by a fresh manual identity.
+        persist_initial_recipe(&options).expect("persist fixture recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+            .expect("submit standalone manual record");
+        agent_task_lifecycle::record_metadata_value(
+            run_id,
+            "manual_finalization_identity",
+            serde_json::json!(true),
+        )
+        .expect("mark manual identity");
+        seed_review_form_aggregate(run_id, &options.initial_plan);
+        let promotion = promotion_with_existing_path(run_id, target.path());
+        let mut finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("manual finalization options");
+        finalization.manual_finalization = true;
+        let candidate = crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+            changed_files: vec!["src/lib.rs".to_string()],
+            push_required: false,
+        };
+        let preflight = crate::agent_task_finalization::preflight_pr_with_backend(
+            finalization,
+            &mut CaptureBackend {
+                candidate_state: Some(candidate.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("manual preflight");
+        persist_manual_finalization_intent(run_id, &preflight).expect("persist validated intent");
+        std::fs::remove_file(
+            homeboy_core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-cooks/cook-11974-fixture/recipe.json"),
+        )
+        .expect("remove fixture recipe before continuation");
+
+        let continuation = format!("homeboy agent-task finalize-pr --recover {run_id}");
+        assert_eq!(
+            continuation,
+            "homeboy agent-task finalize-pr --recover manual-11974"
+        );
+        let mut publish_backend = CaptureBackend {
+            candidate_state: Some(candidate),
+            ..Default::default()
+        };
+        let published =
+            recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut publish_backend)
+                .expect("continuation resolves standalone validated intent");
+        assert_eq!(published["status"], "review_ready");
+        assert!(publish_backend.created);
+
+        let mut repeated_backend = CaptureBackend::default();
+        assert_eq!(
+            recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut repeated_backend)
+                .expect("continuation is idempotent after publication"),
+            published
+        );
+        assert!(!repeated_backend.created);
+    });
+}
+
+#[test]
 fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980-normal";

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -401,7 +401,7 @@ pub struct AdoptArgs {
 }
 #[derive(Args, Debug)]
 pub struct FinalizePrArgs {
-    /// Hydrate finalization from a durable Cook recipe and its applied promotion.
+    /// Hydrate finalization from a durable Cook recipe or a validated manual-finalization record.
     #[arg(
         long,
         value_name = "RUN_OR_COOK_ID",

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1796,6 +1796,7 @@ pub(crate) fn read_promotion_source(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use homeboy::agents::agent_tasks::promotion::{
         AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
         AgentTaskPromotionNotification, AgentTaskPromotionSource, AgentTaskPromotionTarget,
@@ -1805,6 +1806,7 @@ mod tests {
         AgentTaskOutcomeStatus, AgentTaskReconciliationDecision, AGENT_TASK_ARTIFACT_SCHEMA,
     };
     use sha2::{Digest, Sha256};
+    use std::process::Command;
 
     #[test]
     fn compact_provider_bounds_extensions_and_large_diagnostics() {
@@ -2549,6 +2551,234 @@ mod tests {
             handoff["next_actions"][0],
             "PR was not opened; inspect finalization status and git/PR errors"
         );
+    }
+
+    #[test]
+    fn manual_preflight_continuation_dispatches_once_and_is_idempotent() {
+        homeboy::test_support::with_isolated_home(|_| {
+            let root = tempfile::tempdir().expect("fixture root");
+            let remote = root.path().join("origin.git");
+            let checkout = root.path().join("checkout");
+            run_git(
+                root.path(),
+                &[
+                    "init",
+                    "--bare",
+                    "--initial-branch=main",
+                    remote.to_str().expect("remote path"),
+                ],
+            );
+            run_git(
+                root.path(),
+                &[
+                    "init",
+                    "--initial-branch=main",
+                    checkout.to_str().expect("checkout path"),
+                ],
+            );
+            run_git(&checkout, &["config", "user.email", "test@example.test"]);
+            run_git(&checkout, &["config", "user.name", "Finalization Test"]);
+            std::fs::write(
+                checkout.join("homeboy.json"),
+                r#"{"id":"manual-finalization","remote_url":"https://github.com/example/manual-finalization.git"}"#,
+            )
+            .expect("write portable component config");
+            std::fs::write(checkout.join("base.txt"), "base\n").expect("write base");
+            run_git(&checkout, &["add", "."]);
+            run_git(&checkout, &["commit", "-m", "base"]);
+            run_git(
+                &checkout,
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    remote.to_str().expect("remote path"),
+                ],
+            );
+            run_git(&checkout, &["push", "-u", "origin", "main"]);
+            let base_sha = git_output(&checkout, &["rev-parse", "HEAD"]);
+            run_git(&checkout, &["checkout", "-b", "feature"]);
+            std::fs::write(checkout.join("feature.txt"), "feature\n").expect("write feature");
+            run_git(&checkout, &["add", "."]);
+            run_git(&checkout, &["commit", "-m", "feature"]);
+            run_git(&checkout, &["push", "-u", "origin", "feature"]);
+            run_git(
+                &checkout,
+                &[
+                    "remote",
+                    "set-url",
+                    "origin",
+                    "git@github.com:example/manual-finalization.git",
+                ],
+            );
+
+            let bin = root.path().join("bin");
+            std::fs::create_dir(&bin).expect("fake gh bin");
+            let ssh = bin.join("ssh");
+            std::fs::write(
+                &ssh,
+                r#"#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    *git-upload-pack*) exec git-upload-pack "$HOMEBOY_FAKE_GIT_REMOTE" ;;
+    *git-receive-pack*) exec git-receive-pack "$HOMEBOY_FAKE_GIT_REMOTE" ;;
+  esac
+done
+exit 2
+"#,
+            )
+            .expect("write fake SSH transport");
+            let gh = bin.join("gh");
+            std::fs::write(
+                &gh,
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "$HOMEBOY_FAKE_GH_LOG"
+case "$1 $2" in
+  "auth status"|"repo view") printf '%s\n' '{"nameWithOwner":"example/manual-finalization"}' ;;
+  "pr list") printf '%s\n' '[]' ;;
+  "pr create") printf '%s\n' 'https://github.com/example/manual-finalization/pull/1' ;;
+  "pr view") sha=$(git rev-parse HEAD); printf '{"baseRefName":"main","headRefName":"feature","headRefOid":"%s","headRepository":{"nameWithOwner":"example/manual-finalization"}}\n' "$sha" ;;
+  *) [ "$1" = "--version" ] || exit 2 ;;
+esac
+"#,
+            )
+            .expect("write fake gh");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755))
+                    .expect("make fake SSH transport executable");
+                std::fs::set_permissions(&gh, std::fs::Permissions::from_mode(0o755))
+                    .expect("make fake gh executable");
+            }
+            let log = root.path().join("gh.log");
+            let old_path = std::env::var_os("PATH");
+            let old_ssh_command = std::env::var_os("GIT_SSH_COMMAND");
+            std::env::set_var(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    bin.display(),
+                    old_path.as_deref().unwrap_or_default().to_string_lossy()
+                ),
+            );
+            std::env::set_var("HOMEBOY_FAKE_GH_LOG", &log);
+            std::env::set_var("HOMEBOY_FAKE_GIT_REMOTE", &remote);
+            std::env::set_var("GIT_SSH_COMMAND", &ssh);
+
+            let preflight = dispatch_agent_task(&[
+                "homeboy",
+                "agent-task",
+                "finalize-pr",
+                "--manual-finalization",
+                "--preflight",
+                "--run-id",
+                "manual-cli-11974",
+                "--path",
+                checkout.to_str().expect("checkout path"),
+                "--base",
+                "main",
+                "--verified-base-sha",
+                &base_sha,
+                "--head",
+                "feature",
+                "--title",
+                "Manual continuation",
+                "--commit-message",
+                "fixture",
+                "--gate-result",
+                "fixture=passed",
+                "--changed-file",
+                "feature.txt",
+                "--targeted-check-run",
+                "cargo test fixture",
+                "--ai-model",
+                "fixture-model",
+                "--ai-used-for",
+                "CLI recovery coverage",
+            ]);
+            assert_eq!(preflight["status"], "validated");
+            let continuation = preflight["handoff"]["finalize_command"]
+                .as_str()
+                .expect("emitted continuation")
+                .to_string();
+            let argv = continuation.split_whitespace().collect::<Vec<_>>();
+            let published = dispatch_agent_task(&argv);
+            assert_eq!(published["status"], "review_ready");
+            let repeated = dispatch_agent_task(&argv);
+            assert_eq!(repeated, published);
+            let error = dispatch_agent_task_error(&[
+                "homeboy",
+                "agent-task",
+                "finalize-pr",
+                "--recover",
+                "missing-manual-finalization",
+            ]);
+            assert!(error
+                .message
+                .contains("no durable Cook recipe or manual finalization record"));
+            let created = std::fs::read_to_string(&log)
+                .expect("fake gh log")
+                .lines()
+                .filter(|line| line.starts_with("pr create "))
+                .count();
+            assert_eq!(
+                created, 1,
+                "the emitted continuation publishes exactly once"
+            );
+
+            match old_path {
+                Some(path) => std::env::set_var("PATH", path),
+                None => std::env::remove_var("PATH"),
+            }
+            std::env::remove_var("HOMEBOY_FAKE_GH_LOG");
+            std::env::remove_var("HOMEBOY_FAKE_GIT_REMOTE");
+            match old_ssh_command {
+                Some(command) => std::env::set_var("GIT_SSH_COMMAND", command),
+                None => std::env::remove_var("GIT_SSH_COMMAND"),
+            }
+        });
+    }
+
+    fn dispatch_agent_task(argv: &[&str]) -> Value {
+        let cli = crate::cli_surface::Cli::try_parse_from(argv).expect("parse CLI command");
+        let crate::cli_surface::Commands::AgentTask(args) = cli.command else {
+            panic!("expected agent-task command");
+        };
+        let (value, exit_code) =
+            crate::commands::agent_task::run(args).expect("dispatch CLI command");
+        assert_eq!(exit_code, 0, "CLI command succeeds");
+        value
+    }
+
+    fn dispatch_agent_task_error(argv: &[&str]) -> homeboy::core::Error {
+        let cli = crate::cli_surface::Cli::try_parse_from(argv).expect("parse CLI command");
+        let crate::cli_surface::Commands::AgentTask(args) = cli.command else {
+            panic!("expected agent-task command");
+        };
+        crate::commands::agent_task::run(args).expect_err("CLI command fails")
+    }
+
+    fn run_git(path: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn git_output(path: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {args:?} failed");
+        String::from_utf8(output.stdout)
+            .expect("Git output is UTF-8")
+            .trim()
+            .to_string()
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve standalone manual-finalization preflight records through `finalize-pr --recover`
- validate persisted intent integrity before publication and reuse the terminal receipt idempotently
- execute the exact emitted continuation command through CLI-level behavioral coverage

## Verification
- `cargo test --locked -p homeboy-cli manual_preflight_continuation_dispatches_once_and_is_idempotent --lib`
- `cargo test --locked -p homeboy-agents manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering --lib`
- `cargo fmt --check`

Closes #11974

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the fix, a separate OpenCode general agent reviewed persistence/idempotency behavior, and the candidate was revised from that review; Chris Huber remains responsible for every line.