### PR TITLE
fix(cook): preserve AI disclosure provenance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1244,22 +1244,41 @@ where
     }
 }
 
-fn persist_resolved_provider_model(outcome: &mut AgentTaskOutcome, request: &AgentTaskRequest) {
-    let Some(model) = request
+pub(crate) fn persist_resolved_provider_model(
+    outcome: &mut AgentTaskOutcome,
+    request: &AgentTaskRequest,
+) {
+    let provider_reported = outcome.selected_model().map(str::to_string);
+    let requested = request.metadata["model_selection"]["requested"]
+        .as_str()
+        .filter(|model| !model.trim().is_empty())
+        .map(str::to_string);
+    let resolved = request
         .executor
         .model()
         .filter(|model| !model.trim().is_empty())
-    else {
-        return;
-    };
+        .map(str::to_string);
     if !outcome.metadata.is_object() {
         outcome.metadata = serde_json::json!({});
     }
-    outcome
+    let metadata = outcome
         .metadata
         .as_object_mut()
-        .expect("outcome metadata object")
-        .insert("model".to_string(), serde_json::json!(model));
+        .expect("outcome metadata object");
+    // Keep each authority distinct: dispatch intent, selected runtime, and the
+    // provider's response must never overwrite one another.
+    metadata.insert(
+        "model_identity".to_string(),
+        serde_json::json!({
+            "requested": requested,
+            "resolved": resolved,
+            "provider_reported": provider_reported,
+            "actual": provider_reported,
+        }),
+    );
+    if let Some(actual) = provider_reported {
+        metadata.insert("model".to_string(), serde_json::json!(actual));
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -11,6 +11,30 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 #[test]
+fn provider_reported_model_is_retained_separately_from_requested_and_resolved_models() {
+    let mut request = request("task-1");
+    request.executor.model = Some("openai/gpt-5.6-terra".to_string());
+    request.metadata = json!({
+        "model_selection": { "requested": "openai/gpt-5.6-sol" }
+    });
+    let mut outcome = outcome("task-1".to_string(), AgentTaskOutcomeStatus::Succeeded);
+    outcome.metadata = json!({ "model": "openai/gpt-5.6-terra" });
+
+    crate::agent_task_scheduler::engine::persist_resolved_provider_model(&mut outcome, &request);
+
+    assert_eq!(outcome.selected_model(), Some("openai/gpt-5.6-terra"));
+    assert_eq!(
+        outcome.metadata["model_identity"],
+        json!({
+            "requested": "openai/gpt-5.6-sol",
+            "resolved": "openai/gpt-5.6-terra",
+            "provider_reported": "openai/gpt-5.6-terra",
+            "actual": "openai/gpt-5.6-terra",
+        })
+    );
+}
+
+#[test]
 fn nested_failed_executor_status_fails_succeeded_wrapper_outcome() {
     let scheduler = AgentTaskScheduler::new(NestedFailedStatusExecutor);
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1332,6 +1332,14 @@ pub(crate) fn cook_finalization_options(
         })?;
     let mut review_dossier = cook_review_dossier(options, promotion, successful_run_id)?;
     review_dossier.overrides = overrides;
+    // A non-empty option is an explicit operator disclosure. Otherwise retain
+    // the validated review form's process statement as durable PR provenance.
+    let ai_used_for = if options.ai_used_for.trim().is_empty() {
+        review_dossier.ai_assistance.used_for.clone()
+    } else {
+        options.ai_used_for.clone()
+    };
+    review_dossier.ai_assistance.used_for = ai_used_for.clone();
     let targeted_checks_run = review_dossier
         .how_to_test
         .iter()
@@ -1387,7 +1395,7 @@ pub(crate) fn cook_finalization_options(
                 .ok()
                 .map(|record| record.lifecycle),
         },
-        ai_used_for: options.ai_used_for.clone(),
+        ai_used_for,
         review_dossier,
         review_profile: resolve_review_profile(&path)?,
         manual_finalization: false,
@@ -2377,15 +2385,22 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
             )
         })?;
     let model = outcome.selected_model();
-    if let (Some(planned_model), Some(model)) = (task.executor.model(), model) {
-        if planned_model != model {
-            return Err(Error::validation_invalid_argument(
-                "provider_model",
-                "Cook lineage plan model conflicts with the concrete executed model",
-                Some(run_id.to_string()),
-                None,
-            ));
-        }
+    let requested_model = outcome.metadata["model_identity"]["requested"].as_str();
+    let resolved_model = outcome.metadata["model_identity"]["resolved"].as_str();
+    let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"]
+        .as_str();
+    if model.is_none()
+        && provider_reported_model.is_none()
+        && requested_model.zip(resolved_model).is_some_and(|(requested, resolved)| {
+            requested != resolved
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "provider_model",
+            "Cook lineage has unresolved requested and resolved model disagreement without a provider-reported executed model",
+            Some(run_id.to_string()),
+            None,
+        ));
     }
     if task.executor.backend.trim().is_empty() {
         return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9581,6 +9581,43 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
 }
 
 #[test]
+fn cook_finalization_adopts_validated_review_form_used_for_when_option_is_empty() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "cook-empty-used-for-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(
+            "cook-empty-used-for",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.initial_run_id = run_id.to_string();
+        options.ai_used_for.clear();
+        let plan = options.initial_plan.clone();
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).unwrap();
+        persist_initial_recipe(&options).unwrap();
+        agent_task_lifecycle::record_cook_attempt(&options.cook_id, 1, run_id).unwrap();
+        seed_review_form_aggregate(run_id, &plan);
+        let promotion = promotion_with_existing_path(run_id, target.path());
+
+        let finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("finalization options");
+        assert_eq!(finalization.ai_used_for, test_review_form().used_for);
+        assert_eq!(
+            finalization.review_dossier.ai_assistance.used_for,
+            test_review_form().used_for
+        );
+
+        options.ai_used_for = "Operator-authored disclosure.".to_string();
+        let finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("finalization options with override");
+        assert_eq!(finalization.ai_used_for, "Operator-authored disclosure.");
+        assert_eq!(
+            finalization.review_dossier.ai_assistance.used_for,
+            "Operator-authored disclosure."
+        );
+    });
+}
+
+#[test]
 fn manual_finalization_identity_resolves_cook_and_failed_attempt_or_reserves_fresh_id() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-11334";


### PR DESCRIPTION
## Summary
- preserve requested, resolved, and provider-reported actual model identities in task outcomes
- disclose the provider-reported executed model while failing closed on unresolved remaps
- adopt validated review-form process provenance unless an explicit operator disclosure overrides it

Closes #12168

## Verification
- `git diff --check`
- Local Cargo commands were not run by request; CI verifies.

## AI assistance
- **Model:** OpenAI GPT-5.6 Terra
- **Tool:** OpenCode
- **Used for:** Audited model and finalization provenance paths, completed the implementation, and reviewed the source diff. Chris Huber reviews and owns the change.