### PR TITLE
perf(gates): reuse managed Cargo target stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1900,9 +1900,7 @@ impl SelectedGateEnvironment {
             resolution: target.resolution().to_string(),
             owner: target.evidence().owner,
             identity,
-            state: bytes_before.map(|bytes| {
-                if bytes == 0 { "miss" } else { "hit" }.to_string()
-            }),
+            state: bytes_before.map(|bytes| if bytes == 0 { "miss" } else { "hit" }.to_string()),
             bytes_before,
             bytes_after: None,
             elapsed_ms: None,

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -679,6 +679,16 @@ pub struct AgentTaskGateCargoTargetEvidence {
     pub path: String,
     pub resolution: String,
     pub owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_before: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bytes_after: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u128>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1467,6 +1477,7 @@ pub(crate) fn run_gate_command_with_supervision(
         }
         homeboy_core::engine::command::isolate_process_tree(&mut process);
     }
+    let target_started = Instant::now();
     let mut child = process.spawn().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -1568,6 +1579,7 @@ pub(crate) fn run_gate_command_with_supervision(
     let failure_evidence = (exit_code != 0)
         .then(|| gate_failure_evidence(command, exit_code, &stdout, &stderr, test_result.as_ref()));
 
+    selected_environment.finish_cargo_target(target_started.elapsed())?;
     let mut report = AgentTaskGateReport::new(
         format!("gate-{index}"),
         command_vec,
@@ -1622,6 +1634,7 @@ pub(crate) fn run_gate_command_with_timeout(
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
     homeboy_core::engine::command::isolate_process_tree(&mut process);
+    let target_started = Instant::now();
     let mut child = process.spawn().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -1659,6 +1672,7 @@ pub(crate) fn run_gate_command_with_timeout(
     let exit_code = effective_gate_exit_code(runner_exit_code, test_result.as_ref());
     let failure_evidence = (exit_code != 0)
         .then(|| gate_failure_evidence(command, exit_code, &stdout, &stderr, test_result.as_ref()));
+    selected_environment.finish_cargo_target(target_started.elapsed())?;
     let mut report = AgentTaskGateReport::new(
         format!("gate-{index}"),
         command_vec,
@@ -1868,6 +1882,15 @@ impl SelectedGateEnvironment {
             cwd,
             explicit_target.as_deref(),
         )?;
+        // Store sizing is evidence only. A concurrent gate may update the
+        // shared target while this observation walks it.
+        let bytes_before = target.size_bytes().ok();
+        // The managed store identity is repository-scoped. Cargo separates all
+        // source, feature, profile, target, and toolchain fingerprints within it.
+        let identity = (target.resolution() == "shared")
+            .then(|| target.target_dir().file_name())
+            .flatten()
+            .map(|name| name.to_string_lossy().to_string());
         self.values.insert(
             "CARGO_TARGET_DIR".to_string(),
             target.target_dir().to_string_lossy().to_string(),
@@ -1876,8 +1899,25 @@ impl SelectedGateEnvironment {
             path: target.target_dir().to_string_lossy().to_string(),
             resolution: target.resolution().to_string(),
             owner: target.evidence().owner,
+            identity,
+            state: bytes_before.map(|bytes| {
+                if bytes == 0 { "miss" } else { "hit" }.to_string()
+            }),
+            bytes_before,
+            bytes_after: None,
+            elapsed_ms: None,
         });
         self._cargo_target = Some(target);
+        Ok(())
+    }
+
+    fn finish_cargo_target(&mut self, elapsed: Duration) -> Result<()> {
+        let (Some(target), Some(evidence)) = (&self._cargo_target, &mut self.report.cargo_target)
+        else {
+            return Ok(());
+        };
+        evidence.bytes_after = target.size_bytes().ok();
+        evidence.elapsed_ms = Some(elapsed.as_millis());
         Ok(())
     }
 }
@@ -3317,6 +3357,115 @@ mod tests {
                 "shared"
             );
         });
+    }
+
+    #[test]
+    fn shared_cargo_target_reports_miss_then_hit_and_metrics() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("gate fixture");
+            let mut policy = AgentTaskGateEnvironmentPolicy::default();
+            policy.shared_cargo_target = Some(true);
+            policy
+                .variables
+                .insert("CARGO_TARGET_DIR".to_string(), String::new());
+
+            let first = run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
+                temp.path(),
+                1,
+                "printf artifact > \"$CARGO_TARGET_DIR/artifact\"",
+                AgentTaskGateVisibility::Visible,
+                AgentTaskGateRevealPolicy::FullEvidence,
+                None,
+                &policy,
+                &[],
+            )
+            .expect("first managed gate");
+            let first = first
+                .environment
+                .cargo_target
+                .expect("first target evidence");
+            assert_eq!(first.state.as_deref(), Some("miss"));
+            assert_eq!(first.bytes_before, Some(0));
+            assert!(first.bytes_after.expect("target bytes") > 0);
+            assert!(first.elapsed_ms.is_some());
+
+            let second = run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
+                temp.path(),
+                2,
+                "printf artifact > \"$CARGO_TARGET_DIR/artifact\"",
+                AgentTaskGateVisibility::Visible,
+                AgentTaskGateRevealPolicy::FullEvidence,
+                None,
+                &policy,
+                &[],
+            )
+            .expect("reused managed gate");
+            let second = second
+                .environment
+                .cargo_target
+                .expect("second target evidence");
+            assert_eq!(second.state.as_deref(), Some("hit"));
+            assert_eq!(first.identity, second.identity);
+            assert_eq!(first.path, second.path);
+        });
+    }
+
+    #[test]
+    fn concurrent_shared_cargo_target_gates_reuse_one_live_store() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("gate fixture");
+            let barrier = std::sync::Barrier::new(2);
+            let reports = std::thread::scope(|scope| {
+                let first = scope.spawn(|| {
+                    barrier.wait();
+                    run_shared_target_fixture_gate(temp.path(), 1)
+                });
+                let second = scope.spawn(|| {
+                    barrier.wait();
+                    run_shared_target_fixture_gate(temp.path(), 2)
+                });
+                [
+                    first.join().expect("first gate thread"),
+                    second.join().expect("second gate thread"),
+                ]
+            });
+
+            let first = reports[0]
+                .as_ref()
+                .expect("first managed gate")
+                .environment
+                .cargo_target
+                .as_ref()
+                .expect("first target evidence");
+            let second = reports[1]
+                .as_ref()
+                .expect("second managed gate")
+                .environment
+                .cargo_target
+                .as_ref()
+                .expect("second target evidence");
+            assert_eq!(first.path, second.path);
+            assert_eq!(first.identity, second.identity);
+            assert!(std::path::Path::new(&first.path).is_dir());
+        });
+    }
+
+    fn run_shared_target_fixture_gate(cwd: &Path, index: usize) -> Result<AgentTaskGateReport> {
+        let mut policy = AgentTaskGateEnvironmentPolicy::default();
+        policy.shared_cargo_target = Some(true);
+        policy
+            .variables
+            .insert("CARGO_TARGET_DIR".to_string(), String::new());
+        run_gate_command_with_policy_and_runtime_tmpdir_and_environment(
+            cwd,
+            index,
+            "sleep 0.1; printf artifact > \"$CARGO_TARGET_DIR/artifact-$$\"",
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            None,
+            &policy,
+            &[],
+        )
     }
 
     /// Restores process-global environment variables when dropped.

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -115,6 +115,10 @@ impl ManagedCargoTarget {
             owner: self.owner.clone(),
         }
     }
+
+    pub fn size_bytes(&self) -> Result<u64> {
+        path_size(&self.target_dir)
+    }
 }
 
 impl SharedCargoTargetLease {


### PR DESCRIPTION
Closes #12166

## Summary
- Route isolated Cook gates through the existing repository-scoped managed Cargo target lease.
- Record opaque shared-store identity, hit/miss state, before/after byte observations, and elapsed gate time in durable gate evidence.
- Cover sequential reuse and concurrent gates sharing one live leased store.

Cargo already separates source, feature, profile, target, and toolchain fingerprints within a target directory. The managed shared lease retains the store throughout each child process and keeps cleanup mutually exclusive with active gates.

## Verification
- `git diff --check`
- Cargo/tests intentionally not run locally per task request; CI is the verification authority.

## AI assistance
- **Model:** OpenAI GPT-5.6 Terra
- **Tool:** OpenCode
- **Used for:** Reviewed the prior implementation, reduced it to the existing managed Cargo target primitive, added focused evidence/concurrency coverage, and performed source/diff checks. Chris Huber remains responsible for every line.