### PR TITLE
fix(status): bound startup discovery probes

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
+++ b/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
@@ -83,6 +83,9 @@ fn record_unavailable(git_diagnostic: &str) {
         runner_id: None,
         reason_code: REASON_PROBE_UNAVAILABLE,
         timeout_seconds: 0,
+        elapsed_ms: 0,
+        deadline_ms: 0,
+        follow_up: readonly_probe::runner_status_follow_up(None),
         detail: unavailable_detail(git_diagnostic),
     });
 }

--- a/crates/homeboy-core/src/extension_update_check.rs
+++ b/crates/homeboy-core/src/extension_update_check.rs
@@ -3,7 +3,7 @@
 //! core paths/git/error + the core extension store, no extension behavior.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::time::{Duration, Instant};
 
 use crate::extension_store::{is_extension_linked, load_extension};
 use crate::git;
@@ -22,6 +22,28 @@ pub fn is_git_url(source: &str) -> bool {
 /// Runs `git fetch` then checks if HEAD is behind the remote tracking branch.
 /// Returns None for linked extensions or if check fails.
 pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
+    check_update_available_with_timeout(extension_id, EXTENSION_UPDATE_PROBE_TIMEOUT)
+}
+
+/// The startup update check is advisory, but it runs before every normal CLI
+/// command. Keep each extension probe bounded so an unreachable Git transport
+/// or credential helper cannot withhold unrelated command output.
+pub const EXTENSION_UPDATE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub fn check_update_available_with_timeout(
+    extension_id: &str,
+    timeout: Duration,
+) -> Option<UpdateAvailable> {
+    check_update_available_until(extension_id, Instant::now() + timeout)
+}
+
+/// Probe one extension only until the caller-owned startup deadline. The fetch
+/// and rev-list phases share that deadline rather than each receiving a full
+/// timeout.
+pub fn check_update_available_until(
+    extension_id: &str,
+    deadline: Instant,
+) -> Option<UpdateAvailable> {
     let extension_dir = paths::extension(extension_id).ok()?;
     if !extension_dir.exists() || is_extension_linked(extension_id) {
         return None;
@@ -32,25 +54,17 @@ pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
         return None;
     }
 
-    // Fetch latest (best-effort, short timeout)
-    Command::new("git")
-        .args(["fetch", "--quiet"])
-        .current_dir(&extension_dir)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .ok()?;
-
-    // Check how many commits we're behind
-    let output = Command::new("git")
-        .args(["rev-list", "HEAD..@{u}", "--count"])
-        .current_dir(&extension_dir)
-        .stdin(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
-    let count_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let count_str = run_update_phases_with_deadline(deadline, |args, timeout| {
+        git::run_git_with_env_timeout(
+            &extension_dir,
+            args,
+            "extension startup update check",
+            &[],
+            timeout,
+        )
+        .ok()
+    })?;
+    let count_str = count_str.trim();
     let behind_count: usize = count_str.parse().ok()?;
 
     if behind_count == 0 {
@@ -67,11 +81,88 @@ pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
         behind_count,
     })
 }
