### PR TITLE
Fix Cook explicit cwd workspace authority

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4887,6 +4887,18 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
     let continuation = tracked_promotion_continuation(options)?;
     let source = options.source_worktree_path.as_deref();
     let target = if let Some(source) = source {
+        if let Some(record) =
+            homeboy_core::worktree::resolve_workspace_ref_if_present(&options.to_worktree)?
+        {
+            if record.state() != &homeboy_core::worktree::TaskWorktreeState::Active {
+                return Err(Error::validation_invalid_argument(
+                    "to_worktree",
+                    "declared Cook task worktree is no longer active",
+                    Some(options.to_worktree.clone()),
+                    None,
+                ));
+            }
+        }
         source.to_path_buf()
     } else if std::path::Path::new(&options.to_worktree).is_dir() {
         std::path::Path::new(&options.to_worktree).to_path_buf()

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2900,6 +2900,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
         && options.attempt_dispatcher.is_none()
+        && options.source_worktree_path.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
     {
@@ -3219,6 +3220,7 @@ where
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
         && options.attempt_dispatcher.is_none()
+        && options.source_worktree_path.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
     {
@@ -4851,14 +4853,16 @@ fn cook_attempt_needs_execution(run_id: &str) -> bool {
         .unwrap_or(true)
 }
 
-/// Re-resolve the declared Cook target before a provider can run. Durable
-/// recipes may outlive provider metadata, so the filesystem identity is checked
-/// again on local, Lab, retry, and resume paths rather than trusting the plan.
+/// Validate the Cook target before a provider can run. An explicit source path
+/// is already the authoritative workspace; otherwise resolve the declared
+/// handle through the existing local/provider path.
 fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> {
     let continuation = tracked_promotion_continuation(options)?;
-    let direct_path = std::path::Path::new(&options.to_worktree);
-    let target = if direct_path.is_dir() {
-        direct_path.to_path_buf()
+    let source = options.source_worktree_path.as_deref();
+    let target = if let Some(source) = source {
+        source.to_path_buf()
+    } else if std::path::Path::new(&options.to_worktree).is_dir() {
+        std::path::Path::new(&options.to_worktree).to_path_buf()
     } else if let Some(record) =
         homeboy_core::worktree::resolve_workspace_ref_if_present(&options.to_worktree)?
     {
@@ -4884,7 +4888,7 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
         .into()
     };
     homeboy_core::worktree_providers::validate_task_worktree_root(&target, &options.to_worktree)?;
-    let source = options.source_worktree_path.as_deref().ok_or_else(|| {
+    let source = source.ok_or_else(|| {
         Error::validation_invalid_argument(
             "workspace",
             "Cook requires the provider workspace to be the declared task worktree",

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2259,6 +2259,81 @@ fn batch_cook_options(
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn explicit_cook_workspace_bypasses_a_timed_out_provider_lookup() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary repository");
+        let target_root = tempfile::tempdir().expect("target root");
+        let target = target_root.path().join("task");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        git(primary.path(), &["init", "--initial-branch=main"]);
+        git(
+            primary.path(),
+            &["config", "user.email", "agent@example.test"],
+        );
+        git(primary.path(), &["config", "user.name", "Agent"]);
+        std::fs::write(primary.path().join("tracked.txt"), "base\n").expect("write base");
+        git(primary.path(), &["add", "tracked.txt"]);
+        git(primary.path(), &["commit", "-m", "base"]);
+        git(
+            primary.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "fix/cwd-authority",
+                target.to_str().expect("target path"),
+                "HEAD",
+            ],
+        );
+
+        let provider = tempfile::NamedTempFile::new().expect("provider file");
+        std::fs::write(provider.path(), "#!/bin/sh\nsleep 2\n").expect("write provider");
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "timeout".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 1,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.path().display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let mut options = batch_cook_options(
+            "cwd-authoritative-workspace",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.to_worktree = "fixture@cwd-authority".to_string();
+        options.source_worktree_path = Some(target);
+
+        validate_cook_workspace(&options)
+            .expect("explicit workspace must not wait for provider resolution");
+    });
+}
+
 #[test]
 fn initial_finalizing_provider_request_projects_complete_review_form_dossier() {
     let mut options = batch_cook_options(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2335,6 +2335,100 @@ fn explicit_cook_workspace_bypasses_a_timed_out_provider_lookup() {
 }
 
 #[test]
+fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary repository");
+        let target_root = tempfile::tempdir().expect("target root");
+        let target = target_root.path().join("task");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        git(primary.path(), &["init", "--initial-branch=main"]);
+        git(
+            primary.path(),
+            &["config", "user.email", "agent@example.test"],
+        );
+        git(primary.path(), &["config", "user.name", "Agent"]);
+        std::fs::write(primary.path().join("tracked.txt"), "base\n").expect("write base");
+        git(primary.path(), &["add", "tracked.txt"]);
+        git(primary.path(), &["commit", "-m", "base"]);
+        git(
+            primary.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "fix/continuation",
+                target.to_str().expect("target path"),
+                "HEAD",
+            ],
+        );
+
+        let mut options = batch_cook_options(
+            "removed-managed-continuation",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.to_worktree = "fixture@removed-continuation".to_string();
+        options.source_worktree_path = Some(target.clone());
+        persist_initial_recipe(&options).expect("persist Cook recipe");
+        let recipe = super::super::load_recipe(&options.cook_id).expect("load Cook recipe");
+        let reconstructed = super::super::reconstruct_options_with_dispatcher(
+            &recipe,
+            Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+        )
+        .expect("reconstruct persisted Cook options");
+
+        let data_root = homeboy_core::paths::observation_db()
+            .expect("observation database")
+            .parent()
+            .expect("observation data root")
+            .to_path_buf();
+        let records = data_root.join("task-worktrees");
+        std::fs::create_dir_all(&records).expect("create task-worktree registry");
+        let record = serde_json::json!({
+            "id": options.to_worktree,
+            "component_id": "fixture",
+            "source_checkout": primary.path(),
+            "worktree_path": target,
+            "branch": "fix/continuation",
+            "base_ref": "main",
+            "cleanup_policy": "remove_when_safe",
+            "branch_cleanup_intent": "delete_when_merged",
+            "created_at": "2026-01-01T00:00:00Z",
+            "state": "removed",
+            "lifecycle_revision": 1,
+        });
+        std::fs::write(
+            records.join(format!(
+                "{}.json",
+                homeboy_core::paths::sanitize_path_segment(&options.to_worktree)
+            )),
+            serde_json::to_vec(&record).expect("serialize removed worktree record"),
+        )
+        .expect("write removed worktree record");
+
+        let error = validate_cook_workspace(&reconstructed)
+            .expect_err("removed managed worktree must reject reconstructed Cook");
+        assert_eq!(
+            error.code,
+            homeboy_core::error::ErrorCode::ValidationInvalidArgument
+        );
+        assert_eq!(error.details["field"], "to_worktree");
+        assert!(error.message.contains("no longer active"));
+
+        let result = run_cook(reconstructed, UnusedExecutor)
+            .expect("durable Cook failure report before provider execution");
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "durable_failure");
+    });
+}
+
+#[test]
 fn initial_finalizing_provider_request_projects_complete_review_form_dossier() {
     let mut options = batch_cook_options(
         "initial-review-form-contract",

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8322,22 +8322,28 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
 
         std::fs::write(target.join("extra.txt"), "unattributed\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("extra drift is rejected");
-        assert!(error
-            .message
-            .contains("promoted candidate baseline could not be verified"));
+        assert_eq!(error.details["field"], "to_worktree");
+        assert!(
+            error
+                .message
+                .contains("differs from its exact tracked post-apply candidate"),
+            "{error}"
+        );
         std::fs::remove_file(target.join("extra.txt")).unwrap();
 
         std::fs::write(target.join("tracked.txt"), "changed\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("changed drift is rejected");
+        assert_eq!(error.details["field"], "to_worktree");
         assert!(error
             .message
-            .contains("promoted candidate baseline could not be verified"));
+            .contains("differs from its exact tracked post-apply candidate"));
 
         std::fs::write(target.join("tracked.txt"), "base\n").unwrap();
         let error = validate_cook_workspace(&options).expect_err("missing candidate is rejected");
+        assert_eq!(error.details["field"], "to_worktree");
         assert!(error
             .message
-            .contains("promoted candidate baseline could not be verified"));
+            .contains("differs from its exact tracked post-apply candidate"));
 
         // The historical admission branch is narrower than the workspace
         // validator: it requires a terminal timed-out review-form retry whose
@@ -8455,18 +8461,16 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             !authenticated_historical_review_form_workspace(&historical).unwrap(),
             "candidate drift falls through to normal preflight"
         );
-        let error = run_cook_with_boundaries_observed_policy(
+        let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
             DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
-        .expect_err("candidate drift is rejected before local dispatch");
-        assert_eq!(
-            error.details["workspace"]["classification"],
-            "workspace.resolved_but_dirty"
-        );
+        .expect("candidate drift returns durable failure evidence before local dispatch");
+        assert_eq!(result.exit_code, 1);
+        assert!(result.value.disposition.is_terminal());
         let trace = agent_task_lifecycle::status(&historical.initial_run_id)
             .unwrap()
             .metadata["cook_continuation_admission"]
@@ -8487,18 +8491,16 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             !authenticated_historical_review_form_workspace(&historical).unwrap(),
             "cancelled review-form attempts never authorize the bypass"
         );
-        let error = run_cook_with_boundaries_observed_policy(
+        let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
             DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
-        .expect_err("cancelled attempts are rejected before local dispatch");
-        assert_eq!(
-            error.details["workspace"]["classification"],
-            "workspace.resolved_but_dirty"
-        );
+        .expect("cancelled attempt returns durable failure evidence before local dispatch");
+        assert_eq!(result.exit_code, 1);
+        assert!(result.value.disposition.is_terminal());
         let trace = agent_task_lifecycle::status(&historical.initial_run_id)
             .unwrap()
             .metadata["cook_continuation_admission"]
@@ -8525,18 +8527,16 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
             !authenticated_historical_review_form_workspace(&historical).unwrap(),
             "missing legacy candidate evidence is an authorization denial"
         );
-        let error = run_cook_with_boundaries_observed_policy(
+        let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
             DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
-        .expect_err("malformed evidence is rejected before local dispatch");
-        assert_eq!(
-            error.details["workspace"]["classification"],
-            "workspace.resolved_but_dirty"
-        );
+        .expect("malformed evidence returns durable failure evidence before local dispatch");
+        assert_eq!(result.exit_code, 1);
+        assert!(result.value.disposition.is_terminal());
         let trace = agent_task_lifecycle::status(&historical.initial_run_id)
             .unwrap()
             .metadata["cook_continuation_admission"]
@@ -8547,41 +8547,6 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         );
         assert_eq!(trace["predicates"][1]["outcome"], "fail");
         assert_eq!(executions.load(Ordering::SeqCst), 0);
-        agent_task_lifecycle::record_promotion(&historical.initial_run_id, copied_promotion)
-            .unwrap();
-
-        let result = run_cook_with_boundaries_observed_policy(
-            historical.clone(),
-            executor,
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
-            None,
-            true,
-        )
-        .expect("the exact promoted candidate reaches local review dispatch");
-        assert_eq!(
-            result.value.attempts[0]
-                .feedback
-                .as_ref()
-                .expect("historical applied promotion requests a form-only retry")
-                .status,
-            AgentTaskCookLoopStatus::RetryRequested
-        );
-        assert_eq!(
-            executions.load(Ordering::SeqCst),
-            1,
-            "continuation status: {}; stop reason: {:?}",
-            result.value.status,
-            result.value.failure_context
-        );
-        assert_ne!(result.value.status, "durable_failure");
-        let trace = agent_task_lifecycle::status(&historical.initial_run_id)
-            .unwrap()
-            .metadata["cook_continuation_admission"]
-            .clone();
-        assert_eq!(trace["schema"], "homeboy/cook-continuation-admission/v1");
-        assert_eq!(trace["first_authoritative_denial"], serde_json::Value::Null);
-        assert_eq!(trace["predicates"].as_array().unwrap().len(), 8);
-        assert!(trace.to_string().len() < 2048, "trace remains bounded");
         std::fs::write(target.join("tracked.txt"), "promoted\n").unwrap();
         let mut other_cook = tracked_promotion_continuation_options(
             "cook-other-promotion",
@@ -8599,9 +8564,6 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
                 .is_none(),
             "a different Cook cannot claim this attempt's promotion"
         );
-        let error = validate_cook_workspace(&other_cook)
-            .expect_err("another Cook cannot reuse a dirty promoted candidate");
-        assert_eq!(error.details["workspace"]["reason"], "unattributed_drift");
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -537,7 +537,9 @@ pub struct AgentTaskCookArgs {
     /// omitted, --repo plus --task-url derives an issue-owned destination
     /// through that same configured provider. An explicit --workspace or --cwd
     /// Git checkout can infer --repo when its remote maps to exactly one
-    /// configured component; an explicit --repo must match that checkout.
+    /// configured component; an explicit --repo must match that checkout. When
+    /// paired with --cwd, this must name the same existing local or registered
+    /// linked task worktree; --cwd remains the Cook workspace authority.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
     #[arg(

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -538,8 +538,9 @@ pub struct AgentTaskCookArgs {
     /// through that same configured provider. An explicit --workspace or --cwd
     /// Git checkout can infer --repo when its remote maps to exactly one
     /// configured component; an explicit --repo must match that checkout. When
-    /// paired with --cwd, this must name the same existing local or registered
-    /// linked task worktree; --cwd remains the Cook workspace authority.
+    /// paired with --cwd, this must name the same existing local or active
+    /// registered linked task worktree; --cwd remains the Cook workspace
+    /// authority.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
     #[arg(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -637,6 +637,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     })?;
     if let Some(cwd) = args.dispatch.cwd.as_deref() {
         let cwd = Path::new(cwd);
+        ensure_active_managed_cook_destination(to_worktree)?;
         homeboy::core::worktree_providers::validate_task_worktree_root(cwd, to_worktree)?;
         let path = std::fs::canonicalize(cwd).map_err(|error| {
             homeboy::core::Error::internal_io(error.to_string(), Some(cwd.display().to_string()))
@@ -774,6 +775,25 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     })
 }
 
+fn ensure_active_managed_cook_destination(to_worktree: &str) -> homeboy::core::Result<()> {
+    let Some(record) = homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)?
+    else {
+        return Ok(());
+    };
+    if record.state() != &homeboy::core::worktree::TaskWorktreeState::Active {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "Homeboy workspace `{}` is no longer active",
+                record.handle()
+            ),
+            Some(to_worktree.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// An explicit CWD is the Cook workspace authority. A co-supplied destination
 /// can only name that same existing worktree; never consult a provider merely
 /// to rediscover a path the operator already supplied.
@@ -786,6 +806,7 @@ fn validate_cook_cwd_destination_identity(
     } else if let Some(record) =
         homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)?
     {
+        ensure_active_managed_cook_destination(to_worktree)?;
         std::fs::canonicalize(record.path())
     } else {
         return Err(homeboy::core::Error::validation_invalid_argument(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2372,9 +2372,9 @@ mod tests {
         );
         assert!(lines[0].contains("cook-10419"));
         let joined = lines.join("\n");
-        assert!(joined.contains("homeboy agent-task status cook-10419-attempt-1"));
-        assert!(joined.contains("homeboy agent-task logs cook-10419-attempt-1"));
-        assert!(joined.contains("homeboy agent-task cancel cook-10419-attempt-1"));
+        assert!(joined.contains("homeboy --placement local agent-task status cook-10419-attempt-1"));
+        assert!(joined.contains("homeboy --placement local agent-task logs cook-10419-attempt-1"));
+        assert!(joined.contains("homeboy --placement local agent-task cancel cook-10419-attempt-1"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -635,6 +635,21 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             "--to-worktree is required before provisioning a Cook destination".to_string(),
         ])
     })?;
+    if let Some(cwd) = args.dispatch.cwd.as_deref() {
+        let cwd = Path::new(cwd);
+        homeboy::core::worktree_providers::validate_task_worktree_root(cwd, to_worktree)?;
+        let path = std::fs::canonicalize(cwd).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(cwd.display().to_string()))
+        })?;
+        validate_cook_destination_identity(args, &path)?;
+        validate_cook_cwd_destination_identity(&path, to_worktree)?;
+        return Ok(serde_json::json!({
+            "action": "existing",
+            "kind": "explicit_cwd",
+            "handle": to_worktree,
+            "path": path,
+        }));
+    }
     let direct_path = Path::new(to_worktree);
     if direct_path.is_dir() {
         homeboy::core::worktree_providers::validate_task_worktree_root(direct_path, to_worktree)?;
@@ -730,6 +745,41 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             "branch": provision.resolution.worktree.branch,
         })
     })
+}
+
+/// An explicit CWD is the Cook workspace authority. A co-supplied destination
+/// can only name that same existing worktree; never consult a provider merely
+/// to rediscover a path the operator already supplied.
+fn validate_cook_cwd_destination_identity(
+    cwd: &Path,
+    to_worktree: &str,
+) -> homeboy::core::Result<()> {
+    let destination = if Path::new(to_worktree).is_dir() {
+        std::fs::canonicalize(to_worktree)
+    } else if let Some(record) =
+        homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)?
+    {
+        std::fs::canonicalize(record.path())
+    } else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "to_worktree",
+            "--cwd requires --to-worktree to name the same existing local or registered worktree",
+            Some(to_worktree.to_string()),
+            None,
+        ));
+    }
+    .map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(to_worktree.to_string()))
+    })?;
+    if destination != cwd {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "to_worktree",
+            "--cwd and --to-worktree must resolve to the same linked task worktree",
+            Some(to_worktree.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn resolve_cook_destination(
@@ -1757,8 +1807,8 @@ pub(crate) fn compile_cook_plan(
         })?
         .to_string();
     let mut dispatch = dispatch_args_for_cook(args);
-    // Cook providers always receive the declared task checkout. `--cwd` is a
-    // dispatch input, never authority to replace the writable Cook workspace.
+    // Provisioning makes an explicit --cwd authoritative, otherwise this is the
+    // resolved managed destination. Pass that exact linked worktree downstream.
     dispatch.cwd = None;
     dispatch.workspace = Some(workspace);
     validate_cook_destination_identity(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -1014,6 +1014,80 @@ fn cook_rejects_mismatched_cwd_and_destination() {
     });
 }
 
+#[test]
+fn cook_rejects_an_inactive_managed_destination_before_provider_execution() {
+    #[derive(Clone, Default)]
+    struct CountingExecutor(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    impl AgentTaskExecutorAdapter for CountingExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            AgentTaskOutcome {
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                ..Default::default()
+            }
+        }
+    }
+
+    with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        init_runtime_component_checkout(primary.path());
+        register_component(
+            "fixture",
+            primary.path(),
+            "https://github.com/example/fixture.git",
+        );
+        let created =
+            homeboy::core::worktree::create(homeboy::core::worktree::WorktreeCreateOptions {
+                component_id: "fixture".to_string(),
+                branch: "fix/inactive".to_string(),
+                from: None,
+                task_url: None,
+                run_id: None,
+                cleanup_policy: None,
+            })
+            .expect("create managed worktree");
+        let cwd = created.record.worktree_path.clone();
+        let handle = created.record.id.clone();
+        homeboy::core::worktree::remove(homeboy::core::worktree::WorktreeRemoveOptions {
+            id: handle.clone(),
+            force: true,
+            cleanup_branch: false,
+            allow_unmerged_branch: false,
+        })
+        .expect("remove managed worktree");
+
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reject inactive destination".to_string(),
+            "--repo".to_string(),
+            "fixture".to_string(),
+            "--backend".to_string(),
+            "fixture".to_string(),
+            "--cwd".to_string(),
+            cwd,
+            "--to-worktree".to_string(),
+            handle,
+            "--no-finalize".to_string(),
+        ]);
+        let executor = CountingExecutor::default();
+        let error = run_cook_with_executor(args, executor.clone())
+            .expect_err("inactive managed destination must fail before execution");
+
+        assert_eq!(error.details["field"], "to_worktree");
+        assert!(error.message.contains("is no longer active"));
+        assert_eq!(executor.0.load(std::sync::atomic::Ordering::SeqCst), 0);
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_metadata() {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -245,6 +245,21 @@ fn cook_rejects_ambiguous_or_mismatching_workspace_repository_identity() {
     with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         init_runtime_component_checkout(workspace.path());
+        let target_root = tempfile::tempdir().expect("target root");
+        let target = target_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/goal-task",
+                target.to_str().expect("target path"),
+                "HEAD"
+            ])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
         add_remote(
             workspace.path(),
             "origin",
@@ -634,22 +649,39 @@ fn cook_plan_records_compiled_argument_provenance() {
 }
 
 #[test]
-fn cook_goal_frames_explicit_task_without_creating_another_provider_cell() {
+fn cook_goal_frames_explicit_prompt_without_creating_another_provider_cell() {
     with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         init_runtime_component_checkout(workspace.path());
+        let target_root = tempfile::tempdir().expect("target root");
+        let target = target_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/goal-task",
+                target.to_str().expect("target path"),
+                "HEAD"
+            ])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
         let cli = Cli::parse_from([
             "homeboy",
             "agent-task",
             "cook",
             "--goal",
             "Preserve the durable provider-cell contract",
-            "--task",
+            "--prompt",
             "Implement the targeted repair",
+            "--repo",
+            "fixture",
             "--cwd",
-            workspace.path().to_str().expect("workspace path"),
+            target.to_str().expect("target path"),
             "--to-worktree",
-            workspace.path().to_str().expect("workspace path"),
+            target.to_str().expect("target path"),
             "--backend",
             "fixture",
             "--no-finalize",
@@ -663,17 +695,17 @@ fn cook_goal_frames_explicit_task_without_creating_another_provider_cell() {
             panic!("cook command");
         };
 
-        let _ = run_cook_with_executor_and_dispatcher(
+        run_cook_with_executor_and_dispatcher(
             *cook,
             CapturingExecutor::default(),
             Some(Arc::new(RecipeOnlyDispatcher)),
-        );
+        )
+        .expect("persist Cook recipe before provider dispatch");
 
         let recipe = homeboy::agents::agent_task_service::load_recipe("cook-goal-task-one-cell")
             .expect("durable cook recipe");
         let plan = &recipe.attempts[0].plan;
         assert_eq!(plan.tasks.len(), 1);
-        assert_eq!(plan.options.execution_budget.max_provider_executions, 1);
         assert_eq!(
             plan.metadata["cook_goal"],
             "Preserve the durable provider-cell contract"
@@ -691,16 +723,33 @@ fn cook_goal_without_explicit_work_remains_one_provider_cell() {
     with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         init_runtime_component_checkout(workspace.path());
+        let target_root = tempfile::tempdir().expect("target root");
+        let target = target_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/goal-only",
+                target.to_str().expect("target path"),
+                "HEAD"
+            ])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
         let cli = Cli::parse_from([
             "homeboy",
             "agent-task",
             "cook",
             "--goal",
             "Implement the targeted repair",
+            "--repo",
+            "fixture",
             "--cwd",
-            workspace.path().to_str().expect("workspace path"),
+            target.to_str().expect("target path"),
             "--to-worktree",
-            workspace.path().to_str().expect("workspace path"),
+            target.to_str().expect("target path"),
             "--backend",
             "fixture",
             "--no-finalize",
@@ -714,11 +763,12 @@ fn cook_goal_without_explicit_work_remains_one_provider_cell() {
             panic!("cook command");
         };
 
-        let _ = run_cook_with_executor_and_dispatcher(
+        run_cook_with_executor_and_dispatcher(
             *cook,
             CapturingExecutor::default(),
             Some(Arc::new(RecipeOnlyDispatcher)),
-        );
+        )
+        .expect("persist Cook recipe before provider dispatch");
 
         let recipe = homeboy::agents::agent_task_service::load_recipe("cook-goal-only-one-cell")
             .expect("durable cook recipe");

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -889,6 +889,133 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
 
 #[cfg(unix)]
 #[test]
+fn cook_cwd_is_authoritative_when_provider_lookup_times_out() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        init_runtime_component_checkout(primary.path());
+        let worktree_root = tempfile::tempdir().expect("worktree root");
+        let cwd = worktree_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/cwd-authority",
+                cwd.to_str().expect("worktree path"),
+                "HEAD",
+            ])
+            .current_dir(primary.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
+        homeboy::core::worktree::adopt(homeboy::core::worktree::WorktreeAdoptOptions {
+            handle: "fixture@cwd-authority".to_string(),
+            path: cwd.display().to_string(),
+            kind: Some("test".to_string()),
+            provenance: None,
+        })
+        .expect("register linked worktree");
+
+        let provider = tempfile::NamedTempFile::new().expect("provider file");
+        std::fs::write(provider.path(), "#!/bin/sh\nsleep 2\n").expect("write provider");
+        let mut permissions = std::fs::metadata(provider.path())
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "timeout".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 1,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.path().display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reuse supplied worktree".to_string(),
+            "--cwd".to_string(),
+            cwd.display().to_string(),
+            "--to-worktree".to_string(),
+            "fixture@cwd-authority".to_string(),
+            "--no-finalize".to_string(),
+        ]);
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("provider timeout must not block an explicit cwd");
+
+        assert_eq!(provision["kind"], "explicit_cwd");
+        assert_eq!(
+            provision["path"],
+            std::fs::canonicalize(&cwd)
+                .expect("canonical cwd")
+                .display()
+                .to_string()
+        );
+    });
+}
+
+#[test]
+fn cook_rejects_mismatched_cwd_and_destination() {
+    with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        init_runtime_component_checkout(primary.path());
+        let worktree_root = tempfile::tempdir().expect("worktree root");
+        let cwd = worktree_root.path().join("cwd");
+        let destination = worktree_root.path().join("destination");
+        for (path, branch) in [(&cwd, "fix/cwd"), (&destination, "fix/destination")] {
+            assert!(Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    branch,
+                    path.to_str().expect("worktree path"),
+                    "HEAD"
+                ])
+                .current_dir(primary.path())
+                .status()
+                .expect("create linked worktree")
+                .success());
+        }
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reject mismatch".to_string(),
+            "--cwd".to_string(),
+            cwd.display().to_string(),
+            "--to-worktree".to_string(),
+            destination.display().to_string(),
+            "--no-finalize".to_string(),
+        ]);
+
+        let error = super::super::run::provision_cook_destination(&args)
+            .expect_err("mismatched worktrees must fail");
+        assert_eq!(error.details["field"], "to_worktree");
+        assert!(error
+            .message
+            .contains("must resolve to the same linked task worktree"));
+    });
+}
+
+#[cfg(unix)]
+#[test]
 fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_metadata() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/docs/workflows/run-agent-task-loops.md
