### PR TITLE
Add extension-owned remote recipe providers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -183,6 +183,37 @@ pub fn record_runner_exec_execution_record(
     store.upsert_imported_run_preserving_terminal(&run)
 }
 
+/// Persist extension-owned invocation identity and the terminal structured
+/// result beside the generic runner execution record.
+pub fn record_runner_exec_provider_result(
+    run_id: &str,
+    provider_id: &str,
+    provider_version: &str,
+    invocation: &[String],
+    source_snapshot: &serde_json::Value,
+    terminal_result: &serde_json::Value,
+) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND) {
+        return Ok(());
+    }
+    let metadata = run.metadata_json.as_object_mut().expect("metadata object");
+    metadata.insert(
+        "execution_provider".to_string(),
+        json!({
+            "id": provider_id,
+            "version": provider_version,
+            "invocation": invocation,
+        }),
+    );
+    metadata.insert("source_snapshot".to_string(), source_snapshot.clone());
+    metadata.insert("terminal_json_result".to_string(), terminal_result.clone());
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
 /// Create (or validate ownership of) a generic runner-exec run that has no
 /// daemon runner job — the diagnostic-SSH transport executes synchronously and
 /// never accepts a durable runner job, but a caller-supplied `--run-id` with

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -503,6 +503,26 @@ pub(super) enum RunnerCommand {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
+    /// Execute an extension-owned recipe provider in one materialized workspace.
+    RecipeRun {
+        /// Runner ID
+        runner_id: String,
+        /// Stable extension-owned recipe execution provider ID
+        #[arg(long)]
+        provider: String,
+        /// Controller-local workspace to snapshot once before execution
+        #[arg(long = "sync-workspace")]
+        sync_workspace: String,
+        /// Recipe path relative to the materialized workspace
+        #[arg(long)]
+        recipe: String,
+        /// Artifact directory relative to the materialized workspace
+        #[arg(long)]
+        artifacts: String,
+        /// Durable run identity that receives execution evidence
+        #[arg(long = "run-id")]
+        run_id: String,
+    },
     /// Show the effective environment injected into runner jobs
     Env {
         /// Runner ID

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -290,6 +290,21 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             command,
             extension_env_providers,
         )),
