### PR TITLE
Reuse SSH control sessions for key-authenticated Lab runners

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -13,7 +13,7 @@ use crate::error::{Error, Result};
 
 use super::super::session::ensure_control_path_parent;
 use super::super::ssh_args::{client_ssh_args, SshArgOptions, SshPortFlag};
-use super::super::{ManagedSshSession, ManagedSshSessionOutput, Server, ServerAuthMode};
+use super::super::{ManagedSshSession, ManagedSshSessionOutput, Server};
 use super::host::{is_local_host, is_transient_ssh_error};
 use super::local_exec::{
     execute_local_command, execute_local_command_in_dir_with_timeout,
@@ -129,19 +129,14 @@ impl SshClient {
             );
         }
 
-        let auth = match &server.auth {
-            Some(auth) if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster => {
-                Some(ManagedSshSession::from_auth(auth))
-            }
-            _ => None,
-        };
+        let session = server.auth.as_ref().map(ManagedSshSession::from_auth);
 
         Ok(Self {
             host: server.host.clone(),
             user: server.user.clone(),
             port: server.port,
             identity_file,
-            auth,
+            auth: session,
             is_local,
             env: server.env.clone(),
         })

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -676,6 +676,32 @@ fn managed_session_config_adds_controlmaster_args() {
 }
 
 #[test]
