### PR TITLE
fix(cleanup): omit continuation after convergence

### DIFF
--- a/crates/contracts/homeboy-command-contract/src/cleanup.rs
+++ b/crates/contracts/homeboy-command-contract/src/cleanup.rs
@@ -141,8 +141,13 @@ pub struct CleanupArtifactsArgs {
     /// Sort artifact candidates before reporting or applying cleanup.
     #[arg(long, value_enum, default_value = "discovery")]
     pub sort: CleanupArtifactsSortArg,
-    /// Limit artifact candidates reported or removed after sorting.
-    #[arg(long, value_name = "N")]
+    /// Limit artifact candidates reported or removed after sorting. A positive
+    /// limit ensures a continuation always makes progress.
+    #[arg(
+        long,
+        value_name = "N",
+        value_parser = parse_positive_usize
+    )]
     pub limit: Option<usize>,
     /// Only reclaim artifacts from worktrees whose branch is already merged
     /// into its upstream. Preserves in-progress cooks' build dirs.
@@ -164,6 +169,15 @@ pub enum CleanupArtifactsSortArg {
     #[default]
     Discovery,
     Size,
+}
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let limit = value.parse::<usize>().map_err(|error| error.to_string())?;
+    if limit == 0 {
+        Err("must be at least 1".to_string())
+    } else {
+        Ok(limit)
+    }
 }
 
 #[derive(Args, Debug, PartialEq, Eq)]
@@ -361,6 +375,23 @@ mod tests {
         };
         assert_eq!(args.limit, 3);
         assert_eq!(args.cursor.as_deref(), Some("prior-reference"));
