### PR TITLE
Verify runner tunnel durability before connect succeeds

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -1106,12 +1106,22 @@ mod tests {
             assert!(root
                 .finalized_root
                 .join("blobs")
-                .join(value.artifacts[0].sha256.as_deref().expect("transcript digest"))
+                .join(
+                    value.artifacts[0]
+                        .sha256
+                        .as_deref()
+                        .expect("transcript digest")
+                )
                 .is_file());
             assert!(root
                 .finalized_root
                 .join("blobs")
-                .join(value.artifacts[1].sha256.as_deref().expect("runtime digest"))
+                .join(
+                    value.artifacts[1]
+                        .sha256
+                        .as_deref()
+                        .expect("runtime digest")
+                )
                 .is_file());
         });
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2387,13 +2387,12 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
     let model = outcome.selected_model();
     let requested_model = outcome.metadata["model_identity"]["requested"].as_str();
     let resolved_model = outcome.metadata["model_identity"]["resolved"].as_str();
-    let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"]
-        .as_str();
+    let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"].as_str();
     if model.is_none()
         && provider_reported_model.is_none()
-        && requested_model.zip(resolved_model).is_some_and(|(requested, resolved)| {
-            requested != resolved
-        })
+        && requested_model
+            .zip(resolved_model)
+            .is_some_and(|(requested, resolved)| requested != resolved)
     {
         return Err(Error::validation_invalid_argument(
             "provider_model",

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -1422,6 +1422,7 @@ pub(super) fn failed_connect(
                 remote_address: None,
                 local_address: None,
                 tunnel_state: Some("not_established".to_string()),
+                durability_stage: None,
                 health_attempt_count: 0,
                 health_attempts: Vec::new(),
             }),

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1543,7 +1543,7 @@ fn recovery_retry_reattaches_journaled_b_after_four_lost_health_requests() {
         let health_requests = Arc::new(AtomicUsize::new(0));
         let health_requests_for_server = Arc::clone(&health_requests);
         let endpoint = std::thread::spawn(move || {
-            for request_number in 0..11 {
+            for request_number in 0..10 {
                 let (mut stream, _) = listener.accept().expect("endpoint request");
                 let mut request = [0; 4096];
                 let length = stream.read(&mut request).expect("read endpoint request");
@@ -1690,7 +1690,7 @@ fn normal_start_response_loss_replays_b_without_creating_c() {
         let health_requests = Arc::new(AtomicUsize::new(0));
         let health_requests_for_server = Arc::clone(&health_requests);
         let endpoint = std::thread::spawn(move || {
-            for request_number in 0..4 {
+            for request_number in 0..5 {
                 let (mut stream, _) = listener.accept().expect("endpoint request");
                 let mut request = [0; 4096];
                 let length = stream.read(&mut request).expect("read endpoint request");
@@ -1846,7 +1846,7 @@ esac
             "1",
             "replay must return B rather than starting C"
         );
-        assert_eq!(health_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(health_requests.load(Ordering::SeqCst), 3);
         assert!(
             !old_replay.exists(),
             "the obsolete absolute Homeboy path must not execute the replay"

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1534,7 +1534,7 @@ fn rejected_fresh_state_loss_envelope_is_retired_before_plain_connect_retries() 
 /// authenticate B. It must never create an unjournaled C.
 #[cfg(unix)]
 #[test]
-fn recovery_retry_reattaches_journaled_b_after_two_lost_health_requests() {
+fn recovery_retry_reattaches_journaled_b_after_four_lost_health_requests() {
     test_support::with_isolated_home(|home| {
         let daemon = home.path().join("remote-homeboy");
         let generation_count = home.path().join("daemon-generations");
@@ -1543,7 +1543,7 @@ fn recovery_retry_reattaches_journaled_b_after_two_lost_health_requests() {
         let health_requests = Arc::new(AtomicUsize::new(0));
         let health_requests_for_server = Arc::clone(&health_requests);
         let endpoint = std::thread::spawn(move || {
-            for request_number in 0..7 {
+            for request_number in 0..11 {
                 let (mut stream, _) = listener.accept().expect("endpoint request");
                 let mut request = [0; 4096];
                 let length = stream.read(&mut request).expect("read endpoint request");
@@ -1554,7 +1554,7 @@ fn recovery_retry_reattaches_journaled_b_after_two_lost_health_requests() {
                 }
                 if request.starts_with("GET /health ") {
                     let health_request = health_requests_for_server.fetch_add(1, Ordering::SeqCst);
-                    if health_request < 2 {
+                    if health_request < 4 {
                         // Simulate a controller response loss after B started.
                         drop(stream);
                         continue;
@@ -1629,8 +1629,8 @@ esac
         let evidence = first.failure_evidence.expect("known B failure evidence");
         assert_eq!(evidence.known_remote_lease_id.as_deref(), Some("lease-b"));
         assert_eq!(evidence.known_remote_pid, Some(4242));
-        assert_eq!(evidence.health_attempt_count, 2);
-        assert_eq!(evidence.health_attempts.len(), 2);
+        assert_eq!(evidence.health_attempt_count, 4);
+        assert_eq!(evidence.health_attempts.len(), 4);
         assert_eq!(
             evidence.recovery_command,
             "homeboy runner connect local-runner"
@@ -1666,7 +1666,7 @@ esac
             std::fs::read_to_string(&generation_count).expect("generation count"),
             "1"
         );
-        assert_eq!(health_requests.load(Ordering::SeqCst), 3);
+        assert_eq!(health_requests.load(Ordering::SeqCst), 7);
         assert!(!journal_dir.join("pending-replacement.json").exists());
         assert!(!journal_dir.join("replacement-operation.json").exists());
         endpoint.join().expect("endpoint");

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -178,14 +178,15 @@ fn endpoint_identity_matches(
     expected_version: &str,
     expected_identity: &str,
 ) -> bool {
+    let Ok(response) = daemon_http_body(local_url) else {
+        return false;
+    };
     let identity_matches = expected_identity.trim().is_empty()
-        || daemon_http_identity(local_url)
-            .ok()
+        || daemon_identity_from_body(&response.body)
             .is_some_and(|identity| identity.trim() == expected_identity.trim());
     let version_matches = expected_version.trim().is_empty()
-        || daemon_http_version(local_url)
-            .ok()
-            .is_some_and(|version| versions_match(&version, expected_version));
+        || daemon_version_from_body(&response.body)
+            .is_some_and(|version| versions_match(version, expected_version));
     identity_matches && version_matches
 }
 

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -79,6 +79,7 @@ pub(super) fn connect_remote_daemon(
         |tunnel_pid: Option<u32>,
          tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
          message: String,
+         durability_stage: Option<String>,
          health_attempts: Vec<String>,
          local_url: &str| {
             if let Some(pid) = tunnel_pid {
@@ -102,6 +103,7 @@ pub(super) fn connect_remote_daemon(
                 remote_address: Some(daemon.address.clone()),
                 local_address: Some(local_url.to_string()),
                 tunnel_state: Some("established_then_health_failed".to_string()),
+                durability_stage,
                 health_attempt_count: health_attempts.len(),
                 health_attempts,
             });
@@ -109,7 +111,12 @@ pub(super) fn connect_remote_daemon(
         };
     let (local_port, tunnel_pid, tunnel_process_start_identity, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
-    match probe_daemon_health_until_ready(&local_url, &daemon) {
+    match probe_daemon_health_until_durable(
+        &local_url,
+        &daemon,
+        tunnel_pid,
+        tunnel_process_start_identity.as_ref(),
+    ) {
         Ok(()) if endpoint_identity_matches(&local_url, expected_version, expected_identity) => {
             Ok((
                 local_port,
@@ -123,29 +130,46 @@ pub(super) fn connect_remote_daemon(
             tunnel_pid,
             tunnel_process_start_identity,
             "remote daemon endpoint identity did not match the controller-selected generation; refusing to publish it".to_string(),
+            Some("endpoint_identity".to_string()),
             Vec::new(),
             &local_url,
         )),
-        Err(DaemonHealthProbeFailure::IdentityMismatch(report)) => Err(failed_after_tunnel(
-            tunnel_pid,
-            tunnel_process_start_identity,
-            format!(
-                "remote daemon health identity changed or is unavailable (expected lease {:?}, PID {:?}; got lease {:?}, PID {:?}); refusing to write session{}",
-                daemon.lease_id, daemon.pid, report.freshness.lease_id, report.pid,
-                active_job_recovery_guidance(&daemon),
-            ),
-            Vec::new(),
-            &local_url,
-        )),
-        Err(DaemonHealthProbeFailure::Unreachable { message, attempts }) => {
-            Err(failed_after_tunnel(
-                tunnel_pid,
-                tunnel_process_start_identity,
-                message,
-                attempts,
-                &local_url,
-            ))
+        Err(failure) => {
+            let durability_stage = Some(failure_stage(&failure).to_string());
+            match failure {
+                DaemonHealthProbeFailure::IdentityMismatch(report) => Err(failed_after_tunnel(
+                    tunnel_pid,
+                    tunnel_process_start_identity,
+                    format!(
+                        "remote daemon health identity changed or is unavailable (expected lease {:?}, PID {:?}; got lease {:?}, PID {:?}); refusing to write session{}",
+                        daemon.lease_id, daemon.pid, report.freshness.lease_id, report.pid,
+                        active_job_recovery_guidance(&daemon),
+                    ),
+                    durability_stage,
+                    Vec::new(),
+                    &local_url,
+                )),
+                DaemonHealthProbeFailure::Unreachable { message, attempts }
+                | DaemonHealthProbeFailure::TunnelExited { message, attempts } => {
+                    Err(failed_after_tunnel(
+                        tunnel_pid,
+                        tunnel_process_start_identity,
+                        message,
+                        durability_stage,
+                        attempts,
+                        &local_url,
+                    ))
+                }
+            }
         }
+    }
+}
+
+fn failure_stage(failure: &DaemonHealthProbeFailure) -> &'static str {
+    match failure {
+        DaemonHealthProbeFailure::IdentityMismatch(_) => "health_identity",
+        DaemonHealthProbeFailure::Unreachable { .. } => "health_settle",
+        DaemonHealthProbeFailure::TunnelExited { .. } => "tunnel_durability",
     }
 }
 
@@ -175,6 +199,12 @@ enum DaemonHealthProbeFailure {
         message: String,
         attempts: Vec<String>,
     },
+    /// The captured local tunnel process no longer has the exact identity that
+    /// opened this connection, so it cannot be published as a live session.
+    TunnelExited {
+        message: String,
+        attempts: Vec<String>,
+    },
 }
 
 /// A freshly started daemon can have its TCP listener accepting connections
@@ -186,17 +216,20 @@ enum DaemonHealthProbeFailure {
 ///
 /// An identity mismatch is authoritative — the daemon is up but is the wrong
 /// one — so it is never retried.
-fn probe_daemon_health_until_ready(
+fn probe_daemon_health_until_durable(
     local_url: &str,
     daemon: &RemoteDaemon,
+    tunnel_pid: Option<u32>,
+    tunnel_process_start_identity: Option<&RunnerTunnelProcessStartIdentity>,
 ) -> std::result::Result<(), DaemonHealthProbeFailure> {
-    const MAX_ATTEMPTS: usize = 2;
+    const MAX_ATTEMPTS: usize = 4;
     const RETRY_INTERVAL: Duration = Duration::from_millis(250);
+    const DURABILITY_OBSERVATIONS: usize = 2;
 
     let mut attempts = Vec::with_capacity(MAX_ATTEMPTS);
     for attempt in 1..=MAX_ATTEMPTS {
         match daemon_health_report(local_url) {
-            Ok(report) if health_identity_matches(&report, daemon) => return Ok(()),
+            Ok(report) if health_identity_matches(&report, daemon) => break,
             Ok(report) => return Err(DaemonHealthProbeFailure::IdentityMismatch(Box::new(report))),
             Err(message) => attempts.push(format!("attempt {attempt}: {message}")),
         }
@@ -204,15 +237,77 @@ fn probe_daemon_health_until_ready(
             std::thread::sleep(RETRY_INTERVAL);
         }
     }
-    Err(DaemonHealthProbeFailure::Unreachable {
-        message: format!(
-            "remote daemon health endpoint failed after {MAX_ATTEMPTS} bounded requests: {}",
-            attempts
-                .last()
-                .expect("health probe records failed attempt")
-        ),
-        attempts,
-    })
+    if attempts.len() == MAX_ATTEMPTS {
+        return Err(DaemonHealthProbeFailure::Unreachable {
+            message: format!(
+                "remote daemon health endpoint failed after {MAX_ATTEMPTS} bounded requests: {}",
+                attempts
+                    .last()
+                    .expect("health probe records failed attempt")
+            ),
+            attempts,
+        });
+    }
+
+    if !tunnel_process_identity_matches(tunnel_pid, tunnel_process_start_identity) {
+        attempts.push(
+            "durability observation 0: owned tunnel process exited or changed identity".to_string(),
+        );
+        return Err(DaemonHealthProbeFailure::TunnelExited {
+            message: "owned SSH tunnel exited or changed identity before the post-establishment durability window".to_string(),
+            attempts,
+        });
+    }
+
+    // SSH may report its forward ready while its parent command is still
+    // handing off. Observe beyond that window before publishing the PID.
+    for observation in 1..=DURABILITY_OBSERVATIONS {
+        std::thread::sleep(RETRY_INTERVAL);
+        if !tunnel_process_identity_matches(tunnel_pid, tunnel_process_start_identity) {
+            attempts.push(format!("durability observation {observation}: owned tunnel process exited or changed identity"));
+            return Err(DaemonHealthProbeFailure::TunnelExited {
+                message: "owned SSH tunnel exited or changed identity during the post-establishment durability window".to_string(),
+                attempts,
+            });
+        }
+        match daemon_health_report(local_url) {
+            Ok(report) if health_identity_matches(&report, daemon) => {}
+            Ok(report) => return Err(DaemonHealthProbeFailure::IdentityMismatch(Box::new(report))),
+            Err(message) => {
+                attempts.push(format!("durability observation {observation}: {message}"));
+                return Err(DaemonHealthProbeFailure::Unreachable {
+                    message: format!("remote daemon health endpoint failed during post-establishment durability observation {observation}"),
+                    attempts,
+                });
+            }
+        }
+        if !tunnel_process_identity_matches(tunnel_pid, tunnel_process_start_identity) {
+            attempts.push(format!("durability observation {observation}: owned tunnel process exited after health response"));
+            return Err(DaemonHealthProbeFailure::TunnelExited {
+                message: "owned SSH tunnel exited after a health response during the post-establishment durability window".to_string(),
+                attempts,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn tunnel_process_identity_matches(
+    pid: Option<u32>,
+    expected: Option<&RunnerTunnelProcessStartIdentity>,
+) -> bool {
+    match (pid, expected) {
+        (Some(pid), Some(expected)) => {
+            super::capture_tunnel_process_start_identity(Some(pid))
+                .ok()
+                .flatten()
+                .as_ref()
+                == Some(expected)
+        }
+        // Loopback connections have no SSH child to own.
+        (None, None) => true,
+        _ => false,
+    }
 }
 
 fn active_job_recovery_guidance(daemon: &RemoteDaemon) -> String {
@@ -968,19 +1063,21 @@ mod tests {
             // `error sending request` transport failure on the controller side.
             let (first, _) = listener.accept().expect("first health request");
             drop(first);
-            // Second connection: answer correctly so the retry converges.
-            let (mut stream, _) = listener.accept().expect("second health request");
-            let mut request = [0; 1024];
-            let _ = stream.read(&mut request).expect("read request");
-            stream
-                .write_all(
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        body.len(), body
+            // The retry and both post-establishment observations must answer.
+            for _ in 0..3 {
+                let (mut stream, _) = listener.accept().expect("health request");
+                let mut request = [0; 1024];
+                let _ = stream.read(&mut request).expect("read request");
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(), body
+                        )
+                        .as_bytes(),
                     )
-                    .as_bytes(),
-                )
-                .expect("health response");
+                    .expect("health response");
+            }
         });
 
         let daemon = RemoteDaemon {
@@ -991,12 +1088,45 @@ mod tests {
             build_identity: None,
             inspected_freshness: None,
         };
-        let result = probe_daemon_health_until_ready(&format!("http://{address}"), &daemon);
+        let started = std::time::Instant::now();
+        let result =
+            probe_daemon_health_until_durable(&format!("http://{address}"), &daemon, None, None);
         assert!(
             result.is_ok(),
-            "probe must retry through the transient startup failure: {result:?}"
+            "probe must retry through startup and observe durable health: {result:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "bounded health settle and durability observations must not hang"
         );
         server.join().expect("server");
+    }
+
+    #[test]
+    fn unreachable_health_probe_is_bounded() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        drop(listener);
+        let daemon = RemoteDaemon {
+            address: address.to_string(),
+            pid: Some(7331),
+            lease_id: Some("lease-live".to_string()),
+            version: None,
+            build_identity: None,
+            inspected_freshness: None,
+        };
+
+        let started = std::time::Instant::now();
+        let result =
+            probe_daemon_health_until_durable(&format!("http://{address}"), &daemon, None, None);
+        assert!(matches!(
+            result,
+            Err(DaemonHealthProbeFailure::Unreachable { attempts, .. }) if attempts.len() == 4
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "four bounded refused health probes must not hang"
+        );
     }
 
     /// An identity mismatch is authoritative — the daemon is up but is the
@@ -1035,7 +1165,8 @@ mod tests {
             inspected_freshness: None,
         };
         let started = std::time::Instant::now();
-        let result = probe_daemon_health_until_ready(&format!("http://{address}"), &daemon);
+        let result =
+            probe_daemon_health_until_durable(&format!("http://{address}"), &daemon, None, None);
         assert!(
             matches!(result, Err(DaemonHealthProbeFailure::IdentityMismatch(_))),
             "identity mismatch must fail immediately: {result:?}"
@@ -1079,6 +1210,120 @@ mod tests {
             None,
             "the former post-readiness capture would report the child exited"
         );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn durability_check_rejects_a_tunnel_that_exits_after_apparent_readiness() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let body = serde_json::json!({
+            "freshness": report("lease-live", 7331).freshness,
+            "pid": 7331,
+        })
+        .to_string();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("initial health request");
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).expect("read request");
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(), body
+                    )
+                    .as_bytes(),
+                )
+                .expect("health response");
+        });
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.05")
+            .spawn()
+            .expect("start tunnel child");
+        let pid = child.id();
+        let identity = super::super::capture_tunnel_process_start_identity(Some(pid))
+            .expect("capture child identity")
+            .expect("child identity");
+        let daemon = RemoteDaemon {
+            address: address.to_string(),
+            pid: Some(7331),
+            lease_id: Some("lease-live".to_string()),
+            version: None,
+            build_identity: None,
+            inspected_freshness: None,
+        };
+
+        let started = std::time::Instant::now();
+        let result = probe_daemon_health_until_durable(
+            &format!("http://{address}"),
+            &daemon,
+            Some(pid),
+            Some(&identity),
+        );
+        let Err(failure) = result else {
+            panic!("exited tunnel must fail the durability window");
+        };
+        assert!(matches!(
+            failure,
+            DaemonHealthProbeFailure::TunnelExited { .. }
+        ));
+        assert_eq!(failure_stage(&failure), "tunnel_durability");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "an exited tunnel must fail within the bounded durability window"
+        );
+        assert!(child.wait().expect("reap tunnel child").success());
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn loopback_durability_has_no_ssh_identity_requirement() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let body = serde_json::json!({
+            "freshness": report("lease-live", 7331).freshness,
+            "pid": 7331,
+        })
+        .to_string();
+        let server = std::thread::spawn(move || {
+            for _ in 0..3 {
+                let (mut stream, _) = listener.accept().expect("health request");
+                let mut request = [0; 1024];
+                let _ = stream.read(&mut request).expect("read request");
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(), body
+                        )
+                        .as_bytes(),
+                    )
+                    .expect("health response");
+            }
+        });
+        let daemon = RemoteDaemon {
+            address: address.to_string(),
+            pid: Some(7331),
+            lease_id: Some("lease-live".to_string()),
+            version: None,
+            build_identity: None,
+            inspected_freshness: None,
+        };
+
+        let started = std::time::Instant::now();
+        assert!(probe_daemon_health_until_durable(
+            &format!("http://{address}"),
+            &daemon,
+            None,
+            None,
+        )
+        .is_ok());
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "loopback durability observations must not hang"
+        );
+        server.join().expect("server");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -431,6 +431,12 @@ pub struct RunnerConnectFailureEvidence {
     pub local_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tunnel_state: Option<String>,
+    /// The connect lifecycle stage that produced this evidence. Older callers
+    /// can continue reading the existing health fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub durability_stage: Option<String>,
+    /// Failed initial health probes and failed durability observations only;
+    /// successful health observations are intentionally omitted.
     pub health_attempt_count: usize,
     pub health_attempts: Vec<String>,
 }

--- a/docs/architecture/runner-connection.md
+++ b/docs/architecture/runner-connection.md
@@ -32,6 +32,14 @@ the daemon through an SSH `-L 127.0.0.1:<local>:127.0.0.1:<remote>` tunnel.
 Session metadata is stored at `~/.config/homeboy/runner-sessions/<id>.json` so
 `status` and `disconnect` can inspect or close the local tunnel later.
 
+Before a direct-SSH connect is reported as successful, Homeboy captures the
+local tunnel process start identity and observes it through a bounded
+post-establishment window while the exact remote lease/PID continues answering
+`/health`. A failed observation cleans only that exact owned child. Connect
+failure evidence may add `durability_stage`; existing health attempt fields are
+preserved. `health_attempt_count` and `health_attempts` contain failed initial
+health probes and failed durability observations, not successful observations.
+
 ## Rolling Generations
 
 The runner-layer rolling-generation primitive models daemon replacement as


### PR DESCRIPTION
## Summary

- retain exact tunnel process identity through a bounded post-establishment observation window
- require the same daemon lease/PID to remain healthy before publishing connect success
- retry delayed health convergence with bounded backoff and reattach the journaled daemon lease
- return additive stage-specific failure evidence and clean only the exact owned child
- cover immediate tunnel exit, loopback behavior, bounded failures, and same-generation reattach

Fixes #10430.

## Verification

- `cargo check -p homeboy-lab-runner`
- `cargo test -p homeboy-lab-runner connection_daemon::tests --lib` (16 passed)
- `cargo test -p homeboy-lab-runner recovery_retry_reattaches_journaled_b_after_four_lost_health_requests --lib` (1 passed)
- `git diff --check`

## Compatibility

Direct SSH success now waits about 500 ms for durability proof. Reverse runner paths are unchanged. Failure evidence adds optional `durability_stage`; existing health fields and identity-before-signal cleanup remain intact.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the post-return tunnel failure, directed and reviewed a direct general coding subagent, strengthened real endpoint/process timing and bounded-duration coverage, and ran verification. Chris Huber reviewed the resulting diff and remains responsible for every line.