### PR TITLE
Follow-up: preserve repo-only Cook identity safety

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4992,13 +4992,17 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
 }
 
 fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path) -> Result<()> {
-    let Some(expected) = plan
+    let expected_remote = plan
         .metadata
         .pointer("/cook_repository_identity/remote_identity")
-        .and_then(Value::as_str)
-    else {
+        .and_then(Value::as_str);
+    let expected_repository_name = plan
+        .metadata
+        .pointer("/cook_repository_identity/repository_name")
+        .and_then(Value::as_str);
+    if expected_remote.is_none() && expected_repository_name.is_none() {
         return Ok(());
-    };
+    }
     let Some(git_root) = homeboy_core::git::repo_root(target) else {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
@@ -5013,15 +5017,35 @@ fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path
         .filter_map(|remote| homeboy_core::git::remote_url(&git_root, remote))
         .filter_map(|remote| canonical_remote_identity(&remote))
         .collect::<std::collections::BTreeSet<_>>();
-    if identities.len() == 1 && identities.contains(expected) {
+    if let Some(expected) = expected_remote {
+        if identities.len() == 1 && identities.contains(expected) {
+            return Ok(());
+        }
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("Cook destination repository identity does not match resolved `{expected}`"),
+            Some(target.display().to_string()),
+            None,
+        ));
+    }
+    let expected = expected_repository_name.expect("repository expectation exists");
+    if identities.len() == 1
+        && identities.iter().any(|identity| {
+            repository_name_from_canonical_remote_identity(identity) == Some(expected)
+        })
+    {
         return Ok(());
     }
     Err(Error::validation_invalid_argument(
         "to_worktree",
-        format!("Cook destination repository identity does not match resolved `{expected}`"),
+        "Cook destination repository does not match the requested Cook repository",
         Some(target.display().to_string()),
         None,
     ))
+}
+
+fn repository_name_from_canonical_remote_identity(identity: &str) -> Option<&str> {
+    identity.strip_prefix("git://")?.rsplit('/').next()
 }
 
 fn canonical_remote_identity(remote_url: &str) -> Option<String> {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4992,85 +4992,15 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
 }
 
 fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path) -> Result<()> {
-    let expected_remote = plan
-        .metadata
-        .pointer("/cook_repository_identity/remote_identity")
-        .and_then(Value::as_str);
-    let expected_repository_name = plan
-        .metadata
-        .pointer("/cook_repository_identity/repository_name")
-        .and_then(Value::as_str);
-    if expected_remote.is_none() && expected_repository_name.is_none() {
-        return Ok(());
-    }
-    let Some(git_root) = homeboy_core::git::repo_root(target) else {
-        return Err(Error::validation_invalid_argument(
-            "to_worktree",
-            "Cook destination is not a Git checkout bound to the resolved repository identity",
-            Some(target.display().to_string()),
-            None,
-        ));
-    };
-    let identities = homeboy_core::git::output_optional(&git_root, &["remote"])
-        .unwrap_or_default()
-        .lines()
-        .filter_map(|remote| homeboy_core::git::remote_url(&git_root, remote))
-        .filter_map(|remote| canonical_remote_identity(&remote))
-        .collect::<std::collections::BTreeSet<_>>();
-    if let Some(expected) = expected_remote {
-        if identities.len() == 1 && identities.contains(expected) {
-            return Ok(());
-        }
-        return Err(Error::validation_invalid_argument(
-            "to_worktree",
-            format!("Cook destination repository identity does not match resolved `{expected}`"),
-            Some(target.display().to_string()),
-            None,
-        ));
-    }
-    let expected = expected_repository_name.expect("repository expectation exists");
-    if identities.len() == 1
-        && identities.iter().any(|identity| {
-            repository_name_from_canonical_remote_identity(identity) == Some(expected)
-        })
-    {
-        return Ok(());
-    }
-    Err(Error::validation_invalid_argument(
-        "to_worktree",
-        "Cook destination repository does not match the requested Cook repository",
-        Some(target.display().to_string()),
-        None,
-    ))
-}
-
-fn repository_name_from_canonical_remote_identity(identity: &str) -> Option<&str> {
-    identity.strip_prefix("git://")?.rsplit('/').next()
-}
-
-fn canonical_remote_identity(remote_url: &str) -> Option<String> {
-    let remote_url = remote_url.trim();
-    let (host, path) = if let Some((_, rest)) = remote_url.split_once("://") {
-        let (authority, path) = rest.split_once('/')?;
-        (authority.rsplit('@').next()?, path)
-    } else {
-        let (authority, path) = remote_url.split_once(':')?;
-        (authority.rsplit('@').next()?, path)
-    };
-    let path = path.trim_matches('/').trim_end_matches(".git");
-    (!host.is_empty()
-        && path
-            .split('/')
-            .filter(|segment| !segment.is_empty())
-            .count()
-            >= 2)
-        .then(|| {
-            format!(
-                "git://{}/{}",
-                host.to_ascii_lowercase(),
-                path.to_ascii_lowercase()
-            )
-        })
+    homeboy_core::worktree_providers::validate_task_worktree_repository_identity(
+        target,
+        plan.metadata
+            .pointer("/cook_repository_identity/remote_identity")
+            .and_then(Value::as_str),
+        plan.metadata
+            .pointer("/cook_repository_identity/repository_name")
+            .and_then(Value::as_str),
+    )
 }
 
 /// The normal configured-provider preflight rejects every dirty destination. A

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3153,6 +3153,147 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn pending_repo_only_lookup_rejects_provider_workspace_from_another_repository() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider tempdir");
+        let primary = temp.path().join("foreign-primary");
+        let foreign = temp.path().join("foreign-worktree");
+        for args in [
+            vec![
+                "init",
+                "--initial-branch",
+                "main",
+                primary.to_str().expect("primary path"),
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "config",
+                "user.email",
+                "test@example.com",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "config",
+                "user.name",
+                "Test",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "remote",
+                "add",
+                "origin",
+                "https://token:provider-secret@example.com/foreign.git",
+            ],
+            vec![
+                "-C",
+                primary.to_str().expect("primary path"),
+                "worktree",
+                "add",
+                "-b",
+                "foreign",
+                foreign.to_str().expect("foreign path"),
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .status()
+                .expect("git runs")
+                .success());
+        }
+        let provider = temp.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@repo-only-mismatch\",\"path\":\"{}\",\"branch\":\"foreign\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                foreign.display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+        let cook_id = "repo-only-mismatch";
+        let run_id = "repo-only-mismatch-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.attempt_dispatcher = None;
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending", "kind": "provider", "handle": options.to_worktree,
+            "worktree_provider_id": "fixture",
+        });
+        options.initial_plan.metadata["cook_repository_identity"] = serde_json::json!({
+            "slug": "expected", "remote_identity": "git://example.com/expected",
+            "provenance": "--repo:configured-component",
+        });
+
+        let result = run_cook(options, UnusedExecutor).expect("Cook records identity failure");
+
+        assert_eq!(result.value.status, "pre_execution_failure");
+        let record = agent_task_lifecycle::status(run_id).expect("durable identity failure");
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "worktree_provider_lookup"
+        );
+        assert!(record.metadata["pre_execution_failure"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("does not match"));
+        assert!(!record.metadata.to_string().contains("provider-secret"));
+        let persisted = agent_task_lifecycle::load_plan(run_id).expect("persisted plan");
+        assert!(persisted.tasks[0].workspace.root.is_none());
+        assert!(persisted.tasks[0]
+            .metadata
+            .get("cook_workspace_identity")
+            .is_none());
+    });
+}
+
 #[test]
 fn active_cooks_on_the_same_canonical_worktree_record_a_nonblocking_warning() {
     homeboy_core::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3267,8 +3267,8 @@ fn pending_repo_only_lookup_rejects_provider_workspace_from_another_repository()
             "worktree_provider_id": "fixture",
         });
         options.initial_plan.metadata["cook_repository_identity"] = serde_json::json!({
-            "slug": "expected", "remote_identity": "git://example.com/expected",
-            "provenance": "--repo:configured-component",
+            "slug": "expected", "repository_name": "expected",
+            "provenance": "--repo:requested-repository",
         });
 
         let result = run_cook(options, UnusedExecutor).expect("Cook records identity failure");

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -879,8 +879,8 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
 }
 
 /// A repo-only Cook has no local checkout to attest before a deferred provider
