### PR TITLE
Supply managed repo identity in reverse Cook acceptance fixture

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1838,6 +1838,7 @@ mod tests {
             candidate_ref: "deadbeef".to_string(),
             ai_model: Some("openai/gpt-5.6-terra".to_string()),
             replace_interrupted: false,
+            accept_inherited_failures: false,
             full: false,
         };
 

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -209,6 +209,15 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
         &checkout,
         &["commit", "-m", "ignore runner workspace"],
     );
+    homeboy::core::component::inventory::write_standalone_registration(
+        &homeboy::core::component::Component::new(
+            "cook-source".to_string(),
+            checkout.display().to_string(),
+            String::new(),
+            None,
+        ),
+    )
+    .expect("register Cook source component");
     let task_worktree = context.root().join("cook-task");
     homeboy_core::test_support::run_git_fixture_command(
         &checkout,
@@ -346,6 +355,8 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
             "--detach-after-handoff",
             "agent-task",
             "cook",
+            "--repo",
+            "cook-source",
             "--prompt",
             "Run the deterministic fixture provider.",
             "--backend",


### PR DESCRIPTION
## Summary
- register the committed reverse-Cook source checkout as managed component `cook-source`
- pass that explicit repository identity to detached Cook while retaining the existing `--cwd` and task-worktree destination
- leave fail-closed production repository admission unchanged
- include the existing one-line #11996 compile prerequisite so current `main` reaches the acceptance test

## Verification
- `cargo nextest run --locked -p homeboy --test reverse_cook_queue_acceptance pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_lifecycle --no-fail-fast`: passed in 30.186s
- `git diff --check`
- independent review: no findings

Closes #12010.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode extracted the structured admission failure, implemented and reviewed the hermetic fixture registration, and verified the complete reverse-Cook lifecycle under human direction. Chris Huber remains responsible for every line.