### PR TITLE
fix(deploy): reuse the canonical release asset for exact tag refs

### DIFF
--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -847,6 +847,109 @@ mod tests {
         }
     }
 
+    /// A component that is eligible for release-asset reuse, so these tests
+    /// isolate the ref/tag decision rather than the eligibility preconditions.
+    fn release_asset_component() -> Component {
+        Component {
+            id: "example".to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("build/example.zip".to_string()),
+            ..Component::default()
+        }
+    }
+
+    fn deploy_config_with_ref(requested_ref: Option<&str>, tagged: bool) -> DeployConfig {
+        DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            skip_deps_hydration: false,
+            expected_version: None,
+            no_pull: false,
+            allow_stale_source: false,
+            allow_downgrade: false,
+            head: false,
+            requested_ref: requested_ref.map(str::to_string),
+            requested_refs: Default::default(),
+            resolved_refs: Default::default(),
+            preflighted_source_paths: Default::default(),
+            preflighted_component_identities: Default::default(),
+            prepared_projection: None,
+            tagged,
+            prepared_artifact: None,
+            resume_run_id: None,
+        }
+    }
+
+    /// The regression: an exact tag ref used to force `local_build`, which ships
+    /// locally rebuilt bytes instead of the canonical release package and then
+    /// reads back as `remote_modified` against it (#12215).
+    #[test]
+    fn tag_valued_ref_reuses_the_canonical_release_asset() {
+        let component = release_asset_component();
+        let config = deploy_config_with_ref(Some("v0.55.1"), false);
+
+        match release_artifact_plan(&component, &config, false, false) {
+            ReleaseArtifactPlan::Reuse { tag, url } => {
+                // The asset is bound to the requested ref, not to whatever the
+                // latest local tag happens to be.
+                assert_eq!(tag, "v0.55.1");
+                assert!(url.contains("v0.55.1"), "{url}");
+                assert!(url.ends_with("example.zip"), "{url}");
+            }
+            ReleaseArtifactPlan::LocalBuild { reason } => {
+                panic!("tag-valued --ref must reuse the release asset, got local_build: {reason}")
+            }
+        }
+    }
+
+    #[test]
+    fn branch_valued_ref_still_builds_locally() {
+        let component = release_asset_component();
+
+        for branch in ["main", "release/v0.55.1", "vnext"] {
+            let config = deploy_config_with_ref(Some(branch), false);
+            assert!(
+                !should_try_download_release_artifact(&component, &config, false, false),
+                "branch ref '{branch}' must build locally"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_sha_valued_ref_still_builds_locally() {
+        let component = release_asset_component();
+        let config =
+            deploy_config_with_ref(Some("9b780f558f0e4a1b2c3d4e5f60718293a4b5c6d7"), false);
+
+        assert!(!should_try_download_release_artifact(
+            &component, &config, false, false
+        ));
+    }
+
+    /// `--tagged` is the escape hatch for "I want a local build of this tag",
+    /// including when the tag has a reusable asset, so it must outrank `--ref`.
+    #[test]
+    fn tagged_outranks_a_tag_valued_ref() {
+        let component = release_asset_component();
+        let config = deploy_config_with_ref(Some("v0.55.1"), true);
+
+        match release_artifact_plan(&component, &config, false, false) {
+            ReleaseArtifactPlan::LocalBuild { reason } => {
+                assert!(reason.contains("--tagged"), "{reason}")
+            }
+            ReleaseArtifactPlan::Reuse { tag, .. } => {
+                panic!("--tagged must force a local build, got release asset reuse for {tag}")
+            }
+        }
+    }
+
     fn write_zip(path: &std::path::Path, files: &[(&str, &str)]) {
         let file = std::fs::File::create(path).expect("zip file");
         let mut zip = zip::ZipWriter::new(file);

--- a/crates/homeboy-deploy/src/execution/release_plan.rs
+++ b/crates/homeboy-deploy/src/execution/release_plan.rs
@@ -26,9 +26,9 @@ pub(crate) fn release_artifact_plan(
     if config.head {
         return local_release_artifact_plan("--head deploys the current checkout");
     }
-    if config.requested_ref_for(&component.id).is_some() {
-        return local_release_artifact_plan("--ref deploys an exact materialized commit");
-    }
+    // Checked before `--ref` so an explicit local tag build always wins, and so
+    // it stays the documented escape hatch when a release tag has no reusable
+    // asset (#12215).
     if config.tagged {
         return local_release_artifact_plan("--tagged forces a local tag build");
     }
@@ -46,8 +46,35 @@ pub(crate) fn release_artifact_plan(
             "component has no build_artifact filename for release asset lookup",
         );
     };
-    let Some(tag) = deploy_release_tag(component, config) else {
-        return local_release_artifact_plan("no version tag found for release asset lookup");
+    // An exact `--ref` addresses one specific commit, but generated release
+    // bytes are not necessarily reproducible from the tagged source alone, so
+    // exact Git identity does not imply exact package identity. When the ref
+    // names a release, the canonical asset for that release *is* the artifact;
+    // rebuilding it locally is what shipped bytes that then read back as
+    // `remote_modified` against the release package (#12215).
+    //
+    // The discrimination is the component's own tag namespace, so this stays a
+    // pure, network-free plan: a ref outside that namespace (branch, raw SHA,
+    // foreign tag) is not a release ref and still builds locally.
+    let tag = match config.requested_ref_for(&component.id) {
+        Some(requested_ref) => {
+            match release::component_release_tag_version(component, requested_ref) {
+                Ok(Some(_)) => requested_ref.to_string(),
+                _ => {
+                    return local_release_artifact_plan(format!(
+                        "--ref '{requested_ref}' is not a release tag for this component"
+                    ))
+                }
+            }
+        }
+        None => {
+            let Some(tag) = deploy_release_tag(component, config) else {
+                return local_release_artifact_plan(
+                    "no version tag found for release asset lookup",
+                );
+            };
+            tag
+        }
     };
 
     ReleaseArtifactPlan::Reuse {

--- a/crates/homeboy-version/src/lib.rs
+++ b/crates/homeboy-version/src/lib.rs
@@ -46,6 +46,101 @@ pub fn latest_component_tag(component: &Component) -> homeboy_core::Result<Optio
     scope.latest_tag()
 }
 
+/// Resolve the version a git ref names, when that ref is this component's
+/// release tag.
+///
+/// The exact inverse of [`component_tag_name`], and the shared answer to "is
+/// this ref a release tag?". Returns `None` for branches, raw SHAs, and tags
+/// outside this component's release namespace.
+///
+/// Deploy needs this to decide whether an exact `--ref` addresses a release
+/// whose canonical asset should be reused rather than rebuilt locally (#12215).
+/// It lives here, next to the tag naming contract it inverts, so the two cannot
+/// drift apart — and, like the rest of this crate, it stays ecosystem-agnostic.
+pub fn component_release_tag_version(
+    component: &Component,
+    git_ref: &str,
+) -> homeboy_core::Result<Option<String>> {
+    let scope = scope::ReleaseScope::resolve(component, &component.id)?;
+    Ok(release_tag_version_for_prefix(git_ref, scope.tag_prefix()))
+}
+
+/// Strip the namespace a component tags under and keep what remains only when
+/// it is a real version.
+///
+/// The version check is what separates a release tag from a same-shaped branch:
+/// `v2` and `release/v1` are not releases, `v1.2.3` is.
+fn release_tag_version_for_prefix(git_ref: &str, tag_prefix: Option<&str>) -> Option<String> {
+    let version = match tag_prefix {
+        Some(prefix) => git_ref.strip_prefix(&format!("{prefix}-v"))?,
+        None => git_ref.strip_prefix('v')?,
+    };
+
+    semver::Version::parse(version)
+        .ok()
+        .map(|_| version.to_string())
+}
+
+#[cfg(test)]
+mod release_tag_version_tests {
+    use super::release_tag_version_for_prefix;
+
+    #[test]
+    fn a_root_component_release_tag_resolves_its_version() {
+        assert_eq!(
+            release_tag_version_for_prefix("v1.2.3", None),
+            Some("1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    fn a_scoped_component_release_tag_resolves_its_version() {
+        assert_eq!(
+            release_tag_version_for_prefix(
+                "data-machine-events-v0.55.1",
+                Some("data-machine-events")
+            ),
+            Some("0.55.1".to_string())
+        );
+    }
+
+    #[test]
+    fn a_tag_outside_the_components_namespace_is_not_a_release_tag() {
+        // A scoped component does not release under bare `vX.Y.Z`, and must not
+        // claim another component's namespace.
+        assert_eq!(
+            release_tag_version_for_prefix("v0.55.1", Some("events")),
+            None
+        );
+        assert_eq!(
+            release_tag_version_for_prefix("other-component-v0.55.1", Some("events")),
+            None
+        );
+    }
+
+    #[test]
+    fn branches_and_raw_shas_are_not_release_tags() {
+        assert_eq!(release_tag_version_for_prefix("main", None), None);
+        assert_eq!(release_tag_version_for_prefix("release/v1.2.3", None), None);
+        assert_eq!(
+            release_tag_version_for_prefix("9b780f558f0e4a1b2c3d4e5f60718293a4b5c6d7", None),
+            None
+        );
+        // A `v`-prefixed branch name is the case that makes the version parse
+        // load-bearing rather than decorative.
+        assert_eq!(release_tag_version_for_prefix("vnext", None), None);
+        assert_eq!(release_tag_version_for_prefix("v2", None), None);
+    }
+
+    #[test]
+    fn prerelease_and_build_metadata_tags_are_release_tags() {
+        assert_eq!(
+            release_tag_version_for_prefix("v1.2.3-rc.1", None),
+            Some("1.2.3-rc.1".to_string())
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     /// The shared version reader must not branch on ecosystem-specific terms —


### PR DESCRIPTION
Closes #12215.

## Problem

`homeboy deploy <project> <component> --ref <tag>` always selected `local_build`, even when `<tag>` had a reusable release asset. **Generated release bytes are not necessarily reproducible from the tagged source alone, so exact Git identity does not imply exact package identity** — the locally rebuilt tree then reads back as `remote_modified` against the canonical package.

`crates/homeboy-deploy/src/execution/release_plan.rs::release_artifact_plan()` returned `LocalBuild` for *any* requested ref before anything resolved whether that ref named a release with a reusable asset:

```rust
if config.requested_ref_for(&component.id).is_some() {
    return local_release_artifact_plan("--ref deploys an exact materialized commit");
}
```

## Change

A tag-valued `--ref` now plans `Reuse`, **bound to the requested ref** so the deployed bytes are the ones published for the ref the user asked for, fetched through the existing run-scoped release-asset path. No second download path, no change to replacement/rollback/remote transport.

| ref | plan |
|---|---|
| `v0.55.1` (component's release namespace) | `release_asset` |
| `main`, `release/v0.55.1`, `vnext`, `v2` | `local_build` |
| raw SHA | `local_build` |
| anything, with `--tagged` | `local_build` |

## How "is this ref a release tag" is decided

Lexically, against **the component's own tag namespace** — new `component_release_tag_version` in `homeboy-version`, the exact inverse of `component_tag_name`, placed beside the tag naming contract it inverts so the two cannot drift. That crate is already the declared home for shared tag-naming primitives and is explicitly ecosystem-agnostic, so this adds **no ecosystem special cases** and covers plugins, themes, and any generic artifact component alike.

Parsing the version is load-bearing rather than decorative: it is what separates the tag `v1.2.3` from same-shaped branch names like `vnext` and `v2`. A scoped component also cannot claim a bare `vX.Y.Z` or another component's namespace.

Deciding this lexically keeps `release_artifact_plan` **pure and network-free**, which matters for two reasons: its existing in-memory test seam (`should_try_download_release_artifact`) keeps working, and branch/SHA refs never pay for a release lookup.

## How I resolved the missing-asset ambiguity

The issue lists *"missing assets"* among things that keep local-building, but also says to preserve the *"existing fail-closed contract"*. Those conflict, so I split the cases:

- A ref that is **not a release tag** (branch, raw SHA, foreign tag) selects `local_build`. That is "not a release ref", not "missing asset", and it must not start failing deploys that work today.
- A ref that **is** a release tag whose asset cannot be fetched follows the existing fail-closed contract — `release_asset_download_error` is untouched and still refuses to degrade to `local_build`.

This is deliberately **consistent with the pre-existing non-`--ref` path**, which already resolves a local tag via `latest_component_tag` and then hard-fails if that tag has no asset. A tag-valued `--ref` is now treated exactly like the tag the tag-less path would have chosen, rather than getting its own weaker rule. The reviewer-relevant consequence: deploying a release-shaped tag that has no published asset now fails closed instead of silently local-building. `--tagged` is the escape hatch, and the fail-closed error already names it.

`--tagged` moved above the ref check so an explicit local tag build always wins. Both arms were `local_build` before, so only the reported reason changes.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests -j2` — clean
- `cargo test -p homeboy-version --lib -- release_tag_version` — 5 new tests pass (root vs scoped namespaces, foreign namespaces, branches/SHAs, prerelease tags)
- `cargo test -p homeboy-deploy --lib` — the 4 new plan tests pass alongside every pre-existing release-artifact test

New deploy tests: a tag-valued `--ref` selects `release_asset` **and binds the asset URL/tag to that ref**; branch, `release/`-prefixed, `vnext` and `v2` refs select `local_build`; a raw SHA selects `local_build`; `--tagged` outranks a tag-valued ref. All hermetic — no network, no GitHub, reusing the existing in-memory seam.

## Pre-existing failures NOT introduced here

`cargo test -p homeboy-deploy --lib` reports 5 failures that fail **identically on unmodified `main`** (verified by stashing this change and re-running):

`check_tolerates_missing_canonical_package_and_dry_run_skips_resolution`, `deploy_preflight_preserves_preexisting_artifact_after_failed_build`, `equal_inserted_request_builds_once_and_cleans_only_its_payload_copy`, `failed_post_build_validation_removes_only_new_source_output`, `test_deploy_artifact_fails_when_pre_extract_cleanup_fails`

They are permission/cleanup-failure scenarios, which do not fail when the suite runs as root — host-environment artifacts rather than logic breaks.

Separately worth flagging: this crate has **parallelism-flaky tests**. A full-crate run on `main` failed 9, including four `exact_ref_*` tests that pass cleanly in isolation on that same `main`. I verified against isolation rather than trusting either full-run number.