### PR TITLE
fix(upgrade): never suggest an unrunnable extension recovery command

### DIFF
--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -375,6 +375,7 @@ mod tests {
             restart_required: false,
             extensions_updated: Vec::new(),
             extensions_skipped: Vec::new(),
+            extension_skips: Vec::new(),
             runners_updated: Vec::new(),
             runners_skipped: Vec::new(),
             extensions_unrefreshed: Vec::new(),

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -104,8 +104,9 @@ pub use homeboy_extension_contract::{DeployArchiveInstallPolicy, DeployRequiredH
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::source_metadata::{resolve_source_url, resolve_source_url_read_only};
 pub use lifecycle::{
-    derive_id_from_url, install, install_for_component, install_with_revision, refresh, slugify_id,
-    uninstall, update, InstallForComponentResult, InstallResult, RefreshResult, UpdateResult,
+    derive_id_from_url, extension_update_dirty_paths, install, install_for_component,
+    install_with_revision, refresh, slugify_id, uninstall, update, InstallForComponentResult,
+    InstallResult, RefreshResult, UpdateResult,
 };
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{

--- a/crates/homeboy-extension/src/lifecycle/mod.rs
+++ b/crates/homeboy-extension/src/lifecycle/mod.rs
@@ -333,9 +333,9 @@ mod update;
 pub use homeboy_core::extension_update_check::{read_source_revision, read_source_url};
 #[cfg(test)]
 use update::is_extension_update_workdir_clean;
-pub use update::update;
 pub(crate) use update::write_requested_source_ref;
 pub(crate) use update::write_source_metadata;
+pub use update::{extension_update_dirty_paths, update};
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.
 /// - Symlinked extensions: removes symlink only (source preserved)
@@ -1065,7 +1065,7 @@ exec '{}' "$@"
             .expect("source revision metadata");
 
         assert!(
-            is_extension_update_workdir_clean(repo, &extension_dir),
+            is_extension_update_workdir_clean(repo, &extension_dir).is_ok(),
             "generated extension metadata should not block update"
         );
     }
@@ -1087,9 +1087,12 @@ exec '{}' "$@"
         .expect("source url metadata");
         fs::write(extension_dir.join("notes.txt"), "user work").expect("user-authored dirty file");
 
+        let dirty_paths = is_extension_update_workdir_clean(repo, &extension_dir)
+            .expect_err("user-authored dirt should still block update");
         assert!(
-            !is_extension_update_workdir_clean(repo, &extension_dir),
-            "user-authored dirt should still block update"
+            dirty_paths.iter().any(|path| path == "wordpress/notes.txt"),
+            "the gate must name the offending paths, got {:?}",
+            dirty_paths
         );
     }
 

--- a/crates/homeboy-extension/src/lifecycle/update.rs
+++ b/crates/homeboy-extension/src/lifecycle/update.rs
@@ -32,13 +32,19 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         return update_linked_extension(extension_id, &extension_dir, force);
     }
 
-    if !force && !is_extension_update_workdir_clean(&extension_dir, &extension_dir) {
-        return Err(Error::validation_invalid_argument(
-            "extension_id",
-            "Extension has uncommitted changes; update may overwrite them. Use --force to proceed.",
-            Some(extension_id.to_string()),
-            None,
-        ));
+    if !force {
+        if let Err(dirty_paths) = is_extension_update_workdir_clean(&extension_dir, &extension_dir)
+        {
+            return Err(Error::validation_invalid_argument(
+                "extension_id",
+                format!(
+                    "Extension has uncommitted changes ({}); update may overwrite them. Use --force to proceed, which applies the update over the listed changes.",
+                    dirty_path_detail(&dirty_paths),
+                ),
+                Some(extension_id.to_string()),
+                None,
+            ));
+        }
     }
 
     let source = source_metadata::resolve_source_url(extension_id)?;
@@ -174,9 +180,32 @@ pub(crate) fn read_source_requested_ref(extension_dir: &Path) -> Option<String> 
     homeboy_core::extension_update_check::read_source_metadata_value(extension_dir, "requested-ref")
 }
 
