### PR TITLE
fix(runner): persist exec attempts before handoff

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 
 use homeboy_core::api_jobs::{JobStatus, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use homeboy_core::observation::RunStatus;
+use homeboy_core::redaction::redact_argv;
 
 use super::*;
 
@@ -113,7 +114,7 @@ fn ensure_runner_exec_observation_run(
             status: homeboy_core::observation::RunStatus::Running
                 .as_str()
                 .to_string(),
-            command: Some(remote_command.join(" ")),
+            command: Some(redact_argv(remote_command).join(" ")),
             cwd: Some(remote_workspace.to_string()),
             homeboy_version: Some(homeboy_core::build_identity::current().version),
             git_sha: None,
@@ -129,7 +130,10 @@ fn ensure_runner_exec_observation_run(
     metadata.insert("kind".to_string(), json!(RUNNER_EXEC_RUN_KIND));
     metadata.insert("runner_id".to_string(), json!(runner_id));
     metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
-    metadata.insert("remote_command".to_string(), json!(remote_command));
+    metadata.insert(
+        "remote_command".to_string(),
+        json!(redact_argv(remote_command)),
+    );
     if let Some(runner_job_id) = runner_job_id {
         metadata.insert("runner_job_id".to_string(), json!(runner_job_id));
     }
@@ -197,6 +201,85 @@ pub fn ensure_generic_runner_exec_run(
     remote_command: &[String],
 ) -> Result<homeboy_core::observation::RunRecord> {
     ensure_runner_exec_observation_run(run_id, runner_id, remote_workspace, remote_command, None)
+}
+
+/// Record a controller-side phase before work can reach a runner. This local
+/// evidence never implies that a runner job exists.
+pub fn record_runner_exec_pre_handoff_phase(run_id: &str, phase: &str) -> Result<()> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(());
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND)
+        || RunStatus::from_label(&run.status).is_some_and(RunStatus::is_terminal)
+    {
+        return Ok(());
+    }
+    run.metadata_json
+        .as_object_mut()
+        .expect("metadata object")
+        .insert("runner_exec_phase".to_string(), json!(phase));
+    store.upsert_imported_run_preserving_terminal(&run)
+}
+
+/// Terminalize an attempt that failed before a runner accepted a job. Once a
+/// job is bound, normal runner reconciliation owns the terminal outcome.
+pub fn finish_runner_exec_pre_handoff_failure(
+    run_id: &str,
+    transport: &str,
+    phase: &str,
+    handoff_accepted: bool,
+    error: &Error,
+) -> Result<bool> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(&sanitize_run_id(run_id))? else {
+        return Ok(false);
+    };
+    if run.metadata_json.get("kind").and_then(Value::as_str) != Some(RUNNER_EXEC_RUN_KIND)
+        || RunStatus::from_label(&run.status).is_some_and(RunStatus::is_terminal)
+        || run.metadata_json.get("runner_job_id").is_some()
+        || handoff_accepted
+    {
+        return Ok(false);
+    }
+    let recorded_phase = run.metadata_json["runner_exec_phase"]
+        .as_str()
+        .unwrap_or(phase)
+        .to_string();
+    let runner_id = run.metadata_json["runner_id"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    let mut execution_record = run
+        .metadata_json
+        .get("runner_execution_record")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_else(|| {
+            homeboy_core::runner_execution_envelope::RunnerExecutionRecord::terminal(
+                run.id.clone(),
+                &runner_id,
+                transport,
+                1,
+            )
+        });
+    execution_record.status = "failed".to_string();
+    store.finish_running_runner_exec_pre_handoff_failure(
+        &run.id,
+        json!({
+            "phase": recorded_phase,
+            "code": error.code.as_str(),
+            "message": homeboy_core::redaction::redact_string(&error.message),
+            "details": homeboy_core::redaction::redact_json(&error.details),
+            "recovery": {
+                "evidence": format!("homeboy runs evidence {run_id}"),
+                "status": format!("homeboy runs show {run_id}"),
+                "retry": format!("homeboy runner exec {runner_id} --run-id <new-run-id> -- <command>"),
+            },
+        }),
+        json!({ "state": "pre_handoff_failed", "artifact_promotion": "not_started" }),
+        serde_json::to_value(execution_record).expect("runner execution record serializes"),
+    )
 }
 
 /// Persist the output contract before submitting a daemon job. This gives a

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -168,6 +168,197 @@ fn diagnostic_ssh_run_id_creates_generic_run_without_a_runner_job() {
 }
 
 #[test]
+fn pre_handoff_connection_failure_is_terminal_local_evidence_without_a_runner_job() {
+    with_isolated_home(|_| {
+        let run_id = "runner-exec-connection-failure";
+        ensure_generic_runner_exec_run(
+            run_id,
+            "homeboy-lab",
+            "/runner/workspace",
+            &[
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+            ],
+        )
+        .expect("persist attempt before connection");
+        record_runner_exec_pre_handoff_phase(run_id, "connection").expect("record phase");
+        let error = Error::new(
+            ErrorCode::InternalUnexpected,
+            "new tunnel exited before its process identity was captured: Authorization: Bearer abc.def.ghi",
+            serde_json::json!({ "token": "secretvalue123" }),
+        );
+
+        assert!(finish_runner_exec_pre_handoff_failure(
+            run_id,
+            "pre_handoff",
+            "connection",
+            false,
+            &error
+        )
+        .expect("terminalize connection failure"));
+
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let run = store.get_run(run_id).expect("read").expect("persisted run");
+        assert_eq!(run.status, "fail");
+        assert!(run.finished_at.is_some());
+        assert_eq!(run.metadata_json["runner_exec_phase"], "connection");
+        assert_eq!(
+            run.metadata_json["runner_pre_handoff_failure"]["code"],
+            "internal.unexpected"
+        );
+        assert!(!run.metadata_json["runner_pre_handoff_failure"]
+            .to_string()
+            .contains("abc.def.ghi"));
+        assert_eq!(
+            run.metadata_json["runner_pre_handoff_failure"]["details"]["token"],
+            "[REDACTED]"
+        );
+        assert!(run.metadata_json.get("runner_job_id").is_none());
+        assert!(store.list_artifacts(run_id).expect("artifacts").is_empty());
+        assert_eq!(
+            run.metadata_json["runner_terminal_projection"]["state"],
+            "pre_handoff_failed"
+        );
+        assert!(
+            run.metadata_json["runner_pre_handoff_failure"]["recovery"]["evidence"]
+                .as_str()
+                .expect("evidence command")
+                .contains(run_id)
+        );
+        assert!(
+            run.metadata_json["runner_pre_handoff_failure"]["recovery"]["retry"]
+                .as_str()
+                .expect("retry command")
+                .contains("--run-id <new-run-id>")
+        );
+    });
+}
+
+#[test]
+fn duplicate_pre_handoff_failure_is_idempotent() {
+    with_isolated_home(|_| {
+        let run_id = "runner-exec-duplicate-pre-handoff";
+        let command = vec!["homeboy".to_string(), "review".to_string()];
+        ensure_generic_runner_exec_run(run_id, "homeboy-lab", "/runner/workspace", &command)
+            .expect("first attempt");
+        let error = Error::internal_unexpected("connection refused");
+        assert!(finish_runner_exec_pre_handoff_failure(
+            run_id,
+            "pre_handoff",
+            "connection",
+            false,
+            &error
+        )
+        .expect("first terminal failure"));
+
+        let duplicate =
+            ensure_generic_runner_exec_run(run_id, "homeboy-lab", "/runner/workspace", &command)
+                .expect("duplicate lookup reuses the persisted attempt");
+        assert_eq!(duplicate.status, "fail");
+        assert!(!finish_runner_exec_pre_handoff_failure(
+            run_id,
+            "pre_handoff",
+            "connection",
+            false,
+            &error
+        )
+        .expect("duplicate terminalization is ignored"));
+
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let run = store.get_run(run_id).expect("read").expect("run");
+        assert!(run.metadata_json.get("runner_job_id").is_none());
+        assert!(store.list_artifacts(run_id).expect("artifacts").is_empty());
+    });
+}
+
+#[test]
+fn accepted_handoff_marker_prevents_pre_handoff_terminalization() {
+    with_isolated_home(|_| {
+        let run_id = "runner-exec-accepted-but-unbound";
+        ensure_generic_runner_exec_run(run_id, "homeboy-lab", "/runner/workspace", &[])
+            .expect("persist attempt");
+        let error = Error::internal_unexpected("controller binding failed");
+
+        assert!(!finish_runner_exec_pre_handoff_failure(
+            run_id,
+            "pre_handoff",
+            "handoff",
+            true,
+            &error
+        )
+        .expect("accepted handoff remains non-terminal"));
+
+        let run = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .get_run(run_id)
+            .expect("read")
+            .expect("run");
+        assert_eq!(run.status, "running");
+        assert!(run
+            .metadata_json
+            .get("runner_pre_handoff_failure")
+            .is_none());
+    });
+}
+
+#[test]
+fn accepted_binding_wins_the_pre_handoff_terminalization_race() {
+    with_isolated_home(|_| {
+        let run_id = "runner-exec-accepted-race";
+        let command = vec!["homeboy".to_string(), "review".to_string()];
+        ensure_generic_runner_exec_run(run_id, "homeboy-lab", "/runner/workspace", &command)
+            .expect("persist attempt");
+
+        // This mirrors the race between a controller that has already built a
+        // failure payload and a binding write that wins before its CAS update.
+        let ready = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let bound = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let bind_ready = ready.clone();
+        let bind_done = bound.clone();
+        let binding = std::thread::spawn(move || {
+            bind_ready.wait();
+            record_runner_exec_job_identity(
+                run_id,
+                "homeboy-lab",
+                "accepted-job",
+                "/runner/workspace",
+                &command,
+            )
+            .expect("accepted binding");
+            bind_done.wait();
+        });
+        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
+        let run = store.get_run(run_id).expect("read").expect("attempt");
+        let failure = serde_json::json!({ "phase": "handoff", "code": "connection", "message": "lost", "details": {}, "recovery": {} });
+        let projection = serde_json::json!({ "state": "pre_handoff_failed" });
+        let execution = serde_json::to_value(
+            homeboy_core::runner_execution_envelope::RunnerExecutionRecord::terminal(
+                run.id,
+                "homeboy-lab",
+                "pre_handoff",
+                1,
+            ),
+        )
+        .expect("execution record");
+        ready.wait();
+        bound.wait();
+
+        assert!(!store
+            .finish_running_runner_exec_pre_handoff_failure(run_id, failure, projection, execution,)
+            .expect("CAS terminalization"));
+        binding.join().expect("binding thread");
+        let run = store.get_run(run_id).expect("read").expect("run");
+        assert_eq!(run.status, "running");
+        assert_eq!(run.metadata_json["runner_job_id"], "accepted-job");
+        assert!(run
+            .metadata_json
+            .get("runner_pre_handoff_failure")
+            .is_none());
+    });
+}
+
+#[test]
 fn generic_runner_exec_run_supports_artifact_attachment() {
     // The end-to-end contract #9485 restores: once the generic run exists, the
     // declared evidence attaches to it (previously `run record not found`).

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -678,6 +678,56 @@ mod tests {
     }
 
     #[test]
+    fn evidence_command_surfaces_local_pre_handoff_failure_without_runner_connectivity() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "runner_execution",
+                    "homeboy-lab",
+                    "",
+                    serde_json::json!({
+                        "runner_pre_handoff_failure": {
+                            "phase": "connection",
+                            "code": "runner.lab_transport_failure",
+                            "message": "tunnel setup failed: token=<redacted>",
+                            "details": { "token": "<redacted>" },
+                            "recovery": {
+                                "evidence": "homeboy runs evidence local-pre-handoff",
+                                "status": "homeboy runs show local-pre-handoff",
+                                "retry": "homeboy runner exec homeboy-lab --run-id <new-run-id> -- <command>"
+                            }
+                        }
+                    }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, homeboy::core::observation::RunStatus::Fail, None)
+                .expect("finish");
+
+            let (output, _) = evidence(&run.id).expect("local evidence does not need a runner");
+            let RunsOutput::Evidence(report) = output else {
+                panic!("full evidence output");
+            };
+            let failure = report
+                .failure
+                .runner_pre_handoff_failure
+                .expect("pre-handoff evidence");
+            assert_eq!(failure.phase, "connection");
+            assert_eq!(failure.code, "runner.lab_transport_failure");
+            assert!(failure.message.contains("<redacted>"));
+            assert_eq!(
+                failure.recovery["evidence"],
+                "homeboy runs evidence local-pre-handoff"
+            );
+            assert!(failure.recovery["retry"]
+                .as_str()
+                .expect("retry command")
+                .contains("--run-id <new-run-id>"));
+        });
+    }
+
+    #[test]
     fn evidence_projection_bounds_large_inventories_and_keeps_the_top_diagnostic() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();

