### PR TITLE
Persist timed-out exact worktree resolution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3,7 +3,7 @@
 //! resolution. Pure move out of the former `agent_task_service.rs` god-file.
 
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -4950,12 +4950,24 @@ fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
 /// only after Cook's recipe and first run record exist, then persist that path
 /// before any provider can receive work.
 fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
-    let resolution =
-        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            &options.to_worktree,
-            &homeboy_core::defaults::load_config(),
-            None,
-        )?;
+    let provider_id = options
+        .initial_plan
+        .metadata
+        .pointer("/cook_provision/worktree_provider_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "worktree_provider",
+                "pending Cook workspace lookup is missing its timed-out provider identity",
+                Some(options.to_worktree.clone()),
+                None,
+            )
+        })?;
+    let resolution = homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_by_id_from_config(
+        &options.to_worktree,
+        provider_id,
+        &homeboy_core::defaults::load_config(),
+    )?;
     if resolution.worktree.handle != options.to_worktree {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
@@ -4969,6 +4981,7 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
     let target = std::fs::canonicalize(&target).map_err(|error| {
         Error::internal_io(error.to_string(), Some(target.display().to_string()))
     })?;
+    validate_pending_cook_repository_identity(&options.initial_plan, &target)?;
     for task in &mut options.initial_plan.tasks {
         task.workspace.root = Some(target.display().to_string());
         task.metadata["cook_workspace_identity"] =
@@ -4976,6 +4989,64 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
     }
     options.source_worktree_path = Some(target);
     agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
+}
+
+fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path) -> Result<()> {
+    let Some(expected) = plan
+        .metadata
+        .pointer("/cook_repository_identity/remote_identity")
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+    let Some(git_root) = homeboy_core::git::repo_root(target) else {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "Cook destination is not a Git checkout bound to the resolved repository identity",
+            Some(target.display().to_string()),
+            None,
+        ));
+    };
+    let identities = homeboy_core::git::output_optional(&git_root, &["remote"])
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|remote| homeboy_core::git::remote_url(&git_root, remote))
+        .filter_map(|remote| canonical_remote_identity(&remote))
+        .collect::<std::collections::BTreeSet<_>>();
+    if identities.len() == 1 && identities.contains(expected) {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "to_worktree",
+        format!("Cook destination repository identity does not match resolved `{expected}`"),
+        Some(target.display().to_string()),
+        None,
+    ))
+}
+
+fn canonical_remote_identity(remote_url: &str) -> Option<String> {
+    let remote_url = remote_url.trim();
+    let (host, path) = if let Some((_, rest)) = remote_url.split_once("://") {
+        let (authority, path) = rest.split_once('/')?;
+        (authority.rsplit('@').next()?, path)
+    } else {
+        let (authority, path) = remote_url.split_once(':')?;
+        (authority.rsplit('@').next()?, path)
+    };
+    let path = path.trim_matches('/').trim_end_matches(".git");
+    (!host.is_empty()
+        && path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .count()
+            >= 2)
+        .then(|| {
+            format!(
+                "git://{}/{}",
+                host.to_ascii_lowercase(),
+                path.to_ascii_lowercase()
+            )
+        })
 }
 
 /// The normal configured-provider preflight rejects every dirty destination. A

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2899,6 +2899,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -2906,6 +2907,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
         crate::agent_task_promotion::preflight_configured_workspace_provider(&options.to_worktree)?;
     }
     if cook_attempt_needs_execution(&options.initial_run_id)
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(options)?;
@@ -3218,6 +3220,7 @@ where
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -3298,6 +3301,7 @@ where
     // Its initial handoff has no controller-local source path to validate yet;
     // requiring one here turns an accepted detached retry into a local failure.
     if cook_attempt_needs_execution(&options.initial_run_id)
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(&options)?;
@@ -3331,6 +3335,29 @@ where
         .transpose()?;
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     materialize_initial_cook_attempt(&options)?;
+    if cook_workspace_lookup_pending(&options.initial_plan) {
+        if let Err(error) = materialize_pending_cook_workspace(&mut options) {
+            let error = with_pre_execution_phase(error, "worktree_provider_lookup");
+            record_pre_execution_failure(
+                &options.initial_plan,
+                &options.initial_run_id,
+                &error,
+                "worktree_provider_lookup",
+            )?;
+            return Ok(pre_execution_failure_report(
+                options.cook_id.clone(),
+                Vec::new(),
+                pre_execution_failure_details(
+                    agent_task_lifecycle::exact_record(&options.initial_run_id)
+                        .ok()
+                        .as_ref(),
+                    &error,
+                ),
+                error,
+                Some(&options.initial_run_id),
+            ));
+        }
+    }
     record_active_cook_worktree_warning(&options)?;
     // Durable identity now exists and resolves through the Cook alias. Publish
     // it before every remaining long controller phase — gate toolchain
