### PR TITLE
Preserve admitted Lab routing decisions

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -325,6 +325,11 @@ pub fn route_after_parse_with_provenance(
     // durable record (#11597, #11599) and how an explicitly local run acquired
     // a Lab handoff it could not later recover (#11600).
     let route_runner_id = generic_route_runner_id(cli, lab_command.as_ref(), &inferred_runner_id);
+    if lab_command.is_none()
+        || (route_runner_id.is_none() && cli.placement != homeboy::cli_surface::Placement::Lab)
+    {
+        return Ok(None);
+    }
     let run_handoff = if lab_command.is_some() && route_runner_id.is_some() {
         materialize_agent_task_run_handoff(cli, &normalized_args)?
     } else {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -177,24 +177,30 @@ pub fn route_after_parse_with_provenance(
     let lab_command = lab_offload_command(&cli.command)?;
     let normalized_args = inline_portable_settings_profiles(cli, normalized_args)?;
 
-    // Keep the readiness verdict, not just the selected id: when no runner is
-    // eligible the reasons and remediation commands are the only thing that can
-    // explain a local fallback to the operator.
-    let mut lab_readiness = if lab_command.is_some() && cli.runner.is_none() {
-        runners::lab_runner_readiness().ok()
-    } else {
-        None
-    };
+    // Reuse the admission snapshot when preflight captured one. A second
+    // readiness lookup could otherwise turn an admitted Lab attempt into a
+    // local fallback before routing constructs its immutable decision.
+    let admitted_lab_runner = admitted_lab_runner_id(cli, lab_command.as_ref());
+    let mut lab_readiness =
+        if lab_command.is_some() && cli.runner.is_none() && admitted_lab_runner.is_none() {
+            runners::lab_runner_readiness().ok()
+        } else {
+            None
+        };
     let mut inferred_runner_id = if lab_command.is_some() {
-        cli.runner.clone().or_else(|| {
-            lab_readiness
-                .as_ref()
-                .and_then(|readiness| readiness.selected_runner_id.clone())
-        })
+        cli.runner
+            .clone()
+            .or_else(|| admitted_lab_runner.clone().flatten())
+            .or_else(|| {
+                lab_readiness
+                    .as_ref()
+                    .and_then(|readiness| readiness.selected_runner_id.clone())
+            })
     } else {
         None
     };
-    if inferred_runner_id.is_none() && detached_cook_can_queue(cli) {
+    if inferred_runner_id.is_none() && admitted_lab_runner.is_none() && detached_cook_can_queue(cli)
+    {
         // The first readiness observation is intentionally non-mutating. Before
         // refusing a hot-machine Cook, reconcile the live Lab inventory: a
         // terminal runner job may have freed capacity since that observation.
@@ -567,6 +573,19 @@ pub fn route_after_parse_with_provenance(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+/// Return the Lab choice made by resource admission. `Some(None)` is an
+/// intentional no-runner decision and must retain normal local fallback.
+fn admitted_lab_runner_id(
+    cli: &Cli,
+    lab_command: Option<&runners::LabOffloadCommand>,
+) -> Option<Option<String>> {
+    (lab_command.is_some() && cli.runner.is_none())
+        .then(resource_policy::captured_context)
+        .flatten()
+        .filter(|context| !context.local_override)
+        .map(|context| context.runner_selection.runner_id)
 }
 
 /// The runner the *generic* Lab route may use, given what the command's

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -644,6 +644,55 @@ fn default_placement_provider_discovery_stays_local_despite_connected_default_ru
 }
 
 #[test]
+fn route_reuses_the_admitted_lab_runner_without_a_second_readiness_lookup() {
+    homeboy::core::resource_policy_context::reset_captured_context_for_test();
+    homeboy::core::resource_policy_context::capture_context(
+        homeboy::core::resource_policy_context::ResourcePolicyContext {
+            command: "review lint".to_string(),
+            severity: "hot".to_string(),
+            local_override: false,
+            warned: true,
+            message: None,
+            runner_selection:
+                homeboy::core::resource_policy_context::ResourcePolicyRunnerSelection {
+                    runner_id: Some("admitted-lab".to_string()),
+                    available_runner_ids: vec!["admitted-lab".to_string()],
+                    readiness_state: "connected_ready".to_string(),
+                    readiness_reasons: Vec::new(),
+                    remediation_commands: Vec::new(),
+                    reason: "default_lab_runner".to_string(),
+                },
+            host: homeboy::core::resource_policy_context::ResourcePolicyHostSnapshot {
+                load_severity: "hot".to_string(),
+                load_one: None,
+                load_five: None,
+                load_fifteen: None,
+                cpu_count: 1,
+                memory_severity: None,
+                memory_used_percent: None,
+                memory_available_mb: None,
+                memory_total_mb: None,
+                relevant_process_count: 0,
+                process_severity: "ok".to_string(),
+                active_rig_lease_count: 0,
+                rig_lease_severity: "ok".to_string(),
+                rig_lease_concurrency_limit: None,
+            },
+        },
+    );
+    let cli = Cli::parse_from(["homeboy", "review", "lint", "--path", "."]);
+    let command = lab_offload_command(&cli.command)
+        .expect("Lab route contract resolves")
+        .expect("review lint is portable");
+
+    assert_eq!(
+        admitted_lab_runner_id(&cli, Some(&command)),
+        Some(Some("admitted-lab".to_string()))
+    );
+    homeboy::core::resource_policy_context::reset_captured_context_for_test();
+}
+
+#[test]
 fn agent_task_controller_run_from_spec_supports_lab_placement_runner_routing() {
     let cli = Cli::parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary

- carry the preflight-selected Lab runner through routing instead of re-reading readiness
- preserve an intentional no-runner admission decision
- prevent runner readiness races from silently changing an admitted Lab route to local execution
- retain explicit local placement and pinned-runner precedence

Fixes #7740.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli route_reuses_the_admitted_lab_runner_without_a_second_readiness_lookup --lib`
- `cargo test -p homeboy-cli explicit_lab_placement_still_reaches_the_default_runner --lib`
- `cargo check -p homeboy-cli`

## AI assistance

GPT-5.6-sol via OpenCode coordinated parallel implementation and review; OpenCode general coding subagents traced placement TOCTOU behavior, removed duplicated retry scope, and verified explicit placement precedence. Chris Huber reviewed and remains responsible for every line.