### PR TITLE
fix(runner): capture tunnel ownership before readiness

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -151,9 +151,6 @@ fn open_controller_proxy_forward(server: &Server) -> Result<Option<RunnerProxyFo
     };
     let tunnel = remote_daemon::open_reverse_proxy_tunnel(server, &proxy.host, proxy.port);
     if !tunnel.success {
-        if let Some(pid) = tunnel.pid {
-            terminate_pid(pid);
-        }
         return Err(Error::validation_invalid_argument(
             "controller_proxy",
             format!(
@@ -165,14 +162,15 @@ fn open_controller_proxy_forward(server: &Server) -> Result<Option<RunnerProxyFo
         ));
     }
     let tunnel_pid = tunnel.pid.expect("remote SSH forward has a child process");
+    let tunnel_process_start_identity = capture_tunnel_process_start_identity(Some(tunnel_pid))?;
     let port = tunnel.stderr.parse::<u16>().map_err(|_| {
-        terminate_pid(tunnel_pid);
+        terminate_tunnel_if_owned_parts(tunnel_pid, tunnel_process_start_identity.as_ref());
         Error::internal_unexpected("controller proxy forward returned no allocated port")
     })?;
     Ok(Some(RunnerProxyForward {
         runner_url: format!("{}://127.0.0.1:{port}", proxy.scheme),
         tunnel_pid,
-        tunnel_process_start_identity: capture_tunnel_process_start_identity(Some(tunnel_pid))?,
+        tunnel_process_start_identity,
     }))
 }
 
@@ -362,7 +360,7 @@ pub(crate) fn rotate_daemon_generation(
         inspected_freshness: None,
     };
     let session_path = session_path(runner_id)?;
-    let (local_port, tunnel_pid, local_url, daemon) =
+    let (local_port, tunnel_pid, tunnel_process_start_identity, local_url, daemon) =
         match connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
             server: &server,
             homeboy: candidate_homeboy,
@@ -412,7 +410,7 @@ pub(crate) fn rotate_daemon_generation(
                 let _ = client.execute(&command);
             }
             if let Some(pid) = tunnel_pid {
-                terminate_pid(pid);
+                terminate_tunnel_if_owned_parts(pid, tunnel_process_start_identity.as_ref());
             }
             // The candidate was never activated. Remove any retained entry for
             // this generation just as the preceding startup-validation path
@@ -432,7 +430,7 @@ pub(crate) fn rotate_daemon_generation(
         local_port: Some(local_port),
         local_url: Some(local_url),
         tunnel_pid,
-        tunnel_process_start_identity: capture_tunnel_process_start_identity(tunnel_pid)?,
+        tunnel_process_start_identity,
         proxy_forward: current.proxy_forward.clone(),
         remote_daemon_pid: daemon.pid,
         remote_daemon_lease_id: daemon.lease_id,
@@ -1154,15 +1152,16 @@ fn connect_with_orphan_adoption_and_live_lease(
         runner_id,
         session_path: &session_path,
     });
-    let (local_port, tunnel_pid, local_url, daemon) = match connection {
-        Ok(connection) => connection,
-        Err(report) => {
-            let (mut report, exit_code) = *report;
-            attach_state_loss_recovery(&mut report, state_loss_recovery);
-            attach_leaseless_recovery(&mut report, leaseless_recovery, recovery_evidence);
-            return Ok((report, exit_code));
-        }
-    };
+    let (local_port, tunnel_pid, tunnel_process_start_identity, local_url, daemon) =
+        match connection {
+            Ok(connection) => connection,
+            Err(report) => {
+                let (mut report, exit_code) = *report;
+                attach_state_loss_recovery(&mut report, state_loss_recovery);
+                attach_leaseless_recovery(&mut report, leaseless_recovery, recovery_evidence);
+                return Ok((report, exit_code));
+            }
+        };
     // Proxy exposure belongs to explicitly requesting jobs. Connecting a runner
     // must not capture an ambient controller endpoint or create an idle tunnel.
     let proxy_forward = None;