@@ -3592,11 +3619,11 @@ where
                     attempt_limit,
                 );
             }
-            if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
-                validate_cook_workspace(&options)?;
-            }
             let mut failed_dispatch_plan = None;
             let execution = (|| {
+                if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
+                    validate_cook_workspace(&options)?;
+                }
                 homeboy_core::cleanup::admit_reconstructable_artifact_work(
                     plan.tasks
                         .iter()
@@ -4910,6 +4937,45 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
         ));
     }
     Ok(())
+}
+
+fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
+    plan.metadata
+        .pointer("/cook_provision/action")
+        .and_then(Value::as_str)
+        == Some("lookup_pending")
+}
+
+/// A pending lookup carries no provider path. Resolve the declared exact handle
+/// only after Cook's recipe and first run record exist, then persist that path
+/// before any provider can receive work.
+fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
+    let resolution =
+        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            &options.to_worktree,
+            &homeboy_core::defaults::load_config(),
+            None,
+        )?;
+    if resolution.worktree.handle != options.to_worktree {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree provider did not resolve the declared exact Cook handle",
+            Some(options.to_worktree.clone()),
+            None,
+        ));
+    }
+    let target = PathBuf::from(&resolution.worktree.path);
+    homeboy_core::worktree_providers::validate_task_worktree_root(&target, &options.to_worktree)?;
+    let target = std::fs::canonicalize(&target).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(target.display().to_string()))
+    })?;
+    for task in &mut options.initial_plan.tasks {
+        task.workspace.root = Some(target.display().to_string());
+        task.metadata["cook_workspace_identity"] =
+            crate::agent_task_workspace_identity::attest_workspace(&target)?;
+    }
+    options.source_worktree_path = Some(target);
+    agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
 }
 
 /// The normal configured-provider preflight rejects every dirty destination. A

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2953,6 +2953,7 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
             "action": "lookup_pending",
             "kind": "provider",
             "handle": options.to_worktree,
+            "worktree_provider_id": "fixture",
         });
         let exact_handle = options.to_worktree.clone();
 
@@ -3000,6 +3001,154 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
         let retry = agent_task_lifecycle::retry(run_id, Some("cook-slow-worktree-lookup-retry"))
             .expect("lookup timeout remains retryable");
         assert_eq!(retry.metadata["retry_of"], run_id);
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider tempdir");
+        let primary = temp.path().join("primary");
+        let original = temp.path().join("original");
+        let switched = temp.path().join("switched");
+        for args in [
+            vec![
+                "init",
+                "--initial-branch",
+                "main",
+                primary.to_str().expect("primary path"),
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "config",
+                "user.email",
+                "test@example.com",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "config",
+                "user.name",
+                "Test",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "worktree",
+                "add",
+                "-b",
+                "original",
+                original.to_str().expect("original path"),
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "worktree",
+                "add",
+                "-b",
+                "switched",
+                switched.to_str().expect("switched path"),
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .status()
+                .expect("git runs")
+                .success());
+        }
+        let marker = temp.path().join("provider-marker");
+        let original_provider = temp.path().join("original-provider");
+        let switched_provider = temp.path().join("switched-provider");
+        for (script, label, branch, path) in [
+            (&original_provider, "original", "original", &original),
+            (&switched_provider, "switched", "switched", &switched),
+        ] {
+            std::fs::write(
+                script,
+                format!(
+                    "#!/bin/sh\nprintf '%s' '{label}' > '{}'\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@provider-bound\",\"path\":\"{}\",\"branch\":\"{branch}\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                    marker.display(), path.display()
+                ),
+            )
+            .expect("write provider");
+            let mut permissions = std::fs::metadata(script)
+                .expect("provider metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(script, permissions).expect("make provider executable");
+        }
+        let provider_config =
+            |script: &std::path::Path| homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![script.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            };
+        // The timeout recipe predates the new provider. A re-selection would use
+        // `a-switched`; durable retry must invoke only `z-original`.
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "z-original".to_string(),
+            provider_config(&original_provider),
+        );
+        config.worktree_providers.insert(
+            "a-switched".to_string(),
+            provider_config(&switched_provider),
+        );
+        homeboy_core::defaults::save_config(&config).expect("save changed provider config");
+        let mut options = batch_cook_options(
+            "provider-bound",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending", "kind": "provider", "handle": options.to_worktree,
+            "worktree_provider_id": "z-original",
+        });
+
+        materialize_pending_cook_workspace(&mut options)
+            .expect("materialize original provider workspace");
+
+        assert_eq!(
+            std::fs::read_to_string(marker).expect("provider marker"),
+            "original"
+        );
+        assert_eq!(
+            options.source_worktree_path.as_deref(),
+            Some(original.as_path())
+        );
+        assert_eq!(
+            options.initial_plan.tasks[0].workspace.root.as_deref(),
+            original.to_str()
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3141,13 +3141,14 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
             std::fs::read_to_string(marker).expect("provider marker"),
             "original"
         );