-/// lookup. Bind its configured repository identity into the durable recipe so
-/// the returned provider workspace still has to prove the requested ownership.
+/// lookup. Prefer configured remote identity; otherwise retain a normalized
+/// repository name that the resolved checkout must prove through its remote.
 fn bind_cook_repository_identity_from_config(
     args: &mut AgentTaskCookArgs,
 ) -> homeboy::core::Result<()> {
@@ -889,28 +889,36 @@ fn bind_cook_repository_identity_from_config(
     };
     let component = homeboy::core::component::registered()?
         .into_iter()
-        .find(|component| component.id == repo)
-        .ok_or_else(|| repository_identity_unavailable_error(repo))?;
-    let remote_identity = component
-        .remote_url
-        .as_deref()
-        .and_then(canonical_remote_identity)
-        .ok_or_else(|| repository_identity_unavailable_error(repo))?;
-    args.repository_identity = Some(serde_json::json!({
-        "slug": component.id,
-        "remote_identity": remote_identity,
-        "provenance": "--repo:configured-component",
-    }));
+        .find(|component| component.id == repo);
+    args.repository_identity = Some(
+        match component
+            .as_ref()
+            .and_then(|component| component.remote_url.as_deref())
+            .and_then(canonical_remote_identity)
+        {
+            Some(remote_identity) => serde_json::json!({
+                "slug": repo,
+                "remote_identity": remote_identity,
+                "provenance": "--repo:configured-component",
+            }),
+            None => serde_json::json!({
+                "slug": repo,
+                "repository_name": normalize_repository_name(repo),
+                "provenance": "--repo:requested-repository",
+            }),
+        },
+    );
     Ok(())
 }
 
