### PR TITLE
Repin Test to homeboy-action v2.11.26 (scoped audit + shard coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.24, DEREFERENCED to its commit. These tags are annotated, so the tag
+    # v2.11.26, DEREFERENCED to its commit. These tags are annotated, so the tag
     # ref's own object SHA is a tag object, which `uses:` cannot resolve — pinning
     # one fails the whole workflow at startup with zero jobs scheduled (#12153).
     # Always pin `git rev-parse v<tag>^{commit}`.
@@ -239,8 +239,10 @@ jobs:
     # unreachable sharded baseline phase is removed, closing a latent
     # no-enforcement green), #378 (test binaries built once into a nextest
     # archive instead of recompiled in every shard), and #379 (a passing
-    # candidate no longer reruns its baseline). Refs #10997 and #11751 W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@72aa27783c33672b95ff1f6018c3c18736c9dad9
+    # candidate no longer reruns its baseline), #380 (the differential audit is
+    # changed-scoped instead of scanning the whole repository) and #381 (shard
+    # partitioning coverage). Refs #10997 and #11751 W1-2, W1-7, W1-10.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@3b20c22160bceb5c324fb2643ab7215e7cf73a53
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
Lands two Wave 1 items (#11751).

## W1-2 — the differential audit is now changed-scoped (homeboy-action#380)

`scripts/scope/flags.sh` exempted `audit` from `--changed-since` under differential gating, so it scanned the **whole repository** on both the candidate and the base.

Audit job `94106689265`:

```
dependency_build_setup   629s    building the CLI from source
command_execution        727s    candidate audit, full repository
command_execution       ~600s    the SAME audit again, at the base ref
[audit] DRIFT INCREASED: 445 new finding(s) since baseline
##[error]homeboy review audit: FAILED (exit code 1)
RESULTS: {"review audit":"baseline_red"}
```

Both sides fail, so the gate downgrades to the non-blocking `baseline_red` and the job publishes **green**. **32.7 minutes — the most expensive job in CI — for no verdict**, with 445 real findings discarded.

`review audit` already answers the actual question when given `--changed-since`: it separates *introduced* findings from *contextual* ones already present in the touched scope. Combined with #379 (already live), a passing candidate audit now also skips its baseline entirely.

**This narrows the gate**: a finding introduced outside the changed files is no longer caught by the PR check. Today it is nominally caught and then discarded as `baseline_red`, so the practical loss is small — but it is real, and it was merged as an explicit decision rather than slipped in.

## W1-7 — shard partitioning coverage (homeboy-action#381)

No producer emits `duration_ms` (`cargo nextest list` enumerates without running), so LPT falls back to equal-count. Every existing fixture carried durations, so **the only shape production emits was untested**. Now pinned, including determinism — the manifest fingerprints gating shard replay are computed from membership.

The duration-blindness itself is left alone deliberately: shards average 9.0–9.3 min, a **3% spread**, so real timings could not recover more than a rounding error.

## Pinning

`v2.11.26^{commit}` = `3b20c221`. The tag ref's own object is `7e92ee0f`, an annotated tag — the shape that broke `main` in #12152. `.github/validate-action-pin.sh` (#12187) confirms:

```
action-pin: Extra-Chill/homeboy-action@3b20c221... is a commit
```

Workflow YAML only. 10 jobs intact.

## Expected red `Test` check

This PR touches no Rust, so `scope: auto` yields zero Rust tests and `Plan candidate Test shards` fails on *"Test inventory is missing"*. Pre-existing (#11037), unrelated, and hit by every YAML-only PR.

Refs #11751, #10997