### PR TITLE
Declare Cook attempt publication capability

### DIFF
--- a/crates/homeboy-agents/src/agent_task/request.rs
+++ b/crates/homeboy-agents/src/agent_task/request.rs
@@ -239,6 +239,32 @@ impl std::ops::Deref for AgentTaskExecutorRequest {
 }
 
 impl AgentTaskRequest {
+    /// Declare that a controller, rather than the provider attempt, owns remote
+    /// publication. This is a deliberate request contract, not an inference
+    /// from the attempt workspace's blocked push remote.
+    pub fn controller_owns_publication(&mut self) {
+        if !self.metadata.is_object() {
+            self.metadata = Value::Object(Default::default());
+        }
+        self.metadata["publication"] = serde_json::json!({
+            "capability": "unavailable",
+            "owner": "controller",
+            "status": "not_attempted"
+        });
+    }
+
+    pub fn publication_is_controller_owned(&self) -> bool {
+        self.metadata
+            .pointer("/publication/owner")
+            .and_then(Value::as_str)
+            == Some("controller")
+            && self
+                .metadata
+                .pointer("/publication/capability")
+                .and_then(Value::as_str)
+                == Some("unavailable")
+    }
+
     pub fn capability_requirements(&self) -> Result<AgentTaskCapabilityRequirements, String> {
         let mut requirements = super::capabilities::requirements_from_metadata(
             &self.metadata,

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -113,6 +113,27 @@ fn attach_runtime_tool_provenance(
     }
 }
 
+pub(super) fn describe_controller_owned_publication(
+    request: &AgentTaskExecutorRequest,
+    outcome: &mut AgentTaskOutcome,
+) {
+    if !request.request.publication_is_controller_owned() {
+        return;
+    }
+    if outcome.metadata.is_null() {
+        outcome.metadata = json!({});
+    }
+    if let Some(metadata) = outcome.metadata.as_object_mut() {
+        metadata.insert(
+            "publication".to_string(),
+            json!({
+                "owner": "controller",
+                "status": "not_attempted"
+            }),
+        );
+    }
+}
+
 /// True when an outcome represents a transient provider/network failure that is
 /// safe to retry.
 fn outcome_is_transient(outcome: &AgentTaskOutcome) -> bool {
@@ -825,6 +846,7 @@ fn run_materialized_provider_command_once_contained(
                     .map(std::path::Path::new),
             );
             validate_declared_outputs(&mut outcome, request);
+            describe_controller_owned_publication(request, &mut outcome);
             surface_provider_process_failure(
                 &mut outcome,
                 request,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -2,6 +2,40 @@ use super::common::request;
 use super::*;
 
 #[test]
+fn controller_owned_publication_is_reported_as_not_attempted() {
+    let (mut request, _) = request("controller-publication", "node provider.js".to_string());
+    request.controller_owns_publication();
+    let executor_request = AgentTaskExecutorRequest {
+        request,
+        artifacts_path: tempfile::tempdir().expect("artifacts").keep(),
+        artifacts_path_provenance: AgentTaskArtifactsPathProvenance {
+            owner: "homeboy".to_string(),
+            locality: "runner".to_string(),
+            plan_id: "plan".to_string(),
+            run_id: Some("run".to_string()),
+            task_id: "controller-publication".to_string(),
+            attempt: 1,
+        },
+        resolved_runtime_tools: Vec::new(),
+        artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(&tempfile::tempdir().expect("identity artifacts").keep()).expect("artifact identity"),
+    };
+    let mut outcome = AgentTaskOutcome {
+        task_id: "controller-publication".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        ..Default::default()
+    };
+
+    super::command_runner::describe_controller_owned_publication(&executor_request, &mut outcome);
+
+    assert_eq!(
+        outcome.metadata["publication"],
+        json!({ "owner": "controller", "status": "not_attempted" })
+    );
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert!(outcome.failure_classification.is_none());
+}
+
+#[test]
 fn provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks() {
     let (mut request_a, mut provider_a) = request("task-a", "node provider-a.js".to_string());
     request_a.executor.backend = "provider-a".to_string();

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -776,6 +776,7 @@ fn project_initial_finalizing_review_form_contract(options: &mut AgentTaskCookSe
     }
 
     for request in &mut options.initial_plan.tasks {
+        request.controller_owns_publication();
         request.output_declarations.retain(|declaration| {
             declaration.name != crate::agent_task_review_dossier::AI_REVIEW_FORM_OUTPUT_KEY
         });
@@ -785,6 +786,14 @@ fn project_initial_finalizing_review_form_contract(options: &mut AgentTaskCookSe
         if !request.instructions.contains("reviewer-facing PR dossier") {
             request.instructions.push_str(
                 "\n\nProvide the reviewer-facing PR dossier in `outputs.review_form`. Return an object with `summary` (the change and its purpose), `what_changed` (concrete change bullets), qualitative `compatibility` (impact assessment), optional structured `verification` entries (exact command plus total/passed/failed/ignored counts), and `used_for` (a concise reflection of the process used). Homeboy links verification entries to durable candidate gate evidence. A successful response supplies specific, complete content for every field so Homeboy can finalize a clear pull request.",
+            );
+        }
+        if !request
+            .instructions
+            .contains("controller-owned publication")
+        {
+            request.instructions.push_str(
+                "\n\nThis is a non-publishable attempt workspace. controller-owned publication is not attempted by this provider: produce the commit or patch and reviewer-facing dossier, but do not push, create a pull request, release, or deploy. Homeboy's controller finalization handles any authorized publication after this attempt.",
             );
         }
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2515,6 +2515,23 @@ fn initial_finalizing_provider_request_projects_complete_review_form_dossier() {
     );
     assert!(request.instructions.contains("reviewer-facing PR dossier"));
     assert!(request.instructions.contains("A successful response"));
+    assert_eq!(
+        request.metadata["publication"],
+        serde_json::json!({
+            "capability": "unavailable",
+            "owner": "controller",
+            "status": "not_attempted"
+        })
+    );
+    assert!(request
+        .instructions
+        .contains("non-publishable attempt workspace"));
+    assert!(request
+        .instructions
+        .contains("do not push, create a pull request"));
+    assert!(request
+        .instructions
+        .contains("controller-owned publication"));
 
     project_initial_finalizing_review_form_contract(&mut options);
     assert_eq!(


### PR DESCRIPTION
Closes #12159

## Summary
- declare controller-owned publication in Cook executor requests
- tell provider agents that attempt worktrees cannot push or create PRs
- preserve controller finalization as the authoritative publication path

## Verification
CI is the verification authority for this PR.

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode general coding agent
- **Used for:** implementation and focused contract coverage; Chris Huber reviewed and owns the change.