### PR TITLE
fix(cleanup): reclaim local Cargo target caches

### DIFF
--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -57,7 +57,8 @@ use self_artifacts::{homeboy_source_checkout, self_temp_artifact_candidates};
 
 const ARTIFACT_DIR_REMOVE_ATTEMPTS: usize = 3;
 const ARTIFACT_DIR_REMOVE_RETRY_DELAY: Duration = Duration::from_millis(50);
-const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] = &[("target", "rust_target")];
+const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] =
+    &[("target", "rust_target"), (".cargo-target", "rust_target")];
 const SECONDS_PER_DAY: u64 = 86_400;
 const AUTOMATIC_ARTIFACT_AGE_POLICY: u64 = u64::MAX;
 
@@ -520,26 +521,30 @@ impl ActiveWorktrees {
     }
 }
 
-/// Whether a Cargo build currently owns `worktree`'s target directory.
+/// Whether a Cargo build currently owns one of `worktree`'s target directories.
 ///
-/// Cargo holds an exclusive advisory lock on `target/<profile>/.cargo-lock` for
-/// the duration of a build and releases it on completion, so probing that lock
-/// answers "is something building here right now" for ANY checkout — managed,
-/// unmanaged, or mid-rebase. Registry state cannot: it only describes checkouts
-/// Homeboy created (#9481).
+/// Cargo holds an exclusive advisory lock on `<target>/<profile>/.cargo-lock`
+/// for the duration of a build and releases it on completion, so probing every
+/// declared local Rust target answers "is something building here right now" for
+/// ANY checkout — managed, unmanaged, or mid-rebase. Registry state cannot: it
+/// only describes checkouts Homeboy created (#9481).
 ///
 /// Deliberately fail-open. An unreadable or absent lock means "no evidence of a
 /// build", never "definitely safe to delete" — the registry and age gates still
 /// apply on top of this.
 fn cargo_build_lock_is_held(worktree: &Path) -> bool {
-    let target = worktree.join("target");
-    let Ok(entries) = fs::read_dir(&target) else {
-        return false;
-    };
-    entries
-        .flatten()
-        .map(|entry| entry.path().join(".cargo-lock"))
-        .any(|lock| path_lock_is_held(&lock))
+    BUILTIN_ARTIFACT_PATHS
+        .iter()
+        .filter(|(_, kind)| *kind == "rust_target")
+        .any(|(relative_path, _)| {
+            fs::read_dir(worktree.join(relative_path))
+                .ok()
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|entry| entry.path().join(".cargo-lock"))
+                .any(|lock| path_lock_is_held(&lock))
+        })
 }
 
 /// Probe one advisory lock without blocking.
@@ -1912,6 +1917,18 @@ mod tests {
             assert!(cargo_build_lock_is_held(dir.path()));
         }
 
+        #[test]
+        fn a_held_cargo_target_lock_is_an_active_build() {
+            let dir = tempfile::tempdir().expect("worktree");
+            let profile = dir.path().join(".cargo-target/debug");
+            std::fs::create_dir_all(&profile).expect("Cargo target profile dir");
+            let lock = profile.join(".cargo-lock");
+            std::fs::write(&lock, b"").expect("Cargo lock");
+            let _held = hold(&lock);
+
+            assert!(cargo_build_lock_is_held(dir.path()));
+        }
+
         /// Releasing must clear the signal, or a finished build would pin the
         /// target as undeletable forever.
         #[test]
@@ -2066,7 +2083,7 @@ mod tests {
 
             let declarations = artifact_declarations(tmp.path()).expect("declarations");
 
-            assert_eq!(declarations.len(), 1);
+            assert_eq!(declarations.len(), 2);
             assert_eq!(declarations[0].relative_path, "target");
             assert_eq!(declarations[0].kind, "rust_target");
             assert_eq!(
@@ -2076,6 +2093,8 @@ mod tests {
             assert_eq!(declarations[0].category, LEGACY_ARTIFACT_CATEGORY);
             assert!(declarations[0].reconstructable);
             assert!(declarations[0].liveness_protected);
+            assert_eq!(declarations[1].relative_path, ".cargo-target");
+            assert_eq!(declarations[1].kind, "rust_target");
         });
     }
 
@@ -2145,6 +2164,79 @@ mod tests {
             fs::read_to_string(repo.path().join("src/lib.rs")).expect("source remains"),
             "changed source"
         );
