### PR TITLE
Route review-form timeouts to Cook continuation

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1318,7 +1318,8 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         .map(causal_chain_from_aggregate)
         .unwrap_or_default();
     let retry = retry_replay_action(&record);
-    let next_commands = diagnose_next_commands(&record, retry.action.as_ref());
+    let next_commands =
+        diagnose_next_commands(&record, retry.action.as_ref(), retry.continuation.as_ref());
 
     let mut value = json!({
         "schema": "homeboy/agent-task-diagnose/v1",
@@ -1359,6 +1360,7 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         &missing_artifacts,
         record.runner_id(),
         retry.action.as_ref(),
+        retry.continuation.as_ref(),
     );
     bound_full_reader_payload(&mut value);
     preserve_controller_owner_placement(&mut value, run_id);
@@ -1422,6 +1424,7 @@ fn attach_diagnose_actionable(
     missing_artifacts: &[Value],
     runner_id: Option<&str>,
     retry_action: Option<&CommandNextAction>,
+    continuation_action: Option<&CommandNextAction>,
 ) {
     let run_id = record.run_id.as_str();
     let candidate_payload = candidate_result_payload(
@@ -1432,7 +1435,9 @@ fn attach_diagnose_actionable(
         .state()
         .is_available();
     let failures = aggregate.map(diagnosed_failures).unwrap_or_default();
-    let (next_actions, basis) = if candidate_recoverable {
+    let (next_actions, basis) = if let Some(continuation) = continuation_action {
+        (vec![continuation.clone()], DIAGNOSE_ACTION_BASIS_CANDIDATE)
+    } else if candidate_recoverable {
         (
             vec![CommandNextAction::new(
                 "review the canonical candidate",
@@ -4202,6 +4207,7 @@ struct RetryReplayAction {
     readiness: &'static str,
     reason: Option<String>,
     action: Option<CommandNextAction>,
+    continuation: Option<CommandNextAction>,
 }
 
 impl RetryReplayAction {
@@ -4211,6 +4217,7 @@ impl RetryReplayAction {
             readiness: "unavailable",
             reason: Some(reason.into()),
             action: None,
+            continuation: None,
         }
     }
 
@@ -4242,6 +4249,30 @@ fn retry_replay_action(record: &AgentTaskRunRecord) -> RetryReplayAction {
             );
         }
     };
+    match cook_continuation_action(record) {
+        Ok(true) => {
+            return RetryReplayAction {
+                owner,
+                readiness: "unavailable",
+                reason: Some(
+                    "the authenticated review-form continuation must resume through Cook"
+                        .to_string(),
+                ),
+                action: None,
+                continuation: Some(cook_continuation_command(&record.run_id)),
+            };
+        }
+        Ok(false) => {}
+        Err(error) => {
+            return RetryReplayAction::unavailable(
+                owner,
+                format!(
+                    "cannot validate whether this run requires Cook continuation: {}",
+                    error.message
+                ),
+            );
+        }
+    }
     if !plan_has_retry_materialization_identity(&plan) {
         return RetryReplayAction::unavailable(
             owner,
@@ -4288,7 +4319,34 @@ fn retry_replay_action(record: &AgentTaskRunRecord) -> RetryReplayAction {
         readiness: "ready",
         reason: None,
         action: Some(owner_bound_retry_action(&record.run_id, runner_id, owner)),
+        continuation: None,
     }
+}
+
+/// A promoted review-form follow-up retains the candidate through Cook's
+/// authenticated continuation route. Generic retry replays its obsolete clean
+/// workspace attestation and is therefore not a legal recovery action.
+fn cook_continuation_action(record: &AgentTaskRunRecord) -> homeboy::core::Result<bool> {
+    let Some(recipe) = agent_task_service_direct::load_recipe_for_attempt(&record.run_id)? else {
+        return Ok(false);
+    };
+    agent_task_service_direct::validate_recipe_attempt_record(&recipe, &record.run_id, record)?;
+    let Some(attempt) = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == record.run_id)
+    else {
+        return Ok(false);
+    };
+    agent_task_service_direct::terminal_review_form_continuation_is_eligible(&attempt.plan, record)
+}
+
+fn cook_continuation_command(run_id: &str) -> CommandNextAction {
+    CommandNextAction::new(
+        "resume the authenticated Cook continuation",
+        format!("homeboy agent-task cook-continue {}", quote_arg(run_id)),
+    )
+    .with_kind(CommandNextActionKind::Repair)
 }
 
 fn owner_bound_retry_action(
@@ -4366,6 +4424,7 @@ fn plan_has_retry_materialization_identity(plan: &AgentTaskPlan) -> bool {
 fn diagnose_next_commands(
     record: &AgentTaskRunRecord,
     retry_action: Option<&CommandNextAction>,
+    continuation_action: Option<&CommandNextAction>,
 ) -> Vec<String> {
     let owner = record
         .runner_id()
@@ -4377,7 +4436,11 @@ fn diagnose_next_commands(
         format!("homeboy {owner} agent-task artifacts {run_id}"),
         format!("homeboy {owner} agent-task review {run_id}"),
     ];
-    commands.extend(retry_action.map(|action| action.command.clone()));
+    commands.extend(
+        continuation_action
+            .or(retry_action)
+            .map(|action| action.command.clone()),
+    );
     commands
 }
 
@@ -4625,7 +4688,7 @@ mod tests {
         }))
         .expect("minimal durable record");
 
-        let commands = diagnose_next_commands(&record, None);
+        let commands = diagnose_next_commands(&record, None, None);
 
         assert!(commands
             .iter()
@@ -4663,6 +4726,47 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("no longer matches"));
+    }
+
+    #[test]
+    fn cook_continuation_replaces_generic_retry_in_diagnose_commands() {
+        let record: AgentTaskRunRecord = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-run/v1",
+            "run_id": "review-form-timeout",
+            "plan_id": "plan",
+            "state": "partial_failure",
+            "submitted_at": "2026-08-08T00:00:00Z",
+            "plan_path": "plan.json",
+            "metadata": {}
+        }))
+        .expect("minimal durable record");
+        let retry = RetryReplayAction {
+            owner: json!({ "placement": "local" }),
+            readiness: "unavailable",
+            reason: Some(
+                "the authenticated review-form continuation must resume through Cook".to_string(),
+            ),
+            action: None,
+            continuation: Some(
+                CommandNextAction::new(
+                    "resume the authenticated Cook continuation",
+                    "homeboy agent-task cook-continue review-form-timeout",
+                )
+                .with_kind(CommandNextActionKind::Repair),
+            ),
+        };
+
+        let commands =
+            diagnose_next_commands(&record, retry.action.as_ref(), retry.continuation.as_ref());
+
+        assert_eq!(retry.projection()["readiness"], "unavailable");
+        assert!(retry.projection()["action"].is_null());
+        assert!(
+            commands.contains(&"homeboy agent-task cook-continue review-form-timeout".to_string())
+        );
+        assert!(commands
+            .iter()
+            .all(|command| !command.contains("agent-task retry")));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1164,6 +1164,146 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn diagnose_routes_timed_out_review_form_continuation_away_from_generic_retry() {
+    with_temp_home(|| {
+        let cook_id = "cook-diagnose-review-form";
+        let source_run_id = "cook-diagnose-review-form-attempt-1";
+        let run_id = "cook-diagnose-review-form-attempt-2";
+        let mut plan = test_plan();
+        plan.tasks[0].inputs = json!({
+            "cook_loop": {
+                "review_form_required": true,
+                "execution_budget_authority": {
+                    "kind": "fresh_cook_review",
+                    "max_same_provider_retries": 1
+                }
+            }
+        });
+        let options = homeboy::agents::agent_task_service::AgentTaskCookServiceOptions {
+            cook_id: cook_id.to_string(),
+            initial_run_id: run_id.to_string(),
+            initial_plan: plan.clone(),
+            to_worktree: "fixture@review-form".to_string(),
+            source_worktree_path: None,
+            provider_command: None,
+            provider_invocation: None,
+            gates: Default::default(),
+            max_attempts: 1,
+            no_finalize: true,
+            draft_pr: false,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Review form continuation".to_string(),
+            commit_message: "Review form continuation".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "fixture".to_string(),
+            ai_model: Some("fixture-model".to_string()),
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: None,
+            harvest_context: homeboy::agents::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                .expect("harvest context"),
+        };
+        homeboy::agents::agent_task_service::persist_initial_recipe(&options)
+            .expect("persist Cook recipe");
+        let mut observed_plan = plan.clone();
+        observed_plan.tasks[0].instructions = "runtime detail is not recipe identity".to_string();
+        agent_task_lifecycle::submit_plan(&observed_plan, Some(source_run_id))
+            .expect("persist source run");
+        agent_task_lifecycle::submit_plan(&observed_plan, Some(run_id))
+            .expect("persist review run");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, source_run_id)
+            .expect("record source attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, run_id)
+            .expect("record review attempt");
+
+        let source_promotion = json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "applied",
+            "source": { "kind": "aggregate", "task_id": "task-a", "run_id": source_run_id },
+            "to_worktree": "fixture@review-form",
+            "target": { "worktree": "fixture@review-form", "path": "/tmp/review-form-candidate" },
+            "patch_artifact": { "id": "patch", "kind": "patch", "path": "patch" },
+            "changed_files": ["src/lib.rs"],
+            "deterministic_gates": [],
+            "gate_results": [],
+            "operator_notification": { "status": "completed", "message": "complete" },
+            "provenance": { "candidate": { "sha256": "exact-candidate" } }
+        });
+        agent_task_lifecycle::record_promotion(source_run_id, source_promotion.clone())
+            .expect("persist applied source promotion");
+        let mut review_promotion = source_promotion;
+        review_promotion["source"]["run_id"] = json!(run_id);
+        review_promotion["provenance"]["cook_follow_up"] = json!({
+            "kind": "review_form_only",
+            "source_run_id": source_run_id,
+        });
+        agent_task_lifecycle::record_promotion(run_id, review_promotion)
+            .expect("persist copied review promotion");
+        agent_task_lifecycle::record_run_aggregate(
+            run_id,
+            &observed_plan,
+            &AgentTaskAggregate {
+                schema: "homeboy/agent-task-aggregate/v1".to_string(),
+                plan_id: observed_plan.plan_id.clone(),
+                status: homeboy::agents::agent_tasks::scheduler::AgentTaskAggregateStatus::Failed,
+                totals: Default::default(),
+                outcomes: vec![AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    status: AgentTaskOutcomeStatus::Timeout,
+                    summary: Some("review form timed out".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::Timeout),
+                    artifacts: Vec::new(),
+                    typed_artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    outputs: Value::Null,
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                }],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: Default::default(),
+            },
+        )
+        .expect("persist timeout aggregate");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.state = AgentTaskRunState::PartialFailure;
+        })
+        .expect("mark review attempt terminal");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: true,
+        })
+        .expect("diagnose timed-out review form");
+
+        let continuation = format!("homeboy agent-task cook-continue {run_id}");
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["retry_replay"]["readiness"], "unavailable");
+        assert!(value["retry_replay"]["action"].is_null());
+        assert!(value["next_commands"]
+            .as_array()
+            .expect("next commands")
+            .iter()
+            .any(|command| command == &json!(continuation)));
+        let actions = value["_homeboy_actionable"]["next_actions"]
+            .as_array()
+            .expect("actionable next actions");
+        assert!(actions
+            .iter()
+            .any(|action| action["command"] == continuation));
+        assert!(value.to_string().contains("cook-continue"));
+        assert!(!value.to_string().contains("agent-task retry"));
+    });
+}
+
+#[test]
 fn diagnose_prioritizes_structured_policy_denial_over_successful_provider_exit() {
     with_temp_home(|| {
         let evidence_dir = tempfile::tempdir().expect("evidence dir");


### PR DESCRIPTION
## Summary
- detect timed-out review-form attempts through the same immutable recipe-attempt contract as `cook-continue`
- suppress illegal generic retry guidance and emit the authenticated continuation command
- fail closed when recipe lookup or continuation eligibility cannot be established

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p homeboy-cli diagnose_routes_timed_out_review_form_continuation_away_from_generic_retry` passed before rebasing
- `cargo test --locked -p homeboy-cli cook_continuation_replaces_generic_retry_in_diagnose_commands` passed before rebasing
- post-rebase CLI test compilation is inherited-blocked by #11995 / #11996; the candidate diff does not touch the failing fixture

Closes #11980

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode implemented, tested, and reviewed this repair under human direction. Chris Huber remains responsible for every line.