### PR TITLE
Split worktree identity resolution from safety attestation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4940,23 +4940,24 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
 }
 
 fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
-    plan.metadata
-        .pointer("/cook_provision/action")
-        .and_then(Value::as_str)
-        == Some("lookup_pending")
+    matches!(
+        plan.metadata
+            .pointer("/cook_provision/action")
+            .and_then(Value::as_str),
+        Some("lookup_pending" | "attestation_pending")
+    )
 }
 
 /// A pending lookup carries no provider path. Resolve the declared exact handle
 /// only after Cook's recipe and first run record exist, then persist that path
 /// before any provider can receive work.
 fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
-    let resolution =
-        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-            &options.to_worktree,
-            &homeboy_core::defaults::load_config(),
-            None,
-        )?;
-    if resolution.worktree.handle != options.to_worktree {
+    let config = homeboy_core::defaults::load_config();
+    let identity = homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(
+        &options.to_worktree,
+        &config,
+    )?;
+    if identity.handle != options.to_worktree {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             "worktree provider did not resolve the declared exact Cook handle",
@@ -4964,7 +4965,46 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
             None,
         ));
     }
-    let target = PathBuf::from(&resolution.worktree.path);
+    if let Some(expected) = options
+        .initial_plan
+        .metadata
+        .pointer("/cook_provision/workspace_identity")
+    {
+        let expected: homeboy_core::worktree_providers::WorktreeProviderExactIdentity =
+            serde_json::from_value(expected.clone()).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "cook_provision.workspace_identity",
+                    format!("pending Cook identity is invalid: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+        if expected.schema != identity.schema
+            || expected.provider_id != identity.provider_id
+            || expected.token != identity.token
+            || expected.handle != identity.handle
+            || expected.path != identity.path
+            || expected.branch != identity.branch
+            || expected.primary != identity.primary
+        {
+            return Err(Error::validation_invalid_argument(
+                "to_worktree",
+                "provider exact identity no longer matches the durable pending Cook identity",
+                Some(options.to_worktree.clone()),
+                None,
+            ));
+        }
+    }
+    let safety = homeboy_core::worktree_providers::attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config)?;
+    if !safety.fresh || safety.dirty || safety.unpushed || identity.primary {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "provider safety attestation is not current and safe for pending Cook execution",
+            Some(options.to_worktree.clone()),
+            None,
+        ));
+    }
+    let target = PathBuf::from(&identity.path);
     homeboy_core::worktree_providers::validate_task_worktree_root(&target, &options.to_worktree)?;
     let target = std::fs::canonicalize(&target).map_err(|error| {
         Error::internal_io(error.to_string(), Some(target.display().to_string()))
@@ -4974,6 +5014,12 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
         task.metadata["cook_workspace_identity"] =
             crate::agent_task_workspace_identity::attest_workspace(&target)?;
     }
+    options.initial_plan.metadata["cook_provision"]["workspace_identity"] =
+        serde_json::to_value(&identity).expect("workspace identity serializes");
+    options.initial_plan.metadata["cook_provision"]["workspace_safety"] =
+        serde_json::to_value(&safety).expect("workspace safety serializes");
+    options.initial_plan.metadata["cook_provision"]["action"] =
+        Value::String("existing".to_string());
     options.source_worktree_path = Some(target);
     agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2899,6 +2899,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -2906,6 +2907,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
         crate::agent_task_promotion::preflight_configured_workspace_provider(&options.to_worktree)?;
     }
     if cook_attempt_needs_execution(&options.initial_run_id)
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(options)?;
@@ -3218,6 +3220,7 @@ where
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
         && options.provider_command.is_none()
         && options.provider_invocation.is_none()
@@ -3298,6 +3301,7 @@ where
     // Its initial handoff has no controller-local source path to validate yet;
     // requiring one here turns an accepted detached retry into a local failure.
     if cook_attempt_needs_execution(&options.initial_run_id)
+        && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(&options)?;
@@ -3331,6 +3335,29 @@ where
         .transpose()?;
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     materialize_initial_cook_attempt(&options)?;
+    if cook_workspace_lookup_pending(&options.initial_plan) {
+        if let Err(error) = materialize_pending_cook_workspace(&mut options) {
+            let error = with_pre_execution_phase(error, "worktree_provider_lookup");
+            record_pre_execution_failure(
+                &options.initial_plan,
+                &options.initial_run_id,
+                &error,
+                "worktree_provider_lookup",
+            )?;
+            return Ok(pre_execution_failure_report(
+                options.cook_id.clone(),
+                Vec::new(),
+                pre_execution_failure_details(
+                    agent_task_lifecycle::exact_record(&options.initial_run_id)
+                        .ok()
+                        .as_ref(),
+                    &error,
+                ),
+                error,
+                Some(&options.initial_run_id),
+            ));
+        }
+    }
     record_active_cook_worktree_warning(&options)?;
     // Durable identity now exists and resolves through the Cook alias. Publish
     // it before every remaining long controller phase — gate toolchain
