### PR TITLE
Load resolved runs and artifacts through one facade

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/dossier.rs
+++ b/crates/homeboy-cli/src/commands/runs/dossier.rs
@@ -100,10 +100,7 @@ pub struct RunsDossierCommandHint {
 
 pub fn runs_dossier(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_readonly()?;
-    let run = runs_service::require_run(&store, run_id)?;
-    // A dossier is an inspection command. Avoid the service helper here because
-    // it refreshes and indexes remote evidence, both of which can write.
-    let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(run_id)?);
+    let (run, artifacts) = runs_service::load_run_with_artifacts(&store, run_id)?;
     let artifact_index = evidence_report::evidence_artifact_index(&artifacts);
     let failure = evidence_report::evidence_failure_summary(&run);
     let stale_reason = reconcile::running_status_note(&run);

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -33,8 +33,7 @@ pub type RunsEvidenceOutput = RunEvidenceReport<RunSummary>;
 
 pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
-    let run = require_run(&store, run_id)?;
-    let mut artifacts = runs_service::list_artifacts_for_run(&store, &run.id)?;
+    let (run, mut artifacts) = runs_service::load_run_with_artifacts(&store, run_id)?;
     artifacts.extend(runs_service::related_lab_artifacts_for_runner_job(
         &store, &run,
     )?);

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -683,8 +683,7 @@ fn active_runner_job_run_summary_if_durable(
 
 pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_readonly()?;
-    let run = runs_service::require_run(&store, run_id)?;
-    let run = run_detail(&store, run)?;
+    let run = run_detail(&store, run_id)?;
     let actionable = actionable_for_run_detail(&run);
     Ok((
         RunsOutput::Show(RunsShowOutput {
@@ -1504,9 +1503,9 @@ pub(super) fn require_run(
 
 pub(super) fn run_detail(
     store: &ObservationStore,
-    run: RunRecord,
+    run_id: &str,
 ) -> homeboy::core::Result<RunDetail> {
-    let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(&run.id)?);
+    let (run, artifacts) = runs_service::load_run_with_artifacts(store, run_id)?;
     Ok(RunDetail {
         summary: run_summary(run.clone()),
         homeboy_version: run.homeboy_version,

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -815,6 +815,33 @@ fn runs_dossier_aggregates_failure_env_refs_artifacts_and_commands() {
 }
 
 #[test]
+fn runs_dossier_loads_artifacts_for_a_durable_run_label() {
+    with_isolated_home(|_home| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("agent-task")
+                    .metadata(serde_json::json!({"run_id": "dossier-label"}))
+                    .build(),
+            )
+            .expect("run");
+        store
+            .record_url_artifact(&run.id, "report", "https://example.test/report")
+            .expect("artifact");
+        drop(store);
+
+        let (output, _) = runs_dossier("dossier-label").expect("dossier by durable label");
+        let RunsOutput::Dossier(output) = output else {
+            panic!("expected dossier output");
+        };
+
+        assert_eq!(output.run_id, run.id);
+        assert_eq!(output.artifacts.count, 1);
+        assert_eq!(output.artifacts.artifacts[0].kind, "report");
+    });
+}
+
+#[test]
 fn run_show_reads_owned_dead_running_run_without_mutating_it() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();

--- a/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
+++ b/crates/homeboy-core/src/observation/runs_service/artifact_links.rs
@@ -105,9 +105,17 @@ pub fn list_artifacts_for_run(
     store: &ObservationStore,
     run_id: &str,
 ) -> Result<Vec<ArtifactRecord>> {
+    load_run_with_artifacts(store, run_id).map(|(_, artifacts)| artifacts)
+}
+
+/// Resolve a run reference and load its enriched artifacts by canonical ID.
+pub fn load_run_with_artifacts(
+    store: &ObservationStore,
+    run_id: &str,
+) -> Result<(RunRecord, Vec<ArtifactRecord>)> {
     let run = require_run(store, run_id)?;
     let artifacts = store.list_artifacts(&run.id)?;
-    Ok(enrich_artifact_links(artifacts))
+    Ok((run, enrich_artifact_links(artifacts)))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/observation/runs_service/tests.rs
+++ b/crates/homeboy-core/src/observation/runs_service/tests.rs
@@ -245,6 +245,36 @@ fn list_artifacts_for_run_enriches_url_artifact_links() {
 }
 
 #[test]
+fn load_run_with_artifacts_uses_the_resolved_canonical_run_id() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("bench")
+                    .component_id("homeboy")
+                    .metadata(serde_json::json!({"run_id": "durable-label"}))
+                    .build(),
+            )
+            .expect("run");
+        store
+            .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
+            .expect("record URL artifact");
+
+        let (resolved, artifacts) =
+            load_run_with_artifacts(&store, "durable-label").expect("resolved run and artifacts");
+
+        assert_eq!(resolved.id, run.id);
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].run_id, run.id);
+        assert_eq!(
+            artifacts[0].public_url.as_deref(),
+            Some("https://example.test/")
+        );
+    });
+}
+
+#[test]
 fn resolve_artifact_for_run_rejects_unknown_artifact_id() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
Closes #12145
Closes #6768

## Summary
- add `runs_service::load_run_with_artifacts` as the canonical resolve/list/enrich operation
- key artifact loading by the resolved run ID so durable labels work correctly
- migrate `runs dossier`, `runs show`, and primary `runs evidence` loading to the shared facade
- preserve evidence-specific related Lab and descendant expansion outside the generic helper

## Remaining direct reads
- `query`, `compare`, and `latest` are filter/history projections rather than single-run loading
- `refs` intentionally emits raw un-enriched refs
- `hotspots` resolves inputs through the facade and batches artifact reads
- trace production store access is write-side lifecycle recording

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-cli --tests`
- canonical-label service test: 1 passed
- durable-label dossier test: 1 passed
- existing dossier regression: 1 passed
- `cargo test -p homeboy-cli commands::runs:: --lib`: 231 passed, 1 inherited failure
- inherited failure `apply_reaps_runner_workspace_through_runner_transport` reproduces identically on current `main` because its fixture removes `runner-workspace.json` before the assertion path

## Compatibility
No output schema changes. Artifact order and link enrichment are unchanged. The behavioral fix is that aliases/durable labels now load artifacts attached to the canonical resolved run.

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** consumer audit, facade implementation, compatibility review, and verification; Chris Huber reviewed and remains responsible for the change.