### PR TITLE
Expose installed recipe provider inventory

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -523,6 +523,8 @@ pub(super) enum RunnerCommand {
         #[arg(long = "run-id")]
         run_id: String,
     },
+    /// List installed extension-owned recipe-run providers.
+    RecipeProviders,
     /// Show the effective environment injected into runner jobs
     Env {
         /// Runner ID
@@ -830,5 +832,53 @@ mod tests {
             "homeboy", "runner", "job", "list", "lab", "--active", "--queued"
         ])
         .is_err());
+    }
+
+    #[test]
+    fn recipe_run_preserves_required_execution_arguments_and_recipe_providers_is_a_sibling() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "runner",
+            "recipe-run",
+            "local",
+            "--provider",
+            "fixture.run",
+            "--sync-workspace",
+            "/workspace",
+            "--recipe",
+            "recipe.json",
+            "--artifacts",
+            "artifacts",
+            "--run-id",
+            "run-12157",
+        ])
+        .expect("existing recipe-run invocation parses");
+        assert!(matches!(
+            cli.command,
+            Commands::Runner(RunnerArgs {
+                command: RunnerCommand::RecipeRun {
+                    runner_id,
+                    provider,
+                    ..
+                }
+            }) if runner_id == "local" && provider == "fixture.run"
+        ));
+
+        let cli = Cli::try_parse_from(["homeboy", "runner", "recipe-providers"])
+            .expect("provider inventory parses");
+        assert!(matches!(
+            cli.command,
+            Commands::Runner(RunnerArgs {
+                command: RunnerCommand::RecipeProviders
+            })
+        ));
+
+        let error = match Cli::try_parse_from(["homeboy", "runner", "recipe-run", "local"]) {
+            Ok(_) => panic!("normal recipe-run remains required"),
+            Err(error) => error,
+        };
+        let rendered = error.to_string();
+        assert!(rendered.contains("--provider"));
+        assert!(!rendered.contains("--runner_id"));
     }
 }

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -11,7 +11,7 @@ use super::cli::{RunnerArgs, RunnerCommand};
 use super::exec::exec_with_hydration;
 use super::jobs::RunnerJobCommandOutput;
 use super::registry::{add, connect, enable, list, remove, set, show, RunnerAddInput};
