### PR TITLE
Reset stale runner control-plane overrides

### DIFF
--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -413,7 +413,7 @@ impl RunnerCapabilitySnapshot {
             .into_iter()
             .map(|tool| {
                 let command = if tool.id() == "homeboy" {
-                    remote_runner_homeboy_path(runner, "runner capability preflight")?.to_string()
+                    effective_homeboy_command(runner, "runner capability preflight")?
                 } else {
                     RunnerToolRegistry::spec_for_required_tool(&tool)
                         .map(|spec| spec.command)
@@ -465,19 +465,15 @@ impl RunnerCapabilitySnapshot {
             .into_iter()
             .map(|tool| {
                 let command = if tool.id() == "homeboy" {
-                    runner
-                        .settings
-                        .homeboy_path
-                        .clone()
-                        .unwrap_or_else(|| "homeboy".to_string())
+                    effective_homeboy_command(runner, "runner capability preflight")?
                 } else {
                     RunnerToolRegistry::spec_for_required_tool(&tool)
                         .map(|spec| spec.command)
                         .unwrap_or_else(|| tool.id().to_string())
                 };
-                (tool, command)
+                Ok((tool, command))
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
         let command_names = normalized_command_names(&preflight.required_commands);
         let capability_probes = normalized_tool_capability_probes(preflight);
         let script = batch_probe_script(
@@ -521,6 +517,17 @@ impl RunnerCapabilitySnapshot {
         client.env.extend(runner.env.clone());
         Ok(client)
     }
+}
+
+fn effective_homeboy_command(runner: &Runner, context: &str) -> Result<String> {
+    runner
+        .env
+        .get("HOMEBOY_COMMAND")
+        .map(String::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .map(str::to_string)
+        .map(Ok)
+        .unwrap_or_else(|| remote_runner_homeboy_path(runner, context).map(str::to_string))
 }
 
 // `Clone` so one probe's answer can be handed to every caller that coalesced
@@ -903,6 +910,21 @@ mod tests {
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }
+    }
+
+    #[test]
+    fn capability_preflight_uses_injected_homeboy_command() {
+        let mut runner = ssh_runner();
+        runner.settings.homeboy_path = Some("/configured/homeboy".to_string());
+        runner.env.insert(
+            "HOMEBOY_COMMAND".to_string(),
+            "/injected/homeboy".to_string(),
+        );
+
+        assert_eq!(
+            effective_homeboy_command(&runner, "test").expect("effective command"),
+            "/injected/homeboy"
+        );
     }
 
     /// The probe gate collapses concurrent callers that share a fingerprint, so

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1551,7 +1551,11 @@ pub(super) fn preflight_runner_capability_plan(
         return Ok(());
     }
 
-    let capabilities = runner_capability_snapshot_for_preflight(runner, preflight)?;
+    // Probe the command and state authority that this job will receive, not
+    // merely the runner's persisted configuration.
+    let mut effective_runner = runner.clone();
+    effective_runner.env = request_env.clone();
+    let capabilities = runner_capability_snapshot_for_preflight(&effective_runner, preflight)?;
     validate_runner_capability_preflight(&runner.id, preflight, &capabilities, request_env)
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -2313,15 +2313,24 @@ fn refreshed_runner_env(
 ) -> Result<std::collections::HashMap<String, String>> {
     let runner = load(runner_id)?;
     let mut env = runner.env;
+    // A refreshed daemon must not inherit a prior generation's control-plane
+    // authority. The selected binary becomes the new command authority below.
+    env.remove("HOMEBOY_COMMAND");
+    env.remove("HOMEBOY_DAEMON_STATE_DIR");
     normalize_runner_command_env_for_homeboy_path(&mut env, Some(homeboy_path));
     Ok(env)
 }
 
 fn refreshed_runner_patch(runner_id: &str, homeboy_path: &str) -> Result<Value> {
-    let _ = runner_id;
-    Ok(serde_json::json!({
+    let env = refreshed_runner_env(runner_id, homeboy_path)?;
+    let mut patch = serde_json::json!({
         "homeboy_path": homeboy_path,
-    }))
+        "env": env,
+    });
+    // Config merge deletes null object fields. Include the deletion explicitly
+    // because omitted map keys retain their prior persisted values.
+    patch["env"]["HOMEBOY_DAEMON_STATE_DIR"] = Value::Null;
+    Ok(patch)
 }
 
 /// Persist a verified selection in the controller-owned runner registry.
@@ -2329,9 +2338,6 @@ fn refreshed_runner_patch(runner_id: &str, homeboy_path: &str) -> Result<Value> 
 /// the controller so subsequent jobs use the selected binary.
 fn promote_verified_runner_binary(runner_id: &str, homeboy_path: &str) -> Result<Vec<String>> {
     homeboy_core::config::with_config_lock(|| {
-        if load(runner_id)?.settings.homeboy_path.as_deref() == Some(homeboy_path) {
-            return Ok(Vec::new());
-        }
         let patch = refreshed_runner_patch(runner_id, homeboy_path)?;
         match merge(Some(runner_id), &patch.to_string(), &[])? {
             MergeOutput::Single(result) => Ok(result.updated_fields),

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -52,7 +52,7 @@ fn materialized_identity_requires_commit_and_matching_source_sha() {
 }
 
 #[test]
-fn refreshed_runner_env_prepends_selected_homeboy_dir_to_path() {
+fn refreshed_runner_env_replaces_stale_control_plane_overrides() {
     test_support::with_isolated_home(|_| {
         crate::create(
             r#"{
@@ -60,7 +60,12 @@ fn refreshed_runner_env_prepends_selected_homeboy_dir_to_path() {
                 "kind": "local",
                 "workspace_root": "/runner/ws",
                 "homeboy_path": "/old/homeboy",
-                "env": {"PATH": "/usr/bin:/bin", "RUST_LOG": "info"}
+                "env": {
+                    "PATH": "/usr/bin:/bin",
+                    "RUST_LOG": "info",
+                    "HOMEBOY_COMMAND": "/old/homeboy",
+                    "HOMEBOY_DAEMON_STATE_DIR": "/old/daemon-state"
+                }
             }"#,
             false,
         )
@@ -81,6 +86,19 @@ fn refreshed_runner_env_prepends_selected_homeboy_dir_to_path() {
             env.get("HOMEBOY_COMMAND").map(String::as_str),
             Some("/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy")
         );
+        assert_eq!(env.get("HOMEBOY_DAEMON_STATE_DIR"), None);
+
+        promote_verified_runner_binary(
+            "lab-local",
+            "/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy",
+        )
+        .expect("promote refreshed binary");
+        let offload_env = crate::effective_env("lab-local").expect("effective offload env");
+        assert_eq!(
+            offload_env.get("HOMEBOY_COMMAND").map(String::as_str),
+            Some("/runner/ws/_homeboy_binaries/homeboy-main/target/release/homeboy")
+        );
+        assert_eq!(offload_env.get("HOMEBOY_DAEMON_STATE_DIR"), None);
     });
 }
 


### PR DESCRIPTION
## Summary

- Refresh promotion replaces stale persisted command authority and explicitly removes stale daemon-state authority.
- Capability preflight resolves Homeboy from the effective injected job environment, matching the eventual Lab offload environment.
- Add regressions for stale environment -> refresh promotion -> effective offload environment and injected command preflight selection.

Closes #12053.

## Testing

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner refreshed_runner_env_replaces_stale_control_plane_overrides --quiet`
- `cargo test -p homeboy-lab-runner capabilities::tests --quiet`
- `cargo check -p homeboy-lab-runner`

## AI assistance

- **AI assistance:** Yes
- **Model:** openai/gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Diagnosed, filed, implemented, and verified this generic runner control-plane fix under Chris Huber's direction.