### PR TITLE
fix(extension): reject malformed provider declarations without the agent-task layer

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/agent_task_executor_declaration.rs
+++ b/crates/contracts/homeboy-extension-contract/src/agent_task_executor_declaration.rs
@@ -1,0 +1,177 @@
+//! The authoritative shape of an agent-task executor provider *as an extension
+//! declares it*.
+//!
+//! `agent_task_executors` is carried opaquely as `Vec<serde_json::Value>` on the
+//! runtime manifest so that lower layers stay agnostic of the agent-task
+//! provider types. Something still has to decide whether a declaration is
+//! well-formed, and that decision has to be made in two places that cannot see
+//! each other:
+//!
+//! - `homeboy-extension`, at install/replace time, so a malformed declaration is
+//!   rejected and rolled back instead of installed silently.
+//! - `homeboy-agents`, at discovery time, which owns the far richer resolved
+//!   provider type.
+//!
+//! `homeboy-agents` depends on `homeboy-extension`, so `homeboy-extension` can
+//! never call into it. Rather than duplicate the rule on both sides (which would
+//! drift), the rule lives here once and both sides call it.
+//!
+//! This type deliberately models only what an extension *declares* and what
+//! decides validity. It is not a second copy of the resolved provider: fields
+//! such as `extension_id`, `extension_path`, `runtime_id` and `runtime_path` are
+//! injected by discovery after parsing, never authored in a manifest, so they
+//! have no place in a declaration contract. Everything else an extension may
+//! declare is preserved verbatim in `extra` and interpreted by the agent-task
+//! layer.
+
+use std::collections::BTreeMap;
+
+use homeboy_error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
+
+fn default_provider_schema() -> String {
+    AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string()
+}
+
+/// One `agent_runtimes[].agent_task_executors[]` entry as authored in an
+/// extension manifest.
+///
+/// `id` and `backend` are required: they are the identity a provider is selected
+/// by, and a declaration missing either cannot be resolved to anything. Every
+/// other declared key is retained in `extra` so this contract never rejects a
+/// provider feature it does not itself model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExecutorProviderDeclaration {
+    #[serde(default = "default_provider_schema")]
+    pub schema: String,
+    pub id: String,
+    pub backend: String,
+    /// Rejected whenever non-empty. The string form was replaced by
+    /// `invocation.argv` / `argv`; accepting it silently would let a manifest
+    /// declare a command that is never executed.
+    #[serde(default, deserialize_with = "reject_deprecated_provider_command")]
+    pub command: String,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+fn reject_deprecated_provider_command<'de, D>(
+    deserializer: D,
+) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let command = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    if command.trim().is_empty() {
+        return Ok(command);
+    }
+
+    Err(<D::Error as serde::de::Error>::custom(
+        "agent-task provider string-form 'command' is no longer supported; use invocation.argv or argv instead",
+    ))
+}
+
+/// Parse one declared executor entry, producing the canonical diagnostic used by
+/// both the install-time gate and agent-task discovery.
+///
+/// `extension_id` and `runtime_id` only shape the error; they are not part of
+/// the declaration.
+pub fn parse_agent_task_executor_declaration(
+    extension_id: &str,
+    runtime_id: &str,
+    value: &Value,
+) -> Result<AgentTaskExecutorProviderDeclaration> {
+    serde_json::from_value(value.clone()).map_err(|err| {
+        Error::validation_invalid_argument(
+            "agent_runtimes.agent_task_executors",
+            format!(
+                "Extension '{}' declares an agent runtime provider that cannot be parsed: {}",
+                extension_id, err
+            ),
+            Some(runtime_id.to_string()),
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_complete_declaration_parses() {
+        let declaration = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({"id": "wordpress.default", "backend": "wp-codebox"}),
+        )
+        .expect("complete declaration parses");
+
+        assert_eq!(declaration.id, "wordpress.default");
+        assert_eq!(declaration.backend, "wp-codebox");
+        assert_eq!(declaration.schema, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA);
+    }
+
+    #[test]
+    fn a_declaration_missing_backend_cannot_be_parsed() {
+        let error = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({"id": "wordpress.default"}),
+        )
+        .expect_err("a declaration without a backend must be rejected");
+
+        assert!(
+            error.message.contains("cannot be parsed"),
+            "got {}",
+            error.message
+        );
+        assert!(error.message.contains("wordpress"), "got {}", error.message);
+    }
+
+    #[test]
+    fn a_declaration_missing_id_cannot_be_parsed() {
+        let error = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({"backend": "wp-codebox"}),
+        )
+        .expect_err("a declaration without an id must be rejected");
+
+        assert!(error.message.contains("cannot be parsed"));
+    }
+
+    #[test]
+    fn the_deprecated_string_command_form_is_rejected() {
+        let error = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({"id": "a", "backend": "b", "command": "run --thing"}),
+        )
+        .expect_err("string-form command must be rejected");
+
+        assert!(error.message.contains("cannot be parsed"));
+    }
+
+    #[test]
+    fn unmodelled_provider_keys_are_preserved_rather_than_rejected() {
+        let declaration = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({
+                "id": "a",
+                "backend": "b",
+                "capabilities": ["x"],
+                "some_future_provider_key": {"nested": true}
+            }),
+        )
+        .expect("a declaration carrying keys this contract does not model still parses");
+
+        assert!(declaration.extra.contains_key("capabilities"));
+        assert!(declaration.extra.contains_key("some_future_provider_key"));
+    }
+}

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -22,6 +22,7 @@ pub use manifest_toolchain_config::{
 };
 pub use manifest_toolchain_config::{CliConfig, RemotePathInferenceRule};
 pub mod action_types;
