### PR TITLE
Clamp implicit rotations to explicit provider budgets

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_budget.rs
@@ -38,9 +38,12 @@ impl ExecutionBudgetUsage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EffectiveCookBudget {
     pub requested_attempts: u32,
+    pub requested_provider_executions: u32,
     pub provider_executions: u32,
     pub same_provider_remediations: u32,
+    pub requested_provider_rotations: u32,
     pub provider_rotations: u32,
+    pub truncated_provider_rotations: u32,
 }
 
 /// Resolve Cook's retry intent into the scheduler's three execution budgets.
@@ -54,21 +57,42 @@ pub fn resolve_cook_budget(
     explicit_provider_rotations: Option<u32>,
 ) -> Result<EffectiveCookBudget> {
     let requested_attempts = max_attempts.max(1);
-    let provider_rotations = explicit_provider_rotations.unwrap_or(configured_rotations);
+    let requested_provider_rotations = explicit_provider_rotations.unwrap_or(configured_rotations);
     let same_provider_remediations =
         explicit_same_provider_retries.unwrap_or_else(|| requested_attempts.saturating_sub(1));
-    let required_provider_executions = requested_attempts.saturating_add(provider_rotations);
-    let provider_executions = explicit_provider_executions.unwrap_or(required_provider_executions);
+    let requested_provider_executions =
+        requested_attempts.saturating_add(requested_provider_rotations);
+    let provider_executions = explicit_provider_executions.unwrap_or(requested_provider_executions);
+    // An explicit total cap is the strongest boundary. It trims only rotations
+    // inherited from configuration; an explicit rotation remains a requested
+    // contract and must be funded in full.
+    let provider_rotations = if explicit_provider_rotations.is_some() {
+        requested_provider_rotations
+    } else {
+        requested_provider_rotations.min(provider_executions.saturating_sub(requested_attempts))
+    };
+    let truncated_provider_rotations = requested_provider_rotations - provider_rotations;
     let correction = format!(
-        "Start a new Cook with `--max-attempts {requested_attempts} --max-provider-executions {required_provider_executions} --max-same-provider-retries {} --max-provider-rotations {provider_rotations}`.",
+        "Start a new Cook with `--max-attempts {requested_attempts} --max-provider-executions {requested_provider_executions} --max-same-provider-retries {} --max-provider-rotations {requested_provider_rotations}`.",
         requested_attempts.saturating_sub(1),
     );
 
-    if provider_executions < required_provider_executions {
+    if provider_executions < requested_attempts {
         return Err(Error::validation_invalid_argument(
             "max-provider-executions",
             format!(
-                "Cook retry intent needs {required_provider_executions} provider executions: {requested_attempts} attempt(s) plus {provider_rotations} configured or requested provider rotation(s), but --max-provider-executions is {provider_executions}. {correction}"
+                "Cook retry intent needs at least {requested_attempts} provider executions for {requested_attempts} attempt(s), but --max-provider-executions is {provider_executions}. {correction}"
+            ),
+            None,
+            Some(vec![correction]),
+        ));
+    }
+    if explicit_provider_rotations.is_some() && provider_executions < requested_provider_executions
+    {
+        return Err(Error::validation_invalid_argument(
+            "max-provider-executions",
+            format!(
+                "Cook retry intent needs {requested_provider_executions} provider executions: {requested_attempts} attempt(s) plus {requested_provider_rotations} explicitly requested provider rotation(s), but --max-provider-executions is {provider_executions}. {correction}"
             ),
             None,
             Some(vec![correction]),
@@ -87,9 +111,12 @@ pub fn resolve_cook_budget(
     }
     Ok(EffectiveCookBudget {
         requested_attempts,
+        requested_provider_executions,
         provider_executions,
         same_provider_remediations,
+        requested_provider_rotations,
         provider_rotations,
+        truncated_provider_rotations,
     })
 }
 
@@ -99,9 +126,12 @@ pub fn effective_cook_budget(
 ) -> EffectiveCookBudget {
     EffectiveCookBudget {
         requested_attempts: max_attempts.max(1),
+        requested_provider_executions: budget.max_provider_executions,
         provider_executions: budget.max_provider_executions,
         same_provider_remediations: budget.max_same_provider_retries,
+        requested_provider_rotations: budget.max_provider_rotations,
         provider_rotations: budget.max_provider_rotations,
+        truncated_provider_rotations: 0,
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -527,7 +527,7 @@ fn recipe_mismatch_fields(
     if left.gate_policy != right.gate_policy {
         fields.push("gate_policy");
     }
-    if left.retry_budget != right.retry_budget {
+    if !retry_budgets_match(&left.retry_budget, &right.retry_budget) {
         fields.push("retry_budget");
     }
     if left.finalization != right.finalization {
@@ -580,6 +580,22 @@ fn recipe_mismatch_fields(
         fields.push("attempts");
     }
     fields
+}
+
+/// Retry-policy provenance may gain these descriptive views as the controller
+/// learns to explain a resolved budget more completely. Every other policy
+/// field remains immutable, including future policy-bearing fields.
+fn retry_budgets_match(left: &Value, right: &Value) -> bool {
+    let mut left = left.clone();
+    let mut right = right.clone();
+    for budget in [&mut left, &mut right] {
+        if let Some(policy) = budget.get_mut("policy").and_then(Value::as_object_mut) {
+            for field in ["requested", "effective", "truncated"] {
+                policy.remove(field);
+            }
+        }
+    }
+    left == right
 }
 
 fn attempt_inputs_match(
@@ -2192,6 +2208,9 @@ mod tests {
             persisted.retry_budget["policy"] = serde_json::json!({
                 "operator_intent": { "max_attempts": 2, "max_provider_executions": null, "max_same_provider_retries": null, "max_provider_rotations": null },
                 "resolved": { "max_attempts": 2, "max_provider_executions": 3, "max_same_provider_retries": 1, "max_provider_rotations": 1 },
+                "requested": { "max_attempts": 2, "max_provider_executions": 3, "max_same_provider_retries": 1, "max_provider_rotations": 1 },
+                "effective": { "max_attempts": 2, "max_provider_executions": 3, "max_same_provider_retries": 1, "max_provider_rotations": 1 },
+                "truncated": { "max_provider_rotations": 0 },
             });
             write_recipe(&persisted).unwrap();
 
@@ -2210,6 +2229,50 @@ mod tests {
                 load_recipe("cook").unwrap().retry_budget["policy"]["resolved"]
                     ["max_provider_rotations"],
                 1
+            );
+            assert_eq!(
+                load_recipe("cook").unwrap().retry_budget["policy"]["truncated"]
+                    ["max_provider_rotations"],
+                0
+            );
+        });
+    }
+
+    #[test]
+    fn persisted_old_retry_policy_remains_compatible_after_provider_execution() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut persisted = recipe();
+            let old_policy = serde_json::json!({
+                "operator_intent": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": null, "max_provider_rotations": null },
+                "resolved": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": 0, "max_provider_rotations": 0 },
+            });
+            persisted.attempts[0].plan.metadata["cook_retry_policy"] = old_policy.clone();
+            persisted.retry_budget["policy"] = old_policy;
+            write_recipe(&persisted).unwrap();
+            crate::agent_task_lifecycle::submit_plan(&persisted.attempts[0].plan, Some("run"))
+                .expect("materialize old provider attempt");
+            crate::agent_task_lifecycle::rewrite_record_for_test("run", |record| {
+                record.metadata["provider_executions_consumed"] = serde_json::json!(1);
+            })
+            .expect("record provider execution");
+
+            let mut options = reconstruct_options(&persisted).expect("old recipe reconstructs");
+            options.initial_plan.metadata["cook_retry_policy"] = serde_json::json!({
+                "operator_intent": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": null, "max_provider_rotations": null },
+                "resolved": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": 0, "max_provider_rotations": 0 },
+                "requested": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": 0, "max_provider_rotations": 0 },
+                "effective": { "max_attempts": 1, "max_provider_executions": 1, "max_same_provider_retries": 0, "max_provider_rotations": 0 },
+                "truncated": { "max_provider_rotations": 0 },
+            });
+
+            validate_initial_recipe_compatibility(&options)
+                .expect("descriptive retry-policy additions preserve the frozen recipe");
+
+            options.initial_plan.metadata["cook_retry_policy"]["resolved"]
+                ["max_provider_executions"] = serde_json::json!(2);
+            assert!(
+                validate_initial_recipe_compatibility(&options).is_err(),
+                "a resolved execution budget mutation remains fenced after provider execution"
             );
         });
     }

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -286,6 +286,19 @@ fn cook_retry_intent_adds_configured_rotation_allowance() {
     assert_eq!(resolved.provider_executions, 4);
     assert_eq!(resolved.same_provider_remediations, 1);
     assert_eq!(resolved.provider_rotations, 2);
+    assert_eq!(resolved.truncated_provider_rotations, 0);
+}
+
+#[test]
+fn cook_retry_intent_explicit_execution_cap_truncates_configured_rotations() {
+    let resolved = resolve_cook_budget(1, 2, Some(1), None, None)
+        .expect("an explicit execution cap bounds inherited rotations");
+
+    assert_eq!(resolved.requested_provider_executions, 3);
+    assert_eq!(resolved.provider_executions, 1);
+    assert_eq!(resolved.requested_provider_rotations, 2);
+    assert_eq!(resolved.provider_rotations, 0);
+    assert_eq!(resolved.truncated_provider_rotations, 2);
 }
 
 #[test]
@@ -299,8 +312,8 @@ fn cook_retry_intent_preserves_explicit_zero_rotation_override() {
 }
 
 #[test]
-fn cook_retry_intent_rejects_contradictory_explicit_override_with_correction() {
-    let error = resolve_cook_budget(2, 1, Some(2), Some(1), None)
+fn cook_retry_intent_rejects_contradictory_explicit_rotation_with_correction() {
+    let error = resolve_cook_budget(2, 1, Some(2), Some(1), Some(1))
         .expect_err("rotation requires its own provider execution allowance");
 
     assert_eq!(error.details["field"], "max-provider-executions");

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -330,6 +330,48 @@ mod tests {
     }
 
     #[test]
+    fn cook_help_documents_explicit_execution_cap_precedence_over_configured_rotations() {
+        let help = rendered_cook_help();
+        assert!(
+            help.contains("--max-attempts 1 --max-provider-executions 1"),
+            "{help}"
+        );
+        assert!(
+            help.contains("explicit `--max-provider-rotations`"),
+            "{help}"
+        );
+    }
+
+    #[test]
+    fn cook_parser_preserves_an_explicit_execution_cap_without_a_rotation_override() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--max-attempts",
+            "1",
+            "--max-provider-executions",
+            "1",
+            "--no-finalize",
+            "--prompt",
+            "test",
+            "--to-worktree",
+            "repo@branch",
+        ])
+        .expect("parse an explicitly bounded Cook");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("Cook command");
+        };
+
+        assert_eq!(cook.max_attempts, 1);
+        assert_eq!(cook.dispatch.core.attempts, Some(1));
+        assert_eq!(cook.dispatch.core.provider_rotations, None);
+    }
+
+    #[test]
     fn cook_help_exposes_quiet_progress_for_orchestration() {
         let help = rendered_cook_help();
         assert!(help.contains("--no-progress"), "{help}");

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -85,6 +85,22 @@ pub(crate) fn cook_rotation_disclosure(plan: &AgentTaskPlan) -> String {
     let funded = entries
         .min(budget.max_provider_rotations)
         .min(executions.saturating_sub(1));
+    let budget_facts = plan.metadata["cook_retry_policy"]
+        .get("truncated")
+        .and_then(|truncated| truncated.get("max_provider_rotations"))
+        .and_then(Value::as_u64)
+        .filter(|truncated| *truncated > 0)
+        .map(|truncated| {
+            let requested = plan.metadata["cook_retry_policy"]["requested"]
+                ["max_provider_rotations"]
+                .as_u64()
+                .unwrap_or(u64::from(budget.max_provider_rotations) + truncated);
+            format!(
+                "; requested {requested} rotation(s), effective {}, truncated {truncated}",
+                budget.max_provider_rotations
+            )
+        })
+        .unwrap_or_default();
     if funded == 0 {
         let unreachable = if entries > 0 {
             format!(
@@ -95,10 +111,12 @@ pub(crate) fn cook_rotation_disclosure(plan: &AgentTaskPlan) -> String {
         } else {
             String::new()
         };
-        format!("cook: rotation: disabled ({executions} provider execution(s)){unreachable}")
+        format!(
+            "cook: rotation: disabled ({executions} provider execution(s)){unreachable}{budget_facts}"
+        )
     } else {
         format!(
-            "cook: rotation: {funded} fallback provider(s), up to {executions} provider execution(s)"
+            "cook: rotation: {funded} fallback provider(s), up to {executions} provider execution(s){budget_facts}"
         )
     }
 }
@@ -1249,6 +1267,21 @@ fn resolve_cook_execution_budget(
             "max_same_provider_retries": resolved.same_provider_remediations,
             "max_provider_rotations": resolved.provider_rotations,
         },
+        "requested": {
+            "max_attempts": resolved.requested_attempts,
+            "max_provider_executions": resolved.requested_provider_executions,
+            "max_same_provider_retries": resolved.same_provider_remediations,
+            "max_provider_rotations": resolved.requested_provider_rotations,
+        },
+        "effective": {
+            "max_attempts": resolved.requested_attempts,
+            "max_provider_executions": resolved.provider_executions,
+            "max_same_provider_retries": resolved.same_provider_remediations,
+            "max_provider_rotations": resolved.provider_rotations,
+        },
+        "truncated": {
+            "max_provider_rotations": resolved.truncated_provider_rotations,
+        },
     });
     Ok(())
 }
@@ -1320,6 +1353,21 @@ mod rotation_disclosure_tests {
         assert!(disclosure.contains("disabled"), "{disclosure}");
         assert!(
             disclosure.contains("3 configured rotation provider(s) are unreachable"),
+            "{disclosure}"
+        );
+    }
+
+    #[test]
+    fn a_clamped_rotation_discloses_requested_effective_and_truncated_budgets() {
+        let mut plan = plan_with(1, 0, 2);
+        plan.metadata["cook_retry_policy"] = serde_json::json!({
+            "requested": { "max_provider_rotations": 2 },
+            "truncated": { "max_provider_rotations": 2 },
+        });
+
+        let disclosure = cook_rotation_disclosure(&plan);
+        assert!(
+            disclosure.contains("requested 2 rotation(s), effective 0, truncated 2"),
             "{disclosure}"
         );
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -247,6 +247,51 @@ fn cook_preflight_rejects_contradictory_retry_budget_with_corrected_command() {
     );
 }
 
+#[test]
+fn cook_preflight_allows_explicit_execution_cap_to_clamp_configured_rotations() {
+    with_isolated_home(|_| {
+        let mut config = homeboy::core::defaults::load_config();
+        config.agent_task.rotation = Some(
+            serde_json::to_value(
+                homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationPolicy {
+                    entries: vec![
+                        homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("fallback-one".to_string()),
+                            ..Default::default()
+                        },
+                        homeboy::agents::agent_task_scheduler::AgentTaskProviderRotationEntry {
+                            model: Some("fallback-two".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            )
+            .expect("serialize configured rotation"),
+        );
+        homeboy::core::defaults::save_config(&config).expect("save configured rotation");
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "Implement the outcome".to_string(),
+            "--to-worktree".to_string(),
+            "sample-plugin@fix-issue".to_string(),
+            "--backend".to_string(),
+            "fixture".to_string(),
+            "--no-finalize".to_string(),
+            "--max-attempts".to_string(),
+            "1".to_string(),
+            "--max-provider-executions".to_string(),
+            "1".to_string(),
+        ]);
+
+        validate_cook_request(&args)
+            .expect("explicit total cap truncates rotations inherited from configuration");
+    });
+}
+
 impl AgentTaskCookAttemptDispatcher for RecoverableRunnerDispatcher {
     fn durable_recipe(&self) -> Result<Value> {
         Ok(json!({ "kind": "test-recoverable-runner" }))

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -29,9 +29,13 @@ pub struct DispatchCoreArgs {
     /// Maximum total provider executions per task, including same-provider
     /// retries and provider rotations. For Cook, this must be at least
     /// --max-attempts; use --max-same-provider-retries for gate and review-form
-    /// remediation. `--attempts 1` runs exactly once. When omitted, defaults to
-    /// the total attempts the configured provider rotation needs, or 1 when no
-    /// rotation is configured.
+    /// remediation. `--attempts 1` runs exactly once. An explicit total cap
+    /// bounds rotations inherited from configuration: for example,
+    /// `--max-attempts 1 --max-provider-executions 1` runs once even when a
+    /// rotation is configured, and reports those rotations as unreachable. An
+    /// explicit `--max-provider-rotations` must fit within this total. When
+    /// omitted, defaults to the total attempts the configured provider rotation
+    /// needs, or 1 when no rotation is configured.
     #[arg(long = "max-provider-executions", alias = "attempts", value_name = "N")]
     pub attempts: Option<u32>,
 
@@ -50,7 +54,9 @@ pub struct DispatchCoreArgs {
     /// Rotations are distinct from same-provider Cook remediation and do not
     /// satisfy its required review-form retry budget. When omitted, defaults to
     /// the number of entries in the configured provider rotation, or 0 when no
-    /// rotation is configured.
+    /// rotation is configured. When supplied with an explicit total execution
+    /// cap, this request must fit within that cap; only inherited rotations are
+    /// truncated automatically.
     #[arg(
         long = "max-provider-rotations",
         alias = "provider-rotations",


### PR DESCRIPTION
## Summary
- make explicit total provider execution caps authoritative over rotations inherited from configuration
- preserve hard failures for explicitly contradictory rotation and remediation requests
- record requested, effective, and truncated budget facts without breaking historical recipe compatibility

## Verification
- `cargo test -p homeboy-agents persisted_old_retry_policy_remains_compatible_after_provider_execution --lib`
- `cargo test -p homeboy-cli cook_preflight_allows_explicit_execution_cap_to_clamp_configured_rotations`
- focused budget, parser, disclosure, and help tests
- `cargo fmt --check`

Closes #11975

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the fix, a separate OpenCode general agent identified and drove the historical recipe compatibility correction, and Chris Huber remains responsible for every line.