### PR TITLE
Make the Test gate declaration real, and verify action pins are commits

### DIFF
--- a/.github/validate-action-pin.sh
+++ b/.github/validate-action-pin.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Reusable-workflow pin validator.
+#
+# `uses: owner/repo/.github/workflows/file.yml@<ref>` resolves COMMIT SHAs only.
+# An annotated tag's ref object is a *tag* object, not a commit, so pinning the
+# SHA that `git/refs/tags/<tag>` reports fails the whole workflow at startup —
+# no jobs scheduled, no logs, just "This run likely failed because of a workflow
+# file issue".
+#
+# That is not hypothetical. On 2026-08-12 PR #12152 pinned a6ff2f5d, the tag
+# object for homeboy-action v2.11.21, and every pull request's CI died at
+# startup until #12153 repinned the dereferenced commit 82033fe6. It passed
+# local review because `git show <tagobj>:path` and `git rev-parse` both
+# dereference annotated tags transparently: the YAML parsed, the file content
+# was correct, and only GitHub's resolver disagreed.
+#
+# Pin `git rev-parse v<tag>^{commit}`, and let this catch it when someone does
+# not. Consumed by the `homeboy / Required Gates Declaration` job.
+#
+# Requires network and a token. Unreadable refs are reported as `unverified`
+# and never treated as valid, but only `tag` — a positively identified wrong
+# object type — fails the build.
+
+set -euo pipefail
+
+ci_workflow="${ACTION_PIN_WORKFLOW:-.github/workflows/ci.yml}"
+
+if [ ! -f "${ci_workflow}" ]; then
+  echo "action-pin: ${ci_workflow} not found" >&2
+  exit 1
+fi
+
+mapfile -t pins < <(grep -oE 'uses: [A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/[A-Za-z0-9_.-]+@[0-9a-f]{40}' "${ci_workflow}" | sed 's/^uses: //')
+
+if [ "${#pins[@]}" -eq 0 ]; then
+  echo "action-pin: no SHA-pinned reusable workflows in ${ci_workflow}; nothing to verify"
+  exit 0
+fi
+
+status=0
+
+for pin in "${pins[@]}"; do
+  target="${pin%@*}"
+  sha="${pin##*@}"
+  repo="$(printf '%s' "${target}" | cut -d/ -f1-2)"
+
+  # `git/commits/<sha>` is the discriminator: it 404s for a tag object and
+  # succeeds only for a commit. Asking `git/refs` would re-introduce the exact
+  # dereferencing ambiguity this script exists to remove.
+  if resolved="$(gh api "repos/${repo}/git/commits/${sha}" --jq '.sha' 2>/dev/null)" && [ "${resolved}" = "${sha}" ]; then
+    echo "action-pin: ${repo}@${sha} is a commit"
+    continue
+  fi
+
+  if object_type="$(gh api "repos/${repo}/git/tags/${sha}" --jq '.object.type' 2>/dev/null)"; then
+    commit="$(gh api "repos/${repo}/git/tags/${sha}" --jq '.object.sha' 2>/dev/null || echo unknown)"
+    echo "::error::action-pin: ${repo}@${sha} is an ANNOTATED TAG object, not a commit (${object_type} -> ${commit}). \`uses:\` cannot resolve it and CI will fail at startup with zero jobs. Pin the dereferenced commit ${commit} instead." >&2
+    status=1
+    continue
+  fi
+
+  echo "::warning::action-pin: ${repo}@${sha} could not be read as either a commit or a tag object; reporting unverified rather than valid." >&2
+done
+
+exit "${status}"

--- a/.github/validate-required-gates.sh
+++ b/.github/validate-required-gates.sh
@@ -106,14 +106,24 @@ for context in "${contexts[@]}"; do
     continue
   fi
 
+  # Anchored: an unanchored `title: ${title}` is a SUBSTRING match, and
+  # `comment-section-title: Test` satisfied it. That made the declaration check
+  # for `homeboy / Test` vacuous — it passed with the Test job repointed at a
+  # foreign workflow and no longer running `review test` at all (#10997).
   title="${context#homeboy / }"
   if grep -Fq 'name: homeboy / ${{ matrix.title }}' "${ci_workflow}" \
-    && grep -Fq "title: ${title}" "${ci_workflow}"; then
+    && grep -Eq "^[[:space:]]+title: ${title}[[:space:]]*$" "${ci_workflow}"; then
     continue
   fi
 
