### PR TITLE
Repin Test reconciliation to homeboy-action v2.11.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,10 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # Includes the jq-portable exact shard partitioning fix from homeboy-action#372.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@8f90f5c37f703240c8b0f4327845ac8c89fb2b08
+    # v2.11.21. Includes the jq-portable exact shard partitioning fix from
+    # homeboy-action#372, and homeboy-action#376, which stops the `Test`
+    # reconciliation job from publishing a cancelled run as a red verdict (#10997).
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@a6ff2f5d47ad4b628ffbb0861f2159ed8cb7af1e
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
Delivery half of #10997. Extra-Chill/homeboy-action#376 is merged and released as **v2.11.21** (`a6ff2f5d`); this repin is what actually brings it into this repo's CI.

## What it fixes

`homeboy / Test` has been going **red on cancellation**, carrying no test verdict.

The sharded `Test` reconciliation job in the reusable workflow ran under `always()`, so it executed even after `cancel-in-progress` killed the shards. Then:

1. `needs.candidate-test-plan.result` was `cancelled`, which is `!= 'success'`
2. → the *"Report candidate Test inventory generation failure"* step fired
3. → it downloaded `homeboy-test-inventory-failure-<attempt>`, an artifact the cancelled plan job had **never uploaded**
4. → `Artifact not found` failed the job → red check

homeboy-action#376 changes that job to `!cancelled()`: a genuinely FAILED upstream phase still reaches a verdict, a CANCELLED run no longer manufactures one.

## Evidence this was live here

Run `31564611927`, job `94014048247` — shards cancelled `04:53:05`, reconciliation started **13s later** at `04:53:18`, failed `04:53:23` on `Artifact not found for name: homeboy-test-inventory-failure-1`.

The five merged PRs immediately before this one — #12142, #12141, #12137, #12130, #12128 — **all** show `homeboy / Test` = FAILURE with every shard job underneath CANCELLED.

The trigger is cadence: #12142 opened `04:51:25` and merged `04:52:45`, 80 seconds, so cancellation lands almost immediately.

## Safety

`policy` in the reusable workflow gates on `needs.reconcile-test-shards.result == 'success'`, so when reconciliation is skipped, PR Policy is skipped too — fails closed. A cancelled run's conclusion stays `cancelled`; this does not turn a killed run green, per constraint 1 in #10997.

## Scope

Workflow YAML only, no Rust touched. Re-parsed: 10 jobs intact, `homeboy` job now resolves to `a6ff2f5d`. `required_gates_policy_test.rs` and `pr_ci_lifecycle_test.rs` assert only the `...ci.yml@` prefix, which is unchanged.

Does **not** close #10997 — that tracks the terminations themselves and the cadence-vs-gate decision, which is still open. This only stops them being misreported as test failures.

### Unrelated observation

`.github/validate-required-gates.sh:116` special-cases `homeboy / Test` by grepping for `ci.yml@v2`, which has not matched since the pin became a full SHA. Dead branch both before and after this change; flagging rather than fixing here.