--- a/crates/homeboy-core/src/observation/evidence_report.rs
+++ b/crates/homeboy-core/src/observation/evidence_report.rs
@@ -336,6 +336,29 @@ pub struct EvidenceFailureSummary {
     /// Missing for local and pre-projection records to preserve their schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_failure: Option<RunnerFailureEvidence>,
+    /// Controller-side runner failure before a daemon or broker accepted a job.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_pre_handoff_failure: Option<RunnerPreHandoffFailureEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerPreHandoffFailureEvidence {
+    pub phase: String,
+    pub code: String,
+    pub message: String,
+    pub details: Value,
+    pub recovery: Value,
+}
+
+impl RunnerPreHandoffFailureEvidence {
+    fn from_metadata(value: &Value) -> Option<Self> {
+        let evidence: Self = serde_json::from_value(value.clone()).ok()?;
+        (!evidence.phase.is_empty()
+            && !evidence.code.is_empty()
+            && !evidence.message.is_empty()
+            && evidence.recovery.is_object())
+        .then_some(evidence)
+    }
 }
 
 /// Versioned, controller-owned projection of a runner terminal failure.
@@ -964,6 +987,9 @@ pub fn evidence_failure_summary(run: &RunRecord) -> EvidenceFailureSummary {
         runner_failure: metadata
             .pointer("/lab/failure")
             .and_then(RunnerFailureEvidence::from_metadata),
+        runner_pre_handoff_failure: metadata
+            .get("runner_pre_handoff_failure")
+            .and_then(RunnerPreHandoffFailureEvidence::from_metadata),
     }
 }
 

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -243,6 +243,29 @@ impl ObservationStore {
         Ok(rows == 1)
     }
 