-use super::types::{RunnerCommandOutput, RunnerEnvOutput, RunnerOutput};
+use super::types::{RecipeRunProvidersOutput, RunnerCommandOutput, RunnerEnvOutput, RunnerOutput};
 use super::{
     doctor, env as env_mod, jobs, lifecycle, policy, refresh_plan, registry, status as status_mod,
     workspace,
@@ -289,6 +289,14 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             raw,
             command,
             extension_env_providers,
+        )),
+        RunnerCommand::RecipeProviders => Ok((
+            RunnerCommandOutput::RecipeRunProviders(Box::new(RecipeRunProvidersOutput {
+                variant: "recipe_run_providers",
+                command: "list",
+                providers: homeboy_extension::recipe_run_provider_inventory(),
+            })),
+            0,
         )),
         RunnerCommand::RecipeRun {
             runner_id,
@@ -1000,6 +1008,25 @@ fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerC
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recipe_run_provider_inventory_has_typed_command_output() {
+        homeboy::test_support::with_isolated_home(|_| {
+            let (output, exit_code) = run(RunnerArgs {
+                command: RunnerCommand::RecipeProviders,
+            })
+            .expect("inventory output");
+            assert_eq!(exit_code, 0);
+            assert_eq!(
+                serde_json::to_value(output).expect("serialize output"),
+                serde_json::json!({
+                    "variant": "recipe_run_providers",
+                    "command": "list",
+                    "providers": []
+                })
+            );
+        });
+    }
 
     #[test]
     fn refresh_failure_maps_parent_run_job_evidence_and_recovery_actions() {

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -351,6 +351,7 @@ pub enum RunnerCommandOutput {
     Preflight(Box<homeboy::runner::runners::PlacementReadiness>),
     Execution(Box<RunnerExecutionCommandOutput>),
     Env(Box<RunnerEnvOutput>),
+    RecipeRunProviders(Box<RecipeRunProvidersOutput>),
     Lifecycle(Box<lifecycle::RunnerLifecycleOutput>),
     JobList(Box<RunnerJobListOutput>),
     Job(Box<RunnerJobOutput>),
@@ -362,6 +363,13 @@ pub enum RunnerCommandOutput {
     Workspace(Box<workspace::RunnerWorkspaceOutput>),
     RefreshPlan(Box<refresh_plan::LabRefreshPlanOutput>),
     Broker(Box<RunnerBrokerOutput>),
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecipeRunProvidersOutput {
+    pub variant: &'static str,
+    pub command: &'static str,
+    pub providers: Vec<homeboy_extension::RecipeRunProviderInventoryEntry>,
 }
 
 /// An authoritative job observation or a retained generation ownership record.

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -138,7 +138,8 @@ pub use manifest::{
     EXTENSION_MATERIALIZATION_SOURCE_SCHEMA, NOTIFICATION_TRANSPORT_SCHEMA,
 };
 pub use recipe_run::{
-    recipe_run_providers, resolve_recipe_run_provider, RecipeRunProviderDescriptor,
+    recipe_run_provider_inventory, recipe_run_providers, resolve_recipe_run_provider,
+    RecipeRunProviderDescriptor, RecipeRunProviderInventoryEntry, RecipeRunProviderValidation,
     RecipeRunRequest,
 };
 pub use refactor_protocol::{

--- a/crates/homeboy-extension/src/recipe_run.rs
+++ b/crates/homeboy-extension/src/recipe_run.rs
@@ -3,6 +3,9 @@
 use homeboy_core::error::{Error, Result};
 
 use crate::manifest::ExtensionManifest;
+use crate::DiscoveredExtension;
+
+const AVAILABLE_ID_LIMIT: usize = 20;
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct RecipeRunProviderDescriptor {
@@ -18,6 +21,40 @@ pub struct RecipeRunRequest {
     pub artifact_path: String,
 }
 
+/// One installed extension declaration as surfaced by recipe-run diagnostics.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct RecipeRunProviderInventoryEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub owning_extension: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
+    /// True only when this installed declaration is structurally resolvable.
+    /// Executable readiness remains runner-specific and is unprobed here.
+    pub resolvable: bool,
+    pub validation: RecipeRunProviderValidation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecipeRunProviderValidation {
+    Valid,
+    Invalid,
+    Duplicate,
+}
+
+#[derive(Debug, Clone)]
+struct DiscoveredProvider {
+    entry: RecipeRunProviderInventoryEntry,
+    descriptor: Option<RecipeRunProviderDescriptor>,
+}
+
 /// Read recipe-run descriptors from an installed extension manifest.
 pub fn recipe_run_providers(manifest: &ExtensionManifest) -> Vec<RecipeRunProviderDescriptor> {
     manifest
@@ -28,22 +65,71 @@ pub fn recipe_run_providers(manifest: &ExtensionManifest) -> Vec<RecipeRunProvid
         .unwrap_or_default()
 }
 
+/// List every installed recipe-run declaration, including malformed entries.
+pub fn recipe_run_provider_inventory() -> Vec<RecipeRunProviderInventoryEntry> {
+    let mut providers = discover_recipe_run_providers();
+    let duplicate_ids = providers
+        .iter()
+        .filter_map(|provider| provider.entry.id.as_deref())
+        .fold(std::collections::BTreeMap::new(), |mut counts, id| {
+            *counts.entry(id.to_string()).or_insert(0usize) += 1;
+            counts
+        });
+    for provider in &mut providers {
+        if provider.entry.validation == RecipeRunProviderValidation::Valid
+            && provider
+                .entry
+                .id
+                .as_ref()
+                .is_some_and(|id| duplicate_ids.get(id).copied().unwrap_or_default() > 1)
+        {
+            provider.entry.resolvable = false;
+            provider.entry.validation = RecipeRunProviderValidation::Duplicate;
+            provider.entry.diagnostic =
+                Some("Multiple installed extensions declare this provider ID.".to_string());
+        }
+    }
+    providers
+        .into_iter()
+        .map(|provider| provider.entry)
+        .collect()
+}
+
 /// Discover one installed extension-owned provider by its stable ID.
 pub fn resolve_recipe_run_provider(id: &str) -> Result<RecipeRunProviderDescriptor> {
-    let matches = crate::load_all_extensions()?
-        .into_iter()
-        .flat_map(|manifest| recipe_run_providers(&manifest))
-        .filter(|provider| provider.id == id)
+    let inventory = recipe_run_provider_inventory();
+    let matches = inventory
+        .iter()
+        .filter(|provider| provider.id.as_deref() == Some(id))
         .collect::<Vec<_>>();
     match matches.as_slice() {
-        [provider] => validate_descriptor(provider.clone()),
-        [] => Err(Error::validation_invalid_argument(
+        [provider] if provider.validation == RecipeRunProviderValidation::Valid => {
+            discover_recipe_run_providers()
+                .into_iter()
+                .find(|candidate| candidate.entry.id.as_deref() == Some(id))
+                .and_then(|candidate| candidate.descriptor)
+                .ok_or_else(|| malformed_provider_error(id))
+        }
+        [] => {
+            let mut error = Error::validation_invalid_argument(
+                "provider",
+                format!("No installed extension declares recipe-run provider '{id}'"),
+                Some(id.to_string()),
+                None,
+            );
+            for hint in unknown_provider_hints(&inventory) {
+                error = error.with_hint(hint);
+            }
+            Err(error)
+        }
+        [provider] => Err(Error::validation_invalid_argument(
             "provider",
-            format!("No installed extension declares recipe-run provider '{id}'"),
+            format!(
+                "Installed recipe-run provider '{id}' is {}",
+                provider.validation_name()
+            ),
             Some(id.to_string()),
-            Some(vec![
-                "Install an extension manifest with recipe_run_providers.".to_string(),
-            ]),
+            None,
         )),
         _ => Err(Error::validation_invalid_argument(
             "provider",
@@ -52,6 +138,88 @@ pub fn resolve_recipe_run_provider(id: &str) -> Result<RecipeRunProviderDescript
             None,
         )),
     }
+}
+
+impl RecipeRunProviderInventoryEntry {
+    fn validation_name(&self) -> &'static str {
+        match self.validation {
+            RecipeRunProviderValidation::Valid => "valid",
+            RecipeRunProviderValidation::Invalid => "invalid",
+            RecipeRunProviderValidation::Duplicate => "declared more than once",
+        }
+    }
+}
+
+fn discover_recipe_run_providers() -> Vec<DiscoveredProvider> {
+    let mut providers = crate::discover_extensions()
+        .into_iter()
+        .flat_map(|extension| match extension {
+            DiscoveredExtension::Valid(manifest) => declarations_from_manifest(&manifest),
+            DiscoveredExtension::Invalid(_) => Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    providers.sort_by(|left, right| {
+        (&left.entry.id, &left.entry.owning_extension)
+            .cmp(&(&right.entry.id, &right.entry.owning_extension))
+    });
+    providers
+}
+
+fn declarations_from_manifest(manifest: &ExtensionManifest) -> Vec<DiscoveredProvider> {
+    let Some(value) = manifest.extra.get("recipe_run_providers") else {
+        return Vec::new();
+    };
+    let source_ref = manifest.extension_path.clone();
+    let declarations = value
+        .as_array()
+        .cloned()
+        .unwrap_or_else(|| vec![value.clone()]);
+    declarations
+        .into_iter()
+        .map(|value| {
+            let id = value.get("id").and_then(serde_json::Value::as_str).map(str::to_string);
+            let version = value.get("version").and_then(serde_json::Value::as_str).map(str::to_string);
+            let executable = value.get("executable").and_then(serde_json::Value::as_str).map(str::to_string);
+            let descriptor = serde_json::from_value::<RecipeRunProviderDescriptor>(value);
+            match descriptor
+                .ok()
+                .and_then(|descriptor| validate_descriptor(descriptor).ok())
+            {
+                Some(descriptor) => DiscoveredProvider {
+                    entry: RecipeRunProviderInventoryEntry { id, version, owning_extension: manifest.id.clone(), source_ref: source_ref.clone(), executable, resolvable: true, validation: RecipeRunProviderValidation::Valid, diagnostic: None },
+                    descriptor: Some(descriptor),
+                },
+                None => DiscoveredProvider {
+                    entry: RecipeRunProviderInventoryEntry { id, version, owning_extension: manifest.id.clone(), source_ref: source_ref.clone(), executable, resolvable: false, validation: RecipeRunProviderValidation::Invalid, diagnostic: Some("Provider requires id, version, executable, and argv beginning with executable.".to_string()) },
+                    descriptor: None,
+                },
+            }
+        })
+        .collect()
+}
+
+fn malformed_provider_error(id: &str) -> Error {
+    Error::validation_invalid_argument(
+        "provider",
+        format!("Installed recipe-run provider '{id}' is invalid"),
+        Some(id.to_string()),
+        None,
+    )
+}
+
+fn unknown_provider_hints(inventory: &[RecipeRunProviderInventoryEntry]) -> Vec<String> {
+    let available = inventory
+        .iter()
+        .filter(|provider| provider.resolvable)
+        .filter_map(|provider| provider.id.as_deref())
+        .take(AVAILABLE_ID_LIMIT)
+        .collect::<Vec<_>>();
+    let mut hints =
+        vec!["Run 'homeboy runner recipe-providers' to inspect installed providers.".to_string()];
+    if !available.is_empty() {
+        hints.push(format!("Available provider IDs: {}", available.join(", ")));
+    }
+    hints
 }
 
 impl RecipeRunProviderDescriptor {
@@ -160,6 +328,78 @@ mod tests {
                     "--artifacts",
                     "artifacts"
                 ]
+            );
+        });
+    }
+
+    #[test]
+    fn inventories_valid_invalid_and_duplicate_declarations() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("extension source");
+            std::fs::write(
+                source.path().join("fixture.json"),
+                serde_json::json!({
+                    "name": "Recipe fixture",
+                    "version": "1.0.0",
+                    "recipe_run_providers": [
+                        { "id": "fixture.valid", "version": "1.0.0", "executable": "fixture-run", "command": ["fixture-run"] },
+                        { "id": "fixture.invalid", "version": "1.0.0", "executable": "fixture-run", "command": ["other-run"] },
+                        { "id": "fixture.duplicate", "version": "1.0.0", "executable": "fixture-run", "command": ["fixture-run"] }
+                    ]
+                })
+                .to_string(),
+            )
+            .expect("manifest");
+            crate::install(&source.path().display().to_string(), Some("fixture")).expect("install");
+            let duplicate_source = tempfile::tempdir().expect("duplicate extension source");
+            std::fs::write(
+                duplicate_source.path().join("duplicate.json"),
+                serde_json::json!({
+                    "name": "Duplicate fixture", "version": "1.0.0",
+                    "recipe_run_providers": [{ "id": "fixture.duplicate", "version": "1.0.0", "executable": "fixture-run", "command": ["fixture-run"] }]
+                })
+                .to_string(),
+            )
+            .expect("duplicate manifest");
+            crate::install(
+                &duplicate_source.path().display().to_string(),
+                Some("duplicate"),
+            )
+            .expect("install duplicate");
+
+            let inventory = recipe_run_provider_inventory();
+            assert_eq!(inventory.len(), 4);
+            assert!(inventory
+                .iter()
+                .any(|provider| provider.id.as_deref() == Some("fixture.valid")
+                    && provider.resolvable));
+            assert!(inventory
+                .iter()
+                .any(|provider| provider.id.as_deref() == Some("fixture.invalid")
+                    && provider.validation == RecipeRunProviderValidation::Invalid));
+            assert_eq!(
+                inventory
+                    .iter()
+                    .filter(
+                        |provider| provider.id.as_deref() == Some("fixture.duplicate")
+                            && provider.validation == RecipeRunProviderValidation::Duplicate
+                    )
+                    .count(),
+                2
+            );
+            assert!(resolve_recipe_run_provider("fixture.duplicate").is_err());
+        });
+    }
+
+    #[test]
+    fn unknown_provider_diagnostic_has_inventory_command_and_bounded_ids() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let error =
+                resolve_recipe_run_provider("fixture.missing").expect_err("missing provider");
+            let hints = error.hints;
+            assert_eq!(
+                hints[0].message,
+                "Run 'homeboy runner recipe-providers' to inspect installed providers."
             );
         });
     }

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -913,6 +913,20 @@ validated workspace-relative paths without shell parsing. Homeboy discovers thes
 descriptors from installed extensions at execution time; product extensions can
 therefore supply providers without being linked into the Homeboy binary.
 
