### PR TITLE
fix(review): preserve candidate gate evidence

### DIFF
--- a/crates/homeboy-extension/src/lint/run/exit_code.rs
+++ b/crates/homeboy-extension/src/lint/run/exit_code.rs
@@ -72,7 +72,12 @@ pub(super) fn effective_lint_exit_code(
     exit_code: i32,
     baseline_exit_override: Option<i32>,
     hard_error: bool,
+    current_findings_empty: bool,
 ) -> i32 {
+    if exit_code == 0 && current_findings_empty && !hard_error {
+        return 0;
+    }
+
     match baseline_exit_override {
         Some(0) if hard_error => exit_code.max(1),
         Some(override_code) => override_code,

--- a/crates/homeboy-extension/src/lint/run/tests/exit_code.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/exit_code.rs
@@ -66,8 +66,35 @@ fn crashed_zero_finding_producer_remains_failure() {
 
 #[test]
 fn baseline_clean_override_honors_known_findings_but_not_infrastructure_errors() {
-    assert_eq!(effective_lint_exit_code(1, Some(0), false), 0);
-    assert_eq!(effective_lint_exit_code(2, Some(0), true), 2);
-    assert_eq!(effective_lint_exit_code(1, Some(0), true), 1);
-    assert_eq!(effective_lint_exit_code(0, Some(0), true), 1);
+    assert_eq!(effective_lint_exit_code(1, Some(0), false, false), 0);
+    assert_eq!(effective_lint_exit_code(2, Some(0), true, true), 2);
+    assert_eq!(effective_lint_exit_code(1, Some(0), true, true), 1);
+    assert_eq!(effective_lint_exit_code(0, Some(0), true, false), 1);
+}
+
+#[test]
+fn unrelated_baseline_context_cannot_fail_clean_current_scope() {
+    let unrelated_baseline_delta = 250;
+    let baseline_exit_override = (unrelated_baseline_delta > 0).then_some(1);
+    let all_current_producers_clean_exit_code = 0;
+
+    assert_eq!(
+        effective_lint_exit_code(
+            all_current_producers_clean_exit_code,
+            baseline_exit_override,
+            false,
+            true,
+        ),
+        0
+    );
+    assert_eq!(
+        effective_lint_exit_code(0, baseline_exit_override, false, false),
+        1,
+        "introduced current findings must remain blocking"
+    );
+    assert_eq!(
+        effective_lint_exit_code(0, baseline_exit_override, true, true),
+        1,
+        "infrastructure failures must remain blocking"
+    );
 }

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -241,7 +241,12 @@ pub fn run_main_lint_workflow(
         || producer_summaries
             .iter()
             .any(|producer| producer.status == "error");
-    let exit_code = effective_lint_exit_code(lint_exit_code, baseline_exit_override, hard_error);
+    let exit_code = effective_lint_exit_code(
+        lint_exit_code,
+        baseline_exit_override,
+        hard_error,
+        lint_findings.is_empty(),
+    );
     let status = if exit_code == 0 {
         "passed"
     } else if infrastructure_failure {

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -1277,10 +1277,9 @@ mod tests {
         normalize_declared_test_failures(run_dir.path(), &[declaration("test.failures")])
             .expect("normalize failures");
 
-        let payload: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&failures).expect("normalized failures"),
-        )
-        .expect("failure array");
+        let payload: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&failures).expect("normalized failures"))
+                .expect("failure array");
         assert_eq!(payload, json!([]));
         homeboy_core::structured_sidecar::validate_payload("test.failures", &payload)
             .expect("schema-valid failure array");

--- a/crates/homeboy-extension/src/runner.rs
+++ b/crates/homeboy-extension/src/runner.rs
@@ -328,6 +328,11 @@ impl ExtensionRunner {
             !secret_env.is_empty(),
         )?;
         let output = redact_runner_output(output, &secret_env);
+        if self.execution_context.capability == ExtensionCapability::Test {
+            if let Some(run_dir_path) = &self.run_dir_path {
+                normalize_declared_test_failures(run_dir_path, &declared_sidecars)?;
+            }
+        }
         if !output.success {
             if let Some(run_dir_path) = &self.run_dir_path {
                 let command = self.command_string(&prepared.execution.extension_path);
@@ -704,6 +709,38 @@ fn initialize_structured_sidecars(
         write_json_sidecar(&path, &empty)?;
     }
     Ok(())
+}
+
+/// Canonicalize the legacy test producer envelope to the registry's array-only
+/// failure contract. Counts and runner diagnoses belong to `test.results` and
+/// captured output; this sidecar contains only individual failure records.
+fn normalize_declared_test_failures(
+    run_dir_path: &Path,
+    declared: &[crate::StructuredSidecarDeclaration],
+) -> Result<()> {
+    let Some(declaration) = declared
+        .iter()
+        .find(|declaration| declaration.name == "test.failures")
+    else {
+        return Ok(());
+    };
+    let Some(path) = run_dir_relative_sidecar_path(run_dir_path, &declaration.path) else {
+        return Ok(());
+    };
+
+    let failures = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .and_then(|payload| match payload {
+            serde_json::Value::Array(items) => Some(items),
+            serde_json::Value::Object(mut object) => object
+                .remove("failures")
+                .and_then(|value| value.as_array().cloned()),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    write_json_sidecar(&path, &serde_json::Value::Array(failures))
 }
 
 /// Check every structured sidecar *this extension declares* against core's
@@ -1210,6 +1247,56 @@ mod tests {
         assert!(!run_dir.step_file(run_dir::files::TEST_FAILURES).exists());
         assert!(!run_dir.step_file(run_dir::files::BENCH_RESULTS).exists());
         assert!(!run_dir.step_file(run_dir::files::TRACE_RESULTS).exists());
+
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn normalizes_test_failure_envelopes_without_losing_runner_diagnosis() {
+        let run_dir = RunDir::create().expect("run dir");
+        let failures = run_dir.step_file(run_dir::files::TEST_FAILURES);
+        let output = CommandOutput {
+            stdout: "PHPUNIT_ZERO_TESTS cause=changed_file_filter_mismatch".to_string(),
+            stderr: String::new(),
+            success: true,
+            exit_code: 0,
+            timed_out: false,
+            child_resource: None,
+        };
+        std::fs::write(
+            &failures,
+            serde_json::to_string(&json!({
+                "failures": [],
+                "total": 0,
+                "passed": 0,
+            }))
+            .expect("serialize fixture"),
+        )
+        .expect("write legacy failure envelope");
+
+        normalize_declared_test_failures(run_dir.path(), &[declaration("test.failures")])
+            .expect("normalize failures");
+
+        let payload: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&failures).expect("normalized failures"),
+        )
+        .expect("failure array");
+        assert_eq!(payload, json!([]));
+        homeboy_core::structured_sidecar::validate_payload("test.failures", &payload)
+            .expect("schema-valid failure array");
+        assert!(output
+            .stdout
+            .contains("PHPUNIT_ZERO_TESTS cause=changed_file_filter_mismatch"));
+
+        std::fs::remove_file(&failures).expect("remove sidecar");
+        normalize_declared_test_failures(run_dir.path(), &[declaration("test.failures")])
+            .expect("normalize absent infrastructure sidecar");
+        assert_eq!(
+            std::fs::read_to_string(&failures)
+                .expect("seeded failure array")
+                .trim(),
+            "[]"
+        );
 
         run_dir.cleanup();
     }


### PR DESCRIPTION
## Summary
- keep a clean final touched lint scope passing even when unrelated baseline context reports drift, while preserving introduced-finding and infrastructure failures
- normalize declared `test.failures` producer output to the schema-v1 JSON array contract for empty, zero-test, and infrastructure paths without replacing captured runner diagnostics
- add focused regressions for the contradictory candidate lint verdict and PHPUnit changed-filter zero-test sidecar

Closes #12006.

## Verification
- `cargo test -p homeboy-extension unrelated_baseline_context_cannot_fail_clean_current_scope` (1 passed)
- `cargo test -p homeboy-extension normalizes_test_failure_envelopes_without_losing_runner_diagnosis` (1 passed)
- `cargo check -p homeboy-extension` (passed)
- `git diff --check` (passed)
- `cargo test -p homeboy-extension` (718 passed; 18 unrelated environment-dependent failures involving unavailable extension fixtures and toolchain PATH)

## Residual risk
- The shared stable toolchain does not include the `rustfmt` component, so `cargo fmt --check` could not run locally. The focused compile/tests and whitespace check pass; CI remains the formatting authority.
- The broader crate's 18 existing environment-dependent failures prevent a locally green all-crate result, but both touched mechanisms pass their focused regressions.