+    /// Atomically terminalize a generic runner-exec attempt only while it has
+    /// not crossed the durable runner-job handoff boundary. `json_set` preserves
+    /// metadata written by a concurrent accepted-handoff binder.
+    pub fn finish_running_runner_exec_pre_handoff_failure(
+        &self,
+        run_id: &str,
+        failure: serde_json::Value,
+        terminal_projection: serde_json::Value,
+        execution_record: serde_json::Value,
+    ) -> Result<bool> {
+        let failure = serialize_metadata(&failure)?;
+        let terminal_projection = serialize_metadata(&terminal_projection)?;
+        let execution_record = serialize_metadata(&execution_record)?;
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let rows = execute_with_retry("finish pre-handoff runner exec", || {
+            self.connection.execute(
+                "UPDATE runs SET finished_at = ?1, status = 'fail', metadata_json = json_set(metadata_json, '$.runner_pre_handoff_failure', json(?2), '$.runner_terminal_projection', json(?3), '$.runner_execution_record', json(?4)) WHERE id = ?5 AND status = 'running' AND json_extract(metadata_json, '$.kind') = 'runner_exec' AND COALESCE(json_extract(metadata_json, '$.runner_job_id'), json_extract(metadata_json, '$.agent_task_run.metadata.runner_job_id')) IS NULL",
+                params![finished_at, failure, terminal_projection, execution_record, run_id],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
     /// Claim a running runner-exec source for one child identity. The child
     /// token fences later source terminalization after a retry or takeover.
     pub fn claim_running_runner_exec_recovery_source(

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -271,6 +271,34 @@ pub(super) fn exec_via_reverse_broker(
             Some("parse reverse broker job".to_string()),
         )
     })?;
+    if let Some(run_id) = run_id.as_deref() {
+        // The broker has accepted this job. Persist that boundary before local
+        // follow-up work can fail, preserving the authoritative remote identity.
+        let binding = if !run_id_owns_generic_exec {
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                    run_id,
+                    &runner.id,
+                    job.id.to_string(),
+                ),
+                &cwd,
+                &command,
+            )
+            .map(|_| ())
+        } else {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                run_id,
+                &runner.id,
+                &job.id.to_string(),
+                &cwd,
+                &command,
+            )
+            .map(|_| ())
+        };
+        binding.map_err(|error| {
+            super::accepted_handoff_persistence_error(error, &runner.id, &job.id.to_string())
+        })?;
+    }
     persist_runner_execution_transition(
         &RunnerExecutionRecord::in_flight(job.id.to_string(), runner.id.clone(), "reverse_broker")
             .with_job_id(job.id.to_string())
@@ -288,31 +316,6 @@ pub(super) fn exec_via_reverse_broker(
         &cwd,
         &command,
     )?;
-    if let Some(run_id) = run_id.as_deref() {
-        // Every portable agent-task run is a controller-owned Lab handoff.
-        // Persist the accepted daemon job before foreground cook or retry can
-        // validate a runner snapshot; metadata-only binding leaves the typed
-        // handoff pending and loses that identity at preacceptance (#9240).
-        if !run_id_owns_generic_exec {
-            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
-                &homeboy_core::lab_contract::RunnerJobIdentity::new(
-                    run_id,
-                    &runner.id,
-                    job.id.to_string(),
-                ),
-                &cwd,
-                &command,
-            )?;
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
-                &cwd,
-                &command,
-            )?;
-        }
-    }
     let persisted_run_id = mirror_evidence
         .then(|| {
             persist_lab_offload_handoff_run(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -178,6 +178,35 @@ pub(super) fn exec_via_daemon(
     let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
     })?;
+    if let Some(run_id) = run_id.as_deref() {
+        // `/exec` has accepted the job. Bind this fact before any local
+        // bookkeeping can fail so a later error never misclassifies an accepted
+        // handoff as a controller-only pre-handoff failure.
+        let binding = if !run_id_owns_generic_exec {
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                    run_id,
+                    &runner.id,
+                    job.id.to_string(),
+                ),
+                &cwd,
+                &command,
+            )
+            .map(|_| ())
+        } else {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                run_id,
+                &runner.id,
+                &job.id.to_string(),
+                &cwd,
+                &command,
+            )
+            .map(|_| ())
+        };
+        binding.map_err(|error| {
+            super::accepted_handoff_persistence_error(error, &runner.id, &job.id.to_string())
+        })?;
+    }
     if let Some(session) = accepted_session.as_ref() {
         // Persist the endpoint selected at admission before any controller-side
         // wait or evidence work can fail. Follow-up operations route by this
@@ -209,36 +238,6 @@ pub(super) fn exec_via_daemon(
         &cwd,
         &command,
     )?;
-    if let Some(run_id) = run_id.as_deref() {
-        // The daemon has durably accepted this child. Bind it before waiting so
-        // a lost controller still leaves cancellation and reconciliation with a
-        // concrete runner job identity.
-        if !run_id_owns_generic_exec {
-            // Every portable agent-task run is a controller-owned Lab handoff,
-            // including foreground cook and retry attempts. Persist the daemon
-            // acceptance before either runner-result preacceptance path can read
-            // the controller record. Metadata-only binding leaves the typed
-            // handoff pending and can expose a valid snapshot to validation with
-            // no accepted controller job identity (#9240).
-            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
-                &homeboy_core::lab_contract::RunnerJobIdentity::new(
-                    run_id,
-                    &runner.id,
-                    job.id.to_string(),
-                ),
-                &cwd,
-                &command,
-            )?;
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
-                &cwd,
-                &command,
-            )?;
-        }
-    }
     let foreground_source_lease = run_id
         .as_deref()
         .map(|run_id| {

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -768,6 +768,13 @@ const RUNNER_EXEC_RUN_ID_ENV_NAMES: &[&str] = &[
 
 const RUNNER_EXEC_SCRUBBED_RUN_ID_ENV_NAMES: &[&str] = &["WORKFLOW_BENCH_RUN_ID"];
 
+fn explicit_generic_runner_exec_id(options: &RunnerExecOptions) -> Option<&str> {
+    options
+        .run_id_owns_generic_exec
+        .then(|| options.run_id.as_deref())
+        .flatten()
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RunnerProcessRequest {
     pub runner_id: String,
@@ -830,6 +837,87 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 /// that verified transport rather than resolving a controller-scoped session a
 /// second time during the same transaction.
 pub(crate) fn exec_with_status_snapshot(
+    runner_id: &str,
+    options: RunnerExecOptions,
+    status_snapshot: Option<RunnerStatusReport>,
+) -> Result<(RunnerExecOutput, i32)> {
+    let explicit_generic_run_id = options
+        .run_id_owns_generic_exec
+        .then(|| options.run_id.clone())
+        .flatten();
+    if let Some(run_id) = explicit_generic_run_id.as_deref() {
+        // Persist before preparation, which can materialize inputs, or connection,
+        // which can create a tunnel. No runner job is claimed at this boundary.
+        let attempt = homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+            run_id,
+            runner_id,
+            options.cwd.as_deref().unwrap_or_default(),
+            &options.command,
+        )?;
+        if homeboy_core::observation::RunStatus::from_label(&attempt.status)
+            .is_some_and(homeboy_core::observation::RunStatus::is_terminal)
+        {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!(
+                    "runner exec attempt `{run_id}` is already terminal; use a new --run-id to submit another attempt"
+                ),
+                Some(run_id.to_string()),
+                Some(vec![format!("Inspect the existing evidence: homeboy runs evidence {run_id}" )]),
+            ));
+        }
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_execution_record(
+            run_id,
+            &RunnerExecutionRecord::planned(run_id, runner_id, "pre_handoff"),
+        )?;
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_pre_handoff_phase(
+            run_id,
+            "preflight",
+        )?;
+    }
+    let result = exec_with_status_snapshot_attempt(runner_id, options, status_snapshot);
+    if let (Some(run_id), Err(error)) = (explicit_generic_run_id.as_deref(), &result) {
+        let accepted = error.details.get("runner_exec_accepted_handoff").is_some();
+        if let Err(persistence_error) =
+            homeboy_agents::agent_task_lifecycle::finish_runner_exec_pre_handoff_failure(
+                run_id,
+                "pre_handoff",
+                "pre_handoff",
+                accepted,
+                error,
+            )
+        {
+            let mut primary = error.clone();
+            primary.details["pre_handoff_evidence_persistence"] = json!({
+                "code": persistence_error.code.as_str(),
+                "message": homeboy_core::redaction::redact_string(&persistence_error.message),
+                "details": homeboy_core::redaction::redact_json(&persistence_error.details),
+                "run_id": run_id,
+            });
+            primary = primary.with_hint(format!(
+                "The primary runner exec failure could not be persisted as local evidence; inspect and retry with `homeboy runs evidence {run_id}`."
+            ));
+            return Err(primary);
+        }
+    }
+    result
+}
+
+pub(super) fn accepted_handoff_persistence_error(
+    mut error: Error,
+    runner_id: &str,
+    job_id: &str,
+) -> Error {
+    error.details["runner_exec_accepted_handoff"] = json!({
+        "runner_id": runner_id,
+        "job_id": job_id,
+    });
+    error.with_hint(format!(
+        "Runner handoff was accepted as job `{job_id}` on `{runner_id}`; inspect it with `homeboy runner job logs {runner_id} {job_id}`."
+    ))
+}
+
+fn exec_with_status_snapshot_attempt(
     runner_id: &str,
     options: RunnerExecOptions,
     status_snapshot: Option<RunnerStatusReport>,
@@ -947,6 +1035,12 @@ pub(crate) fn exec_with_status_snapshot(
     }
     // Observe the session before selecting diagnostic SSH. This keeps a stale
     // runner diagnosable without bypassing healthy daemon admission.
+    if let Some(run_id) = explicit_generic_runner_exec_id(&options) {
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_pre_handoff_phase(
+            run_id,
+            "connection",
+        )?;
+    }
     let connected = if should_force_diagnostic_ssh(&runner, &options) {
         // Admission status reconnects a disconnected direct SSH session. A
         // diagnostic must only observe controller state and must not rotate it.
@@ -964,6 +1058,12 @@ pub(crate) fn exec_with_status_snapshot(
             &required_extensions,
         )
     {
+        if let Some(run_id) = explicit_generic_runner_exec_id(&options) {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_pre_handoff_phase(
+                run_id,
+                "materialization",
+            )?;
+        }
         let extension_parity_plan = plan_extension_parity(
             runner_id,
             &runner,
@@ -1080,6 +1180,11 @@ pub(crate) fn exec_with_status_snapshot(
         return Err(read_only_artifact_access_unresolved_error(
             runner_id, &connected,
         ));
+    }
+    if let Some(run_id) = explicit_generic_runner_exec_id(&options) {
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_pre_handoff_phase(
+            run_id, "handoff",
+        )?;
     }
     let result = match select_runner_transport(&runner, Some(&connected), false) {
         RunnerTransport::DirectDaemon(handle) => {

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -1072,6 +1072,44 @@ fn test_exec_runs_local_runner_command() {
 }
 
 #[test]
+fn real_runner_exec_rejects_a_duplicate_terminal_explicit_run_id() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        super::super::super::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+            .expect("create local runner");
+        let run_id = "duplicate-terminal-run";
+        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+            run_id,
+            "lab-local",
+            ".",
+            &[],
+        )
+        .expect("persist prior attempt");
+        homeboy_agents::agent_task_lifecycle::finish_runner_exec_pre_handoff_failure(
+            run_id,
+            "pre_handoff",
+            "connection",
+            false,
+            &Error::internal_unexpected("connection refused"),
+        )
+        .expect("terminal prior attempt");
+
+        let mut options = RunnerExecOptions::raw_command(vec!["true".to_string()]);
+        options.run_id = Some(run_id.to_string());
+        options.run_id_owns_generic_exec = true;
+        let error = exec("lab-local", options).expect_err("terminal run ID must not execute again");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+        assert!(error.message.contains("already terminal"));
+        assert!(error.details["tried"]
+            .as_array()
+            .is_some_and(|suggestions| suggestions.iter().any(|suggestion| suggestion
+                .as_str()
+                .is_some_and(
+                    |suggestion| suggestion.contains(&format!("runs evidence {run_id}"))
+                ))));
+    });
+}
+
+#[test]
 fn test_exec_does_not_leak_ambient_process_env() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let _guard = EnvVarGuard::set("HOMEBOY_TEST_AMBIENT_ONLY", "leaked");

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -8,6 +8,28 @@ use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 #[test]
+fn accepted_handoff_persistence_error_carries_an_explicit_remote_boundary() {
+    let error = accepted_handoff_persistence_error(
+        Error::internal_unexpected("controller write failed"),
+        "lab",
+        "job-accepted",
+    );
+
+    assert_eq!(
+        error.details["runner_exec_accepted_handoff"]["runner_id"],
+        "lab"
+    );
+    assert_eq!(
+        error.details["runner_exec_accepted_handoff"]["job_id"],
+        "job-accepted"
+    );
+    assert!(error
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("runner job logs lab job-accepted")));
+}
+
+#[test]
 fn timeout_mirrors_remote_job_without_cancelling() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let runner = ssh_runner();


### PR DESCRIPTION
## Summary

- persist explicit runner-exec attempts before connection, materialization, and handoff
- render redacted typed pre-handoff failures through local `runs evidence`
- atomically prevent pre-handoff failure terminalization from overwriting accepted job ownership

Fixes #12135.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::runner_exec --lib`
- `cargo test -p homeboy-cli evidence_command_surfaces_local_pre_handoff_failure_without_runner_connectivity --lib`
- `cargo test -p homeboy-lab-runner real_runner_exec_rejects_a_duplicate_terminal_explicit_run_id --lib`
- `cargo check -p homeboy-agents -p homeboy-cli -p homeboy-lab-runner`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the durable runner-exec evidence contract with direct general coding subagents. Chris Huber reviewed the resulting diff and remains responsible for every line.
