### PR TITLE
Plan absent fanout worktrees in dry runs

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1452,7 +1452,7 @@ fn cook_batch_inner(
             (branch, cook.to_worktree.clone())
         })
         .collect::<Vec<_>>();
-    let worktrees = queue_or_reuse_worktrees(&args, &branches)?;
+    let worktrees = queue_or_reuse_worktrees(&args, &plan, &branches)?;
     bind_materialized_worktree_paths(&mut plan, &worktrees);
     let blocked = worktrees
         .rows
@@ -1461,7 +1461,7 @@ fn cook_batch_inner(
             !matches!(
                 row.status,
                 worktree::WorktreeQueueCreateStatus::Created
-                    | worktree::WorktreeQueueCreateStatus::Queued
+                    | worktree::WorktreeQueueCreateStatus::WouldCreate
             )
         })
         .count();
@@ -1478,7 +1478,7 @@ fn cook_batch_inner(
         // materialization.
         preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
     } else if args.dry_run {
-        preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
+        preflight_batch_cook_recipe_declarations(&plan)?;
     }
     let run_result = if args.run_plan && can_run {
         let (value, exit_code) = match attempt_dispatcher {
@@ -1499,7 +1499,7 @@ fn cook_batch_inner(
     } else if blocked > 0 {
         "blocked"
     } else if args.dry_run {
-        "planned"
+        "ready"
     } else {
         "ready"
     };
@@ -1774,16 +1774,24 @@ fn bind_materialized_worktree_paths(
         if cook.cwd.is_some() || cook.workspace.is_some() {
             continue;
         }
-        cook.workspace = worktrees
+        let row = worktrees
             .rows
             .iter()
-            .find(|row| row.handle == cook.to_worktree)
-            .and_then(|row| row.path.clone());
+            .find(|row| row.handle == cook.to_worktree);
+        // A planned path describes the future mutation. Keeping its handle in
+        // the emitted plan lets normal execution create that exact destination.
+        if matches!(
+            row.map(|row| &row.status),
+            Some(worktree::WorktreeQueueCreateStatus::Created)
+        ) {
+            cook.workspace = row.and_then(|row| row.path.clone());
+        }
     }
 }
 
 fn queue_or_reuse_worktrees(
     args: &AgentTaskFanoutCookBatchArgs,
+    plan: &BatchCookFanoutPlan,
     branches: &[(String, String)],
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
     let queue_create = |create_branches: Vec<String>, dry_run: bool| {
@@ -1799,10 +1807,10 @@ fn queue_or_reuse_worktrees(
     };
 
     if args.dry_run {
-        return queue_create(
-            branches.iter().map(|(branch, _)| branch.clone()).collect(),
-            true,
-        );
+        if configured_provider_workspace_creation()? {
+            return plan_provider_worktrees_dry_run(args, plan);
+        }
+        return queue_or_reuse_worktrees_dry_run(args, branches, queue_create);
     }
 
     let mut reused = Vec::new();
@@ -1847,6 +1855,153 @@ fn queue_or_reuse_worktrees(
     })
 }
 
+/// Provider-managed destinations have provider-owned path policy. Dry-run
+/// therefore asks the provider's optional read-only plan command rather than
+/// deriving native sibling paths or invoking ensure.
+fn plan_provider_worktrees_dry_run(
+    args: &AgentTaskFanoutCookBatchArgs,
+    plan: &BatchCookFanoutPlan,
+) -> Result<worktree::WorktreeQueueCreateOutput> {
+    use homeboy::core::worktree_providers::{
+        plan_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
+        WorktreeProviderCreatePlan,
+    };
+
+    let config = homeboy::core::defaults::load_config();
+    let mut rows = Vec::new();
+    for cook in &plan.cooks {
+        let head = cook.head.as_ref().expect("generated cooks have heads");
+        let task_url = cook
+            .task_url
+            .as_ref()
+            .expect("generated cooks have task URLs");
+        let intent = WorktreeProviderCreateIntent {
+            handle: cook.to_worktree.clone(),
+            repo: args.repo.clone(),
+            base: args.from.clone(),
+            head: head.clone(),
+            task_url: task_url.clone(),
+        };
+        let command = worktree_create_command(args, head);
+        match plan_apply_enabled_worktree_provider_from_config(&intent, &config) {
+            Ok(WorktreeProviderCreatePlan::Existing(resolution)) => {
+                rows.push(worktree::WorktreeQueueCreateRow {
+                    branch: head.clone(),
+                    handle: resolution.worktree.handle,
+                    status: worktree::WorktreeQueueCreateStatus::Created,
+                    command,
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: Some(resolution.worktree.path),
+                    error: None,
+                });
+            }
+            Ok(WorktreeProviderCreatePlan::WouldCreate(resolution)) => {
+                rows.push(worktree::WorktreeQueueCreateRow {
+                    branch: head.clone(),
+                    handle: resolution.worktree.handle,
+                    status: worktree::WorktreeQueueCreateStatus::WouldCreate,
+                    command,
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: Some(resolution.worktree.path),
+                    error: None,
+                });
+            }
+            Err(error) => {
+                let mut row = worktree::WorktreeQueueCreateRow {
+                    branch: head.clone(),
+                    handle: cook.to_worktree.clone(),
+                    status: worktree::WorktreeQueueCreateStatus::Failed,
+                    command,
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: None,
+                    error: Some(error.message),
+                };
+                row.error = Some(
+                    serde_json::json!({
+                        "message": row.error,
+                        "details": error.details,
+                    })
+                    .to_string(),
+                );
+                rows.push(row);
+            }
+        }
+    }
+    Ok(worktree::WorktreeQueueCreateOutput {
+        schema: "homeboy/worktree-queue-create/v1",
+        repo: args.repo.clone(),
+        base_ref: args.from.clone(),
+        dry_run: true,
+        rows,
+    })
+}
+
+fn configured_provider_workspace_creation() -> Result<bool> {
+    let config = homeboy::core::defaults::load_config();
+    Ok(config.worktree_providers.values().any(|provider| {
+        provider.enabled && provider.apply_enabled && provider.commands.ensure.is_some()
+    }))
+}
+
+/// Dry-run observes existing managed worktrees but only plans creation for
+/// missing handles. This preserves the exact native creation path while never
+/// asking dispatch to resolve a workspace that does not exist yet.
+fn queue_or_reuse_worktrees_dry_run(
+    args: &AgentTaskFanoutCookBatchArgs,
+    branches: &[(String, String)],
+    queue_create: impl Fn(Vec<String>, bool) -> Result<worktree::WorktreeQueueCreateOutput>,
+) -> Result<worktree::WorktreeQueueCreateOutput> {
+    let mut reused = Vec::new();
+    let mut to_create = Vec::new();
+    for (branch, handle) in branches {
+        match worktree::status(handle) {
+            Ok(status)
+                if status.record.state == worktree::TaskWorktreeState::Active
+                    && !status.safety.worktree_missing =>
+            {
+                reused.push(worktree::WorktreeQueueCreateRow {
+                    branch: branch.clone(),
+                    handle: handle.clone(),
+                    status: worktree::WorktreeQueueCreateStatus::Created,
+                    command: worktree_create_command(args, branch),
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: Some(status.record.worktree_path),
+                    error: None,
+                });
+            }
+            _ => to_create.push(branch.clone()),
+        }
+    }
+    let planned = queue_create(to_create, true)?;
+    let rows = branches
+        .iter()
+        .filter_map(|(branch, handle)| {
+            reused
+                .iter()
+                .find(|row| row.handle == *handle)
+                .cloned()
+                .or_else(|| {
+                    planned
+                        .rows
+                        .iter()
+                        .find(|row| row.branch == *branch)
+                        .cloned()
+                })
+        })
+        .collect();
+    Ok(worktree::WorktreeQueueCreateOutput {
+        schema: "homeboy/worktree-queue-create/v1",
+        repo: args.repo.clone(),
+        base_ref: args.from.clone(),
+        dry_run: true,
+        rows,
+    })
+}
+
 fn preflight_batch_cook_recipes(
     plan: &BatchCookFanoutPlan,
     attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
@@ -1870,6 +2025,16 @@ fn preflight_batch_cook_recipes(
             options.attempt_dispatcher = Some(dispatcher(&options));
         }
         agent_task_service::validate_initial_recipe_compatibility(&options)?;
+    }
+    Ok(())
+}
+
+/// A dry-run validates the immutable recipe declaration, not a future
+/// workspace. Dispatch compilation resolves workspace handles by design, so it
+/// runs only after execution has materialized the declared destination.
+fn preflight_batch_cook_recipe_declarations(plan: &BatchCookFanoutPlan) -> Result<()> {
+    for cook in &plan.cooks {
+        cook.to_cook_invocation(plan)?;
     }
     Ok(())
 }