+        let canonical_original = std::fs::canonicalize(&original).expect("canonical original");
         assert_eq!(
             options.source_worktree_path.as_deref(),
-            Some(original.as_path())
+            Some(canonical_original.as_path())
         );
         assert_eq!(
             options.initial_plan.tasks[0].workspace.root.as_deref(),
-            original.to_str()
+            canonical_original.to_str()
         );
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2894,6 +2894,115 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            "#!/bin/sh\nprintf '%s\\n' '{\"status\":\"failed\",\"error\":{\"code\":\"git_command_timeout\",\"access_token\":\"provider-secret-must-not-persist\"}}'\n",
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let cook_id = "cook-slow-worktree-lookup";
+        let run_id = "cook-slow-worktree-lookup-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        // Exercise normal local Cook: a retryable provider failure must retain
+        // the exact handle without persisting provider-owned diagnostics.
+        options.attempt_dispatcher = None;
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+        });
+        let exact_handle = options.to_worktree.clone();
+
+        let result = run_cook(options, UnusedExecutor).expect("Cook records lookup failure");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.cook_id, cook_id);
+        assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
+        assert_eq!(result.value.status, "pre_execution_failure");
+        let record = agent_task_lifecycle::status(run_id).expect("durable failed lookup");
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "worktree_provider_lookup"
+        );
+        assert_eq!(record.metadata["pre_execution_failure"]["retryable"], true);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["failure_classification"],
+            "transient"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_lookup"],
+            "timed_out"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["provider_timeout_attribution"],
+            serde_json::json!({ "error_code": "git_command_timeout" })
+        );
+        assert!(!record
+            .metadata
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
+        let recipe = super::super::load_recipe(cook_id).expect("durable Cook identity");
+        assert_eq!(recipe.attempts[0].run_id, run_id);
+        let persisted_plan = agent_task_lifecycle::load_plan(run_id).expect("durable lookup plan");
+        assert_eq!(
+            persisted_plan.metadata["cook_provision"]["handle"],
+            exact_handle
+        );
+        assert_eq!(persisted_plan.tasks[0].workspace.root, None);
+        assert!(persisted_plan.tasks[0]
+            .metadata
+            .get("cook_workspace_identity")
+            .is_none());
+        let retry = agent_task_lifecycle::retry(run_id, Some("cook-slow-worktree-lookup-retry"))
+            .expect("lookup timeout remains retryable");
+        assert_eq!(retry.metadata["retry_of"], run_id);
+    });
+}
+
 #[test]
 fn active_cooks_on_the_same_canonical_worktree_record_a_nonblocking_warning() {
     homeboy_core::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -700,11 +700,22 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         {
             // The lookup is bounded, but a timeout says nothing about whether
             // this exact handle exists. Carry only the declared handle into
-            // Cook; durable materialization retries the same exact lookup.
+            // Cook; durable materialization retries the same exact provider.
+            let provider_id = error
+                .details
+                .get("worktree_provider_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    homeboy::core::Error::internal_unexpected(
+                        "timed-out worktree provider lookup omitted its provider identity"
+                            .to_string(),
+                    )
+                })?;
             return Ok(serde_json::json!({
                 "action": "lookup_pending",
                 "kind": "provider",
                 "handle": to_worktree,
+                "worktree_provider_id": provider_id,
             }));
         }
         Err(error) => return Err(error),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -691,6 +691,22 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                 .get("worktree_provider_lookup")
                 .and_then(Value::as_str)
                 == Some("not_found") => {}
+        Err(error)
+            if error
+                .details
+                .get("worktree_provider_lookup")
+                .and_then(Value::as_str)
+                == Some("timed_out") =>
+        {
+            // The lookup is bounded, but a timeout says nothing about whether
+            // this exact handle exists. Carry only the declared handle into
+            // Cook; durable materialization retries the same exact lookup.
+            return Ok(serde_json::json!({
+                "action": "lookup_pending",
+                "kind": "provider",
+                "handle": to_worktree,
+            }));
+        }
         Err(error) => return Err(error),
     }
 
