### PR TITLE
fix(test): align descendant liveness with zombie semantics

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1355,7 +1355,10 @@ mod baseline_tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !homeboy_engine_primitives::command::process_is_running(descendant_pid as u32),
+            "bounded baseline gate left descendant {descendant_pid} runnable"
+        );
     }
 }
 
@@ -5207,7 +5210,10 @@ mod tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !homeboy_engine_primitives::command::process_is_running(descendant_pid as u32),
+            "toolchain preflight left descendant {descendant_pid} runnable"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -925,9 +925,8 @@ mod tests {
                 .trim()
                 .parse()
                 .expect("numeric pid");
-            assert_ne!(
-                unsafe { libc::kill(pid, 0) },
-                0,
+            assert!(
+                !homeboy::core::process::pid_is_running(pid as u32),
                 "status must terminate Git descendants"
             );
         });

--- a/crates/homeboy-core/src/git/primitives.rs
+++ b/crates/homeboy-core/src/git/primitives.rs
@@ -614,7 +614,7 @@ mod tests {
             .parse()
             .expect("numeric pid");
         assert!(
-            unsafe { libc::kill(pid, 0) } != 0,
+            !crate::process::pid_is_running(pid as u32),
             "timeout must terminate every subprocess in the Git process group"
         );
     }

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -230,24 +230,7 @@ pub fn detach_from_caller_session(command: &mut Command) {
 pub fn detach_from_caller_session(_command: &mut Command) {}
 
 pub fn pid_is_running(pid: u32) -> bool {
-    if pid > i32::MAX as u32 {
-        return false;
-    }
-
-    #[cfg(target_os = "linux")]
-    if let Some(state) = linux_process_state(pid) {
-        return state != 'Z';
-    }
-
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, 0) == 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        pid == std::process::id()
-    }
+    homeboy_engine_primitives::command::process_is_running(pid)
 }
 
 /// The result of checking a persisted local process identity.
@@ -1357,12 +1340,6 @@ fn descendant_pids_from_ps(ps_output: &str, owner_pid: u32) -> Vec<u32> {
         }
     }
     descendants
-}
-
-#[cfg(target_os = "linux")]
-fn linux_process_state(pid: u32) -> Option<char> {
-    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    parse_linux_stat(&stat).map(|process| process.state)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -31,6 +31,39 @@ pub const fn supports_process_tree_isolation() -> bool {
     cfg!(unix)
 }
 
+/// Whether a PID still names a process that can execute work.
+///
+/// Linux retains an exited process as a zombie until its parent reaps it, and
+/// `kill(pid, 0)` still succeeds during that interval. Zombies cannot execute
+/// work, so lifecycle supervision and descendant cleanup treat them as exited.
+pub fn process_is_running(pid: u32) -> bool {
+    if pid > i32::MAX as u32 {
+        return false;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(state) = linux_process_state(pid) {
+        return state != 'Z';
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, 0) == 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        pid == std::process::id()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_state(pid: u32) -> Option<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let (_, fields) = stat.rsplit_once(')')?;
+    fields.split_whitespace().next()?.chars().next()
+}
+
 /// Keeps an isolated child tree owned by the controller that spawned it.
 ///
 /// On Unix, a small guard process watches a pipe whose write end is held only
@@ -1463,7 +1496,10 @@ mod tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !process_is_running(descendant_pid as u32),
+            "cancellation left descendant {descendant_pid} runnable"
+        );
     }
 
     #[cfg(unix)]
@@ -1512,7 +1548,7 @@ mod tests {
             );
         }
         for _ in 0..100 {
-            if unsafe { libc::kill(descendant_pid, 0) } != 0 {
+            if !process_is_running(descendant_pid as u32) {
                 return;
             }
             thread::sleep(Duration::from_millis(10));
@@ -1554,7 +1590,10 @@ mod tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !process_is_running(descendant_pid as u32),
+            "completed parent left descendant {descendant_pid} runnable"
+        );
     }
 
     #[cfg(unix)]
@@ -1593,6 +1632,9 @@ mod tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !process_is_running(descendant_pid as u32),
+            "cancellable wait left descendant {descendant_pid} runnable"
+        );
     }
 }

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -1077,7 +1077,10 @@ mod tests {
             .trim()
             .parse::<libc::pid_t>()
             .expect("numeric descendant pid");
-        assert_ne!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+        assert!(
+            !homeboy_core::process::pid_is_running(descendant_pid as u32),
+            "initial identity persistence failure left descendant {descendant_pid} runnable"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -191,10 +191,10 @@ fn source_upgrade_timeout_terminates_the_entire_child_process_group() {
         .trim()
         .parse::<i32>()
         .expect("numeric pid");
-    // The shell is the process-group leader and timeout termination must
-    // remove its background child as well as reap the direct child.
+    // The shell is the process-group leader and timeout termination must stop
+    // its background child as well as reap the direct child.
     for _ in 0..40 {
-        if unsafe { libc::kill(child_pid, 0) } != 0 {
+        if !homeboy_core::process::pid_is_running(child_pid as u32) {
             return;
         }
         std::thread::sleep(Duration::from_millis(25));


### PR DESCRIPTION
## Summary
- centralize executable PID liveness in engine primitives, treating Linux zombies as exited
- preserve core liveness semantics through the shared primitive
- apply the shared assertion to the known descendant cleanup sites from #12118 and #12008, while retaining strict direct-child reaping checks

Closes #12118
Relates to #12008

## Verification
- `git diff --check`
- Cargo and local tests were not run per task instruction; GitHub CI is the verification authority.
- `rustup run 1.95.0 rustfmt --edition 2024 --check ...` was attempted. The configured formatter parses the repository only in 2024 mode because of an existing C-string literal, then reports unrelated existing layout changes in touched modules; no formatter rewrites were retained.

## AI assistance
- **Model:** OpenAI gpt-5.6-sol
- **Tool:** OpenCode
- **Used for:** Investigated the cited CI failures, traced the production zombie-aware liveness contract, implemented the shared test liveness primitive and affected assertions, and performed Git-only validation. Chris Huber remains responsible for every line.