@@ -3592,11 +3619,11 @@ where
                     attempt_limit,
                 );
             }
-            if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
-                validate_cook_workspace(&options)?;
-            }
             let mut failed_dispatch_plan = None;
             let execution = (|| {
+                if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
+                    validate_cook_workspace(&options)?;
+                }
                 homeboy_core::cleanup::admit_reconstructable_artifact_work(
                     plan.tasks
                         .iter()
@@ -4910,6 +4937,45 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
         ));
     }
     Ok(())
+}
+
+fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
+    plan.metadata
+        .pointer("/cook_provision/action")
+        .and_then(Value::as_str)
+        == Some("lookup_pending")
+}
+
+/// A pending lookup carries no provider path. Resolve the declared exact handle
+/// only after Cook's recipe and first run record exist, then persist that path
+/// before any provider can receive work.
+fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
+    let resolution =
+        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            &options.to_worktree,
+            &homeboy_core::defaults::load_config(),
+            None,
+        )?;
+    if resolution.worktree.handle != options.to_worktree {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree provider did not resolve the declared exact Cook handle",
+            Some(options.to_worktree.clone()),
+            None,
+        ));
+    }
+    let target = PathBuf::from(&resolution.worktree.path);
+    homeboy_core::worktree_providers::validate_task_worktree_root(&target, &options.to_worktree)?;
+    let target = std::fs::canonicalize(&target).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(target.display().to_string()))
+    })?;
+    for task in &mut options.initial_plan.tasks {
+        task.workspace.root = Some(target.display().to_string());
+        task.metadata["cook_workspace_identity"] =
+            crate::agent_task_workspace_identity::attest_workspace(&target)?;
+    }
+    options.source_worktree_path = Some(target);
+    agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
 }
 
 /// The normal configured-provider preflight rejects every dirty destination. A

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2896,7 +2896,7 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
 
 #[cfg(unix)]
 #[test]
-fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
+fn cook_persists_pending_identity_when_safety_attestation_times_out() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -2904,7 +2904,7 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
         let provider = provider_dir.path().join("provider");
         std::fs::write(
             &provider,
-            "#!/bin/sh\nprintf '%s\\n' '{\"status\":\"failed\",\"error\":{\"code\":\"git_command_timeout\",\"access_token\":\"provider-secret-must-not-persist\"}}'\n",
+            "#!/bin/sh\nif test \"$1\" = safety; then sleep 1; else printf '%s\\n' '{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"pending-identity\",\"handle\":\"fixture@cook-slow-worktree-lookup\",\"path\":\"/tmp/pending-worktree\",\"branch\":\"cook-slow-worktree-lookup\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}'; fi\n",
         )
         .expect("write provider");
         let mut permissions = std::fs::metadata(&provider)