-fn repository_identity_unavailable_error(repo: &str) -> homeboy::core::Error {
-    homeboy::core::Error::validation_invalid_argument(
-        "repo",
-        "Cook requires the selected configured component to declare a canonical repository identity before deferred workspace lookup",
-        Some(repo.to_string()),
-        None,
-    )
+fn normalize_repository_name(repository: &str) -> String {
+    repository
+        .trim()
+        .trim_end_matches(".git")
+        .rsplit('/')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
 }
 
 fn require_explicit_cook_repo(args: &AgentTaskCookArgs, reason: &str) -> homeboy::core::Result<()> {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -825,7 +825,7 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
                 "the supplied workspace is not a Git checkout with a configured repository remote",
             );
         }
-        return Ok(());
+        return bind_cook_repository_identity_from_config(args);
     }
 
     let source_remotes = source_identities
@@ -876,6 +876,41 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
         "provenance": selected.provenance,
     }));
     Ok(())
+}
+
+/// A repo-only Cook has no local checkout to attest before a deferred provider
+/// lookup. Bind its configured repository identity into the durable recipe so
+/// the returned provider workspace still has to prove the requested ownership.
+fn bind_cook_repository_identity_from_config(
+    args: &mut AgentTaskCookArgs,
+) -> homeboy::core::Result<()> {
+    let Some(repo) = args.dispatch.repo.as_deref() else {
+        return Ok(());
+    };
+    let component = homeboy::core::component::registered()?
+        .into_iter()
+        .find(|component| component.id == repo)
+        .ok_or_else(|| repository_identity_unavailable_error(repo))?;
+    let remote_identity = component
+        .remote_url
+        .as_deref()
+        .and_then(canonical_remote_identity)
+        .ok_or_else(|| repository_identity_unavailable_error(repo))?;
+    args.repository_identity = Some(serde_json::json!({
+        "slug": component.id,
+        "remote_identity": remote_identity,
+        "provenance": "--repo:configured-component",
+    }));
+    Ok(())
+}
+
+fn repository_identity_unavailable_error(repo: &str) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "repo",
+        "Cook requires the selected configured component to declare a canonical repository identity before deferred workspace lookup",
+        Some(repo.to_string()),
+        None,
+    )
 }
 
 fn require_explicit_cook_repo(args: &AgentTaskCookArgs, reason: &str) -> homeboy::core::Result<()> {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -681,6 +681,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                 Path::new(&resolution.worktree.path),
                 to_worktree,
             )?;
