### PR TITLE
fix(runner): share remote authority snapshot

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -453,6 +453,39 @@ pub(super) enum RemoteDaemonWorkEvidence {
     AuthoritativelyIdle,
 }
 
+/// The remote daemon is the authority for lifecycle decisions. Consumers must
+/// derive zero-job and rotation decisions from this snapshot rather than
+/// interpreting a persisted controller session as current daemon state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RemoteDaemonAuthoritySnapshot {
+    pub(super) source: &'static str,
+    pub(super) active_jobs: usize,
+    pub(super) active_lease_id: Option<String>,
+    pub(super) proven_idle: bool,
+    pub(super) safe_to_rotate: bool,
+}
+
+pub(super) fn authority_snapshot(status: &RemoteDaemonStatus) -> RemoteDaemonAuthoritySnapshot {
+    let proven_idle = status.reachable
+        && status.endpoint_probe_error.is_none()
+        && status.active_jobs == 0
+        && status.work_evidence.is_authoritatively_idle();
+    let daemon = status.daemon.as_ref();
+    let active_lease_id = daemon.and_then(|daemon| daemon.lease_id.clone());
+    let safe_to_rotate = proven_idle
+        && daemon.is_some_and(|daemon| daemon.pid.is_some())
+        && active_lease_id
+            .as_deref()
+            .is_some_and(|lease| !lease.is_empty());
+    RemoteDaemonAuthoritySnapshot {
+        source: "remote daemon SSH status and typed /jobs probe",
+        active_jobs: status.active_jobs,
+        active_lease_id,
+        proven_idle,
+        safe_to_rotate,
+    }
+}
+
 /// Return the one live lease that may replace a ledger containing only stale
 /// leases. The remote daemon status and typed jobs endpoint are authoritative;
 /// a persisted lease is never used to stop a different daemon.
