### PR TITLE
Repin Test to homeboy-action v2.11.23 (nextest archive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,16 +229,18 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.22, DEREFERENCED to its commit. These tags are annotated, so the tag
+    # v2.11.23, DEREFERENCED to its commit. These tags are annotated, so the tag
     # ref's own object SHA is a tag object, which `uses:` cannot resolve — pinning
     # one fails the whole workflow at startup with zero jobs scheduled (#12153).
     # Always pin `git rev-parse v<tag>^{commit}`.
     #
     # Carries homeboy-action#372 (jq-portable exact shard partitioning),
     # homeboy-action#376 (a cancelled run no longer publishes a red `Test`
-    # verdict), and homeboy-action#377 (the unreachable sharded baseline phase is
-    # removed, closing a latent no-enforcement green). All refs #10997.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5e028c09159f574c8e0d9b6fa229530a13926317
+    # verdict), homeboy-action#377 (the unreachable sharded baseline phase is
+    # removed, closing a latent no-enforcement green), and homeboy-action#378,
+    # which builds the test binaries once into a nextest archive instead of
+    # recompiling the workspace in every shard. All refs #10997.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5e8b3fb5388351bb1a0d73cf283f08eed02ffbae
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
Delivery half of the compile-prefix work. Carries Extra-Chill/homeboy-action#378; pairs with Extra-Chill/homeboy-extensions#2603, released as `rust-v1.34.0`.

## What it changes

Test binaries are now built **once** into a `cargo nextest archive` by `Plan candidate Test shards` — which already had to compile everything to enumerate tests — and every shard runs from that archive instead of recompiling.

## Why

`nextest run -E <filter>` filters what **executes**, not what **compiles**. With `--workspace`, each shard rebuilt the entire workspace for its own slice.

Run `31570203797`, shard-1:

```
...7.8 minutes of silence...
Starting 30 tests across 2 binaries (4702 tests and 76 binaries skipped)
Summary [4.046s] 30 tests run: 30 passed
```

**7.8 minutes compiling, 4 seconds testing** — in all four shards, plus once more for the inventory. **Five identical full-workspace debug compiles per run.**

Sharding was splitting the part that takes seconds and duplicating the part that takes minutes, so raising `test_shards` was making the gate *slower*. After this, shard count divides real work for the first time.

Expected critical path: **~32.5m → ~23m**.

## The number that decides whether this pays

**Archive size is not yet known.** 78 debug binaries with debuginfo could be multiple GB, and upload + 4× download is not free. If transfer approaches the ~8 minute per-shard compile it replaces, the change stops paying.

The archive step writes its size to the step summary, so **this PR's own run produces the answer**, directly comparable to the numbers above. If it is too large, the follow-up is stripping debuginfo from the archived profile.

I could not measure it locally: building the full test archive is the ~28G `cargo test --no-run` step, and this host's 35G free would drop under its own safety floor mid-build.

## Pinning

`v2.11.23^{commit}` = `5e8b3fb5`. The tag ref's own object is `d160e9f3`, an annotated tag — the shape that broke `main` earlier today in #12152.

`.github/validate-action-pin.sh`, added in #12187 for exactly this, confirms the pin:

```
action-pin: Extra-Chill/homeboy-action@5e8b3fb5... is a commit
```

Workflow YAML only, no Rust touched. 10 jobs intact.

Refs #10997