+            validate_cook_destination_identity(args, Path::new(&resolution.worktree.path))?;
             return Ok(
                 serde_json::json!({ "action": "existing", "kind": "provider", "provider": resolution.provider_id, "handle": resolution.worktree.handle, "path": resolution.worktree.path, "branch": resolution.worktree.branch }),
             );
@@ -1045,44 +1046,16 @@ fn validate_cook_destination_identity(
     args: &AgentTaskCookArgs,
     destination: &Path,
 ) -> homeboy::core::Result<()> {
-    let Some(expected) = args
-        .repository_identity
-        .as_ref()
-        .and_then(|identity| identity.get("remote_identity"))
-        .and_then(Value::as_str)
-    else {
-        return Ok(());
-    };
-    let Some(git_root) = homeboy::core::git::repo_root(destination) else {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "to_worktree",
-            "Cook destination is not a Git checkout bound to the resolved repository identity",
-            Some(destination.display().to_string()),
-            None,
-        ));
-    };
-    let identities = homeboy::core::git::output_optional(&git_root, &["remote"])
-        .unwrap_or_default()
-        .lines()
-        .filter_map(|remote| homeboy::core::git::remote_url(&git_root, remote))
-        .filter_map(|remote| canonical_remote_identity(&remote))
-        .collect::<std::collections::BTreeSet<_>>();
-    if identities.len() == 1 && identities.contains(expected) {
-        return Ok(());
-    }
-    Err(homeboy::core::Error::validation_invalid_argument(
-        "to_worktree",
-        format!(
-            "Cook destination repository identity does not match resolved `{expected}`; destination identities: {}",
-            if identities.is_empty() {
-                "unresolved".to_string()
-            } else {
-                identities.into_iter().collect::<Vec<_>>().join(", ")
-            }
-        ),
-        Some(destination.display().to_string()),
-        None,
-    ))
+    let identity = args.repository_identity.as_ref();
+    homeboy::core::worktree_providers::validate_task_worktree_repository_identity(
+        destination,
+        identity
+            .and_then(|identity| identity.get("remote_identity"))
+            .and_then(Value::as_str),
+        identity
+            .and_then(|identity| identity.get("repository_name"))
+            .and_then(Value::as_str),
+    )
 }
 
 fn repository_identity_error(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -177,6 +177,62 @@ fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance()
 }
 
 #[test]