+        RunnerCommand::RecipeRun {
+            runner_id,
+            provider,
+            sync_workspace,
+            recipe,
+            artifacts,
+            run_id,
+        } => map_execution(super::recipe_run::recipe_run(
+            &runner_id,
+            &provider,
+            sync_workspace,
+            recipe,
+            artifacts,
+            run_id,
+        )),
         RunnerCommand::Env { id } => map_env(env_mod::env(&id)),
         RunnerCommand::Lifecycle {
             runner_id,

--- a/crates/homeboy-cli/src/commands/runner/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/mod.rs
@@ -18,6 +18,7 @@ mod exec;
 mod jobs;
 mod lifecycle;
 mod log_projection;
+mod recipe_run;
 mod registry;
 mod status;
 mod types;

--- a/crates/homeboy-cli/src/commands/runner/recipe_run.rs
+++ b/crates/homeboy-cli/src/commands/runner/recipe_run.rs
@@ -1,0 +1,241 @@
+use std::path::{Component, Path};
+
+use homeboy::core::Error;
+use homeboy::runner::runners::RunnerExecOutput;
+
+use super::super::CmdResult;
+use super::exec::exec_with_hydration;
+
+pub(super) fn recipe_run(
+    runner_id: &str,
+    provider_id: &str,
+    sync_workspace: String,
+    recipe: String,
+    artifacts: String,
+    run_id: String,
+) -> CmdResult<RunnerExecOutput> {
+    validate_workspace_relative_path("recipe", &recipe)?;
+    validate_workspace_relative_path("artifacts", &artifacts)?;
+    if run_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "runner recipe-run requires a non-empty durable --run-id",
+            Some(run_id),
+            None,
+        ));
+    }
+    let descriptor = homeboy_extension::resolve_recipe_run_provider(provider_id)?;
+    let command = descriptor.render(&homeboy_extension::RecipeRunRequest {
+        recipe_path: recipe,
+        artifact_path: artifacts.clone(),
+    })?;
+    let (output, exit_code) = exec_with_hydration(
+        runner_id,
+        None,
+        Some(sync_workspace),
+        false,
+        None,
+        false,
+        false,
+        Vec::new(),
+        None,
+        Vec::new(),
+        Vec::new(),
+        None,
+        None,
+        false,
+        Some(run_id.clone()),
+        Vec::new(),
+        vec![artifacts],
+        Vec::new(),
+        false,
+        false,
+        command.clone(),
+        Vec::new(),
+    )?;
+    let terminal_json = serde_json::from_str(&output.stdout).unwrap_or_else(|_| {
+        serde_json::json!({ "exit_code": output.exit_code, "stdout": output.stdout, "stderr": output.stderr })
+    });
+    let source_snapshot =
+        serde_json::to_value(&output.source_snapshot).expect("runner source snapshot serializes");
+    homeboy_agents::agent_task_lifecycle::record_runner_exec_provider_result(
+        &run_id,
+        &descriptor.id,
+        &descriptor.version,
+        &command,
+        &source_snapshot,
+        &terminal_json,
+    )?;
+    Ok((output, exit_code))
+}
+
+fn validate_workspace_relative_path(argument: &str, value: &str) -> homeboy::core::Result<()> {
+    let path = Path::new(value);
+    if value.is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(Error::validation_invalid_argument(argument, format!("runner recipe-run --{argument} must be a non-empty workspace-relative path without '..'"), Some(value.to_string()), None));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn install_fixture_extension(
+        id: &str,
+        provider_id: &str,
+        command: Vec<String>,
+    ) -> tempfile::TempDir {
+        let source = tempfile::tempdir().expect("extension source");
+        std::fs::write(
+            source.path().join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Recipe fixture",
+                "version": "1.0.0",
+                "recipe_run_providers": [{
+                    "id": provider_id,
+                    "version": "1.0.0",
+                    "executable": "sh",
+                    "command": command,
+                }],
+            })
+            .to_string(),
+        )
+        .expect("manifest");
+        homeboy_extension::install(&source.path().display().to_string(), Some(id))
+            .expect("install extension");
+        // Installed extensions are linked to their source. Keep the fixture
+        // alive until discovery and execution complete.
+        source
+    }
+
+    #[test]
+    fn rejects_absolute_and_escaping_paths() {
+        assert!(validate_workspace_relative_path("recipe", "/recipe.json").is_err());
+        assert!(validate_workspace_relative_path("artifacts", "../artifacts").is_err());
+        assert!(validate_workspace_relative_path("recipe", "recipes/run.json").is_ok());
+    }
+
+    #[test]
+    fn rejects_unknown_provider_before_workspace_sync() {
+        let error = recipe_run(
+            "missing-runner",
+            "fixture.missing",
+            "/missing".to_string(),
+            "recipe.json".to_string(),
+            "artifacts".to_string(),
+            "missing-provider-run".to_string(),
+        )
+        .expect_err("provider must resolve before dispatch");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("No installed extension declares"));
+    }
+
+    #[test]
+    fn materializes_once_promotes_artifacts_and_records_provider_result() {
+        homeboy::test_support::with_isolated_home(|_| {
+            let runner_root = tempfile::tempdir().expect("runner root");
+            let workspace = tempfile::tempdir().expect("workspace");
+            std::fs::write(workspace.path().join("recipe.json"), "{}").expect("recipe");
+            homeboy::runner::runners::create(
+                &format!(
+                    r#"{{"id":"recipe-local","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("runner");
+            let _extension = install_fixture_extension(
+                "recipe-fixture",
+                "fixture.recipe-run",
+                vec!["sh".to_string(), "-c".to_string(), "mkdir -p {artifacts}; printf '{\"recipe\":\"{recipe}\"}' | tee {artifacts}/result.json".to_string()],
+            );
+
+            let (output, code) = recipe_run(
+                "recipe-local",
+                "fixture.recipe-run",
+                workspace.path().display().to_string(),
+                "recipe.json".to_string(),
+                "artifacts".to_string(),
+                "recipe-provider-run".to_string(),
+            )
+            .expect("recipe run");
+
+            assert_eq!(code, 0, "{}", output.stderr);
+            assert_eq!(output.promoted_outputs.len(), 1);
+            let store =
+                homeboy::core::observation::ObservationStore::open_initialized().expect("store");
+            let run = store
+                .get_run("recipe-provider-run")
+                .expect("read run")
+                .expect("run");
+            assert_eq!(
+                run.metadata_json["execution_provider"]["id"],
+                "fixture.recipe-run"
+            );
+            assert_eq!(
+                run.metadata_json["terminal_json_result"]["recipe"],
+                "recipe.json"
+            );
+            assert!(run.metadata_json["source_snapshot"].is_object());
+        });
+    }
+
+    #[test]
+    fn provider_failure_retains_terminal_result_and_artifacts() {
+        homeboy::test_support::with_isolated_home(|_| {
+            let runner_root = tempfile::tempdir().expect("runner root");
+            let workspace = tempfile::tempdir().expect("workspace");
+            std::fs::write(workspace.path().join("recipe.json"), "{}").expect("recipe");
+            homeboy::runner::runners::create(
+                &format!(
+                    r#"{{"id":"failure-local","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("runner");
+            let _extension = install_fixture_extension(
+                "recipe-failure-fixture",
+                "fixture.recipe-run-failure",
+                vec!["sh".to_string(), "-c".to_string(), "mkdir -p {artifacts}; printf '{\"status\":\"failed\"}' | tee {artifacts}/result.json; exit 7".to_string()],
+            );
+
+            let (output, code) = recipe_run(
+                "failure-local",
+                "fixture.recipe-run-failure",
+                workspace.path().display().to_string(),
+                "recipe.json".to_string(),
+                "artifacts".to_string(),
+                "recipe-provider-failure".to_string(),
+            )
+            .expect("provider failure is a terminal execution result");
+
+            assert_eq!(code, 7);
+            assert_eq!(output.promoted_outputs.len(), 1);
+            let store =
+                homeboy::core::observation::ObservationStore::open_initialized().expect("store");
+            let run = store
+                .get_run("recipe-provider-failure")
+                .expect("read run")
+                .expect("run");
+            assert_eq!(
+                run.metadata_json["terminal_json_result"]["status"],
+                "failed"
+            );
+        });
+    }
+
+    #[test]
+    fn generic_substrate_contains_no_product_literals() {
+        let source = include_str!("recipe_run.rs");
+        let cms = concat!("Word", "Press");
+        let sandbox = concat!("WP ", "Codebox");
+        assert!(!source.contains(cms));
+        assert!(!source.contains(sandbox));
+    }
+}

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -30,6 +30,7 @@ mod maintenance;
 mod manifest;
 mod manifest_config;
 mod manifest_sidecar;
+pub mod recipe_run;
 mod refactor_protocol;
 // Manifest store relocated to homeboy_core::extension_store (core-level; operates on
 // the contract ExtensionManifest type). Re-exported here for path stability.
@@ -135,6 +136,10 @@ pub use manifest::{
     TraceBrowserSummaryAliasConfig, TraceConfig, VersionPatternConfig,
     DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA, EXTENSION_CONTRACT_PRODUCER_SCHEMA,
     EXTENSION_MATERIALIZATION_SOURCE_SCHEMA, NOTIFICATION_TRANSPORT_SCHEMA,
+};
+pub use recipe_run::{
+    recipe_run_providers, resolve_recipe_run_provider, RecipeRunProviderDescriptor,
+    RecipeRunRequest,
 };
 pub use refactor_protocol::{
     run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,

--- a/crates/homeboy-extension/src/recipe_run.rs
+++ b/crates/homeboy-extension/src/recipe_run.rs
@@ -1,0 +1,166 @@
+//! Manifest-backed extension-owned remote recipe execution descriptors.
+
+use homeboy_core::error::{Error, Result};
+
+use crate::manifest::ExtensionManifest;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct RecipeRunProviderDescriptor {
+    pub id: String,
+    pub version: String,
+    pub executable: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecipeRunRequest {
+    pub recipe_path: String,
+    pub artifact_path: String,
+}
+
+/// Read recipe-run descriptors from an installed extension manifest.
+pub fn recipe_run_providers(manifest: &ExtensionManifest) -> Vec<RecipeRunProviderDescriptor> {
+    manifest
+        .extra
+        .get("recipe_run_providers")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
+}
+
+/// Discover one installed extension-owned provider by its stable ID.
+pub fn resolve_recipe_run_provider(id: &str) -> Result<RecipeRunProviderDescriptor> {
+    let matches = crate::load_all_extensions()?
+        .into_iter()
+        .flat_map(|manifest| recipe_run_providers(&manifest))
+        .filter(|provider| provider.id == id)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [provider] => validate_descriptor(provider.clone()),
+        [] => Err(Error::validation_invalid_argument(
+            "provider",
+            format!("No installed extension declares recipe-run provider '{id}'"),
+            Some(id.to_string()),
+            Some(vec![
+                "Install an extension manifest with recipe_run_providers.".to_string(),
+            ]),
+        )),
+        _ => Err(Error::validation_invalid_argument(
+            "provider",
+            format!("Multiple installed extensions declare recipe-run provider '{id}'"),
+            Some(id.to_string()),
+            None,
+        )),
+    }
+}
+
+impl RecipeRunProviderDescriptor {
+    /// Render the extension-declared argv without introducing shell parsing.
+    pub fn render(&self, request: &RecipeRunRequest) -> Result<Vec<String>> {
+        validate_descriptor(self.clone())?;
+        Ok(self
+            .command
+            .iter()
+            .map(|argument| {
+                argument
+                    .replace("{recipe}", &request.recipe_path)
+                    .replace("{artifacts}", &request.artifact_path)
+            })
+            .collect())
+    }
+}
+
+fn validate_descriptor(
+    descriptor: RecipeRunProviderDescriptor,
+) -> Result<RecipeRunProviderDescriptor> {
+    if descriptor.id.trim().is_empty()
+        || descriptor.version.trim().is_empty()
+        || descriptor.executable.trim().is_empty()
+        || descriptor.command.is_empty()
+        || descriptor.command.first() != Some(&descriptor.executable)
+    {
+        return Err(Error::validation_invalid_argument(
+            "provider",
+            "recipe-run provider requires id, version, executable, and argv beginning with executable",
+            Some(descriptor.id),
+            None,
+        ));
+    }
+    Ok(descriptor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_manifest_owned_argv_without_shell_parsing() {
+        let provider = RecipeRunProviderDescriptor {
+            id: "fixture.recipe-run".to_string(),
+            version: "1.0.0".to_string(),
+            executable: "fixture-run".to_string(),
+            command: vec![
+                "fixture-run".to_string(),
+                "--recipe".to_string(),
+                "{recipe}".to_string(),
+                "--artifacts={artifacts}".to_string(),
+            ],
+        };
+        assert_eq!(
+            provider
+                .render(&RecipeRunRequest {
+                    recipe_path: "recipe.json".to_string(),
+                    artifact_path: "artifacts".to_string(),
+                })
+                .expect("render"),
+            vec![
+                "fixture-run",
+                "--recipe",
+                "recipe.json",
+                "--artifacts=artifacts"
+            ]
+        );
+    }
+
+    #[test]
+    fn discovers_a_descriptor_from_an_installed_extension() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("extension source");
+            std::fs::write(
+                source.path().join("fixture.json"),
+                serde_json::json!({
+                    "name": "Recipe fixture",
+                    "version": "1.0.0",
+                    "recipe_run_providers": [{
+                        "id": "fixture.recipe-run",
+                        "version": "1.0.0",
+                        "executable": "fixture-run",
+                        "command": ["fixture-run", "--recipe", "{recipe}", "--artifacts", "{artifacts}"],
+                    }],
+                })
+                .to_string(),
+            )
+            .expect("manifest");
+            crate::install(&source.path().display().to_string(), Some("fixture"))
+                .expect("install extension");
+
+            let provider = resolve_recipe_run_provider("fixture.recipe-run").expect("discover");
+            assert_eq!(provider.version, "1.0.0");
+            assert_eq!(
+                provider
+                    .render(&RecipeRunRequest {
+                        recipe_path: "recipe.json".to_string(),
+                        artifact_path: "artifacts".to_string(),
+                    })
+                    .expect("render"),
+                vec![
+                    "fixture-run",
+                    "--recipe",
+                    "recipe.json",
+                    "--artifacts",
+                    "artifacts"
+                ]
+            );
+        });
+    }
+}

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -892,6 +892,27 @@ homeboy runner env <runner-id>
 
 `exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
 
+### `recipe-run`
+
+```sh
+homeboy runner recipe-run <runner-id> --provider <provider-id> --sync-workspace <local-workspace> --recipe <relative-recipe> --artifacts <relative-artifact-directory> --run-id <durable-run-id>
+```
+
+`recipe-run` snapshots its declared workspace once, resolves the recipe and artifact
+directory beneath that materialized root, and dispatches an extension-owned provider.
+The provider descriptor declares its executable and version; Homeboy preflights the
+executable through the normal runner execution path and records the provider,
+resolved argv, source snapshot, terminal JSON result, and promoted artifacts on the
+durable run. Recipe and artifact paths must be non-empty relative paths without
+parent traversal. `runner exec` remains available for low-level invocation.
+
+The Homeboy contract is the installed extension manifest's
+`recipe_run_providers` array. Each descriptor has `id`, `version`, `executable`,
+and a `command` argv array. `{recipe}` and `{artifacts}` tokens expand to the
+validated workspace-relative paths without shell parsing. Homeboy discovers these
+descriptors from installed extensions at execution time; product extensions can
+therefore supply providers without being linked into the Homeboy binary.
+
 `--script-file <path>` reads the controller-side source, then materializes it as a private, content-addressed `script-<sha256>.sh` under `${XDG_RUNTIME_DIR:-/tmp}/homeboy-runner-exec/<job-id>/` on the runner. Bash executes that file directly, so `$0` is its runner path. The job exports `HOMEBOY_RUNNER_EXEC_SCRIPT` with the same path and `HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256` as `sha256:<digest>`; the wrapper records the digest in its durable command evidence, makes the file mode `0500`, and removes it when the runner job exits.
 
 `--script-file -` reads stdin verbatim on the controller with the same bounded capture and materialization behavior; it does not stream stdin through `bash -s`. Zero-byte stdin is a validation error before Homeboy builds or submits a runner execution plan. Whitespace-only stdin is valid and is materialized verbatim, including newlines.


### PR DESCRIPTION
## Summary

- add manifest-discovered extension-owned recipe execution providers
- add `homeboy runner recipe-run` with single workspace materialization and relative path validation
- reuse runner exec lifecycle, executable preflight, durable evidence, and artifact promotion
- persist provider identity, invocation, source snapshot, and terminal JSON result

Closes #12131.

## Verification

```text
cargo fmt --check
cargo check -p homeboy-cli
cargo test -p homeboy-extension recipe_run --lib
cargo test -p homeboy-cli recipe_run --lib
git diff --check
```

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode researched the existing extension and runner contracts, implemented the generic substrate through a coding subagent, reviewed and repaired provider discovery and test lifetime issues, and ran verification. Chris Huber reviewed the resulting changes and remains responsible for every line.