@@ -1747,29 +1763,24 @@ pub(crate) fn compile_cook_plan(
     args: &AgentTaskCookArgs,
     provision: Value,
 ) -> homeboy::core::Result<AgentTaskPlan> {
+    let pending_lookup = provision.get("action").and_then(Value::as_str) == Some("lookup_pending");
     let workspace = provision
         .get("path")
         .and_then(Value::as_str)
-        .ok_or_else(|| {
-            homeboy::core::Error::internal_unexpected(
-                "Cook destination provisioning did not return a task worktree path".to_string(),
-            )
-        })?
-        .to_string();
+        .map(str::to_string);
+    if workspace.is_none() && !pending_lookup {
+        return Err(homeboy::core::Error::internal_unexpected(
+            "Cook destination provisioning did not return a task worktree path".to_string(),
+        ));
+    }
     let mut dispatch = dispatch_args_for_cook(args);
     // Cook providers always receive the declared task checkout. `--cwd` is a
     // dispatch input, never authority to replace the writable Cook workspace.
     dispatch.cwd = None;
-    dispatch.workspace = Some(workspace);
-    validate_cook_destination_identity(
-        args,
-        Path::new(
-            dispatch
-                .workspace
-                .as_deref()
-                .expect("Cook workspace is set"),
-        ),
-    )?;
+    dispatch.workspace = workspace.clone();
+    if let Some(workspace) = workspace.as_deref() {
+        validate_cook_destination_identity(args, Path::new(workspace))?;
+    }
     let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
     let mut plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
         Ok(plan) => plan,
@@ -1793,6 +1804,9 @@ pub(crate) fn compile_cook_plan(
         plan.metadata["cook_repository_identity"] = identity.clone();
     }
     for task in &mut plan.tasks {
+        if pending_lookup {
+            continue;
+        }
         let root = task.workspace.root.as_deref().ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
                 "workspace",

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1146,7 +1146,7 @@ fn run_provider_lookup_command(
     })?;
     let elapsed_ms = started.elapsed().as_millis();
     if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
-        return Err(Error::validation_invalid_argument(
+        let mut error = Error::validation_invalid_argument(
             "to_worktree",
             format!(
                 "worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured lookup_timeout_ms: {})",
@@ -1157,7 +1157,16 @@ fn run_provider_lookup_command(
                 "Refresh or repair the configured workspace provider, then retry the operation."
                     .to_string(),
             ]),
-        ));
+        );
+        // A bounded read-only probe cannot establish that an exact handle is
+        // invalid. Preserve that distinction for durable callers instead of
+        // turning provider latency into an input error.
+        error.retryable = Some(true);
+        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+        error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+        error.details["lookup_timeout_ms"] = Value::from(timeout.as_millis() as u64);
+        return Err(error);
     }
     let output = output.output;
     if output.capture.stdout.truncated {
@@ -1207,6 +1216,28 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
+    if let Some(attribution) = provider_failed_lookup_timeout_attribution(&value) {
+        let mut error = Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command completed with a retryable git command timeout"
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![
+                "Refresh or repair the configured workspace provider, then retry the operation."
+                    .to_string(),
+            ]),
+        );
+        error.retryable = Some(true);
+        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+        error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+        // Provider output can contain credentials and arbitrary diagnostics.
+        // Persist only this fixed, redacted timeout classification.
+        error.details["provider_timeout_attribution"] =
+            serde_json::to_value(attribution).expect("fixed timeout attribution serializes");
+        return Err(error);
+    }
     let mapping = provider.list_result_mapping.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "worktree_providers.list_result_mapping",
@@ -1218,6 +1249,28 @@ fn run_provider_lookup_command(
         )
     })?;
     map_provider_list_result(provider_id, mapping, &value)