@@ -1181,7 +1180,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             error,
             state_loss_recovery,
             tunnel_pid,
-            session_store::terminate_pid,
+            tunnel_process_start_identity.as_ref(),
         ));
     }
     let connection_warning = daemon
@@ -1199,7 +1198,7 @@ fn connect_with_orphan_adoption_and_live_lease(
         local_port: Some(local_port),
         local_url: Some(local_url),
         tunnel_pid,
-        tunnel_process_start_identity: capture_tunnel_process_start_identity(tunnel_pid)?,
+        tunnel_process_start_identity,
         proxy_forward,
         remote_daemon_pid: daemon.pid,
         remote_daemon_lease_id,
@@ -1235,7 +1234,7 @@ fn connect_with_orphan_adoption_and_live_lease(
             error,
             state_loss_recovery,
             session.tunnel_pid,
-            session_store::terminate_pid,
+            session.tunnel_process_start_identity.as_ref(),
         ));
     }
 
@@ -1531,19 +1530,16 @@ fn attach_state_loss_recovery(
     report.state_loss_recovery = recovery;
 }
 
-fn session_write_failure_report<Terminate>(
+fn session_write_failure_report(
     runner_id: &str,
     session_path: PathBuf,
     error: Error,
     recovery: Option<DaemonStateLossRecoveryResult>,
     tunnel_pid: Option<u32>,
-    terminate: Terminate,
-) -> (RunnerConnectReport, i32)
-where
-    Terminate: FnOnce(u32),
-{
+    tunnel_process_start_identity: Option<&RunnerTunnelProcessStartIdentity>,
+) -> (RunnerConnectReport, i32) {
     if let Some(pid) = tunnel_pid {
-        terminate(pid);
+        terminate_tunnel_if_owned_parts(pid, tunnel_process_start_identity);
     }
     let (mut report, exit_code) = failed_connect(
         runner_id,
@@ -2102,7 +2098,7 @@ fn reconnect_job_owner(runner_id: &str, job_id: &str) -> Result<RunnerSession> {
         inspected_freshness: None,
     };
     let session_path = session_path(runner_id)?;
-    let (local_port, tunnel_pid, local_url, daemon) =
+    let (local_port, tunnel_pid, tunnel_process_start_identity, local_url, daemon) =
         connect_remote_daemon(connection_daemon::RemoteDaemonConnectRequest {
             server: &server,
             homeboy: "",
@@ -2123,15 +2119,6 @@ fn reconnect_job_owner(runner_id: &str, job_id: &str) -> Result<RunnerSession> {
                 None,
             )
         })?;
-    let tunnel_process_start_identity = match capture_tunnel_process_start_identity(tunnel_pid) {
-        Ok(identity) => identity,
-        Err(error) => {
-            if let Some(pid) = tunnel_pid {
-                terminate_pid(pid);
-            }
-            return Err(error);
-        }
-    };
     let session = RunnerSession {
         local_port: Some(local_port),
         local_url: Some(local_url),
@@ -2247,12 +2234,7 @@ fn capture_tunnel_process_start_identity(
 
 pub(crate) fn terminate_tunnel_if_owned(session: &RunnerSession) {
     if let Some(pid) = session.tunnel_pid {
-        terminate_tunnel_with_identity(
-            pid,
-            session.tunnel_process_start_identity.as_ref(),
-            homeboy_core::process::process_start_identity,
-            terminate_pid,
-        );
+        terminate_tunnel_if_owned_parts(pid, session.tunnel_process_start_identity.as_ref());
     }
     if let Some(proxy_forward) = &session.proxy_forward {
         terminate_tunnel_with_identity(
@@ -2262,6 +2244,18 @@ pub(crate) fn terminate_tunnel_if_owned(session: &RunnerSession) {
             terminate_pid,
         );
     }
+}
+
+pub(super) fn terminate_tunnel_if_owned_parts(
+    pid: u32,
+    expected_identity: Option<&RunnerTunnelProcessStartIdentity>,
+) {
+    terminate_tunnel_with_identity(
+        pid,
+        expected_identity,
+        homeboy_core::process::process_start_identity,
+        terminate_pid,
+    );
 }
 
 fn terminate_tunnel_with_identity<Inspect, Terminate>(

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -221,6 +221,26 @@ fn pid_reuse_never_signals_a_temporary_tunnel() {
 }
 
 #[test]
+fn matching_tunnel_identity_signals_only_the_owned_process() {
+    let expected = RunnerTunnelProcessStartIdentity::Linux {
+        starttime_ticks: 123,
+    };
+    let actual = homeboy_core::process::ProcessStartIdentity::Linux {
+        starttime_ticks: 123,
+    };
+    let signaled = std::cell::Cell::new(false);
+
+    terminate_tunnel_with_identity(
+        42,
+        Some(&expected),
+        |_| Ok(Some(actual.clone())),
+        |_| signaled.set(true),
+    );
+
+    assert!(signaled.get(), "the exact owned tunnel is cleaned up");
+}
+
+#[test]
 fn missing_or_uninspectable_tunnel_identity_never_signals() {
     let signaled = std::cell::Cell::new(false);
     terminate_tunnel_with_identity(42, None, |_| Ok(None), |_| signaled.set(true));

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -10,7 +10,7 @@ use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
 use homeboy_core::engine::shell;
 use homeboy_core::server::Server;
 
-use super::super::session::RunnerStaleRuntimePath;
+use super::super::session::{RunnerStaleRuntimePath, RunnerTunnelProcessStartIdentity};
 use super::{
     failed_connect, open_loopback_tunnel, parse_loopback_daemon_addr, reserve_loopback_port,
     terminate_pid, wait_for_tcp, RemoteDaemon,
@@ -43,10 +43,25 @@ pub(super) struct RemoteDaemonConnectRequest<'a> {
     pub(super) session_path: &'a Path,
 }
 
-type RemoteDaemonConnectResult =
-    std::result::Result<(u16, Option<u32>, String, RemoteDaemon), Box<(RunnerConnectReport, i32)>>;
-type TunnelOpenResult =
-    std::result::Result<(u16, Option<u32>, String), Box<(RunnerConnectReport, i32)>>;
+type RemoteDaemonConnectResult = std::result::Result<
+    (
+        u16,
+        Option<u32>,
+        Option<RunnerTunnelProcessStartIdentity>,
+        String,
+        RemoteDaemon,
+    ),
+    Box<(RunnerConnectReport, i32)>,
+>;
+type TunnelOpenResult = std::result::Result<
+    (
+        u16,
+        Option<u32>,
+        Option<RunnerTunnelProcessStartIdentity>,
+        String,
+    ),
+    Box<(RunnerConnectReport, i32)>,
+>;
 
 pub(super) fn connect_remote_daemon(
     request: RemoteDaemonConnectRequest<'_>,
@@ -60,50 +75,60 @@ pub(super) fn connect_remote_daemon(
         runner_id,
         session_path,
     } = request;
-    let failed_after_tunnel = |tunnel_pid: Option<u32>,
-                               message: String,
-                               health_attempts: Vec<String>,
-                               local_url: &str| {
-        if let Some(pid) = tunnel_pid {
-            terminate_pid(pid);
-        }
-        let (mut report, exit_code) = failed_connect(
-            runner_id,
-            session_path.to_path_buf(),
-            RunnerFailureKind::DaemonStartupFailure,
-            message,
-        );
-        report.failure_evidence = Some(RunnerConnectFailureEvidence {
-            recovery_command: format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
-            classification: "daemon_health".to_string(),
-            remote_start_command: Some(format!(
-                "{} daemon ensure-running --addr 127.0.0.1:0",
-                shell::quote_arg(homeboy)
-            )),
-            known_remote_pid: daemon.pid,
-            known_remote_lease_id: daemon.lease_id.clone(),
-            remote_address: Some(daemon.address.clone()),
-            local_address: Some(local_url.to_string()),
-            tunnel_state: Some("established_then_health_failed".to_string()),
-            health_attempt_count: health_attempts.len(),
-            health_attempts,
-        });
-        Box::new((report, exit_code))
-    };
-    let (local_port, tunnel_pid, local_url) =
+    let failed_after_tunnel =
+        |tunnel_pid: Option<u32>,
+         tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
+         message: String,
+         health_attempts: Vec<String>,
+         local_url: &str| {
+            if let Some(pid) = tunnel_pid {
+                super::terminate_tunnel_if_owned_parts(pid, tunnel_process_start_identity.as_ref());
+            }
+            let (mut report, exit_code) = failed_connect(
+                runner_id,
+                session_path.to_path_buf(),
+                RunnerFailureKind::DaemonStartupFailure,
+                message,
+            );
+            report.failure_evidence = Some(RunnerConnectFailureEvidence {
+                recovery_command: format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
+                classification: "daemon_health".to_string(),
+                remote_start_command: Some(format!(
+                    "{} daemon ensure-running --addr 127.0.0.1:0",
+                    shell::quote_arg(homeboy)
+                )),
+                known_remote_pid: daemon.pid,
+                known_remote_lease_id: daemon.lease_id.clone(),
+                remote_address: Some(daemon.address.clone()),
+                local_address: Some(local_url.to_string()),
+                tunnel_state: Some("established_then_health_failed".to_string()),
+                health_attempt_count: health_attempts.len(),
+                health_attempts,
+            });
+            Box::new((report, exit_code))
+        };
+    let (local_port, tunnel_pid, tunnel_process_start_identity, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
     match probe_daemon_health_until_ready(&local_url, &daemon) {
         Ok(()) if endpoint_identity_matches(&local_url, expected_version, expected_identity) => {
-            Ok((local_port, tunnel_pid, local_url, daemon))
+            Ok((
+                local_port,
+                tunnel_pid,
+                tunnel_process_start_identity,
+                local_url,
+                daemon,
+            ))
         }
         Ok(()) => Err(failed_after_tunnel(
             tunnel_pid,
+            tunnel_process_start_identity,
             "remote daemon endpoint identity did not match the controller-selected generation; refusing to publish it".to_string(),
             Vec::new(),
             &local_url,
         )),
         Err(DaemonHealthProbeFailure::IdentityMismatch(report)) => Err(failed_after_tunnel(
             tunnel_pid,
+            tunnel_process_start_identity,
             format!(
                 "remote daemon health identity changed or is unavailable (expected lease {:?}, PID {:?}; got lease {:?}, PID {:?}); refusing to write session{}",
                 daemon.lease_id, daemon.pid, report.freshness.lease_id, report.pid,
@@ -113,7 +138,13 @@ pub(super) fn connect_remote_daemon(
             &local_url,
         )),
         Err(DaemonHealthProbeFailure::Unreachable { message, attempts }) => {
-            Err(failed_after_tunnel(tunnel_pid, message, attempts, &local_url))
+            Err(failed_after_tunnel(
+                tunnel_pid,
+                tunnel_process_start_identity,
+                message,
+                attempts,
+                &local_url,
+            ))
         }
     }
 }
@@ -248,9 +279,28 @@ fn open_daemon_tunnel(
         )));
     }
 
-    if !wait_for_tcp(local_port, Duration::from_secs(5)) {
+    // Capture the local process identity before readiness can cause a fast SSH
+    // child to exit and be reaped. Session cleanup relies on this exact identity.
+    let (tunnel_process_start_identity, tunnel_ready) =
+        match capture_identity_before_tunnel_readiness(
+            tunnel.pid,
+            super::capture_tunnel_process_start_identity,
+            || wait_for_tcp(local_port, Duration::from_secs(5)),
+        ) {
+            Ok(identity) => identity,
+            Err(error) => {
+                return Err(Box::new(failed_connect(
+                    runner_id,
+                    session_path.to_path_buf(),
+                    RunnerFailureKind::TunnelFailure,
+                    error.message,
+                )));
+            }
+        };
+
+    if !tunnel_ready {
         if let Some(pid) = tunnel.pid {
-            terminate_pid(pid);
+            super::terminate_tunnel_if_owned_parts(pid, tunnel_process_start_identity.as_ref());
         }
         return Err(Box::new(failed_connect(
             runner_id,
@@ -265,8 +315,22 @@ fn open_daemon_tunnel(
     Ok((
         local_port,
         tunnel.pid,
+        tunnel_process_start_identity,
         format!("http://127.0.0.1:{}", local_port),
     ))
+}
+
+fn capture_identity_before_tunnel_readiness<C, W>(
+    pid: Option<u32>,
+    capture: C,
+    readiness: W,
+) -> homeboy_core::error::Result<(Option<RunnerTunnelProcessStartIdentity>, bool)>
+where
+    C: FnOnce(Option<u32>) -> homeboy_core::error::Result<Option<RunnerTunnelProcessStartIdentity>>,
+    W: FnOnce() -> bool,
+{
+    let identity = capture(pid)?;
+    Ok((identity, readiness()))
 }
 
 pub(crate) fn versions_match(left: &str, right: &str) -> bool {
@@ -651,6 +715,7 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::process::{Command, Stdio};
 
     fn report(lease_id: &str, pid: u32) -> DaemonHealthReport {
         DaemonHealthReport {
@@ -980,5 +1045,60 @@ mod tests {
             "identity mismatch must not burn the retry budget"
         );
         server.join().expect("server");
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn captures_tunnel_identity_before_readiness_reaps_a_fast_exit() {
+        // The child remains live until readiness releases stdin. This removes
+        // scheduler timing from the race while exercising the real identity API.
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("read _; exit 0")
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("start blocked tunnel child");
+        let pid = child.id();
+
+        let result = capture_identity_before_tunnel_readiness(
+            Some(pid),
+            super::super::capture_tunnel_process_start_identity,
+            || {
+                drop(child.stdin.take());
+                assert!(child.wait().expect("reap tunnel child").success());
+                false
+            },
+        )
+        .expect("identity is captured before readiness reaps the child");
+
+        assert!(result.0.is_some());
+        assert!(!result.1);
+        assert_eq!(
+            homeboy_core::process::process_start_identity(pid)
+                .expect("inspect reaped child identity"),
+            None,
+            "the former post-readiness capture would report the child exited"
+        );
+    }
+
+    #[test]
+    fn does_not_probe_readiness_when_tunnel_identity_capture_fails() {
+        let mut readiness_called = false;
+
+        let result = capture_identity_before_tunnel_readiness(
+            Some(42),
+            |_| {
+                Err(homeboy_core::error::Error::internal_unexpected(
+                    "child exited",
+                ))
+            },
+            || {
+                readiness_called = true;
+                true
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(!readiness_called);
     }
 }


### PR DESCRIPTION
## Summary

- capture SSH tunnel process identity before readiness can reap a fast-exiting child
- carry identity through health and rollback paths
- refuse to signal recycled or unowned PIDs during cleanup

Fixes #12133.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner connection_daemon::tests --lib`
- `cargo test -p homeboy-lab-runner connection::tests::recovery::pid_reuse_never_signals_a_temporary_tunnel -- --exact`
- `cargo test -p homeboy-lab-runner connection::tests::recovery::matching_tunnel_identity_signals_only_the_owned_process -- --exact`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the tunnel ownership fix with direct general coding subagents. Chris Huber reviewed the resulting diff and remains responsible for every line.
