### PR TITLE
fix(cook): fork recovery after checkpoint mismatch

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -356,12 +356,18 @@ fn validate_resume_candidate(
             target_path.to_string_lossy().as_ref(),
         )?;
         if actual != expected {
-            return Err(Error::validation_invalid_argument(
+            let mut error = Error::validation_invalid_argument(
                 "promotion",
                 "promotion resume target differs from the exact checkpointed applied candidate",
                 Some(target_path.display().to_string()),
                 None,
-            ));
+            );
+            // Continuing would authenticate a different candidate. Tell the
+            // Cook recovery projection to preserve this checkpoint and fork.
+            error.details["recovery"] = serde_json::json!({
+                "action": "fork_replacement",
+            });
+            return Err(error);
         }
     }
     if let Some(recorded_base) = previous.get("verified_base") {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -697,6 +697,10 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
     assert!(mismatch
         .message
         .contains("differs from the exact checkpointed"));
+    assert_eq!(
+        mismatch.details.pointer("/recovery/action").and_then(Value::as_str),
+        Some("fork_replacement")
+    );
 
     std::fs::write(worktree_path.join("extra.rs"), "extra\n").expect("add extra candidate file");
     let extra = resume_promoted_patch(resume_options(), &worktree_path, &checkpoint)
@@ -704,6 +708,10 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
     assert!(extra
         .message
         .contains("differs from the exact checkpointed"));
+    assert_eq!(
+        extra.details.pointer("/recovery/action").and_then(Value::as_str),
+        Some("fork_replacement")
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -698,7 +698,10 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
         .message
         .contains("differs from the exact checkpointed"));
     assert_eq!(
-        mismatch.details.pointer("/recovery/action").and_then(Value::as_str),
+        mismatch
+            .details
+            .pointer("/recovery/action")
+            .and_then(Value::as_str),
         Some("fork_replacement")
     );
 
@@ -709,7 +712,10 @@ fn promotion_checkpoints_applied_target_before_gate_transport_failure() {
         .message
         .contains("differs from the exact checkpointed"));
     assert_eq!(
-        extra.details.pointer("/recovery/action").and_then(Value::as_str),
+        extra
+            .details
+            .pointer("/recovery/action")
+            .and_then(Value::as_str),
         Some("fork_replacement")
     );
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2913,6 +2913,7 @@ fn cook_failure_context(
             < recipe.retry_budget["max_attempts"]
                 .as_u64()
                 .unwrap_or_default(),
+        exact_checkpoint_candidate_mismatch(&diagnostic),
         record.as_ref().and_then(lab_handoff_runtime_recovery),
     );
     let promotion_provenance = promotion.cloned();
@@ -2957,6 +2958,7 @@ fn cook_recovery_actions(
     recovery_legal: bool,
     blocking_claim: bool,
     provider_retry_available: bool,
+    exact_checkpoint_candidate_mismatch: bool,
     lab_runtime_recovery: Option<agent_task_lifecycle::AgentTaskLabRuntimeRecovery>,
 ) -> CookRecoveryActions {
     if !recovery_legal {
@@ -2993,7 +2995,15 @@ fn cook_recovery_actions(
             command: format!("homeboy agent-task reconcile {run_id} --dry-run"),
         });
     }
-    if continuation_eligible {
+    if exact_checkpoint_candidate_mismatch {
+        // The checkpoint authenticates one exact destination candidate. A
+        // replacement run preserves that immutable evidence without claiming it
+        // can safely continue against a diverged worktree.
+        actions.push(super::AgentTaskCookRecoveryAction {
+            action: "fork_replacement".to_string(),
+            command: format!("homeboy agent-task retry {run_id} --run"),
+        });
+    } else if continuation_eligible {
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "resume".to_string(),
             command: format!("homeboy agent-task cook-continue {run_id}"),
@@ -3018,6 +3028,14 @@ fn cook_recovery_actions(
     }
 }
 
+fn exact_checkpoint_candidate_mismatch(diagnostic: &Option<Value>) -> bool {
+    diagnostic
+        .as_ref()
+        .and_then(|diagnostic| diagnostic.pointer("/details/recovery/action"))
+        .and_then(Value::as_str)
+        == Some("fork_replacement")
+}
+
 #[cfg(test)]
 mod recovery_action_tests {
     use super::*;
@@ -3025,32 +3043,36 @@ mod recovery_action_tests {
     #[test]
     fn recovery_actions_follow_the_cook_state_matrix() {
         let cases = [
-            ("gate_failed", true, vec!["status", "diagnose", "resume"]),
+            ("gate_failed", true, false, vec!["status", "diagnose", "resume"]),
             (
                 "execution_budget_exhausted",
+                false,
                 false,
                 vec!["status", "diagnose"],
             ),
             (
                 "verification_pending",
                 false,
+                false,
                 vec!["status", "diagnose", "resume"],
             ),
             (
                 "finalization_failed",
                 false,
+                false,
                 vec!["status", "diagnose", "resume"],
             ),
-            ("completed", false, vec!["status", "diagnose"]),
+            ("completed", false, false, vec!["status", "diagnose"]),
         ];
 
-        for (status, retry_available, expected) in cases {
+        for (status, retry_available, exact_checkpoint_candidate_mismatch, expected) in cases {
             let recovery = cook_recovery_actions(
                 status,
                 "cook-state-matrix-attempt-1",
                 true,
                 false,
                 retry_available,
+                exact_checkpoint_candidate_mismatch,
                 None,
             );
             let actions = recovery
@@ -3088,6 +3110,45 @@ mod recovery_action_tests {
                 )
             }));
         }
+    }
+
+    #[test]
+    fn exact_checkpoint_mismatch_offers_a_replacement_not_an_illegal_resume() {
+        let recovery = cook_recovery_actions(
+            "verification_pending",
+            "checkpoint-mismatch-attempt-1",
+            true,
+            false,
+            false,
+            true,
+            None,
+        );
+
+        let actions = |actions: &[super::super::AgentTaskCookRecoveryAction]| {
+            actions
+                .iter()
+                .map(|action| (action.action.clone(), action.command.clone()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            actions(&recovery.legal_actions),
+            vec![
+                ("status".to_string(), "homeboy agent-task status checkpoint-mismatch-attempt-1 --full".to_string()),
+                ("diagnose".to_string(), "homeboy agent-task diagnose checkpoint-mismatch-attempt-1".to_string()),
+                ("fork_replacement".to_string(), "homeboy agent-task retry checkpoint-mismatch-attempt-1 --run".to_string()),
+            ]
+        );
+        assert_eq!(actions(&recovery.next_actions), actions(&recovery.legal_actions));
+    }
+
+    #[test]
+    fn exact_checkpoint_mismatch_matches_only_the_typed_recovery_action() {
+        assert!(exact_checkpoint_candidate_mismatch(&Some(serde_json::json!({
+            "details": { "recovery": { "action": "fork_replacement" } },
+        }))));
+        assert!(!exact_checkpoint_candidate_mismatch(&Some(serde_json::json!({
+            "details": { "recovery": { "action": "resume" } },
+        }))));
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -3043,7 +3043,12 @@ mod recovery_action_tests {
     #[test]
     fn recovery_actions_follow_the_cook_state_matrix() {
         let cases = [
-            ("gate_failed", true, false, vec!["status", "diagnose", "resume"]),
+            (
+                "gate_failed",
+                true,
+                false,
+                vec!["status", "diagnose", "resume"],
+            ),
             (
                 "execution_budget_exhausted",
                 false,
@@ -3133,22 +3138,38 @@ mod recovery_action_tests {
         assert_eq!(
             actions(&recovery.legal_actions),
             vec![
-                ("status".to_string(), "homeboy agent-task status checkpoint-mismatch-attempt-1 --full".to_string()),
-                ("diagnose".to_string(), "homeboy agent-task diagnose checkpoint-mismatch-attempt-1".to_string()),
-                ("fork_replacement".to_string(), "homeboy agent-task retry checkpoint-mismatch-attempt-1 --run".to_string()),
+                (
+                    "status".to_string(),
+                    "homeboy agent-task status checkpoint-mismatch-attempt-1 --full".to_string()
+                ),
+                (
+                    "diagnose".to_string(),
+                    "homeboy agent-task diagnose checkpoint-mismatch-attempt-1".to_string()
+                ),
+                (
+                    "fork_replacement".to_string(),
+                    "homeboy agent-task retry checkpoint-mismatch-attempt-1 --run".to_string()
+                ),
             ]
         );
-        assert_eq!(actions(&recovery.next_actions), actions(&recovery.legal_actions));
+        assert_eq!(
+            actions(&recovery.next_actions),
+            actions(&recovery.legal_actions)
+        );
     }
 
     #[test]
     fn exact_checkpoint_mismatch_matches_only_the_typed_recovery_action() {
-        assert!(exact_checkpoint_candidate_mismatch(&Some(serde_json::json!({
-            "details": { "recovery": { "action": "fork_replacement" } },
-        }))));
-        assert!(!exact_checkpoint_candidate_mismatch(&Some(serde_json::json!({
-            "details": { "recovery": { "action": "resume" } },
-        }))));
+        assert!(exact_checkpoint_candidate_mismatch(&Some(
+            serde_json::json!({
+                "details": { "recovery": { "action": "fork_replacement" } },
+            })
+        )));
+        assert!(!exact_checkpoint_candidate_mismatch(&Some(
+            serde_json::json!({
+                "details": { "recovery": { "action": "resume" } },
+            })
+        )));
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11308,6 +11308,69 @@ fn recovery_context_uses_current_gate_and_finalization_evidence_not_an_older_can
     });
 }
 
+#[test]
+fn exact_checkpoint_destination_mismatch_projects_a_fork_replacement_response() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-checkpoint-destination-mismatch";
+        let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .expect("persist lifecycle record");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, &options.initial_run_id)
+            .expect("index Cook attempt");
+        let operation_key = format!("promote:{}", options.initial_run_id);
+        agent_task_lifecycle::claim_cook_operation(
+            &options.initial_run_id,
+            &operation_key,
+            std::time::Duration::from_secs(60),
+        )
+        .expect("claim promotion");
+        agent_task_lifecycle::fail_cook_operation(
+            &options.initial_run_id,
+            &operation_key,
+            serde_json::json!({
+                "code": "ValidationInvalidArgument",
+                "details": {
+                    "field": "promotion",
+                    "recovery": { "action": "fork_replacement" },
+                },
+                "deepest_cause": {
+                    "code": "validation.invalid_argument",
+                    "field": "promotion",
+                    "message": "promotion resume target differs from the exact checkpointed applied candidate",
+                },
+            }),
+        )
+        .expect("persist exact checkpoint rejection");
+
+        let context = cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "durable_failure",
+            disposition: CookDisposition::Terminal,
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 1,
+            invocation_latest_run_id: Some(&options.initial_run_id),
+        })
+        .value
+        .failure_context
+        .expect("durable failure context");
+
+        assert_eq!(context.phase, "promotion");
+        assert!(context.legal_actions.iter().any(|action| {
+            action.action == "fork_replacement"
+                && action.command
+                    == format!("homeboy agent-task retry {} --run", options.initial_run_id)
+        }));
+        assert!(context
+            .legal_actions
+            .iter()
+            .chain(&context.next_actions)
+            .all(|action| action.action != "resume" && !action.command.contains("cook-continue")));
+    });
+}
+
 /// #11114: `select_cook_candidate` deliberately spans invocations, so a report
 /// can name this invocation's `latest_run_id` while `selected_candidate` names a
 /// prior attempt. `invocation_scoped` makes that difference legible instead of


### PR DESCRIPTION
## Summary
- Mark exact post-apply checkpoint candidate mismatches with a typed fork-replacement recovery action.
- Replace the impossible Cook continuation with a new-run retry while retaining status and diagnostic actions.
- Cover the promotion marker and durable Cook failure projection.

Closes #6123

## Verification
- `git diff --check`
- Tests not run locally per request; CI is the verification authority.

AI assistance: OpenAI GPT-5.6 Terra via OpenCode reviewed the recovery contracts, implemented the typed restart/fork projection, and performed source/diff checks. Chris Huber reviewed and owns the change.