+
+fn run_update_phases_with_deadline<F>(deadline: Instant, mut run: F) -> Option<String>
+where
+    F: FnMut(&[&str], Duration) -> Option<String>,
+{
+    run(
+        &["fetch", "--quiet"],
+        deadline.checked_duration_since(Instant::now())?,
+    )?;
+    run(
+        &["rev-list", "HEAD..@{u}", "--count"],
+        deadline.checked_duration_since(Instant::now())?,
+    )
+}
 #[derive(Debug, Clone)]
 pub struct UpdateAvailable {
     pub extension_id: String,
     pub installed_version: String,
     pub behind_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support;
+    use std::process::Command;
+    use std::time::Instant;
+
+    #[test]
+    fn startup_update_probe_bounds_a_hung_extension_fetch() {
+        test_support::with_isolated_home(|home| {
+            let extension = paths::extension("slow").expect("extension path");
+            std::fs::create_dir_all(&extension).expect("extension directory");
+            git(&extension, &["init", "-q"]);
+            git(&extension, &["config", "protocol.ext.allow", "always"]);
+            git(&extension, &["remote", "add", "origin", "ext::sleep 10"]);
+
+            let started = Instant::now();
+            let result = check_update_available_with_timeout("slow", Duration::from_millis(50));
+
+            assert!(result.is_none());
+            assert!(
+                started.elapsed() < Duration::from_secs(2),
+                "startup extension update probe exceeded its deadline in {}",
+                home.path().display()
+            );
+        });
+    }
+
+    #[test]
+    fn update_phases_share_one_deadline() {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut timeouts = Vec::new();
+
+        let result = run_update_phases_with_deadline(deadline, |args, timeout| {
+            timeouts.push((args[0].to_string(), timeout));
+            std::thread::sleep(Duration::from_millis(20));
+            Some(if args[0] == "rev-list" {
+                "0".to_string()
+            } else {
+                String::new()
+            })
+        });
+
+        assert!(result.is_some());
+        assert_eq!(timeouts.len(), 2);
+        assert!(timeouts[1].1 < timeouts[0].1);
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git fixture command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 pub fn read_source_revision(extension_id: &str) -> Option<String> {
@@ -237,6 +328,7 @@ fn source_metadata_file(extension_dir: &std::path::Path, kind: &str) -> String {
 #[cfg(test)]
 mod cleanliness_tests {
     use super::*;
+    use std::process::Command;
 
     #[test]
     fn modified_and_untracked_status_lines_yield_paths() {

--- a/crates/homeboy-extension/src/update_check.rs
+++ b/crates/homeboy-extension/src/update_check.rs
@@ -17,9 +17,11 @@ use crate as extension;
 use homeboy_core::update_check_cache;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 const CACHE_FILENAME: &str = "extension_update_check.json";
 const CHECK_INTERVAL_SECS: u64 = 86400;
+const STARTUP_UPDATE_CHECK_BUDGET: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionUpdateCache {
@@ -95,13 +97,11 @@ pub fn run_startup_check() {
     }
 
     let extension_ids = extension::available_extension_ids();
-    let mut extensions_behind: HashMap<String, usize> = HashMap::new();
-
-    for id in &extension_ids {
-        if let Some(update) = homeboy_core::extension_update_check::check_update_available(id) {
-            extensions_behind.insert(update.extension_id, update.behind_count);
-        }
-    }
+    let extensions_behind = collect_updates_with_budget(
+        &extension_ids,
+        STARTUP_UPDATE_CHECK_BUDGET,
+        homeboy_core::extension_update_check::check_update_available_until,
+    );
 
     write_cache(&ExtensionUpdateCache {
         extensions_behind: extensions_behind.clone(),
@@ -111,6 +111,27 @@ pub fn run_startup_check() {
     if !already_printed && !extensions_behind.is_empty() {
         print_extension_hints(&extensions_behind);
     }
+}
+
+fn collect_updates_with_budget<F>(
+    extension_ids: &[String],
+    budget: Duration,
+    mut check: F,
+) -> HashMap<String, usize>
+where
+    F: FnMut(&str, Instant) -> Option<homeboy_core::extension_update_check::UpdateAvailable>,
+{
+    let deadline = Instant::now() + budget;
+    let mut extensions_behind = HashMap::new();
+    for id in extension_ids {
+        if deadline <= Instant::now() {
+            break;
+        }
+        if let Some(update) = check(id, deadline) {
+            extensions_behind.insert(update.extension_id, update.behind_count);
+        }
+    }
+    extensions_behind
 }
 
 #[cfg(test)]
@@ -154,5 +175,50 @@ mod tests {
         assert_eq!(parsed.extensions_behind.len(), 1);
         assert_eq!(parsed.extensions_behind["wordpress"], 3);
         assert_eq!(parsed.checked_at, 1700000000);
+    }
+
+    #[test]
+    fn startup_budget_skips_probes_after_its_deadline() {
+        let extensions = vec!["one".to_string(), "two".to_string()];
+        let mut calls = 0;
+
+        let updates = collect_updates_with_budget(&extensions, Duration::ZERO, |_, _| {
+            calls += 1;
+            None
+        });
+
+        assert!(updates.is_empty());
+        assert_eq!(calls, 0, "an exhausted startup budget must stay silent");
+    }
+
+    #[test]
+    fn fast_update_probe_keeps_the_startup_path_quiet_and_complete() {
+        let extensions = vec!["one".to_string(), "two".to_string()];
+        let mut calls = Vec::new();
+
+        let updates = collect_updates_with_budget(&extensions, Duration::from_secs(1), |id, _| {
+            calls.push(id.to_string());
+            None
+        });
+
+        assert!(updates.is_empty());
+        assert_eq!(calls, extensions);
+    }
+
+    #[test]
+    fn startup_collection_passes_one_decreasing_deadline_to_each_probe() {
+        let extensions = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+        let mut deadlines = Vec::new();
+
+        let updates =
+            collect_updates_with_budget(&extensions, Duration::from_secs(1), |_, deadline| {
+                deadlines.push(deadline);
+                std::thread::sleep(Duration::from_millis(25));
+                None
+            });
+
+        assert!(updates.is_empty());
+        assert_eq!(deadlines.len(), extensions.len());
+        assert!(deadlines.windows(2).all(|pair| pair[0] == pair[1]));
     }
 }

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -2726,6 +2726,7 @@ fn runner_jobs_with_client(
     client: &Client,
     timeout: Duration,
 ) -> Result<(Vec<ActiveRunnerJobSummary>, Vec<ActiveRunnerJobSummary>)> {
+    let started = Instant::now();
     let result: Result<(Vec<ActiveRunnerJobSummary>, Vec<ActiveRunnerJobSummary>)> = (|| {
         let (body, source) = if let Some(local_url) = session.local_url.as_deref() {
             let data = daemon_get(client, local_url, "/jobs")?;
@@ -2784,7 +2785,14 @@ fn runner_jobs_with_client(
             } else {
                 crate::readonly_probe::REASON_PROBE_UNAVAILABLE
             },
-            timeout_seconds: if timed_out { timeout.as_secs() } else { 0 },
+            timeout_seconds: if timed_out {
+                timeout.as_secs().max(1)
+            } else {
+                0
+            },
+            elapsed_ms: started.elapsed().as_millis(),
+            deadline_ms: if timed_out { timeout.as_millis() } else { 0 },
+            follow_up: crate::readonly_probe::runner_status_follow_up(Some(runner_id)),
             detail: format!(
                 "read-only typed-job probe for runner `{runner_id}` did not complete; active-job state is partial: {}",
                 error.message
@@ -2819,11 +2827,48 @@ fn runner_running_runs(session: &RunnerSession) -> Result<Vec<RunSummary>> {
     let Some(local_url) = session.local_url.as_deref() else {
         return Ok(Vec::new());
     };
+    let timeout = crate::readonly_probe::readonly_probe_timeout();
     let client = Client::builder()
-        .timeout(Duration::from_secs(10))
+        .timeout(timeout)
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build runner runs client: {err}")))?;
-    let data = daemon_get(&client, local_url, "/runs?status=running&limit=1000")?;
+    runner_running_runs_with_client(&session.runner_id, local_url, &client, timeout)
+}
+
+fn runner_running_runs_with_client(
+    runner_id: &str,
+    local_url: &str,
+    client: &Client,
+    timeout: Duration,
+) -> Result<Vec<RunSummary>> {
+    let started = Instant::now();
+    let data = daemon_get(client, local_url, "/runs?status=running&limit=1000").map_err(|error| {
+        let timed_out = error.details["request_timeout"]
+            .as_bool()
+            .unwrap_or_else(|| error.message.to_ascii_lowercase().contains("timed out"));
+        crate::readonly_probe::record_degradation(crate::readonly_probe::ReadOnlyProbeDegradation {
+            probe: "runner_running_runs".to_string(),
+            runner_id: Some(runner_id.to_string()),
+            reason_code: if timed_out {
+                crate::readonly_probe::REASON_PROBE_TIMEOUT
+            } else {
+                crate::readonly_probe::REASON_PROBE_UNAVAILABLE
+            },
+            timeout_seconds: if timed_out {
+                timeout.as_secs().max(1)
+            } else {
+                0
+            },
+            elapsed_ms: started.elapsed().as_millis(),
+            deadline_ms: if timed_out { timeout.as_millis() } else { 0 },
+            follow_up: crate::readonly_probe::runner_status_follow_up(Some(runner_id)),
+            detail: format!(
+                "read-only running-runs probe for runner `{}` did not complete; orphaned child-run detection is partial: {}",
+                runner_id, error.message
+            ),
+        });
+        error
+    })?;
     let runs: Vec<RunSummary> =
         serde_json::from_value(data["body"]["runs"].clone()).map_err(|err| {
             Error::internal_json(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -57,10 +57,12 @@ pub(super) fn bounded_remote_homeboy_version(
 ) -> std::result::Result<String, String> {
     let command = remote_homeboy_version_command(homeboy);
     let timeout = crate::readonly_probe::readonly_probe_timeout();
+    let started = std::time::Instant::now();
     let output = client.execute_with_timeout(&command, timeout);
     crate::readonly_probe::record_probe_outcome(
         "runner_homeboy_version",
         runner_id,
+        started,
         timeout,
         &output,
     );
@@ -134,10 +136,12 @@ pub(super) fn bounded_remote_homeboy_identity(
 ) -> std::result::Result<RemoteHomeboyIdentity, String> {
     let command = remote_homeboy_identity_command(homeboy);
     let timeout = crate::readonly_probe::readonly_probe_timeout();
+    let started = std::time::Instant::now();
     let output = client.execute_with_timeout(&command, timeout);
     let degraded = crate::readonly_probe::record_probe_outcome(
         "runner_homeboy_identity",
         runner_id,
+        started,
         timeout,
         &output,
     );
@@ -1309,11 +1313,13 @@ fn remote_daemon_status_with_timeout(
     runner_id: Option<&str>,
 ) -> std::result::Result<RemoteDaemonStatus, String> {
     let command = format!("{} daemon status", shell::quote_arg(homeboy));
+    let started = std::time::Instant::now();
     let output = client.execute_with_timeout(&command, timeout);
     if let Some(runner_id) = runner_id {
         crate::readonly_probe::record_probe_outcome(
             "runner_remote_daemon_status",
             Some(runner_id),
+            started,
             timeout,
             &output,
         );
@@ -1482,10 +1488,12 @@ pub(super) fn probe_remote_daemon_endpoint(
         shell::quote_arg(&format!("http://{}", daemon.address))
     );
     let timeout = crate::readonly_probe::readonly_probe_timeout();
+    let started = std::time::Instant::now();
     let output = client.execute_with_timeout(&command, timeout);
     crate::readonly_probe::record_probe_outcome(
         "runner_remote_endpoint_identity",
         runner_id,
+        started,
         timeout,
         &output,
     );
@@ -1528,10 +1536,12 @@ pub(super) fn probe_remote_daemon_endpoint(
         "curl --fail --silent --show-error --max-time 2 {}/jobs",
         shell::quote_arg(&format!("http://{}", daemon.address))
     );
+    let started = std::time::Instant::now();
     let output = client.execute_with_timeout(&command, timeout);
     crate::readonly_probe::record_probe_outcome(
         "runner_remote_typed_jobs",
         runner_id,
+        started,
         timeout,
         &output,
     );

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -240,6 +240,9 @@ fn record_partial_peer_projection(runner_id: &str, reason_code: &'static str, de
         runner_id: Some(runner_id.to_string()),
         reason_code,
         timeout_seconds: 0,
+        elapsed_ms: 0,
+        deadline_ms: 0,
+        follow_up: crate::readonly_probe::runner_status_follow_up(Some(runner_id)),
         detail: format!(
             "{detail}; status is partial. Run `homeboy runner connect {runner_id}` to re-establish and validate the authoritative session."
         ),

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -2228,6 +2228,47 @@ fn broker_typed_job_body_timeout_records_runner_attributed_partial_status() {
 }
 
 #[test]
+fn running_runs_timeout_returns_partial_status_with_targeted_follow_up() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("request");
+        let mut request = [0; 1024];
+        let _ = stream.read(&mut request).expect("read request");
+        std::thread::sleep(Duration::from_millis(100));
+    });
+    let client = Client::builder()
+        .timeout(Duration::from_millis(10))
+        .build()
+        .expect("client");
+    crate::readonly_probe::clear_degradations();
+
+    assert!(runner_running_runs_with_client(
+        "homeboy-lab",
+        &format!("http://{address}"),
+        &client,
+        Duration::from_millis(10),
+    )
+    .is_err());
+
+    server.join().expect("server");
+    let degradations = crate::readonly_probe::take_degradations();
+    assert_eq!(degradations.len(), 1);
+    assert_eq!(degradations[0].probe, "runner_running_runs");
+    assert_eq!(degradations[0].timeout_seconds, 1);
+    assert_eq!(
+        degradations[0].reason_code,
+        crate::readonly_probe::REASON_PROBE_TIMEOUT
+    );
+    assert!(degradations[0].elapsed_ms >= 10);
+    assert_eq!(degradations[0].deadline_ms, 10);
+    assert_eq!(
+        degradations[0].follow_up,
+        "homeboy runner status homeboy-lab --full"
+    );
+}
+
+#[test]
 fn child_run_matching_accepts_durable_run_id_or_command_reference() {
     let run = sample_run_summary("run-child-1");
     let by_durable_id = sample_active_job(Some("run-child-1"), "homeboy test wpcom");

--- a/crates/homeboy-lab-runner/src/readonly_probe.rs
+++ b/crates/homeboy-lab-runner/src/readonly_probe.rs
@@ -15,7 +15,7 @@
 //! *reported* instead of being silently swallowed into "nothing to report".
 
 use std::cell::RefCell;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
@@ -59,10 +59,18 @@ pub struct ReadOnlyProbeDegradation {
     pub runner_id: Option<String>,
     /// Machine-readable classification of the degradation.
     pub reason_code: &'static str,
-    /// The bound that fired, in seconds. `0` when the probe never reached its
-    /// bound because it could not run at all
-    /// (see [`REASON_PROBE_UNAVAILABLE`]).
+    /// The bound that fired, rounded up to seconds. `0` means no deadline was
+    /// applied because the probe could not run at all (see
+    /// [`REASON_PROBE_UNAVAILABLE`]); use `deadline_ms` for exact precision.
     pub timeout_seconds: u64,
+    /// The elapsed wall-clock time when the probe stopped, in milliseconds.
+    pub elapsed_ms: u128,
+    /// The probe deadline, in milliseconds. Zero means the probe was
+    /// unavailable before it could start.
+    pub deadline_ms: u128,
+    /// The narrowest command that can provide more detail after this partial
+    /// observation.
+    pub follow_up: String,
     /// Operator-facing explanation of what is missing from the result.
     pub detail: String,
 }
@@ -114,6 +122,7 @@ pub fn record_degradation(degradation: ReadOnlyProbeDegradation) {
 pub fn record_probe_outcome(
     probe: &str,
     runner_id: Option<&str>,
+    started: Instant,
     timeout: Duration,
     output: &homeboy_core::server::CommandOutput,
 ) -> bool {
@@ -129,10 +138,11 @@ pub fn record_probe_outcome(
     } else {
         REASON_PROBE_INTERRUPTED
     };
+    let deadline_ms = timeout.as_millis();
+    let elapsed_ms = started.elapsed().as_millis();
     let detail = if output.timed_out {
         format!(
-            "read-only probe `{probe}` exceeded its {}s bound and was terminated; the runner did not answer, so this result is partial. Set {READONLY_PROBE_TIMEOUT_ENV} to change the bound.",
-            timeout.as_secs()
+            "read-only probe `{probe}` exceeded its {deadline_ms}ms bound and was terminated after {elapsed_ms}ms; the runner did not answer, so this result is partial. Set {READONLY_PROBE_TIMEOUT_ENV} to change the bound."
         )
     } else {
         format!("read-only probe `{probe}` was cancelled by the caller before the runner answered; this result is partial.")
@@ -141,10 +151,20 @@ pub fn record_probe_outcome(
         probe: probe.to_string(),
         runner_id: runner_id.map(str::to_string),
         reason_code,
-        timeout_seconds: timeout.as_secs(),
+        timeout_seconds: timeout.as_secs().max(u64::from(!timeout.is_zero())),
+        elapsed_ms,
+        deadline_ms,
+        follow_up: runner_status_follow_up(runner_id),
         detail,
     });
     true
+}
+
+pub fn runner_status_follow_up(runner_id: Option<&str>) -> String {
+    runner_id.map_or_else(
+        || "homeboy runner status --full".to_string(),
+        |runner_id| format!("homeboy runner status {runner_id} --full"),
+    )
 }
 
 /// Read the degradations recorded so far without clearing them.
@@ -187,6 +207,7 @@ mod tests {
         let recorded = record_probe_outcome(
             "runner_homeboy_identity",
             Some("homeboy-lab"),
+            Instant::now(),
             Duration::from_secs(15),
             &output(true, "Homeboy remote probe timed out after 15000ms"),
         );
@@ -198,6 +219,12 @@ mod tests {
         assert_eq!(degradations[0].runner_id.as_deref(), Some("homeboy-lab"));
         assert_eq!(degradations[0].reason_code, REASON_PROBE_TIMEOUT);
         assert_eq!(degradations[0].timeout_seconds, 15);
+        assert!(degradations[0].elapsed_ms <= 100);
+        assert_eq!(degradations[0].deadline_ms, 15_000);
+        assert_eq!(
+            degradations[0].follow_up,
+            "homeboy runner status homeboy-lab --full"
+        );
         assert!(degradations[0].detail.contains("partial"));
     }
 
@@ -208,6 +235,7 @@ mod tests {
         assert!(record_probe_outcome(
             "runner_homeboy_identity",
             Some("homeboy-lab"),
+            Instant::now(),
             Duration::from_secs(15),
             &output(
                 false,
@@ -227,6 +255,7 @@ mod tests {
         assert!(!record_probe_outcome(
             "runner_homeboy_identity",
             Some("homeboy-lab"),
+            Instant::now(),
             Duration::from_secs(15),
             &output(false, ""),
         ));
@@ -241,12 +270,31 @@ mod tests {
             record_probe_outcome(
                 "runner_homeboy_identity",
                 Some("homeboy-lab"),
+                Instant::now(),
                 Duration::from_secs(15),
                 &output(true, ""),
             );
         }
 
         assert_eq!(take_degradations().len(), 1);
+    }
+
+    #[test]
+    fn subsecond_timeout_preserves_milliseconds_and_nonzero_seconds() {
+        clear_degradations();
+
+        assert!(record_probe_outcome(
+            "runner_homeboy_identity",
+            Some("homeboy-lab"),
+            Instant::now() - Duration::from_millis(12),
+            Duration::from_millis(50),
+            &output(true, "timed out"),
+        ));
+
+        let degradation = take_degradations().pop().expect("degradation");
+        assert_eq!(degradation.timeout_seconds, 1);
+        assert_eq!(degradation.deadline_ms, 50);
+        assert!(degradation.elapsed_ms >= 12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bound startup extension Git checks with shared absolute deadlines across all extensions and Git phases
- return truthful elapsed/deadline values for degraded read-only runner probes
- retain silent fast paths and additive partial-status diagnostics

Fixes #12136.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-core extension_update_check --lib`
- `cargo test -p homeboy-extension update_check --lib`
- `cargo test -p homeboy-lab-runner readonly_probe --lib`
- `cargo test -p homeboy-lab-runner running_runs_timeout_returns_partial_status_with_targeted_follow_up --lib`
- `cargo check -p homeboy-extension -p homeboy-lab-runner`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the bounded discovery probes with direct general coding subagents. Chris Huber reviewed the resulting diff and remains responsible for every line.
