### PR TITLE
Reap cancelled route test process trees

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[alias]
+# Focused deterministic reproduction for #12132's affected route/dispatch family.
+test-route-dispatch = "test -p homeboy-cli commands::infra::route::tests::dispatch -- --test-threads=1"
+
+# Every test binary runs under a small supervisor. It creates a private process
+# group and reaps it when Cargo cancels the runner, so a test cannot leave a
+# daemonized fixture behind after the test binary is interrupted.
+[target.'cfg(unix)']
+runner = "scripts/nextest-hermetic-test-environment.sh"

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1712,7 +1712,8 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
         git_add_remote(primary.path(), FIXTURE_REPOSITORY_REMOTE);
         register_component("homeboy", primary.path(), FIXTURE_REPOSITORY_REMOTE);
         let workspace = primary.path().join("provenance-worktree");
-        let linked = Command::new("git")
+        let mut command = Command::new("git");
+        command
             .args([
                 "worktree",
                 "add",
@@ -1720,9 +1721,8 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
                 "provenance-worktree",
                 workspace.to_str().expect("utf8 workspace"),
             ])
-            .current_dir(primary.path())
-            .output()
-            .expect("create linked workspace");
+            .current_dir(primary.path());
+        let linked = homeboy::core::test_support::bounded_output(command);
         assert!(linked.status.success(), "{linked:?}");
         let workspace = workspace.display().to_string();
         let cook = Cli::parse_from([
@@ -1788,7 +1788,8 @@ fn lab_cook_plan_preserves_actual_cli_provenance_through_handoff_serialization()
         let primary = tempfile::tempdir().expect("primary workspace");
         git_init(primary.path());
         let workspace = primary.path().join("provenance-worktree");
-        let linked = Command::new("git")
+        let mut command = Command::new("git");
+        command
             .args([
                 "worktree",
                 "add",
@@ -1796,9 +1797,8 @@ fn lab_cook_plan_preserves_actual_cli_provenance_through_handoff_serialization()
                 "provenance-worktree",
                 workspace.to_str().expect("utf8 workspace"),
             ])
-            .current_dir(primary.path())
-            .output()
-            .expect("create linked workspace");
+            .current_dir(primary.path());
+        let linked = homeboy::core::test_support::bounded_output(command);
         assert!(linked.status.success(), "{linked:?}");
         let workspace = workspace.display().to_string();
         let matches = Cli::command_with_scoped_lab_args()
@@ -2359,7 +2359,8 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
         git_add_remote(workspace.path(), FIXTURE_REPOSITORY_REMOTE);
         let provider_dir = tempfile::tempdir().expect("provider dir");
         let provider_workspace = provider_dir.path().join("worktree");
-        let commit = Command::new("git")
+        let mut commit_command = Command::new("git");
+        commit_command
             .args([
                 "-c",
                 "user.email=fixture@example.com",
@@ -2370,11 +2371,11 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
                 "-m",
                 "fixture",
             ])
-            .current_dir(workspace.path())
-            .output()
-            .expect("create fixture commit");
+            .current_dir(workspace.path());
+        let commit = homeboy::core::test_support::bounded_output(commit_command);
         assert!(commit.status.success(), "{:?}", commit);
-        let worktree = Command::new("git")
+        let mut worktree_command = Command::new("git");
+        worktree_command
             .args([
                 "worktree",
                 "add",
@@ -2384,9 +2385,8 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
                     .to_str()
                     .expect("utf8 provider workspace"),
             ])
-            .current_dir(workspace.path())
-            .output()
-            .expect("create linked provider workspace");
+            .current_dir(workspace.path());
+        let worktree = homeboy::core::test_support::bounded_output(worktree_command);
         assert!(worktree.status.success(), "{:?}", worktree);
         let provider = provider_dir.path().join("provider");
         let payload = serde_json::json!({

--- a/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
@@ -4,6 +4,7 @@ mod dispatch;
 mod handoff;
 
 use super::*;
+use homeboy::core::test_support::bounded_output;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -14,11 +15,9 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 pub(super) const FIXTURE_REPOSITORY_REMOTE: &str = "https://github.com/Extra-Chill/homeboy.git";
 
 pub(super) fn git_init(path: &Path) {
-    let output = Command::new("git")
-        .args(["init", "-b", "main"])
-        .current_dir(path)
-        .output()
-        .expect("initialize git workspace");
+    let mut command = Command::new("git");
+    command.args(["init", "-b", "main"]).current_dir(path);
+    let output = bounded_output(command);
     assert!(
         output.status.success(),
         "{}",
@@ -32,11 +31,11 @@ pub(super) fn git_init(path: &Path) {
 /// configured remote (#11987). A bare `git init` has none, so a fixture without
 /// this is not a checkout Cook can accept.
 pub(super) fn git_add_remote(path: &Path, remote_url: &str) {
-    let output = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .args(["remote", "add", "origin", remote_url])
-        .current_dir(path)
-        .output()
-        .expect("add fixture remote");
+        .current_dir(path);
+    let output = bounded_output(command);
     assert!(
         output.status.success(),
         "{}",

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -31,6 +31,8 @@ use super::{
     DaemonTerminationClassification, DaemonTerminationEvidence, DAEMON_STARTUP_TOKEN_ENV,
 };
 
+const TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV: &str = "HOMEBOY_TEST_KEEP_DAEMON_IN_PROCESS_GROUP";
+
 /// Enumerate foreground daemon processes without inferring ownership from a
 /// command substring. A candidate is an owner only when its explicit HOME
 /// environment resolves to this durable store and its executable is the active
@@ -2422,6 +2424,12 @@ fn spawn_and_wait_for_lease_attempt(
 /// Keep the daemon and its workload children alive when a transient launcher
 /// connection, such as direct SSH, disconnects.
 fn detach_from_launcher_session(command: &mut Command) {
+    // The hermetic Cargo runner owns the test binary's process group and reaps
+    // it on cancellation. Test daemons must remain in that group; a `setsid`
+    // here would reparent a cancelled fixture to PID 1 and leak it forever.
+    if cfg!(debug_assertions) && std::env::var_os(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV).is_some() {
+        return;
+    }
     crate::process::detach_from_caller_session(command);
 }
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -15,6 +15,10 @@ use tempfile::TempDir;
 use crate::api_jobs::{Job, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult};
 
 const TEST_DAEMON_NAMESPACE_ENV: &str = "HOMEBOY_TEST_DAEMON_NAMESPACE";
+/// Test-only contract between the hermetic context and the Cargo test runner.
+/// The runner owns and reaps this process group when the test binary is
+/// cancelled, so a daemon must not create a detached session that escapes it.
+pub const TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV: &str = "HOMEBOY_TEST_KEEP_DAEMON_IN_PROCESS_GROUP";
 
 static SHARED_EMPTY_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
 static SHARED_COMMITTED_GIT_REPO_TEMPLATE: OnceLock<TempDir> = OnceLock::new();
@@ -145,6 +149,7 @@ impl HermeticTestContext {
             .env(crate::paths::HOMEBOY_DATA_DIR_ENV, self.data_dir())
             .env(crate::paths::DAEMON_STATE_DIR_ENV, self.daemon_dir())
             .env(TEST_DAEMON_NAMESPACE_ENV, self.daemon_dir())
+            .env(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV, "1")
             .env("HOMEBOY_ARTIFACT_ROOT", self.artifact_dir())
             .env("HOMEBOY_RUNTIME_TMPDIR", self.runtime_dir())
             .env("TMPDIR", self.temp_dir())
@@ -447,6 +452,7 @@ pub struct HomeGuard {
     prior_data_dir: Option<String>,
     prior_daemon_state_dir: Option<String>,
     prior_daemon_namespace: Option<String>,
+    prior_keep_daemon_in_process_group: Option<String>,
     prior_artifact_root: Option<String>,
     prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
@@ -557,6 +563,8 @@ impl HomeGuard {
         let prior_data_dir = std::env::var(crate::paths::HOMEBOY_DATA_DIR_ENV).ok();
         let prior_daemon_state_dir = std::env::var(crate::paths::DAEMON_STATE_DIR_ENV).ok();
         let prior_daemon_namespace = std::env::var(TEST_DAEMON_NAMESPACE_ENV).ok();
+        let prior_keep_daemon_in_process_group =
+            std::env::var(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV).ok();
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
         let prior_runtime_tmpdir = std::env::var("HOMEBOY_RUNTIME_TMPDIR").ok();
         let prior_invocation_runtime =
@@ -599,6 +607,7 @@ impl HomeGuard {
         std::env::remove_var(crate::paths::HOMEBOY_DATA_DIR_ENV);
         std::env::set_var(crate::paths::DAEMON_STATE_DIR_ENV, context.daemon_dir());
         std::env::set_var(TEST_DAEMON_NAMESPACE_ENV, context.daemon_dir());
+        std::env::set_var(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV, "1");
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
         std::env::set_var("HOMEBOY_NO_UPDATE_CHECK", "1");
         std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", context.runtime_dir());
@@ -643,6 +652,7 @@ impl HomeGuard {
             prior_data_dir,
             prior_daemon_state_dir,
             prior_daemon_namespace,
+            prior_keep_daemon_in_process_group,
             prior_artifact_root,
             prior_runtime_tmpdir,
             prior_invocation_runtime,
@@ -1048,6 +1058,10 @@ impl Drop for HomeGuard {
         match &self.prior_daemon_namespace {
             Some(value) => std::env::set_var(TEST_DAEMON_NAMESPACE_ENV, value),
             None => std::env::remove_var(TEST_DAEMON_NAMESPACE_ENV),
+        }
+        match &self.prior_keep_daemon_in_process_group {
+            Some(value) => std::env::set_var(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV, value),
+            None => std::env::remove_var(TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV),
         }
         match &self.prior_artifact_root {
             Some(value) => std::env::set_var("HOMEBOY_ARTIFACT_ROOT", value),
@@ -2141,6 +2155,171 @@ mod tests {
         command.get_envs().find_map(|(key, value)| {
             (key == std::ffi::OsStr::new(name)).then(|| value.map(std::ffi::OsStr::to_os_string))
         })
+    }
+
+    #[test]
+    fn hermetic_contexts_isolate_concurrent_fixture_roots() {
+        let contexts = std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                let context = HermeticTestContext::new();
+                let command = context.command(TestBinary::CurrentTest);
+                (
+                    context.root().to_path_buf(),
+                    command_env(&command, "HOME").expect("HOME override"),
+                    command_env(&command, crate::paths::HOMEBOY_DATA_DIR_ENV)
+                        .expect("data override"),
+                    command_env(&command, crate::paths::DAEMON_STATE_DIR_ENV)
+                        .expect("daemon override"),
+                    command_env(
+                        &command,
+                        crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                    )
+                    .expect("invocation runtime override"),
+                )
+            });
+            let second = scope.spawn(|| {
+                let context = HermeticTestContext::new();
+                let command = context.command(TestBinary::CurrentTest);
+                (
+                    context.root().to_path_buf(),
+                    command_env(&command, "HOME").expect("HOME override"),
+                    command_env(&command, crate::paths::HOMEBOY_DATA_DIR_ENV)
+                        .expect("data override"),
+                    command_env(&command, crate::paths::DAEMON_STATE_DIR_ENV)
+                        .expect("daemon override"),
+                    command_env(
+                        &command,
+                        crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                    )
+                    .expect("invocation runtime override"),
+                )
+            });
+            (
+                first.join().expect("first context"),
+                second.join().expect("second context"),
+            )
+        });
+
+        let (first, second) = contexts;
+        assert_ne!(first.0, second.0);
+        assert_ne!(first.1, second.1, "HOME must be worktree-scoped");
+        assert_ne!(
+            first.2, second.2,
+            "data and artifact state must be worktree-scoped"
+        );
+        assert_ne!(first.3, second.3, "daemon state must be worktree-scoped");
+        assert_ne!(
+            first.4, second.4,
+            "socket-capable invocation runtime must be worktree-scoped"
+        );
+    }
+
+    #[cfg(unix)]
+    fn wait_for_pid_file(path: &Path) -> libc::pid_t {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !path.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        fs::read_to_string(path)
+            .expect("descendant pid fixture")
+            .trim()
+            .parse()
+            .expect("numeric descendant pid")
+    }
+
+    #[cfg(unix)]
+    fn assert_pid_reaped(pid: libc::pid_t) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_ne!(
+            unsafe { libc::kill(pid, 0) },
+            0,
+            "hermetic cleanup left descendant {pid} alive"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_output_timeout_reaps_term_resistant_descendants() {
+        let _lock = env_lock();
+        let _budget = EnvRestore::capture(&[HERMETIC_SUBPROCESS_BUDGET_ENV]);
+        std::env::set_var(HERMETIC_SUBPROCESS_BUDGET_ENV, "1");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let descendant = temp.path().join("descendant.pid");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!(
+                "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; wait",
+                crate::engine::shell::quote_path(&descendant.display().to_string())
+            ),
+        ]);
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| bounded_output(command)));
+        assert!(result.is_err(), "timeout must fail the owning test");
+        assert_pid_reaped(wait_for_pid_file(&descendant));
+    }
+
+    #[test]
+    fn hermetic_commands_keep_daemons_in_the_test_runner_process_group() {
+        let command = HermeticTestContext::new().command(TestBinary::CurrentTest);
+        assert_eq!(
+            command_env(&command, TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV),
+            Some(Some("1".into()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hermetic_runner_reaps_descendants_after_a_panicking_test_binary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let descendant = temp.path().join("descendant.pid");
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root");
+        let runner = workspace.join("scripts/nextest-hermetic-test-environment.sh");
+        let mut command = Command::new("sh");
+        command
+            .arg(runner)
+            .args([
+                "sh",
+                "-c",
+                &format!(
+                    "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; exit 101",
+                    crate::engine::shell::quote_path(&descendant.display().to_string())
+                ),
+            ]);
+        let output = command.output().expect("run hermetic test runner");
+        assert_eq!(output.status.code(), Some(101));
+        assert_pid_reaped(wait_for_pid_file(&descendant));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hermetic_runner_reaps_descendants_after_a_successful_test_binary() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let descendant = temp.path().join("descendant.pid");
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root");
+        let runner = workspace.join("scripts/nextest-hermetic-test-environment.sh");
+        let mut command = Command::new("sh");
+        command.arg(runner).args([
+            "sh",
+            "-c",
+            &format!(
+                "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & echo $! > {}; exit 0",
+                crate::engine::shell::quote_path(&descendant.display().to_string())
+            ),
+        ]);
+        let output = command.output().expect("run hermetic test runner");
+        assert!(output.status.success());
+        assert_pid_reaped(wait_for_pid_file(&descendant));
     }
 
     #[test]

--- a/scripts/nextest-hermetic-test-environment.sh
+++ b/scripts/nextest-hermetic-test-environment.sh
@@ -11,4 +11,28 @@ unset CARGO_TARGET_DIR
 # outside each test's isolated home.
 unset HOMEBOY_RUNTIME_TMPDIR
 unset TMPDIR TMP TEMP
-exec "$@"
+
+# Cargo's runner is the last parent guaranteed to receive cancellation when a
+# test binary is interrupted. A Perl parent uses waitpid(WNOHANG), rather than
+# a shell `wait` held open by inherited descriptors, then reaps the test group.
+# Homeboy test daemons deliberately stay in this group instead of daemonizing.
+exec perl -MPOSIX=setsid,WNOHANG -e '
+    my $child = fork();
+    die "fork: $!\n" unless defined $child;
+    if ($child == 0) {
+        setsid() or die "setsid: $!\n";
+        exec @ARGV or die "exec: $!\n";
+    }
+    my $cleanup = sub {
+        kill "TERM", -$child;
+        select undef, undef, undef, 1;
+        kill "KILL", -$child;
+        waitpid $child, 0;
+    };
+    $SIG{HUP} = $SIG{INT} = $SIG{TERM} = sub { $cleanup->(); exit 143; };
+    my $status;
+    while (($status = waitpid $child, WNOHANG) == 0) { select undef, undef, undef, 0.05; }
+    my $exit = $?;
+    $cleanup->();
+    exit($exit >> 8);
+' -- "$@"


### PR DESCRIPTION
## Summary

- run Unix Cargo test binaries under a process-group supervisor that reaps descendants on success, failure, and cancellation
- keep test-marked Homeboy daemons inside the supervisor-owned process group instead of escaping through `setsid`
- bound route-test fixture subprocess output and isolate concurrent fixture roots
- add a focused `cargo test-route-dispatch` shard and descendant cleanup regression tests

Closes #12132.

## Verification

- `cargo test-route-dispatch` (90 passed in 308.62s)
- focused timeout, success, panic, daemon-group, and concurrent-root cleanup tests
- `cargo check -p homeboy-core -p homeboy-cli --tests`
- `cargo fmt --check`
- `git diff --check`
- process-table check after cancelled shard attempts: zero survivors from this worktree

The original broad concurrent proof has not been repeated after this repair. Before the repair, six test binaries from three candidate worktrees survived as PPID 1 for more than two hours, ignored `SIGTERM`, and required `SIGKILL`. This PR provides the focused process-tree and route-shard evidence; CI and review should validate the broader gate.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode coordinated reproduction, process inspection, implementation, and verification. An OpenCode general coding subagent implemented the candidate after the initial repair attempt was cancelled. Chris Huber directed the work and remains responsible for every line.
