### PR TITLE
HOTFIX: pin dereferenced v2.11.21 commit, not the annotated tag object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,13 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.21. Includes the jq-portable exact shard partitioning fix from
-    # homeboy-action#372, and homeboy-action#376, which stops the `Test`
-    # reconciliation job from publishing a cancelled run as a red verdict (#10997).
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@a6ff2f5d47ad4b628ffbb0861f2159ed8cb7af1e
+    # v2.11.21, dereferenced to its commit: `v2.11.21` is an annotated tag, so the
+    # tag ref's own object SHA (a6ff2f5d) is the tag object, which `uses:` cannot
+    # resolve — pin `git rev-parse v2.11.21^{commit}` instead.
+    # Includes the jq-portable exact shard partitioning fix from homeboy-action#372,
+    # and homeboy-action#376, which stops the `Test` reconciliation job from
+    # publishing a cancelled run as a red verdict (#10997).
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@82033fe633d680c696b27421755e56eae8b4af4b
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
## Main is broken — every PR's CI fails at startup

My fault. #12152 pinned `a6ff2f5d47ad4b628ffbb0861f2159ed8cb7af1e`, taken from `refs/tags/v2.11.21`'s `.object.sha`. **`v2.11.21` is an annotated tag**, so that SHA is the *tag object*, not a commit:

```
$ gh api repos/Extra-Chill/homeboy-action/git/refs/tags/v2.11.21 --jq '{sha:.object.sha,type:.object.type}'
{"sha":"a6ff2f5d47ad4b628ffbb0861f2159ed8cb7af1e","type":"tag"}

$ gh api repos/Extra-Chill/homeboy-action/git/tags/a6ff2f5d... --jq '.object.sha'
82033fe633d680c696b27421755e56eae8b4af4b
```

`uses:` resolves **commit** SHAs only, so the reusable workflow cannot be resolved and the run dies before scheduling anything:

- run `31566675711` — conclusion `failure`, **0 jobs**
- run `31566733507` — conclusion `failure`, **0 jobs**
- `gh run view`: *"This run likely failed because of a workflow file issue."*

`git show <tagobj>:file` and `git rev-parse` both dereference transparently, which is why this passed local verification — the YAML parsed, the file content was correct, and the fix was genuinely present at that object. Only GitHub's `uses:` resolver rejects it.

## Fix

Pin `git rev-parse v2.11.21^{commit}` = **`82033fe6`**, which carries identical content (homeboy-action#376, verified: `!cancelled()` present).

## Why hotfix

This is on `main` and blocks CI for every open and future PR, so it needs to land ahead of normal queue. A correction was already pushed to `fix-10997-repin-test-reconcile` as `ee05eb1c1`, but #12152 merged at `0b439077` before it landed — this PR re-lands that same one-line change against current main.

## Worth pinning as a test

homeboy-action already has `scripts/core/test-action-ref-pinning.sh` asserting its *own* resolver "prefers the dereferenced commit over the annotated tag object". This repo has no equivalent guard on the `uses:` pin in `ci.yml`, which is exactly how this got through. Happy to add one as a follow-up: assert the pinned SHA resolves to `type: commit`.

Refs #10997