+}
+
+#[derive(Serialize)]
+struct ProviderLookupTimeoutAttribution {
+    error_code: &'static str,
+}
+
+/// A command can finish successfully while its provider reports a failed lookup.
+/// Treat only this explicit failure envelope as retryable; payload metadata is
+/// provider-owned data rather than a causal error signal.
+fn provider_failed_lookup_timeout_attribution(
+    value: &Value,
+) -> Option<ProviderLookupTimeoutAttribution> {
+    let failed = matches!(
+        value.get("status").and_then(Value::as_str),
+        Some("failed" | "error")
+    );
+    let timed_out =
+        value.pointer("/error/code").and_then(Value::as_str) == Some("git_command_timeout");
+    (failed && timed_out).then_some(ProviderLookupTimeoutAttribution {
+        error_code: "git_command_timeout",
+    })
 }
 
 fn provider_lookup_timeout(provider: &WorktreeProviderConfig) -> Result<Duration> {
@@ -3541,6 +3594,82 @@ mod tests {
 
         assert!(error.message.contains("timed out"));
         assert!(error.message.contains("configured lookup_timeout_ms: 25"));
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
+        assert_eq!(error.details["worktree_provider_operation"], "list");
+    }
+
+    #[test]
+    fn failed_provider_timeout_envelope_is_retryable_and_redacted() {
+        let script = fake_list_provider_script(json!({
+            "status": "failed",
+            "error": {
+                "code": "git_command_timeout",
+                "access_token": "provider-secret-must-not-persist"
+            }
+        }));
+        let error = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![script, "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect_err("explicit failed timeout remains retryable");
+
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
+        assert_eq!(error.details["worktree_provider_operation"], "resolve");
+        assert_eq!(
+            error.details["provider_timeout_attribution"],
+            json!({ "error_code": "git_command_timeout" })
+        );
+        assert!(!error
+            .details
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
+    }
+
+    #[test]
+    fn successful_payload_timeout_metadata_does_not_classify_a_timeout() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(json!({
+            "status": "completed",
+            "metadata": { "error": { "code": "git_command_timeout" } },
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }]
+        }));
+        let resolved = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![script, "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect("successful payload metadata is not an error envelope");
+
+        assert_eq!(resolved.handle, "fixture@cook-target");
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -360,6 +360,58 @@ pub fn resolve_apply_enabled_worktree_provider_from_config(
     )
 }
 
+/// Resolve a workspace through one previously selected apply-enabled provider.
+/// Durable callers use this when the provider identity is part of their recipe.
+pub fn resolve_apply_enabled_worktree_provider_by_id_from_config(
+    handle: &str,
+    provider_id: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
+    let provider = config.worktree_providers.get(provider_id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "worktree_provider",
+            "timed-out worktree provider is no longer configured",
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    if !provider.enabled || !provider.apply_enabled {
+        return Err(Error::validation_invalid_argument(
+            "worktree_provider",
+            "timed-out worktree provider is no longer enabled and apply-enabled",
+            Some(provider_id.to_string()),
+            None,
+        ));
+    }
+    let worktrees = if let Some(command) = provider.commands.resolve.as_ref() {
+        run_provider_resolve_command(provider_id, provider, command, handle)?
+    } else if let Some(command) = provider.commands.list.as_ref() {
+        run_provider_list_command(provider_id, provider, command)?
+    } else {
+        return Err(Error::validation_invalid_argument(
+            "worktree_provider",
+            "timed-out worktree provider has no resolve or list command",
+            Some(provider_id.to_string()),
+            None,
+        ));
+    };
+    let worktree = worktrees.into_iter().find(|item| item.handle == handle).ok_or_else(|| {
+        let mut error = Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree handle `{handle}` was not returned by timed-out provider `{provider_id}`"),
+            Some(handle.to_string()),
+            None,
+        );
+        error.details["worktree_provider_lookup"] = Value::String("not_found".to_string());
+        error
+    })?;
+    validate_provider_handle(provider_id, &worktree, None, None)?;
+    Ok(WorktreeProviderResolution {
+        provider_id: provider_id.to_string(),
+        worktree,
+    })
+}
+
 /// Find the sole apply-enabled provider worktree owned by a tracker URL.
 /// Providers must map `task_url` to participate, preserving existing provider
 /// configurations that only support handle-based lookup.


### PR DESCRIPTION
## Summary

- classify bounded exact-handle provider timeouts as retryable lookup state rather than invalid input
- materialize Cook identity before retrying deferred exact resolution
- retain fail-closed workspace attestation and never select a fallback workspace
- persist only bounded redacted timeout attribution from provider error envelopes

Fixes #11372.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- `cargo test -p homeboy-agents cook_persists_only_redacted_failed_provider_timeout_attribution --lib`
- `cargo test -p homeboy-core provider_timeout --lib`

## AI assistance

GPT-5.6-sol via OpenCode coordinated parallel implementation and review; OpenCode general coding subagents reproduced the resolver boundary, implemented durable deferred lookup, and audited exact-handle safety and secret redaction. Chris Huber reviewed and remains responsible for every line.