@@ -2970,7 +3135,7 @@ fn cook_batch_next_actions(
             !matches!(
                 row.status,
                 worktree::WorktreeQueueCreateStatus::Created
-                    | worktree::WorktreeQueueCreateStatus::Queued
+                    | worktree::WorktreeQueueCreateStatus::WouldCreate
             )
         })
         .collect::<Vec<_>>();
@@ -4671,11 +4836,13 @@ fi
     #[test]
     fn cook_batch_dry_run_returns_status_and_resume_commands() {
         with_materialized_cook_batch_worktrees(|| {
-            let (value, exit_code) = cook_batch(cook_batch_args()).expect("cook batch dry run");
+            let mut args = cook_batch_args();
+            args.branch_prefix = "dry-run-plan-test".to_string();
+            let (value, exit_code) = cook_batch(args).expect("cook batch dry run");
 
-            assert_eq!(exit_code, 0);
+            assert_eq!(exit_code, 0, "{value}");
             assert_eq!(value["schema"], "homeboy/agent-task-cook-batch/v1");
-            assert_eq!(value["status"], "planned");
+            assert_eq!(value["status"], "ready");
             assert_eq!(value["summary"]["issues"], 2);
             assert_eq!(
                 value["preflight"]["provider_selection"]["executor"]["backend"],
@@ -4687,7 +4854,7 @@ fi
                 "provided"
             );
             assert_eq!(value["worktrees"]["dry_run"], true);
-            assert_eq!(value["worktrees"]["rows"][0]["status"], "queued");
+            assert_eq!(value["worktrees"]["rows"][0]["status"], "would_create");
             assert!(value["commands"]["resume_from_plan"]
                 .as_str()
                 .expect("resume command")
@@ -4716,6 +4883,104 @@ fi
                 );
                 assert!(action["kind"].is_string(), "next action must carry a kind");
             }
+        });
+    }
+
+    #[test]
+    fn dry_run_plans_absent_worktrees_without_creating_them() {
+        with_isolated_home(|home| {
+            let parent = home.path().join("Developer");
+            let source = parent.join("fanout-dry-run-fixture");
+            std::fs::create_dir_all(&source).expect("source directory");
+            std::fs::write(
+                source.join("homeboy.json"),
+                r#"{"id":"fanout-dry-run-fixture"}"#,
+            )
+            .expect("component manifest");
+            for args in [
+                ["init", "-b", "main"].as_slice(),
+                ["config", "user.email", "test@example.com"].as_slice(),
+                ["config", "user.name", "Homeboy Test"].as_slice(),
+                ["commit", "--allow-empty", "-m", "initial"].as_slice(),
+            ] {
+                assert!(Command::new("git")
+                    .args(args)
+                    .current_dir(&source)
+                    .status()
+                    .unwrap()
+                    .success());
+            }
+            write_component_registration(home.path(), "fanout-dry-run-fixture", &source);
+
+            let mut args = cook_batch_args();
+            args.repo = "fanout-dry-run-fixture".to_string();
+            args.from = "HEAD".to_string();
+            let (value, exit_code) = cook_batch(args).expect("dry-run plan");
+
+            assert_eq!(exit_code, 0, "{value}");
+            assert_eq!(value["status"], "ready");
+            for row in value["worktrees"]["rows"].as_array().expect("rows") {
+                assert_eq!(row["status"], "would_create");
+                let path = row["path"].as_str().expect("planned path");
+                assert!(!std::path::Path::new(path).exists());
+            }
+            assert!(value["plan"]["cooks"]
+                .as_array()
+                .expect("cooks")
+                .iter()
+                .all(|cook| cook["workspace"].is_null()));
+            assert!(!home
+                .path()
+                .join(".local/share/homeboy/agent-task-recipes")
+                .exists());
+        });
+    }
+
+    #[test]
+    fn dry_run_reuses_existing_worktrees_and_plans_missing_children() {
+        with_isolated_home(|home| {
+            let parent = home.path().join("Developer");
+            let source = parent.join("fanout-mixed-fixture");
+            std::fs::create_dir_all(&source).expect("source directory");
+            std::fs::write(
+                source.join("homeboy.json"),
+                r#"{"id":"fanout-mixed-fixture"}"#,
+            )
+            .expect("component manifest");
+            for args in [
+                ["init", "-b", "main"].as_slice(),
+                ["config", "user.email", "test@example.com"].as_slice(),
+                ["config", "user.name", "Homeboy Test"].as_slice(),
+                ["add", "."].as_slice(),
+                ["commit", "-m", "initial"].as_slice(),
+            ] {
+                assert!(Command::new("git")
+                    .args(args)
+                    .current_dir(&source)
+                    .status()
+                    .unwrap()
+                    .success());
+            }
+            write_component_registration(home.path(), "fanout-mixed-fixture", &source);
+            worktree::queue_create(worktree::WorktreeQueueCreateOptions {
+                repo: "fanout-mixed-fixture".to_string(),
+                branches: vec!["fix/issue-6453-homeboy".to_string()],
+                from: "HEAD".to_string(),
+                task_url: None,
+                task_ref: None,
+                dry_run: false,
+                retry_after_seconds: 30,
+            })
+            .expect("create existing child worktree");
+
+            let mut args = cook_batch_args();
+            args.repo = "fanout-mixed-fixture".to_string();
+            args.from = "HEAD".to_string();
+            let (value, exit_code) = cook_batch(args).expect("mixed dry-run plan");
+
+            assert_eq!(exit_code, 0, "{value}");
+            assert_eq!(value["worktrees"]["rows"][0]["status"], "created");
+            assert_eq!(value["worktrees"]["rows"][1]["status"], "would_create");
         });
     }
 

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -628,6 +628,11 @@ pub struct WorktreeProviderCommands {
     /// `{cleanup_policy}`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ensure: Option<Vec<String>>,
+    /// Read-only projection of an `ensure` request. It receives the same
+    /// placeholders as `ensure` and returns the prospective workspace through
+    /// `list_result_mapping`, without creating a branch or checkout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup_preview: Option<Vec<String>>,
     /// Maximum time allowed for the cleanup preview command.
@@ -660,6 +665,7 @@ impl Default for WorktreeProviderCommands {
             resolve_not_found_exit_codes: Vec::new(),
             list: None,
             ensure: None,
+            plan: None,
             cleanup_preview: None,
             cleanup_preview_timeout_ms: DEFAULT_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS,
             cleanup_apply: None,
@@ -1095,6 +1101,7 @@ mod tests {
             resolve_not_found_exit_codes: Vec::new(),
             list: Some(vec!["provider".to_string(), "list".to_string()]),
             ensure: Some(vec!["provider".to_string(), "ensure".to_string()]),
+            plan: None,
             cleanup_preview: None,
             cleanup_preview_timeout_ms: DEFAULT_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS,
             cleanup_apply: None,

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -491,12 +491,24 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
         let handle = worktree_handle(&options.repo, branch);
 
         if options.dry_run {
-            rows.push(queue_row(
-                branch,
-                handle,
-                command,
-                WorktreeQueueCreateStatus::Queued,
-            ));
+            match planned_create_path(&options.repo, branch, &options.from) {
+                Ok(path) => {
+                    let mut row = queue_row(
+                        branch,
+                        handle,
+                        command,
+                        WorktreeQueueCreateStatus::WouldCreate,
+                    );
+                    row.path = Some(path);
+                    rows.push(row);
+                }
+                Err(error) => {
+                    let mut row =
+                        queue_row(branch, handle, command, WorktreeQueueCreateStatus::Failed);
+                    row.error = Some(error.message);
+                    rows.push(row);
+                }
+            }
             continue;
         }
 
@@ -538,6 +550,44 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
         dry_run: options.dry_run,
         rows,
     })
+}
+
+/// Validate a prospective native worktree creation and return the exact path
+/// that `create` will use, without creating a branch, checkout, or record.
+pub fn planned_create_path(repo: &str, branch: &str, from: &str) -> Result<String> {
+    let target = component::resolve_target(TargetSpec {
+        component_id: Some(repo),
+        path_override: None,
+        project: None,
+        capability: None,
+        allow_synthetic: false,
+        accept_bare_directory: false,
+        ..TargetSpec::default()
+    })?;
+    let source_checkout = queue_ops::source_checkout_for_worktree(&target)?;
+    git::run_git(
+        &source_checkout,
+        &["rev-parse", "--verify", &format!("{from}^{{commit}}")],
+        "git rev-parse --verify",
+    )?;
+    let parent = source_checkout.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "source checkout has no parent: {}",
+            source_checkout.display()
+        ))
+    })?;
+    let path = parent.join(handle_for_branch(&target.component_id, branch));
+    if path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "branch",
+            "Task worktree path already exists",
+            Some(path.display().to_string()),
+            Some(vec![
+                "Use a unique branch name or remove the existing task worktree".to_string(),
+            ]),
+        ));
+    }
+    Ok(path.display().to_string())
 }
 
 use queue_ops::*;

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1529,27 +1529,60 @@ fn queue_options() -> WorktreeQueueCreateOptions {
 
 #[test]
 fn queue_create_dry_run_returns_queued_rows_with_exact_homeboy_commands() {
-    let output = queue_create(queue_options()).unwrap();
+    use crate::test_support::with_isolated_home;
 
-    assert_eq!(output.schema, "homeboy/worktree-queue-create/v1");
-    assert_eq!(output.rows.len(), 2);
-    assert_eq!(output.rows[0].status, WorktreeQueueCreateStatus::Queued);
-    assert_eq!(output.rows[0].handle, "homeboy@cook-one");
-    assert_eq!(
-        output.rows[0].command,
-        vec![
-            "homeboy",
-            "worktree",
-            "create",
-            "homeboy",
-            "--branch",
-            "cook/one",
-            "--from",
-            "origin/main",
-            "--task-url",
-            "https://github.com/Extra-Chill/homeboy/issues/5786",
-        ]
-    );
+    with_isolated_home(|home| {
+        let parent = home.path().join("Developer");
+        let source = parent.join("queue-fixture");
+        fs::create_dir_all(&source).unwrap();
+        run_git(&source, &["init", "-q"]);
+        run_git(&source, &["config", "user.email", "homeboy@example.com"]);
+        run_git(&source, &["config", "user.name", "Homeboy Test"]);
+        fs::write(source.join("homeboy.json"), r#"{"id":"queue-fixture"}"#).unwrap();
+        run_git(&source, &["add", "."]);
+        run_git(&source, &["commit", "-q", "-m", "initial"]);
+        write_component_registration(home.path(), "queue-fixture", &source);
+
+        let mut options = queue_options();
+        options.repo = "queue-fixture".to_string();
+        options.from = "HEAD".to_string();
+        let output = queue_create(options).unwrap();
+
+        assert_eq!(output.schema, "homeboy/worktree-queue-create/v1");
+        assert_eq!(output.rows.len(), 2);
+        assert_eq!(
+            output.rows[0].status,
+            WorktreeQueueCreateStatus::WouldCreate
+        );
+        assert_eq!(output.rows[0].handle, "queue-fixture@cook-one");
+        assert_eq!(
+            output.rows[0].path.as_deref(),
+            Some(
+                parent
+                    .canonicalize()
+                    .unwrap()
+                    .join("queue-fixture@cook-one")
+                    .to_str()
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            output.rows[0].command,
+            vec![
+                "homeboy",
+                "worktree",
+                "create",
+                "queue-fixture",
+                "--branch",
+                "cook/one",
+                "--from",
+                "HEAD",
+                "--task-url",
+                "https://github.com/Extra-Chill/homeboy/issues/5786",
+            ]
+        );
+        assert!(!parent.join("queue-fixture@cook-one").exists());
+    });
 }
 
 #[test]

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -621,6 +621,7 @@ pub struct WorktreeQueueCreateRow {
 #[serde(rename_all = "snake_case")]
 pub enum WorktreeQueueCreateStatus {
     Queued,
+    WouldCreate,
     ActiveLockHolder,
     Created,
     Failed,

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -163,6 +163,16 @@ pub struct WorktreeProviderResolution {
     pub worktree: WorktreeProviderHandle,
 }
 
+/// Non-mutating provider answer for one explicit workspace creation intent.
+/// Existing destinations retain their resolved metadata; absent destinations
+/// require a provider-declared path projection before they can be represented
+/// as a runnable plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeProviderCreatePlan {
+    Existing(WorktreeProviderResolution),
+    WouldCreate(WorktreeProviderResolution),
+}
+
 /// Exact provider identity, intentionally separate from mutable workspace
 /// safety. `token` is opaque to Homeboy and is the sole value accepted by a
 /// versioned provider safety command.
@@ -777,6 +787,111 @@ pub fn select_apply_enabled_worktree_provider_from_config(
         [] => Err(Error::validation_invalid_argument("to_worktree", format!("worktree handle `{}` is missing and no enabled apply-enabled provider configures commands.ensure, so Homeboy cannot create it", intent.handle), Some(intent.handle.clone()), Some(missing_ensure_provider_remediation(intent)))),
         _ => Err(Error::validation_invalid_argument("to_worktree", format!("worktree handle `{}` is missing and multiple providers can ensure it: {}", intent.handle, providers.join(", ")), Some(intent.handle.clone()), Some(ambiguous_ensure_provider_remediation(&providers.iter().map(String::as_str).collect::<Vec<_>>())))),
     }
+}
+
+/// Resolve an existing provider workspace or ask its configured read-only
+/// `plan` command to project the exact workspace that `ensure` would create.
+/// A provider without that command is intentionally not guessed from native
+/// worktree naming, because provider path policy is provider-owned.
+pub fn plan_apply_enabled_worktree_provider_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderCreatePlan> {
+    match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
+        Ok(resolution) => return Ok(WorktreeProviderCreatePlan::Existing(resolution)),
+        Err(error)
+            if error
+                .details
+                .get("worktree_provider_lookup")
+                .and_then(Value::as_str)
+                == Some("not_found") => {}
+        Err(error) => return Err(error),
+    }
+    let mut provider_ids = config
+        .worktree_providers
+        .iter()
+        .filter_map(|(id, provider)| {
+            (provider.enabled && provider.apply_enabled && provider.commands.ensure.is_some())
+                .then_some(id.clone())
+        })
+        .collect::<Vec<_>>();
+    provider_ids.sort();
+    let provider_id = match provider_ids.as_slice() {
+        [provider_id] => provider_id.clone(),
+        [] => return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree handle `{}` is missing and no enabled apply-enabled provider configures commands.ensure", intent.handle),
+            Some(intent.handle.clone()),
+            None,
+        )),
+        _ => return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            format!("worktree handle `{}` is missing and multiple providers can ensure it: {}", intent.handle, provider_ids.join(", ")),
+            Some(intent.handle.clone()),
+            None,
+        )),
+    };
+    let provider = config
+        .worktree_providers
+        .get(&provider_id)
+        .expect("selected provider is configured");
+    let Some(command) = provider.commands.plan.as_ref() else {
+        let mut error = Error::validation_invalid_argument(
+            "worktree_providers.commands.plan",
+            format!(
+                "worktree provider `{provider_id}` can ensure `{}` but cannot non-mutatingly plan its destination",
+                intent.handle
+            ),
+            Some(provider_id.clone()),
+            Some(vec![format!(
+                "Configure worktree_providers.{provider_id}.commands.plan with the same intent placeholders as commands.ensure."
+            )]),
+        );
+        error.details["worktree_provider_planning"] = Value::String("unsupported".to_string());
+        error.details["worktree_provider_id"] = Value::String(provider_id);
+        error.details["handle"] = Value::String(intent.handle.clone());
+        return Err(error);
+    };
+    let command = expand_ensure_command(command, intent, &provision_idempotency_key(intent));
+    let worktrees = run_provider_lookup_command(
+        &provider_id,
+        provider,
+        &command,
+        "plan",
+        &provider.commands.resolve_not_found_exit_codes,
+    )?;
+    let worktree = worktrees
+        .into_iter()
+        .find(|worktree| worktree.handle == intent.handle)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "worktree_providers.commands.plan",
+                format!(
+                    "worktree provider `{provider_id}` plan did not return requested handle `{}`",
+                    intent.handle
+                ),
+                Some(provider_id.clone()),
+                None,
+            )
+        })?;
+    if worktree.path.trim().is_empty() || worktree.branch != intent.head || worktree.safety.primary
+    {
+        return Err(Error::validation_invalid_argument(
+            "worktree_providers.commands.plan",
+            format!(
+                "worktree provider `{provider_id}` returned an incomplete or unsafe planned destination for `{}`",
+                intent.handle
+            ),
+            Some(provider_id),
+            None,
+        ));
+    }
+    Ok(WorktreeProviderCreatePlan::WouldCreate(
+        WorktreeProviderResolution {
+            provider_id,
+            worktree,
+        },
+    ))
 }
 
 /// Auto-creation is not a default capability: it needs an operator-configured