-pub(crate) fn is_extension_update_workdir_clean(git_root: &Path, extension_dir: &Path) -> bool {
+/// The extension update gate. `Ok(())` when the worktree holds nothing an
+/// update would overwrite; `Err(dirty_paths)` names the repo-relative paths
+/// that block it. An unreadable git status also refuses (with no names) so an
+/// update never proceeds over unknown state. Only generated metadata Homeboy
+/// itself writes (`.source-url`, `.source-revision`) is tolerated.
+pub(crate) fn is_extension_update_workdir_clean(
+    git_root: &Path,
+    extension_dir: &Path,
+) -> std::result::Result<(), Vec<String>> {
+    match extension_update_dirty_paths(git_root, extension_dir) {
+        Some(paths) if paths.is_empty() => Ok(()),
+        Some(paths) => Err(paths),
+        None => Err(Vec::new()),
+    }
+}
+
+/// Repo-relative paths with changes an extension update would overwrite,
+/// ignoring the generated metadata paths Homeboy itself writes
+/// (`.source-url`, `.source-revision`). `Some` when the worktree state is
+/// known (empty means clean enough to refresh); `None` when it cannot be
+/// determined. Public so the upgrade path can reuse the exact gate tolerance
+/// when deciding whether a symlinked clone can be refreshed with a plain
+/// `pull --ff-only` (#12181).
+pub fn extension_update_dirty_paths(git_root: &Path, extension_dir: &Path) -> Option<Vec<String>> {
     if !git::is_git_repo(&git_root.to_string_lossy()) {
-        return true;
+        return Some(Vec::new());
     }
 
     let Ok(output) = Command::new("git")
@@ -184,10 +213,10 @@ pub(crate) fn is_extension_update_workdir_clean(git_root: &Path, extension_dir: 
         .current_dir(git_root)
         .output()
     else {
-        return false;
+        return None;
     };
     if !output.status.success() {
-        return false;
+        return None;
     }
 
     let extension_rel = extension_dir
@@ -196,11 +225,12 @@ pub(crate) fn is_extension_update_workdir_clean(git_root: &Path, extension_dir: 
         .map(|path| path.to_string_lossy().replace('\\', "/"));
     let status = String::from_utf8_lossy(&output.stdout);
 
-    status.lines().all(|line| {
-        dirty_path_from_status_line(line).is_some_and(|path| {
-            is_generated_extension_metadata_path(&path, extension_rel.as_deref())
-        })
-    })
+    let dirty = status
+        .lines()
+        .filter_map(dirty_path_from_status_line)
+        .filter(|path| !is_generated_extension_metadata_path(path, extension_rel.as_deref()))
+        .collect();
+    Some(dirty)
 }
 
 fn dirty_path_from_status_line(line: &str) -> Option<String> {
@@ -210,6 +240,17 @@ fn dirty_path_from_status_line(line: &str) -> Option<String> {
         .map(|(_, new_path)| new_path)
         .unwrap_or(path);
     Some(path.trim_matches('"').replace('\\', "/"))
+}
+
+/// Human detail for the dirty paths blocking an update. Falls back to an
+/// explicit "cannot be verified" when the gate refused without names (e.g. git
+/// status unavailable), so the message never names an empty list.
+fn dirty_path_detail(dirty_paths: &[String]) -> String {
+    if dirty_paths.is_empty() {
+        "state could not be verified".to_string()
+    } else {
+        dirty_paths.join(", ")
+    }
 }
 
 fn is_generated_extension_metadata_path(path: &str, extension_rel: Option<&str>) -> bool {
@@ -273,16 +314,20 @@ fn update_linked_extension(
         )),
         None => {
             let result = (|| {
-                if !force && !is_extension_update_workdir_clean(&git_root, &source_dir) {
-                    return Err(Error::validation_invalid_argument(
-                        "extension_id",
-                        format!(
-                            "Linked extension source repo has uncommitted changes for {}. Use --force to proceed.",
-                            extension_id,
-                        ),
-                        Some(extension_id.to_string()),
-                        None,
-                    ));
+                if !force {
+                    if let Err(dirty_paths) = is_extension_update_workdir_clean(&git_root, &source_dir)
+                    {
+                        return Err(Error::validation_invalid_argument(
+                            "extension_id",
+                            format!(
+                                "Linked extension source repo has uncommitted changes for {}: {}. Use --force to proceed, which applies the update over the listed changes.",
+                                extension_id,
+                                dirty_path_detail(&dirty_paths),
+                            ),
+                            Some(extension_id.to_string()),
+                            None,
+                        ));
+                    }
                 }
 
                 git::update_to_remote_default_branch(&git_root)?;

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -253,7 +253,7 @@ pub fn run_upgrade_with_method(
             check.update_available,
         ) {
             // Even when no binary update is needed, still run extension updates.
-            let (extensions_updated, extensions_skipped) = if skip_extensions {
+            let (extensions_updated, extension_skips) = if skip_extensions {
                 (vec![], vec![])
             } else {
                 update_all_extensions()
@@ -285,6 +285,12 @@ pub fn run_upgrade_with_method(
                 &runners_skipped,
                 Some(previous_version.as_str()),
             );
+            let extensions_status = extension_component_status(
+                !skip_extensions,
+                skip_extensions,
+                &extensions_updated,
+                &extension_skips,
+            );
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
@@ -296,29 +302,42 @@ pub fn run_upgrade_with_method(
                 upgraded: false,
                 outcome: Some("controller_unchanged".to_string()),
                 controller: Some(component_status("unchanged", "controller already current")),
-                extensions: Some(extension_component_status(!skip_extensions, skip_extensions, &extensions_updated, &extensions_skipped)),
-                runners: Some(runner_component_status(runner_disposition, &runners_updated, &runners_skipped, false)),
+                extensions: Some(extensions_status.clone()),
+                runners: Some(runner_component_status(
+                    runner_disposition,
+                    &runners_updated,
+                    &runners_skipped,
+                    false,
+                )),
                 partial,
                 runner_convergence: Some(runner_disposition),
-                message: match runner_disposition {
-                    RunnerConvergenceDisposition::Partial => {
-                        "PARTIAL: controller is already current, but configured runners did not converge"
-                            .to_string()
-                    }
-                    RunnerConvergenceDisposition::Skipped => {
-                        "Already at latest version; runner convergence skipped".to_string()
-                    }
-                    RunnerConvergenceDisposition::NoRunnersConfigured => {
-                        "Already at latest version; no configured runners".to_string()
-                    }
-                    RunnerConvergenceDisposition::Converged => {
-                        "Already at latest version; configured runners converged".to_string()
-                    }
-                },
+                message: format!(
+                    "{}{}",
+                    match runner_disposition {
+                        RunnerConvergenceDisposition::Partial => {
+                            "PARTIAL: controller is already current, but configured runners did not converge"
+                                .to_string()
+                        }
+                        RunnerConvergenceDisposition::Skipped => {
+                            "Already at latest version; runner convergence skipped".to_string()
+                        }
+                        RunnerConvergenceDisposition::NoRunnersConfigured => {
+                            "Already at latest version; no configured runners".to_string()
+                        }
+                        RunnerConvergenceDisposition::Converged => {
+                            "Already at latest version; configured runners converged".to_string()
+                        }
+                    },
+                    extension_partial_clause(Some(&extensions_status)),
+                ),
                 restart_required: false,
                 extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
                 extensions_updated,
-                extensions_skipped,
+                extensions_skipped: extension_skips
+                    .iter()
+                    .map(|skip| skip.extension_id.clone())
+                    .collect(),
+                extension_skips,
                 runners_updated,
                 runners_skipped,
                 // No binary swap happened, so resident services already run the
@@ -388,7 +407,7 @@ pub fn run_upgrade_with_method(
     // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
-    let (extensions_updated, extensions_skipped) = if upgrade_completed && !skip_extensions {
+    let (extensions_updated, extension_skips) = if upgrade_completed && !skip_extensions {
         upgrade_phase("refreshing installed extensions");
         update_all_extensions()
     } else {
@@ -428,6 +447,13 @@ pub fn run_upgrade_with_method(
         new_version.as_deref(),
     );
 
+    let extensions_status = extension_component_status(
+        upgrade_completed,
+        skip_extensions,
+        &extensions_updated,
+        &extension_skips,
+    );
+
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
@@ -446,12 +472,7 @@ pub fn run_upgrade_with_method(
                 "controller installation did not complete"
             },
         )),
-        extensions: Some(extension_component_status(
-            upgrade_completed,
-            skip_extensions,
-            &extensions_updated,
-            &extensions_skipped,
-        )),
+        extensions: Some(extensions_status.clone()),
         runners: Some(runner_component_status(
             runner_disposition,
             &runners_updated,
@@ -471,6 +492,7 @@ pub fn run_upgrade_with_method(
             runner_disposition,
             &runners_updated,
             &runners_skipped,
+            Some(&extensions_status),
         ),
         // Source replacement updates the on-disk executable, but this command
         // exits immediately afterwards. Re-execing only `--version` skips the
@@ -478,7 +500,11 @@ pub fn run_upgrade_with_method(
         restart_required: false,
         extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
         extensions_updated,
-        extensions_skipped,
+        extensions_skipped: extension_skips
+            .iter()
+            .map(|skip| skip.extension_id.clone())
+            .collect(),
+        extension_skips,
         runners_updated,
         runners_skipped,
         services_restarted,
@@ -515,6 +541,7 @@ fn source_upgrade_noop_result(
         restart_required: false,
         extensions_updated: Vec::new(),
         extensions_skipped: Vec::new(),
+        extension_skips: Vec::new(),
         runners_updated: Vec::new(),
         runners_skipped: Vec::new(),
         extensions_unrefreshed: Vec::new(),
@@ -568,6 +595,7 @@ fn runner_preflight_failure_result(
         restart_required: false,
         extensions_updated: Vec::new(),
         extensions_skipped: Vec::new(),
+        extension_skips: Vec::new(),
         runners_updated: Vec::new(),
         runners_skipped,
         extensions_unrefreshed: Vec::new(),
@@ -886,6 +914,7 @@ fn run_targeted_runner_upgrade(
         restart_required: false,
         extensions_updated: Vec::new(),
         extensions_skipped: Vec::new(),
+        extension_skips: Vec::new(),
         runners_updated,
         runners_skipped,
         extensions_unrefreshed: Vec::new(),
@@ -905,7 +934,7 @@ fn extension_component_status(
     attempted: bool,
     skipped_by_flag: bool,
     updated: &[ExtensionUpgradeEntry],
-    skipped: &[String],
+    skipped: &[ExtensionUpgradeSkip],
 ) -> UpgradeComponentStatus {
     let status = if skipped_by_flag {
         "skipped"
@@ -916,10 +945,25 @@ fn extension_component_status(
     } else {
         "partial"
     };
-    component_status(
-        status,
-        &format!("{} updated, {} skipped", updated.len(), skipped.len()),
-    )
+    // A bare count buries a real failure: when anything was skipped, the
+    // summary carries each extension id with the reason it was skipped, so a
+    // `partial` extension outcome is self-explanatory (#12181).
+    let summary = if skipped.is_empty() {
+        format!("{} updated, {} skipped", updated.len(), skipped.len())
+    } else {
+        let detail = skipped
+            .iter()
+            .map(|skip| format!("{}: {}", skip.extension_id, skip.reason))
+            .collect::<Vec<_>>()
+            .join("; ");
+        format!(
+            "{} updated, {} skipped ({})",
+            updated.len(),
+            skipped.len(),
+            detail
+        )
+    };
+    component_status(status, &summary)
 }
 
 fn runner_component_status(
@@ -985,6 +1029,18 @@ fn runner_convergence_disposition(
     RunnerConvergenceDisposition::Converged
 }
 
+/// Human clause appended to the upgrade banner when extensions were only
+/// partially refreshed, so a real extension failure is prominent rather than a
+/// passing count after a success banner (#12181). Empty when the extension
+/// outcome is anything other than `partial` (deliberately skipped, not run,
+/// completed).
+fn extension_partial_clause(extensions: Option<&UpgradeComponentStatus>) -> String {
+    match extensions.filter(|status| status.status == "partial") {
+        Some(status) => format!(". EXTENSIONS PARTIAL: {}", status.summary),
+        None => String::new(),
+    }
+}
+
 fn upgrade_message(
     success: bool,
     new_version: Option<&str>,
@@ -992,18 +1048,18 @@ fn upgrade_message(
     disposition: RunnerConvergenceDisposition,
     updated: &[RunnerUpgradeEntry],
     skipped: &[RunnerUpgradeEntry],
+    extensions: Option<&UpgradeComponentStatus>,
 ) -> String {
     let controller = new_version.unwrap_or("unverified");
     let identity = new_build_identity
         .map(|identity| format!(" ({identity})"))
         .unwrap_or_default();
-    if disposition == RunnerConvergenceDisposition::Partial {
-        return format!(
+    let base = if disposition == RunnerConvergenceDisposition::Partial {
+        format!(
             "PARTIAL: controller upgraded to {controller}{identity}, but {} selected configured runner(s) did not converge",
             updated.len() + skipped.len()
-        );
-    }
-    if success {
+        )
+    } else if success {
         // Report the runner disposition honestly: an explicit skip is never
         // rendered as convergence, and a fleet with no configured runners is
         // distinguished from a verified convergence (#9842).
@@ -1017,6 +1073,15 @@ fn upgrade_message(
         format!("Upgrade command completed but active controller is still {controller}")
     } else {
         "Upgrade command completed but active controller version could not be verified".to_string()
+    };
+    let clause = extension_partial_clause(extensions);
+    if clause.is_empty() {
+        base
+    } else if base.ends_with('.') {
+        // Avoid a doubled period when the base already ends in one.
+        format!("{}{}", base.trim_end_matches('.'), clause)
+    } else {
+        format!("{base}{clause}")
     }
 }
 
@@ -1269,9 +1334,10 @@ pub(crate) fn should_sync_after_upgrade(new_version: Option<&str>) -> bool {
     new_version.is_some()
 }
 
-/// Update all installed extensions. Best-effort — failures are logged and
-/// the extension is added to the skipped list.
-fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
+/// Update all installed extensions. Best-effort — failures are logged, and the
+/// extension is added to the skipped list carrying its error reason so the
+/// structured result can say *why* it was skipped (#12181).
+fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeSkip>) {
     let extension_ids = extension::available_extension_ids();
     if extension_ids.is_empty() {
         return (vec![], vec![]);
@@ -1352,7 +1418,10 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
             }
             Err(e) => {
                 homeboy_core::log_status!("upgrade", "  {} skipped: {}", id, e.message);
-                skipped.push(id.clone());
+                skipped.push(ExtensionUpgradeSkip {
+                    extension_id: id.clone(),
+                    reason: e.message,
+                });
             }
         }
     }
@@ -1381,21 +1450,43 @@ fn warn_unrefreshed_symlinked_extensions(
     );
     homeboy_core::log_status!(
         "upgrade",
-        "  Extension resolution is $HOME-scoped, so a sudo upgrade only refreshes root's copies. Run each recovery command below to bring the symlinked clone(s) current:",
+        "  Extension resolution is $HOME-scoped, so a sudo upgrade only refreshes root's copies. Inspect each clone below and run the recovery command shown:",
     );
     for w in &warnings {
         let behind = w
             .behind
             .map(|n| format!("{} commit(s) behind", n))
             .unwrap_or_else(|| "behind upstream".to_string());
-        homeboy_core::log_status!(
-            "upgrade",
-            "  {} ({}) -> {}: {}",
-            w.extension_id,
-            behind,
-            w.source_path,
-            w.recovery_command,
-        );
+        if w.dirty {
+            let detail = if w.dirty_paths.is_empty() {
+                "worktree state could not be verified".to_string()
+            } else {
+                w.dirty_paths.join(", ")
+            };
+            homeboy_core::log_status!(
+                "upgrade",
+                "  {} ({}, BLOCKED by uncommitted changes: {}) -> {}: {}",
+                w.extension_id,
+                behind,
+                detail,
+                w.source_path,
+                w.recovery_command,
+            );
+            homeboy_core::log_status!(
+                "upgrade",
+                "  Resolve the uncommitted changes in the {} clone before refreshing; a `git pull --ff-only` cannot succeed while the checkout holds them.",
+                w.extension_id,
+            );
+        } else {
+            homeboy_core::log_status!(
+                "upgrade",
+                "  {} ({}) -> {}: {}",
+                w.extension_id,
+                behind,
+                w.source_path,
+                w.recovery_command,
+            );
+        }
     }
 
     warnings
@@ -1414,8 +1505,10 @@ fn warn_unrefreshed_symlinked_extensions(
 /// We do not refresh those clones here: they are owned by a different user and
 /// may carry dirty/unpushed state, so mutating them from a privileged process
 /// is unsafe. Instead we emit a loud, actionable warning with the exact
-/// recovery command. Returns an empty vec when not running under `sudo`, when
-/// the invoking user's config dir is absent, or when nothing is stale.
+/// recovery command. Detection is read-only: it may fetch and inspect, and it
+/// never resets, stashes, checks out, or otherwise mutates a worktree owned by
+/// another user. Returns an empty vec when not running under `sudo`, when the
+/// invoking user's config dir is absent, or when nothing is stale.
 fn detect_unrefreshed_symlinked_extensions(
     refreshed: &[ExtensionUpgradeEntry],
 ) -> Vec<UnrefreshedExtensionWarning> {
@@ -1434,7 +1527,18 @@ fn detect_unrefreshed_symlinked_extensions(
         .join(".config")
         .join(homeboy_product_identity::PRODUCT_IDENTITY.config_dirname)
         .join("extensions");
-    let Ok(entries) = std::fs::read_dir(&extensions_dir) else {
+    detect_unrefreshed_in_extensions_dir(&extensions_dir, &sudo_user, refreshed)
+}
+
+/// The symlink-scan half of [`detect_unrefreshed_symlinked_extensions`],
+/// separated so tests can drive detection against an isolated fixture dir
+/// instead of a real user's home (#12181).
+fn detect_unrefreshed_in_extensions_dir(
+    extensions_dir: &Path,
+    sudo_user: &str,
+    refreshed: &[ExtensionUpgradeEntry],
+) -> Vec<UnrefreshedExtensionWarning> {
+    let Ok(entries) = std::fs::read_dir(extensions_dir) else {
         return Vec::new();
     };
 
@@ -1481,17 +1585,36 @@ fn detect_unrefreshed_symlinked_extensions(
         // Only warn when we can confirm the clone is actually behind. If we
         // can't determine drift, stay quiet rather than crying wolf.
         if behind.is_some_and(|n| n > 0) {
+            // A `git pull --ff-only` is guaranteed to abort when the worktree
+            // holds uncommitted changes, so before emitting that recovery
+            // command check the same generated-metadata tolerance the update
+            // gate uses. A dirty clone is reported as blocked with its
+            // offending paths named; an unreadable status is treated as
+            // blocked rather than risking a command we cannot verify (#12181).
+            let dirty_paths = extension::extension_update_dirty_paths(&git_root, &target);
+            // Unknown status is blocked (like the update gate) rather than
+            // risking a recovery command we cannot verify.
+            let dirty = dirty_paths.as_ref().is_none_or(|paths| !paths.is_empty());
+            let dirty_paths = dirty_paths.unwrap_or_default();
             warnings.push(UnrefreshedExtensionWarning {
                 extension_id,
-                invoking_user: sudo_user.clone(),
+                invoking_user: sudo_user.to_string(),
                 symlink_path: symlink_path.to_string_lossy().to_string(),
                 source_path: git_root.to_string_lossy().to_string(),
                 behind,
-                recovery_command: format!(
-                    "sudo -u {} git -C {} pull --ff-only",
-                    sudo_user,
-                    git_root.display()
-                ),
+                dirty,
+                dirty_paths,
+                recovery_command: if dirty {
+                    // No single command can safely refresh a dirty clone; point
+                    // the user at the state they must resolve first.
+                    format!("sudo -u {} git -C {} status", sudo_user, git_root.display())
+                } else {
+                    format!(
+                        "sudo -u {} git -C {} pull --ff-only",
+                        sudo_user,
+                        git_root.display()
+                    )
+                },
             });
         }
     }
@@ -2325,6 +2448,109 @@ mod symlinked_extension_tests {
         let _guard = SudoUserGuard::set(Some("definitely-not-a-real-user-xyz"));
         assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
     }
+
+    fn git_fixture(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args(args)
+            .output()
+            .expect("run git fixture command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Build a local remote plus a clone of it that is exactly one commit
+    /// behind, and a second clone used only to advance the remote. Returns the
+    /// tempdir (kept alive by the caller) and the behind clone path.
+    fn behind_clone_fixture() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let remote = dir.path().join("remote.git");
+        git_fixture(
+            dir.path(),
+            &["init", "--bare", "-b", "main", &remote.to_string_lossy()],
+        );
+
+        let clone = dir.path().join("clone");
+        git_fixture(dir.path(), &["clone", &remote.to_string_lossy(), "clone"]);
+        git_fixture(&clone, &["config", "user.email", "test@example.com"]);
+        git_fixture(&clone, &["config", "user.name", "test"]);
+        std::fs::write(clone.join("wordpress.txt"), "initial").expect("write initial");
+        git_fixture(&clone, &["add", "-A"]);
+        git_fixture(&clone, &["commit", "-m", "initial"]);
+        git_fixture(&clone, &["push", "-u", "origin", "main"]);
+
+        let upstream = dir.path().join("upstream");
+        git_fixture(
+            dir.path(),
+            &["clone", &remote.to_string_lossy(), "upstream"],
+        );
+        git_fixture(&upstream, &["config", "user.email", "test@example.com"]);
+        git_fixture(&upstream, &["config", "user.name", "test"]);
+        std::fs::write(upstream.join("wordpress.txt"), "advanced").expect("write advanced");
+        git_fixture(&upstream, &["add", "-A"]);
+        git_fixture(&upstream, &["commit", "-m", "advance"]);
+        git_fixture(&upstream, &["push", "origin", "main"]);
+
+        (dir, clone)
+    }
+
+    #[test]
+    fn clean_behind_symlink_gets_pull_ff_only_recovery() {
+        let (dir, clone) = behind_clone_fixture();
+        let extensions_dir = dir.path().join("extensions");
+        std::fs::create_dir_all(&extensions_dir).expect("extensions dir");
+        std::os::unix::fs::symlink(&clone, extensions_dir.join("wordpress"))
+            .expect("symlink extension");
+
+        let warnings = detect_unrefreshed_in_extensions_dir(&extensions_dir, "alice", &[]);
+
+        assert_eq!(warnings.len(), 1);
+        let warning = &warnings[0];
+        assert_eq!(warning.extension_id, "wordpress");
+        assert!(!warning.dirty, "{:?}", warning);
+        assert!(warning.dirty_paths.is_empty(), "{:?}", warning);
+        assert!(
+            warning.recovery_command.contains("pull --ff-only"),
+            "{}",
+            warning.recovery_command
+        );
+    }
+
+    #[test]
+    fn dirty_behind_symlink_never_emits_pull_ff_only_and_names_paths() {
+        let (dir, clone) = behind_clone_fixture();
+        let extensions_dir = dir.path().join("extensions");
+        std::fs::create_dir_all(&extensions_dir).expect("extensions dir");
+        std::os::unix::fs::symlink(&clone, extensions_dir.join("wordpress"))
+            .expect("symlink extension");
+
+        // The user's clone holds an uncommitted change a pull would refuse to
+        // fast-forward over (#12181).
+        std::fs::write(clone.join("notes.txt"), "local edit").expect("write local edit");
+
+        let warnings = detect_unrefreshed_in_extensions_dir(&extensions_dir, "alice", &[]);
+
+        assert_eq!(warnings.len(), 1);
+        let warning = &warnings[0];
+        assert!(warning.dirty, "{:?}", warning);
+        assert_eq!(warning.dirty_paths, vec!["notes.txt".to_string()]);
+        assert!(
+            !warning.recovery_command.contains("pull --ff-only"),
+            "{}",
+            warning.recovery_command
+        );
+        assert!(
+            warning.recovery_command.contains(" status"),
+            "{}",
+            warning.recovery_command
+        );
+    }
 }
 
 #[cfg(test)]
@@ -2369,10 +2595,16 @@ mod convergence_tests {
             Some("0.304.0"),
         );
         assert_eq!(disposition, RunnerConvergenceDisposition::Partial);
-        assert!(
-            upgrade_message(true, Some("0.304.0"), None, disposition, &[runner], &[])
-                .starts_with("PARTIAL: controller upgraded to 0.304.0")
-        );
+        assert!(upgrade_message(
+            true,
+            Some("0.304.0"),
+            None,
+            disposition,
+            &[runner],
+            &[],
+            None
+        )
+        .starts_with("PARTIAL: controller upgraded to 0.304.0"));
     }
 
     #[test]
@@ -2380,7 +2612,7 @@ mod convergence_tests {
         // #9842: --skip-runners must never claim convergence.
         let disposition = runner_convergence_disposition(true, &[], &[], Some("0.310.0"));
         assert_eq!(disposition, RunnerConvergenceDisposition::Skipped);
-        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[]);
+        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[], None);
         assert!(message.contains("runner convergence skipped"), "{message}");
         assert!(!message.contains("converged"), "{message}");
     }
@@ -2392,7 +2624,7 @@ mod convergence_tests {
             disposition,
             RunnerConvergenceDisposition::NoRunnersConfigured
         );
-        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[]);
+        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[], &[], None);
         assert!(message.contains("no configured runners"), "{message}");
     }
 
@@ -2406,7 +2638,15 @@ mod convergence_tests {
             Some("0.310.0"),
         );
         assert_eq!(disposition, RunnerConvergenceDisposition::Converged);
-        let message = upgrade_message(true, Some("0.310.0"), None, disposition, &[runner], &[]);
+        let message = upgrade_message(
+            true,
+            Some("0.310.0"),
+            None,
+            disposition,
+            &[runner],
+            &[],
+            None,
+        );
         assert!(
             message.contains("configured runners converged"),
             "{message}"
@@ -2435,6 +2675,52 @@ mod convergence_tests {
             extension_component_status(true, false, &[], &[]).status,
             "completed"
         );
+    }
+
+    #[test]
+    fn extension_status_names_each_skip_reason_when_partial() {
+        let skips = vec![ExtensionUpgradeSkip {
+            extension_id: "wordpress".to_string(),
+            reason: "Linked extension source repo has uncommitted changes".to_string(),
+        }];
+        let status = extension_component_status(true, false, &[], &skips);
+        assert_eq!(status.status, "partial");
+        assert_eq!(
+            status.summary,
+            "0 updated, 1 skipped (wordpress: Linked extension source repo has uncommitted changes)"
+        );
+    }
+
+    #[test]
+    fn partial_extension_outcome_is_prominent_in_upgrade_message() {
+        let skips = vec![ExtensionUpgradeSkip {
+            extension_id: "wordpress".to_string(),
+            reason: "Linked extension source repo has uncommitted changes".to_string(),
+        }];
+        let status = extension_component_status(true, false, &[], &skips);
+        let message = upgrade_message(
+            true,
+            Some("0.310.0"),
+            None,
+            RunnerConvergenceDisposition::Converged,
+            &[],
+            &[],
+            Some(&status),
+        );
+        assert!(
+            message.ends_with(". EXTENSIONS PARTIAL: 0 updated, 1 skipped (wordpress: Linked extension source repo has uncommitted changes)"),
+            "{message}"
+        );
+        let plain = upgrade_message(
+            true,
+            Some("0.310.0"),
+            None,
+            RunnerConvergenceDisposition::Converged,
+            &[],
+            &[],
+            Some(&component_status("completed", "1 updated, 0 skipped")),
+        );
+        assert!(!plain.contains("EXTENSIONS PARTIAL"), "{plain}");
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -27,8 +27,9 @@ pub use release_catalog::{
 pub(crate) use runner_upgrade_provider::with_runner_upgrade;
 pub use runner_upgrade_provider::{register_runner_upgrade_provider, RunnerUpgradeProvider};
 pub use types::{
-    ExtensionUpgradeEntry, InstallMethod, RunnerDaemonDriftEntry, RunnerExtensionSyncEntry,
-    RunnerUpgradeEntry, ServiceRestartEntry, UpgradeComponentStatus, UpgradeResult, VersionCheck,
+    ExtensionUpgradeEntry, ExtensionUpgradeSkip, InstallMethod, RunnerDaemonDriftEntry,
+    RunnerExtensionSyncEntry, RunnerUpgradeEntry, ServiceRestartEntry, UpgradeComponentStatus,
+    UpgradeResult, VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -137,6 +137,12 @@ pub struct UpgradeResult {
     pub extensions_updated: Vec<ExtensionUpgradeEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extensions_skipped: Vec<String>,
+    /// Per-extension reason for each entry in `extensions_skipped`, alongside
+    /// the bare ids, so a `partial` extension outcome carries *why* the
+    /// extension was skipped instead of burying the reason in a log line
+    /// (#12181).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_skips: Vec<ExtensionUpgradeSkip>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runners_updated: Vec<RunnerUpgradeEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -183,6 +189,18 @@ pub struct ServiceRestartEntry {
     pub detail: Option<String>,
 }
 
+/// Why one extension was skipped during the upgrade, mirroring the per-runner
+/// `RunnerExtensionSyncEntry` detail pattern so a `partial` extension outcome
+/// carries its failure reason in the structured result rather than only in a
+/// log line (#12181).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionUpgradeSkip {
+    /// Extension id (e.g. `wordpress`).
+    pub extension_id: String,
+    /// The error message for why the extension was skipped.
+    pub reason: String,
+}
+
 /// A symlinked extension in the invoking user's config dir that a privileged
 /// (sudo) upgrade left stale, because extension resolution is `$HOME`-scoped
 /// and the privileged run only ever sees root's own extension copies.
@@ -199,7 +217,21 @@ pub struct UnrefreshedExtensionWarning {
     /// How many commits the clone is behind its upstream, if determinable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub behind: Option<u32>,
-    /// The exact command the user should run to refresh the clone.
+    /// True when the clone holds uncommitted changes (ignoring the generated
+    /// `.source-url`/`.source-revision` metadata) that would make the recovery
+    /// command fail. Lets a machine consumer distinguish "stale but
+    /// refreshable" from "stale and blocked". Omitted (`false`) for clean
+    /// clones so existing consumers and fixtures keep their shape (#12181).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub dirty: bool,
+    /// Repo-relative paths with the uncommitted changes blocking refresh. Only
+    /// populated when `dirty`, so it is omitted for clean clones.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dirty_paths: Vec<String>,
+    /// The exact command the user should run to bring the clone current. When
+    /// the clone is clean this is `git pull --ff-only`; a dirty clone cannot be
+    /// refreshed by any single command, so this names a read-only status
+    /// inspection and `dirty_paths` names what the user must resolve first.
     pub recovery_command: String,
 }
 
@@ -285,6 +317,91 @@ mod tests {
         assert!(!result.partial);
         assert!(result.runners_updated.is_empty());
         assert!(result.services_pending_restart.is_empty());
+        assert!(result.extension_skips.is_empty());
+    }
+
+    #[test]
+    fn extension_skip_reason_reaches_serialized_result() {
+        let mut result = UpgradeResult {
+            command: "upgrade".to_string(),
+            install_method: InstallMethod::Binary,
+            previous_version: "0.327.5".to_string(),
+            new_version: Some("0.338.0".to_string()),
+            previous_build_identity: None,
+            new_build_identity: None,
+            source_revision: None,
+            upgraded: true,
+            outcome: Some("controller_updated".to_string()),
+            controller: Some(UpgradeComponentStatus {
+                status: "updated".to_string(),
+                summary: "controller installation completed".to_string(),
+            }),
+            extensions: Some(UpgradeComponentStatus {
+                status: "partial".to_string(),
+                summary: "0 updated, 1 skipped (wordpress: Linked extension source repo has uncommitted changes)".to_string(),
+            }),
+            runners: None,
+            partial: false,
+            runner_convergence: None,
+            message: "Controller upgraded to 0.338.0".to_string(),
+            restart_required: false,
+            extensions_updated: Vec::new(),
+            extensions_skipped: vec!["wordpress".to_string()],
+            extension_skips: vec![ExtensionUpgradeSkip {
+                extension_id: "wordpress".to_string(),
+                reason: "Linked extension source repo has uncommitted changes".to_string(),
+            }],
+            runners_updated: Vec::new(),
+            runners_skipped: Vec::new(),
+            extensions_unrefreshed: Vec::new(),
+            services_restarted: Vec::new(),
+            services_pending_restart: Vec::new(),
+        };
+
+        let json = serde_json::to_value(&result).expect("upgrade result serializes");
+        assert_eq!(json["extension_skips"][0]["extension_id"], "wordpress");
+        assert_eq!(
+            json["extension_skips"][0]["reason"],
+            "Linked extension source repo has uncommitted changes"
+        );
+
+        result.extension_skips = Vec::new();
+        let json = serde_json::to_value(&result).expect("upgrade result serializes");
+        assert!(
+            json.get("extension_skips").is_none(),
+            "empty extension_skips is omitted for existing consumers"
+        );
+    }
+
+    #[test]
+    fn unrefreshed_warning_omits_dirty_fields_when_clean() {
+        let warning = UnrefreshedExtensionWarning {
+            extension_id: "wordpress".to_string(),
+            invoking_user: "opencode".to_string(),
+            symlink_path: "/home/opencode/.config/homeboy/extensions/wordpress".to_string(),
+            source_path: "/home/opencode/homeboy-extensions/source/wordpress".to_string(),
+            behind: Some(145),
+            dirty: false,
+            dirty_paths: Vec::new(),
+            recovery_command: "sudo -u opencode git -C /home/opencode/homeboy-extensions/source/wordpress pull --ff-only".to_string(),
+        };
+
+        let json = serde_json::to_value(&warning).expect("warning serializes");
+        assert!(json.get("dirty").is_none(), "{json}");
+        assert!(json.get("dirty_paths").is_none(), "{json}");
+        assert_eq!(
+            json["recovery_command"],
+            "sudo -u opencode git -C /home/opencode/homeboy-extensions/source/wordpress pull --ff-only"
+        );
+
+        let dirty = UnrefreshedExtensionWarning {
+            dirty: true,
+            dirty_paths: vec!["package-lock.json".to_string()],
+            ..warning
+        };
+        let json = serde_json::to_value(&dirty).expect("warning serializes");
+        assert_eq!(json["dirty"], true);
+        assert_eq!(json["dirty_paths"][0], "package-lock.json");
     }
 }
 


### PR DESCRIPTION
Closes #12181 (reporting half). The root cause — the `package-lock.json` checkout error itself — is fixed in the companion PR Extra-Chill/homeboy-extensions#2601.

## Correction to the issue title

The issue asks to "refresh extension source before setup mutates checkout". Investigation shows **that ordering is already correct**: `update_linked_extension()` runs clean-gate → `git fetch`/`switch`/`pull --ff-only` → shared assets → `run_setup_if_configured` (setup last). No ordering change was made here. The real mutation bug is that setup writes into its own tracked source checkout, which lives in `homeboy-extensions` and is fixed there.

What *is* wrong in this repo is the reporting.

## 1. A recovery command guaranteed to fail

`detect_unrefreshed_symlinked_extensions()` emitted `sudo -u <user> git -C <root> pull --ff-only` for every stale clone, decided **solely** by `git_commits_behind_upstream() > 0`. It never inspected whether the worktree was dirty — and `git pull --ff-only` aborts unconditionally against uncommitted changes. In the reported run both `wordpress` and `dependency-adapters` were handed a command that could not possibly work.

Now, before choosing a command, detection checks the target with the **same generated-metadata tolerance the update gate uses** (`.source-url` / `.source-revision` only), via the new `extension_update_dirty_paths()`:

- **verified clean** → `git pull --ff-only`, unchanged
- **dirty** → reported as blocked, with the offending paths in the new `dirty` / `dirty_paths` fields, and a read-only `git status` inspection as the command
- **unverifiable** → treated as blocked rather than risking a command we cannot verify

Detection stays strictly **read-only**: it may fetch and inspect, and never resets, stashes, checks out, or otherwise mutates a worktree owned by another user. Preserving user-authored local changes was an explicit requirement of the issue.

## 2. A failure buried in a count

`extensions.status: "partial"` carried only `"0 updated, 1 skipped"`. The actual error text reached a `log_status!` line and nothing else, so no machine consumer of the structured result could tell *why*.

- New `extension_skips: Vec<ExtensionUpgradeSkip>` on `UpgradeResult` carries `{ extension_id, reason }` per skip.
- The `partial` summary and the upgrade banner now name the extension and its reason (`EXTENSIONS PARTIAL: …`), so a real extension failure is prominent rather than a passing count after a success banner.
- `success` still reports the **controller** upgrade truthfully — the controller genuinely did upgrade, so it is not flipped.
- `extensions_skipped` keeps its id-only shape for existing readers.

## 3. An unactionable gate error

`is_extension_update_workdir_clean()` said only "Linked extension source repo has uncommitted changes … Use --force to proceed" without naming a single file — and `--force` is dangerous advice when the user cannot see what it would apply the update over. It now returns `Result<(), Vec<String>>` and both dirty-gate messages name the offending paths. Gate semantics are unchanged: it still refuses by default, and unknown/unreadable state is still treated as dirty so updates never proceed over unverified state.

## Compatibility

All new fields are `#[serde(default, skip_serializing_if = ...)]`, so old payloads deserialize and old consumers ignore the new keys. The `is_extension_update_workdir_clean` signature change is `pub(crate)`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests -j2` — clean (3m12s)

`cargo test` / `cargo build` are not run on this host (a test build consumes ~28G and has previously exhausted the root volume); the full suite runs in CI on this branch.

New tests cover the behaviour rather than just compilation: `detect_unrefreshed_in_extensions_dir()` was factored out so detection can be driven against **real local git fixtures** (a bare remote plus a clone deliberately one commit behind), asserting that a clean clone still yields `pull --ff-only` and a dirty one does not. Serialization tests assert a skip reason reaches the structured result and that the new fields are omitted when empty.