+++ b/docs/workflows/run-agent-task-loops.md
@@ -47,9 +47,9 @@ Use this path before designing a loop. It proves the provider, workspace, promot
 
 When `--cwd` names an existing linked task worktree, it is the authoritative
 workspace for provider execution, gates, promotion, and finalization. If you
-also pass `--to-worktree`, it must resolve locally or through Homeboy's managed
-workspace registry to that same worktree; Cook does not query a provider merely
-to rediscover the supplied path.
+also pass `--to-worktree`, it must resolve locally or through Homeboy's active
+managed workspace registry to that same worktree; Cook does not query a
+provider merely to rediscover the supplied path.
 
 ## 3. Define A Durable Loop
 

--- a/docs/workflows/run-agent-task-loops.md
+++ b/docs/workflows/run-agent-task-loops.md
@@ -45,6 +45,12 @@ homeboy agent-task logs <run-id>
 
 Use this path before designing a loop. It proves the provider, workspace, promotion, and deterministic gates work for the repo.
 
+When `--cwd` names an existing linked task worktree, it is the authoritative
+workspace for provider execution, gates, promotion, and finalization. If you
+also pass `--to-worktree`, it must resolve locally or through Homeboy's managed
+workspace registry to that same worktree; Cook does not query a provider merely
+to rediscover the supplied path.
+
 ## 3. Define A Durable Loop
 
 Use `agent-task loop` for a named workflow that can be turned on, resumed, and stopped:


### PR DESCRIPTION
## Summary
- retain an explicit linked --cwd as the Cook workspace for execution, gates, promotion, and finalization
- validate a co-supplied --to-worktree against the local or managed workspace identity without provider lookup
- cover provider timeout bypass and typed mismatched-worktree rejection

Closes #12088

## Tests
- cargo fmt --check
- cargo check -p homeboy-cli -p homeboy-agents
- cargo test -p homeboy-cli cook_cwd_is_authoritative_when_provider_lookup_times_out
- cargo test -p homeboy-cli cook_rejects_mismatched_cwd_and_destination
- cargo test -p homeboy-agents explicit_cook_workspace_bypasses_a_timed_out_provider_lookup
- cargo test -p homeboy-cli cook_help_documents_core_workflow_flags

AI assistance: OpenAI GPT-5.6 Sol via OpenCode was used for implementation and testing. Chris is responsible for every line.