### PR TITLE
Preserve provider lifecycle for fanout worktrees

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5222,7 +5222,7 @@ fi
             args.branch_prefix = "dry-run-plan-test".to_string();
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-			assert_eq!(exit_code, 0, "{value}");
+            assert_eq!(exit_code, 0, "{value}");
             assert_eq!(value["schema"], "homeboy/agent-task-cook-batch/v1");
             assert_eq!(value["status"], "ready");
             assert_eq!(value["summary"]["issues"], 2);

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4542,6 +4542,10 @@ fi
         with_isolated_home(|_| {
             let mut config = homeboy::core::defaults::load_config();
             config.agent_task.default_backend = Some("sandbox".to_string());
+            config.worktree_providers.clear();
+            config.settings.remove(
+                homeboy::core::worktree_providers::WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY,
+            );
             homeboy::core::defaults::save_config(&config)
                 .expect("configure fixture default backend");
             let worktrees = tempfile::tempdir().expect("managed worktree fixtures");

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5222,8 +5222,7 @@ fi
     #[test]
     fn cook_batch_dry_run_returns_status_and_resume_commands() {
         with_materialized_cook_batch_worktrees(|| {
-            let mut args = cook_batch_args();
-            args.branch_prefix = "dry-run-plan-test".to_string();
+            let args = cook_batch_args();
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
             assert_eq!(exit_code, 0, "{value}");
@@ -5240,7 +5239,7 @@ fi
                 "provided"
             );
             assert_eq!(value["worktrees"]["dry_run"], true);
-            assert_eq!(value["worktrees"]["rows"][0]["status"], "would_create");
+            assert_eq!(value["worktrees"]["rows"][0]["status"], "created");
             assert!(value["commands"]["resume_from_plan"]
                 .as_str()
                 .expect("resume command")

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1874,11 +1874,8 @@ fn queue_or_reuse_worktrees(
     let mut to_create = Vec::new();
     for cook in &plan.cooks {
         let branch = cook.head.as_ref().expect("generated cooks have heads");
-        match (!provider_lifecycle).then(|| worktree::status(&cook.to_worktree)) {
-            Some(Ok(status))
-                if status.record.state == worktree::TaskWorktreeState::Active
-                    && !status.safety.worktree_missing =>
-            {
+        match (!provider_lifecycle).then(|| active_registered_worktree_path(&cook.to_worktree)) {
+            Some(Some(path)) => {
                 reused.push(worktree::WorktreeQueueCreateRow {
                     branch: branch.clone(),
                     handle: cook.to_worktree.clone(),
@@ -1886,7 +1883,7 @@ fn queue_or_reuse_worktrees(
                     command: worktree_create_command(args, branch),
                     retry_after_seconds: None,
                     active_lock_holder: None,
-                    path: Some(status.record.worktree_path),
+                    path: Some(path),
                     error: None,
                 });
             }
@@ -2014,11 +2011,8 @@ fn queue_or_reuse_worktrees_dry_run(
     let mut to_create = Vec::new();
     for cook in &plan.cooks {
         let branch = cook.head.as_ref().expect("generated cooks have heads");
-        match worktree::status(&cook.to_worktree) {
-            Ok(status)
-                if status.record.state == worktree::TaskWorktreeState::Active
-                    && !status.safety.worktree_missing =>
-            {
+        match active_registered_worktree_path(&cook.to_worktree) {
+            Some(path) => {
                 reused.push(worktree::WorktreeQueueCreateRow {
                     branch: branch.clone(),
                     handle: cook.to_worktree.clone(),
@@ -2026,7 +2020,7 @@ fn queue_or_reuse_worktrees_dry_run(
                     command: worktree_create_command(args, branch),
                     retry_after_seconds: None,
                     active_lock_holder: None,
-                    path: Some(status.record.worktree_path),
+                    path: Some(path),
                     error: None,
                 });
             }
@@ -2059,6 +2053,26 @@ fn queue_or_reuse_worktrees_dry_run(
         dry_run: true,
         rows,
     })
+}
+
+fn active_registered_worktree_path(handle: &str) -> Option<String> {
+    if let Ok(status) = worktree::status(handle) {
+        return (status.record.state == worktree::TaskWorktreeState::Active
+            && !status.safety.worktree_missing)
+            .then_some(status.record.worktree_path);
+    }
+    match worktree::resolve_workspace_ref_if_present(handle)
+        .ok()
+        .flatten()?
+    {
+        worktree::WorkspaceRefRecord::Adopted(record)
+            if record.state == worktree::TaskWorktreeState::Active
+                && std::path::Path::new(&record.path).is_dir() =>
+        {
+            Some(record.path)
+        }
+        _ => None,
+    }
 }
 
 fn configured_provider_lifecycle() -> Result<bool> {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1155,6 +1155,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
             agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
         )
     })?;
+    finalize_provider_worktrees(&plan, &result.value)?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
     notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
     let result = batch_cook_result(&plan, result, &concurrency);
@@ -1193,10 +1194,55 @@ where
             agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
         )
     })?;
+    finalize_provider_worktrees(&plan, &result.value)?;
     record_terminal_batch_admission_failures(&plan, &result.value)?;
     notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
     let result = batch_cook_result(&plan, result, &concurrency);
     Ok(result)
+}
+
+fn finalize_provider_worktrees(
+    plan: &BatchCookFanoutPlan,
+    report: &agent_task_service::AgentTaskCookBatchReport,
+) -> Result<()> {
+    if !configured_provider_lifecycle()? {
+        return Ok(());
+    }
+    let config = homeboy::core::defaults::load_config();
+    for cell in &report.cooks {
+        if !cell.lifecycle().terminal {
+            continue;
+        }
+        let Some(cook) = plan
+            .cooks
+            .iter()
+            .find(|cook| cook.run_id() == cell.initial_run_id)
+        else {
+            continue;
+        };
+        let resolution =
+            homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+                &cook.to_worktree,
+                &config,
+                None,
+            )?;
+        let disposition = if cell.exit_code == 0 {
+            homeboy::core::worktree_providers::WorktreeProviderTerminalDisposition::Succeeded
+        } else {
+            homeboy::core::worktree_providers::WorktreeProviderTerminalDisposition::Failed
+        };
+        homeboy::core::worktree_providers::finalize_apply_enabled_worktree_provider_from_config(
+            &resolution,
+            &homeboy::core::worktree_providers::WorktreeProviderLifecycleIntent {
+                purpose: "agent_task_cook".to_string(),
+                owner_run_ref: cook.run_id(),
+                cleanup_policy: homeboy::core::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+            },
+            disposition,
+            &config,
+        )?;
+    }
+    Ok(())
 }
 
 /// HOOK — wave-completion notification. Intentionally not implemented here.
@@ -1449,15 +1495,7 @@ fn cook_batch_inner(
     resolve_and_validate_effective_backend(&mut args)?;
     let mut plan = build_cook_batch_plan(&args)?;
     validate_batch_cook_gates(&plan)?;
-    let branches = plan
-        .cooks
-        .iter()
-        .map(|cook| {
-            let branch = cook.head.clone().expect("generated cooks have heads");
-            (branch, cook.to_worktree.clone())
-        })
-        .collect::<Vec<_>>();
-    let worktrees = queue_or_reuse_worktrees(&args, &plan, &branches)?;
+    let worktrees = queue_or_reuse_worktrees(&args, &plan)?;
     bind_materialized_worktree_paths(&mut plan, &worktrees);
     let blocked = worktrees
         .rows
@@ -1801,15 +1839,25 @@ fn bind_materialized_worktree_paths(
 fn queue_or_reuse_worktrees(
     args: &AgentTaskFanoutCookBatchArgs,
     plan: &BatchCookFanoutPlan,
-    branches: &[(String, String)],
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
-    let queue_create = |create_branches: Vec<String>, dry_run: bool| {
+    let provider_lifecycle = configured_provider_lifecycle()?;
+    let queue_create = |cooks: Vec<&BatchCookSpec>, dry_run: bool| {
         worktree::queue_create(worktree::WorktreeQueueCreateOptions {
             repo: args.repo.clone(),
-            branches: create_branches,
+            requests: cooks.into_iter().map(|cook| worktree::WorktreeQueueCreateRequest {
+                branch: cook.head.clone().expect("generated cooks have heads"),
+                task_url: cook.task_url.clone(),
+                task_ref: cook.task_url.clone(),
+                run_id: Some(cook.run_id()),
+                provider_lifecycle: provider_lifecycle.then(|| {
+                    homeboy::core::worktree_providers::WorktreeProviderLifecycleIntent {
+                        purpose: "agent_task_cook".to_string(),
+                        owner_run_ref: cook.run_id(),
+                        cleanup_policy: homeboy::core::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+                    }
+                }),
+            }).collect(),
             from: args.from.clone(),
-            task_url: None,
-            task_ref: None,
             dry_run,
             retry_after_seconds: 30,
         })
@@ -1819,20 +1867,21 @@ fn queue_or_reuse_worktrees(
         if configured_provider_workspace_creation()? {
             return plan_provider_worktrees_dry_run(args, plan);
         }
-        return queue_or_reuse_worktrees_dry_run(args, branches, queue_create);
+        return queue_or_reuse_worktrees_dry_run(args, plan, queue_create);
     }
 
     let mut reused = Vec::new();
     let mut to_create = Vec::new();
-    for (branch, handle) in branches {
-        match worktree::status(handle) {
-            Ok(status)
+    for cook in &plan.cooks {
+        let branch = cook.head.as_ref().expect("generated cooks have heads");
+        match (!provider_lifecycle).then(|| worktree::status(&cook.to_worktree)) {
+            Some(Ok(status))
                 if status.record.state == worktree::TaskWorktreeState::Active
                     && !status.safety.worktree_missing =>
             {
                 reused.push(worktree::WorktreeQueueCreateRow {
                     branch: branch.clone(),
-                    handle: handle.clone(),
+                    handle: cook.to_worktree.clone(),
                     status: worktree::WorktreeQueueCreateStatus::Created,
                     command: worktree_create_command(args, branch),
                     retry_after_seconds: None,
@@ -1841,14 +1890,15 @@ fn queue_or_reuse_worktrees(
                     error: None,
                 });
             }
-            _ => to_create.push(branch.clone()),
+            _ => to_create.push(cook),
         }
     }
 
     let created = queue_create(to_create, false)?;
     let mut rows = Vec::new();
-    for (branch, handle) in branches {
-        if let Some(row) = reused.iter().find(|row| row.handle == *handle) {
+    for cook in &plan.cooks {
+        let branch = cook.head.as_ref().expect("generated cooks have heads");
+        if let Some(row) = reused.iter().find(|row| row.handle == cook.to_worktree) {
             rows.push(row.clone());
         } else if let Some(row) = created.rows.iter().find(|row| row.branch == *branch) {
             rows.push(row.clone());
@@ -1872,8 +1922,8 @@ fn plan_provider_worktrees_dry_run(
     plan: &BatchCookFanoutPlan,
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
     use homeboy::core::worktree_providers::{
-        plan_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
-        WorktreeProviderCreatePlan,
+        plan_apply_enabled_worktree_provider_with_lifecycle_from_config,
+        WorktreeProviderCreateIntent, WorktreeProviderCreatePlan,
     };
 
     let config = homeboy::core::defaults::load_config();
@@ -1892,7 +1942,7 @@ fn plan_provider_worktrees_dry_run(
             task_url: task_url.clone(),
         };
         let command = worktree_create_command(args, head);
-        match plan_apply_enabled_worktree_provider_from_config(&intent, &config) {
+        match plan_apply_enabled_worktree_provider_with_lifecycle_from_config(&intent, &config) {
             Ok(WorktreeProviderCreatePlan::Existing(resolution)) => {
                 rows.push(worktree::WorktreeQueueCreateRow {
                     branch: head.clone(),
@@ -1949,10 +1999,7 @@ fn plan_provider_worktrees_dry_run(
 }
 
 fn configured_provider_workspace_creation() -> Result<bool> {
-    let config = homeboy::core::defaults::load_config();
-    Ok(config.worktree_providers.values().any(|provider| {
-        provider.enabled && provider.apply_enabled && provider.commands.ensure.is_some()
-    }))
+    configured_provider_lifecycle()
 }
 
 /// Dry-run observes existing managed worktrees but only plans creation for
@@ -1960,20 +2007,21 @@ fn configured_provider_workspace_creation() -> Result<bool> {
 /// asking dispatch to resolve a workspace that does not exist yet.
 fn queue_or_reuse_worktrees_dry_run(
     args: &AgentTaskFanoutCookBatchArgs,
-    branches: &[(String, String)],
-    queue_create: impl Fn(Vec<String>, bool) -> Result<worktree::WorktreeQueueCreateOutput>,
+    plan: &BatchCookFanoutPlan,
+    queue_create: impl Fn(Vec<&BatchCookSpec>, bool) -> Result<worktree::WorktreeQueueCreateOutput>,
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
     let mut reused = Vec::new();
     let mut to_create = Vec::new();
-    for (branch, handle) in branches {
-        match worktree::status(handle) {
+    for cook in &plan.cooks {
+        let branch = cook.head.as_ref().expect("generated cooks have heads");
+        match worktree::status(&cook.to_worktree) {
             Ok(status)
                 if status.record.state == worktree::TaskWorktreeState::Active
                     && !status.safety.worktree_missing =>
             {
                 reused.push(worktree::WorktreeQueueCreateRow {
                     branch: branch.clone(),
-                    handle: handle.clone(),
+                    handle: cook.to_worktree.clone(),
                     status: worktree::WorktreeQueueCreateStatus::Created,
                     command: worktree_create_command(args, branch),
                     retry_after_seconds: None,
@@ -1982,16 +2030,18 @@ fn queue_or_reuse_worktrees_dry_run(
                     error: None,
                 });
             }
-            _ => to_create.push(branch.clone()),
+            _ => to_create.push(cook),
         }
     }
     let planned = queue_create(to_create, true)?;
-    let rows = branches
+    let rows = plan
+        .cooks
         .iter()
-        .filter_map(|(branch, handle)| {
+        .filter_map(|cook| {
+            let branch = cook.head.as_ref().expect("generated cooks have heads");
             reused
                 .iter()
-                .find(|row| row.handle == *handle)
+                .find(|row| row.handle == cook.to_worktree)
                 .cloned()
                 .or_else(|| {
                     planned
@@ -2009,6 +2059,20 @@ fn queue_or_reuse_worktrees_dry_run(
         dry_run: true,
         rows,
     })
+}
+
+fn configured_provider_lifecycle() -> Result<bool> {
+    let config = homeboy::core::defaults::load_config();
+    for (id, provider) in &config.worktree_providers {
+        if provider.enabled
+            && provider.apply_enabled
+            && provider.commands.ensure.is_some()
+            && homeboy::core::worktree_providers::worktree_provider_lifecycle_finalizer_argv_from_config(id, &config)?.is_some()
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn preflight_batch_cook_recipes(
@@ -3375,8 +3439,30 @@ mod tests {
     use crate::test_support::{env_lock, with_isolated_home};
     use clap::Parser;
     use serde_json::json;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+
+    #[derive(Debug)]
+    struct FailingFanoutDispatcher;
+
+    impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher for FailingFanoutDispatcher {
+        fn durable_recipe(&self) -> Result<Value> {
+            Ok(json!({ "kind": "failing-fanout-dispatcher" }))
+        }
+
+        fn dispatch_attempt(
+            &self,
+            _plan: homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+            _run_id: &str,
+            _derived_cook_baseline: Option<
+                &homeboy::agents::agent_task_service::DerivedCookBaselineCapability,
+            >,
+        ) -> Result<()> {
+            Err(Error::internal_unexpected("fixture dispatcher failed"))
+        }
+    }
 
     fn test_concurrency_decision() -> BatchConcurrencyDecision {
         BatchConcurrencyDecision {
@@ -3433,6 +3519,152 @@ mod tests {
         ) -> Result<()> {
             Ok(())
         }
+    }
+
+    #[cfg(unix)]
+    fn provider_finalization_fixture() -> (tempfile::TempDir, PathBuf, BatchCookFanoutPlan) {
+        let fixture = tempfile::tempdir().expect("provider fixture");
+        let workspace = fixture.path().join("workspace");
+        let records = fixture.path().join("records");
+        let script = fixture.path().join("provider");
+        std::fs::create_dir(&workspace).expect("create provider workspace");
+        let output = Command::new("git")
+            .args(["init", "-q", "-b", "fixture"])
+            .current_dir(&workspace)
+            .output()
+            .expect("initialize provider workspace");
+        assert!(output.status.success(), "initialize provider workspace");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
+                workspace.display(),
+                records.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).expect("make provider executable");
+        let mut config = homeboy::core::defaults::load_config();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ensure: Some(vec![script.display().to_string(), "ensure".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        config.settings.insert(
+            homeboy::core::worktree_providers::WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY.to_string(),
+            json!({ "fixture": { "finalize": [script.display().to_string(), "finalize", "{handle}", "{purpose}", "{owner_run_ref}", "{cleanup_policy}", "{disposition}", "{idempotency_key}"] } }),
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+        let mut plan = test_batch_plan();
+        for cook in &mut plan.cooks {
+            cook.to_worktree = format!("homeboy@{}", cook.cook_id);
+        }
+        (fixture, records, plan)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatcher_fanout_terminalization_finalizes_success_and_failure_provider_records() {
+        with_isolated_home(|_| {
+            let (_fixture, records, plan) = provider_finalization_fixture();
+            let report = agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "partial_failure".to_string(),
+                total: 2,
+                queued: 0,
+                running: 0,
+                succeeded: 1,
+                failed: 1,
+                cancelled: 0,
+                timed_out: 0,
+                cooks: plan
+                    .cooks
+                    .iter()
+                    .enumerate()
+                    .map(
+                        |(index, cook)| agent_task_service::AgentTaskCookBatchCellReport {
+                            cook_id: cook.cook_id.clone(),
+                            initial_run_id: cook.run_id(),
+                            status: if index == 0 { "succeeded" } else { "failed" }.to_string(),
+                            exit_code: index as i32,
+                            result: None,
+                            error: None,
+                        },
+                    )
+                    .collect(),
+            };
+
+            finalize_provider_worktrees(&plan, &report).expect("dispatcher fanout terminalization");
+
+            let records = std::fs::read_to_string(records).expect("provider finalization records");
+            assert!(records.contains(&format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|succeeded|finalize:{}",
+                plan.cooks[0].cook_id,
+                plan.cooks[0].run_id(),
+                plan.cooks[0].run_id(),
+            )));
+            assert!(records.contains(&format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|failed|finalize:{}",
+                plan.cooks[1].cook_id,
+                plan.cooks[1].run_id(),
+                plan.cooks[1].run_id(),
+            )));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatcher_fanout_execution_finalizes_failed_provider_lifecycle() {
+        with_isolated_home(|_| {
+            let (_fixture, records, mut plan) = provider_finalization_fixture();
+            plan.cooks.truncate(1);
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+
+            let (_, exit_code) =
+                run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                    .expect("dispatcher fanout result");
+
+            assert_ne!(exit_code, 0);
+            let records = std::fs::read_to_string(records).expect("provider finalization record");
+            assert!(records.contains(&format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|failed|finalize:{}",
+                plan.cooks[0].cook_id,
+                plan.cooks[0].run_id(),
+                plan.cooks[0].run_id(),
+            )));
+        });
     }
 
     struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
@@ -4976,7 +5208,7 @@ fi
             args.branch_prefix = "dry-run-plan-test".to_string();
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-            assert_eq!(exit_code, 0, "{value}");
+            assert_eq!(exit_code, 0);
             assert_eq!(value["schema"], "homeboy/agent-task-cook-batch/v1");
             assert_eq!(value["status"], "ready");
             assert_eq!(value["summary"]["issues"], 2);
@@ -5053,7 +5285,7 @@ fi
             args.from = "HEAD".to_string();
             let (value, exit_code) = cook_batch(args).expect("dry-run plan");
 
-            assert_eq!(exit_code, 0, "{value}");
+            assert_eq!(exit_code, 0);
             assert_eq!(value["status"], "ready");
             for row in value["worktrees"]["rows"].as_array().expect("rows") {
                 assert_eq!(row["status"], "would_create");
@@ -5100,10 +5332,14 @@ fi
             write_component_registration(home.path(), "fanout-mixed-fixture", &source);
             worktree::queue_create(worktree::WorktreeQueueCreateOptions {
                 repo: "fanout-mixed-fixture".to_string(),
-                branches: vec!["fix/issue-6453-homeboy".to_string()],
+                requests: vec![worktree::WorktreeQueueCreateRequest {
+                    branch: "fix/issue-6453-homeboy".to_string(),
+                    task_url: None,
+                    task_ref: None,
+                    run_id: None,
+                    provider_lifecycle: None,
+                }],
                 from: "HEAD".to_string(),
-                task_url: None,
-                task_ref: None,
                 dry_run: false,
                 retry_after_seconds: 30,
             })
@@ -5505,7 +5741,7 @@ fi
 
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-            assert_eq!(exit_code, 0);
+            assert_eq!(exit_code, 0, "{value}");
             assert_eq!(
                 value["preflight"]["provider_selection"]["profile"],
                 "example-profile"
@@ -5526,7 +5762,7 @@ fi
 
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-            assert_eq!(exit_code, 0);
+            assert_eq!(exit_code, 0, "{value}");
             assert!(value["preflight"]["provider_selection"]["warnings"]
                 .as_array()
                 .expect("warnings")

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5222,7 +5222,7 @@ fi
             args.branch_prefix = "dry-run-plan-test".to_string();
             let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-            assert_eq!(exit_code, 0);
+			assert_eq!(exit_code, 0, "{value}");
             assert_eq!(value["schema"], "homeboy/agent-task-cook-batch/v1");
             assert_eq!(value["status"], "ready");
             assert_eq!(value["summary"]["issues"], 2);

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -402,10 +402,17 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             retry_after_seconds,
         } => WorktreeOutput::QueueCreate(worktree::queue_create(WorktreeQueueCreateOptions {
             repo,
-            branches,
+            requests: branches
+                .into_iter()
+                .map(|branch| worktree::WorktreeQueueCreateRequest {
+                    branch,
+                    task_url: task_url.clone(),
+                    task_ref: task_ref.clone(),
+                    run_id: None,
+                    provider_lifecycle: None,
+                })
+                .collect(),
             from,
-            task_url,
-            task_ref,
             dry_run,
             retry_after_seconds,
         })?),

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -593,6 +593,10 @@ impl HomeGuard {
         // they read it under a lock instead of racing this `setenv` from
         // worker threads a test spawns inside itself (#7505).
         crate::paths::set_home_root_override(Some(context.home().to_path_buf()));
+        // Reset hooks may read path-dependent state while clearing their caches.
+        // Run them again after switching roots so they cannot retain values from
+        // the preceding test home.
+        reset_cached_test_state();
         // Preserve the legacy in-process data fallback while the subprocess
         // context uses explicit paths. Unit tests assert this resolver's XDG
         // behavior, so an inherited explicit data root must not override it.

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -593,10 +593,6 @@ impl HomeGuard {
         // they read it under a lock instead of racing this `setenv` from
         // worker threads a test spawns inside itself (#7505).
         crate::paths::set_home_root_override(Some(context.home().to_path_buf()));
-        // Reset hooks may read path-dependent state while clearing their caches.
-        // Run them again after switching roots so they cannot retain values from
-        // the preceding test home.
-        reset_cached_test_state();
         // Preserve the legacy in-process data fallback while the subprocess
         // context uses explicit paths. Unit tests assert this resolver's XDG
         // behavior, so an inherited explicit data root must not override it.

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -29,10 +29,11 @@ pub use types::{
     WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence, WorktreeInventoryOptions,
     WorktreeInventoryOutput, WorktreeInventoryRecord, WorktreeListOutput,
     WorktreeLivenessAuthority, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
-    WorktreeQueueCreateRow, WorktreeQueueCreateStatus, WorktreeQueueLockHolder,
-    WorktreeReconciliationAction, WorktreeReconciliationAuthority, WorktreeReconciliationResult,
-    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
-    TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+    WorktreeQueueCreateRequest, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
+    WorktreeQueueLockHolder, WorktreeReconciliationAction, WorktreeReconciliationAuthority,
+    WorktreeReconciliationResult, WorktreeRemoveOptions, WorktreeRemoveOutput,
+    WorktreeSafetyReport, WorktreeStatusOutput, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
+    TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
 /// The managed handle a repo and branch pair resolves to. Creation slugifies the
@@ -485,16 +486,16 @@ use store_ops::*;
 
 pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueueCreateOutput> {
     let mut rows = Vec::new();
-    let total = options.branches.len();
-    for (index, branch) in options.branches.iter().enumerate() {
-        let command = worktree_create_command(&options, branch);
-        let handle = worktree_handle(&options.repo, branch);
+    let total = options.requests.len();
+    for (index, request) in options.requests.iter().enumerate() {
+        let command = worktree_create_command(&options, request);
+        let handle = worktree_handle(&options.repo, &request.branch);
 
         if options.dry_run {
-            match planned_create_path(&options.repo, branch, &options.from) {
+            match planned_create_path(&options.repo, &request.branch, &options.from) {
                 Ok(path) => {
                     let mut row = queue_row(
-                        branch,
+                        &request.branch,
                         handle,
                         command,
                         WorktreeQueueCreateStatus::WouldCreate,
@@ -503,8 +504,12 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     rows.push(row);
                 }
                 Err(error) => {
-                    let mut row =
-                        queue_row(branch, handle, command, WorktreeQueueCreateStatus::Failed);
+                    let mut row = queue_row(
+                        &request.branch,
+                        handle,
+                        command,
+                        WorktreeQueueCreateStatus::Failed,
+                    );
                     row.error = Some(error.message);
                     rows.push(row);
                 }
@@ -512,29 +517,57 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
             continue;
         }
 
-        match create(WorktreeCreateOptions {
-            component_id: options.repo.clone(),
-            branch: branch.clone(),
-            from: Some(options.from.clone()),
-            task_url: options.task_url.clone(),
-            run_id: None,
-            cleanup_policy: None,
-        }) {
-            Ok(created) => {
-                let mut row =
-                    queue_row(branch, handle, command, WorktreeQueueCreateStatus::Created);
-                row.path = Some(created.record.worktree_path);
+        let created = if let Some(lifecycle) = &request.provider_lifecycle {
+            let task_url = request.task_url.clone().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "task_url",
+                    "provider-owned queue worktree requires task_url",
+                    Some(handle.clone()),
+                    None,
+                )
+            })?;
+            crate::worktree_providers::provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
+                &crate::worktree_providers::WorktreeProviderCreateIntent {
+                    handle: handle.clone(), repo: options.repo.clone(), base: options.from.clone(),
+                    head: request.branch.clone(), task_url,
+                }, lifecycle, &crate::defaults::load_config(),
+            ).map(|provision| provision.resolution.worktree.path)
+        } else {
+            create(WorktreeCreateOptions {
+                component_id: options.repo.clone(),
+                branch: request.branch.clone(),
+                from: Some(options.from.clone()),
+                task_url: request.task_url.clone(),
+                run_id: request.run_id.clone(),
+                cleanup_policy: None,
+            })
+            .map(|created| created.record.worktree_path)
+        };
+        match created {
+            Ok(path) => {
+                let mut row = queue_row(
+                    &request.branch,
+                    handle,
+                    command,
+                    WorktreeQueueCreateStatus::Created,
+                );
+                row.path = Some(path);
                 rows.push(row);
             }
             Err(error) => {
-                let mut row = queue_row(branch, handle, command, WorktreeQueueCreateStatus::Failed);
+                let mut row = queue_row(
+                    &request.branch,
+                    handle,
+                    command,
+                    WorktreeQueueCreateStatus::Failed,
+                );
                 row.error = Some(error.message);
                 rows.push(row);
-                for queued_branch in options.branches.iter().take(total).skip(index + 1) {
+                for queued_request in options.requests.iter().take(total).skip(index + 1) {
                     rows.push(queue_row(
-                        queued_branch,
-                        worktree_handle(&options.repo, queued_branch),
-                        worktree_create_command(&options, queued_branch),
+                        &queued_request.branch,
+                        worktree_handle(&options.repo, &queued_request.branch),
+                        worktree_create_command(&options, queued_request),
                         WorktreeQueueCreateStatus::Queued,
                     ));
                 }

--- a/crates/homeboy-core/src/worktree/queue_ops.rs
+++ b/crates/homeboy-core/src/worktree/queue_ops.rs
@@ -80,7 +80,7 @@ pub(super) fn queue_row(
 
 pub(super) fn worktree_create_command(
     options: &WorktreeQueueCreateOptions,
-    branch: &str,
+    request: &WorktreeQueueCreateRequest,
 ) -> Vec<String> {
     let mut args = vec![
         "homeboy".to_string(),
@@ -88,11 +88,11 @@ pub(super) fn worktree_create_command(
         "create".to_string(),
         options.repo.clone(),
         "--branch".to_string(),
-        branch.to_string(),
+        request.branch.clone(),
         "--from".to_string(),
         options.from.clone(),
     ];
-    if let Some(task_url) = &options.task_url {
+    if let Some(task_url) = &request.task_url {
         args.push("--task-url".to_string());
         args.push(task_url.clone());
     }

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1518,10 +1518,23 @@ fn sibling_worktree_path(source: &Path, suffix: &str) -> PathBuf {
 fn queue_options() -> WorktreeQueueCreateOptions {
     WorktreeQueueCreateOptions {
         repo: "homeboy".to_string(),
-        branches: vec!["cook/one".to_string(), "cook/two".to_string()],
+        requests: vec![
+            WorktreeQueueCreateRequest {
+                branch: "cook/one".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5786".to_string()),
+                task_ref: Some("Extra-Chill/homeboy#5786".to_string()),
+                run_id: None,
+                provider_lifecycle: None,
+            },
+            WorktreeQueueCreateRequest {
+                branch: "cook/two".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5786".to_string()),
+                task_ref: Some("Extra-Chill/homeboy#5786".to_string()),
+                run_id: None,
+                provider_lifecycle: None,
+            },
+        ],
         from: "origin/main".to_string(),
-        task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5786".to_string()),
-        task_ref: Some("Extra-Chill/homeboy#5786".to_string()),
         dry_run: true,
         retry_after_seconds: 30,
     }
@@ -1609,10 +1622,14 @@ fn queue_create_records_successful_homeboy_worktree() {
 
         let output = queue_create(WorktreeQueueCreateOptions {
             repo: "queue-fixture".to_string(),
-            branches: vec!["cook/one".to_string()],
+            requests: vec![WorktreeQueueCreateRequest {
+                branch: "cook/one".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5924".to_string()),
+                task_ref: None,
+                run_id: None,
+                provider_lifecycle: None,
+            }],
             from: "HEAD".to_string(),
-            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/5924".to_string()),
-            task_ref: None,
             dry_run: false,
             retry_after_seconds: 30,
         })
@@ -1641,6 +1658,135 @@ fn queue_create_records_successful_homeboy_worktree() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn queue_create_uses_provider_lifecycle_with_per_child_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    crate::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider fixture");
+        let workspace = temp.path().join("workspace");
+        let records = temp.path().join("records");
+        let script = temp.path().join("provider");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}'; fi\nelif [ \"$1\" = ensure ]; then\n  printf 'ensure|%s|%s|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" \"$8\" \"$9\" >> '{}'\n  if [ ! -d '{}' ]; then git init -q -b fix/12124 '{}'; fi\nelse\n  printf 'finalize|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
+                workspace.display(),
+                workspace.display(),
+                records.display(),
+                workspace.display(),
+                workspace.display(),
+                records.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).expect("make provider executable");
+
+        let mut config = crate::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            crate::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: crate::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: crate::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    resolve_not_found_exit_codes: vec![1],
+                    ensure: Some(vec![
+                        script.display().to_string(),
+                        "ensure".to_string(),
+                        "{handle}".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                        "{purpose}".to_string(),
+                        "{owner_run_ref}".to_string(),
+                        "{cleanup_policy}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(crate::defaults::WorktreeProviderListResultMapping {
+                    items: "$.worktrees".to_string(),
+                    handle: "$.handle".to_string(),
+                    path: "$.path".to_string(),
+                    branch: "$.branch".to_string(),
+                    dirty: "$.safety.dirty".to_string(),
+                    unpushed: "$.safety.unpushed".to_string(),
+                    primary: "$.safety.primary".to_string(),
+                    task_url: None,
+                }),
+            },
+        );
+        config.settings.insert(
+            crate::worktree_providers::WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY.to_string(),
+            serde_json::json!({ "fixture": { "finalize": [script.display().to_string(), "finalize", "{handle}", "{purpose}", "{owner_run_ref}", "{cleanup_policy}", "{disposition}", "{idempotency_key}"] } }),
+        );
+        crate::defaults::save_config(&config).expect("save provider config");
+
+        let lifecycle = crate::worktree_providers::WorktreeProviderLifecycleIntent {
+            purpose: "agent_task_cook".to_string(),
+            owner_run_ref: "cook-issue-12124".to_string(),
+            cleanup_policy:
+                crate::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+        };
+        let request = WorktreeQueueCreateRequest {
+            branch: "fix/12124".to_string(),
+            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/12124".to_string()),
+            task_ref: Some("Extra-Chill/homeboy#12124".to_string()),
+            run_id: Some(lifecycle.owner_run_ref.clone()),
+            provider_lifecycle: Some(lifecycle.clone()),
+        };
+        let options = WorktreeQueueCreateOptions {
+            repo: "homeboy".to_string(),
+            requests: vec![request],
+            from: "main".to_string(),
+            dry_run: false,
+            retry_after_seconds: 30,
+        };
+        let first = queue_create(options.clone()).expect("provider creates worktree");
+        let second = queue_create(options).expect("provider reuses worktree");
+        assert_eq!(
+            first.rows[0].path.as_deref(),
+            workspace.to_str(),
+            "provider queue row: {:?}",
+            first.rows[0]
+        );
+        assert_eq!(second.rows[0].status, WorktreeQueueCreateStatus::Created);
+        let records_text = std::fs::read_to_string(&records).expect("provider records");
+        assert!(records_text.lines().all(|line| line == "ensure|homeboy@fix-12124|homeboy|main|fix/12124|https://github.com/Extra-Chill/homeboy/issues/12124|agent_task_cook|cook-issue-12124|remove_on_success"));
+
+        let resolution =
+            crate::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+                "homeboy@fix-12124",
+                &config,
+                None,
+            )
+            .expect("resolve provider worktree");
+        crate::worktree_providers::finalize_apply_enabled_worktree_provider_from_config(
+            &resolution,
+            &lifecycle,
+            crate::worktree_providers::WorktreeProviderTerminalDisposition::Succeeded,
+            &config,
+        )
+        .expect("finalize provider worktree");
+        assert!(std::fs::read_to_string(records).expect("finalization record").contains(
+            "finalize|homeboy@fix-12124|agent_task_cook|cook-issue-12124|remove_on_success|succeeded|finalize:cook-issue-12124"
+        ));
+    });
+}
+
 #[test]
 fn queue_create_uses_runner_checkout_when_lab_snapshot_is_not_git_backed() {
     use crate::test_support::with_isolated_home;
@@ -1664,10 +1810,14 @@ fn queue_create_uses_runner_checkout_when_lab_snapshot_is_not_git_backed() {
 
         let output = queue_create(WorktreeQueueCreateOptions {
             repo: "lab-fixture".to_string(),
-            branches: vec!["cook/lab".to_string()],
+            requests: vec![WorktreeQueueCreateRequest {
+                branch: "cook/lab".to_string(),
+                task_url: None,
+                task_ref: None,
+                run_id: None,
+                provider_lifecycle: None,
+            }],
             from: "HEAD".to_string(),
-            task_url: None,
-            task_ref: None,
             dry_run: false,
             retry_after_seconds: 30,
         })

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -584,12 +584,19 @@ pub struct WorktreeCleanupOptions {
 #[derive(Debug, Clone)]
 pub struct WorktreeQueueCreateOptions {
     pub repo: String,
-    pub branches: Vec<String>,
+    pub requests: Vec<WorktreeQueueCreateRequest>,
     pub from: String,
-    pub task_url: Option<String>,
-    pub task_ref: Option<String>,
     pub dry_run: bool,
     pub retry_after_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeQueueCreateRequest {
+    pub branch: String,
+    pub task_url: Option<String>,
+    pub task_ref: Option<String>,
+    pub run_id: Option<String>,
+    pub provider_lifecycle: Option<crate::worktree_providers::WorktreeProviderLifecycleIntent>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -801,8 +801,38 @@ pub fn plan_apply_enabled_worktree_provider_from_config(
     intent: &WorktreeProviderCreateIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderCreatePlan> {
+    plan_apply_enabled_worktree_provider_from_config_with_id(intent, None, config)
+}
+
+/// Plan a purpose-owned workspace with the same lifecycle-eligible provider
+/// selection that execution uses, without running its ensure command.
+pub fn plan_apply_enabled_worktree_provider_with_lifecycle_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderCreatePlan> {
+    let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
+    plan_apply_enabled_worktree_provider_from_config_with_id(intent, Some(provider_id), config)
+}
+
+fn plan_apply_enabled_worktree_provider_from_config_with_id(
+    intent: &WorktreeProviderCreateIntent,
+    selected_provider_id: Option<String>,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderCreatePlan> {
     match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
-        Ok(resolution) => return Ok(WorktreeProviderCreatePlan::Existing(resolution)),
+        Ok(resolution) => {
+            if selected_provider_id.as_deref() != Some(resolution.provider_id.as_str())
+                && selected_provider_id.is_some()
+            {
+                return Err(Error::validation_invalid_argument(
+                    "worktree_provider",
+                    "provider selection changed before lifecycle workspace planning",
+                    Some(resolution.provider_id.clone()),
+                    None,
+                ));
+            }
+            return Ok(WorktreeProviderCreatePlan::Existing(resolution));
+        }
         Err(error)
             if error
                 .details
@@ -811,29 +841,36 @@ pub fn plan_apply_enabled_worktree_provider_from_config(
                 == Some("not_found") => {}
         Err(error) => return Err(error),
     }
-    let mut provider_ids = config
-        .worktree_providers
-        .iter()
-        .filter_map(|(id, provider)| {
-            (provider.enabled && provider.apply_enabled && provider.commands.ensure.is_some())
-                .then_some(id.clone())
-        })
-        .collect::<Vec<_>>();
-    provider_ids.sort();
-    let provider_id = match provider_ids.as_slice() {
-        [provider_id] => provider_id.clone(),
-        [] => return Err(Error::validation_invalid_argument(
-            "to_worktree",
-            format!("worktree handle `{}` is missing and no enabled apply-enabled provider configures commands.ensure", intent.handle),
-            Some(intent.handle.clone()),
-            None,
-        )),
-        _ => return Err(Error::validation_invalid_argument(
-            "to_worktree",
-            format!("worktree handle `{}` is missing and multiple providers can ensure it: {}", intent.handle, provider_ids.join(", ")),
-            Some(intent.handle.clone()),
-            None,
-        )),
+    let provider_id = match selected_provider_id {
+        Some(provider_id) => provider_id,
+        None => {
+            let mut provider_ids = config
+                .worktree_providers
+                .iter()
+                .filter_map(|(id, provider)| {
+                    (provider.enabled
+                        && provider.apply_enabled
+                        && provider.commands.ensure.is_some())
+                    .then_some(id.clone())
+                })
+                .collect::<Vec<_>>();
+            provider_ids.sort();
+            match provider_ids.as_slice() {
+                [provider_id] => provider_id.clone(),
+                [] => return Err(Error::validation_invalid_argument(
+                    "to_worktree",
+                    format!("worktree handle `{}` is missing and no enabled apply-enabled provider configures commands.ensure", intent.handle),
+                    Some(intent.handle.clone()),
+                    None,
+                )),
+                _ => return Err(Error::validation_invalid_argument(
+                    "to_worktree",
+                    format!("worktree handle `{}` is missing and multiple providers can ensure it: {}", intent.handle, provider_ids.join(", ")),
+                    Some(intent.handle.clone()),
+                    None,
+                )),
+            }
+        }
     };
     let provider = config
         .worktree_providers
@@ -979,9 +1016,22 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     lifecycle: Option<&WorktreeProviderLifecycleIntent>,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
+    // Lifecycle callers select once using the stricter lifecycle eligibility
+    // contract. Keep that exact identity through ensure and postcondition lookup.
+    let lifecycle_provider = lifecycle
+        .map(|_| select_apply_enabled_worktree_provider_from_config(intent, config))
+        .transpose()?;
     match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
         Ok(resolution) => {
             if let Some(lifecycle) = lifecycle {
+                if lifecycle_provider.as_deref() != Some(&resolution.provider_id) {
+                    return Err(Error::validation_invalid_argument(
+                        "worktree_provider",
+                        "provider selection changed before lifecycle workspace adoption",
+                        Some(resolution.provider_id.clone()),
+                        None,
+                    ));
+                }
                 let provider = config
                     .worktree_providers
                     .get(&resolution.provider_id)
@@ -1019,16 +1069,25 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
         Err(error) => return Err(error),
     }
 
-    let mut providers = config
-        .worktree_providers
-        .iter()
-        .filter_map(|(id, provider)| {
-            provider
-                .enabled
-                .then_some((id.as_str(), provider))
-                .filter(|(_, provider)| provider.commands.ensure.is_some())
-        })
-        .collect::<Vec<_>>();
+    let mut providers = match lifecycle_provider.as_deref() {
+        Some(provider_id) => vec![(
+            provider_id,
+            config
+                .worktree_providers
+                .get(provider_id)
+                .expect("selected provider is configured"),
+        )],
+        None => config
+            .worktree_providers
+            .iter()
+            .filter_map(|(id, provider)| {
+                provider
+                    .enabled
+                    .then_some((id.as_str(), provider))
+                    .filter(|(_, provider)| provider.commands.ensure.is_some())
+            })
+            .collect::<Vec<_>>(),
+    };
     providers.sort_by_key(|(id, _)| *id);
     if providers.len() > 1 {
         let ids = providers.iter().map(|(id, _)| *id).collect::<Vec<_>>();
@@ -1093,6 +1152,16 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     let resolution =
         resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
             .map_err(mark_bootstrap_postcondition_failure)?;
+    if lifecycle_provider.as_deref() != Some(resolution.provider_id.as_str())
+        && lifecycle_provider.is_some()
+    {
+        return Err(Error::validation_invalid_argument(
+            "worktree_provider",
+            "provider postcondition resolved a different provider than the lifecycle owner",
+            Some(resolution.provider_id.clone()),
+            None,
+        ));
+    }
     Ok(WorktreeProviderProvision {
         resolution,
         action: "ensured",
@@ -1108,8 +1177,6 @@ pub fn provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
     lifecycle: &WorktreeProviderLifecycleIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
-    let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
-    validate_lifecycle_provider(&provider_id, config)?;
     provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
         intent,
         Some(lifecycle),
@@ -3281,6 +3348,92 @@ mod tests {
         .expect_err("missing finalizer must reject lifecycle ownership");
         assert!(error.message.contains("no enabled apply-enabled provider"));
         assert!(!marker.path().exists(), "ensure command must not run");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_provision_uses_the_selected_eligible_provider() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let selected_effect = temp.path().join("selected-effect");
+        let competing_effect = temp.path().join("competing-effect");
+        let selected = temp.path().join("selected-provider");
+        let competing = temp.path().join("competing-provider");
+        fs::write(
+            &selected,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else exit 1; fi\nelse\n  touch '{}'\n  git init -q -b fix/12124 '{}'\nfi\n",
+                selected_effect.display(),
+                workspace.display(),
+                selected_effect.display(),
+                workspace.display(),
+            ),
+        )
+        .expect("write selected provider");
+        fs::write(
+            &competing,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then exit 1; fi\ntouch '{}'\n",
+                competing_effect.display(),
+            ),
+        )
+        .expect("write competing provider");
+        for script in [&selected, &competing] {
+            let mut permissions = fs::metadata(script).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).expect("executable");
+        }
+        let provider = |script: &std::path::Path, apply_enabled| WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![script.display().to_string(), "resolve".to_string()]),
+                resolve_not_found_exit_codes: vec![1],
+                ensure: Some(vec![script.display().to_string(), "ensure".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+        let mut config = HomeboyConfig::default();
+        config
+            .worktree_providers
+            .insert("selected".to_string(), provider(&selected, true));
+        config
+            .worktree_providers
+            .insert("competing".to_string(), provider(&competing, false));
+        config.settings.insert(
+            WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY.to_string(),
+            serde_json::json!({ "selected": { "finalize": ["finalize"] } }),
+        );
+        let intent = WorktreeProviderCreateIntent {
+            handle: "homeboy@fix-12124".to_string(),
+            repo: "homeboy".to_string(),
+            base: "main".to_string(),
+            head: "fix/12124".to_string(),
+            task_url: "https://github.com/Extra-Chill/homeboy/issues/12124".to_string(),
+        };
+        let lifecycle = WorktreeProviderLifecycleIntent {
+            purpose: "agent_task_cook".to_string(),
+            owner_run_ref: "cook-12124".to_string(),
+            cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+        };
+
+        let provision = provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
+            &intent, &lifecycle, &config,
+        )
+        .expect("selected provider provisions lifecycle worktree");
+
+        assert_eq!(provision.resolution.provider_id, "selected");
+        assert!(selected_effect.exists(), "selected ensure ran");
+        assert!(
+            !competing_effect.exists(),
+            "ineligible provider was not invoked"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- carry per-child task, branch/base, run-owner, purpose, and cleanup intent through fanout worktree creation
- provision and adopt worktrees through one exact configured generic provider lifecycle
- finalize provider-owned worktrees after dispatcher and executor fanout terminalization
- cover provider selection, creation, reuse, success/failure finalization, and cleanup eligibility

Closes #12124.

## Verification

- `cargo test -p homeboy-core worktree_providers::tests::lifecycle -- --nocapture`
- `cargo test -p homeboy-core worktree::tests::queue_create -- --nocapture`
- `cargo test -p homeboy-cli dispatcher_fanout -- --nocapture`
- `cargo check -p homeboy-core -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

The broad crate gate exposed the independent leaked-process defect tracked by #12132. This PR overlaps #12125 in fanout queue APIs; land this provider lifecycle contract first, then rebase/integrate #12125's dry-run planning on its per-child request model.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode coordinated implementation, review, and verification. OpenCode general coding subagents implemented and revised the candidate from review findings. Chris Huber directed the work and remains responsible for every line.