+fn repo_only_cook_persists_configured_repository_identity_for_deferred_lookup() {
+    with_isolated_home(|_| {
+        let component_root = tempfile::tempdir().expect("component root");
+        register_component(
+            "expected",
+            component_root.path(),
+            "https://token:secret@github.com/example/expected.git",
+        );
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--repo".to_string(),
+            "expected".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@expected".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("bind configured repository identity");
+
+        let identity = args.repository_identity.expect("repository identity");
+        assert_eq!(
+            identity["remote_identity"],
+            "git://github.com/example/expected"
+        );
+        assert_eq!(identity["provenance"], "--repo:configured-component");
+        assert!(!identity.to_string().contains("secret"));
+    });
+}
+
+#[test]
+fn repo_only_cook_rejects_component_without_a_canonical_repository_identity() {
+    with_isolated_home(|_| {
+        let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--repo".to_string(),
+            "unidentified".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@unidentified".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("repo-only Cook must establish an identity before deferred lookup");
+
+        assert_eq!(error.details["field"], "repo");
+        assert!(!error.message.contains("git://"));
+    });
+}
+
+#[test]
 fn cook_rejects_ambiguous_or_mismatching_workspace_repository_identity() {
     with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -82,6 +82,13 @@ fn cook_derives_issue_destination_and_preserves_explicit_override() {
             Some("homeboy@fix-issue-11225-homeboy")
         );
         assert_eq!(derived.head.as_deref(), Some("fix/issue-11225-homeboy"));
+        assert_eq!(
+            derived
+                .repository_identity
+                .as_ref()
+                .expect("repo expectation")["repository_name"],
+            "homeboy"
+        );
 
         let suffixed = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
             "homeboy".to_string(),
@@ -211,9 +218,9 @@ fn repo_only_cook_persists_configured_repository_identity_for_deferred_lookup() 
 }
 
 #[test]
-fn repo_only_cook_rejects_component_without_a_canonical_repository_identity() {
+fn repo_only_cook_without_registered_component_persists_requested_repository_expectation() {
     with_isolated_home(|_| {
-        let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
             "cook".to_string(),
@@ -225,10 +232,11 @@ fn repo_only_cook_rejects_component_without_a_canonical_repository_identity() {
             "fixture@unidentified".to_string(),
             "--no-finalize".to_string(),
         ]))
-        .expect_err("repo-only Cook must establish an identity before deferred lookup");
+        .expect("repo-only Cook remains compatible without component registration");
 
-        assert_eq!(error.details["field"], "repo");
-        assert!(!error.message.contains("git://"));
+        let identity = args.repository_identity.expect("repository expectation");
+        assert_eq!(identity["repository_name"], "unidentified");
+        assert_eq!(identity["provenance"], "--repo:requested-repository");
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -872,6 +872,11 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
     with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         init_runtime_component_checkout(workspace.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://github.com/example/existing.git",
+        );
         let destination_root = tempfile::tempdir().expect("destination root");
         let destination = destination_root.path().join("task");
         assert!(Command::new("git")
@@ -932,22 +937,124 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
         );
         homeboy::core::defaults::save_config(&config).expect("save provider config");
 
-        let args = cook_args_from_cli(vec![
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
             "homeboy".to_string(),
             "agent-task".to_string(),
             "cook".to_string(),
             "--prompt".to_string(),
             "reuse destination".to_string(),
+            "--repo".to_string(),
+            "existing".to_string(),
             "--to-worktree".to_string(),
             "fixture@existing".to_string(),
             "--no-finalize".to_string(),
-        ]);
+        ]))
+        .expect("repo-only Cook retains its requested repository expectation");
         let provision = super::super::run::provision_cook_destination(&args)
             .expect("existing provider destination resolves without creation fields");
 
         assert_eq!(provision["action"], "existing");
         assert_eq!(provision["provider"], "fixture");
         assert_eq!(provision["path"], destination.display().to_string());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn cook_rejects_immediately_resolved_provider_destination_from_another_repository() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://token:provider-secret@github.com/example/foreign.git",
+        );
+        let destination_root = tempfile::tempdir().expect("destination root");
+        let destination = destination_root.path().join("task");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/foreign",
+                destination.to_str().expect("destination path"),
+                "HEAD",
+            ])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
+        let provider_dir = tempfile::tempdir().expect("provider dir");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@foreign\",\"path\":\"{}\",\"branch\":\"fix/foreign\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                destination.display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reject foreign destination".to_string(),
+            "--repo".to_string(),
+            "expected".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@foreign".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("persist generic repo expectation");
+
+        let error = super::super::run::provision_cook_destination(&args)
+            .expect_err("foreign immediate provider checkout is rejected before plan creation");
+
+        assert!(
+            error
+                .message
+                .contains("does not match the requested Cook repository"),
+            "{}",
+            error.message
+        );
+        assert!(!error.message.contains("provider-secret"));
     });
 }
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1810,6 +1810,85 @@ pub fn validate_task_worktree_root(path: &std::path::Path, handle: &str) -> Resu
     Ok(())
 }
 