+fn key_authenticated_session_adds_controlmaster_args_without_password_mode() {
+    let server: Server = serde_json::from_str(
+        r#"{
+            "host":"runner.example.test",
+            "user":"runner",
+            "auth":{
+                "mode":"key_controlmaster",
+                "control_path":"/tmp/homeboy-key-%h-%p-%r",
+                "persist":"8h"
+            }
+        }"#,
+    )
+    .expect("key session server");
+
+    let client = SshClient::from_server(&server, "runner").expect("client");
+    let args = client.build_ssh_args(Some("true"), false);
+
+    assert!(args.contains(&"ControlPath=/tmp/homeboy-key-%h-%p-%r".to_string()));
+    assert!(args.contains(&"ControlMaster=no".to_string()));
+    assert_eq!(
+        client.auth.as_ref().map(|session| session.persist.as_str()),
+        Some("8h")
+    );
+}
+
+#[test]
 fn managed_session_connect_builds_master_command() {
     let client = SshClient {
         host: "bastion.example.test".to_string(),
@@ -815,7 +841,7 @@ fn test_from_server() {
     assert_eq!(client.host, "localhost");
     assert_eq!(client.user, "tester");
     assert_eq!(
-        client.auth.as_ref().map(|auth| auth.persist.as_str()),
+        client.auth.as_ref().map(|session| session.persist.as_str()),
         Some("5m")
     );
 }

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -225,6 +225,7 @@ pub struct ServerSessionConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServerAuthMode {
+    KeyControlmaster,
     KeyPlusPasswordControlmaster,
 }
 
@@ -331,7 +332,10 @@ impl ConfigEntity for Server {
 
     fn validate(&self) -> Result<()> {
         if let Some(auth) = self.auth.as_ref() {
-            if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster {
+            if matches!(
+                auth.mode,
+                ServerAuthMode::KeyControlmaster | ServerAuthMode::KeyPlusPasswordControlmaster
+            ) {
                 match auth.session.persist.as_deref() {
                     Some(persist) => {
                         if auth.session.persist_source
@@ -374,7 +378,10 @@ impl ConfigEntity for Server {
 
     fn post_load(&mut self, _stored_json: &str) {
         if let Some(auth) = self.auth.as_mut() {
-            if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster {
+            if matches!(
+                auth.mode,
+                ServerAuthMode::KeyControlmaster | ServerAuthMode::KeyPlusPasswordControlmaster
+            ) {
                 if auth.session.persist.is_none() {
                     auth.session.persist_source =
                         Some(ManagedSshSessionPersistSource::LegacyDefault);
@@ -407,10 +414,6 @@ impl ConfigEntity for Server {
             });
 
         if let Some(auth) = self.auth.as_mut() {
-            if auth.mode != ServerAuthMode::KeyPlusPasswordControlmaster {
-                return;
-            }
-
             auth.session.legacy_persist_loaded =
                 was_legacy_default && auth.session.persist.is_none();
             if auth.session.persist.is_none() {
@@ -475,6 +478,16 @@ mod tests {
     fn managed_session_requires_explicit_persist_for_new_configurations() {
         assert!(managed_server(None).validate().is_err());
         assert!(managed_server(Some("30m")).validate().is_ok());
+    }
+
+    #[test]
+    fn key_controlmaster_requires_an_explicit_persist_lifetime() {
+        let mut server = managed_server(Some("4h"));
+        server.auth.as_mut().expect("auth").mode = ServerAuthMode::KeyControlmaster;
+        assert!(server.validate().is_ok());
+
+        server.auth.as_mut().expect("auth").session.persist = None;
+        assert!(server.validate().is_err());
     }
 
     #[test]

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -1,6 +1,6 @@
 use crate::engine::shell;
 
-use super::{ManagedSshSession, Server, ServerAuthMode, SshClient};
+use super::{ManagedSshSession, Server, SshClient};
 
 #[derive(Clone, Copy)]
 pub enum SshPortFlag {
@@ -49,11 +49,7 @@ pub fn client_option_args(client: &SshClient, options: SshArgOptions<'_>) -> Vec
 }
 
 pub fn server_option_args(server: &Server, options: SshArgOptions<'_>) -> Vec<String> {
-    let auth = server
-        .auth
-        .as_ref()
-        .filter(|auth| auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster)
-        .map(ManagedSshSession::from_auth);
+    let session = server.auth.as_ref().map(ManagedSshSession::from_auth);
     client_connection_args(
         &server.user,
         &server.host,
@@ -62,7 +58,7 @@ pub fn server_option_args(server: &Server, options: SshArgOptions<'_>) -> Vec<St
             .identity_file
             .as_deref()
             .filter(|path| !path.is_empty()),
-        auth.as_ref(),
+        session.as_ref(),
         options,
     )
 }
@@ -79,7 +75,7 @@ fn client_connection_args(
     _host: &str,
     port: u16,
     identity_file: Option<&str>,
-    auth: Option<&ManagedSshSession>,
+    session: Option<&ManagedSshSession>,
     options: SshArgOptions<'_>,
 ) -> Vec<String> {
     let mut args = Vec::new();
@@ -107,18 +103,7 @@ fn client_connection_args(
         push_option(&mut args, "StrictHostKeyChecking=no");
     }
 
-    // Connection multiplexing is enabled only when a managed session exists,
-    // and `SshClient::from_server` populates one only for
-    // `ServerAuthMode::KeyPlusPasswordControlmaster`. So multiplexing is coupled
-    // to a password-recovery auth mode rather than to connection reuse: an
-    // ordinary key-authenticated server gets no `ControlPath` and every command
-    // pays a full connect plus key exchange. That is why 55 concurrent probe
-    // connections reached one Lab runner despite this block existing (#11080).
-    // Probe volume is bounded at the source in
-    // `homeboy_lab_runner::runner_probe_gate`; decoupling multiplexing from the
-    // auth mode is a separate change with its own blast radius (control-socket
-    // lifetime, forwarding, interactive sessions).
-    if let Some(session) = auth {
+    if let Some(session) = session {
         // A managed session is established explicitly by `server connect`. Command
         // clients attach to that socket rather than starting a competing master.
         // `-o ControlPath` is understood by both ssh and scp; scp's `-S` means

--- a/crates/homeboy-lab-runner/src/runner_probe_gate.rs
+++ b/crates/homeboy-lab-runner/src/runner_probe_gate.rs
@@ -16,16 +16,10 @@
 //! `ssh_args::client_connection_args` does inject
 //! `ControlMaster=auto` / `ControlPath` / `ControlPersist` — but only when
 //! `SshClient::auth` is `Some`, and `SshClient::from_server` only populates
-//! `auth` for servers whose `auth.mode` is
-//! [`ServerAuthMode::KeyPlusPasswordControlmaster`](homeboy_core::server::ServerAuthMode).
-//! Multiplexing is therefore coupled to a *password-recovery auth mode*, not to
-//! connection reuse. An ordinary key-authenticated Lab runner — the common
-//! shape, and the one in the incident — gets **no** `ControlPath` at all, so
-//! every probe is a full TCP connect plus key exchange plus a login shell. The
-//! multiplexing that exists is real; it simply is not on the code path that
-//! stormed. Decoupling multiplexing from the auth mode is a separate change
-//! with its own blast radius (control-socket lifetime, forwarding, interactive
-//! sessions); this module bounds the storm at the source instead — fewer
+//! `auth` only for servers with an explicit managed-session mode. Both key-only
+//! and password-recovery sessions can opt in; an unconfigured runner still gets
+//! no `ControlPath` and every probe is a full TCP connect plus key exchange plus
+//! a login shell. This module bounds that residual storm at the source — fewer
 //! connections beats cheaper connections.
 //!
 //! ### What this module guarantees

--- a/docs/architecture/ssh-key-management.md
+++ b/docs/architecture/ssh-key-management.md
@@ -136,6 +136,12 @@ Note: The exact key name depends on the key file path hash.
 
 When `forward_agent` is enabled in server configuration, SSH keys from your local agent are forwarded to the remote server.
 
+For agents that cannot sign while the controller is locked, configure
+`auth.mode: key_controlmaster` with an explicit `auth.persist` lifetime and run
+`homeboy server connect <server>` while the key is available. Homeboy commands
+then reuse that authenticated control socket until its configured idle lifetime
+expires.
+
 ### Benefits
 
 - Remote servers can use your local SSH keys

--- a/docs/reference/schemas/server-schema.md
+++ b/docs/reference/schemas/server-schema.md
@@ -14,7 +14,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
   "identity_file": "string",
   "kind": "string",
   "auth": {
-    "mode": "key_plus_password_controlmaster",
+    "mode": "key_controlmaster | key_plus_password_controlmaster",
     "control_path": "string",
     "persist": "string",
     "persist_source": "configured | migrated | legacy_default (engine-owned output)"
@@ -145,6 +145,24 @@ Precedence for both is the same: a truthy environment value (`1`, `true`, `yes`,
 `require_fresh_runtime_overlay` escalates only builds *proven* stale. An overlay whose freshness cannot be established — no containing checkout, no artifacts, or an unreadable source history — is reported as unknown and never refused. Freshness itself is derived from the artifact's newest file mtime against the containing checkout's history, which is an indication rather than a proof: a freshly created checkout rewrites mtimes and makes every artifact in it look newly built. Set this on runners where silently executing a stale build is worse than a failed dispatch.
 
 ## Managed SSH Sessions
+
+Key-authenticated servers can keep an explicitly bounded authenticated session
+available for unattended work:
+
+```json
+{
+  "auth": {
+    "mode": "key_controlmaster",
+    "control_path": "~/.ssh/controlmasters/%h-%p-%r",
+    "persist": "8h"
+  }
+}
+```
+
+Run `homeboy server connect <server_id>` while the key is available. Later
+commands attach to that control socket instead of requesting another key
+signature. This is useful for hardware-backed or interactive key agents that
+cannot sign while the controller session is locked.
 
 Servers that accept a key and then require an operator-entered password can opt into managed control-master reuse:
 


### PR DESCRIPTION
## Summary

- add an explicit `key_controlmaster` managed-session mode for key-authenticated servers
- reuse the existing bounded `ControlPath`/`ControlPersist` contract without claiming password-recovery semantics
- route all declared managed-session modes through the same SSH and SCP transport arguments
- document hardware-backed agent use and update stale probe architecture notes

Closes #12116.

## Root cause

`SshClient::from_server` only materialized a control session for `key_plus_password_controlmaster`. The key-authenticated Lab runner had no applicable mode, so every probe and detached handoff opened a fresh SSH connection. AutoProxxy stores its Secure Enclave key behind the interactive macOS keychain; when the desktop locked, those fresh signatures failed with `OSStatus=-25300`.

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p homeboy-core server::` (118 passed, 11 ignored; Cargo printed success before the outer 30-minute wrapper deadline)
- `cargo test -p homeboy-core key_authenticated_session_adds_controlmaster_args_without_password_mode`
- `cargo test -p homeboy-core key_controlmaster_requires_an_explicit_persist_lifetime`
- `cargo test -p homeboy-lab-runner runner_probe_gate` (9 passed)

## Runtime evidence

Configured `homeboy-lab` with a 24-hour control session and established it once. Then forced fresh authentication to be unavailable with `SSH_AUTH_SOCK=/tmp/nonexistent-agent`:

```text
$ SSH_AUTH_SOCK=/tmp/nonexistent-agent homeboy ssh homeboy-lab --as-server --timeout 20 --raw -- 'printf installed-homeboy-reused-session'
installed-homeboy-reused-session

$ homeboy server status homeboy-lab
session.live: true
session.stderr: Master running (pid=94887)
```

The full `runner status homeboy-lab --full` path also succeeded with the nonexistent agent, proving Lab probes reused the authenticated control socket instead of requesting another Secure Enclave signature.

Original failing run: `agent-task-389b38bd-a0cd-4b19-b54f-e726107b76a6`, phase `detached_lab_handoff_preacceptance`.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to correlate Homeboy run evidence with AutoProxxy logs, implement the generic SSH session mode, run deterministic verification, and produce runtime evidence. Chris Huber is responsible for every line and the final review.