+    }
+
+    #[test]
+    fn artifact_cleanup_reclaims_idle_cargo_target_alongside_target() {
+        let repo = repo_with_ignored_artifacts();
+        write_file(&repo.path().join("target/debug/app"), "target artifact");
+        write_file(
+            &repo.path().join(".cargo-target/debug/app"),
+            "Cargo target artifact",
+        );
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            ..Default::default()
+        })
+        .expect("cleanup idle Cargo targets");
+
+        assert_eq!(output.applied_count, 2);
+        assert!(!repo.path().join("target").exists());
+        assert!(!repo.path().join(".cargo-target").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn artifact_cleanup_keeps_cargo_target_with_active_cargo_lock() {
+        use std::os::unix::io::AsRawFd;
+
+        let repo = repo_with_ignored_artifacts();
+        let lock_path = repo.path().join(".cargo-target/debug/.cargo-lock");
+        write_file(&lock_path, "");
+        let lock = fs::File::open(&lock_path).expect("open Cargo lock");
+        assert_eq!(
+            unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0,
+            "test must hold the Cargo lock"
+        );
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            ..Default::default()
+        })
+        .expect("cleanup active Cargo target");
+
+        assert_eq!(output.applied_count, 0);
+        assert!(repo.path().join(".cargo-target").exists());
+        assert!(output
+            .skipped
+            .iter()
+            .any(|row| row.relative_path == ".cargo-target" && row.reason.contains("active")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn artifact_cleanup_unlinks_cargo_target_symlink_without_following_it() {
+        let repo = repo_with_ignored_artifacts();
+        let external = TempDir::new().expect("external artifact");
+        write_file(&external.path().join("debug/app"), "external artifact");
+        std::os::unix::fs::symlink(external.path(), repo.path().join(".cargo-target"))
+            .expect("link external artifact");
+        write_file(&repo.path().join(".git/info/exclude"), "/.cargo-target\n");
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+            ..Default::default()
+        })
+        .expect("cleanup Cargo target symlink");
+
+        assert_eq!(output.applied_count, 1);
+        assert!(!repo.path().join(".cargo-target").exists());
+        assert!(external.path().join("debug/app").exists());
     }
 
     #[test]
