### PR TITLE
Preserve nested runner lifecycle records

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -37,15 +37,33 @@ impl HarvestExecutionContext {
     pub fn from_current_process() -> homeboy_core::Result<Self> {
         let source = std::env::var(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV).ok();
         let lab = std::env::var(homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV).ok();
-        Self::from_transport_values(source.as_deref(), lab.as_deref())
+        Self::from_transport_values_with_runner_execution(
+            source.as_deref(),
+            lab.as_deref(),
+            homeboy_core::resource_policy_context::has_lab_execution_provenance(),
+        )
     }
 
     fn from_transport_values(
         source: Option<&str>,
         lab: Option<&str>,
     ) -> homeboy_core::Result<Self> {
+        Self::from_transport_values_with_runner_execution(source, lab, false)
+    }
+
+    fn from_transport_values_with_runner_execution(
+        source: Option<&str>,
+        lab: Option<&str>,
+        runner_execution: bool,
+    ) -> homeboy_core::Result<Self> {
         match (source, lab) {
             (None, None) => Ok(Self::default()),
+            (Some(_), None) if runner_execution => {
+                // Generic runner exec owns this snapshot provenance. A nested
+                // local plan is not a Lab handoff and harvests its existing Git
+                // workspace normally; the outer run retains the snapshot.
+                Ok(Self::default())
+            }
             (Some(source), Some(lab)) if !source.trim().is_empty() && !lab.trim().is_empty() => {
                 let lab_offload = homeboy_core::observation::resolve_json_value(lab).ok_or_else(
                     || incomplete_transport_error("invalid Lab offload metadata".to_string()),
@@ -818,6 +836,18 @@ mod tests {
             "runner-a"
         );
         assert_eq!(context.lab_offload.expect("lab")["runner_id"], "runner-a");
+    }
+
+    #[test]
+    fn generic_runner_exec_snapshot_stays_with_the_outer_command() {
+        let context = HarvestExecutionContext::from_transport_values_with_runner_execution(
+            Some(r#"{"runner_id":"runner-a"}"#),
+            None,
+            true,
+        )
+        .expect("generic runner exec is not a Lab handoff");
+
+        assert!(!context.snapshot_signaled());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -103,6 +103,7 @@ where
             )?;
             return Err(error);
         }
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
         let harvest_context = match supplied_harvest_context.clone().map(Ok).unwrap_or_else(
             crate::agent_task_scheduler::HarvestExecutionContext::from_current_process,
         ) {
@@ -120,7 +121,6 @@ where
         if harvest_context.snapshot_signaled() {
             bind_runner_snapshot_workspace_attestations(&mut plan)?;
         }
-        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
         agent_task_lifecycle::mark_running(run_id)?;
         let aggregate = run_plan_with_scheduler(
             plan.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -601,6 +601,44 @@ fn lab_runner_handoff_materializes_the_run_before_preparation_failure() {
 }
 
 #[test]
+fn runner_exec_materializes_the_run_before_incomplete_harvest_transport_failure() {
+    with_isolated_home(|_| {
+        let source_env = homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV;
+        let lab_env = homeboy_core::observation::LAB_OFFLOAD_METADATA_ENV;
+        let previous_source = std::env::var_os(source_env);
+        let previous_lab = std::env::var_os(lab_env);
+        std::env::set_var(source_env, "{}");
+        std::env::remove_var(lab_env);
+
+        let error = run_loaded_plan(
+            test_plan(),
+            Some("runner-exec-incomplete-harvest-transport"),
+            SucceedingExecutor,
+        )
+        .expect_err("runner exec source metadata requires paired Lab transport");
+
+        match previous_source {
+            Some(value) => std::env::set_var(source_env, value),
+            None => std::env::remove_var(source_env),
+        }
+        match previous_lab {
+            Some(value) => std::env::set_var(lab_env, value),
+            None => std::env::remove_var(lab_env),
+        }
+
+        let record = lifecycle_status("runner-exec-incomplete-harvest-transport")
+            .expect("pre-execution failure remains inspectable");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("incomplete Lab snapshot transport"));
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "validate_harvest_transport"
+        );
+    });
+}
+
+#[test]
 fn submitted_terminal_runs_reuse_durable_evidence_without_reexecution() {
     with_isolated_home(|_| {
         for (run_id, expected_exit_code) in [("terminal-succeeded", 0), ("terminal-failed", 1)] {


### PR DESCRIPTION
## Summary

- scope generic runner-exec source snapshots to the outer command instead of treating them as an incomplete agent-task Lab handoff
- persist direct run-plan records before harvest transport validation so malformed transport remains inspectable
- cover both nested runner execution and genuine incomplete transport

Fixes #12051.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents generic_runner_exec_snapshot_stays_with_the_outer_command`
- `cargo test -p homeboy-agents runner_exec_materializes_the_run_before_incomplete_harvest_transport_failure`
- `cargo test -p homeboy-agents process_context_rejects_incomplete_lab_transport_before_scheduler_execution`
- Linux runner reproduction: built the patched `homeboy` binary inside a runner snapshot, then successfully executed nested `agent-task run-plan --placement local --record-run-id inner-12051-patched-linux-v2` under normal runner-injected source snapshot provenance

## Existing Gate Noise

- Full `cargo test -p homeboy-agents`: 1,673 passed; 16 existing parallel-state failures and 6 ignored
- Strict package Clippy reaches pre-existing `homeboy-core` warnings in `http_api.rs` and `notify_outbox.rs`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to trace the runner lifecycle, implement the ownership fix, add focused tests, and execute verification. Chris Huber remains responsible for every line.