+Inspect the installed provider inventory before dispatching:
+
+```sh
+homeboy runner recipe-providers
+```
+
+The JSON output lists each declaration's provider ID and version, owning extension,
+installed source reference, executable, structural `resolvable` state, and validation
+state. `resolvable` does not probe executable readiness on a selected runner; execution
+uses the normal runner preflight path. Invalid and duplicate declarations remain visible
+but unresolvable; `recipe-run` fails closed for either.
+Unknown provider errors include this exact inventory command and a bounded list of
+available provider IDs.
+
 `--script-file <path>` reads the controller-side source, then materializes it as a private, content-addressed `script-<sha256>.sh` under `${XDG_RUNTIME_DIR:-/tmp}/homeboy-runner-exec/<job-id>/` on the runner. Bash executes that file directly, so `$0` is its runner path. The job exports `HOMEBOY_RUNNER_EXEC_SCRIPT` with the same path and `HOMEBOY_RUNNER_EXEC_SCRIPT_SHA256` as `sha256:<digest>`; the wrapper records the digest in its durable command evidence, makes the file mode `0500`, and removes it when the runner job exits.
 
 `--script-file -` reads stdin verbatim on the controller with the same bounded capture and materialization behavior; it does not stream stdin through `bash -s`. Zero-byte stdin is a validation error before Homeboy builds or submits a runner execution plan. Whitespace-only stdin is valid and is materialized verbatim, including newlines.


### PR DESCRIPTION
## Summary

- add generic `homeboy runner recipe-providers` inventory
- report provider ID, version, owning extension, source ref, executable, structural resolvability, and validation state
- expose malformed and duplicate declarations while keeping them unresolvable
- include the exact inventory command and bounded available IDs in unknown-provider diagnostics
- preserve the existing required `runner recipe-run` parser and argv-only execution

Fixes #12157.

## Verification

- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-extension recipe_run --lib` (4 passed)
- `cargo test -p homeboy-cli recipe_run_preserves_required_execution_arguments --lib` (1 passed)
- `cargo test -p homeboy-cli recipe_run_provider_inventory --lib` (1 passed)
- `cargo fmt --check`
- `git diff --check`

## Compatibility

The existing recipe execution syntax and fail-closed duplicate behavior are unchanged. Inventory is additive and explicitly distinguishes structural resolution from runner-specific executable readiness.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the missing provider inventory, directed and reviewed a direct general coding subagent, simplified the CLI design to preserve parser compatibility, and ran verification. Chris Huber reviewed the resulting diff and remains responsible for every line.