### PR TITLE
Repin Test to homeboy-action v2.11.24 (skip baseline when candidate passed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,18 +229,18 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.23, DEREFERENCED to its commit. These tags are annotated, so the tag
+    # v2.11.24, DEREFERENCED to its commit. These tags are annotated, so the tag
     # ref's own object SHA is a tag object, which `uses:` cannot resolve — pinning
     # one fails the whole workflow at startup with zero jobs scheduled (#12153).
     # Always pin `git rev-parse v<tag>^{commit}`.
     #
-    # Carries homeboy-action#372 (jq-portable exact shard partitioning),
-    # homeboy-action#376 (a cancelled run no longer publishes a red `Test`
-    # verdict), homeboy-action#377 (the unreachable sharded baseline phase is
-    # removed, closing a latent no-enforcement green), and homeboy-action#378,
-    # which builds the test binaries once into a nextest archive instead of
-    # recompiling the workspace in every shard. All refs #10997.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5e8b3fb5388351bb1a0d73cf283f08eed02ffbae
+    # Carries homeboy-action#372 (jq-portable exact shard partitioning), #376 (a
+    # cancelled run no longer publishes a red `Test` verdict), #377 (the
+    # unreachable sharded baseline phase is removed, closing a latent
+    # no-enforcement green), #378 (test binaries built once into a nextest
+    # archive instead of recompiled in every shard), and #379 (a passing
+    # candidate no longer reruns its baseline). Refs #10997 and #11751 W1-10.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@72aa27783c33672b95ff1f6018c3c18736c9dad9
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
Delivery of Extra-Chill/homeboy-action#379 — **#11751 W1-10**.

## What it does

A command whose candidate **passed** no longer reruns its baseline at the base ref.

A baseline exists to excuse the candidate for breakage that *predates* it. If the candidate passed, there is nothing to excuse — the rerun could never change the verdict. Measured here:

| | duration |
|---|---|
| Audit baseline | **684s** |
| Lint baseline | 110s, against 137s of real work (**+80%**) |

Audit's log shows it directly: `command_execution` runs `06:43:11 → 06:55:18`, then starts **again** at `06:55:21`.

The sharded Test path already made exactly this call in `select-test-baseline.sh`. This aligns the unsharded audit/lint path with it rather than inventing new policy.

Fail-safe: absent or unparseable candidate status keeps **every** baseline. Failing, timed-out and unrecorded commands still run theirs.

## Pinning

`v2.11.24^{commit}` = `72aa2778`. The tag ref's own object is `37465fec`, an annotated tag — the shape that broke `main` in #12152. `.github/validate-action-pin.sh` (added in #12187) confirms:

```
action-pin: Extra-Chill/homeboy-action@72aa2778... is a commit
```

Workflow YAML only. 10 jobs intact.

## Note on the expected red `Test` check

This PR changes no Rust files, so `scope: auto` resolves to zero Rust tests, the extension reports `review test: pass` and writes no inventory, and `Plan candidate Test shards` fails on *"Test inventory is missing"*.

That is **pre-existing and unrelated to this change** — it is #11037 (*"empty test scope defaults to the full workspace"*) surfacing at the inventory stage. Any YAML-only PR hits it; it is normally invisible because runs get cancelled long before reaching the plan job. #12201 merged through the same red check for the same reason.

Refs #11751, #10997