+/// Verify a resolved linked worktree belongs to Cook's durable repository
+/// expectation without exposing provider-owned remote URLs in failures.
+pub fn validate_task_worktree_repository_identity(
+    path: &std::path::Path,
+    expected_remote: Option<&str>,
+    expected_repository_name: Option<&str>,
+) -> Result<()> {
+    if expected_remote.is_none() && expected_repository_name.is_none() {
+        return Ok(());
+    }
+    let Some(git_root) = crate::git::repo_root(path) else {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "Cook destination is not a Git checkout bound to the resolved repository identity",
+            Some(path.display().to_string()),
+            None,
+        ));
+    };
+    let identities = crate::git::output_optional(&git_root, &["remote"])
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|remote| crate::git::remote_url(&git_root, remote))
+        .filter_map(|remote| canonical_remote_identity(&remote))
+        .collect::<std::collections::BTreeSet<_>>();
+    if let Some(expected) = expected_remote {
+        if identities.len() == 1 && identities.contains(expected) {
+            return Ok(());
+        }
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("Cook destination repository identity does not match resolved `{expected}`"),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    let expected = expected_repository_name.expect("repository expectation exists");
+    if identities.len() == 1
+        && identities.iter().any(|identity| {
+            identity
+                .strip_prefix("git://")
+                .and_then(|identity| identity.rsplit('/').next())
+                == Some(expected)
+        })
+    {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "to_worktree",
+        "Cook destination repository does not match the requested Cook repository",
+        Some(path.display().to_string()),
+        None,
+    ))
+}
+
+fn canonical_remote_identity(remote_url: &str) -> Option<String> {
+    let remote_url = remote_url.trim();
+    let (host, path) = if let Some((_, rest)) = remote_url.split_once("://") {
+        let (authority, path) = rest.split_once('/')?;
+        (authority.rsplit('@').next()?, path)
+    } else {
+        let (authority, path) = remote_url.split_once(':')?;
+        (authority.rsplit('@').next()?, path)
+    };
+    let path = path.trim_matches('/').trim_end_matches(".git");
+    (!host.is_empty()
+        && path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .count()
+            >= 2)
+        .then(|| {
+            format!(
+                "git://{}/{}",
+                host.to_ascii_lowercase(),
+                path.to_ascii_lowercase()
+            )
+        })
+}
+
 fn trusted_unpushed_destination_matches(
     path: &std::path::Path,
     trusted: Option<&TrustedUnpushedWorktree>,


### PR DESCRIPTION
Follow-up to #12076 and #11372.

This PR contains the two safety and compatibility commits that landed after #12076 merged:
- 01c009673 binds repo-only Cook invocations to configured canonical repository identity and rejects a pinned provider checkout from another repository before workspace attestation or task-provider execution.
- 9e1e29145 preserves existing repo-only Cook behavior when no component registration/canonical remote is available. It persists a normalized requested repository expectation and validates it against the resolved checkout canonical Git remote.

Provider identity remains pinned to the timed-out provider. Repository identity remains enforced before execution; cross-repository resolution fails with zero provider executions and no persisted workspace attestation.

Tests:
- cargo fmt --check
- cargo check -p homeboy-cli -p homeboy-agents --no-default-features
- cargo test -p homeboy-cli cook_derives_issue_destination_and_preserves_explicit_override --lib --no-default-features
- cargo test -p homeboy-cli repo_only_cook_ --lib --no-default-features
- cargo test -p homeboy-agents pending_repo_only_lookup_rejects_provider_workspace_from_another_repository --no-default-features
- cargo test -p homeboy-agents pending_cook_workspace_lookup_remains_bound_to_timed_out_provider --no-default-features

AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode used for implementation/testing; Chris responsible.