### PR TITLE
Allow candidate adoption to prove inherited failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -672,6 +672,40 @@ pub struct AgentTaskGateArtifactPathProvenance {
     pub sha256: Option<String>,
 }
 
+impl AgentTaskGateEnvironment {
+    /// Reconstruct the candidate's package inputs for immutable-base replay.
+    /// A replay never broadens to new ambient input: source mappings remain
+    /// explicit, while fixed mappings retain their recorded resolved value.
+    pub(crate) fn package_artifact_replay_requirements(
+        &self,
+    ) -> Option<Vec<AgentTaskGatePackageArtifactRequirement>> {
+        self.package_artifacts
+            .iter()
+            .map(|artifact| {
+                (!artifact.artifacts.is_empty()
+                    && artifact.artifacts.iter().all(|path| path.sha256.is_some()))
+                .then(|| AgentTaskGatePackageArtifactRequirement {
+                    id: artifact.id.clone(),
+                    environment: AgentTaskGateArtifactEnvironmentMapping {
+                        name: artifact.environment.clone(),
+                        source: artifact.source.clone(),
+                        default: artifact.source.is_none().then(|| artifact.value.clone()),
+                    },
+                    required_paths: artifact
+                        .artifacts
+                        .iter()
+                        .map(|path| AgentTaskGateArtifactPathRequirement {
+                            path: path.path.clone(),
+                            sha256: path.sha256.clone(),
+                        })
+                        .collect(),
+                    remediation: artifact.remediation.clone(),
+                })
+            })
+            .collect()
+    }
+}
+
 /// Identity and source provenance for an extension directory made available to
 /// a gate. The destination is stable beneath the gate's isolated HOME.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2043,19 +2077,30 @@ fn validate_package_artifacts(
                 missing.push(artifact.path.clone());
                 continue;
             }
