### PR TITLE
style: restore rustfmt compliance on main

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -1106,12 +1106,22 @@ mod tests {
             assert!(root
                 .finalized_root
                 .join("blobs")
-                .join(value.artifacts[0].sha256.as_deref().expect("transcript digest"))
+                .join(
+                    value.artifacts[0]
+                        .sha256
+                        .as_deref()
+                        .expect("transcript digest")
+                )
                 .is_file());
             assert!(root
                 .finalized_root
                 .join("blobs")
-                .join(value.artifacts[1].sha256.as_deref().expect("runtime digest"))
+                .join(
+                    value.artifacts[1]
+                        .sha256
+                        .as_deref()
+                        .expect("runtime digest")
+                )
                 .is_file());
         });
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2387,13 +2387,12 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
     let model = outcome.selected_model();
     let requested_model = outcome.metadata["model_identity"]["requested"].as_str();
     let resolved_model = outcome.metadata["model_identity"]["resolved"].as_str();
-    let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"]
-        .as_str();
+    let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"].as_str();
     if model.is_none()
         && provider_reported_model.is_none()
-        && requested_model.zip(resolved_model).is_some_and(|(requested, resolved)| {
-            requested != resolved
-        })
+        && requested_model
+            .zip(resolved_model)
+            .is_some_and(|(requested, resolved)| requested != resolved)
     {
         return Err(Error::validation_invalid_argument(
             "provider_model",


### PR DESCRIPTION
## Problem

`cargo fmt --all -- --check` currently **fails on `main`**, so the `homeboy / Rustfmt` gate is red for every open PR regardless of that PR's own contents. I hit this rebasing #12193 onto current main: my branch's fmt gate went from green to red without touching either offending file.

Two files have drifted:

- `crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs`
- `crates/homeboy-agents/src/agent_task_service/cook_promotion.rs`

The `cook_promotion.rs` drift came in through a `main` merge into `fix/12162-cook-completion-state` (#12184), where the conflict-resolved text was never re-formatted — the shape of drift that fast merging produces and that a changed-file-scoped gate does not catch on the merge itself.

## Change

`cargo fmt --all` output only. No logic change, no behavioural change, no test change.

## Verification

- `cargo fmt --all -- --check` — clean after this commit (was failing before)