### PR TITLE
fix(controller-runtime): prove pin identity by digest instead of executing it

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -2184,6 +2184,20 @@ fn executable_identity(path: &Path, verified_digest: Option<&str>) -> Result<Str
     if let Some(identity) = test_controller_identity(path, verified_digest) {
         return identity;
     }
+    // Never spawn our own bytes to ask who we are. A candidate whose contents
+    // are identical to the running executable *is* the running executable, so
+    // its identity is the one compiled into this process — proven by digest
+    // rather than self-reported, which is strictly stronger than asking it.
+    //
+    // This also removes a hazard: the candidate is not always a controller.
+    // Under `cargo test` the running executable is a libtest binary, and a pin
+    // taken from it is a byte-identical copy. Executing that copy makes libtest
+    // parse `self identity` as two test *name filters* rather than a
+    // subcommand, run every test matching them, and return their output as the
+    // "identity" (#12226).
+    if is_current_executable_content(path, verified_digest) {
+        return Ok(crate::build_identity::current().display);
+    }
     let output = Command::new(path)
         .args(["self", "identity"])
         .output()
@@ -2208,13 +2222,97 @@ fn executable_identity(path: &Path, verified_digest: Option<&str>) -> Result<Str
         return Err(Error::validation_invalid_argument(
             "controller_runtime",
             format!(
-                "pinned controller executable identity check returned invalid output: {stdout}"
+                "pinned controller executable identity check returned invalid output: {}",
+                bounded_identity_output(&stdout)
             ),
             Some(path.display().to_string()),
             None,
         ));
     }
     Ok(actual.expect("identity was checked above"))
+}
+
+/// Whether `path` is the executable this process is running from.
+///
+/// Compared by canonical path so a pin reached through a symlink still resolves
+/// to the same file. An unresolvable path is treated as "not us", which keeps
+/// the probe fail-closed: the worst case is the pre-existing spawn.
+fn is_current_executable(path: &Path) -> bool {
+    let Ok(current) = std::env::current_exe() else {
+        return false;
+    };
+    match (path.canonicalize(), current.canonicalize()) {
+        (Ok(candidate), Ok(current)) => candidate == current,
+        _ => false,
+    }
+}
+
+/// SHA-256 of the executable this process is running from, hashed at most once.
+///
+/// Pins are content-addressed copies, so identity questions about them reduce
+/// to "are these our bytes?".
+///
+/// Deliberately hashed outside [`executable_digest`]'s memo. That memo is keyed
+/// by observed file identity precisely so it *expires* when a pin is replaced
+/// underneath it — that expiry is the reason pins are validated at all. Our own
+/// executable is a different question: it cannot change under this process, so
+/// it is cached for the process lifetime and kept out of a cache whose whole
+/// job is to notice change.
+fn current_executable_digest() -> Option<&'static str> {
+    static CURRENT_EXECUTABLE_DIGEST: OnceLock<Option<String>> = OnceLock::new();
+    CURRENT_EXECUTABLE_DIGEST
+        .get_or_init(|| {
+            let current = std::env::current_exe().ok()?;
+            content_hash::sha256_file(&current).ok()
+        })
+        .as_deref()
+}
+
+/// Whether `path` holds the same bytes as the running executable.
+///
+/// Path equality is only the fast path: a controller-runtime pin is a *copy*
+/// living under a content-addressed directory, so it is never the same path as
+/// the executable it was taken from. Any failure to establish this answers
+/// "no", leaving the pre-existing spawn as the fallback.
+fn is_current_executable_content(path: &Path, verified_digest: Option<&str>) -> bool {
+    if is_current_executable(path) {
+        return true;
+    }
+    let Some(current_digest) = current_executable_digest() else {
+        return false;
+    };
+    // Reuse the digest the caller already computed and checked when it has one;
+    // pin verification hashes the candidate immediately before asking for its
+    // identity, so the common path adds no work at all.
+    //
+    // Without one, hash directly rather than through `executable_digest`: this
+    // is an identity question about a candidate, not a pin whose memo must
+    // expire when it is replaced underneath us.
+    match verified_digest {
+        Some(digest) => digest == current_digest,
+        None => content_hash::sha256_file(path).is_ok_and(|digest| digest == current_digest),
+    }
+}
+
+/// Cap untrusted probe output before it becomes an error message.
+///
+/// This output is whatever an arbitrary executable wrote, and the error
+/// carrying it is serialized into durable run records. An unbounded copy turned
+/// one failed probe into a ~40 KB diagnostic that buried its own cause.
+fn bounded_identity_output(stdout: &str) -> String {
+    const LIMIT: usize = 512;
+    if stdout.len() <= LIMIT {
+        return stdout.to_string();
+    }
+    let mut end = LIMIT;
+    while end > 0 && !stdout.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}... [truncated, {} bytes total]",
+        &stdout[..end],
+        stdout.len()
+    )
 }
 
 /// Test-support uses a copied libtest executable as its fixture. The contract
