### PR TITLE
fix: preserve promotion I/O diagnostics

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1967,12 +1967,16 @@ fn hydrate_rust_cache_with_timeout(cwd: &Path, cache: &Path, timeout: Duration) 
             cache.join("rustup").display().to_string(),
         ),
     ]);
+    // The host rustup proxy refuses to run after CARGO_HOME is isolated unless
+    // the proxy itself lives under that new home. Seed the cache with a real
+    // file rather than inheriting the host home into controller-owned state.
+    let rustup_proxy = prepare_rustup_proxy(cache)?;
     let rustup = run_rust_cache_command(
         cwd,
         cache,
         &environment,
         "install_toolchain",
-        Path::new("rustup"),
+        &rustup_proxy,
         &["toolchain", "install"],
         timeout,
     )?;
@@ -1982,7 +1986,7 @@ fn hydrate_rust_cache_with_timeout(cwd: &Path, cache: &Path, timeout: Duration) 
         cache,
         &environment,
         "resolve_toolchain_cargo",
-        Path::new("rustup"),
+        &rustup_proxy,
         &["which", "cargo"],
         timeout,
     )?;
@@ -2018,6 +2022,44 @@ fn hydrate_rust_cache_with_timeout(cwd: &Path, cache: &Path, timeout: Duration) 
         timeout,
     )?;
     Ok(relative.to_path_buf())
+}
+
+fn prepare_rustup_proxy(cache: &Path) -> Result<PathBuf> {
+    let host_path = std::env::var_os("PATH").ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "PATH",
+            "unavailable for Rust gate cache hydration",
+            None,
+            None,
+        )
+    })?;
+    let source = std::env::split_paths(&host_path)
+        .map(|directory| directory.join("rustup"))
+        .find(|candidate| candidate.is_file())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "rustup",
+                "unavailable for Rust gate cache hydration",
+                None,
+                None,
+            )
+        })?;
+    let destination = cache.join("cargo/bin/rustup");
+    fs::create_dir_all(destination.parent().expect("rustup proxy has a parent")).map_err(
+        |error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("prepare isolated Rust gate cache rustup proxy".to_string()),
+            )
+        },
+    )?;
+    fs::copy(&source, &destination).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("prepare isolated Rust gate cache rustup proxy".to_string()),
+        )
+    })?;
+    Ok(destination)
 }
 
 fn run_rust_cache_command(
@@ -4548,7 +4590,7 @@ mod tests {
         fs::write(
             &rustup,
             format!(
-                "#!/bin/sh\nif test \"$1\" = toolchain; then\n  /bin/mkdir -p \"$CARGO_HOME/registry\" \"$RUSTUP_HOME/toolchains/1.95.0-test/bin\"\n  /bin/cp \"{}\" \"$RUSTUP_HOME/toolchains/1.95.0-test/bin/cargo\"\n  printf '%s\\n' rustup >> \"$CARGO_HOME/registry/hydration.log\"\nelif test \"$1\" = which; then\n  printf '%s\\n' \"$RUSTUP_HOME/toolchains/1.95.0-test/bin/cargo\"\nfi\n/bin/sleep 0.1\n",
+                "#!/bin/sh\ntest \"$0\" = \"$CARGO_HOME/bin/rustup\"\nif test \"$1\" = toolchain; then\n  /bin/mkdir -p \"$CARGO_HOME/registry\" \"$RUSTUP_HOME/toolchains/1.95.0-test/bin\"\n  /bin/cp \"{}\" \"$RUSTUP_HOME/toolchains/1.95.0-test/bin/cargo\"\n  printf '%s\\n' rustup >> \"$CARGO_HOME/registry/hydration.log\"\nelif test \"$1\" = which; then\n  printf '%s\\n' \"$RUSTUP_HOME/toolchains/1.95.0-test/bin/cargo\"\nfi\n/bin/sleep 0.1\n",
                 direct_cargo.display()
             ),
         )

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1307,11 +1307,11 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
     let root_cause = ranked_reasons
         .first()
         .cloned()
-        .map(collected_diagnostic_value);
+        .map(|item| collected_diagnostic_value_with_details(item, args.full));
     let diagnostic_chain = ranked_reasons
         .into_iter()
         .take(FAILURE_REASON_LIMIT)
-        .map(collected_diagnostic_value)
+        .map(|item| collected_diagnostic_value_with_details(item, args.full))
         .collect::<Vec<_>>();
 
     let missing_artifacts = aggregate
@@ -3373,7 +3373,11 @@ fn persisted_cook_failure_diagnostic(record: &AgentTaskRunRecord) -> Option<Coll
             class: cause.get("code")?.as_str()?.to_string(),
             message: cause.get("message")?.as_str()?.to_string(),
             source: "terminal_operation_failure".to_string(),
-            data: json!({ "field": cause.get("field") }),
+            data: diagnostic.get("details").cloned().unwrap_or_else(|| {
+                json!({
+                    "field": cause.get("field"),
+                })
+            }),
         });
     }
     let diagnostic = record.metadata.get("cook_controller_failure")?;