@@ -463,32 +496,27 @@ pub(super) fn authoritative_idle_lease_for_stale_generations(
     if persisted_leases.is_empty() {
         return Ok(None);
     }
-    let daemon = status.daemon.as_ref().ok_or_else(|| {
-        "authoritative daemon reconciliation cannot prove a live daemon lease and PID".to_string()
+    let snapshot = authority_snapshot(status);
+    if status.daemon.is_none() {
+        return Err(
+            "authoritative daemon reconciliation cannot prove a live daemon lease and PID"
+                .to_string(),
+        );
+    }
+    let lease_id = snapshot.active_lease_id.as_deref().ok_or_else(|| {
+        "authoritative daemon reconciliation cannot prove the live daemon lease".to_string()
     })?;
-    let lease_id = daemon
-        .lease_id
-        .as_deref()
-        .filter(|lease| !lease.is_empty())
-        .ok_or_else(|| {
-            "authoritative daemon reconciliation cannot prove the live daemon lease".to_string()
-        })?;
     if persisted_leases
         .iter()
         .any(|persisted| persisted == lease_id)
     {
         return Ok(None);
     }
-    if daemon.pid.is_none()
-        || !status.reachable
-        || status.endpoint_probe_error.is_some()
-        || status.active_jobs != 0
-        || !status.work_evidence.is_authoritatively_idle()
-    {
-        return Err(
-            "authoritative daemon reconciliation requires a reachable lease/PID, successful endpoint probes, and zero typed active jobs"
-                .to_string(),
-        );
+    if !snapshot.safe_to_rotate {
+        return Err(format!(
+            "authoritative daemon reconciliation from {} requires a reachable lease/PID, successful endpoint probes, and zero typed active jobs",
+            snapshot.source
+        ));
     }
     Ok(Some(lease_id.to_string()))
 }
@@ -588,11 +616,11 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
     // branch below, which produced no adoption command and left Lab placement
     // waiting for controller generation admission (#8694). "Protected active
     // jobs" is also nonsensical when there are provably zero.
+    let authority = authority_snapshot(status);
     let recoverable_fresh_idle = !proven_dead
         && !leaseless_reconciliation_available
         && status.fresh
-        && status.active_jobs == 0
-        && status.work_evidence.is_authoritatively_idle();
+        && authority.proven_idle;
     let mut ownership_evidence = if proven_dead {
         Some(format!(
             "remote daemon status over SSH proved PID {} is dead for lease `{}`",
@@ -602,7 +630,10 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
     } else if leaseless_reconciliation_available {
         Some("active durable jobs require explicit reconciliation; it will verify the owner lock, process list, and configured listener before terminalizing them".to_string())
     } else if recoverable_fresh_idle {
-        Some("remote daemon is fresh with zero authoritatively idle jobs; the controller session can be safely reconnected".to_string())
+        Some(format!(
+            "{} proved the remote daemon is fresh with zero authoritatively idle jobs; the controller session can be safely reconnected",
+            authority.source
+        ))
     } else {
         Some("remote daemon lease evidence is unavailable; active jobs are protected from implicit replacement".to_string())
     };

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -342,6 +342,7 @@ pub(in crate::connection) fn rebind_idle_generation_owner(
                     .remote_daemon_address
                     .as_deref()
                     .unwrap_or_default(),
+                stable_generation_owner_identity(generation),
             )
         })?
         .clone();
@@ -349,6 +350,13 @@ pub(in crate::connection) fn rebind_idle_generation_owner(
     authoritative_session.remote_daemon_pid = daemon.pid;
     authoritative_session.remote_daemon_address = Some(daemon.address.clone());
     Some(authoritative_session)
+}
+
+/// The final owner-selection key preserves every identity field that remains
+/// after the authoritative daemon lease, PID, and address are rebound.
+fn stable_generation_owner_identity(generation: &RunnerSession) -> String {
+    serde_json::to_string(generation)
+        .expect("persisted runner sessions must have a stable serialized identity")
 }
 
 /// Clearing the ledger is safe only when every generation is represented by a
@@ -1046,10 +1054,16 @@ mod tests {
 
     #[test]
     fn concurrent_stale_generations_rebind_the_same_canonical_owner() {
-        let mut first = direct_ssh_session("lease-z");
+        let mut first = direct_ssh_session("lease-stale");
         first.controller_id = Some("controller-z".to_string());
-        let mut second = direct_ssh_session("lease-a");
+        first.local_port = Some(49154);
+        first.local_url = Some("http://127.0.0.1:49154".to_string());
+        first.worker_identity = Some("worker-z".to_string());
+        let mut second = direct_ssh_session("lease-stale");
         second.controller_id = Some("controller-a".to_string());
+        second.local_port = Some(49155);
+        second.local_url = Some("http://127.0.0.1:49155".to_string());
+        second.worker_identity = Some("worker-a".to_string());
         let daemon = remote_daemon_status(true, 0, "lease-live", 4242, None)
             .daemon
             .expect("live daemon");
@@ -1060,12 +1074,19 @@ mod tests {
             "lease-live".to_string(),
         )
         .expect("canonical owner");
-        let reverse =
-            rebind_idle_generation_owner(&[second, first], &daemon, "lease-live".to_string())
-                .expect("canonical owner");
+        let reverse = rebind_idle_generation_owner(
+            &[second.clone(), first],
+            &daemon,
+            "lease-live".to_string(),
+        )
+        .expect("canonical owner");
 
-        assert_eq!(forward.controller_id, Some("controller-a".to_string()));
-        assert_eq!(forward, reverse);
+        let mut expected = second;
+        expected.remote_daemon_lease_id = Some("lease-live".to_string());
+        expected.remote_daemon_pid = daemon.pid;
+        expected.remote_daemon_address = Some(daemon.address);
+        assert_eq!(forward, expected);
+        assert_eq!(reverse, expected);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection_stop_transport_recovery.rs
@@ -77,9 +77,7 @@ pub(crate) fn disconnect_local_recovery(runner_id: &str) -> Result<RunnerDisconn
 }
 
 fn local_recovery_zero_jobs_proven(status: &remote_daemon::RemoteDaemonStatus) -> bool {
-    status.active_jobs == 0
-        && status.reachable
-        && status.work_evidence == remote_daemon::RemoteDaemonWorkEvidence::AuthoritativelyIdle
+    remote_daemon::authority_snapshot(status).proven_idle
 }
 
 fn partial_disconnect_report(
@@ -331,7 +329,22 @@ pub(in crate::connection) fn rebind_idle_generation_owner(
     daemon: &remote_daemon::RemoteDaemon,
     lease_id: String,
 ) -> Option<RunnerSession> {
-    let mut authoritative_session = generations.first()?.clone();
+    let mut authoritative_session = generations
+        .iter()
+        .min_by_key(|generation| {
+            (
+                generation
+                    .remote_daemon_lease_id
+                    .as_deref()
+                    .unwrap_or_default(),
+                generation.remote_daemon_pid.unwrap_or_default(),
+                generation
+                    .remote_daemon_address
+                    .as_deref()
+                    .unwrap_or_default(),
+            )
+        })?
+        .clone();
     authoritative_session.remote_daemon_lease_id = Some(lease_id);
     authoritative_session.remote_daemon_pid = daemon.pid;
     authoritative_session.remote_daemon_address = Some(daemon.address.clone());
@@ -613,7 +626,7 @@ fn remote_lease_bound_stop_recovery_command(
         command
     } else {
         format!(
-            "the persisted lease `{persisted_lease_id}` differs from the authoritative active lease `{active_lease_id}` (PID {}); use the authoritative lease only: {command}",
+            "the persisted session lease `{persisted_lease_id}` (source: controller-local session) differs from the authoritative active lease `{active_lease_id}` (source: remote daemon SSH status and typed /jobs probe, PID {}); use the authoritative lease only: {command}",
             daemon.pid.map(|pid| pid.to_string()).as_deref().unwrap_or("unavailable")
         )
     }
@@ -1006,6 +1019,53 @@ mod tests {
         idle.work_evidence = remote_daemon::RemoteDaemonWorkEvidence::AuthoritativelyIdle;
         idle.active_jobs = 1;
         assert!(!local_recovery_zero_jobs_proven(&idle));
+    }
+
+    #[test]
+    fn authority_snapshot_shares_proven_zero_between_reconcile_and_local_recovery() {
+        let mut idle = remote_daemon_status(true, 0, "lease-live", 4242, None);
+        idle.work_evidence = remote_daemon::RemoteDaemonWorkEvidence::AuthoritativelyIdle;
+
+        let authority = remote_daemon::authority_snapshot(&idle);
+        assert!(authority.proven_idle);
+        assert!(authority.safe_to_rotate);
+        assert_eq!(
+            authority.source,
+            "remote daemon SSH status and typed /jobs probe"
+        );
+        assert!(local_recovery_zero_jobs_proven(&idle));
+        assert_eq!(
+            remote_daemon::authoritative_idle_lease_for_stale_generations(
+                &idle,
+                &["lease-stale".to_string()],
+            )
+            .expect("same snapshot accepts a stale persisted lease"),
+            Some("lease-live".to_string())
+        );
+    }
+
+    #[test]
+    fn concurrent_stale_generations_rebind_the_same_canonical_owner() {
+        let mut first = direct_ssh_session("lease-z");
+        first.controller_id = Some("controller-z".to_string());
+        let mut second = direct_ssh_session("lease-a");
+        second.controller_id = Some("controller-a".to_string());
+        let daemon = remote_daemon_status(true, 0, "lease-live", 4242, None)
+            .daemon
+            .expect("live daemon");
+
+        let forward = rebind_idle_generation_owner(
+            &[first.clone(), second.clone()],
+            &daemon,
+            "lease-live".to_string(),
+        )
+        .expect("canonical owner");
+        let reverse =
+            rebind_idle_generation_owner(&[second, first], &daemon, "lease-live".to_string())
+                .expect("canonical owner");
+
+        assert_eq!(forward.controller_id, Some("controller-a".to_string()));
+        assert_eq!(forward, reverse);
     }
 
     #[test]


### PR DESCRIPTION
Closes #12052

## Summary

- derive remote zero-job, active lease, and rotation safety from one authority snapshot shared by reconcile, status/doctor freshness, and local recovery
- accept the same remote-proven idle zero for local recovery and name controller-local versus remote authority in stale-lease recovery guidance
- choose a stable canonical owner when concurrent stale generations rebind

## Tests

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner authority_snapshot_shares_proven_zero_between_reconcile_and_local_recovery`
- `cargo test -p homeboy-lab-runner concurrent_stale_generations_rebind_the_same_canonical_owner`
- `cargo test -p homeboy-lab-runner failed_stop_recovery_uses_the_final_authoritative_lease_not_the_persisted_lease`
- `cargo test -p homeboy-lab-runner stale_persisted_lease_requires_explicit_live_lease_adoption`

`cargo test -p homeboy-lab-runner stop_transport_recovery::tests` had 17 passing tests and one existing fixture failure: `endpoint_reuse_after_identity_probe_never_receives_stop` could not authorize its SSH lifecycle mutation. A full crate run exceeded the two-minute bound and showed unrelated fixture failures.

AI assistance: OpenAI `openai/gpt-5.6-sol` via OpenCode was used to investigate, implement, and test this change. Chris Huber remains responsible for the final change.