@@ -2639,6 +2737,103 @@ fn run_command<const N: usize>(program: &str, args: [&str; N]) -> Result<()> {
             None,
             None,
         ))
+    }
+}
+
+#[cfg(test)]
+mod identity_probe_tests {
+    use super::*;
+
+    /// The running executable under `cargo test` is a libtest binary, which
+    /// would treat `self identity` as test-name filters and re-run the suite.
+    /// Resolving our own identity must never depend on spawning anything.
+    #[test]
+    fn the_current_executable_reports_its_compiled_identity_without_spawning() {
+        let current = std::env::current_exe().expect("current test executable");
+
+        assert!(is_current_executable(&current));
+        assert_eq!(
+            executable_identity(&current, None).expect("self identity"),
+            build_identity::current().display
+        );
+    }
+
+    /// A controller-runtime pin is a *copy* under a content-addressed
+    /// directory, so it is never the same path as the executable it came from.
+    /// Identity must still resolve without executing it.
+    #[cfg(unix)]
+    #[test]
+    fn a_byte_identical_copy_resolves_without_spawning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current = std::env::current_exe().expect("current test executable");
+        let copy = temp.path().join("homeboy");
+        fs::copy(&current, &copy).expect("copy the running executable");
+
+        assert!(!is_current_executable(&copy), "the copy is a distinct path");
+        assert!(is_current_executable_content(&copy, None));
+        assert_eq!(
+            executable_identity(&copy, None).expect("copy identity"),
+            build_identity::current().display
+        );
+    }
+
+    /// The digest the caller already verified is authoritative: a candidate
+    /// carrying some other binary's digest must not be mistaken for us.
+    #[test]
+    fn a_foreign_verified_digest_is_not_treated_as_self() {
+        let current = std::env::current_exe().expect("current test executable");
+
+        assert!(!is_current_executable_content(
+            Path::new("/definitely/missing/homeboy"),
+            Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        ));
+        // ...while our own digest still identifies us through that same seam.
+        let digest = executable_digest(&current).expect("digest the running executable");
+        assert!(is_current_executable_content(
+            Path::new("/definitely/missing/homeboy"),
+            Some(&digest)
+        ));
+    }
+
+    #[test]
+    fn a_path_that_is_not_the_running_executable_is_not_treated_as_self() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let other = temp.path().join("not-the-current-exe");
+        fs::write(&other, b"not an executable").expect("write candidate");
+
+        assert!(!is_current_executable(&other));
+        // A path that cannot be resolved at all must also not claim to be us.
+        assert!(!is_current_executable(Path::new(
+            "/definitely/missing/homeboy"
+        )));
+    }
+
+    #[test]
+    fn probe_output_within_the_cap_is_carried_verbatim() {
+        assert_eq!(bounded_identity_output("boom"), "boom");
+    }
+
+    #[test]
+    fn oversized_probe_output_is_truncated_and_reports_its_true_size() {
+        let noisy = "x".repeat(4096);
+        let bounded = bounded_identity_output(&noisy);
+
+        assert!(bounded.len() < noisy.len());
+        assert!(bounded.starts_with("xxxx"));
+        assert!(
+            bounded.contains("[truncated, 4096 bytes total]"),
+            "{bounded}"
+        );
+    }
+
+    /// Truncation slices bytes, so it must not split a multi-byte character.
+    #[test]
+    fn truncation_never_splits_a_multibyte_character() {
+        let noisy = "é".repeat(4096);
+        let bounded = bounded_identity_output(&noisy);
+
+        assert!(bounded.contains("[truncated,"), "{bounded}");
+        assert!(bounded.starts_with('é'));
     }
 }
 


