### PR TITLE
Materialize runner cleanup fixture provenance

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -1438,6 +1438,21 @@ mod tests {
             std::fs::create_dir_all(&resource_path).expect("runner workspace");
             std::fs::write(resource_path.join("generated.txt"), "generated")
                 .expect("workspace file");
+            std::fs::create_dir_all(resource_path.join(".homeboy")).expect("metadata directory");
+            std::fs::write(
+                resource_path.join(".homeboy/runner-workspace.json"),
+                serde_json::json!({
+                    "schema": "homeboy/runner-workspace/v1",
+                    "runner_id": "lab-local",
+                    "local_path": resource_path.display().to_string(),
+                    "remote_path": resource_path.display().to_string(),
+                    "sync_mode": "snapshot",
+                    "snapshot_identity": "fixture",
+                    "synced_at": "2026-08-12T00:00:00Z"
+                })
+                .to_string(),
+            )
+            .expect("runner workspace metadata");
             homeboy::runner::create(
                 &format!(
                     r#"{{"id":"lab-local","kind":"local","workspace_root":"{}"}}"#,


### PR DESCRIPTION
Closes #12160

## Summary
- materialize the runner workspace manifest required by the cleanup fixture
- preserve coverage that cleanup executes through runner transport

## Verification
CI is the verification authority for this PR.

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode general coding agent
- **Used for:** fixture repair and regression coverage; Chris Huber reviewed and owns the change.