@@ -3609,7 +3701,7 @@ mod tests {
         write_file(&repo.path().join("scope.marker"), "{}");
         write_file(
             &repo.path().join(".gitignore"),
-            "deps/\npackaged/\ntarget/\n",
+            "deps/\npackaged/\ntarget/\n.cargo-target/\n",
         );
         git(
             repo.path(),

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -2711,6 +2711,8 @@ mod tests {
             "[package]\nname = \"homeboy\"\n",
         )
         .expect("write manifest");
+        fs::create_dir(tmp.path().join("src")).expect("source directory");
+        fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").expect("binary source");
         init_git_repository(tmp.path());
 
         let root = validate_homeboy_manifest_dir(tmp.path()).expect("homeboy manifest");

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -540,40 +540,114 @@ fn cargo_build_lock_is_held(worktree: &Path) -> bool {
 }
 
 /// Probe direct `<target>/<profile>` and cross-target
-/// `<target>/<triple>/<profile>` Cargo layouts without following symlinks.
+/// `<target>/<triple>/<profile>` Cargo layouts through no-follow descriptors.
+#[cfg(unix)]
 fn cargo_target_lock_is_held(target: &Path) -> bool {
-    let Ok(metadata) = fs::symlink_metadata(target) else {
+    let Some(target) = open_directory(target) else {
         return false;
     };
-    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+    directory_has_held_cargo_lock(&target, 2)
+}
+
+/// Platforms without descriptor-relative no-follow traversal retain any target
+/// path rather than racing a build while trying to inspect it.
+#[cfg(not(unix))]
+fn cargo_target_lock_is_held(target: &Path) -> bool {
+    fs::symlink_metadata(target).is_ok()
+}
+
+#[cfg(unix)]
+fn directory_has_held_cargo_lock(target: &fs::File, remaining_depth: u8) -> bool {
+    lock_in_directory_is_held(target)
+        || (remaining_depth > 0
+            && directory_has_child(target, |child| {
+                directory_has_held_cargo_lock(&child, remaining_depth - 1)
+            }))
+}
+
+#[cfg(unix)]
+fn open_directory(path: &Path) -> Option<fs::File> {
+    use std::ffi::CString;
+    use std::os::unix::io::FromRawFd;
+
+    let path = CString::new(path.as_os_str().as_encoded_bytes()).ok()?;
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    (fd >= 0).then(|| unsafe { fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn directory_has_child(target: &fs::File, mut inspect: impl FnMut(fs::File) -> bool) -> bool {
+    use std::ffi::CStr;
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let duplicate = unsafe { libc::dup(target.as_raw_fd()) };
+    if duplicate < 0 {
         return false;
     }
-    let Ok(entries) = fs::read_dir(target) else {
-        return false;
-    };
-    entries.flatten().any(|entry| {
-        let path = entry.path();
-        let Ok(metadata) = fs::symlink_metadata(&path) else {
-            return false;
-        };
-        if !metadata.is_dir() || metadata.file_type().is_symlink() {
-            return false;
+    let directory = unsafe { libc::fdopendir(duplicate) };
+    if directory.is_null() {
+        unsafe {
+            libc::close(duplicate);
         }
-        path_lock_is_held(&path.join(".cargo-lock"))
-            || fs::read_dir(path)
-                .ok()
-                .into_iter()
-                .flatten()
-                .flatten()
-                .any(|entry| {
-                    let path = entry.path();
-                    fs::symlink_metadata(&path).is_ok_and(|metadata| {
-                        metadata.is_dir()
-                            && !metadata.file_type().is_symlink()
-                            && path_lock_is_held(&path.join(".cargo-lock"))
-                    })
-                })
-    })
+        return false;
+    }
+    let mut held = false;
+    loop {
+        let entry = unsafe { libc::readdir(directory) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+        if matches!(name.to_bytes(), b"." | b"..") {
+            continue;
+        }
+        let fd = unsafe {
+            libc::openat(
+                target.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd >= 0 && inspect(unsafe { fs::File::from_raw_fd(fd) }) {
+            held = true;
+            break;
+        }
+    }
+    unsafe {
+        libc::closedir(directory);
+    }
+    held
+}
+
+#[cfg(unix)]
+fn lock_in_directory_is_held(target: &fs::File) -> bool {
+    use std::ffi::CStr;
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let lock = CStr::from_bytes_with_nul(b".cargo-lock\0").expect("static Cargo lock name");
+    let fd = unsafe {
+        libc::openat(
+            target.as_raw_fd(),
+            lock.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return false;
+    }
+    let lock = unsafe { fs::File::from_raw_fd(fd) };
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(lock.as_raw_fd(), metadata.as_mut_ptr()) } != 0
+        || unsafe { metadata.assume_init().st_mode & libc::S_IFMT } != libc::S_IFREG
+    {
+        return false;
+    }
+    path_lock_is_held(&lock)
 }
 
 /// Probe one advisory lock without blocking.
@@ -581,18 +655,10 @@ fn cargo_target_lock_is_held(target: &Path) -> bool {
 /// Acquiring it proves no build holds it; the lock is released immediately so
 /// this never delays a build that starts during the probe.
 #[cfg(unix)]
-fn path_lock_is_held(lock: &Path) -> bool {
+fn path_lock_is_held(lock: &fs::File) -> bool {
     use std::os::unix::io::AsRawFd;
 
-    if !fs::symlink_metadata(lock)
-        .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink())
-    {
-        return false;
-    }
-    let Ok(file) = fs::File::open(lock) else {
-        return false;
-    };
-    let fd = file.as_raw_fd();
+    let fd = lock.as_raw_fd();
     let acquired = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
     if acquired == 0 {
         unsafe {
@@ -603,11 +669,6 @@ fn path_lock_is_held(lock: &Path) -> bool {
     // EWOULDBLOCK is the only answer that means "someone else holds it".
     // Any other errno is an unusable probe, which must not read as active.
     io::Error::last_os_error().kind() == io::ErrorKind::WouldBlock
-}
-
-#[cfg(not(unix))]
-fn path_lock_is_held(_lock: &Path) -> bool {
-    false
 }
 
 impl Default for ActiveWorktrees {
@@ -1986,6 +2047,23 @@ mod tests {
             let _held = hold(&lock);
             std::os::unix::fs::symlink(external.path(), dir.path().join(".cargo-target"))
                 .expect("link external target");
+
+            assert!(!cargo_build_lock_is_held(dir.path()));
+        }
+
+        #[test]
+        fn a_symlinked_cross_target_directory_is_not_traversed() {
+            let dir = tempfile::tempdir().expect("worktree");
+            let external = tempfile::tempdir().expect("external target");
+            let profile = external.path().join("release");
+            std::fs::create_dir_all(&profile).expect("external profile dir");
+            let lock = profile.join(".cargo-lock");
+            std::fs::write(&lock, b"").expect("Cargo lock");
+            let _held = hold(&lock);
+            let target = dir.path().join("target");
+            std::fs::create_dir(&target).expect("target dir");
+            std::os::unix::fs::symlink(&external, target.join("aarch64-apple-darwin"))
+                .expect("link external cross-target directory");
 
             assert!(!cargo_build_lock_is_held(dir.path()));
         }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -549,11 +549,11 @@ fn cargo_target_lock_is_held(target: &Path) -> bool {
     directory_has_held_cargo_lock(&target, 2)
 }
 
-/// Platforms without descriptor-relative no-follow traversal retain any target
-/// path rather than racing a build while trying to inspect it.
+/// Platforms without descriptor-relative no-follow traversal preserve the
+/// established fail-open contract: no lock probe means no active-build evidence.
 #[cfg(not(unix))]
-fn cargo_target_lock_is_held(target: &Path) -> bool {
-    fs::symlink_metadata(target).is_ok()
+fn cargo_target_lock_is_held(_target: &Path) -> bool {
+    false
 }
 
 #[cfg(unix)]
@@ -2143,6 +2143,20 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::defaults::{WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind};
+
+    #[cfg(not(unix))]
+    #[test]
+    fn an_existing_cargo_target_is_idle_without_supported_lock_probing() {
+        let dir = TempDir::new().expect("worktree");
+        std::fs::create_dir_all(dir.path().join(".cargo-target/debug"))
+            .expect("Cargo target profile dir");
+
+        assert!(!cargo_build_lock_is_held(dir.path()));
+        assert_eq!(
+            ActiveWorktrees::default().liveness(dir.path()),
+            LIVENESS_IDLE
+        );
+    }
 
     #[test]
     fn safe_artifact_paths_are_repo_relative() {

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -536,15 +536,44 @@ fn cargo_build_lock_is_held(worktree: &Path) -> bool {
     BUILTIN_ARTIFACT_PATHS
         .iter()
         .filter(|(_, kind)| *kind == "rust_target")
-        .any(|(relative_path, _)| {
-            fs::read_dir(worktree.join(relative_path))
+        .any(|(relative_path, _)| cargo_target_lock_is_held(&worktree.join(relative_path)))
+}
+
+/// Probe direct `<target>/<profile>` and cross-target
+/// `<target>/<triple>/<profile>` Cargo layouts without following symlinks.
+fn cargo_target_lock_is_held(target: &Path) -> bool {
+    let Ok(metadata) = fs::symlink_metadata(target) else {
+        return false;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return false;
+    }
+    let Ok(entries) = fs::read_dir(target) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            return false;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return false;
+        }
+        path_lock_is_held(&path.join(".cargo-lock"))
+            || fs::read_dir(path)
                 .ok()
                 .into_iter()
                 .flatten()
                 .flatten()
-                .map(|entry| entry.path().join(".cargo-lock"))
-                .any(|lock| path_lock_is_held(&lock))
-        })
+                .any(|entry| {
+                    let path = entry.path();
+                    fs::symlink_metadata(&path).is_ok_and(|metadata| {
+                        metadata.is_dir()
+                            && !metadata.file_type().is_symlink()
+                            && path_lock_is_held(&path.join(".cargo-lock"))
+                    })
+                })
+    })
 }
 
 /// Probe one advisory lock without blocking.
@@ -555,6 +584,11 @@ fn cargo_build_lock_is_held(worktree: &Path) -> bool {
 fn path_lock_is_held(lock: &Path) -> bool {
     use std::os::unix::io::AsRawFd;
 
+    if !fs::symlink_metadata(lock)
+        .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink())
+    {
+        return false;
+    }
     let Ok(file) = fs::File::open(lock) else {
         return false;
     };
@@ -1929,6 +1963,33 @@ mod tests {
             assert!(cargo_build_lock_is_held(dir.path()));
         }
 
+        #[test]
+        fn a_held_cross_target_cargo_lock_is_an_active_build() {
+            let dir = tempfile::tempdir().expect("worktree");
+            let profile = dir.path().join("target/aarch64-apple-darwin/release");
+            std::fs::create_dir_all(&profile).expect("cross-target profile dir");
+            let lock = profile.join(".cargo-lock");
+            std::fs::write(&lock, b"").expect("Cargo lock");
+            let _held = hold(&lock);
+
+            assert!(cargo_build_lock_is_held(dir.path()));
+        }
+
+        #[test]
+        fn a_symlinked_cargo_target_is_not_traversed() {
+            let dir = tempfile::tempdir().expect("worktree");
+            let external = tempfile::tempdir().expect("external target");
+            let profile = external.path().join("debug");
+            std::fs::create_dir_all(&profile).expect("external profile dir");
+            let lock = profile.join(".cargo-lock");
+            std::fs::write(&lock, b"").expect("Cargo lock");
+            let _held = hold(&lock);
+            std::os::unix::fs::symlink(external.path(), dir.path().join(".cargo-target"))
+                .expect("link external target");
+
+            assert!(!cargo_build_lock_is_held(dir.path()));
+        }
+
         /// Releasing must clear the signal, or a finished build would pin the
         /// target as undeletable forever.
         #[test]
@@ -2153,13 +2214,18 @@ mod tests {
     fn worktree_artifact_cleanup_removes_rebuildable_output_and_preserves_source() {
         let repo = git_repo();
         write_file(&repo.path().join("target/debug/app"), "artifact");
+        write_file(
+            &repo.path().join(".cargo-target/debug/app"),
+            "Cargo artifact",
+        );
         write_file(&repo.path().join("src/lib.rs"), "changed source");
 
         let output = cleanup_worktree_artifacts(repo.path()).expect("cleanup worktree artifacts");
 
         assert_eq!(output.worktree_count, 1);
-        assert_eq!(output.applied_count, 1);
+        assert_eq!(output.applied_count, 2);
         assert!(!repo.path().join("target").exists());
+        assert!(!repo.path().join(".cargo-target").exists());
         assert_eq!(
             fs::read_to_string(repo.path().join("src/lib.rs")).expect("source remains"),
             "changed source"
@@ -2267,6 +2333,36 @@ mod tests {
             assert_eq!(output.applied_count, 1);
             assert!(!large.path().join("target").exists());
             assert!(small.path().join("target").exists());
+        });
+    }
+
+    #[test]
+    fn automatic_artifact_retention_reclaims_idle_cargo_target() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = repo_with_ignored_artifacts();
+            write_file(
+                &repo.path().join(".cargo-target/debug/app"),
+                "Cargo artifact",
+            );
+            let retention = crate::defaults::RetentionConfig {
+                reconstructable_artifact_days: 0,
+                ..Default::default()
+            };
+            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+                retention: retention.clone(),
+                ..Default::default()
+            })
+            .expect("save retention");
+
+            let output = run_automatic_artifact_retention_in(
+                &[repo.path().to_path_buf()],
+                &retention,
+                SystemTime::now(),
+            )
+            .expect("automatic retention");
+
+            assert_eq!(output.applied_count, 1);
+            assert!(!repo.path().join(".cargo-target").exists());
         });
     }
 
@@ -3445,7 +3541,7 @@ mod tests {
         );
         write_file(
             &repo.path().join(".gitignore"),
-            "target/\nnode_modules/\ndist/\n",
+            "target/\n.cargo-target/\nnode_modules/\ndist/\n",
         );
         git(
             repo.path(),

--- a/crates/homeboy-core/src/cleanup/self_artifacts.rs
+++ b/crates/homeboy-core/src/cleanup/self_artifacts.rs
@@ -25,7 +25,19 @@ pub(super) fn homeboy_source_checkout() -> Result<PathBuf> {
             Some("resolve current Homeboy executable".to_string()),
         )
     })?;
-    homeboy_source_checkout_from_binary(&executable, &crate::build_identity::current())
+    let working_dir = std::env::current_dir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve current Homeboy working directory".to_string()),
+        )
+    })?;
+    let cargo_target_dir = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
+    homeboy_source_checkout_from_binary(
+        &executable,
+        &crate::build_identity::current(),
+        &working_dir,
+        cargo_target_dir.as_deref(),
+    )
 }
 
 /// Resolve the source checkout that owns a source-built Homeboy binary.
@@ -35,8 +47,12 @@ pub(super) fn homeboy_source_checkout() -> Result<PathBuf> {
 fn homeboy_source_checkout_from_binary(
     binary: &Path,
     identity: &crate::build_identity::BuildIdentity,
+    working_dir: &Path,
+    cargo_target_dir: Option<&Path>,
 ) -> Result<PathBuf> {
-    let checkout = source_checkout_from_binary_path(binary).ok_or_else(|| {
+    let checkout = source_checkout_from_binary_path(binary).or_else(|| {
+        source_checkout_from_managed_target(binary, working_dir, cargo_target_dir)
+    }).ok_or_else(|| {
         Error::validation_invalid_argument(
             "self_artifacts",
             format!("no managed Homeboy source checkout owns {}", binary.display()),
@@ -50,6 +66,25 @@ fn homeboy_source_checkout_from_binary(
     let checkout = validate_homeboy_manifest_dir(&checkout)?;
     validate_homeboy_build_identity(&checkout, identity)?;
     Ok(checkout)
+}
+
+/// A shared Cargo target is intentionally outside its workspace. When Cargo
+/// names that target explicitly, the invoking checkout is the only local
+/// source candidate and must still prove the binary's recorded revision.
+fn source_checkout_from_managed_target(
+    binary: &Path,
+    working_dir: &Path,
+    cargo_target_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    let target_dir = cargo_target_dir?;
+    let target_dir = fs::canonicalize(target_dir).ok()?;
+    let binary = fs::canonicalize(binary).ok()?;
+    if !binary.starts_with(&target_dir) {
+        return None;
+    }
+    git::get_git_root(&working_dir.to_string_lossy())
+        .ok()
+        .map(PathBuf::from)
 }
 
 fn source_checkout_from_binary_path(binary: &Path) -> Option<PathBuf> {
@@ -125,10 +160,10 @@ pub(super) fn validate_homeboy_manifest_dir(manifest_dir: &Path) -> Result<PathB
     }
 
     if !is_canonical_git_root(manifest_dir) {
-        let error = Error::validation_invalid_argument(
+        let mut error = Error::validation_invalid_argument(
             "self_artifacts",
             format!(
-                "{} is not the canonical root of a Homeboy source git checkout",
+                "{} is not a Homeboy source git checkout: not the canonical root of its Git checkout",
                 manifest_dir.display()
             ),
             None,
@@ -136,6 +171,12 @@ pub(super) fn validate_homeboy_manifest_dir(manifest_dir: &Path) -> Result<PathB
         )
         .with_hint("`homeboy cleanup artifacts --self` requires a source checkout, not a packaged Cargo registry source.")
         .with_hint("Pass an explicit checkout with `homeboy cleanup artifacts --path <PATH>`, or configure and run from a source checkout.");
+        if let Some(checkout) = active_homeboy_checkout_hint() {
+            error = error.with_hint(format!(
+                "Active Homeboy checkout appears to be: {}",
+                checkout.display()
+            ));
+        }
         return Err(error);
     }
 
@@ -152,6 +193,23 @@ pub(super) fn validate_homeboy_manifest_dir(manifest_dir: &Path) -> Result<PathB
     }
 
     Ok(manifest_dir.to_path_buf())
+}
+
+fn active_homeboy_checkout_hint() -> Option<PathBuf> {
+    let executable = std::env::current_exe().ok()?;
+    let working_dir = std::env::current_dir().ok()?;
+    let cargo_target_dir = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
+    let checkout = source_checkout_from_binary_path(&executable).or_else(|| {
+        source_checkout_from_managed_target(&executable, &working_dir, cargo_target_dir.as_deref())
+    })?;
+    if !checkout.join("Cargo.toml").is_file()
+        || !checkout.join("src/main.rs").is_file()
+        || !is_canonical_git_root(&checkout)
+    {
+        return None;
+    }
+    validate_homeboy_build_identity(&checkout, &crate::build_identity::current()).ok()?;
+    Some(checkout)
 }
 
 fn is_canonical_git_root(path: &Path) -> bool {
@@ -485,7 +543,7 @@ mod tests {
         let binary = source_binary(&checkout);
         let identity = build_identity(&checkout);
 
-        let resolved = homeboy_source_checkout_from_binary(&binary, &identity)
+        let resolved = homeboy_source_checkout_from_binary(&binary, &identity, &checkout, None)
             .expect("source-built binary should resolve its checkout");
 
         assert_eq!(
@@ -503,8 +561,13 @@ mod tests {
         fs::create_dir_all(moved_binary.parent().expect("binary parent")).expect("binary parent");
         fs::copy(source_binary, &moved_binary).expect("copy installed binary");
 
-        let error = homeboy_source_checkout_from_binary(&moved_binary, &build_identity(&checkout))
-            .expect_err("moved binary has no source-layout attachment");
+        let error = homeboy_source_checkout_from_binary(
+            &moved_binary,
+            &build_identity(&checkout),
+            fixture.path(),
+            None,
+        )
+        .expect_err("moved binary has no source-layout attachment");
 
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(error
@@ -522,6 +585,8 @@ mod tests {
         let error = homeboy_source_checkout_from_binary(
             &source_binary(&unrelated),
             &build_identity(&expected),
+            &unrelated,
+            None,
         )
         .expect_err("unrelated checkout must not be selected");
 
@@ -536,8 +601,13 @@ mod tests {
         let mut identity = build_identity(&checkout);
         identity.git_commit = None;
 
-        let error = homeboy_source_checkout_from_binary(&source_binary(&checkout), &identity)
-            .expect_err("a revisionless binary must not guess its source checkout");
+        let error = homeboy_source_checkout_from_binary(
+            &source_binary(&checkout),
+            &identity,
+            &checkout,
+            None,
+        )
+        .expect_err("a revisionless binary must not guess its source checkout");
 
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(error.message.contains("no durable source revision"));
@@ -558,8 +628,9 @@ mod tests {
         let binary = source_binary(&vendor);
         commit_git_repository(&outer);
 
-        let error = homeboy_source_checkout_from_binary(&binary, &build_identity(&outer))
-            .expect_err("nested vendor manifest must not be accepted");
+        let error =
+            homeboy_source_checkout_from_binary(&binary, &build_identity(&outer), &outer, None)
+                .expect_err("nested vendor manifest must not be accepted");
 
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(error.message.contains("canonical root"));
@@ -574,8 +645,32 @@ mod tests {
         )
         .expect("manifest");
         fs::write(checkout.join("src/main.rs"), "fn main() {}\n").expect("source");
+        fs::write(checkout.join(".homeboy-fixture"), name).expect("fixture identity");
         commit_git_repository(&checkout);
         checkout
+    }
+
+    #[test]
+    fn managed_cargo_target_resolves_the_invoking_matching_checkout() {
+        let fixture = TempDir::new().expect("fixture root");
+        let checkout = homeboy_checkout(fixture.path(), "source");
+        let target = fixture.path().join("cargo-target");
+        let binary = target.join("debug/deps/homeboy_core-test");
+        fs::create_dir_all(binary.parent().expect("binary parent")).expect("binary parent");
+        fs::write(&binary, "test binary").expect("test binary");
+
+        let resolved = homeboy_source_checkout_from_binary(
+            &binary,
+            &build_identity(&checkout),
+            &checkout,
+            Some(&target),
+        )
+        .expect("managed target should resolve its invoking checkout");
+
+        assert_eq!(
+            resolved,
+            fs::canonicalize(checkout).expect("canonical checkout")
+        );
     }
 
     fn source_binary(checkout: &Path) -> PathBuf {


### PR DESCRIPTION
Closes #12072

## Summary
- Declare `.cargo-target` as a built-in local Rust target artifact.
- Probe Cargo locks across every built-in local Rust target path before cleanup.
- Preserve symlink containment while reclaiming idle output.

## Test evidence
- `cargo fmt --check`
- `cargo test -p homeboy-core --lib cleanup::tests::artifact_cleanup_reclaims_idle_cargo_target_alongside_target -- --test-threads=1`
- `cargo test -p homeboy-core --lib cleanup::tests::artifact_cleanup_keeps_cargo_target_with_active_cargo_lock -- --test-threads=1`
- `cargo test -p homeboy-core --lib cleanup::tests::artifact_cleanup_unlinks_cargo_target_symlink_without_following_it -- --test-threads=1`
- `cargo test -p homeboy-core --lib cleanup::tests::active_build_lock_tests::a_held_cargo_target_lock_is_an_active_build -- --test-threads=1`
- `cargo clippy -p homeboy-core --lib -- -D warnings` remains blocked by existing unrelated warnings in `crates/homeboy-core/src/http_api.rs` and `crates/homeboy-core/src/notify_outbox.rs`.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to implement and verify the change; Chris Huber remains responsible.