### PR DESCRIPTION
Item 1 of #12226 (identity-check hardening). Stands on its own merits; the test-isolation and audit-corpus items remain open there.

## The bug

`executable_identity()` in `crates/homeboy-core/src/controller_runtime.rs` asked a candidate who it was by running it:

```rust
Command::new(path).args(["self", "identity"])
```

When that candidate is a **libtest binary**, `self` and `identity` are not a subcommand — libtest parses them as two test **name filters**, runs every test matching them, and returns their output. Hence the CI diagnostic:

```
pinned controller executable identity check returned invalid output:
running 63 tests\ntest agent_task::tests::attempt_workspace_identity...
```

Every one of those 63 tests has `identity` in its name. A controller-runtime pin is a byte-identical **copy** of the executable it was taken from, so under `cargo test` the pinned candidate is a copy of the test binary, and probing it re-enters the suite.

## The change

A candidate whose contents are identical to the running executable **is** the running executable, so its identity is the one already compiled into this process. Resolve it by digest rather than by asking:

- **Strictly stronger evidence.** Content equality beats a self-report — a binary that lies is caught by its bytes.
- **Removes the spawn**, and with it the possibility of executing something that is not a controller at all.
- **Free where it counts.** Both callers of `verify_self_identity` already hash the candidate and compare it against the pinned record immediately beforehand, and that verified digest is already threaded through as `verified_digest`. The running executable's own digest is hashed at most once, memoized.

Path equality is kept as a fast path. Anything that cannot be established answers "not us", so foreign binaries are still executed and still fail closed — the fallback is exactly the pre-existing behaviour.

Also caps the probe output carried into the error. That output is whatever an arbitrary executable wrote, and the error is serialized into durable run records; one failed probe produced a **~40 KB diagnostic that buried its own cause**. Truncation is char-boundary safe and reports the true byte count.

## What this does and does not fix

It **does not** fix the test-isolation half of #12226. Tests reaching `activate_current_generation()` still inherit a controller-runtime pin from their neighbours under `cargo test`, and run alone under nextest.

It **does** remove the reason that inheritance mattered:

```
cargo test -p homeboy-agents --lib -- active_pinned_run_does_not_block_controller_promotion
  before: FAILED. 0 passed; 1 failed
  after:  ok.     1 passed; 0 failed
```

Run in isolation — which is the nextest condition, and the reason this test is red in CI but green in a local full-suite run.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests -j2` — clean
- `cargo test -p homeboy-core --lib -- identity_probe_tests` — 7 new tests pass
- `cargo test -p homeboy-core --lib -- controller_runtime` — **failure set is byte-identical to unmodified `main`** (verified by checking out `origin/main` in the same worktree and diffing the sorted failure lists). Passing count rises 42 → 49, i.e. the 7 new tests and no regressions.

New tests cover: the running executable resolving without spawning; a **byte-identical copy** resolving without spawning (the pin case, which path equality alone would miss); a foreign `verified_digest` not being mistaken for us while our own digest still identifies us through that seam; unresolvable paths answering "not us"; and truncation behaviour including multi-byte characters.

Note the 9 pre-existing `controller_runtime` failures in that local run are `noexec /tmp` artifacts on my host — they write fake controller binaries to a temp dir and exec them — not logic breaks, and unchanged by this PR.