+    }
+
+    #[test]
+    fn artifact_cleanup_rejects_zero_limit_before_emitting_a_continuation() {
+        let error = match CleanupParserTest::try_parse_from([
+            "cleanup",
+            "artifacts",
+            "--limit",
+            "0",
+            "--apply",
+        ]) {
+            Ok(_) => panic!("zero would produce a non-progressing continuation"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(error.to_string().contains("must be at least 1"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -3085,21 +3085,11 @@ pub(crate) fn render_artifact_cleanup_summary(payload: &Value) -> Option<String>
         );
     }
 
-    let next = if mode == "apply" {
-        format!("homeboy cleanup artifacts --path {}", quote_arg(root))
+    if let Some(next) = payload.get("next_command").and_then(Value::as_str) {
+        lines.push(format!("Next safe command: {next}"));
     } else {
-        payload
-            .get("next_command")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| {
-                format!(
-                    "homeboy cleanup artifacts --path {} --apply",
-                    quote_arg(root)
-                )
-            })
-    };
-    lines.push(format!("Next safe command: {next}"));
+        lines.push("Cleanup complete: no eligible candidates remain.".to_string());
+    }
     lines.push(String::new());
 
     Some(lines.join("\n"))
@@ -4799,9 +4789,32 @@ mod tests {
         assert!(summary.contains("Mode: apply\n"));
         assert!(summary.contains("Remaining candidates: 0\n"));
         assert!(summary.contains("Reclaimed: 3.0 KiB\n"));
-        assert!(
-            summary.contains("Next safe command: homeboy cleanup artifacts --path /tmp/homeboy\n")
-        );
+        assert!(summary.contains("Cleanup complete: no eligible candidates remain.\n"));
+        assert!(!summary.contains("Next safe command:"));
+    }
+
+    #[test]
+    fn cleanup_artifacts_summary_keeps_bounded_continuation() {
+        let payload = json!({
+            "command": "cleanup.artifacts",
+            "mode": "apply",
+            "root": "/tmp/homeboy",
+            "candidate_count": 2,
+            "skipped_count": 0,
+            "applied_count": 2,
+            "remaining_count": 1,
+            "estimated_bytes": 4096,
+            "reclaimed_bytes": 3072,
+            "next_command": "homeboy cleanup artifacts --path /tmp/homeboy --limit 2 --apply",
+            "skipped": []
+        });
+
+        let summary = render_artifact_cleanup_summary(&payload).expect("summary");
+
+        assert!(summary.contains("Remaining candidates: 1\n"));
+        assert!(summary.contains(
+            "Next safe command: homeboy cleanup artifacts --path /tmp/homeboy --limit 2 --apply\n"
+        ));
     }
 
     #[test]

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -316,8 +316,9 @@ pub struct ArtifactCleanupOutput {
     /// are what an operator watching free space actually gets back.
     pub estimated_allocated_bytes: u64,
     pub reclaimed_allocated_bytes: u64,
-    /// Replays the reviewed cleanup scope with mutation explicitly enabled.
-    pub next_command: String,
+    /// Replays the reviewed cleanup scope while eligible artifacts remain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_command: Option<String>,
     pub summary: ArtifactCleanupSummary,
     pub worktrees: Vec<ArtifactCleanupWorktreeSummary>,
     pub candidates: Vec<ArtifactCleanupCandidate>,
@@ -891,7 +892,8 @@ fn cleanup_artifacts_in_worktrees(
     candidates
         .retain(|candidate| seen_artifacts.insert(canonical_or_owned(Path::new(&candidate.path))));
 
-    order_and_limit_candidates(&mut candidates, options.sort, options.limit);
+    let bounded_candidates =
+        order_and_limit_candidates(&mut candidates, options.sort, options.limit);
 
     let cleanup_run = options
         .apply
@@ -928,6 +930,10 @@ fn cleanup_artifacts_in_worktrees(
     let failure_count = failed.len();
     let (remaining_count, remaining_candidate_bytes) =
         remaining_candidate_totals(&candidates, options.apply);
+    let (bounded_remaining_count, bounded_remaining_bytes) =
+        remaining_candidate_totals(&bounded_candidates, false);
+    let remaining_count = remaining_count + bounded_remaining_count;
+    let remaining_candidate_bytes = remaining_candidate_bytes + bounded_remaining_bytes;
     let summary = cleanup_summary(
         &root,
         options.apply,
@@ -951,7 +957,7 @@ fn cleanup_artifacts_in_worktrees(
         reclaimed_bytes,
         estimated_allocated_bytes,
         reclaimed_allocated_bytes,
-        next_command: artifact_cleanup_apply_command(options),
+        next_command: (remaining_count > 0).then(|| artifact_cleanup_apply_command(options)),
         summary,
         worktrees: worktree_rows,
         candidates,
@@ -1102,7 +1108,7 @@ fn order_and_limit_candidates(
     candidates: &mut Vec<ArtifactCleanupCandidate>,
     sort: ArtifactCleanupSort,
     limit: Option<usize>,
-) {
+) -> Vec<ArtifactCleanupCandidate> {
     if sort == ArtifactCleanupSort::Size {
         candidates.sort_by(|left, right| {
             right
@@ -1117,9 +1123,10 @@ fn order_and_limit_candidates(
         });
     }
 
-    if let Some(limit) = limit {
-        candidates.truncate(limit);
-    }
+    limit
+        .filter(|&limit| candidates.len() > limit)
+        .map(|limit| candidates.split_off(limit))
+        .unwrap_or_default()
 }
 
 fn cleanup_summary(
@@ -2777,6 +2784,32 @@ mod tests {
     }
 
     #[test]
+    fn zero_candidate_dry_run_omits_continuation() {
+        let repo = git_repo();
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: false,
+            self_artifacts: false,
+            temp_roots: Vec::new(),
+            sort: ArtifactCleanupSort::Discovery,
+            limit: None,
+            merged_only: false,
+            min_age_days: None,
+            include_active_worktrees: false,
+        })
+        .expect("dry-run cleanup");
+
+        assert_eq!(output.candidate_count, 0);
+        assert_eq!(output.remaining_count, 0);
+        assert!(output.next_command.is_none());
+        assert!(serde_json::to_value(output)
+            .expect("serialize output")
+            .get("next_command")
+            .is_none());
+    }
+
+    #[test]
     fn dry_run_reports_artifact_candidates_across_worktrees() {
         let repo = git_repo();
         let sibling_parent = TempDir::new().expect("sibling parent");
@@ -2880,6 +2913,8 @@ mod tests {
         assert_eq!(paths, vec!["node_modules", "dist"]);
         assert_eq!(output.candidate_count, 2);
         assert_eq!(output.applied_count, 2);
+        assert_eq!(output.remaining_count, 1);
+        assert!(output.next_command.is_some());
         assert!(!repo.path().join("node_modules").exists());
         assert!(!repo.path().join("dist").exists());
         assert!(repo.path().join("target/debug/app").exists());
@@ -2906,6 +2941,8 @@ mod tests {
 
         assert_eq!(output.mode, "apply");
         assert_eq!(output.applied_count, 1);
+        assert_eq!(output.remaining_count, 0);
+        assert!(output.next_command.is_none());
         assert!(!repo.path().join("target").exists());
         assert_eq!(
             fs::read_to_string(repo.path().join("src/lib.rs")).expect("read source"),
@@ -3279,6 +3316,8 @@ mod tests {
         assert!(output.skipped.iter().any(|row| {
             row.relative_path == "target" && row.reason.contains("not merged into its upstream")
         }));
+        assert_eq!(output.remaining_count, 0);
+        assert!(output.next_command.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- omit artifact cleanup continuation commands once no eligible candidates remain
- retain bounded candidates in post-apply remaining totals so partial cleanup continues accurately
- render an explicit completion message in human output

Closes #12073

## Test evidence
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/manual-opencode-homeboy-fixes cargo test -p homeboy-cli cleanup_artifacts_`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/manual-opencode-homeboy-fixes cargo test -p homeboy-core apply_removes_declared_artifacts_only_and_preserves_dirty_source`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/manual-opencode-homeboy-fixes cargo test -p homeboy-core limit_applies_after_size_sort_and_removes_only_selected_artifacts`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/manual-opencode-homeboy-fixes cargo test -p homeboy-core merged_only_preserves_unmerged_worktree_target`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/manual-opencode-homeboy-fixes cargo fmt --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to implement and verify the change; Chris Huber remains responsible.