@@ -2907,6 +3022,107 @@ mod tests {
                 .expect("list result mapping")
                 .items,
             "$.result.items"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_create_plan_projects_absent_existing_and_unsupported_destinations_without_ensure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let existing = temp.path().join("existing");
+        let marker = temp.path().join("ensure-called");
+        let script = temp.path().join("provider");
+        Command::new("git")
+            .args([
+                "init",
+                "-q",
+                "-b",
+                "fix/existing",
+                existing.to_str().unwrap(),
+            ])
+            .status()
+            .expect("initialize existing workspace");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\ncase \"$1\" in\nresolve) if [ \"$2\" = \"fixture@existing\" ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@existing\",\"path\":\"{}\",\"branch\":\"fix/existing\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}'; fi ;;\nplan) printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"/provider/planned/$2\\\",\\\"branch\\\":\\\"$5\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\" ;;\nensure) touch '{}' ;;\nesac\n",
+                existing.display(),
+                marker.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let mut config = config_with_provider(WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![
+                    script.display().to_string(),
+                    "resolve".to_string(),
+                    "{handle}".to_string(),
+                ]),
+                plan: Some(vec![
+                    script.display().to_string(),
+                    "plan".to_string(),
+                    "{handle}".to_string(),
+                    "{repo}".to_string(),
+                    "{base}".to_string(),
+                    "{head}".to_string(),
+                    "{task_url}".to_string(),
+                    "{idempotency_key}".to_string(),
+                ]),
+                ensure: Some(vec![script.display().to_string(), "ensure".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        });
+        let intent = |handle: &str, head: &str| WorktreeProviderCreateIntent {
+            handle: handle.to_string(),
+            repo: "fixture".to_string(),
+            base: "main".to_string(),
+            head: head.to_string(),
+            task_url: "https://example.test/issues/1".to_string(),
+        };
+
+        let existing = plan_apply_enabled_worktree_provider_from_config(
+            &intent("fixture@existing", "fix/existing"),
+            &config,
+        )
+        .expect("existing plan");
+        assert!(matches!(existing, WorktreeProviderCreatePlan::Existing(_)));
+        let absent = plan_apply_enabled_worktree_provider_from_config(
+            &intent("fixture@fix-new", "fix/new"),
+            &config,
+        )
+        .expect("absent plan");
+        let WorktreeProviderCreatePlan::WouldCreate(absent) = absent else {
+            panic!("would create")
+        };
+        assert_eq!(absent.worktree.path, "/provider/planned/fixture@fix-new");
+        assert!(!marker.exists(), "planning must not invoke ensure");
+
+        config
+            .worktree_providers
+            .get_mut("fixture")
+            .unwrap()
+            .commands
+            .plan = None;
+        let error = plan_apply_enabled_worktree_provider_from_config(
+            &intent("fixture@fix-unsupported", "fix/unsupported"),
+            &config,
+        )
+        .expect_err("unsupported planning");
+        assert_eq!(error.details["worktree_provider_planning"], "unsupported");
+        assert!(
+            !marker.exists(),
+            "unsupported planning must not invoke ensure"
         );
     }
 


### PR DESCRIPTION
## Summary

- represent absent native worktrees as side-effect-free `would_create` dry-run mutations
- validate future Cook declarations without requiring the future workspace to exist
- add a generic provider `commands.plan` contract for exact non-mutating worktree projection
- cover absent, existing, mixed, unsupported-provider, and invalid-intent plans

Closes #12125.

## Verification

- focused native absent/mixed dry-run tests
- focused provider existing/absent/unsupported planning tests
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

The broad crate gate exposed the independent leaked-process defect tracked by #12132. This PR overlaps #12124's fanout queue API and should be rebased/reimplemented on #12124 after that provider lifecycle contract lands; the provider planning primitive itself remains separable.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode coordinated implementation, review, and verification. OpenCode general coding subagents implemented and revised the candidate from review findings. Chris Huber directed the work and remains responsible for every line.
