### PR TITLE
Execute extension readiness commands in runner doctor

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -69,7 +69,8 @@ pub use admission::{
 pub use catalog::*;
 pub use command_runner::{
     probe_provider_executor_resolves, provider_command_parts, run_provider_readiness_invocation,
-    ProviderExecutorResolution,
+    ProviderExecutorResolution, ProviderReadinessInvocationResult,
+    PROVIDER_READINESS_RESULT_SCHEMA,
 };
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub use credential_readiness::{

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -271,11 +271,30 @@ pub fn default_backend_for_component(
     default_backend_from_policy(component_id)
 }
 
-pub fn provider_runner_readiness_contracts() -> Vec<AgentTaskProviderRunnerReadiness> {
+#[derive(Debug, Clone)]
+pub struct AgentTaskProviderRunnerReadinessContract {
+    pub provider_id: String,
+    pub backend: String,
+    pub runtime_id: Option<String>,
+    pub runtime_path: Option<String>,
+    pub readiness: AgentTaskProviderRunnerReadiness,
+}
+
+pub fn provider_runner_readiness_contracts() -> Vec<AgentTaskProviderRunnerReadinessContract> {
     AgentTaskProviderCatalog::discover()
         .providers
         .into_iter()
-        .flat_map(|provider| provider.runner_readiness)
+        .flat_map(|provider| {
+            provider.runner_readiness.into_iter().map(move |readiness| {
+                AgentTaskProviderRunnerReadinessContract {
+                    provider_id: provider.id.clone(),
+                    backend: provider.backend.clone(),
+                    runtime_id: provider.runtime_id.clone(),
+                    runtime_path: provider.runtime_path.clone(),
+                    readiness,
+                }
+            })
+        })
         .collect()
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -22,7 +22,8 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
-const PROVIDER_READINESS_RESULT_SCHEMA: &str = "homeboy/agent-task-provider-readiness-result/v1";
+pub const PROVIDER_READINESS_RESULT_SCHEMA: &str =
+    "homeboy/agent-task-provider-readiness-result/v1";
 const PROVIDER_READINESS_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_types.rs
@@ -280,6 +280,7 @@ mod tests {
             readiness_checks: vec![AgentTaskProviderRunnerReadiness {
                 id: "example-token".to_string(),
                 label: "Example token".to_string(),
+                invocation: None,
                 secret_env: vec!["EXAMPLE_TOKEN".to_string()],
                 env_path: None,
                 executable: None,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -1129,6 +1129,7 @@ fn readiness_validation_fails_before_execution_when_provider_executable_is_missi
     provider.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "test.executable".to_string(),
         label: "Test executable".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: None,
         executable: Some(AgentTaskProviderExecutableReadiness {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -15,6 +15,7 @@ fn provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks() {
     provider_a.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "provider-a.auth".to_string(),
         label: "Provider A auth".to_string(),
+        invocation: None,
         secret_env: vec!["PROVIDER_A_TOKEN".to_string()],
         env_path: None,
         executable: None,
@@ -28,6 +29,7 @@ fn provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks() {
     provider_b.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "provider-b.auth".to_string(),
         label: "Provider B auth".to_string(),
+        invocation: None,
         secret_env: vec![
             "PROVIDER_B_TOKEN".to_string(),
             "EXPLICIT_SECRET".to_string(),
@@ -139,6 +141,7 @@ fn provider_command_env_injects_declared_executable_candidate() {
     provider.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "provider.tool".to_string(),
         label: "Provider tool".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: None,
         executable: Some(AgentTaskProviderExecutableReadiness {
@@ -167,6 +170,7 @@ fn provider_command_env_prefers_declared_executable_env_value() {
     provider.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "provider.tool".to_string(),
         label: "Provider tool".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: None,
         executable: Some(AgentTaskProviderExecutableReadiness {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -978,6 +978,7 @@ fn provider_command_receives_canonical_secret_env_plan_without_values() {
     provider.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
         id: "test.provider.auth".to_string(),
         label: "Test provider auth".to_string(),
+        invocation: None,
         secret_env: vec![secret_name.clone()],
         env_path: None,
         executable: None,

--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -437,6 +437,10 @@ pub(crate) fn wildcard_match(pattern: &str, value: &str) -> bool {
 pub struct AgentTaskProviderRunnerReadiness {
     pub id: String,
     pub label: String,
+    /// Optional extension-owned readiness command run by runner doctor.
+    /// `{{runtime_path}}` is resolved against the selected runner's runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation: Option<CommandInvocation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_env: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -398,13 +398,14 @@ pub mod provider {
         AgentTaskProviderCapabilityContract, AgentTaskProviderCatalog,
         AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
         AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
-        AgentTaskProviderRunnerSource, AgentTaskProviderWorkspaceMaterialization,
-        AgentTaskRuntimeApplyBack, AgentTaskRuntimeContract, AgentTaskRuntimeLifecycleStates,
+        AgentTaskProviderRunnerReadinessContract, AgentTaskProviderRunnerSource,
+        AgentTaskProviderWorkspaceMaterialization, AgentTaskRuntimeApplyBack,
+        AgentTaskRuntimeContract, AgentTaskRuntimeLifecycleStates,
         AgentTaskRuntimeMutationArtifact, AgentTaskRuntimeNormalization,
         AgentTaskRuntimeOutputArtifactMapping, ExtensionProviderAgentTaskExecutor,
-        ProviderResolution, ProviderRuntimeReadinessCache, WorkspaceMaterializationSpec,
-        WorkspaceMountSpec, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
-        AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+        ProviderReadinessInvocationResult, ProviderResolution, ProviderRuntimeReadinessCache,
+        WorkspaceMaterializationSpec, WorkspaceMountSpec, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+        AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA, PROVIDER_READINESS_RESULT_SCHEMA,
     };
     /// Credential readiness: whether a *declared* provider is actually
     /// *dispatchable* here, and the pre-dispatch preflight that enforces it

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -389,7 +389,7 @@ fn semantic_version_parts(version: &str) -> Vec<u64> {
 
 pub fn provider_readiness_checks(
     client: &SshClient,
-    contracts: &[AgentTaskProviderRunnerReadiness],
+    contracts: &[homeboy::agents::agent_tasks::provider::AgentTaskProviderRunnerReadinessContract],
 ) -> Vec<RunnerCheck> {
     contracts
         .iter()
@@ -584,20 +584,35 @@ fn runtime_relative_entrypoint_part(
 ) -> Option<RemoteProviderExecutorEntrypointPart> {
     let path = Path::new(value);
     if !path.is_absolute() {
+        if !runtime_relative_path_is_safe(path) {
+            return None;
+        }
         return Some(RemoteProviderExecutorEntrypointPart::Literal(
             value.to_string(),
         ));
     }
-    path.strip_prefix(runtime_root).ok().map(|path| {
-        RemoteProviderExecutorEntrypointPart::RuntimeRelative(path.to_string_lossy().to_string())
-    })
+    path.strip_prefix(runtime_root)
+        .ok()
+        .filter(|path| runtime_relative_path_is_safe(path))
+        .map(|path| {
+            RemoteProviderExecutorEntrypointPart::RuntimeRelative(
+                path.to_string_lossy().to_string(),
+            )
+        })
 }
 
 fn runtime_relative_path(runtime_root: &Path, value: &str) -> Option<String> {
     Path::new(value)
         .strip_prefix(runtime_root)
         .ok()
+        .filter(|path| runtime_relative_path_is_safe(path))
         .map(|path| path.to_string_lossy().to_string())
+}
+
+fn runtime_relative_path_is_safe(path: &Path) -> bool {
+    !path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
 }
 
 pub(super) fn provider_executor_resolution_remote_shell(
@@ -880,8 +895,12 @@ pub(super) fn managed_runner_source_state_check(
 
 fn provider_readiness_check(
     client: &SshClient,
-    contract: &AgentTaskProviderRunnerReadiness,
+    contract: &homeboy::agents::agent_tasks::provider::AgentTaskProviderRunnerReadinessContract,
 ) -> Option<RunnerCheck> {
+    if contract.readiness.invocation.is_some() {
+        return Some(provider_command_readiness_check(client, contract));
+    }
+    let contract = &contract.readiness;
     let env_path = contract.env_path.as_ref()?;
     let env_names = env_path
         .env
@@ -952,6 +971,217 @@ fn provider_readiness_check(
         details.get("revision").cloned(),
         resolved_canonical,
     ))
+}
+
+fn provider_command_readiness_check(
+    client: &SshClient,
+    contract: &homeboy::agents::agent_tasks::provider::AgentTaskProviderRunnerReadinessContract,
+) -> RunnerCheck {
+    let readiness = &contract.readiness;
+    let mut details = BTreeMap::new();
+    details.insert("provider_id".to_string(), contract.provider_id.clone());
+    let Some(runtime_id) = contract
+        .runtime_id
+        .as_deref()
+        .filter(|id| !id.trim().is_empty())
+    else {
+        return checks::error(
+            readiness.id.clone(),
+            format!(
+                "{} cannot run because its provider has no runtime identity",
+                readiness.label
+            ),
+            readiness.remediation.clone(),
+            details,
+        );
+    };
+    let Some(runtime_path) = contract
+        .runtime_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return checks::error(
+            readiness.id.clone(),
+            format!(
+                "{} cannot run because its provider has no runtime path",
+                readiness.label
+            ),
+            readiness.remediation.clone(),
+            details,
+        );
+    };
+    let invocation = readiness.invocation.as_ref().expect("checked invocation");
+    let Some(entrypoint) = remote_readiness_entrypoint(runtime_id, runtime_path, invocation) else {
+        return checks::error(
+            readiness.id.clone(),
+            format!(
+                "{} declares an invalid runtime-relative readiness invocation",
+                readiness.label
+            ),
+            readiness.remediation.clone(),
+            details,
+        );
+    };
+    details.insert("command".to_string(), entrypoint.display());
+    details.insert("runtime_id".to_string(), runtime_id.to_string());
+
+    let request = serde_json::json!({
+        "schema": "homeboy/agent-task-provider-readiness-request/v1",
+        "provider_id": contract.provider_id,
+        "backend": contract.backend,
+        "effective_config": {},
+    });
+    let request = match serde_json::to_string(&request) {
+        Ok(request) => request,
+        Err(error) => {
+            return checks::error(
+                readiness.id.clone(),
+                format!(
+                    "{} readiness request could not be encoded: {error}",
+                    readiness.label
+                ),
+                readiness.remediation.clone(),
+                details,
+            );
+        }
+    };
+    let output = client.execute(&provider_readiness_remote_shell(&entrypoint, &request));
+    if !output.success {
+        details.insert(
+            "detail".to_string(),
+            if output.timed_out {
+                "readiness invocation timed out".to_string()
+            } else {
+                first_stderr_lines(&output.stderr, 8)
+            },
+        );
+        return checks::error(
+            readiness.id.clone(),
+            format!(
+                "{} readiness invocation failed on the Lab runner",
+                readiness.label
+            ),
+            readiness.remediation.clone(),
+            details,
+        );
+    }
+    let result: homeboy::agents::agent_tasks::provider::ProviderReadinessInvocationResult =
+        match serde_json::from_str::<serde_json::Value>(output.stdout.trim()) {
+            Ok(result)
+                if result.get("schema").and_then(serde_json::Value::as_str)
+                    == Some(
+                        homeboy::agents::agent_tasks::provider::PROVIDER_READINESS_RESULT_SCHEMA,
+                    ) =>
+            {
+                match serde_json::from_value(result) {
+                    Ok(result) => result,
+                    Err(_) => {
+                        return checks::error(
+                            readiness.id.clone(),
+                            format!(
+                                "{} readiness invocation returned an invalid result",
+                                readiness.label
+                            ),
+                            readiness.remediation.clone(),
+                            details,
+                        )
+                    }
+                }
+            }
+            _ => {
+                return checks::error(
+                    readiness.id.clone(),
+                    format!(
+                        "{} readiness invocation returned an invalid result",
+                        readiness.label
+                    ),
+                    readiness.remediation.clone(),
+                    details,
+                );
+            }
+        };
+    details.insert("classification".to_string(), result.classification.clone());
+    details.insert("reason".to_string(), result.reason.clone());
+    details.insert("remediation".to_string(), result.remediation.clone());
+    details.insert("retryable".to_string(), result.retryable.to_string());
+    details.insert("identity".to_string(), result.identity.to_string());
+    if result.ready {
+        checks::ok_with_details(
+            readiness.id.clone(),
+            format!("{} is ready on the Lab runner", readiness.label),
+            details,
+        )
+    } else {
+        let remediation = (!result.remediation.trim().is_empty())
+            .then(|| result.remediation.clone())
+            .or_else(|| readiness.remediation.clone());
+        let reason = if result.reason.trim().is_empty() {
+            "provider-owned readiness check failed"
+        } else {
+            &result.reason
+        };
+        checks::error(
+            readiness.id.clone(),
+            format!(
+                "{} is not ready on the Lab runner: {reason}",
+                readiness.label
+            ),
+            remediation,
+            details,
+        )
+    }
+}
+
+pub(super) fn remote_readiness_entrypoint(
+    runtime_id: &str,
+    runtime_path: &str,
+    invocation: &homeboy::core::command_invocation::CommandInvocation,
+) -> Option<RemoteProviderExecutorEntrypoint> {
+    let runtime_root = Path::new(runtime_path);
+    let render = |value: &str| value.replace("{{runtime_path}}", runtime_path);
+    let mut argv = invocation.argv.iter().map(|value| render(value));
+    let program = runtime_relative_entrypoint_part(runtime_root, &argv.next()?)?;
+    let args = argv
+        .map(|value| runtime_relative_entrypoint_part(runtime_root, &value))
+        .collect::<Option<Vec<_>>>()?;
+    let cwd = invocation
+        .cwd
+        .as_deref()
+        .map(render)
+        .and_then(|cwd| runtime_relative_path(runtime_root, &cwd));
+    Some(RemoteProviderExecutorEntrypoint {
+        runtime_id: runtime_id.to_string(),
+        program,
+        args,
+        cwd,
+    })
+}
+
+pub(super) fn provider_readiness_remote_shell(
+    entrypoint: &RemoteProviderExecutorEntrypoint,
+    request: &str,
+) -> String {
+    let runtime_root = format!(
+        "runtime_root=\"$HOME/.config/homeboy/agent-runtimes\"/{}",
+        common::shell_word(&entrypoint.runtime_id)
+    );
+    let runner_path = |value: &str| format!("\"$runtime_root\"/{}", common::shell_word(value));
+    let shell_part = |part: &RemoteProviderExecutorEntrypointPart| match part {
+        RemoteProviderExecutorEntrypointPart::Literal(value) => common::shell_word(value),
+        RemoteProviderExecutorEntrypointPart::RuntimeRelative(value) => runner_path(value),
+    };
+    let mut argv = vec![shell_part(&entrypoint.program)];
+    argv.extend(entrypoint.args.iter().map(shell_part));
+    let invocation = argv.join(" ");
+    let cwd = entrypoint
+        .cwd
+        .as_deref()
+        .map(runner_path)
+        .unwrap_or_else(|| "\"$runtime_root\"".to_string());
+    format!(
+        "{runtime_root}; test -d \"$runtime_root\" && cd {cwd} && printf '%s' {} | exec {invocation}",
+        common::shell_word(request)
+    )
 }
 
 /// Returns true when `path` is the canonical root itself or lives beneath

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/provider.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use homeboy::agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
 };
+use homeboy::core::command_invocation::CommandInvocation;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -14,6 +15,7 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
     let contract = AgentTaskProviderRunnerReadiness {
         id: "lab.fake_runtime.cache".to_string(),
         label: "Fake runtime cache".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: Some(AgentTaskProviderEnvPathReadiness {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
@@ -52,6 +54,7 @@ fn provider_readiness_warns_on_non_canonical_checkout() {
     let contract = AgentTaskProviderRunnerReadiness {
         id: "lab.fake_runtime.cache".to_string(),
         label: "Fake runtime cache".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: Some(AgentTaskProviderEnvPathReadiness {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
@@ -89,6 +92,7 @@ fn provider_readiness_ok_when_path_within_canonical_root() {
     let contract = AgentTaskProviderRunnerReadiness {
         id: "lab.fake_runtime.cache".to_string(),
         label: "Fake runtime cache".to_string(),
+        invocation: None,
         secret_env: Vec::new(),
         env_path: Some(AgentTaskProviderEnvPathReadiness {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
@@ -265,6 +269,52 @@ fn remote_executor_probe_keeps_missing_runner_local_dependency_actionable() {
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("Cannot find module"));
+}
+
+#[test]
+fn command_readiness_surfaces_incomplete_cache_repair() {
+    let controller_runtime = "/Users/controller/.config/homeboy/agent-runtimes/cache-fixture";
+    let invocation = CommandInvocation {
+        argv: vec![
+            "node".to_string(),
+            "{{runtime_path}}/scripts/readiness.cjs".to_string(),
+        ],
+        ..CommandInvocation::default()
+    };
+    let entrypoint =
+        probes::remote_readiness_entrypoint("cache-fixture", controller_runtime, &invocation)
+            .expect("runtime-relative readiness invocation");
+    let home = tempfile::tempdir().expect("runner home");
+    let script = home
+        .path()
+        .join(".config/homeboy/agent-runtimes/cache-fixture/scripts/readiness.cjs");
+    std::fs::create_dir_all(script.parent().expect("script parent")).expect("create scripts");
+    std::fs::write(
+        &script,
+        "process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:false,classification:'incomplete_cache',retryable:false,reason:'built CLI is missing',remediation:'repair the managed runtime cache',identity:{runtime:'cache-fixture'}}));",
+    )
+    .expect("write readiness script");
+
+    let shell = probes::provider_readiness_remote_shell(
+        &entrypoint,
+        r#"{"schema":"homeboy/agent-task-provider-readiness-request/v1"}"#,
+    );
+    assert!(!shell.contains(controller_runtime));
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(shell)
+        .env("HOME", home.path())
+        .output()
+        .expect("run runner-local readiness");
+
+    assert!(output.status.success());
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("structured readiness result");
+    assert_eq!(result["ready"], false);
+    assert_eq!(result["classification"], "incomplete_cache");
+    assert_eq!(result["reason"], "built CLI is missing");
+    assert_eq!(result["remediation"], "repair the managed runtime cache");
+    assert_eq!(result["identity"]["runtime"], "cache-fixture");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- allow extension runner-readiness declarations to provide structured command invocations
- execute runtime-relative readiness commands through Lab runner doctor
- validate readiness-result envelopes and surface extension-owned reason and remediation
- preserve existing executable-only readiness behavior and fail closed on invalid commands or output

Closes #12138.

## Verification

```text
cargo fmt --check
cargo check -p homeboy-cli
cargo test -p homeboy-cli command_readiness_surfaces_incomplete_cache_repair --lib
git diff --check
```

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode identified the generic readiness gap while repairing a live WP Codebox runner, designed the product-neutral manifest boundary, implemented it through a coding subagent, reviewed the changes, and ran verification. Chris Huber reviewed the resulting changes and remains responsible for every line.