-            if let Some(expected) = &artifact.sha256 {
+            let observed = if path.is_file() {
                 let bytes = fs::read(&path).map_err(|error| {
                     Error::internal_io(error.to_string(), Some(path.display().to_string()))
                 })?;
-                let actual = format!("sha256:{:x}", Sha256::digest(bytes));
-                if expected != &actual {
+                Some(format!("sha256:{:x}", Sha256::digest(bytes)))
+            } else {
+                None
+            };
+            if let Some(expected) = &artifact.sha256 {
+                let actual = observed.as_ref().ok_or_else(|| {
+                    package_artifact_error(
+                        requirement,
+                        "required artifact digest cannot be verified for a non-file path",
+                        vec![artifact.path.clone()],
+                    )
+                })?;
+                if expected != actual {
                     missing.push(artifact.path.clone());
                     continue;
                 }
             }
             artifacts.push(AgentTaskGateArtifactPathProvenance {
                 path: artifact.path.clone(),
-                sha256: artifact.sha256.clone(),
+                sha256: observed.or_else(|| artifact.sha256.clone()),
             });
         }
         if !missing.is_empty() {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -843,6 +843,9 @@ fn has_cook_continue_route(options: &AgentTaskCookServiceOptions) -> bool {
 pub struct AgentTaskCandidateAdoptionOptions {
     pub ai_model: Option<String>,
     pub replace_interrupted: bool,
+    /// Explicitly permit a candidate whose failed gate reproduces on the
+    /// immutable base. Regressions remain ineligible after differential replay.
+    pub accept_inherited_failures: bool,
 }
 
 /// A Cook outcome.

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -240,6 +240,10 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     let (record, recipe) = resolve_adoption_target_with_attempt(cook_or_run_id, attempt)?;
     let cook_id = &recipe.cook_id;
     let mut options = super::reconstruct_adoption_options(&recipe)?;
+    // Adoption is a separate explicit authorization. The durable recipe keeps
+    // its historical policy, while this invocation may accept only normalized
+    // immutable-baseline matches produced below.
+    options.gates.accept_inherited_failures = adoption.accept_inherited_failures;
     let run_id = record.run_id.clone();
     let plan = agent_task_lifecycle::load_plan(&run_id)?;
     let recipe_attempt = recipe
@@ -311,6 +315,14 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         // failed attempt is archived when the new adoption starts.
         && !legacy_adoption_budget_failure(&recipe, &run_id, persisted_adoption_result)
     {
+        let persisted_promotion = persisted_promotion_for_attempt(&record.run_id)?;
+        let inherited_failure_requires_authorization =
+            persisted_promotion.as_ref().is_some_and(|promotion| {
+                promotion.deterministic_gates.iter().any(|gate| {
+                    gate.status
+                        == crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+                })
+            });
         if let Some(result) = record
             .candidate_adoption
             .as_ref()
@@ -318,6 +330,28 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         {
             let result: CandidateAdoptionTerminalResult = serde_json::from_value(result)
                 .map_err(|error| Error::internal_json(error.to_string(), None))?;
+            if inherited_failure_requires_authorization && !adoption.accept_inherited_failures {
+                return Ok(cook_report(CookReportInput {
+                    cook_id: cook_id.to_string(),
+                    status: "baseline_red",
+                    disposition: CookDisposition::Terminal,
+                    attempts: vec![AgentTaskCookAttemptReport {
+                        attempt: 1,
+                        run_id: record.run_id.clone(),
+                        run_state: format!("{:?}", record.state),
+                        aggregate_path: record.aggregate_path.clone(),
+                        promotion: persisted_promotion,
+                        feedback: None,
+                    }],
+                    finalization: None,
+                    stop_reason: Some(
+                        "completed adoption contains accepted inherited baseline-red gate evidence; rerun adopt with --accept-inherited-failures to reauthorize it"
+                            .to_string(),
+                    ),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(record.run_id.as_str()),
+                }));
+            }
             let exit_code = if matches!(
                 result.status.as_str(),
                 "review_ready" | "draft_published" | "green_no_finalize"
@@ -340,9 +374,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     run_id: record.run_id.clone(),
                     run_state: format!("{:?}", record.state),
                     aggregate_path: record.aggregate_path.clone(),
-                    promotion: persisted_promotion_for_attempt(&record.run_id)
-                        .ok()
-                        .flatten(),
+                    promotion: persisted_promotion,
                     feedback: None,
                 }],
                 finalization: None,
@@ -359,6 +391,28 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 None,
             )
         })?;
+        if inherited_failure_requires_authorization && !adoption.accept_inherited_failures {
+            return Ok(cook_report(CookReportInput {
+                cook_id: cook_id.to_string(),
+                status: "baseline_red",
+                disposition: CookDisposition::Terminal,
+                attempts: vec![AgentTaskCookAttemptReport {
+                    attempt: 1,
+                    run_id: record.run_id.clone(),
+                    run_state: format!("{:?}", record.state),
+                    aggregate_path: record.aggregate_path.clone(),
+                    promotion: Some(promotion),
+                    feedback: None,
+                }],
+                finalization: None,
+                stop_reason: Some(
+                    "completed adoption contains accepted inherited baseline-red gate evidence; rerun adopt with --accept-inherited-failures to reauthorize it"
+                        .to_string(),
+                ),
+                exit_code: 1,
+                invocation_latest_run_id: Some(record.run_id.as_str()),
+            }));
+        }
         let feedback = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request,
             promotion_report: promotion.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -337,6 +337,17 @@ pub(crate) fn compare_gate_failures_to_verified_base(
             }
             compared += 1;
             checkpoint(compared, unresolved)?;
+            let Some(package_artifacts) = gate.environment.package_artifact_replay_requirements()
+            else {
+                gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                    base_ref: base_sha.to_string(),
+                    exit_code: 124,
+                    failure_fingerprint: String::new(),
+                    matches_candidate_failure: false,
+                    result: AgentTaskGateDifferentialResult::Inconclusive,
+                });
+                continue;
+            };
             let command = gate.command.last().cloned().unwrap_or_default();
             let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
             let baseline = (|| {
@@ -353,9 +364,22 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                     &runtime.context().tmp_dir,
                     timeout,
                     &gate.environment.replay_policy(),
-                    &[],
+                    &package_artifacts,
                 )
             })();
