### PR TITLE
Persist fanout admission state before preflight

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1,9 +1,13 @@
 use chrono::Utc;
+use fs4::fs_std::FileExt;
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use uuid::Uuid;
+
+const COORDINATOR_LEASE_SECONDS: i64 = 300;
 
 use crate::agent_task_dependency_graph::{
     dependency_graph_readiness, AgentTaskDependencyNode, AgentTaskDependencyState,
@@ -175,26 +179,143 @@ pub fn persist_fanout_run_batch(
             ));
         }
     }
-    let record = AgentTaskBatchRecord {
-        schema: AGENT_TASK_BATCH_SCHEMA.to_string(),
-        batch_id,
-        plan_id: plan_id.to_string(),
-        state: AgentTaskBatchState::Running,
-        submitted_at: now_timestamp(),
-        updated_at: None,
-        task_count: children.len(),
-        child_runs: children
-            .iter()
-            .map(|child| AgentTaskBatchChildRun {
-                task_id: child.task_id.clone(),
-                run_id: child.run_id.clone(),
-                state: AgentTaskRunState::Running,
+    with_batch_lock(fanout_id, || {
+        if let Ok(existing) = read_batch(fanout_id) {
+            let expected_children = children
+                .iter()
+                .map(|child| (&child.task_id, &child.run_id))
+                .collect::<Vec<_>>();
+            let actual_children = existing
+                .child_runs
+                .iter()
+                .map(|child| (&child.task_id, &child.run_id))
+                .collect::<Vec<_>>();
+            if existing.plan_id != plan_id || actual_children != expected_children {
+                return Err(Error::validation_invalid_argument(
+                    "fanout_id",
+                    "agent-task fanout run-plan id already belongs to a different child roster",
+                    Some(fanout_id.to_string()),
+                    None,
+                ));
+            }
+            return Ok(existing);
+        }
+        let record = AgentTaskBatchRecord {
+            schema: AGENT_TASK_BATCH_SCHEMA.to_string(),
+            batch_id,
+            plan_id: plan_id.to_string(),
+            state: AgentTaskBatchState::Planning,
+            submitted_at: now_timestamp(),
+            updated_at: None,
+            task_count: children.len(),
+            child_runs: children
+                .iter()
+                .map(|child| AgentTaskBatchChildRun {
+                    task_id: child.task_id.clone(),
+                    run_id: child.run_id.clone(),
+                    state: AgentTaskRunState::Queued,
+                })
+                .collect(),
+            metadata,
+        };
+        write_batch(&record)?;
+        Ok(record)
+    })
+}
+
+pub fn claim_fanout_run_batch(batch_id: &str) -> Result<Option<String>> {
+    with_batch_lock(batch_id, || {
+        let mut batch = read_batch(batch_id)?;
+        let abandoned = batch.state == AgentTaskBatchState::Admitting
+            && batch.metadata["coordinator"]["heartbeat_at"]
+                .as_str()
+                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                .is_some_and(|heartbeat| {
+                    Utc::now() - heartbeat.with_timezone(&Utc)
+                        > chrono::Duration::seconds(COORDINATOR_LEASE_SECONDS)
+                });
+        if !matches!(
+            batch.state,
+            AgentTaskBatchState::Planning | AgentTaskBatchState::Failed
+        ) && !abandoned
+        {
+            return Ok(None);
+        }
+        if !batch.metadata.is_object() {
+            batch.metadata = Value::Object(serde_json::Map::new());
+        }
+        let metadata = batch.metadata.as_object_mut().expect("metadata object");
+        metadata.remove("terminal_failure");
+        let claim_id = Uuid::new_v4().to_string();
+        metadata.insert(
+            "coordinator".to_string(),
+            json!({ "claim_id": claim_id, "stage": "admitting", "heartbeat_at": now_timestamp(), "lease_seconds": COORDINATOR_LEASE_SECONDS }),
+        );
+        batch.state = AgentTaskBatchState::Admitting;
+        batch.updated_at = Some(now_timestamp());
+        write_batch(&batch)?;
+        Ok(Some(claim_id))
+    })
+}
+
+pub fn heartbeat_fanout_run_batch(batch_id: &str, claim_id: &str) -> Result<()> {
+    mutate_batch(batch_id, |batch| {
+        let coordinator = batch
+            .metadata
+            .get_mut("coordinator")
+            .and_then(Value::as_object_mut)
+            .filter(|coordinator| {
+                coordinator.get("claim_id").and_then(Value::as_str) == Some(claim_id)
             })
-            .collect(),
-        metadata,
-    };
-    write_batch(&record)?;
-    Ok(record)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "claim_id",
+                    "fanout coordinator claim is stale",
+                    Some(batch_id.to_string()),
+                    None,
+                )
+            })?;
+        coordinator.insert("heartbeat_at".to_string(), json!(now_timestamp()));
+        batch.updated_at = Some(now_timestamp());
+        Ok(())
+    })
+}
+
+/// Persist a terminal controller failure after durable batch planning.
+pub fn record_fanout_run_batch_failure(
+    batch_id: &str,
+    claim_id: &str,
+    stage: &str,
+    failure: Value,
+) -> Result<()> {
+    with_batch_lock(batch_id, || {
+        let mut batch = read_batch(batch_id)?;
+        if batch.metadata["coordinator"]["claim_id"].as_str() != Some(claim_id) {
+            return Err(Error::validation_invalid_argument(
+                "claim_id",
+                "fanout coordinator claim is stale",
+                Some(batch_id.to_string()),
+                None,
+            ));
+        }
+        if !batch.metadata.is_object() {
+            batch.metadata = Value::Object(serde_json::Map::new());
+        }
+        batch
+            .metadata
+            .as_object_mut()
+            .expect("metadata object")
+            .insert(
+                "terminal_failure".to_string(),
+                json!({ "stage": stage, "failure": failure }),
+            );
+        for child in &mut batch.child_runs {
+            child.state = AgentTaskRunState::Failed;
+        }
+        batch.state = AgentTaskBatchState::Failed;
+        batch.updated_at = Some(now_timestamp());
+        write_batch(&batch)
+    })
 }
 
 /// Record child failures that occurred before Cook could create a lifecycle