+  # `homeboy / Test` is the caller job name plus the called reconciliation job
+  # name, so no literal `name: homeboy / Test` exists to match. Accept the
+  # reusable-workflow call instead — at a floating major OR a pinned commit SHA.
+  # This branch previously required `@v2` and had therefore been dead since the
+  # pin became a full SHA, which is why the broken title match above was the
+  # only thing keeping this context green.
   if [ "${context}" = "homeboy / Test" ] \
-    && grep -Fq 'uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2' "${ci_workflow}" \
+    && grep -Eq 'uses: Extra-Chill/homeboy-action/\.github/workflows/ci\.yml@(v[0-9]+|[0-9a-f]{40})' "${ci_workflow}" \
     && grep -Fq 'commands: review test' "${ci_workflow}"; then
     continue
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/validate-required-gates.sh --report
+      # A reusable-workflow pin must be a COMMIT. Pinning an annotated tag's ref
+      # object kills every run at startup with zero jobs scheduled, which is how
+      # #12152 broke `main` until #12153 repinned the dereferenced commit.
+      - name: Validate reusable workflow pins resolve to commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/validate-action-pin.sh
 
   # Non-differential safety net for crate-topology changes. The `review test`
   # gate below is changed-file scoped, so a crate extraction that orphans a

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -168,14 +168,35 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
         let reusable_test = context == "homeboy / Test"
             && ci_workflow().contains("uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@")
             && ci_workflow().contains("commands: review test");
+        // Anchored to a whole YAML key. A bare `contains("title: Test")` also
+        // matches `comment-section-title: Test`, which made this assertion — and
+        // the shipped validator's matching branch — vacuous for `homeboy / Test`.
+        let declares_matrix_title = ci_workflow().contains("name: homeboy / ${{ matrix.title }}")
+            && ci_workflow()
+                .lines()
+                .any(|line| line.trim() == format!("title: {matrix_title}"));
         assert!(
             ci_workflow().contains(&format!("name: {context}"))
-                || (ci_workflow().contains("name: homeboy / ${{ matrix.title }}")
-                    && ci_workflow().contains(&format!("title: {matrix_title}")))
+                || declares_matrix_title
                 || reusable_test,
             "required context {context:?} is not emitted by the always-run CI workflow"
         );
     }
