### PR TITLE
fix(upgrade): refresh managed runner slots

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -2933,7 +2933,7 @@ fn dev_sync_next_actions(runner_id: &str, options: &RunnerDevSyncOptions) -> Vec
     actions
 }
 
-fn controller_refresh_ref() -> String {
+pub(crate) fn controller_refresh_ref() -> String {
     homeboy_product_identity::build_identity()
         .git_commit
         .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -38,6 +38,47 @@ pub fn runner_upgrade_command(
     command
 }
 
+/// A Homeboy-managed slot is immutable: replacing it through the binary's
+/// generic installer bypasses controller-owned promotion and daemon rotation.
+pub fn is_managed_immutable_homeboy_path(runner: &Runner, homeboy_path: &str) -> bool {
+    let Some(workspace_root) = runner.workspace_root.as_deref() else {
+        return false;
+    };
+    let Some(slot) = homeboy_path
+        .strip_prefix(workspace_root.trim_end_matches('/'))
+        .and_then(|path| path.strip_prefix("/_homeboy_binaries/"))
+    else {
+        return false;
+    };
+
+    let slot = slot
+        .strip_suffix("/target/release/homeboy")
+        .or_else(|| slot.strip_suffix("/homeboy"));
+    let Some(slot) = slot else {
+        return false;
+    };
+    let immutable_slot = slot
+        .strip_prefix("homeboy-")
+        .is_some_and(|name| name.len() == 64 && name.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        || slot.strip_prefix("dev/").is_some_and(|name| {
+            name.len() == 16 && name.bytes().all(|byte| byte.is_ascii_hexdigit())
+        });
+
+    immutable_slot
+}
+
+pub fn managed_immutable_runner_recovery_commands(runner_id: &str) -> Vec<String> {
+    let refresh = format!(
+        "homeboy runner refresh-homeboy {} --ref {} --reconnect",
+        shell_arg(runner_id),
+        shell_arg(&crate::homeboy_refresh::controller_refresh_ref())
+    );
+    vec![
+        refresh,
+        format!("homeboy runner reconcile {}", shell_arg(runner_id)),
+    ]
+}
+
 pub fn reconnect_runner_daemon(runner_id: &str) -> Result<(String, Option<String>)> {
     runner::disconnect(runner_id)?;
     let (report, exit_code) = runner::connect(runner_id)?;

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -8,6 +8,7 @@ use homeboy_lab_runner_contract::RunnerKind;
 use homeboy_upgrade::upgrade::version_is_newer;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
+use homeboy_upgrade::upgrade::RunnerDaemonDriftEntry;
 use homeboy_upgrade::upgrade::RunnerUpgradeEntry;
 use std::path::Path;
 
@@ -434,6 +435,15 @@ pub fn upgrade_runner_with_executor(
     let previous_version = runner_homeboy_version(runner, &original_homeboy_path, exec)
         .ok()
         .flatten();
+    if is_managed_immutable_homeboy_path(runner, &original_homeboy_path) {
+        return refresh_managed_immutable_runner(
+            runner,
+            original_homeboy_path,
+            previous_version,
+            extension_updates,
+            exec,
+        );
+    }
     let expected_build_identity = expected_controller_identity
         .map(str::to_string)
         .or_else(|| {
@@ -839,6 +849,169 @@ pub fn upgrade_runner_with_executor(
         stale_daemon,
         daemon_previous_version,
         daemon_new_version,
+        exit_code,
+        detail,
+    }
+}
+
+fn refresh_managed_immutable_runner(
+    runner: &Runner,
+    previous_homeboy_path: String,
+    previous_version: Option<String>,
+    extension_updates: &[ExtensionUpgradeEntry],
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> RunnerUpgradeEntry {
+    let recovery_commands = managed_immutable_runner_recovery_commands(&runner.id);
+    let options = crate::HomeboyBinaryRefreshOptions {
+        runner_id: runner.id.clone(),
+        mode: crate::HomeboyBinaryRefreshMode::Materialize,
+        source: None,
+        git_ref: Some(crate::homeboy_refresh::controller_refresh_ref()),
+        target_dir: None,
+        reconnect: true,
+        force: false,
+        allow_downgrade: false,
+        dry_run: false,
+    };
+    let (refreshed, exit_code) = match crate::refresh_homeboy_binary(options) {
+        Ok(result) => result,
+        Err(error) => {
+            return managed_immutable_runner_failure_entry(
+                &runner.id,
+                previous_homeboy_path,
+                previous_version,
+                1,
+                format!(
+                    "managed immutable runner refresh failed: {}; recover with {}",
+                    error.message,
+                    recovery_commands.join(" && ")
+                ),
+            );
+        }
+    };
+    if !managed_refresh_can_reconcile(
+        exit_code,
+        refreshed.daemon_refreshed,
+        refreshed.failure.is_some(),
+    ) {
+        return RunnerUpgradeEntry {
+            runner_id: runner.id.clone(),
+            homeboy_path: refreshed.selected_binary_path,
+            success: false,
+            upgraded: false,
+            previous_version,
+            new_version: None,
+            bare_homeboy_version: None,
+            path_drift: Some("managed immutable runner refresh did not converge".to_string()),
+            recovery_commands,
+            extensions_synced: Vec::new(),
+            extensions_skipped: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            daemon_previous_version: None,
+            daemon_new_version: None,
+            exit_code,
+            detail: format!(
+                "managed immutable runner refresh failed: {:?}",
+                refreshed.failure
+            ),
+        };
+    }
+    let reconciled = match runner::reconcile_status(&runner.id) {
+        Ok(report) => report,
+        Err(error) => {
+            return managed_immutable_runner_failure_entry(
+                &runner.id,
+                refreshed.selected_binary_path,
+                previous_version,
+                1,
+                format!(
+                    "managed immutable runner refresh completed but reconciliation failed: {}; recover with {}",
+                    error.message,
+                    recovery_commands.join(" && ")
+                ),
+            );
+        }
+    };
+    let homeboy_path = refreshed.selected_binary_path;
+    let new_version = runner_homeboy_version(runner, &homeboy_path, exec)
+        .ok()
+        .flatten();
+    let (extensions_synced, extensions_skipped, extensions_failed) =
+        sync_runner_extensions(runner, &homeboy_path, extension_updates, exec);
+    let admission_ready = managed_immutable_admission_ready(&reconciled);
+    let stale_daemon = reconciled
+        .stale_daemon
+        .map(|warning| RunnerDaemonDriftEntry {
+            session_homeboy_version: warning.session_homeboy_version,
+            current_homeboy_version: warning.current_homeboy_version,
+            recovery_commands: warning.recovery_commands,
+        });
+    let success = new_version.is_some()
+        && admission_ready
+        && stale_daemon.is_none()
+        && extensions_failed.is_empty();
+    RunnerUpgradeEntry {
+        runner_id: runner.id.clone(),
+        homeboy_path: homeboy_path.clone(),
+        success,
+        upgraded: homeboy_path != previous_homeboy_path,
+        previous_version,
+        new_version,
+        bare_homeboy_version: None,
+        path_drift: (!success).then(|| {
+            "managed immutable runner did not satisfy binary, daemon, and admission convergence"
+                .to_string()
+        }),
+        recovery_commands: (!success).then_some(recovery_commands).unwrap_or_default(),
+        extensions_synced,
+        extensions_skipped,
+        extensions_failed,
+        stale_daemon,
+        daemon_previous_version: None,
+        daemon_new_version: None,
+        exit_code: i32::from(!success),
+        detail: format!(
+            "managed immutable runner refreshed through controller-owned promotion, daemon rotation, and reconciliation; admission ready: {admission_ready}"
+        ),
+    }
+}
+
+pub(super) fn managed_immutable_admission_ready(status: &crate::RunnerStatusReport) -> bool {
+    status.admission_summary(0).accepting_jobs
+}
+
+pub(super) fn managed_refresh_can_reconcile(
+    exit_code: i32,
+    daemon_refreshed: bool,
+    refresh_failed: bool,
+) -> bool {
+    !refresh_failed && (exit_code == 0 || daemon_refreshed)
+}
+
+fn managed_immutable_runner_failure_entry(
+    runner_id: &str,
+    homeboy_path: String,
+    previous_version: Option<String>,
+    exit_code: i32,
+    detail: String,
+) -> RunnerUpgradeEntry {
+    RunnerUpgradeEntry {
+        runner_id: runner_id.to_string(),
+        homeboy_path,
+        success: false,
+        upgraded: false,
+        previous_version,
+        new_version: None,
+        bare_homeboy_version: None,
+        path_drift: Some("managed immutable runner refresh did not converge".to_string()),
+        recovery_commands: managed_immutable_runner_recovery_commands(runner_id),
+        extensions_synced: Vec::new(),
+        extensions_skipped: Vec::new(),
+        extensions_failed: Vec::new(),
+        stale_daemon: None,
+        daemon_previous_version: None,
+        daemon_new_version: None,
         exit_code,
         detail,
     }

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -13,6 +13,58 @@ thread_local! {
 }
 
 #[test]
+fn managed_immutable_runner_slots_route_to_refresh_and_reconciliation() {
+    let runner = ssh_runner(
+        "homeboy-lab",
+        Some("/home/user/workspace/_homeboy_binaries/homeboy-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/homeboy"),
+    );
+
+    assert!(is_managed_immutable_homeboy_path(
+        &runner,
+        runner
+            .settings
+            .homeboy_path
+            .as_deref()
+            .expect("configured path")
+    ));
+    assert!(is_managed_immutable_homeboy_path(
+        &runner,
+        "/home/user/workspace/_homeboy_binaries/homeboy-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/target/release/homeboy"
+    ));
+    assert!(!is_managed_immutable_homeboy_path(
+        &runner,
+        "/home/user/workspace/_homeboy_binaries/homeboy-main/target/release/homeboy"
+    ));
+
+    let commands = managed_immutable_runner_recovery_commands("homeboy-lab");
+    assert_eq!(commands.len(), 2);
+    assert!(commands[0].starts_with("homeboy runner refresh-homeboy homeboy-lab --ref "));
+    assert!(commands[0].ends_with(" --reconnect"));
+    assert_eq!(commands[1], "homeboy runner reconcile homeboy-lab");
+}
+
+#[test]
+fn managed_immutable_runner_uses_reconciled_admission_postcondition() {
+    let mut before_reconcile = stale_runner_status("homeboy-lab").expect("runner status");
+    before_reconcile.active_job_state = RunnerActiveJobState::Available;
+    assert!(!managed_immutable_admission_ready(&before_reconcile));
+
+    let mut reconciled = runner_status("homeboy-lab").expect("runner status");
+    reconciled.connected = true;
+    reconciled.state = RunnerSessionState::Connected;
+    reconciled.active_job_state = RunnerActiveJobState::Available;
+    assert!(managed_immutable_admission_ready(&reconciled));
+}
+
+#[test]
+fn managed_immutable_runner_reconciles_a_rotated_but_draining_daemon() {
+    assert!(managed_refresh_can_reconcile(1, true, false));
+    assert!(!managed_refresh_can_reconcile(1, false, false));
+    assert!(!managed_refresh_can_reconcile(1, true, true));
+    assert!(!managed_refresh_can_reconcile(0, true, true));
+}
+
+#[test]
 fn materializes_forced_source_upgrade_path_before_forwarding_to_runner() {
     let _local_version = pin_local_version_for_fixtures();
     let runner = ssh_runner("lab", Some("/home/user/.cargo/bin/homeboy"));


### PR DESCRIPTION
## Summary
- recognize Homeboy-managed immutable runner binary slots
- route their upgrades through controller-owned refresh, reconnect, and reconcile lifecycle
- report actionable managed recovery commands and verify final admission from reconciled status

Closes #12021.

## Verification
- `cargo test -p homeboy-lab-runner upgrade_runners` (46 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests` (85 passed, 1 unrelated fixture failure because the fixture omits existing `crates/homeboy-core/src/git_watch_paths.rs`)
- `cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings` reaches three pre-existing `homeboy-core` warnings outside this diff

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode inspected the upgrade and refresh lifecycles, implemented the managed-runner routing and regression coverage, and ran verification. Chris Huber remains responsible for every line.