### PR TITLE
Repin Test to homeboy-action v2.11.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,13 +222,16 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.21, dereferenced to its commit: `v2.11.21` is an annotated tag, so the
-    # tag ref's own object SHA (a6ff2f5d) is the tag object, which `uses:` cannot
-    # resolve — pin `git rev-parse v2.11.21^{commit}` instead.
-    # Includes the jq-portable exact shard partitioning fix from homeboy-action#372,
-    # and homeboy-action#376, which stops the `Test` reconciliation job from
-    # publishing a cancelled run as a red verdict (#10997).
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@82033fe633d680c696b27421755e56eae8b4af4b
+    # v2.11.22, DEREFERENCED to its commit. These tags are annotated, so the tag
+    # ref's own object SHA is a tag object, which `uses:` cannot resolve — pinning
+    # one fails the whole workflow at startup with zero jobs scheduled (#12153).
+    # Always pin `git rev-parse v<tag>^{commit}`.
+    #
+    # Carries homeboy-action#372 (jq-portable exact shard partitioning),
+    # homeboy-action#376 (a cancelled run no longer publishes a red `Test`
+    # verdict), and homeboy-action#377 (the unreachable sharded baseline phase is
+    # removed, closing a latent no-enforcement green). All refs #10997.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5e028c09159f574c8e0d9b6fa229530a13926317
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
Delivery half of Extra-Chill/homeboy-action#377.

## What it brings

The sharded Test path's **baseline phase is deleted** — it could never execute here:

- this repo passes `baseline-commands: none` (set **2026-07-31**, three days before sharding shipped on **2026-08-04**)
- `lib.sh:baseline_command_selected` returns 1 for `none`, so `baseline-command` was always empty
- `baseline-test-plan` and `baseline-test-shards` both gate on `baseline-command != ''`, so both always skipped

That dead surface is where #10997 came from: an unreachable-in-practice branch that fired on cancellation and published a red `Test` check with no verdict behind it.

**Reusable workflow: 1341 → 1063 lines (−21%), 12 jobs → 10.** `reconcile-test-shards` drops from 13 steps to 6.

## It also closes a latent false green

The old enforcement step was gated on `baseline-command == '' || event != pull_request`. With a non-empty `baseline-command` and no baseline jobs present, **no enforcement step would have run** and `Test` would have gone green with nothing checked. Enforcement is now a single step conditioned only on the candidate aggregate.

## Pinning

Pinned as **`v2.11.22^{commit}` = `5e028c09`**, verified `type: commit` via the API before committing.

The tag ref's own object SHA is `d78a4161`, an **annotated tag object**. Pinning that is what took main down earlier today — `uses:` resolves commit SHAs only, so it fails the workflow at startup with zero jobs scheduled (#12152 → fixed by #12153). The expanded comment above the pin now records that rule at the call site.

## Verification

homeboy-action's full shell suite passed on #377: **451 passed, 0 failed**. Workflow YAML re-parsed here: 10 jobs intact, `homeboy` job resolves to `5e028c09`.

No Rust touched.

Refs #10997