### PR TITLE
Fix scoped monorepo release attribution

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/mod.rs
@@ -50,9 +50,10 @@ pub(crate) use gh_cli::{
 };
 #[cfg(test)]
 pub(crate) use notes::{
-    build_github_release_body, fallback_release_notes, github_changelog_url,
+    component_scoped_release_entries, fallback_release_notes, github_changelog_url,
     github_generated_notes_start_tag, github_release_notes_start_tag,
-    replace_full_changelog_footer, GitHubReleaseBody,
+    replace_full_changelog_footer, AssociatedPullRequest, AssociatedPullRequestAuthor,
+    GitHubReleaseBody,
 };
 #[cfg(test)]
 pub(crate) use repair::{

--- a/crates/homeboy-release/src/release/executor/github_release/notes.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/notes.rs
@@ -8,6 +8,8 @@ use homeboy_core::component::GithubConfig;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::git::release_download::GitHubRepo;
+use serde::Deserialize;
+use std::collections::HashSet;
 
 use super::gh_cli::{
     gh_command, gh_failure_diagnostic, github_release_upload_timeout, run_gh_command, safe_filename,
@@ -73,6 +75,7 @@ pub(crate) fn build_github_release_body(
         return GitHubReleaseBody {
             body: component_scoped_release_notes(
                 component,
+                github,
                 state,
                 changelog_url,
                 tag,
@@ -120,6 +123,7 @@ fn component_release_notes_require_changelog_fallback(component: &Component) -> 
 /// durable history without forge-specific links or author metadata.
 fn component_scoped_release_notes(
     component: &Component,
+    github: &GitHubRepo,
     state: &ReleaseState,
     changelog_url: Option<&str>,
     tag: &str,
@@ -128,63 +132,90 @@ fn component_scoped_release_notes(
     let entries = git::get_component_changes_since_tag(component, previous_tag)
         .ok()
         .map(|commits| {
-            commits
-                .into_iter()
-                .filter(|commit| commit.category.to_changelog_entry_type().is_some())
-                .map(|commit| format!("- {}", format_github_release_entry(component, &commit)))
-                .collect::<Vec<_>>()
+            component_scoped_release_entries(commits, |hash| {
+                associated_merged_pull_requests(github, &component.github, hash)
+            })
         })
         .unwrap_or_default();
 
     let base = if entries.is_empty() {
         fallback_release_notes(state, None, tag)
     } else {
-        format!("## {}\n\n{}", tag, entries.join("\n"))
+        format!("## What's Changed\n\n{}", entries.join("\n"))
     };
     changelog_url
         .map(|url| replace_full_changelog_footer(&base, url))
         .unwrap_or(base)
 }
 
-fn format_github_release_entry(component: &Component, commit: &git::CommitInfo) -> String {
-    let subject = git::strip_conventional_prefix(&commit.subject);
-    let subject = github_reference_links(component, subject);
-    match commit_author(component, &commit.hash) {
-        Some(author) => format!("{} (by {})", subject, author),
-        None => subject,
-    }
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssociatedPullRequest {
+    pub(crate) title: String,
+    pub(crate) html_url: String,
+    pub(crate) merged_at: Option<String>,
+    pub(crate) user: AssociatedPullRequestAuthor,
 }
 
-fn commit_author(component: &Component, hash: &str) -> Option<String> {
-    let output =
-        git::execute_git_for_release(&component.local_path, &["show", "-s", "--format=%an", hash])
-            .ok()?;
-    if !output.status.success() {
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssociatedPullRequestAuthor {
+    pub(crate) login: String,
+}
+
+/// Preserve the scoped git collector as the release authority. GitHub metadata
+/// only changes how those selected commits are presented to reviewers.
+pub(crate) fn component_scoped_release_entries(
+    commits: Vec<git::CommitInfo>,
+    mut associated_prs: impl FnMut(&str) -> Option<Vec<AssociatedPullRequest>>,
+) -> Vec<String> {
+    let mut seen_pull_requests = HashSet::new();
+    commits
+        .into_iter()
+        .filter(|commit| commit.category.to_changelog_entry_type().is_some())
+        .map(|commit| {
+            let pull_requests = associated_prs(&commit.hash).unwrap_or_default();
+            let merged = pull_requests
+                .into_iter()
+                .filter(|pull_request| pull_request.merged_at.is_some())
+                .collect::<Vec<_>>();
+            if merged.len() == 1 {
+                let pull_request = &merged[0];
+                if seen_pull_requests.insert(pull_request.html_url.clone()) {
+                    return format!(
+                        "* {} by @{} in {}",
+                        pull_request.title, pull_request.user.login, pull_request.html_url
+                    );
+                }
+                return String::new();
+            }
+            format!("* {}", git::strip_conventional_prefix(&commit.subject))
+        })
+        .filter(|entry| !entry.is_empty())
+        .collect()
+}
+
+fn associated_merged_pull_requests(
+    github: &GitHubRepo,
+    config: &GithubConfig,
+    hash: &str,
+) -> Option<Vec<AssociatedPullRequest>> {
+    let endpoint = format!(
+        "repos/{}/{}/commits/{hash}/pulls",
+        github.owner, github.repo
+    );
+    let output = run_gh_command(
+        gh_command(github, config, &["api", &endpoint]),
+        github_release_upload_timeout(),
+    );
+    if output.timed_out || output.exit_code != Some(0) {
+        homeboy_core::log_status!(
+            "release",
+            "GitHub associated-PR metadata unavailable for commit {}: {}",
+            hash,
+            gh_failure_diagnostic("gh api associated pull requests", &endpoint, &output).summary
+        );
         return None;
     }
-    let author = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!author.is_empty()).then_some(author)
-}
-
-fn github_reference_links(component: &Component, subject: &str) -> String {
-    let remote = component.remote_url.clone().or_else(|| {
-        git::release_download::detect_remote_url(std::path::Path::new(&component.local_path))
-    });
-    let Some(remote) = remote else {
-        return subject.to_string();
-    };
-    let Some(repo) = git::release_download::parse_github_url(&remote) else {
-        return subject.to_string();
-    };
-    let reference = regex::Regex::new(r"#(\d+)").expect("valid GitHub reference regex");
-    reference
-        .replace_all(subject, |captures: &regex::Captures<'_>| {
-            format!(
-                "[#{}](https://{}/{}/{}/pull/{})",
-                &captures[1], repo.host, repo.owner, repo.repo, &captures[1]
-            )
-        })
-        .into_owned()
+    serde_json::from_str(&output.stdout).ok()
 }
 
 /// Persist the exact release body to `build/<tag>-release-notes.md` so it is

--- a/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/notes_tests.rs
@@ -4,7 +4,8 @@ use crate::release::types::ReleaseState;
 
 use super::super::gh_cli::GhCommandOutput;
 use super::super::{
-    build_github_release_body, create_failed_result, fallback_release_notes, GitHubReleaseBody,
+    component_scoped_release_entries, create_failed_result, fallback_release_notes,
+    AssociatedPullRequest, AssociatedPullRequestAuthor, GitHubReleaseBody,
 };
 use super::{data_str, git_repo, test_body, test_repair, test_repo};
 
@@ -40,68 +41,127 @@ fn fallback_release_notes_falls_back_to_minimal_body_when_empty() {
 }
 
 #[test]
-fn component_scoped_release_body_uses_changelog_fallback() {
+fn component_scoped_blocks_engine_notes_attribute_prs_without_including_siblings() {
     let temp = git_repo();
     let root = temp.path();
-    let component_dir = temp.path().join("packages/wordpress");
+    let component_dir = temp.path().join("php-transformer");
     std::fs::create_dir_all(&component_dir).expect("create component dir");
     std::fs::write(root.join("README.md"), "initial").expect("write initial file");
     super::run_git(root, &["add", "README.md"]);
     super::run_git(root, &["commit", "-q", "-m", "chore: initial"]);
-    super::run_git(root, &["tag", "wordpress-v1.2.2"]);
-    std::fs::write(component_dir.join("release.md"), "release").expect("write release file");
-    super::run_git(root, &["add", "packages/wordpress/release.md"]);
-    super::run_git(
+    super::run_git(root, &["tag", "php-transformer-v0.4.15"]);
+    super::commit_file(
         root,
-        &[
-            "commit",
-            "-q",
-            "-m",
-            "fix: bound homeboy activity latency with a reconcile-free runner view (#9522)",
-        ],
+        "php-transformer/src/crop.php",
+        "crop",
+        "fix: generic crop recognition",
     );
-    std::fs::write(component_dir.join("workspace.md"), "workspace").expect("write workspace file");
-    super::run_git(root, &["add", "packages/wordpress/workspace.md"]);
-    super::run_git(
+    super::commit_file(
         root,
-        &[
-            "commit",
-            "-q",
-            "-m",
-            "fix: preserve the prepared workspace on retryable admission failure (#9469)",
-        ],
+        "php-transformer/src/crop-test.php",
+        "test",
+        "fix: crop coverage",
     );
-    super::run_git(root, &["tag", "wordpress-v1.2.3"]);
+    super::commit_file(
+        root,
+        "php-transformer/tools/visual-parity/figma.ts",
+        "figma",
+        "fix: sibling-only change",
+    );
+    super::commit_file(
+        root,
+        "php-transformer/src/direct.php",
+        "direct",
+        "fix: direct push fallback",
+    );
     let component = homeboy_core::component::Component {
-        id: "wordpress".to_string(),
+        id: "php-transformer".to_string(),
         local_path: component_dir.to_string_lossy().to_string(),
-        remote_url: Some("https://github.com/example-org/studio-web.git".to_string()),
+        scopes: Some(homeboy_core::component::ScopeConfig {
+            release: Some(homeboy_core::component::CommandScopeConfig {
+                include: vec![],
+                exclude: vec!["tools/visual-parity/**".to_string()],
+            }),
+            ..Default::default()
+        }),
         ..Default::default()
     };
-    let state = ReleaseState {
-        notes: Some("## wordpress-v1.2.3\n\n- Fix scoped release notes".to_string()),
-        ..Default::default()
-    };
-
-    let body = build_github_release_body(
+    let commits = homeboy_core::git::get_component_changes_since_tag(
         &component,
-        &test_repo(),
-        "wordpress-v1.2.3",
-        &state,
-        Some("https://github.com/example-org/studio-web/blob/wordpress-v1.2.3/packages/wordpress/CHANGELOG.md"),
-        Some("wordpress-v1.2.2"),
+        Some("php-transformer-v0.4.15"),
+    )
+    .expect("scoped commits");
+    assert_eq!(
+        commits.len(),
+        3,
+        "sibling-only commit remains outside the authority set"
     );
+    let first_pr = AssociatedPullRequest {
+        title: "Improve generic image crop recognition".to_string(),
+        html_url: "https://github.com/Automattic/blocks-engine/pull/848".to_string(),
+        merged_at: Some("2026-08-12T00:00:00Z".to_string()),
+        user: AssociatedPullRequestAuthor {
+            login: "chubes4".to_string(),
+        },
+    };
+    let entries = component_scoped_release_entries(commits, |hash| {
+        let subject = homeboy_core::git::execute_git_for_release(
+            &component.local_path,
+            &["show", "-s", "--format=%s", hash],
+        )
+        .expect("subject");
+        match String::from_utf8_lossy(&subject.stdout).trim() {
+            "fix: generic crop recognition" | "fix: crop coverage" => Some(vec![first_pr.clone()]),
+            "fix: direct push fallback" => Some(vec![]),
+            _ => None,
+        }
+    });
 
-    assert!(!body.generated_notes_ok);
-    assert_eq!(body.source_label(), "changelog-fallback");
-    assert!(body.body.contains(
-        "- bound homeboy activity latency with a reconcile-free runner view ([#9522](https://github.com/example-org/studio-web/pull/9522)) (by Homeboy Test)"
-    ));
-    assert!(body.body.contains(
-        "- preserve the prepared workspace on retryable admission failure ([#9469](https://github.com/example-org/studio-web/pull/9469)) (by Homeboy Test)"
-    ));
-    assert!(!body.body.contains("- Fix scoped release notes"));
-    assert!(body.body.contains("packages/wordpress/CHANGELOG.md"));
+    assert_eq!(
+        entries.len(),
+        2,
+        "two selected commits in one PR render once"
+    );
+    assert!(entries.contains(&"* Improve generic image crop recognition by @chubes4 in https://github.com/Automattic/blocks-engine/pull/848".to_string()));
+    assert!(entries.contains(&"* direct push fallback".to_string()));
+    assert!(entries.iter().all(|entry| !entry.contains("sibling-only")));
+}
+
+#[test]
+fn component_scoped_notes_leave_ambiguous_or_unavailable_pr_metadata_unattributed() {
+    let commits = vec![
+        homeboy_core::git::CommitInfo {
+            hash: "ambiguous".to_string(),
+            subject: "fix: ambiguous association".to_string(),
+            category: homeboy_core::git::CommitCategory::Fix,
+        },
+        homeboy_core::git::CommitInfo {
+            hash: "unavailable".to_string(),
+            subject: "fix: metadata unavailable".to_string(),
+            category: homeboy_core::git::CommitCategory::Fix,
+        },
+    ];
+    let pull_request = |number: u64, title: &str| AssociatedPullRequest {
+        title: title.to_string(),
+        html_url: format!("https://github.com/Automattic/blocks-engine/pull/{number}"),
+        merged_at: Some("2026-08-12T00:00:00Z".to_string()),
+        user: AssociatedPullRequestAuthor {
+            login: "chubes4".to_string(),
+        },
+    };
+
+    let entries = component_scoped_release_entries(commits, |hash| match hash {
+        "ambiguous" => Some(vec![
+            pull_request(848, "First PR"),
+            pull_request(849, "Second PR"),
+        ]),
+        _ => None,
+    });
+
+    assert_eq!(
+        entries,
+        vec!["* ambiguous association", "* metadata unavailable"]
+    );
 }
 
 // ---- Issue #3508: the exact GitHub Release body must be discoverable ----


### PR DESCRIPTION
## Summary

Restore standard GitHub pull-request attribution for path-scoped monorepo releases without weakening Homeboy's component filtering.

## What changed

- Keep the existing include/exclude scoped commit collector as the authority.
- Resolve each selected commit through GitHub's associated-pull-request endpoint at the presentation boundary.
- Render `## What's Changed` entries with the PR title, `@login`, and canonical PR URL.
- Deduplicate multiple selected commits belonging to one merged PR.
- Leave direct pushes, unavailable metadata, and ambiguous multiple-PR associations unattributed rather than making false claims.
- Preserve the component tag boundary and changelog footer.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-release`
- `cargo test -p homeboy-release executor::github_release` (107 passed)
- `cargo test -p homeboy-core git::commits` (32 passed)

## Evidence

Production regression: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.4.16

Expected standard presentation: https://github.com/Automattic/blocks-engine/releases/tag/php-transformer-v0.4.15

Cook `agent-task-ab88396e-d55a-464d-8330-0c90dbc3da4c` produced and promoted this candidate. Native deterministic gates passed; Cook finalization was blocked by the isolated Rust cache defect tracked in #12207 and repaired by #12209.

Closes #12204

## AI assistance

OpenCode with OpenAI GPT-5.6 Terra produced the implementation and tests. OpenCode with OpenAI GPT-5.6 Sol traced the production regression, reviewed the candidate, ran verification, and prepared publication. Chris Huber reviewed and remains responsible for the change.