@@ -3386,7 +3390,11 @@ fn persisted_cook_failure_diagnostic(record: &AgentTaskRunRecord) -> Option<Coll
         class: cause.get("code")?.as_str()?.to_string(),
         message: cause.get("message")?.as_str()?.to_string(),
         source: "controller_failure".to_string(),
-        data: json!({ "field": cause.get("field") }),
+        data: diagnostic.get("details").cloned().unwrap_or_else(|| {
+            json!({
+                "field": cause.get("field"),
+            })
+        }),
     })
 }
 
@@ -4123,6 +4131,13 @@ fn evidence_is_test(kind: &str, uri: &str) -> bool {
 }
 
 fn collected_diagnostic_value(item: CollectedDiagnostic) -> Value {
+    collected_diagnostic_value_with_details(item, false)
+}
+
+fn collected_diagnostic_value_with_details(
+    item: CollectedDiagnostic,
+    include_details: bool,
+) -> Value {
     let owner = diagnostic_owner(&item.class, &item.source);
     let mut value = json!({
         "task_id": item.task_id,
@@ -4131,7 +4146,9 @@ fn collected_diagnostic_value(item: CollectedDiagnostic) -> Value {
         "source": item.source,
         "owner": owner,
     });
-    if let Some(details) = policy_denial_details(&item.data) {
+    if include_details && !item.data.is_null() {
+        value["details"] = bounded_diagnostic_value(&item.data);
+    } else if let Some(details) = policy_denial_details(&item.data) {
         value["details"] = details;
     }
     if let Some(field) = item.data.get("field").filter(|field| !field.is_null()) {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -713,6 +713,11 @@ fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_
             }),
             "full output retains the bounded terminal diagnostic after rearm"
         );
+        assert_eq!(
+            rearmed.0["failure_context"]["diagnostic"]["details"]["field"],
+            "promotion_provider.response.schema",
+            "Cook result retains structured terminal failure details"
+        );
         let (diagnosis, diagnosis_exit) = diagnose(DiagnoseArgs {
             run_id: run_id.to_string(),
             full: true,
@@ -731,11 +736,62 @@ fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_
             diagnosis["root_cause"]["message"],
             "Invalid argument 'promotion_provider.response.schema': expected homeboy/agent-task-promotion-apply-response/v1, got homeboy/command-result/v3"
         );
+        assert_eq!(
+            diagnosis["root_cause"]["details"]["field"], "promotion_provider.response.schema",
+            "diagnose --full retains the structured terminal failure details"
+        );
         assert_ne!(
             diagnosis["root_cause"]["source"], "controller_failure",
             "the later promotion terminal record must outrank the stale controller diagnostic"
         );
         assert_eq!(executor.executions.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn diagnose_full_preserves_durable_promotion_io_details() {
+    with_temp_home(|| {
+        let run_id = "run-cli-diagnose-promotion-io";
+        agent_task_lifecycle::submit_plan(&test_plan(), Some(run_id))
+            .expect("persist promotion attempt");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["cook_operation_claims"] = json!([{
+                "operation_key": format!("promote:{run_id}"),
+                "state": "failed",
+                "result": {
+                    "status": "failed",
+                    "code": "internal.io_error",
+                    "message": "IO error",
+                    "details": {
+                        "context": "hydrate Rust gate cache",
+                        "path": "/tmp/promotion-verification/gate-1",
+                        "source_error": "rustup proxy must live under CARGO_HOME"
+                    },
+                    "deepest_cause": {
+                        "code": "internal.io_error",
+                        "message": "IO error"
+                    }
+                }
+            }]);
+        })
+        .expect("persist promotion I/O failure");
+
+        let (diagnosis, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: true,
+        })
+        .expect("diagnose persists promotion I/O details");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(diagnosis["root_cause"]["class"], "internal.io_error");
+        assert_eq!(
+            diagnosis["root_cause"]["details"],
+            json!({
+                "context": "hydrate Rust gate cache",
+                "path": "/tmp/promotion-verification/gate-1",
+                "source_error": "rustup proxy must live under CARGO_HOME"
+            })
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- hydrate isolated Rust gate caches through a cache-local rustup proxy, resolving the promotion verification failure caused by an isolated `CARGO_HOME`
- retain bounded structured terminal-operation details in `agent-task diagnose --full`
- cover durable promotion I/O diagnostic projection alongside promotion-provider failures

Closes #12154

## Verification
- Not run locally per user instruction; CI is the verification authority.
- `git diff --check` passed.

## AI assistance
- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding agent
- Used for: inspected the existing implementation and failure path, completed the diagnostic-preservation and cache-root-cause changes, and added focused regression coverage. Chris Huber remains responsible for every line.