+pub mod agent_task_executor_declaration;
 pub mod autofix_config;
 pub mod bench_artifact;
 pub mod bench_diagnostics;

--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -18,6 +18,7 @@ homeboy-error = { version = "0.1.0", path = "../homeboy-error" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-lab-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-contract" }
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
+homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_json_path = "0.7"
@@ -38,7 +39,6 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage
 
 [dev-dependencies]
 rusqlite = { version = "0.32", features = ["bundled"] }
-homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 # Self-referencing dev-dependency: this crate's own integration tests link the
 # library externally, where `cfg(test)` is off. Enabling `test-support` for the

--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
+use homeboy_extension_contract::agent_task_executor_declaration::parse_agent_task_executor_declaration;
+
 use homeboy_core::agent_runtime_manifest::{
     discover_agent_runtime_catalog, runtime_materialization_plan, AgentRuntimeDiscoveryDiagnostic,
     AgentRuntimeManifest, AgentRuntimeSelectedIdentity, AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT,
@@ -243,21 +245,17 @@ fn expected_agent_runtime_provider_refs(
     let mut expected = Vec::new();
     for runtime in &extension.agent_runtimes {
         for value in &runtime.agent_task_executors {
-            let provider: AgentTaskExecutorProvider = serde_json::from_value(value.clone()).map_err(|err| {
-                Error::validation_invalid_argument(
-                    "agent_runtimes.agent_task_executors",
-                    format!(
-                        "Extension '{}' declares an agent runtime provider that cannot be parsed: {}",
-                        extension.id, err
-                    ),
-                    Some(runtime.id.clone()),
-                    None,
-                )
-            })?;
+            // Parsed through the shared declaration contract rather than the
+            // resolved provider type, so extension install/replace enforces
+            // byte-identical validity without depending on this crate (#12206).
+            // Only `id` and `backend` are consumed here; the resolved provider
+            // is built later by the catalog parse.
+            let declaration =
+                parse_agent_task_executor_declaration(&extension.id, &runtime.id, value)?;
             expected.push(ExpectedAgentRuntimeProviderRef {
                 runtime_id: runtime.id.clone(),
-                provider_id: provider.id,
-                backend: provider.backend,
+                provider_id: declaration.id,
+                backend: declaration.backend,
             });
         }
     }

--- a/crates/homeboy-core/src/extension_provider_discovery.rs
+++ b/crates/homeboy-core/src/extension_provider_discovery.rs
@@ -7,9 +7,26 @@
 //! provider: core owns extension install/repair, the agent-task layer validates
 //! provider discovery.
 //!
+//! The check has two halves, and only one of them is agent-task behavior:
+//!
+//! - **Is the declaration well-formed?** A malformed
+//!   `agent_runtimes[].agent_task_executors[]` entry is malformed whether or not
+//!   the agent-task subsystem is present, so this is validated unconditionally
+//!   against the shared declaration contract.
+//! - **Is the declared provider discoverable?** This reads the extension's
+//!   agent-task executor provider catalog, which *is* agent-task behavior, so it
+//!   stays inverted behind the provider below.
+//!
+//! Collapsing both halves into the inverted hook is what regressed #12206: with
+//! no provider registered the no-op validated *nothing*, so an extension
+//! declaring a provider that cannot be parsed installed silently instead of
+//! being rejected and rolled back.
+//!
 //! With no provider registered (no agent-task subsystem present) the no-op
-//! validates nothing (an install without the agent-task subsystem has no
-//! agent-task providers to discover).
+//! still validates no *discoverability* — an install without the agent-task
+//! subsystem has no agent-task providers to discover.
+
+use homeboy_extension_contract::agent_task_executor_declaration::parse_agent_task_executor_declaration;
 
 use crate::Result;
 
@@ -41,8 +58,31 @@ homeboy_engine_primitives::provider_registry! {
     with: fn with_provider,
 }
 
-/// Validate an installed extension's agent-runtime provider discovery via the
-/// registered validator (or the no-op when the agent-task subsystem is absent).
+/// Validate an installed extension's agent-runtime provider discovery.
+///
+/// Declaration well-formedness is checked unconditionally; discoverability is
+/// delegated to the registered validator (or the no-op when the agent-task
+/// subsystem is absent).
 pub fn validate_installed_extension_provider_discovery(extension_id: &str) -> Result<()> {
+    validate_declared_agent_task_executors(extension_id)?;
     with_provider(|p| p.validate_installed_extension_provider_discovery(extension_id))
+}
+
+/// Reject an extension that declares an agent-task executor which cannot be
+/// parsed, independently of whether the agent-task subsystem is registered.
+///
+/// A manifest that cannot be loaded at all is left to the caller's own manifest
+/// handling rather than reported here as a provider-declaration fault.
+fn validate_declared_agent_task_executors(extension_id: &str) -> Result<()> {
+    let Ok(extension) = crate::extension_store::load_extension(extension_id) else {
+        return Ok(());
+    };
+
+    for runtime in &extension.agent_runtimes {
+        for declared in &runtime.agent_task_executors {
+            parse_agent_task_executor_declaration(&extension.id, &runtime.id, declared)?;
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Closes #12206.

## Correction to the issue

**#12206 proposed the wrong remedy and I wrote it.** It said to move `AgentTaskExecutorProvider` and its type graph down into a shared crate. Two things were wrong with that:

- I sized it from `types.rs` alone. The real transitive closure is **1369 lines across 4 files with 24 `impl` blocks** (`types.rs`, `runtime_types.rs`, `workspace_types.rs`, `secret_types.rs`), and `AgentTaskExecutorProvider` has **184 use-sites**. Not the "pure data types" the issue claimed.
- More importantly, **the inversion was already correct and I missed it.** `homeboy-core::extension_provider_discovery` already defines an `ExtensionProviderDiscoveryValidator` registry; core owns install/repair and the agent-task layer registers the real validator at startup. Nothing needed to move.

## The actual bug

The hook treated **both halves** of the check as agent-task behavior, so with no validator registered the no-op validated *nothing*:

```rust
fn validate_installed_extension_provider_discovery(&self, _extension_id: &str) -> Result<()> {
    Ok(())
}
```

Only one half genuinely needs the subsystem:

| half | needs agent-task layer? |
|---|---|
| is the declared provider **discoverable**? | yes — reads the executor provider catalog |
| is the declaration **well-formed**? | **no** — malformed is malformed regardless |

Because the two tests run inside `homeboy-extension`, where `homeboy-agents` never registers, they hit the no-op and install succeeded. That is also a real production hole: `homeboy_extension::install` is called directly by `homeboy-lab-runner`'s `extension_materialization.rs`, not only by the CLI, so validating in the caller would not have closed it either.

## Change

- New `AgentTaskExecutorProviderDeclaration` in `homeboy-extension-contract` models an `agent_runtimes[].agent_task_executors[]` entry **as an extension authors it**: `id` and `backend` required, deprecated string-form `command` rejected, and every other declared key preserved in `extra` so the contract never rejects a provider feature it does not model. Fields injected by discovery (`extension_id`, `extension_path`, `runtime_id`, `runtime_path` — see `discovery.rs:95-101`) are deliberately absent, since they are never authored in a manifest.
- Core validates declarations unconditionally, then delegates discoverability to the registered validator exactly as before. Both existing call sites — install and replace — inherit it, so the rollback paths are untouched.
- `expected_agent_runtime_provider_refs` in `homeboy-agents` is **the only hard-fail parse** and the sole source of the `"cannot be parsed"` diagnostic (the catalog parse merely collects diagnostics). It now goes through the same shared contract. It only ever consumed `id` and `backend`, so this is one rule in one place rather than a duplicate that drifts.

Nothing moved out of `homeboy-agents`; the resolved provider type and its discovery concerns stay there, and **no call site changed**.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests -j2` — clean
- The two target tests now pass:
  - `lifecycle::tests::linked_install_fails_and_rolls_back_when_declared_provider_is_not_discoverable` — ok
  - `repair::tests::replace_fails_and_restores_existing_install_when_declared_provider_is_not_discoverable` — ok
- `cargo test -p homeboy-extension-contract --lib` — 72 passed, including 5 new tests covering required fields, the deprecated command form, and that unmodelled provider keys are preserved rather than rejected.
- `cargo test -p homeboy-agents --lib -- agent_task_provider` — **172 passed both before and after** this change, so the shared parse did not regress discovery.

## Pre-existing failures NOT addressed here

`cargo test -p homeboy-extension --lib` still reports these, and they fail identically on unmodified `main`:

- `env_provider::tests::providers_cannot_contribute_the_same_public_environment_key`
- `execution::tests::build_exec_env_includes_toolchain_path` (`expected extension env to include PATH`)
- `bench::run::tests::component_script_bench_env_includes_typed_settings_json` (fails acquiring a `/var/tmp/.../.cleanup.lock`, so parallelism/environment-sensitive)

They look like host-environment artifacts rather than logic breaks, and CI's changed-file-scoped shards only ever surfaced the two this PR fixes. Left them rather than papering over them; #12206 stays the record if they turn out to be real.