+            if let Ok(baseline) = &baseline {
+                if baseline.environment.package_artifacts != gate.environment.package_artifacts {
+                    gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {
+                        base_ref: base_sha.to_string(),
+                        exit_code: baseline.exit_code,
+                        failure_fingerprint: String::new(),
+                        matches_candidate_failure: false,
+                        result: AgentTaskGateDifferentialResult::Inconclusive,
+                    });
+                    baseline_run_dir.finish(true);
+                    continue;
+                }
+            }
             let result: Result<()> = match baseline {
                 Ok(baseline) if baseline.exit_code == 124 => {
                     gate.baseline_comparison = Some(AgentTaskGateBaselineComparison {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1337,6 +1337,24 @@ pub(crate) fn cook_finalization_options(
         .iter()
         .map(|step| step.command.clone())
         .collect();
+    let inherited_failure_count = promotion
+        .deterministic_gates
+        .iter()
+        .filter(|gate| {
+            gate.status == crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+        })
+        .count();
+    let attempt_summary = if inherited_failure_count == 0 {
+        format!(
+            "{} deterministic cook gate attempt(s) completed green",
+            promotion.deterministic_gates.len()
+        )
+    } else {
+        format!(
+            "{} deterministic cook gate attempt(s) completed; {inherited_failure_count} inherited baseline-red failure(s) were reproduced on the immutable base and explicitly accepted",
+            promotion.deterministic_gates.len()
+        )
+    };
     Ok(AgentTaskPrFinalizationOptions {
         path: path.clone(),
         run_id: successful_run_id.to_string(),
@@ -1352,10 +1370,7 @@ pub(crate) fn cook_finalization_options(
         evidence: AgentTaskPrEvidence {
             source_refs,
             artifact_refs,
-            attempt_summary: format!(
-                "{} deterministic cook gate attempt(s) completed green",
-                promotion.deterministic_gates.len()
-            ),
+            attempt_summary,
             ai_tool: options.ai_tool.clone(),
             ai_model: options.ai_model.clone(),
             source_relationship: AgentTaskPrSourceRelationship::default(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2313,7 +2313,8 @@ fn no_finalize_initial_request_preserves_its_existing_contract() {
 /// be promoted and adopted.
 struct CandidateAdoptionFixture {
     _temp: tempfile::TempDir,
-    _source: std::path::PathBuf,
+    source: std::path::PathBuf,
+    provider: std::path::PathBuf,
     target: std::path::PathBuf,
     candidate: String,
     cook_id: String,
@@ -2450,7 +2451,8 @@ impl CandidateAdoptionFixture {
 
         let mut fixture = Self {
             _temp: temp,
-            _source: source,
+            source,
+            provider,
             target,
             candidate,
             cook_id: cook_id.to_string(),
@@ -2516,12 +2518,31 @@ impl CandidateAdoptionFixture {
         executor: E,
         backend: &mut CaptureBackend,
     ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
-        self.adopt_run(&self.run_id, dispatcher, executor, backend)
+        self.adopt_run_with_inherited_failure_acceptance(
+            &self.run_id,
+            false,
+            dispatcher,
+            executor,
+            backend,
+        )
     }
 
     fn adopt_run<E: AgentTaskExecutorAdapter + Clone>(
         &self,
         run_id: &str,
+        dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+        executor: E,
+        backend: &mut CaptureBackend,
+    ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+        self.adopt_run_with_inherited_failure_acceptance(
+            run_id, false, dispatcher, executor, backend,
+        )
+    }
+
+    fn adopt_run_with_inherited_failure_acceptance<E: AgentTaskExecutorAdapter + Clone>(
+        &self,
+        run_id: &str,
+        accept_inherited_failures: bool,
         dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
         executor: E,
         backend: &mut CaptureBackend,
@@ -2532,12 +2553,189 @@ impl CandidateAdoptionFixture {
             AgentTaskCandidateAdoptionOptions {
                 ai_model: Some("openai/gpt-5.6-terra".to_string()),
                 replace_interrupted: false,
+                accept_inherited_failures,
             },
             dispatcher,
             executor,
             backend,
         )
     }
+}
+
+#[test]
+fn adoption_accepts_an_identical_immutable_baseline_failure_when_explicitly_authorized() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture = CandidateAdoptionFixture::new("cook-11978-inherited", 1, 0, true, None);
+        fixture.options.gates.verify = vec![
+            "printf inherited >&2; exit 1".to_string(),
+            "test \"$(cat lib.rs)\" = candidate".to_string(),
+        ];
+        fixture.options.gates.execution_policy =
+            crate::agent_task_gate::AgentTaskGateExecutionPolicy::ContinueAll;
+        persist_initial_recipe(&fixture.options).expect("persist inherited-failure recipe");
+        let mut backend = CaptureBackend::default();
+
+        let result = fixture
+            .adopt_run_with_inherited_failure_acceptance(
+                &fixture.run_id,
+                true,
+                |_| Ok(None),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect("identical inherited failure is accepted");
+
+        assert_eq!(result.exit_code, 0, "{:#?}", result.value);
+        assert_eq!(result.value.status, "green_no_finalize");
+        let promotion = result.value.attempts[0].promotion.as_ref().unwrap();
+        assert_eq!(
+            promotion.deterministic_gates[0].status,
+            crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+        );
+        assert_eq!(
+            promotion.deterministic_gates[0]
+                .baseline_comparison
+                .as_ref()
+                .unwrap()
+                .result,
+            crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed
+        );
+        assert_eq!(
+            promotion.deterministic_gates[1].status,
+            crate::agent_task_gate::AgentTaskGateStatus::Succeeded
+        );
+        assert_eq!(
+            promotion.provenance["candidate"]["fingerprint"]["head"],
+            fixture.candidate
+        );
+        assert!(
+            promotion.deterministic_gates[0]
+                .candidate_checkout
+                .is_some(),
+            "normalized inherited-red evidence remains bound to its immutable candidate checkout"
+        );
+
+        let reused = fixture
+            .adopt(|_| Ok(None), UnusedExecutor, &mut backend)
+            .expect("completed adoption returns its durable report");
+        assert_eq!(reused.exit_code, 1, "{:#?}", reused.value);
+        assert_eq!(reused.value.status, "baseline_red");
+        assert!(reused
+            .value
+            .stop_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("--accept-inherited-failures")));
+    });
+}
+
+#[test]
+fn adoption_blocks_a_changed_failure_despite_inherited_failure_authorization() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture = CandidateAdoptionFixture::new("cook-11978-regression", 1, 0, true, None);
+        fixture.options.gates.verify = vec!["cat lib.rs >&2; exit 1".to_string()];
+        persist_initial_recipe(&fixture.options).expect("persist regression recipe");
+        let mut backend = CaptureBackend::default();
+
+        let result = fixture
+            .adopt_run_with_inherited_failure_acceptance(
+                &fixture.run_id,
+                true,
+                |_| Ok(None),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect("regression produces a blocking report");
+
+        assert_eq!(result.exit_code, 1, "{:#?}", result.value);
+        assert_eq!(result.value.status, "gate_failed");
+        let promotion = result.value.attempts[0].promotion.as_ref().unwrap();
+        assert_eq!(
+            promotion.deterministic_gates[0].status,
+            crate::agent_task_gate::AgentTaskGateStatus::Failed
+        );
+        assert_eq!(
+            promotion.deterministic_gates[0]
+                .baseline_comparison
+                .as_ref()
+                .unwrap()
+                .result,
+            crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression
+        );
+    });
+}
+
+#[test]
+fn adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_from_base() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture = CandidateAdoptionFixture::new("cook-11978-artifact", 1, 0, true, None);
+        let artifact = fixture.source.join("fixtures/input.bin");
+        std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+        std::fs::write(&artifact, b"candidate package input").unwrap();
+        git_output(&fixture.source, &["add", "fixtures/input.bin"]).unwrap();
+        git_output(
+            &fixture.source,
+            &["commit", "-m", "candidate package input"],
+        )
+        .unwrap();
+        fixture.candidate = git_output(&fixture.source, &["rev-parse", "HEAD"]).unwrap();
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\ngit -C {target} fetch origin {candidate}\ngit -C {target} reset --hard --quiet FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
+                target = fixture.target.display(),
+                candidate = fixture.candidate,
+            ),
+        )
+        .unwrap();
+        fixture.options.gates.verify = vec!["printf inherited >&2; exit 1".to_string()];
+        fixture.options.gates.gate_package_artifacts = vec![
+            crate::agent_task_gate::AgentTaskGatePackageArtifactRequirement {
+                id: "candidate-input".to_string(),
+                environment: crate::agent_task_gate::AgentTaskGateArtifactEnvironmentMapping {
+                    name: "CANDIDATE_INPUT".to_string(),
+                    source: None,
+                    default: Some("fixtures".to_string()),
+                },
+                required_paths: vec![
+                    crate::agent_task_gate::AgentTaskGateArtifactPathRequirement {
+                        path: "fixtures/input.bin".to_string(),
+                        sha256: None,
+                    },
+                ],
+                remediation: serde_json::json!({"action": "restore_candidate_input"}),
+            },
+        ];
+        persist_initial_recipe(&fixture.options).expect("persist package-artifact recipe");
+        let mut backend = CaptureBackend::default();
+
+        let result = fixture
+            .adopt_run_with_inherited_failure_acceptance(
+                &fixture.run_id,
+                true,
+                |_| Ok(None),
+                UnusedExecutor,
+                &mut backend,
+            )
+            .expect("package drift produces a blocking report");
+
+        assert_eq!(result.exit_code, 1, "{:#?}", result.value);
+        assert_eq!(result.value.status, "gate_failed");
+        let promotion = result.value.attempts[0].promotion.as_ref().unwrap();
+        assert_eq!(
+            promotion.deterministic_gates[0]
+                .baseline_comparison
+                .as_ref()
+                .unwrap()
+                .result,
+            crate::agent_task_gate::AgentTaskGateDifferentialResult::Inconclusive
+        );
+        assert!(promotion.deterministic_gates[0]
+            .environment
+            .package_artifacts[0]
+            .artifacts[0]
+            .sha256
+            .is_some());
+    });
 }
 
 #[test]
@@ -5162,6 +5360,7 @@ fn historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_repla
                 AgentTaskCandidateAdoptionOptions {
                     ai_model: Some("openai/gpt-5.6-sol".to_string()),
                     replace_interrupted: false,
+                    accept_inherited_failures: false,
                 },
                 |_| Ok(None),
                 ReviewFormOnlyExecutor,
@@ -5380,6 +5579,7 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             AgentTaskCandidateAdoptionOptions {
                 ai_model: Some("fixture-model-review".to_string()),
                 replace_interrupted: false,
+                accept_inherited_failures: false,
             },
             |_| Ok(None),
             ReviewFormOnlyExecutor,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -395,6 +395,11 @@ pub struct AdoptArgs {
     /// Replace a stale interrupted adoption while retaining its lifecycle evidence.
     #[arg(long)]
     pub replace_interrupted: bool,
+    /// Permit finalization only when a failed recorded gate reproduces with the
+    /// same bounded fingerprint on the immutable candidate base. New or changed
+    /// failures remain blocking and inherited-red evidence remains in the report.
+    #[arg(long)]
+    pub accept_inherited_failures: bool,
     /// Return the complete cook adoption report, including nested gate evidence.
     #[arg(long)]
     pub full: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -475,6 +475,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
             agent_task_service::AgentTaskCandidateAdoptionOptions {
                 ai_model: args.ai_model.clone(),
                 replace_interrupted: args.replace_interrupted,
+                accept_inherited_failures: args.accept_inherited_failures,
             },
             crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
             ExtensionProviderAgentTaskExecutor::discover(),
@@ -491,6 +492,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
         "candidate_ref": args.candidate_ref,
         "ai_model": args.ai_model,
         "replace_interrupted": args.replace_interrupted,
+        "accept_inherited_failures": args.accept_inherited_failures,
         "controller_owned": true,
     });
     Ok((value, exit_code))

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -944,6 +944,38 @@ fn adopt_attempt_selector_parses_as_an_explicit_cook_attempt() {
 }
 
 #[test]
+fn adopt_inherited_failure_acceptance_is_explicit_and_documented() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "adopt",
+        "cook-11978",
+        "--candidate-ref",
+        "deadbeef",
+        "--accept-inherited-failures",
+    ])
+    .expect("explicit inherited-failure acceptance parses");
+    let Commands::AgentTask(agent_task) = cli.command else {
+        panic!("expected agent-task command");
+    };
+    let AgentTaskCommand::Adopt(args) = agent_task.command else {
+        panic!("expected adopt command");
+    };
+    assert!(args.accept_inherited_failures);
+
+    let Err(error) = Cli::try_parse_from(["homeboy", "agent-task", "adopt", "--help"]) else {
+        panic!("help exits after rendering");
+    };
+    let help = error.to_string();
+    assert!(help.contains("--accept-inherited-failures"), "{help}");
+    assert!(help.contains("immutable candidate base"), "{help}");
+    assert!(
+        help.contains("New or changed failures remain blocking"),
+        "{help}"
+    );
+}
+
+#[test]
 fn cook_execution_budget_flags_parse_and_reject_legacy_attempts_mix() {
     let cli = Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- add explicit `adopt --accept-inherited-failures` authorization
- replay failed gates against the immutable base with package-artifact provenance preserved
- keep identical inherited failures baseline-red while blocking changed failures and requiring authorization on reuse

## Verification
- `cargo test -p homeboy-agents adoption_accepts_an_identical_immutable_baseline_failure_when_explicitly_authorized --lib`
- `cargo test -p homeboy-agents adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_from_base --lib`
- `cargo test -p homeboy-cli adopt_inherited_failure_acceptance_is_explicit_and_documented --lib`
- `cargo fmt --check`

Closes #11978

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the fix, a separate OpenCode general agent identified artifact-provenance and reauthorization gaps that were corrected, and Chris Huber remains responsible for every line.