+
+    // The reusable-workflow branch is the ONLY thing that can legitimately
+    // satisfy `homeboy / Test`: there is no literal `name: homeboy / Test`, and
+    // no matrix entry titled Test. Pin that, so a future edit cannot leave the
+    // context green through an unrelated substring again.
+    assert!(
+        !ci_workflow().contains("name: homeboy / Test"),
+        "if a literal Test job appears, the reusable-workflow branch below is no longer load-bearing and this test must be revisited"
+    );
+    assert!(
+        !ci_workflow()
+            .lines()
+            .any(|line| line.trim() == "title: Test"),
+        "no matrix entry is titled Test, so the matrix branch must not be what keeps `homeboy / Test` declared"
+    );
     assert!(
         !ci_workflow().contains("paths:"),
         "a required CI check cannot be path-filtered because unrelated PRs would wait forever"
@@ -216,6 +237,10 @@ fn ci_job_claims_only_the_declaration_and_reports_live_enforcement() {
     assert!(
         !ci_workflow().contains("name: homeboy / Required Gates Policy"),
         "'Required Gates Policy' asserts live enforcement this job does not verify"
+    );
+    assert!(
+        ci_workflow().contains("bash .github/validate-action-pin.sh"),
+        "the declaration job must verify reusable-workflow pins resolve to commits"
     );
     assert!(
         ci_workflow().contains("bash .github/validate-required-gates.sh --report"),
@@ -629,6 +654,45 @@ fn unknown_mode_is_refused() {
     assert_eq!(output.status.code(), Some(2));
     assert!(
         stderr_of(&output).contains("usage:"),
+        "{}",
+        stderr_of(&output)
+    );
+}
+
+/// The pin validator's parser must be exercisable without network: a workflow
+/// with no SHA-pinned reusable call has nothing to dereference and must not be
+/// treated as a failure. The positive and negative dereferencing paths need the
+/// GitHub API and are exercised by the `Required Gates Declaration` job itself.
+#[test]
+fn action_pin_validator_is_a_noop_without_sha_pinned_reusable_workflows() {
+    let dir = Scratch::new("action-pin-no-pins");
+    let workflow = dir.write(
+        "ci.yml",
+        "jobs:\n  homeboy:\n    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2\n",
+    );
+    let output = Command::new("bash")
+        .arg(".github/validate-action-pin.sh")
+        .env("ACTION_PIN_WORKFLOW", &workflow)
+        .output()
+        .expect("run validate-action-pin.sh");
+    assert_eq!(output.status.code(), Some(0), "{}", stderr_of(&output));
+    assert!(
+        stdout_of(&output).contains("nothing to verify"),
+        "{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn action_pin_validator_refuses_a_missing_workflow() {
+    let output = Command::new("bash")
+        .arg(".github/validate-action-pin.sh")
+        .env("ACTION_PIN_WORKFLOW", "/nonexistent/ci.yml")
+        .output()
+        .expect("run validate-action-pin.sh");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stderr_of(&output).contains("not found"),
         "{}",
         stderr_of(&output)
     );


### PR DESCRIPTION
The two follow-ups from #10997. Both are guards that *should* have caught today's failures and did not.

## 1. The declaration check for `homeboy / Test` was vacuous

`validate-required-gates.sh` accepted a context if the workflow contained `title: <name>` — as an **unanchored substring**. For `homeboy / Test` that matched:

```yaml
comment-section-title: Test     # ci.yml:257
```

An unrelated key. Meanwhile the branch actually *intended* to satisfy this context — the reusable-workflow call — required `ci.yml@v2` and **has been dead since the pin became a full SHA**.

So the most important gate in the policy was green for the wrong reason.

**Demonstrated.** Repoint the Test job at a foreign workflow and delete `commands: review test`:

```
$ REQUIRED_GATES_WORKFLOW=ci-broken.yml bash .github/validate-required-gates.sh --local
EXIT=0          # before
EXIT=1          # after
```

Before this PR the validator was fine with `homeboy / Test` being produced by `Extra-Chill/SOMEONE-ELSE/.github/workflows/evil.yml@main`.

**Fix:** the matrix-title match is anchored to a whole YAML key, and the reusable branch accepts either a floating major (`@v2`) or a 40-hex commit pin. `tests/required_gates_policy_test.rs` mirrored the same substring flaw and is anchored identically, plus two new assertions pinning that neither a literal `name: homeboy / Test` nor a matrix entry titled `Test` exists — so the reusable branch is *provably* the only thing keeping the context declared, rather than accidentally.

## 2. Nothing verified a reusable-workflow pin is a commit

`uses:` resolves **commit** SHAs only. An annotated tag's ref object is a *tag* object, so pinning what `git/refs/tags/<tag>` reports kills every run at startup — zero jobs, no logs, just *"This run likely failed because of a workflow file issue"*.

That is #12152, which broke `main` until #12153 repinned the dereferenced commit. It got through local review because `git show <tagobj>:path` and `git rev-parse` both dereference annotated tags **transparently**: the YAML parsed, the content was correct, and only GitHub's resolver disagreed.

`.github/validate-action-pin.sh` discriminates with `git/commits/<sha>`, which 404s for a tag object — deliberately not `git/refs`, which would reintroduce the same ambiguity. Verified against the exact SHA that broke main:

```
$ ACTION_PIN_WORKFLOW=ci-tagpin.yml bash .github/validate-action-pin.sh
::error::action-pin: Extra-Chill/homeboy-action@a6ff2f5d... is an ANNOTATED TAG object,
not a commit (commit -> 82033fe6...). `uses:` cannot resolve it and CI will fail at
startup with zero jobs. Pin the dereferenced commit 82033fe6... instead.
EXIT=1
```

It names the correct replacement. Wired into `Required Gates Declaration`. An unreadable ref is reported `unverified` and never treated as valid; only a positively identified tag object fails the build.

## Verification

- `cargo check --workspace --tests -j2` — clean
- `cargo test --test required_gates_policy_test` — **18 passed**, including 2 new offline tests for the pin validator's parser
- `cargo test --test pr_ci_lifecycle_test` — 3 passed

The `E0433` this gate exists for showed up on the first run (I referenced a `TempDir` that is named `Scratch` here), which is a decent argument for the gate.

Network paths in the pin validator are exercised by the `Required Gates Declaration` job itself rather than by tests, so no test needs a token.

Refs #10997