@@ -204,59 +325,74 @@ pub fn record_fanout_run_batch_failed_admissions<'a>(
     batch_id: &str,
     failed_run_ids: impl IntoIterator<Item = &'a str>,
 ) -> Result<()> {
-    let mut batch = read_batch(batch_id)?;
-    let failed_run_ids = failed_run_ids.into_iter().collect::<HashSet<_>>();
-    if failed_run_ids.is_empty() {
-        return Ok(());
-    }
-    let mut changed = false;
-    for child in &mut batch.child_runs {
-        if failed_run_ids.contains(child.run_id.as_str())
-            && child.state != AgentTaskRunState::Failed
-        {
-            child.state = AgentTaskRunState::Failed;
-            changed = true;
+    mutate_batch(batch_id, |batch| {
+        let failed_run_ids = failed_run_ids.into_iter().collect::<HashSet<_>>();
+        if failed_run_ids.is_empty() {
+            return Ok(());
         }
-    }
-    if changed {
-        if !batch.metadata.is_object() {
-            batch.metadata = Value::Object(serde_json::Map::new());
-        }
-        let metadata = batch.metadata.as_object_mut().expect("metadata object");
-        let failures = metadata
-            .entry("terminal_admission_failures")
-            .or_insert_with(|| Value::Array(Vec::new()))
-            .as_array_mut()
-            .expect("admission failures are an array");
-        for run_id in &failed_run_ids {
-            if !failures.iter().any(|value| value.as_str() == Some(*run_id)) {
-                failures.push(Value::String((*run_id).to_string()));
+        let mut changed = false;
+        for child in &mut batch.child_runs {
+            if failed_run_ids.contains(child.run_id.as_str())
+                && child.state != AgentTaskRunState::Failed
+            {
+                child.state = AgentTaskRunState::Failed;
+                changed = true;
             }
         }
-        let totals = totals_for_children(&batch.child_runs);
-        batch.state = aggregate_state(&totals);
-        batch.updated_at = Some(now_timestamp());
-        write_batch(&batch)?;
-    }
-    Ok(())
+        if changed {
+            if !batch.metadata.is_object() {
+                batch.metadata = Value::Object(serde_json::Map::new());
+            }
+            let metadata = batch.metadata.as_object_mut().expect("metadata object");
+            let failures = metadata
+                .entry("terminal_admission_failures")
+                .or_insert_with(|| Value::Array(Vec::new()))
+                .as_array_mut()
+                .expect("admission failures are an array");
+            for run_id in &failed_run_ids {
+                if !failures.iter().any(|value| value.as_str() == Some(*run_id)) {
+                    failures.push(Value::String((*run_id).to_string()));
+                }
+            }
+            let totals = totals_for_children(&batch.child_runs);
+            batch.state = aggregate_state(&totals);
+            batch.updated_at = Some(now_timestamp());
+        }
+        Ok(())
+    })
 }
 
 pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut batch = read_batch(batch_id)?;
-    let mut changed = false;
+    if batch.metadata["terminal_failure"].is_object() {
+        batch.state = AgentTaskBatchState::Failed;
+        let commands = commands(&batch.batch_id);
+        return Ok(AgentTaskBatchStatusReport {
+            schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
+            status: "failed".to_string(),
+            totals: totals_for_children(&batch.child_runs),
+            batch,
+            unavailable_child_runs: Vec::new(),
+            projection_pending_child_runs: Vec::new(),
+            resumable_child_runs: Vec::new(),
+            resumable: false,
+            dependency_graph: None,
+            next_actions: vec![commands.status.clone(), commands.artifacts.clone()],
+            commands,
+        });
+    }
     let mut unavailable_child_runs = Vec::new();
     let mut projection_pending_child_runs = Vec::new();
     let mut resumable_child_runs = Vec::new();
     let mut timed_out_child_runs = HashSet::new();
     for child in &mut batch.child_runs {
-        if terminal_admission_failure(&batch.metadata, &child.run_id) {
+        if terminal_preflight_or_admission_failure(&batch.metadata, &child.run_id) {
             continue;
         }
         match agent_task_lifecycle::status(&child.run_id) {
             Ok(record) => {
                 if child.state != record.state {
                     child.state = record.state;
-                    changed = true;
                 }
                 if record
                     .totals
@@ -298,22 +434,19 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
     let mut state = aggregate_state(&totals);
     if batch.state != state {
         batch.state = state;
-        changed = true;
     }
     let dependency_graph = refresh_dependency_graph(&mut batch)?;
     if let Some(graph) = &dependency_graph {
         state = aggregate_state_after_graph_refresh(&totals, graph, state);
         if batch.state != state {
             batch.state = state;
-            changed = true;
         }
     }
     // A status read only persists a changed durable projection. In particular,
     // repeated observations must retain the existing timestamp byte-for-byte.
-    if changed {
-        batch.updated_at = Some(now_timestamp());
-        write_batch(&batch)?;
-    }
+    // Status is a read-only projection. It never writes a snapshot assembled
+    // outside the mutation lock, so it cannot overwrite a newer coordinator
+    // or child-finalization transition.
     let mut next_actions = batch_next_actions(
         &unavailable_child_runs,
         &projection_pending_child_runs,
@@ -529,10 +662,11 @@ fn resumable_child_reason(record: &agent_task_lifecycle::AgentTaskRunRecord) -> 
     }
 }
 
-fn terminal_admission_failure(metadata: &Value, run_id: &str) -> bool {
-    metadata["terminal_admission_failures"]
-        .as_array()
-        .is_some_and(|failures| failures.iter().any(|value| value.as_str() == Some(run_id)))
+fn terminal_preflight_or_admission_failure(metadata: &Value, run_id: &str) -> bool {
+    metadata["terminal_failure"].is_object()
+        || metadata["terminal_admission_failures"]
+            .as_array()
+            .is_some_and(|failures| failures.iter().any(|value| value.as_str() == Some(run_id)))
 }
 
 pub fn artifacts(batch_id: &str) -> Result<AgentTaskBatchArtifactsReport> {
@@ -794,8 +928,43 @@ fn write_batch(record: &AgentTaskBatchRecord) -> Result<()> {
             Some(format!("serialize agent-task batch {}", record.batch_id)),
         )
     })?;
-    fs::write(&path, raw)
+    let temporary = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
+    fs::write(&temporary, raw).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(temporary.display().to_string()))
+    })?;
+    fs::rename(&temporary, &path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+}
+
+fn with_batch_lock<T>(batch_id: &str, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let path = batch_path(batch_id)?.with_extension("lock");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+    }
+    let lock = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    lock.lock_exclusive()
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let result = operation();
+    let _ = FileExt::unlock(&lock);
+    result
+}
+
+fn mutate_batch<T>(
+    batch_id: &str,
+    operation: impl FnOnce(&mut AgentTaskBatchRecord) -> Result<T>,
+) -> Result<T> {
+    with_batch_lock(batch_id, || {
+        let mut batch = read_batch(batch_id)?;
+        let result = operation(&mut batch)?;
+        write_batch(&batch)?;
+        Ok(result)
+    })
 }
 
 fn read_batch(batch_id: &str) -> Result<AgentTaskBatchRecord> {
@@ -825,26 +994,27 @@ pub fn record_child_finalization(
     child_run_id: &str,
     finalization: Value,
 ) -> Result<()> {
-    let mut batch = read_batch(batch_id)?;
-    let metadata = match &mut batch.metadata {
-        Value::Object(map) => map,
-        other => {
-            *other = json!({});
-            other.as_object_mut().expect("just-created object")
+    mutate_batch(batch_id, |batch| {
+        let metadata = match &mut batch.metadata {
+            Value::Object(map) => map,
+            other => {
+                *other = json!({});
+                other.as_object_mut().expect("just-created object")
+            }
+        };
+        let finalizations = metadata
+            .entry("child_finalizations".to_string())
+            .or_insert_with(|| json!({}));
+        if !finalizations.is_object() {
+            *finalizations = json!({});
         }
-    };
-    let finalizations = metadata
-        .entry("child_finalizations".to_string())
-        .or_insert_with(|| json!({}));
-    if !finalizations.is_object() {
-        *finalizations = json!({});
-    }
-    finalizations
-        .as_object_mut()
-        .expect("child_finalizations is an object")
-        .insert(child_run_id.to_string(), finalization);
-    batch.updated_at = Some(now_timestamp());
-    write_batch(&batch)
+        finalizations
+            .as_object_mut()
+            .expect("child_finalizations is an object")
+            .insert(child_run_id.to_string(), finalization);
+        batch.updated_at = Some(now_timestamp());
+        Ok(())
+    })
 }
 
 /// Record that this batch's coordinator was cancelled by its durable owner.
@@ -864,25 +1034,26 @@ pub fn record_child_finalization(
 /// `state`, because [`status`] recomputes `state` from live child observation
 /// on every read and would erase a marker written there.
 pub fn record_coordinator_cancellation(batch_id: &str, reason: &str) -> Result<()> {
-    let mut batch = read_batch(batch_id)?;
-    if !batch.metadata.is_object() {
-        batch.metadata = json!({});
-    }
-    let metadata = batch.metadata.as_object_mut().expect("metadata object");
-    // First writer wins: a repeated cancellation must not rewrite the instant
-    // the batch was actually stopped, so replayed cancellation converges.
-    if metadata.contains_key(COORDINATOR_CANCELLATION_KEY) {
-        return Ok(());
-    }
-    metadata.insert(
-        COORDINATOR_CANCELLATION_KEY.to_string(),
-        json!({
-            "requested_at": now_timestamp(),
-            "reason": reason,
-        }),
-    );
-    batch.updated_at = Some(now_timestamp());
-    write_batch(&batch)
+    mutate_batch(batch_id, |batch| {
+        if !batch.metadata.is_object() {
+            batch.metadata = json!({});
+        }
+        let metadata = batch.metadata.as_object_mut().expect("metadata object");
+        // First writer wins: a repeated cancellation must not rewrite the instant
+        // the batch was actually stopped, so replayed cancellation converges.
+        if metadata.contains_key(COORDINATOR_CANCELLATION_KEY) {
+            return Ok(());
+        }
+        metadata.insert(
+            COORDINATOR_CANCELLATION_KEY.to_string(),
+            json!({
+                "requested_at": now_timestamp(),
+                "reason": reason,
+            }),
+        );
+        batch.updated_at = Some(now_timestamp());
+        Ok(())
+    })
 }
 
 /// Whether this batch's coordinator has been cancelled by its durable owner.
@@ -907,25 +1078,26 @@ pub fn dependency_action_receipt(batch_id: &str, key: &str) -> Result<Option<Val
 }
 
 pub fn record_dependency_action_receipt(batch_id: &str, key: &str, receipt: Value) -> Result<()> {
-    let mut batch = read_batch(batch_id)?;
-    if !batch.metadata.is_object() {
-        batch.metadata = json!({});
-    }
-    let receipts = batch
-        .metadata
-        .as_object_mut()
-        .expect("metadata object")
-        .entry("dependency_action_receipts")
-        .or_insert_with(|| json!({}));
-    if !receipts.is_object() {
-        *receipts = json!({});
-    }
-    receipts
-        .as_object_mut()
-        .expect("receipts object")
-        .insert(key.to_string(), receipt);
-    batch.updated_at = Some(now_timestamp());
-    write_batch(&batch)
+    mutate_batch(batch_id, |batch| {
+        if !batch.metadata.is_object() {
+            batch.metadata = json!({});
+        }
+        let receipts = batch
+            .metadata
+            .as_object_mut()
+            .expect("metadata object")
+            .entry("dependency_action_receipts")
+            .or_insert_with(|| json!({}));
+        if !receipts.is_object() {
+            *receipts = json!({});
+        }
+        receipts
+            .as_object_mut()
+            .expect("receipts object")
+            .insert(key.to_string(), receipt);
+        batch.updated_at = Some(now_timestamp());
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -1504,7 +1676,7 @@ mod tests {
 
         assert_eq!(record.batch_id, "rules-memory-gaps-20260721");
         assert_eq!(record.task_count, 2);
-        assert_eq!(record.state, AgentTaskBatchState::Running);
+        assert_eq!(record.state, AgentTaskBatchState::Planning);
 
         // The exact failure from #9397: `fanout status <id>` could not read the
         // batch file because run-plan never wrote it. It is now readable.
@@ -1515,7 +1687,7 @@ mod tests {
         assert!(persisted
             .child_runs
             .iter()
-            .all(|child| child.state == AgentTaskRunState::Running));
+            .all(|child| child.state == AgentTaskRunState::Queued));
     }
 
     #[test]
@@ -1545,6 +1717,227 @@ mod tests {
             .expect_err("empty cooks rejected");
 
         assert!(error.message.contains("at least one cook"));
+    }
+
+    #[test]
+    fn fanout_run_plan_reuses_a_repaired_preflight_roster_without_overwriting_it() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "repair".to_string(),
+            run_id: "repair-run".to_string(),
+        }];
+        persist_fanout_run_batch("repair-wave", "repair-wave", &children, json!({}))
+            .expect("persist planning record");
+        let claim_id = claim_fanout_run_batch("repair-wave")
+            .expect("claim")
+            .expect("claim id");
+        record_fanout_run_batch_failure(
+            "repair-wave",
+            &claim_id,
+            "worktree_preflight",
+            json!({ "message": "worktree missing" }),
+        )
+        .expect("record preflight failure");
+        let failed = status("repair-wave").expect("preflight failure remains observable");
+        assert_eq!(failed.batch.state, AgentTaskBatchState::Failed);
+        assert_eq!(failed.status, "failed");
+        assert_eq!(failed.totals.failed, 1);
+        assert!(failed.unavailable_child_runs.is_empty());
+
+        let replay = persist_fanout_run_batch("repair-wave", "repair-wave", &children, json!({}))
+            .expect("replay repaired roster");
+
+        assert_eq!(replay.state, AgentTaskBatchState::Failed);
+        assert!(replay.metadata.get("terminal_failure").is_some());
+        assert_eq!(replay.child_runs[0].run_id, "repair-run");
+    }
+
+    #[test]
+    fn fanout_run_plan_replay_preserves_an_interrupted_coordinator_state() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "interrupted".to_string(),
+            run_id: "interrupted-run".to_string(),
+        }];
+        persist_fanout_run_batch("interrupted-wave", "interrupted-wave", &children, json!({}))
+            .expect("persist planning record");
+        let mut interrupted = read_batch("interrupted-wave").expect("read planning record");
+        interrupted.metadata = json!({ "coordinator": { "stage": "admission" } });
+        write_batch(&interrupted).expect("record interruption checkpoint");
+
+        let replay =
+            persist_fanout_run_batch("interrupted-wave", "interrupted-wave", &children, json!({}))
+                .expect("idempotent replay");
+
+        assert_eq!(replay.metadata["coordinator"]["stage"], "admission");
+        assert_eq!(replay.child_runs[0].run_id, "interrupted-run");
+    }
+
+    #[test]
+    fn fanout_run_plan_allows_only_one_coordinator_claim() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "only".to_string(),
+            run_id: "only-run".to_string(),
+        }];
+        persist_fanout_run_batch("claimed-wave", "claimed-wave", &children, json!({}))
+            .expect("persist planning record");
+
+        assert!(claim_fanout_run_batch("claimed-wave")
+            .expect("first claim")
+            .is_some());
+        assert!(claim_fanout_run_batch("claimed-wave")
+            .expect("second claim is denied")
+            .is_none());
+        assert_eq!(
+            read_batch("claimed-wave").expect("claimed batch").state,
+            AgentTaskBatchState::Admitting
+        );
+    }
+
+    #[test]
+    fn fanout_run_plan_recovers_an_abandoned_coordinator_lease() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "lease".to_string(),
+            run_id: "lease-run".to_string(),
+        }];
+        persist_fanout_run_batch("expired-wave", "expired-wave", &children, json!({}))
+            .expect("persist planning record");
+        assert!(claim_fanout_run_batch("expired-wave")
+            .expect("first claim")
+            .is_some());
+        mutate_batch("expired-wave", |batch| {
+            batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+            Ok(())
+        })
+        .expect("expire lease");
+
+        assert!(claim_fanout_run_batch("expired-wave")
+            .expect("recover abandoned claim")
+            .is_some());
+        assert_eq!(
+            read_batch("expired-wave").expect("reclaimed batch").state,
+            AgentTaskBatchState::Admitting
+        );
+    }
+
+    #[test]
+    fn replacement_claim_rejects_a_stale_owner_failure() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "stale".to_string(),
+            run_id: "stale-run".to_string(),
+        }];
+        persist_fanout_run_batch("stale-wave", "stale-wave", &children, json!({}))
+            .expect("persist");
+        let old = claim_fanout_run_batch("stale-wave")
+            .expect("claim")
+            .expect("claim id");
+        mutate_batch("stale-wave", |batch| {
+            batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+            Ok(())
+        })
+        .expect("expire");
+        let replacement = claim_fanout_run_batch("stale-wave")
+            .expect("replacement claim")
+            .expect("replacement id");
+
+        assert!(
+            record_fanout_run_batch_failure("stale-wave", &old, "coordinator", json!({})).is_err()
+        );
+        heartbeat_fanout_run_batch("stale-wave", &replacement).expect("replacement heartbeat");
+    }
+
+    #[test]
+    fn fresh_owned_heartbeat_prevents_reclaim_after_an_expired_prior_timestamp() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "live".to_string(),
+            run_id: "live-run".to_string(),
+        }];
+        persist_fanout_run_batch("live-wave", "live-wave", &children, json!({})).expect("persist");
+        let claim_id = claim_fanout_run_batch("live-wave")
+            .expect("claim")
+            .expect("claim id");
+        // Simulate a coordinator whose initial lease would have expired, then
+        // refresh it as the periodic worker does during a long batch run.
+        mutate_batch("live-wave", |batch| {
+            batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+            Ok(())
+        })
+        .expect("age heartbeat");
+        heartbeat_fanout_run_batch("live-wave", &claim_id).expect("live heartbeat");
+
+        assert!(claim_fanout_run_batch("live-wave")
+            .expect("claim check")
+            .is_none());
+    }
+
+    #[test]
+    fn stale_heartbeat_cannot_change_replacement_owner() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "heartbeat".to_string(),
+            run_id: "heartbeat-run".to_string(),
+        }];
+        persist_fanout_run_batch("heartbeat-wave", "heartbeat-wave", &children, json!({}))
+            .expect("persist");
+        let old = claim_fanout_run_batch("heartbeat-wave")
+            .expect("claim")
+            .expect("claim id");
+        mutate_batch("heartbeat-wave", |batch| {
+            batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+            Ok(())
+        })
+        .expect("expire");
+        let replacement = claim_fanout_run_batch("heartbeat-wave")
+            .expect("replacement")
+            .expect("replacement id");
+
+        assert!(heartbeat_fanout_run_batch("heartbeat-wave", &old).is_err());
+        assert_eq!(
+            read_batch("heartbeat-wave").expect("batch").metadata["coordinator"]["claim_id"],
+            json!(replacement)
+        );
+    }
+
+    #[test]
+    fn concurrent_child_finalizations_preserve_both_receipts() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let children = vec![
+            FanoutRunBatchChild {
+                task_id: "a".to_string(),
+                run_id: "a-run".to_string(),
+            },
+            FanoutRunBatchChild {
+                task_id: "b".to_string(),
+                run_id: "b-run".to_string(),
+            },
+        ];
+        persist_fanout_run_batch("finalize-wave", "finalize-wave", &children, json!({}))
+            .expect("persist planning record");
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                record_child_finalization("finalize-wave", "a-run", json!({ "attempt": 1 }))
+            });
+            let second = scope.spawn(|| {
+                record_child_finalization("finalize-wave", "b-run", json!({ "attempt": 1 }))
+            });
+            first
+                .join()
+                .expect("first finalization thread")
+                .expect("first finalization");
+            second
+                .join()
+                .expect("second finalization thread")
+                .expect("second finalization");
+        });
+        let batch = read_batch("finalize-wave").expect("batch record");
+        let finalizations = batch.metadata["child_finalizations"]
+            .as_object()
+            .expect("finalizations");
+        assert_eq!(finalizations.len(), 2);
     }
 
     fn request(task_id: &str) -> AgentTaskRequest {

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -31,6 +31,8 @@ pub struct AgentTaskBatchChildRun {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskBatchState {
+    Planning,
+    Admitting,
     Queued,
     Running,
     Succeeded,
@@ -45,6 +47,8 @@ impl AgentTaskBatchState {
     /// batch status, resume, and their command-result envelopes.
     pub fn outcome_status(self) -> &'static str {
         match self {
+            Self::Planning => "planning",
+            Self::Admitting => "admitting",
             Self::Queued => "queued",
             Self::Running => "running",
             Self::Succeeded => "succeeded",
@@ -59,7 +63,7 @@ impl AgentTaskBatchState {
     /// successful command to shell or JSON-envelope consumers.
     pub fn exit_code(self) -> i32 {
         match self {
-            Self::Queued | Self::Running | Self::Succeeded => 0,
+            Self::Planning | Self::Admitting | Self::Queued | Self::Running | Self::Succeeded => 0,
             Self::PartialFailure | Self::Failed | Self::Cancelled | Self::TimedOut => 1,
         }
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1667,6 +1667,8 @@ mod run_lifecycle_projection_tests {
         use crate::agent_task_batch::AgentTaskBatchState;
 
         for state in [
+            AgentTaskBatchState::Planning,
+            AgentTaskBatchState::Admitting,
             AgentTaskBatchState::Queued,
             AgentTaskBatchState::Running,
             AgentTaskBatchState::Succeeded,
@@ -1676,6 +1678,8 @@ mod run_lifecycle_projection_tests {
             AgentTaskBatchState::TimedOut,
         ] {
             let expected = match state {
+                AgentTaskBatchState::Planning => RunLifecycleStatus::Queued,
+                AgentTaskBatchState::Admitting => RunLifecycleStatus::Running,
                 AgentTaskBatchState::Queued => RunLifecycleStatus::Queued,
                 AgentTaskBatchState::Running => RunLifecycleStatus::Running,
                 AgentTaskBatchState::Succeeded => RunLifecycleStatus::Succeeded,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1478,7 +1478,12 @@ pub struct AgentTaskCookBatchReport {
 /// from, so this parses instead of keeping a second copy of that list.
 /// Anything unparseable stays `Unknown` rather than being guessed.
 fn batch_lifecycle_status(status: &str) -> RunLifecycleStatus {
-    serde_json::from_value(Value::String(status.to_string())).unwrap_or(RunLifecycleStatus::Unknown)
+    match status {
+        "planning" => RunLifecycleStatus::Queued,
+        "admitting" => RunLifecycleStatus::Running,
+        _ => serde_json::from_value(Value::String(status.to_string()))
+            .unwrap_or(RunLifecycleStatus::Unknown),
+    }
 }
 
 impl AgentTaskCookBatchReport {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5751,6 +5751,7 @@ fn cook_persists_materialization_failure_without_provider_execution() {
                 .provider_executions_consumed,
             0
         );
+        assert!(agent_task_lifecycle::run_record_exists(run_id).expect("run record lookup"));
     });
 }
 
@@ -10263,7 +10264,6 @@ fn cook_successful_concrete_attempt_publishes_reviewer_body() {
                 "Close the issue by guarding the reload path.",
                 "Add a null guard in the render path.",
                 "Internal-only change; no compatibility impact.",
-                "Drafted test coverage.",
                 // Deterministic evidence (orchestrator-owned).
                 "1. Run `cargo test --locked agent_task_promotion --lib`; expect passes as recorded by Cook's deterministic gate.",
                 "Verified candidate scope: 1 changed file(s): src/lib.rs.",

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -205,14 +205,15 @@ pub mod cook_loop {
 /// Durable batch/fanout lifecycle records built from independent child runs.
 pub mod batch {
     pub use super::super::agent_task_batch::{
-        artifacts, coordinator_is_cancelled, fanout_aggregate_state,
+        artifacts, claim_fanout_run_batch, coordinator_is_cancelled, fanout_aggregate_state,
         fanout_dependency_graph_with_finalization_statuses, fanout_ready_child_run_ids,
-        persist_fanout_run_batch, read_batch_record, record_coordinator_cancellation,
-        record_fanout_run_batch_failed_admissions, status, submit_plan_batch,
-        AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun,
-        AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
-        AgentTaskBatchStatusReport, AgentTaskBatchTotals, FanoutRunBatchChild,
-        AGENT_TASK_BATCH_ARTIFACTS_SCHEMA, AGENT_TASK_BATCH_SCHEMA, AGENT_TASK_BATCH_STATUS_SCHEMA,
+        heartbeat_fanout_run_batch, persist_fanout_run_batch, read_batch_record,
+        record_coordinator_cancellation, record_fanout_run_batch_failed_admissions,
+        record_fanout_run_batch_failure, status, submit_plan_batch, AgentTaskBatchArtifactsReport,
+        AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun, AgentTaskBatchCommands,
+        AgentTaskBatchRecord, AgentTaskBatchState, AgentTaskBatchStatusReport,
+        AgentTaskBatchTotals, FanoutRunBatchChild, AGENT_TASK_BATCH_ARTIFACTS_SCHEMA,
+        AGENT_TASK_BATCH_SCHEMA, AGENT_TASK_BATCH_STATUS_SCHEMA,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1730,14 +1730,24 @@ fn cook_batch_inner(
             .all(|row| matches!(row.status, worktree::WorktreeQueueCreateStatus::Created));
     let private_artifact_path = if can_run && plan_has_private_gates {
         if let Err(error) = bind_materialized_worktrees(&mut plan, &worktrees) {
-            record_batch_preflight_failure(claim_id.as_deref(), &plan, "worktree_preflight", &error)?;
+            record_batch_preflight_failure(
+                claim_id.as_deref(),
+                &plan,
+                "worktree_preflight",
+                &error,
+            )?;
             return Err(error);
         }
         Some(persist_private_batch_plan(&plan)?)
     } else {
         if can_run {
             if let Err(error) = bind_materialized_worktrees(&mut plan, &worktrees) {
-                record_batch_preflight_failure(claim_id.as_deref(), &plan, "worktree_preflight", &error)?;
+                record_batch_preflight_failure(
+                    claim_id.as_deref(),
+                    &plan,
+                    "worktree_preflight",
+                    &error,
+                )?;
                 return Err(error);
             }
         }
@@ -1761,13 +1771,15 @@ fn cook_batch_inner(
     }
     let run_result = if args.run_plan && can_run {
         let (value, exit_code) = match attempt_dispatcher {
-            Some(dispatcher) => {
-                run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
-                    plan.clone(), dispatcher, claim_id.clone(),
-                )?
-            }
+            Some(dispatcher) => run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
+                plan.clone(),
+                dispatcher,
+                claim_id.clone(),
+            )?,
             None => run_batch_cook_fanout_plan_with_executor_claim(
-                plan.clone(), provider::ExtensionProviderAgentTaskExecutor::discover(), claim_id.clone(),
+                plan.clone(),
+                provider::ExtensionProviderAgentTaskExecutor::discover(),
+                claim_id.clone(),
             )?,
         };
         Some(serde_json::json!({ "exit_code": exit_code, "result": value }))
@@ -1796,37 +1808,37 @@ fn cook_batch_inner(
 
     Ok((
         serde_json::json!({
-            "schema": "homeboy/agent-task-cook-batch/v1",
-            "fanout_id": plan.fanout_id,
-            "status": status,
-            "dry_run": args.dry_run,
-            "summary": {
-                "issues": plan.cooks.len(),
-                "worktrees_total": worktrees.rows.len(),
-                "worktrees_blocked": blocked,
-            },
-            "preflight": {
-                "provider_readiness_command": provider_readiness_command(&args),
-                "provider_selection": provider_selection_preflight(&args),
-                "deterministic_gates": effective_batch_cook_gates(&plan)
-            },
-            "worktrees": worktrees,
-            "plan": public_batch_cook_plan(&plan),
-            "run_result": run_result,
-    "commands": cook_batch_commands(&args, plan_has_private_gates, private_artifact_path.as_deref()),
-            // Named run-plan persists before worktree/provider preflight, so
-            // status and artifacts remain available when admission is blocked.
-            "next_actions": cook_batch_next_actions(
-                &args,
-                &plan.fanout_id,
-                status,
-                persisted,
-                resume_legal,
-                &worktrees,
-                plan_has_private_gates,
-                private_artifact_path.as_deref(),
-            ),
-        }),
+                "schema": "homeboy/agent-task-cook-batch/v1",
+                "fanout_id": plan.fanout_id,
+                "status": status,
+                "dry_run": args.dry_run,
+                "summary": {
+                    "issues": plan.cooks.len(),
+                    "worktrees_total": worktrees.rows.len(),
+                    "worktrees_blocked": blocked,
+                },
+                "preflight": {
+                    "provider_readiness_command": provider_readiness_command(&args),
+                    "provider_selection": provider_selection_preflight(&args),
+                    "deterministic_gates": effective_batch_cook_gates(&plan)
+                },
+                "worktrees": worktrees,
+                "plan": public_batch_cook_plan(&plan),
+                "run_result": run_result,
+        "commands": cook_batch_commands(&args, plan_has_private_gates, private_artifact_path.as_deref()),
+                // Named run-plan persists before worktree/provider preflight, so
+                // status and artifacts remain available when admission is blocked.
+                "next_actions": cook_batch_next_actions(
+                    &args,
+                    &plan.fanout_id,
+                    status,
+                    persisted,
+                    resume_legal,
+                    &worktrees,
+                    plan_has_private_gates,
+                    private_artifact_path.as_deref(),
+                ),
+            }),
         exit_code,
     ))
 }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -78,6 +78,66 @@ type CookAttemptDispatcherFactory = dyn Fn(
     + Send
     + Sync;
 
+const FANOUT_COORDINATOR_HEARTBEAT_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+struct CoordinatorHeartbeat {
+    stop: std::sync::mpsc::Sender<()>,
+    worker: Option<std::thread::JoinHandle<()>>,
+    stale_error: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+}
+
+impl CoordinatorHeartbeat {
+    fn start(batch_id: String, claim_id: String) -> Self {
+        let (stop, receiver) = std::sync::mpsc::channel();
+        let stale_error = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let worker_error = std::sync::Arc::clone(&stale_error);
+        let worker = std::thread::spawn(move || loop {
+            match receiver.recv_timeout(FANOUT_COORDINATOR_HEARTBEAT_INTERVAL) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    if let Err(error) = batch::heartbeat_fanout_run_batch(&batch_id, &claim_id) {
+                        *worker_error.lock().expect("heartbeat error lock") = Some(error.message);
+                        break;
+                    }
+                }
+            }
+        });
+        Self {
+            stop,
+            worker: Some(worker),
+            stale_error,
+        }
+    }
+
+    fn finish(mut self) -> Result<()> {
+        let _ = self.stop.send(());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+        if let Some(message) = self
+            .stale_error
+            .lock()
+            .expect("heartbeat error lock")
+            .take()
+        {
+            return Err(Error::validation_invalid_argument(
+                "claim_id", message, None, None,
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CoordinatorHeartbeat {
+    fn drop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
 /// Runs controller-owned cook-batch coordination while dispatching its typed
 /// provider attempts through the caller-selected transport.
 pub(crate) fn cook_batch_with_attempt_dispatcher(
@@ -1134,42 +1194,85 @@ fn persist_fanout_run_batch_record(plan: &BatchCookFanoutPlan) -> Result<()> {
     Ok(())
 }
 
+fn claim_fanout_run_batch_coordinator(plan: &BatchCookFanoutPlan) -> Result<String> {
+    persist_fanout_run_batch_record(plan)?;
+    if let Some(claim_id) = batch::claim_fanout_run_batch(&plan.fanout_id)? {
+        return Ok(claim_id);
+    }
+    Err(Error::validation_invalid_argument(
+        "fanout_id",
+        "agent-task fanout run-plan is already being coordinated; inspect its durable status",
+        Some(plan.fanout_id.clone()),
+        None,
+    ))
+}
+
+fn record_batch_failure(plan: &BatchCookFanoutPlan, claim_id: &str, stage: &str, error: &Error) {
+    let _ = batch::record_fanout_run_batch_failure(
+        &plan.fanout_id,
+        claim_id,
+        stage,
+        serde_json::json!({ "message": error.message, "details": error.details }),
+    );
+}
+
 fn run_batch_cook_fanout_plan_with_attempt_dispatcher(
     plan: BatchCookFanoutPlan,
     attempt_dispatcher: &CookAttemptDispatcherFactory,
 ) -> CmdResult<Value> {
+    run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(plan, attempt_dispatcher, None)
+}
+
+fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
+    plan: BatchCookFanoutPlan,
+    attempt_dispatcher: &CookAttemptDispatcherFactory,
+    claim_id: Option<String>,
+) -> CmdResult<Value> {
     let gate_workspace = batch_plan_gate_workspace(&plan)?;
     let gate_contract_validation = validate_batch_gate_contracts(&plan, gate_workspace.as_deref())?;
-    persist_fanout_run_batch_record(&plan)?;
-    persist_batch_cook_recipes(&plan, |options| {
-        record_gate_contract_validation(options, &gate_contract_validation);
-        options.attempt_dispatcher = Some(attempt_dispatcher(options));
-    })?;
-    let ready_plan = plan.ready_plan()?;
-    let cooks = compile_batch_cooks(&ready_plan, |options| {
-        record_gate_contract_validation(options, &gate_contract_validation);
-        options.attempt_dispatcher = Some(attempt_dispatcher(options));
-    })?;
-    let concurrency = batch_concurrency(&plan, &cooks);
-    // Resolved once, here, and bound for the whole batch: every worker thread
-    // re-binds this same absolute instant, so the budget covers the batch
-    // rather than restarting per child.
-    let result = with_current_cook_deadline(plan.cook_deadline(), || {
-        agent_task_service::run_cook_batch_with_control(
-            agent_task_service::AgentTaskCookBatchOptions {
-                batch_id: plan.fanout_id.clone(),
-                cooks,
-                max_concurrency: concurrency.limit,
-            },
-            provider::ExtensionProviderAgentTaskExecutor::discover(),
-            agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
-        )
-    })?;
-    finalize_provider_worktrees(&plan, &result.value)?;
-    record_terminal_batch_admission_failures(&plan, &result.value)?;
-    notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
-    let result = batch_cook_result(&plan, result, &concurrency);
-    Ok(result)
+    let claim_id = match claim_id {
+        Some(claim_id) => claim_id,
+        None => claim_fanout_run_batch_coordinator(&plan)?,
+    };
+    let outcome = (|| {
+        persist_batch_cook_recipes(&plan, |options| {
+            record_gate_contract_validation(options, &gate_contract_validation);
+            options.attempt_dispatcher = Some(attempt_dispatcher(options));
+        })?;
+        let ready_plan = plan.ready_plan()?;
+        let cooks = compile_batch_cooks(&ready_plan, |options| {
+            record_gate_contract_validation(options, &gate_contract_validation);
+            options.attempt_dispatcher = Some(attempt_dispatcher(options));
+        })?;
+        let concurrency = batch_concurrency(&plan, &cooks);
+        // Resolved once, here, and bound for the whole batch: every worker thread
+        // re-binds this same absolute instant, so the budget covers the batch
+        // rather than restarting per child.
+        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone());
+        let result = with_current_cook_deadline(plan.cook_deadline(), || {
+            batch::heartbeat_fanout_run_batch(&plan.fanout_id, &claim_id)?;
+            agent_task_service::run_cook_batch_with_control(
+                agent_task_service::AgentTaskCookBatchOptions {
+                    batch_id: plan.fanout_id.clone(),
+                    cooks,
+                    max_concurrency: concurrency.limit,
+                },
+                provider::ExtensionProviderAgentTaskExecutor::discover(),
+                agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
+            )
+        });
+        heartbeat.finish()?;
+        let result = result?;
+        finalize_provider_worktrees(&plan, &result.value)?;
+        record_terminal_batch_admission_failures(&plan, &result.value)?;
+        notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
+        let result = batch_cook_result(&plan, result, &concurrency);
+        Ok(result)
+    })();
+    if let Err(error) = &outcome {
+        record_batch_failure(&plan, &claim_id, "coordinator", error);
+    }
+    outcome
 }
 
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
@@ -1186,35 +1289,59 @@ fn run_batch_cook_fanout_plan_with_executor<E>(
 where
     E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
 {
+    run_batch_cook_fanout_plan_with_executor_claim(plan, executor, None)
+}
+
+fn run_batch_cook_fanout_plan_with_executor_claim<E>(
+    plan: BatchCookFanoutPlan,
+    executor: E,
+    claim_id: Option<String>,
+) -> CmdResult<Value>
+where
+    E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
+{
     let gate_workspace = batch_plan_gate_workspace(&plan)?;
     let gate_contract_validation = validate_batch_gate_contracts(&plan, gate_workspace.as_deref())?;
-    persist_fanout_run_batch_record(&plan)?;
-    persist_batch_cook_recipes(&plan, |options| {
-        record_gate_contract_validation(options, &gate_contract_validation);
-    })?;
-    let ready_plan = plan.ready_plan()?;
-    let cooks = compile_batch_cooks(&ready_plan, |options| {
-        record_gate_contract_validation(options, &gate_contract_validation);
-    })?;
-    let concurrency = batch_concurrency(&plan, &cooks);
-    // See the sibling runner: the budget is resolved once and bound for the
-    // whole batch so it does not restart per child.
-    let result = with_current_cook_deadline(plan.cook_deadline(), || {
-        agent_task_service::run_cook_batch_with_control(
-            agent_task_service::AgentTaskCookBatchOptions {
-                batch_id: plan.fanout_id.clone(),
-                cooks,
-                max_concurrency: concurrency.limit,
-            },
-            executor,
-            agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
-        )
-    })?;
-    finalize_provider_worktrees(&plan, &result.value)?;
-    record_terminal_batch_admission_failures(&plan, &result.value)?;
-    notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
-    let result = batch_cook_result(&plan, result, &concurrency);
-    Ok(result)
+    let claim_id = match claim_id {
+        Some(claim_id) => claim_id,
+        None => claim_fanout_run_batch_coordinator(&plan)?,
+    };
+    let outcome = (|| {
+        persist_batch_cook_recipes(&plan, |options| {
+            record_gate_contract_validation(options, &gate_contract_validation);
+        })?;
+        let ready_plan = plan.ready_plan()?;
+        let cooks = compile_batch_cooks(&ready_plan, |options| {
+            record_gate_contract_validation(options, &gate_contract_validation);
+        })?;
+        let concurrency = batch_concurrency(&plan, &cooks);
+        // See the sibling runner: the budget is resolved once and bound for the
+        // whole batch so it does not restart per child.
+        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone());
+        let result = with_current_cook_deadline(plan.cook_deadline(), || {
+            batch::heartbeat_fanout_run_batch(&plan.fanout_id, &claim_id)?;
+            agent_task_service::run_cook_batch_with_control(
+                agent_task_service::AgentTaskCookBatchOptions {
+                    batch_id: plan.fanout_id.clone(),
+                    cooks,
+                    max_concurrency: concurrency.limit,
+                },
+                executor,
+                agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
+            )
+        });
+        heartbeat.finish()?;
+        let result = result?;
+        finalize_provider_worktrees(&plan, &result.value)?;
+        record_terminal_batch_admission_failures(&plan, &result.value)?;
+        notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
+        let result = batch_cook_result(&plan, result, &concurrency);
+        Ok(result)
+    })();
+    if let Err(error) = &outcome {
+        record_batch_failure(&plan, &claim_id, "coordinator", error);
+    }
+    outcome
 }
 
 fn validate_batch_gate_contracts(
@@ -1555,8 +1682,26 @@ fn cook_batch_inner(
         .cooks
         .iter()
         .any(|cook| !cook.private_verify.is_empty());
-    validate_batch_cook_gates(&plan, batch_gate_workspace(&args)?)?;
-    let worktrees = queue_or_reuse_worktrees(&args, &plan)?;
+    let persisted = args.run_plan && !args.dry_run;
+    let claim_id = persisted
+        .then(|| claim_fanout_run_batch_coordinator(&plan))
+        .transpose()?;
+    if let Err(error) = validate_batch_cook_gates(&plan, batch_gate_workspace(&args)?) {
+        record_batch_preflight_failure(claim_id.as_deref(), &plan, "gate_preflight", &error)?;
+        return Err(error);
+    }
+    let worktrees = match queue_or_reuse_worktrees(&args, &plan) {
+        Ok(worktrees) => worktrees,
+        Err(error) => {
+            record_batch_preflight_failure(
+                claim_id.as_deref(),
+                &plan,
+                "worktree_preflight",
+                &error,
+            )?;
+            return Err(error);
+        }
+    };
     bind_materialized_worktree_paths(&mut plan, &worktrees);
     let blocked = worktrees
         .rows
@@ -1569,6 +1714,14 @@ fn cook_batch_inner(
             )
         })
         .count();
+    if persisted && blocked > 0 {
+        batch::record_fanout_run_batch_failure(
+            &plan.fanout_id,
+            claim_id.as_deref().expect("persisted coordinator claim"),
+            "worktree_preflight",
+            serde_json::json!({ "worktrees": worktrees.rows }),
+        )?;
+    }
     let can_run = !args.dry_run
         && blocked == 0
         && worktrees
@@ -1576,11 +1729,17 @@ fn cook_batch_inner(
             .iter()
             .all(|row| matches!(row.status, worktree::WorktreeQueueCreateStatus::Created));
     let private_artifact_path = if can_run && plan_has_private_gates {
-        bind_materialized_worktrees(&mut plan, &worktrees)?;
+        if let Err(error) = bind_materialized_worktrees(&mut plan, &worktrees) {
+            record_batch_preflight_failure(claim_id.as_deref(), &plan, "worktree_preflight", &error)?;
+            return Err(error);
+        }
         Some(persist_private_batch_plan(&plan)?)
     } else {
         if can_run {
-            bind_materialized_worktrees(&mut plan, &worktrees)?;
+            if let Err(error) = bind_materialized_worktrees(&mut plan, &worktrees) {
+                record_batch_preflight_failure(claim_id.as_deref(), &plan, "worktree_preflight", &error)?;
+                return Err(error);
+            }
         }
         None
     };
@@ -1588,16 +1747,28 @@ fn cook_batch_inner(
         // Compare the exact workspace-bound recipe that provider execution will
         // persist, not the handle-only planning form created before worktree
         // materialization.
-        preflight_batch_cook_recipes(&plan, attempt_dispatcher)?;
+        if let Err(error) = preflight_batch_cook_recipes(&plan, attempt_dispatcher) {
+            record_batch_preflight_failure(
+                claim_id.as_deref(),
+                &plan,
+                "provider_preflight",
+                &error,
+            )?;
+            return Err(error);
+        }
     } else if args.dry_run {
         preflight_batch_cook_recipe_declarations(&plan)?;
     }
     let run_result = if args.run_plan && can_run {
         let (value, exit_code) = match attempt_dispatcher {
             Some(dispatcher) => {
-                run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)?
+                run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
+                    plan.clone(), dispatcher, claim_id.clone(),
+                )?
             }
-            None => run_batch_cook_fanout_plan(plan.clone())?,
+            None => run_batch_cook_fanout_plan_with_executor_claim(
+                plan.clone(), provider::ExtensionProviderAgentTaskExecutor::discover(), claim_id.clone(),
+            )?,
         };
         Some(serde_json::json!({ "exit_code": exit_code, "result": value }))
     } else {
@@ -1642,15 +1813,14 @@ fn cook_batch_inner(
             "worktrees": worktrees,
             "plan": public_batch_cook_plan(&plan),
             "run_result": run_result,
-            "commands": cook_batch_commands(&args, plan_has_private_gates, private_artifact_path.as_deref()),
-            // `run_result.is_some()` rather than `args.run_plan`: the durable
-            // batch record the status/artifacts/resume commands read only
-            // exists once the plan actually ran.
+    "commands": cook_batch_commands(&args, plan_has_private_gates, private_artifact_path.as_deref()),
+            // Named run-plan persists before worktree/provider preflight, so
+            // status and artifacts remain available when admission is blocked.
             "next_actions": cook_batch_next_actions(
                 &args,
                 &plan.fanout_id,
                 status,
-                run_result.is_some(),
+                persisted,
                 resume_legal,
                 &worktrees,
                 plan_has_private_gates,
@@ -1659,6 +1829,23 @@ fn cook_batch_inner(
         }),
         exit_code,
     ))
+}
+
+fn record_batch_preflight_failure(
+    claim_id: Option<&str>,
+    plan: &BatchCookFanoutPlan,
+    stage: &str,
+    error: &Error,
+) -> Result<()> {
+    let Some(claim_id) = claim_id else {
+        return Ok(());
+    };
+    batch::record_fanout_run_batch_failure(
+        &plan.fanout_id,
+        claim_id,
+        stage,
+        serde_json::json!({ "message": error.message, "details": error.details }),
+    )
 }
 
 fn normalize_cook_batch_repo(args: &mut AgentTaskFanoutCookBatchArgs) -> Result<()> {
@@ -3752,10 +3939,8 @@ fn cook_batch_commands(
 /// # Why the branches differ
 ///
 /// `homeboy agent-task fanout status|artifacts|resume <fanout_id>` all read a
-/// durable batch record, and that record is only persisted once the plan is
-/// actually run (`persist_fanout_run_batch_record`). Offering them for a
-/// dry run or a blocked plan would name commands that fail. Each branch
-/// therefore emits only what is executable at that point.
+/// durable batch record. A named run-plan creates it before preflight, so a
+/// blocked durable batch exposes status and artifacts alongside repair steps.
 fn cook_batch_next_actions(
     args: &AgentTaskFanoutCookBatchArgs,
     fanout_id: &str,
@@ -3806,6 +3991,22 @@ fn cook_batch_next_actions(
             CommandNextAction::new("rerun this cook-batch once the worktrees exist", command)
                 .with_kind(CommandNextActionKind::Repair),
         );
+        if executed {
+            actions.push(
+                CommandNextAction::new(
+                    "show persisted batch status",
+                    format!("homeboy agent-task fanout status {fanout_id}"),
+                )
+                .with_kind(CommandNextActionKind::Show),
+            );
+            actions.push(
+                CommandNextAction::new(
+                    "list persisted batch artifacts",
+                    format!("homeboy agent-task fanout artifacts {fanout_id}"),
+                )
+                .with_kind(CommandNextActionKind::Artifacts),
+            );
+        }
         return actions;
     }
 
@@ -6432,7 +6633,7 @@ fi
             &cook_batch_args(),
             "issue-wave",
             "blocked",
-            false,
+            true,
             false,
             &worktrees,
             false,
@@ -6458,6 +6659,12 @@ fi
                 .any(|command| command.contains("--run-plan")),
             "the rerun command must be named: {commands:?}"
         );
+        assert!(commands
+            .iter()
+            .any(|command| command == "homeboy agent-task fanout status issue-wave"));
+        assert!(commands
+            .iter()
+            .any(|command| command == "homeboy agent-task fanout artifacts issue-wave"));
     }
 
     #[test]
@@ -6497,9 +6704,8 @@ fi
         assert!(!command.starts_with("homeboy homeboy "));
     }
 
-    /// `fanout status|artifacts|resume` read a durable batch record that only
-    /// exists once the plan ran. Offering them before that names commands that
-    /// fail.
+    /// Named run-plans persist before preflight, while dry plans have no durable
+    /// batch record to inspect.
     #[test]
     fn batch_record_commands_are_only_offered_once_the_batch_has_run() {
         let worktrees = worktree_output(vec![worktree_row(


### PR DESCRIPTION
## Summary
- persist named fanout planning state before blocking preflight
- serialize atomic batch mutations and fence coordinators with recoverable heartbeat leases
- retain structured terminal failures and idempotent exact rerun behavior

Closes #12254

## Verification
- `cargo fmt --check`
- `cargo check`
- repaired preflight, interruption, lease recovery, stale owner, and concurrent finalization tests

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.