### PR TITLE
test(upgrade): give the snapshot-notes fixture a repo-local git identity

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -2167,6 +2167,16 @@ version = "0.0.0"
     fn synthetic_snapshot_uses_recorded_source_identity_for_parity() {
         let source = tempdir().expect("source");
         git(source.path(), &["init"]);
+        // `git notes add` below authors an object, so it needs an identity just
+        // as much as `git commit` does. Set it repo-locally right after `init`
+        // rather than per-command: a CI runner has no global git identity, so
+        // any authoring command that misses an inline `-c` fails with "Author
+        // identity unknown" / "empty ident name".
+        git(source.path(), &["config", "user.name", "Homeboy Snapshot"]);
+        git(
+            source.path(),
+            &["config", "user.email", "homeboy-snapshot@localhost"],
+        );
         write_source_manifest(source.path(), "1.2.3");
         git(source.path(), &["add", "."]);
         let commit = Command::new("git")


### PR DESCRIPTION
## Problem

`upgrade::helpers::runner_source_upgrade_tests::synthetic_snapshot_uses_recorded_source_identity_for_parity` fails on any machine without a **global** git identity:

```text
git ["notes", "--ref=homeboy-snapshot", "add", "-m", ...] failed: Author identity unknown
*** Please tell me who you are.
fatal: empty ident name (for <runner@runnervm….internal.cloudapp.net>) not allowed
```

The fixture supplies an identity **inline** (`-c user.name=… -c user.email=…`) for its `git commit`, but `git notes add` authors an object too and was given no identity at all. It passes on a developer box only because `~/.gitconfig` silently supplies one — a GitHub Actions runner has none.

The test dates to #9210 and `crates/homeboy-upgrade` changes rarely, so it sat latent. It surfaced on #12193, whose changed-file scope pulled `homeboy-upgrade`'s test binary into the shard for the first time in a while; it took down three test shards there for a reason entirely unrelated to that PR.

## Change

Set the identity **repo-locally right after `git init`** rather than per-command, so every authoring command in the fixture is covered instead of only the ones that remembered an inline `-c`. Test-only.

## Verification

Reproduced and fixed under CI-like conditions locally (empty `HOME`, `GIT_CONFIG_NOSYSTEM=1`, so no global or system git identity):

| | result |
|---|---|
| without this fix | `FAILED` — reproduces the exact `Author identity unknown` panic above |
| with this fix | `ok. 1 passed; 0 failed` |

Also passes normally (`cargo test -p homeboy-upgrade --lib …`), and `cargo check -p homeboy-upgrade --tests` is clean.

Note: `cargo fmt --all -- --check` is currently failing on `main` for unrelated files — see #12195. `rustfmt --check` on the one file this PR touches is clean.