@@ -2920,10 +2920,19 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
                 enabled: true,
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
-                lookup_timeout_ms: 10_000,
+                lookup_timeout_ms: 25,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
-                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    resolve_identity: Some(vec![
+                        provider.display().to_string(),
+                        "identity".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    attest_safety: Some(vec![
+                        provider.display().to_string(),
+                        "safety".to_string(),
+                        "{identity}".to_string(),
+                    ]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(
@@ -2950,9 +2959,14 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
         options.attempt_dispatcher = None;
         options.initial_run_id = run_id.to_string();
         options.initial_plan.metadata["cook_provision"] = serde_json::json!({
-            "action": "lookup_pending",
+            "action": "attestation_pending",
             "kind": "provider",
             "handle": options.to_worktree,
+            "workspace_identity": {
+                "schema": "homeboy/worktree-provider-identity/v1", "provider_id": "fixture", "token": "pending-identity",
+                "handle": options.to_worktree, "path": "/tmp/pending-worktree", "branch": "cook-slow-worktree-lookup", "primary": false,
+                "latency_ms": 1, "budget_ms": 25
+            }
         });
         let exact_handle = options.to_worktree.clone();
 
@@ -2968,23 +2982,19 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
             record.metadata["pre_execution_failure"]["phase"],
             "worktree_provider_lookup"
         );
-        assert_eq!(record.metadata["pre_execution_failure"]["retryable"], true);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["retryable"], true,
+            "{}",
+            record.metadata
+        );
         assert_eq!(
             record.metadata["pre_execution_failure"]["failure_classification"],
             "transient"
         );
         assert_eq!(
-            record.metadata["pre_execution_failure"]["details"]["worktree_provider_lookup"],
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_split"],
             "timed_out"
         );
-        assert_eq!(
-            record.metadata["pre_execution_failure"]["details"]["provider_timeout_attribution"],
-            serde_json::json!({ "error_code": "git_command_timeout" })
-        );
-        assert!(!record
-            .metadata
-            .to_string()
-            .contains("provider-secret-must-not-persist"));
         let recipe = super::super::load_recipe(cook_id).expect("durable Cook identity");
         assert_eq!(recipe.attempts[0].run_id, run_id);
         let persisted_plan = agent_task_lifecycle::load_plan(run_id).expect("durable lookup plan");
@@ -2993,6 +3003,10 @@ fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
             exact_handle
         );
         assert_eq!(persisted_plan.tasks[0].workspace.root, None);
+        assert_eq!(
+            persisted_plan.metadata["cook_provision"]["workspace_identity"]["token"],
+            "pending-identity"
+        );
         assert!(persisted_plan.tasks[0]
             .metadata
             .get("cook_workspace_identity")

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2894,6 +2894,115 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn cook_persists_only_redacted_failed_provider_timeout_attribution() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            "#!/bin/sh\nprintf '%s\\n' '{\"status\":\"failed\",\"error\":{\"code\":\"git_command_timeout\",\"access_token\":\"provider-secret-must-not-persist\"}}'\n",
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let cook_id = "cook-slow-worktree-lookup";
+        let run_id = "cook-slow-worktree-lookup-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        // Exercise normal local Cook: a retryable provider failure must retain
+        // the exact handle without persisting provider-owned diagnostics.
+        options.attempt_dispatcher = None;
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+        });
+        let exact_handle = options.to_worktree.clone();
+
+        let result = run_cook(options, UnusedExecutor).expect("Cook records lookup failure");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.cook_id, cook_id);
+        assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
+        assert_eq!(result.value.status, "pre_execution_failure");
+        let record = agent_task_lifecycle::status(run_id).expect("durable failed lookup");
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "worktree_provider_lookup"
+        );
+        assert_eq!(record.metadata["pre_execution_failure"]["retryable"], true);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["failure_classification"],
+            "transient"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_lookup"],
+            "timed_out"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["provider_timeout_attribution"],
+            serde_json::json!({ "error_code": "git_command_timeout" })
+        );
+        assert!(!record
+            .metadata
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
+        let recipe = super::super::load_recipe(cook_id).expect("durable Cook identity");
+        assert_eq!(recipe.attempts[0].run_id, run_id);
+        let persisted_plan = agent_task_lifecycle::load_plan(run_id).expect("durable lookup plan");
+        assert_eq!(
+            persisted_plan.metadata["cook_provision"]["handle"],
+            exact_handle
+        );
+        assert_eq!(persisted_plan.tasks[0].workspace.root, None);
+        assert!(persisted_plan.tasks[0]
+            .metadata
+            .get("cook_workspace_identity")
+            .is_none());
+        let retry = agent_task_lifecycle::retry(run_id, Some("cook-slow-worktree-lookup-retry"))
+            .expect("lookup timeout remains retryable");
+        assert_eq!(retry.metadata["retry_of"], run_id);
+    });
+}
+
 #[test]
 fn active_cooks_on_the_same_canonical_worktree_record_a_nonblocking_warning() {
     homeboy_core::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -691,6 +691,22 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                 .get("worktree_provider_lookup")
                 .and_then(Value::as_str)
                 == Some("not_found") => {}
+        Err(error)
+            if error
+                .details
+                .get("worktree_provider_lookup")
+                .and_then(Value::as_str)
+                == Some("timed_out") =>
+        {
+            // The lookup is bounded, but a timeout says nothing about whether
+            // this exact handle exists. Carry only the declared handle into
+            // Cook; durable materialization retries the same exact lookup.
+            return Ok(serde_json::json!({
+                "action": "lookup_pending",
+                "kind": "provider",
+                "handle": to_worktree,
+            }));
+        }
         Err(error) => return Err(error),
     }
 
