### PR TITLE
fix(daemon): bind the advertised repair-plan stop to its reported lease (#11220)

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -537,7 +537,11 @@ fn recover(
         match step.code.as_str() {
             // A lease-bound stop refuses to kill a daemon other than the exact
             // one the report described, which is why the lease is carried here
-            // rather than left to a bare `homeboy daemon stop`.
+            // rather than left to a bare `homeboy daemon stop`. The advertised
+            // repair-plan argv is now already self-sufficient (the stop step
+            // renders its own `--lease-id`, #11220); this injection stays as a
+            // fallback for reports produced by older binaries that still carry
+            // the bare stop.
             code if code == actions::DAEMON_STOP => match lease_id.as_deref() {
                 Some(lease_id) => {
                     daemon::stop_for_lease(lease_id)?;

--- a/crates/homeboy-core/src/daemon/daemon_lease.rs
+++ b/crates/homeboy-core/src/daemon/daemon_lease.rs
@@ -250,9 +250,17 @@ pub(crate) fn freshness_report_from_validation(
     // reconciliation the evidence authorizes; anything else would be prose. The
     // last case is deliberately empty here: a local report that authorizes no
     // mutation is completed by the dispatcher, which owns the diagnostic step.
+    //
+    // The stop names the exact lease whenever the report carries one: a bare
+    // `homeboy daemon stop` would refuse to stop the stale recorded lease and
+    // leave an operator worse than before (#11220).
     let repair_plan = if restartable {
+        let stop_action = lease_id
+            .as_deref()
+            .map(recovery_actions::stop_for_lease)
+            .unwrap_or_else(recovery_actions::stop);
         vec![
-            DaemonRepairStep::executable(recovery_actions::DAEMON_STOP, recovery_actions::stop()),
+            DaemonRepairStep::executable(recovery_actions::DAEMON_STOP, stop_action),
             DaemonRepairStep::executable(recovery_actions::DAEMON_START, recovery_actions::start()),
         ]
     } else if proven_dead {
@@ -313,5 +321,100 @@ pub(crate) fn runtime_snapshot_stale_reason(snapshot: &DaemonRuntimeSnapshot) ->
             "daemon runtime path fingerprints changed: {}",
             stale.join(", ")
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A restartable validation: nothing durable at risk, and a stale reason
+    /// code outside the `LeaseCorrupt` / `TransportUnreachable` exclusions.
+    fn restartable_validation(lease_id: Option<String>) -> DaemonLeaseValidation {
+        let state = lease_id.map(|lease_id| DaemonState {
+            schema: DAEMON_LEASE_SCHEMA.to_string(),
+            lease_id,
+            startup_token: "test-token".to_string(),
+            address: "127.0.0.1:0".to_string(),
+            pid: 0,
+            state_path: "/tmp/state.json".to_string(),
+            started_at: String::new(),
+            last_seen_at: String::new(),
+            build_identity: build_identity::current(),
+            binary_sha256: None,
+            runtime_paths: DaemonRuntimeSnapshot {
+                loaded_at: String::new(),
+                paths: Vec::new(),
+            },
+        });
+        DaemonLeaseValidation {
+            state,
+            running: false,
+            fresh: false,
+            reachable: false,
+            stale_reason: Some("test stale reason".to_string()),
+            stale_reason_code: Some(DaemonStaleReasonCode::VersionMismatch),
+            invalid_pid: None,
+        }
+    }
+
+    fn repair_plan_commands(report: &DaemonFreshnessReport) -> Vec<(String, String)> {
+        report
+            .repair_plan
+            .iter()
+            .map(|step| (step.code.clone(), step.command.clone()))
+            .collect()
+    }
+
+    /// #11220: a restartable report carries its lease, so the advertised stop
+    /// must name it. A bare `homeboy daemon stop` refuses to stop the stale
+    /// recorded lease, so an operator copy-pasting the plan would land worse
+    /// than before.
+    #[test]
+    fn a_restartable_report_binds_the_advertised_stop_to_its_lease() {
+        let report = freshness_report_from_validation(
+            &restartable_validation(Some("lease-restartable".to_string())),
+            0,
+        );
+
+        assert!(report.restartable);
+        assert_eq!(report.lease_id.as_deref(), Some("lease-restartable"));
+        assert_eq!(
+            repair_plan_commands(&report),
+            vec![
+                (
+                    recovery_actions::DAEMON_STOP.to_string(),
+                    "homeboy daemon stop --lease-id lease-restartable".to_string(),
+                ),
+                (
+                    recovery_actions::DAEMON_START.to_string(),
+                    "homeboy daemon start".to_string(),
+                ),
+            ]
+        );
+    }
+
+    /// A restartable report with no lease (a missing lease, nothing durable at
+    /// risk) has nothing to bind, so the bare stop remains the correct
+    /// rendering — `--lease-id` would be a lie.
+    #[test]
+    fn a_restartable_report_without_a_lease_keeps_the_bare_stop() {
+        let report = freshness_report_from_validation(&restartable_validation(None), 0);
+
+        assert!(report.restartable);
+        assert_eq!(report.lease_id, None);
+        assert_eq!(
+            repair_plan_commands(&report),
+            vec![
+                (
+                    recovery_actions::DAEMON_STOP.to_string(),
+                    "homeboy daemon stop".to_string(),
+                ),
+                (
+                    recovery_actions::DAEMON_START.to_string(),
+                    "homeboy daemon start".to_string(),
+                ),
+            ]
+        );
     }
 }

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -56,6 +56,26 @@ pub fn stop() -> ExecutableAction {
     )
 }
 
+/// Stop the exact daemon that holds `lease_id`.
+///
+/// A bare `homeboy daemon stop` refuses to stop a daemon whose recorded lease
+/// has gone stale, so a restartable report with a lease in hand must render the
+/// bound spelling or an operator copy-pasting the plan lands worse than before
+/// (#11220).
+pub fn stop_for_lease(lease_id: &str) -> ExecutableAction {
+    action(
+        "daemon.stop",
+        format!("stop the local daemon holding lease {lease_id}"),
+        [
+            "daemon".to_string(),
+            "stop".to_string(),
+            "--lease-id".to_string(),
+            lease_id.to_string(),
+        ],
+        ActionSafety::Mutating,
+    )
+}
+
 pub fn start() -> ExecutableAction {
     action(
         "daemon.start",
@@ -256,9 +276,18 @@ pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
 mod tests {
     use super::*;
 
+    /// The lease id the `status(...)` fixture carries. Assertions that depend on
+    /// the report's repair rendering reference this so the fixture and the
+    /// expectation cannot drift apart.
+    const LEASE_ID: &str = "661f731f-99c7-436a-aadc-24dee908fd8b";
+
     #[test]
     fn rendered_text_is_derived_from_argv() {
         assert_eq!(stop().render_command(), "homeboy daemon stop");
+        assert_eq!(
+            stop_for_lease("lease-live").render_command(),
+            "homeboy daemon stop --lease-id lease-live"
+        );
         assert_eq!(start().render_command(), "homeboy daemon start");
         assert_eq!(
             adopt_orphan("lease-dead").render_command(),
@@ -318,7 +347,7 @@ mod tests {
                 fresh: stale_reason_code.is_none(),
                 stale_reason_code,
                 restartable: true,
-                lease_id: Some("661f731f-99c7-436a-aadc-24dee908fd8b".to_string()),
+                lease_id: Some(LEASE_ID.to_string()),
                 pid: Some(3_572_046),
                 recovery_evidence: None,
                 ownership_evidence: Some("daemon lease evidence is inconclusive".to_string()),
@@ -344,13 +373,14 @@ mod tests {
     /// The live reproduction this fix was written against: a reachable daemon
     /// whose build identity no longer matches the current binary, zero active
     /// jobs, restartable. The dispatcher must resolve the stop/start pair with
-    /// every argument already filled in.
+    /// every argument already filled in — including the lease the fixture
+    /// carries, so the advertised stop is the exact-lease stop (#11220).
     #[test]
     fn a_version_mismatch_report_resolves_the_restart_plan() {
         let status = status(
             Some(super::super::DaemonStaleReasonCode::VersionMismatch),
             vec![
-                DaemonRepairStep::executable(DAEMON_STOP, stop()),
+                DaemonRepairStep::executable(DAEMON_STOP, stop_for_lease(LEASE_ID)),
                 DaemonRepairStep::executable(DAEMON_START, start()),
             ],
             0,
@@ -366,7 +396,10 @@ mod tests {
                 .map(|step| (step.code.as_str(), step.command.as_str()))
                 .collect::<Vec<_>>(),
             vec![
-                (DAEMON_STOP, "homeboy daemon stop"),
+                (
+                    DAEMON_STOP,
+                    format!("homeboy daemon stop --lease-id {LEASE_ID}").as_str(),
+                ),
                 (DAEMON_START, "homeboy daemon start"),
             ]
         );
@@ -440,7 +473,7 @@ mod tests {
             "every durable job id is named: {args:?}"
         );
         assert!(args.contains(&Uuid::from_u128(1).to_string()));
-        assert!(args.contains(&"661f731f-99c7-436a-aadc-24dee908fd8b".to_string()));
+        assert!(args.contains(&LEASE_ID.to_string()));
         assert_eq!(
             plan.required_confirmations,
             vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
@@ -453,7 +486,7 @@ mod tests {
             job_id,
             operation: "exec".to_string(),
             status: crate::api_jobs::JobStatus::Running,
-            daemon_lease_id: Some("661f731f-99c7-436a-aadc-24dee908fd8b".to_string()),
+            daemon_lease_id: Some(LEASE_ID.to_string()),
             created_at_ms: 0,
             updated_at_ms: 0,
             started_at_ms: None,
@@ -473,6 +506,7 @@ mod tests {
         assert_eq!(diagnose().safety, ActionSafety::ReadOnly);
         for action in [
             stop(),
+            stop_for_lease("lease"),
             start(),
             adopt_orphan("lease"),
             reconcile_leaseless_orphans(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1904,7 +1904,9 @@ fn local_freshness_report_plans_explicit_reconciliation_for_a_restartable_lease(
 
     let status = read_status().expect("status");
 
-    // Zero durable jobs are at risk, so the whole repair is a stop/start.
+    // Zero durable jobs are at risk, so the whole repair is a stop/start. The
+    // report carries its lease, so the advertised stop names it: a bare stop
+    // would refuse to stop the stale recorded lease (#11220).
     assert!(status.freshness.restartable);
     assert_eq!(
         status
@@ -1914,7 +1916,7 @@ fn local_freshness_report_plans_explicit_reconciliation_for_a_restartable_lease(
             .map(|step| (step.code.as_str(), step.command.as_str()))
             .collect::<Vec<_>>(),
         vec![
-            ("daemon_stop", "homeboy daemon stop"),
+            ("daemon_stop", "homeboy daemon stop --lease-id test-lease"),
             ("daemon_start", "homeboy daemon start"),
         ]
     );


### PR DESCRIPTION
Fixes #11220.

## The invariant

`recovery_actions.rs` opens by stating that the plan an operator *reads* and the plan the dispatcher *executes* cannot drift apart (#11103, #11105). For the stop step, it had:

- `freshness_report_from_validation` rendered a bare `homeboy daemon stop` even when the report carried `lease_id`
- `daemon recover` injected `stop_for_lease(lease_id)` at execution time

So `homeboy daemon recover --yes` worked, and copy-pasting the advertised `repair_plan` did not — `"stopped": false` against the stale lease, then `daemon_unleased_process_conflict` on start. Strictly worse than not running it.

## Change

- New `recovery_actions::stop_for_lease(lease_id)` rendering `daemon stop --lease-id <id>`, shaped exactly like the existing `adopt_orphan(lease_id)` builder. The CLI surface already existed (`DaemonCommand::Stop { lease_id, .. }` → `daemon::stop_for_lease`); nothing new was added there.
- `daemon_lease.rs` emits the bound spelling when the report carries a lease, and keeps the bare `stop()` when it does not — `--lease-id` on a leaseless report would be a lie.
- The dispatcher's own lease injection is retained as a fallback for reports produced by older binaries, with a comment saying so.

## A note on the issue text

The issue points at `controller_frame_plan` in `homeboy-lab-runner/src/daemon_repair.rs`. **That was not the culprit** and is untouched here. It discards the daemon-authored plan and emits controller-frame `homeboy runner *` commands — for `VersionMismatch` it emits `RUNNER_REFRESH_HOMEBOY`, on the rationale that an identity drift is a binary problem, not a lease problem. `a_daemon_authored_local_frame_plan_never_survives_the_crossing` pins that. The real site was `homeboy-core`'s local-frame builder.

## Tests

`a_version_mismatch_report_resolves_the_restart_plan` already carried the exact `lease_id`/`pid` from the issue's live reproduction, and its docstring already said the plan must resolve "with every argument already filled in" — it was asserting the right intent against the wrong expectation. Updated, with the magic lease string lifted to a `LEASE_ID` const so fixture and expectation cannot drift.

Added both directions:
- `a_restartable_report_binds_the_advertised_stop_to_its_lease`
- `a_restartable_report_without_a_lease_keeps_the_bare_stop`

Also updated the integration assertion in `tests/core/daemon_test.rs`.

## Verification

- `cargo check --workspace --tests -j2` — passed (deterministic cook gate)
- `cargo test -p homeboy-core --lib daemon::` — **5 failed on this branch, 6 on `origin/main`; the branch failures are a strict subset of the base failures.** Test counts reconcile exactly (base 226 run, branch 228 = the 2 new tests). All pre-existing and tracked in #11897; the extra base failure is the known host-dependent `/proc` flake.
- All 10 tests in `daemon::recovery_actions` + `daemon::daemon_lease` pass.

`cargo check` cannot validate rendered-string assertions, so the focused suite was run deliberately rather than relying on the gate.
