### PR TITLE
fix: report absent component checkouts in project-wide deploy --check

### DIFF
--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -43,8 +43,8 @@ pub use pins::{
 };
 pub(crate) use readiness::component_local_path_blockers;
 pub use readiness::{
-    calculate_deploy_readiness, validate_component_local_path, validate_component_local_paths,
-    validate_deploy_component_local_paths,
+    calculate_deploy_readiness, component_local_path_findings, validate_component_local_path,
+    validate_component_local_paths, validate_deploy_component_local_paths,
 };
 pub use report::{
     build_components_output, build_create_output, build_delete_output, build_init_output,

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -172,15 +172,27 @@ pub fn validate_deploy_component_local_paths(
     Err(err)
 }
 
-pub fn validate_component_local_path(project: &Project, component_id: &str) -> Result<()> {
-    let blockers = project
+/// The operator-facing local_path findings for one attached component, as
+/// values rather than as an error.
+///
+/// A missing local checkout is a fact about *this host*, not a malformed
+/// project. Read-only callers (`deploy --check`, status probes) need to report
+/// it as one scoped finding and keep going, instead of aborting a project-wide
+/// pass and hiding every other component (#12214). `validate_component_local_path`
+/// remains the fail-closed wrapper that every mutating path uses.
+pub fn component_local_path_findings(project: &Project, component_id: &str) -> Vec<String> {
+    project
         .components
         .iter()
         .filter(|attachment| attachment.id == component_id)
         .filter_map(|attachment| {
             component_local_path_blocker(project, &attachment.id, &attachment.local_path)
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+pub fn validate_component_local_path(project: &Project, component_id: &str) -> Result<()> {
+    let blockers = component_local_path_findings(project, component_id);
 
     if blockers.is_empty() {
         return Ok(());
@@ -298,6 +310,40 @@ mod tests {
         assert!(blockers.iter().any(|blocker| {
             blocker.contains("Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist")
         }));
+    }
+
+    /// Read-only callers need the blocker as a value so a missing checkout can be
+    /// reported as one scoped finding instead of aborting a project-wide pass (#12214).
+    #[test]
+    fn component_local_path_findings_report_missing_checkout_without_erroring() {
+        let project = project_with_component("/tmp/homeboy-missing-component-path".to_string());
+
+        let findings = component_local_path_findings(&project, "plugin");
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].contains(
+            "Component 'plugin' local_path '/tmp/homeboy-missing-component-path' does not exist"
+        ));
+    }
+
+    /// The findings helper and the fail-closed validator must agree — one is the
+    /// value form of the other, not a second implementation that can drift.
+    #[test]
+    fn component_local_path_findings_are_empty_for_a_present_checkout() {
+        let repo = repo_with_component("plugin", serde_json::json!({}));
+        let project = project_with_component(repo.path().to_string_lossy().to_string());
+
+        assert!(component_local_path_findings(&project, "plugin").is_empty());
+        validate_component_local_path(&project, "plugin").expect("present checkout validates");
+    }
+
+    /// An unattached component has nothing to report — absence of an attachment is
+    /// a different error, surfaced by resolution.
+    #[test]
+    fn component_local_path_findings_are_empty_for_an_unattached_component() {
+        let project = project_with_component("/tmp/homeboy-missing-component-path".to_string());
+
+        assert!(component_local_path_findings(&project, "not-attached").is_empty());
     }
 
     #[test]

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -168,7 +168,13 @@ fn run_with_release_artifacts(
     // A version-pinned release asset is resolved remotely before orchestration;
     // requiring its configured checkout to exist would reintroduce a mutable
     // source gate. Other modes retain the existing early local-path validation.
-    if config.expected_version.is_none()
+    //
+    // `--check` is read-only and returns before any build or remote write, so
+    // this fail-closed gate protects nothing there — it only aborts the status
+    // pass and hides every other component (#12214). Check mode reports each
+    // absent checkout as a scoped skipped result instead.
+    if !config.check
+        && config.expected_version.is_none()
         && config.prepared_projection.is_none()
         && config.prepared_artifact.is_none()
     {

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -1358,6 +1358,70 @@ mod tests {
         });
     }
 
+    /// A stale attachment (the checkout was moved or deleted) must not blind the
+    /// operator to every other component in a read-only project-wide check (#12214).
+    #[test]
+    fn check_mode_skips_component_with_absent_local_path_instead_of_aborting() {
+        with_isolated_home(|_| {
+            let present = TempDir::new().expect("present dir");
+            write_component_manifest(present.path(), "present", None);
+            let absent = present.path().join("deleted-checkout");
+
+            let project = project_with_component_dirs(&[
+                ("absent", absent.as_path()),
+                ("present", present.path()),
+            ]);
+
+            // --all --check: requested_ids empty, check = true.
+            let loaded = load_project_components(&project, &[], true)
+                .expect("check mode must not hard-fail on an absent local_path");
+
+            // Every component with a valid checkout is still checked.
+            assert_eq!(
+                loaded
+                    .deployable
+                    .iter()
+                    .map(|c| c.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["present"]
+            );
+
+            // The absent one is a scoped finding carrying the remedy, not a silent drop.
+            assert_eq!(loaded.extension_skipped.len(), 1);
+            let skip = &loaded.extension_skipped[0];
+            assert_eq!(skip.id, "absent");
+            assert!(
+                skip.reason.contains("does not exist") && skip.reason.contains("attach-path"),
+                "reason should name the missing checkout and its remedy, got: {}",
+                skip.reason
+            );
+        });
+    }
+
+    /// The absent-checkout skip is scoped to the read-only path: a real deploy
+    /// must still fail closed rather than deploy from a path that does not exist.
+    #[test]
+    fn non_check_mode_still_hard_fails_on_absent_local_path() {
+        with_isolated_home(|_| {
+            let present = TempDir::new().expect("present dir");
+            write_component_manifest(present.path(), "present", None);
+            let absent = present.path().join("deleted-checkout");
+
+            let project = project_with_component_dirs(&[
+                ("absent", absent.as_path()),
+                ("present", present.path()),
+            ]);
+
+            let err = match load_project_components(&project, &[], false) {
+                Ok(_) => panic!("non-check mode must hard-fail on an absent local_path"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("missing local_path"));
+        });
+    }
+
     #[test]
     fn non_check_mode_still_hard_fails_on_missing_extension() {
         with_isolated_home(|_| {

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -695,10 +695,11 @@ where
     buckets
 }
 
-/// A component skipped during loading because a required extension is not installed.
+/// A component skipped during loading because this host cannot resolve it —
+/// an uninstalled extension, an unresolvable artifact, or an absent local checkout.
 ///
 /// Carries the human-readable reason so check-mode output can report
-/// `skipped: missing extension <id>` per component instead of aborting.
+/// `skipped: <reason>` per component instead of aborting the whole pass.
 pub(super) struct ExtensionSkippedComponent {
     pub id: String,
     pub reason: String,
@@ -708,8 +709,9 @@ pub(super) struct ExtensionSkippedComponent {
 pub(super) struct LoadedComponents {
     pub deployable: Vec<Component>,
     pub skipped: Vec<String>,
-    /// Components skipped because a required extension is missing. Only populated
-    /// in check mode; otherwise a missing extension is a hard error.
+    /// Components skipped because this host cannot resolve them (missing
+    /// extension, unresolvable artifact, or absent local checkout). Only
+    /// populated in check mode; every other mode treats these as hard errors.
     pub extension_skipped: Vec<ExtensionSkippedComponent>,
 }
 
@@ -720,9 +722,11 @@ pub(super) struct LoadedComponents {
 /// Returns an actionable error with install instructions when extensions are missing,
 /// rather than silently skipping the component.
 ///
-/// In `check` mode (read-only diff), a component requiring an uninstalled extension is
+/// In `check` mode (read-only diff), a component this host cannot resolve — an
+/// uninstalled extension, an unresolvable artifact, or an absent local checkout — is
 /// *not* a hard error: it is skipped, recorded in `extension_skipped`, and reported so
-/// operators can see the project-wide diff without installing every build toolchain.
+/// operators can see the project-wide diff without installing every build toolchain
+/// or holding a checkout of every component.
 ///
 /// Returns both the deployable components and the IDs of skipped (non-deployable) ones,
 /// so callers can produce accurate error messages.
@@ -754,6 +758,32 @@ pub(super) fn load_project_components_with_projection(
         // unrelated components — a missing extension on an unrequested component
         // should not block deploying the ones you asked for.
         let is_requested = requested_ids.is_empty() || requested_ids.contains(&attachment.id);
+
+        // A component whose local checkout is absent cannot be resolved from
+        // disk, and `resolve_project_component` fails closed on it so a real
+        // deploy never reads from a path that does not exist. In check mode that
+        // hard failure aborted the entire read-only pass, hiding the status of
+        // every other component (#12214). Report it as a scoped skip instead —
+        // the same skip-and-warn contract a missing extension already uses
+        // (#4587). Only applies when this loader would actually read the
+        // checkout: a projected source replaces it.
+        if check && projected_component(project, &attachment.id, projection).is_none() {
+            let findings = project::component_local_path_findings(project, &attachment.id);
+            if !findings.is_empty() {
+                let reason = findings.join("; ");
+                homeboy_core::log_status!(
+                    "deploy",
+                    "Skipping '{}' in check mode: {}",
+                    attachment.id,
+                    reason
+                );
+                extension_skipped.push(ExtensionSkippedComponent {
+                    id: attachment.id.clone(),
+                    reason,
+                });
+                continue;
+            }
+        }
 
         let mut loaded = resolve_project_component(
             project,
@@ -884,6 +914,23 @@ pub(super) fn load_project_components_with_projection(
     })
 }
 
+/// The prepared-projection source for a component, when one exists.
+///
+/// A projected source is a caller-supplied materialization that stands in for
+/// the attachment's on-disk checkout, so callers that would otherwise read
+/// `local_path` must consult this first.
+pub(super) fn projected_component<'a>(
+    project: &Project,
+    component_id: &str,
+    projection: Option<&'a super::types::PreparedDeployProjection>,
+) -> Option<&'a Component> {
+    let projection = projection?;
+    projection
+        .components
+        .get(&format!("{}:{component_id}", project.id))
+        .or_else(|| projection.components.get(component_id))
+}
+
 pub(super) fn resolve_project_component(
     project: &Project,
     component_id: &str,
@@ -891,12 +938,7 @@ pub(super) fn resolve_project_component(
     projection: Option<&super::types::PreparedDeployProjection>,
 ) -> Result<Component> {
     let snapshot_key = format!("{}:{component_id}", project.id);
-    let Some(source) = projection.and_then(|projection| {
-        projection
-            .components
-            .get(&snapshot_key)
-            .or_else(|| projection.components.get(component_id))
-    }) else {
+    let Some(source) = projected_component(project, component_id, projection) else {
         return project::resolve_project_component_with_standalone_snapshot(
             project,
             component_id,

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -30,6 +30,19 @@ pub(super) fn run_if_configured(
     if component_ids.is_empty() {
         return Ok(None);
     }
+    // Deciding whether this project is provider-owned requires reading each
+    // component's declared configuration from its checkout. In check mode a
+    // component whose checkout is absent must not abort that decision for the
+    // whole project (#12214): set it aside as a scoped finding, decide ownership
+    // from the components this host can actually resolve, and report the rest.
+    let (component_ids, unresolvable): (Vec<&str>, Vec<UnresolvableComponent>) = if config.check {
+        partition_unresolvable_components(project, &component_ids, config)
+    } else {
+        (component_ids, Vec::new())
+    };
+    if component_ids.is_empty() {
+        return Ok(None);
+    }
     let components = component_ids
         .iter()
         .map(|id| {
@@ -54,7 +67,7 @@ pub(super) fn run_if_configured(
         ));
     }
     if provider_count == components.len() {
-        let mut results = Vec::with_capacity(components.len());
+        let mut results = Vec::with_capacity(components.len() + unresolvable.len());
         for component in &components {
             results.push(run_component(
                 project_id,
@@ -64,23 +77,84 @@ pub(super) fn run_if_configured(
                 observation.as_deref_mut(),
             )?);
         }
+        results.extend(unresolvable_results(&unresolvable));
         let failed = results
             .iter()
             .filter(|result| result.status == "failed")
             .count() as u32;
+        let skipped = unresolvable.len() as u32;
         let total = results.len() as u32;
         return Ok(Some(DeployOrchestrationResult {
             results,
             summary: DeploySummary {
                 total,
-                succeeded: total - failed,
+                succeeded: total - failed - skipped,
                 failed,
-                skipped: 0,
+                skipped,
             },
             deploy_run_id: None,
         }));
     }
     Ok(None)
+}
+
+/// A component this host cannot resolve, with the operator-facing reason.
+struct UnresolvableComponent {
+    id: String,
+    reason: String,
+}
+
+/// Split requested components into those this host can resolve and those whose
+/// local checkout is absent.
+///
+/// A projected source stands in for the on-disk checkout, so a component the
+/// caller already materialized is always resolvable.
+fn partition_unresolvable_components<'a>(
+    project: &Project,
+    component_ids: &[&'a str],
+    config: &DeployConfig,
+) -> (Vec<&'a str>, Vec<UnresolvableComponent>) {
+    let mut resolvable = Vec::with_capacity(component_ids.len());
+    let mut unresolvable = Vec::new();
+
+    for id in component_ids {
+        if super::planning::projected_component(project, id, config.prepared_projection.as_ref())
+            .is_some()
+        {
+            resolvable.push(*id);
+            continue;
+        }
+
+        let findings = homeboy_core::project::component_local_path_findings(project, id);
+        if findings.is_empty() {
+            resolvable.push(*id);
+        } else {
+            unresolvable.push(UnresolvableComponent {
+                id: (*id).to_string(),
+                reason: findings.join("; "),
+            });
+        }
+    }
+
+    (resolvable, unresolvable)
+}
+
+/// Build `status: "skipped"` rows so a project-wide check reports the components
+/// it could not resolve alongside the ones it did.
+fn unresolvable_results(unresolvable: &[UnresolvableComponent]) -> Vec<ComponentDeployResult> {
+    unresolvable
+        .iter()
+        .map(|skip| {
+            let component = Component {
+                id: skip.id.clone(),
+                ..Default::default()
+            };
+            let mut result = ComponentDeployResult::new(&component, "").with_status("skipped");
+            result.local_path = None;
+            result.warnings.push(format!("skipped: {}", skip.reason));
+            result
+        })
+        .collect()
 }
 
 fn run_component(
@@ -764,6 +838,111 @@ mod tests {
             ])
         );
         assert!(!error.message.contains("server_id"));
+    }
+
+    /// Deciding provider ownership resolves every attached component, so one stale
+    /// attachment used to abort the whole project-wide check before any other
+    /// component was inspected (#12214). Ownership must be decided from the
+    /// components this host can resolve, with the rest reported as skipped.
+    #[test]
+    fn project_wide_check_reports_absent_checkout_and_still_checks_the_rest() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let repository = provider_repository("fixture");
+            write_provider_extension(
+                home.path(),
+                Some("sh {{extension_path}}/run.sh check {{payload.contract}}"),
+            );
+            let mut project = provider_project(repository.path());
+            project.components.push(ProjectComponentAttachment {
+                id: "absent".to_string(),
+                local_path: repository
+                    .path()
+                    .join("deleted-checkout")
+                    .to_string_lossy()
+                    .to_string(),
+                ..Default::default()
+            });
+
+            let result = run_if_configured(
+                "site",
+                &project,
+                &DeployConfig::check_all_no_pull_head(),
+                None,
+            )
+            .expect("an absent checkout must not abort a project-wide check")
+            .expect("provider-owned result");
+
+            assert_eq!(result.summary.total, 2);
+            assert_eq!(result.summary.skipped, 1);
+            assert_eq!(result.summary.failed, 0);
+
+            let checked = result
+                .results
+                .iter()
+                .find(|row| row.id == "fixture")
+                .expect("resolvable component is still checked");
+            assert_eq!(checked.status, "validated");
+
+            let skipped = result
+                .results
+                .iter()
+                .find(|row| row.id == "absent")
+                .expect("absent component is reported");
+            assert_eq!(skipped.status, "skipped");
+            assert!(
+                skipped.warnings.iter().any(|warning| {
+                    warning.contains("does not exist") && warning.contains("attach-path")
+                }),
+                "the skip must carry the remedy: {:?}",
+                skipped.warnings
+            );
+        });
+    }
+
+    /// The reported shape: a server-deployed project with one stale attachment.
+    /// Provider dispatch must decline it so orchestration can run the read-only
+    /// status pass, instead of erroring out of the command entirely (#12214).
+    #[test]
+    fn project_wide_check_with_absent_checkout_defers_non_provider_project() {
+        let generic = tempfile::tempdir().expect("generic repository");
+        std::fs::write(
+            generic.path().join("homeboy.json"),
+            r#"{"id":"generic","deploy_strategy":"git"}"#,
+        )
+        .expect("generic component");
+        let project = Project {
+            id: "site".to_string(),
+            components: vec![
+                ProjectComponentAttachment {
+                    id: "generic".to_string(),
+                    local_path: generic.path().to_string_lossy().to_string(),
+                    ..Default::default()
+                },
+                ProjectComponentAttachment {
+                    id: "absent".to_string(),
+                    local_path: generic
+                        .path()
+                        .join("deleted-checkout")
+                        .to_string_lossy()
+                        .to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let dispatched = run_if_configured(
+            "site",
+            &project,
+            &DeployConfig::check_all_no_pull_head(),
+            None,
+        )
+        .expect("an absent checkout must not abort provider dispatch");
+
+        assert!(
+            dispatched.is_none(),
+            "a server-deployed project must fall through to orchestration"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #12214

## Problem

`homeboy deploy <project> --check` aborted the entire project status check when one configured component had a missing local checkout:

```
Invalid argument components.local_path: Project component has a missing local_path
Component isolated-block-editor local_path /var/lib/datamachine/workspace/isolated-block-editor does not exist
```

One stale attachment made every other component's deploy status invisible.

## Root cause

Three gates fail closed on an absent `local_path`, and all three sit in front of a mode that never builds and never writes to a remote:

1. `provider::run_if_configured` resolves *every* attached component to decide whether the project is provider-owned. This runs first and is what produced the reported error — one unresolvable component aborted the ownership decision for the whole project.
2. The early `validate_deploy_component_local_paths` gate in `run`.
3. The orchestration loader, via `resolve_project_component`.

Failing closed is correct for a real deploy — it stops a deploy reading from a path that does not exist. It protects nothing in `--check`, which returns before any build or remote write.

## Fix

Check mode reports an absent checkout as a scoped `skipped` result carrying the `attach-path` remedy, and keeps checking every component whose path is valid. This is the same skip-and-warn contract a missing extension already uses (#4587).

- Provider ownership is decided from the components this host can resolve; unresolvable ones are reported as skipped rows alongside the checked ones. A server-deployed project with a stale attachment now falls through to orchestration instead of erroring out of the command.
- `component_local_path_findings` exposes the already-computed blocker as a value, so the read-only path and the fail-closed validator share one implementation rather than drifting.
- `projected_component` is factored out so the loader only validates a checkout it would actually read — a caller-supplied projected source still stands in for the on-disk path.

## Acceptance criteria

- [x] Project-wide `deploy --check` reports components whose local paths are absent — as `status: "skipped"` with `skipped: Component 'x' local_path '...' does not exist - update it with: homeboy project components attach-path ...`
- [x] Existing configured components with valid paths are still checked and returned
- [x] No deploy mutation is attempted by the check path — the change is scoped to `config.check`; every mutating mode still fails closed

## Verification

`cargo check --workspace --tests -j2` clean on this branch, rebased onto `origin/main` @ `37bf2bb2e`.

New regression tests (all passing):

- `component_local_path_findings_report_missing_checkout_without_erroring`
- `component_local_path_findings_are_empty_for_a_present_checkout`
- `component_local_path_findings_are_empty_for_an_unattached_component`
- `check_mode_skips_component_with_absent_local_path_instead_of_aborting`
- `non_check_mode_still_hard_fails_on_absent_local_path` — pins the fail-closed half
- `project_wide_check_reports_absent_checkout_and_still_checks_the_rest`
- `project_wide_check_with_absent_checkout_defers_non_provider_project` — the reported shape

5 pre-existing `homeboy-deploy --lib` failures on this VPS (`preparation::*`, `safety_and_artifact::*`, two `orchestration::*`) were confirmed to fail identically on the clean base commit; they need build tooling this box lacks and are unrelated to this change.