@@ -1747,29 +1763,24 @@ pub(crate) fn compile_cook_plan(
     args: &AgentTaskCookArgs,
     provision: Value,
 ) -> homeboy::core::Result<AgentTaskPlan> {
+    let pending_lookup = provision.get("action").and_then(Value::as_str) == Some("lookup_pending");
     let workspace = provision
         .get("path")
         .and_then(Value::as_str)
-        .ok_or_else(|| {
-            homeboy::core::Error::internal_unexpected(
-                "Cook destination provisioning did not return a task worktree path".to_string(),
-            )
-        })?
-        .to_string();
+        .map(str::to_string);
+    if workspace.is_none() && !pending_lookup {
+        return Err(homeboy::core::Error::internal_unexpected(
+            "Cook destination provisioning did not return a task worktree path".to_string(),
+        ));
+    }
     let mut dispatch = dispatch_args_for_cook(args);
     // Cook providers always receive the declared task checkout. `--cwd` is a
     // dispatch input, never authority to replace the writable Cook workspace.
     dispatch.cwd = None;
-    dispatch.workspace = Some(workspace);
-    validate_cook_destination_identity(
-        args,
-        Path::new(
-            dispatch
-                .workspace
-                .as_deref()
-                .expect("Cook workspace is set"),
-        ),
-    )?;
+    dispatch.workspace = workspace.clone();
+    if let Some(workspace) = workspace.as_deref() {
+        validate_cook_destination_identity(args, Path::new(workspace))?;
+    }
     let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
     let mut plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
         Ok(plan) => plan,
@@ -1793,6 +1804,9 @@ pub(crate) fn compile_cook_plan(
         plan.metadata["cook_repository_identity"] = identity.clone();
     }
     for task in &mut plan.tasks {
+        if pending_lookup {
+            continue;
+        }
         let root = task.workspace.root.as_deref().ok_or_else(|| {
             homeboy::core::Error::validation_invalid_argument(
                 "workspace",

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -671,19 +671,25 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     }
 
     let config = defaults::load_config();
-    match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
-        to_worktree,
-        &config,
-        None,
-    ) {
-        Ok(resolution) => {
+    match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(to_worktree, &config) {
+        Ok(identity) => {
             homeboy::core::worktree_providers::validate_task_worktree_root(
-                Path::new(&resolution.worktree.path),
+                Path::new(&identity.path),
                 to_worktree,
             )?;
-            return Ok(
-                serde_json::json!({ "action": "existing", "kind": "provider", "provider": resolution.provider_id, "handle": resolution.worktree.handle, "path": resolution.worktree.path, "branch": resolution.worktree.branch }),
-            );
+            match homeboy::core::worktree_providers::attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config) {
+                Ok(safety) if safety.fresh && !safety.dirty && !safety.unpushed && !identity.primary => return Ok(serde_json::json!({
+                    "action": "existing", "kind": "provider", "provider": identity.provider_id, "handle": identity.handle, "path": identity.path, "branch": identity.branch,
+                    "workspace_identity": identity, "workspace_safety": safety,
+                })),
+                Ok(_) => return Err(homeboy::core::Error::validation_invalid_argument("to_worktree", "worktree provider safety attestation is not safe for mutation", Some(to_worktree.to_string()), None)),
+                Err(error) if error.details["worktree_provider_split"] == "timed_out" => return Ok(serde_json::json!({
+                    "action": "attestation_pending", "kind": "provider", "provider": identity.provider_id, "handle": identity.handle, "path": identity.path, "branch": identity.branch,
+                    "workspace_identity": identity,
+                    "workspace_safety": { "state": "timed_out", "latency_ms": error.details["latency_ms"], "budget_ms": error.details["budget_ms"] },
+                })),
+                Err(error) => return Err(error),
+            }
         }
         Err(error)
             if error
@@ -1763,7 +1769,10 @@ pub(crate) fn compile_cook_plan(
     args: &AgentTaskCookArgs,
     provision: Value,
 ) -> homeboy::core::Result<AgentTaskPlan> {
-    let pending_lookup = provision.get("action").and_then(Value::as_str) == Some("lookup_pending");
+    let pending_lookup = matches!(
+        provision.get("action").and_then(Value::as_str),
+        Some("lookup_pending" | "attestation_pending")
+    );
     let workspace = provision
         .get("path")
         .and_then(Value::as_str)

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -595,6 +595,15 @@ pub enum WorktreeProviderKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorktreeProviderCommands {
+    /// Versioned exact-identity lookup. It receives `{handle}` and returns a
+    /// `homeboy/worktree-provider-identity/v1` envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolve_identity: Option<Vec<String>>,
+    /// Versioned safety lookup. It receives `{identity}` from
+    /// `resolve_identity` and returns a `homeboy/worktree-provider-safety/v1`
+    /// envelope. Configure this together with `resolve_identity`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attest_safety: Option<Vec<String>>,
     /// Targeted handle lookup. Each `{handle}` argument is replaced with the
     /// requested handle. The result uses `list_result_mapping` and may contain one item.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -644,6 +653,8 @@ pub struct WorktreeProviderCommands {
 impl Default for WorktreeProviderCommands {
     fn default() -> Self {
         Self {
+            resolve_identity: None,
+            attest_safety: None,
             resolve: None,
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
@@ -1077,6 +1088,8 @@ mod tests {
     #[test]
     fn legacy_worktree_provider_commands_literal_remains_compatible() {
         let commands = WorktreeProviderCommands {
+            resolve_identity: None,
+            attest_safety: None,
             resolve: None,
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::defaults::{
     self, HomeboyConfig, WorktreeProviderConfig, WorktreeProviderKind,
@@ -160,6 +161,40 @@ pub struct WorktreeProviderHandle {
 pub struct WorktreeProviderResolution {
     pub provider_id: String,
     pub worktree: WorktreeProviderHandle,
+}
+
+/// Exact provider identity, intentionally separate from mutable workspace
+/// safety. `token` is opaque to Homeboy and is the sole value accepted by a
+/// versioned provider safety command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorktreeProviderExactIdentity {
+    pub schema: String,
+    pub provider_id: String,
+    pub token: String,
+    pub handle: String,
+    pub path: String,
+    pub branch: String,
+    pub primary: bool,
+    pub latency_ms: u128,
+    pub budget_ms: u128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorktreeProviderSafetyAttestation {
+    pub schema: String,
+    pub identity_token: String,
+    pub observed_at: String,
+    pub dirty: bool,
+    pub unpushed: bool,
+    pub fresh: bool,
+    pub latency_ms: u128,
+    pub budget_ms: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeProviderSplitResolution {
+    pub identity: WorktreeProviderExactIdentity,
+    pub safety: WorktreeProviderSafetyAttestation,
 }
 
 /// Explicit destination inputs required to create a managed worktree without
@@ -358,6 +393,145 @@ pub fn resolve_apply_enabled_worktree_provider_from_config(
         gate_feedback_baseline,
         None,
     )
+}
+
+/// Resolve exact identity then obtain current safety evidence. Providers that
+/// have not adopted the split commands continue through the established
+/// combined resolver, which is deliberately retained as a compatibility adapter.
+pub fn resolve_apply_enabled_worktree_provider_split_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderSplitResolution> {
+    let identity = resolve_apply_enabled_worktree_provider_identity_from_config(handle, config)?;
+    let safety = attest_apply_enabled_worktree_provider_safety_from_config(&identity, config)?;
+    if !safety.fresh || safety.dirty || safety.unpushed || identity.primary {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree provider safety attestation is not safe for mutation",
+            Some(handle.to_string()),
+            None,
+        ));
+    }
+    Ok(WorktreeProviderSplitResolution { identity, safety })
+}
+
+/// Resolve only an exact provider workspace identity. This operation performs
+/// no cleanliness or freshness assertion and is safe to persist before safety
+/// evidence becomes available.
+pub fn resolve_apply_enabled_worktree_provider_identity_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderExactIdentity> {
+    let mut provider_ids = config
+        .worktree_providers
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    provider_ids.sort();
+    for provider_id in provider_ids {
+        let provider = &config.worktree_providers[&provider_id];
+        if !provider.enabled || !provider.apply_enabled {
+            continue;
+        }
+        match (&provider.commands.resolve_identity, &provider.commands.attest_safety) {
+            (Some(identity_command), Some(safety_command)) => {
+                let identity = run_provider_identity_command(&provider_id, provider, identity_command, handle)?;
+                if identity.handle != handle {
+                    return Err(Error::validation_invalid_argument("to_worktree", "worktree provider identity did not resolve the declared exact handle", Some(handle.to_string()), None));
+                }
+                let _ = safety_command;
+                return Ok(identity);
+            }
+            (None, None) => continue,
+            _ => return Err(Error::validation_invalid_argument("worktree_providers.commands", format!("worktree provider `{provider_id}` must configure both resolve_identity and attest_safety"), Some(provider_id), None)),
+        }
+    }
+    let started = std::time::Instant::now();
+    let resolution = resolve_apply_enabled_worktree_provider_from_config(handle, config, None)?;
+    let elapsed_ms = started.elapsed().as_millis();
+    let token = compatibility_identity_token(&resolution);
+    Ok(WorktreeProviderExactIdentity {
+        schema: "homeboy/worktree-provider-identity/v1".to_string(),
+        provider_id: resolution.provider_id.clone(),
+        token: token.clone(),
+        handle: resolution.worktree.handle.clone(),
+        path: resolution.worktree.path.clone(),
+        branch: resolution.worktree.branch.clone(),
+        primary: resolution.worktree.safety.primary,
+        latency_ms: elapsed_ms,
+        budget_ms: config.worktree_providers[&resolution.provider_id].lookup_timeout_ms as u128,
+    })
+}
+
+/// Attest safety for a previously persisted exact identity. A versioned
+/// provider receives only its opaque token; the compatibility adapter rechecks
+/// the same exact handle and rejects any identity drift.
+pub fn attest_apply_enabled_worktree_provider_safety_from_config(
+    identity: &WorktreeProviderExactIdentity,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderSafetyAttestation> {
+    let provider = config
+        .worktree_providers
+        .get(&identity.provider_id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "worktree_provider",
+                "identity provider is no longer configured",
+                Some(identity.provider_id.clone()),
+                None,
+            )
+        })?;
+    if !provider.enabled || !provider.apply_enabled {
+        return Err(Error::validation_invalid_argument(
+            "worktree_provider",
+            "identity provider is no longer apply-enabled",
+            Some(identity.provider_id.clone()),
+            None,
+        ));
+    }
+    if let Some(command) = &provider.commands.attest_safety {
+        let safety =
+            run_provider_safety_command(&identity.provider_id, provider, command, &identity.token)?;
+        if safety.identity_token != identity.token {
+            return Err(Error::validation_invalid_argument(
+                "to_worktree",
+                "worktree provider safety evidence is bound to a different exact identity",
+                Some(identity.handle.clone()),
+                None,
+            ));
+        }
+        return Ok(safety);
+    }
+    let started = std::time::Instant::now();
+    let resolution =
+        resolve_apply_enabled_worktree_provider_from_config(&identity.handle, config, None)?;
+    if resolution.provider_id != identity.provider_id
+        || compatibility_identity_token(&resolution) != identity.token
+    {
+        return Err(Error::validation_invalid_argument("to_worktree", "combined worktree provider safety evidence no longer matches the persisted exact identity", Some(identity.handle.clone()), None));
+    }
+    Ok(WorktreeProviderSafetyAttestation {
+        schema: "homeboy/worktree-provider-safety/v1".to_string(),
+        identity_token: identity.token.clone(),
+        observed_at: chrono::Utc::now().to_rfc3339(),
+        dirty: resolution.worktree.safety.dirty,
+        unpushed: resolution.worktree.safety.unpushed,
+        fresh: true,
+        latency_ms: started.elapsed().as_millis(),
+        budget_ms: provider.lookup_timeout_ms as u128,
+    })
+}
+
+fn compatibility_identity_token(resolution: &WorktreeProviderResolution) -> String {
+    let mut digest = Sha256::new();
+    digest.update(resolution.provider_id.as_bytes());
+    digest.update([0]);
+    digest.update(resolution.worktree.handle.as_bytes());
+    digest.update([0]);
+    digest.update(resolution.worktree.path.as_bytes());
+    digest.update([0]);
+    digest.update(resolution.worktree.branch.as_bytes());
+    format!("compat-v1:{:x}", digest.finalize())
 }
 
 /// Find the sole apply-enabled provider worktree owned by a tracker URL.
@@ -1034,6 +1208,113 @@ fn run_provider_resolve_command(
         "resolve",
         &provider.commands.resolve_not_found_exit_codes,
     )
+}
+
+fn run_provider_identity_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    handle: &str,
+) -> Result<WorktreeProviderExactIdentity> {
+    let command = command
+        .iter()
+        .map(|argument| argument.replace("{handle}", handle))
+        .collect::<Vec<_>>();
+    let (payload, latency_ms, budget_ms) =
+        run_provider_split_command(provider_id, provider, &command, "resolve_identity")?;
+    let identity: WorktreeProviderExactIdentity = serde_json::from_value(payload).map_err(|error| Error::validation_invalid_argument("worktree_providers.commands.resolve_identity", format!("worktree provider `{provider_id}` returned an invalid identity envelope: {error}"), Some(provider_id.to_string()), None))?;
+    if identity.schema != "homeboy/worktree-provider-identity/v1"
+        || identity.provider_id != provider_id
+        || identity.token.trim().is_empty()
+    {
+        return Err(Error::validation_invalid_argument("worktree_providers.commands.resolve_identity", format!("worktree provider `{provider_id}` returned an unsupported or incomplete identity envelope"), Some(provider_id.to_string()), None));
+    }
+    Ok(WorktreeProviderExactIdentity {
+        latency_ms,
+        budget_ms,
+        ..identity
+    })
+}
+
+fn run_provider_safety_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    token: &str,
+) -> Result<WorktreeProviderSafetyAttestation> {
+    let command = command
+        .iter()
+        .map(|argument| argument.replace("{identity}", token))
+        .collect::<Vec<_>>();
+    let (payload, latency_ms, budget_ms) =
+        run_provider_split_command(provider_id, provider, &command, "attest_safety")?;
+    let safety: WorktreeProviderSafetyAttestation = serde_json::from_value(payload).map_err(|error| Error::validation_invalid_argument("worktree_providers.commands.attest_safety", format!("worktree provider `{provider_id}` returned an invalid safety envelope: {error}"), Some(provider_id.to_string()), None))?;
+    if safety.schema != "homeboy/worktree-provider-safety/v1"
+        || safety.identity_token.trim().is_empty()
+        || safety.observed_at.trim().is_empty()
+    {
+        return Err(Error::validation_invalid_argument("worktree_providers.commands.attest_safety", format!("worktree provider `{provider_id}` returned an unsupported or incomplete safety envelope"), Some(provider_id.to_string()), None));
+    }
+    Ok(WorktreeProviderSafetyAttestation {
+        latency_ms,
+        budget_ms,
+        ..safety
+    })
+}
+
+fn run_provider_split_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    operation: &str,
+) -> Result<(Value, u128, u128)> {
+    let timeout = provider_lookup_timeout(provider)?;
+    let output_limit = provider_lookup_output_limit(provider)?;
+    let (program, args) = command.split_first().filter(|(program, _)| !program.trim().is_empty()).ok_or_else(|| Error::validation_invalid_argument("worktree_providers.commands", format!("worktree provider `{provider_id}` {operation} command must include an executable"), Some(provider_id.to_string()), None))?;
+    let mut process = Command::new(program);
+    process
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::engine::command::isolate_process_tree(&mut process);
+    let mut child = process.spawn().map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command could not start: {error}"
+            ),
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
+    let started = std::time::Instant::now();
+    let supervised = crate::engine::command::wait_with_bounded_output_supervised(&mut child, output_limit, timeout, Duration::from_millis(100), || false, |_, _| Ok(())).map_err(|error| Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command could not be supervised: {error}"), Some(provider_id.to_string()), None))?;
+    let elapsed_ms = started.elapsed().as_millis();
+    if supervised.termination != crate::engine::command::SupervisedCommandTermination::Completed {
+        let mut error = Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured safety/identity budget: {} ms)", timeout.as_millis()), Some(provider_id.to_string()), None);
+        error.retryable = Some(true);
+        error.details["worktree_provider_split_operation"] = Value::String(operation.to_string());
+        error.details["worktree_provider_split"] = Value::String("timed_out".to_string());
+        error.details["latency_ms"] = Value::from(elapsed_ms as u64);
+        error.details["budget_ms"] = Value::from(timeout.as_millis() as u64);
+        return Err(error);
+    }
+    let output = supervised.output;
+    if output.capture.stdout.truncated {
+        return Err(Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes"), Some(provider_id.to_string()), None));
+    }
+    let output = output.into_output();
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument_with_evidence(
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command failed"),
+            Some(provider_id.to_string()),
+            None,
+            Some(provider_command_evidence(command, &output)),
+        ));
+    }
+    let payload = serde_json::from_slice(&output.stdout).map_err(|error| Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command returned invalid JSON: {error}"), Some(provider_id.to_string()), None))?;
+    Ok((payload, elapsed_ms, timeout.as_millis()))
 }
 
 fn run_provider_resolve_path_command(
@@ -4460,6 +4741,55 @@ mod tests {
             provider.follow_up_command.as_deref(),
             Some("provider status cleanup-run-1")
         );
+    }
+
+    #[test]
+    fn split_identity_survives_a_timed_out_safety_attestation() {
+        let mut provider = default_command_provider();
+        provider.lookup_timeout_ms = 25;
+        provider.commands.resolve_identity = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '%s' '{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"opaque-identity\",\"handle\":\"fixture@branch\",\"path\":\"/tmp/fixture\",\"branch\":\"branch\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}'".to_string(),
+        ]);
+        provider.commands.attest_safety = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "sleep 1; printf '%s' '{}'".to_string(),
+        ]);
+        let config = config_with_provider(provider);
+
+        let identity =
+            resolve_apply_enabled_worktree_provider_identity_from_config("fixture@branch", &config)
+                .expect("cheap exact identity is available");
+        let error = attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config)
+            .expect_err("bounded safety probe times out");
+
+        assert_eq!(identity.token, "opaque-identity");
+        assert_eq!(error.details["worktree_provider_split"], "timed_out");
+        assert_eq!(
+            error.details["worktree_provider_split_operation"],
+            "attest_safety"
+        );
+    }
+
+    #[test]
+    fn split_provider_rejects_safety_evidence_for_a_different_identity() {
+        let mut provider = default_command_provider();
+        provider.commands.resolve_identity = Some(vec![
+            "sh".to_string(), "-c".to_string(),
+            "printf '%s' '{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"opaque-identity\",\"handle\":\"fixture@branch\",\"path\":\"/tmp/fixture\",\"branch\":\"branch\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}'".to_string(),
+        ]);
+        provider.commands.attest_safety = Some(vec![
+            "sh".to_string(), "-c".to_string(),
+            "printf '%s' '{\"schema\":\"homeboy/worktree-provider-safety/v1\",\"identity_token\":\"other\",\"observed_at\":\"2026-01-01T00:00:00Z\",\"dirty\":false,\"unpushed\":false,\"fresh\":true,\"latency_ms\":0,\"budget_ms\":0}'".to_string(),
+        ]);
+        let error = resolve_apply_enabled_worktree_provider_split_from_config(
+            "fixture@branch",
+            &config_with_provider(provider),
+        )
+        .expect_err("mismatched evidence is fail-closed");
+        assert!(error.message.contains("different exact identity"));
     }
 
     fn config_with_provider(provider: WorktreeProviderConfig) -> HomeboyConfig {

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1146,7 +1146,7 @@ fn run_provider_lookup_command(
     })?;
     let elapsed_ms = started.elapsed().as_millis();
     if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
-        return Err(Error::validation_invalid_argument(
+        let mut error = Error::validation_invalid_argument(
             "to_worktree",
             format!(
                 "worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured lookup_timeout_ms: {})",
@@ -1157,7 +1157,16 @@ fn run_provider_lookup_command(
                 "Refresh or repair the configured workspace provider, then retry the operation."
                     .to_string(),
             ]),
-        ));
+        );
+        // A bounded read-only probe cannot establish that an exact handle is
+        // invalid. Preserve that distinction for durable callers instead of
+        // turning provider latency into an input error.
+        error.retryable = Some(true);
+        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+        error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+        error.details["lookup_timeout_ms"] = Value::from(timeout.as_millis() as u64);
+        return Err(error);
     }
     let output = output.output;
     if output.capture.stdout.truncated {
@@ -1207,6 +1216,28 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
+    if let Some(attribution) = provider_failed_lookup_timeout_attribution(&value) {
+        let mut error = Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command completed with a retryable git command timeout"
+            ),
+            Some(provider_id.to_string()),
+            Some(vec![
+                "Refresh or repair the configured workspace provider, then retry the operation."
+                    .to_string(),
+            ]),
+        );
+        error.retryable = Some(true);
+        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+        error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+        // Provider output can contain credentials and arbitrary diagnostics.
+        // Persist only this fixed, redacted timeout classification.
+        error.details["provider_timeout_attribution"] =
+            serde_json::to_value(attribution).expect("fixed timeout attribution serializes");
+        return Err(error);
+    }
     let mapping = provider.list_result_mapping.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "worktree_providers.list_result_mapping",
@@ -1218,6 +1249,28 @@ fn run_provider_lookup_command(
         )
     })?;
     map_provider_list_result(provider_id, mapping, &value)
+}
+
+#[derive(Serialize)]
+struct ProviderLookupTimeoutAttribution {
+    error_code: &'static str,
+}
+
+/// A command can finish successfully while its provider reports a failed lookup.
+/// Treat only this explicit failure envelope as retryable; payload metadata is
+/// provider-owned data rather than a causal error signal.
+fn provider_failed_lookup_timeout_attribution(
+    value: &Value,
+) -> Option<ProviderLookupTimeoutAttribution> {
+    let failed = matches!(
+        value.get("status").and_then(Value::as_str),
+        Some("failed" | "error")
+    );
+    let timed_out =
+        value.pointer("/error/code").and_then(Value::as_str) == Some("git_command_timeout");
+    (failed && timed_out).then_some(ProviderLookupTimeoutAttribution {
+        error_code: "git_command_timeout",
+    })
 }
 
 fn provider_lookup_timeout(provider: &WorktreeProviderConfig) -> Result<Duration> {
@@ -3541,6 +3594,82 @@ mod tests {
 
         assert!(error.message.contains("timed out"));
         assert!(error.message.contains("configured lookup_timeout_ms: 25"));
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
+        assert_eq!(error.details["worktree_provider_operation"], "list");
+    }
+
+    #[test]
+    fn failed_provider_timeout_envelope_is_retryable_and_redacted() {
+        let script = fake_list_provider_script(json!({
+            "status": "failed",
+            "error": {
+                "code": "git_command_timeout",
+                "access_token": "provider-secret-must-not-persist"
+            }
+        }));
+        let error = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![script, "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect_err("explicit failed timeout remains retryable");
+
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
+        assert_eq!(error.details["worktree_provider_operation"], "resolve");
+        assert_eq!(
+            error.details["provider_timeout_attribution"],
+            json!({ "error_code": "git_command_timeout" })
+        );
+        assert!(!error
+            .details
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
+    }
+
+    #[test]
+    fn successful_payload_timeout_metadata_does_not_classify_a_timeout() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "cook-target");
+        let script = fake_list_provider_script(json!({
+            "status": "completed",
+            "metadata": { "error": { "code": "git_command_timeout" } },
+            "worktrees": [{
+                "handle": "fixture@cook-target",
+                "path": workspace.path(),
+                "branch": "cook-target",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }]
+        }));
+        let resolved = resolve_worktree_provider_handle_from_config(
+            "fixture@cook-target",
+            &config_with_provider(WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: false,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![script, "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            }),
+        )
+        .expect("successful payload metadata is not an error envelope");
+
+        assert_eq!(resolved.handle, "fixture@cook-target");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add versioned exact-identity and safety-attestation command-provider contracts, retaining the combined resolver as a compatibility adapter
- persist an identity-bound pending Cook attestation without dispatching provider work, then require a fresh matching safety result before execution
- record separate identity and safety latency/budget fields and add timeout and mismatched-evidence coverage

Fixes #12091

## Tests
- `cargo fmt --all`
- `cargo test -p homeboy-core worktree_providers::tests::split`
- `cargo test -p homeboy-agents cook_persists_pending_identity_when_safety_attestation_times_out`
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used for implementation and testing. Chris Huber remains responsible for every line.