### PR TITLE
Render workspace owner repair commands

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1865,9 +1865,17 @@ fn queue_or_reuse_worktrees(
 
     if args.dry_run {
         if configured_provider_workspace_creation()? {
-            return plan_provider_worktrees_dry_run(args, plan);
+            return with_workspace_owner_repair_commands(
+                args,
+                plan,
+                plan_provider_worktrees_dry_run(args, plan)?,
+            );
         }
-        return queue_or_reuse_worktrees_dry_run(args, plan, queue_create);
+        return with_workspace_owner_repair_commands(
+            args,
+            plan,
+            queue_or_reuse_worktrees_dry_run(args, plan, queue_create)?,
+        );
     }
 
     let mut reused = Vec::new();
@@ -1902,13 +1910,59 @@ fn queue_or_reuse_worktrees(
         }
     }
 
-    Ok(worktree::WorktreeQueueCreateOutput {
-        schema: "homeboy/worktree-queue-create/v1",
-        repo: args.repo.clone(),
-        base_ref: args.from.clone(),
-        dry_run: false,
-        rows,
-    })
+    with_workspace_owner_repair_commands(
+        args,
+        plan,
+        worktree::WorktreeQueueCreateOutput {
+            schema: "homeboy/worktree-queue-create/v1",
+            repo: args.repo.clone(),
+            base_ref: args.from.clone(),
+            dry_run: false,
+            rows,
+        },
+    )
+}
+
+fn with_workspace_owner_repair_commands(
+    args: &AgentTaskFanoutCookBatchArgs,
+    plan: &BatchCookFanoutPlan,
+    mut worktrees: worktree::WorktreeQueueCreateOutput,
+) -> Result<worktree::WorktreeQueueCreateOutput> {
+    if !configured_provider_lifecycle()? {
+        return Ok(worktrees);
+    }
+
+    let config = homeboy::core::defaults::load_config();
+    for row in &mut worktrees.rows {
+        let Some(cook) = plan
+            .cooks
+            .iter()
+            .find(|cook| cook.to_worktree == row.handle)
+        else {
+            continue;
+        };
+        let intent = homeboy::core::worktree_providers::WorktreeProviderCreateIntent {
+            handle: row.handle.clone(),
+            repo: args.repo.clone(),
+            base: args.from.clone(),
+            head: row.branch.clone(),
+            task_url: cook
+                .task_url
+                .clone()
+                .expect("generated cooks have task URLs"),
+        };
+        let lifecycle = homeboy::core::worktree_providers::WorktreeProviderLifecycleIntent {
+            purpose: "agent_task_cook".to_string(),
+            owner_run_ref: cook.run_id(),
+            cleanup_policy:
+                homeboy::core::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+        };
+        row.command =
+            homeboy::core::worktree_providers::worktree_provider_lifecycle_ensure_argv_from_config(
+                &intent, &lifecycle, &config,
+            )?;
+    }
+    Ok(worktrees)
 }
 
 /// Provider-managed destinations have provider-owned path policy. Dry-run
@@ -3237,7 +3291,7 @@ fn cook_batch_next_actions(
             .map(|row| {
                 CommandNextAction::new(
                     format!("create blocked worktree {}", row.handle),
-                    format!("homeboy {}", row.command.join(" ")),
+                    quote_args(&row.command),
                 )
                 .with_kind(CommandNextActionKind::Repair)
             })
@@ -5382,6 +5436,7 @@ fi
             handle: handle.to_string(),
             status,
             command: vec![
+                "homeboy".to_string(),
                 "worktree".to_string(),
                 "create".to_string(),
                 "homeboy".to_string(),
@@ -5458,10 +5513,8 @@ fi
         assert_every_action_is_executable(&actions);
         let commands = action_commands(&actions);
         assert!(
-            commands
-                .iter()
-                .any(|command| command
-                    .contains("worktree create homeboy --branch fix/homeboy@fix-b")),
+            commands.iter().any(|command| command
+                == "homeboy worktree create homeboy --branch fix/homeboy@fix-b --from origin/main"),
             "the blocked row's own command must be offered: {commands:?}"
         );
         assert!(
@@ -5476,6 +5529,41 @@ fi
                 .any(|command| command.contains("--run-plan")),
             "the rerun command must be named: {commands:?}"
         );
+    }
+
+    #[test]
+    fn blocked_workspace_owner_action_round_trips_complete_argv() {
+        let owner_argv = vec![
+            "workspace-owner".to_string(),
+            "worktree".to_string(),
+            "add".to_string(),
+            "blocks-engine".to_string(),
+            "fix/issue-855-blocks-engine".to_string(),
+            "--from=origin/trunk".to_string(),
+            "--task-url=https://example.test/issues/855".to_string(),
+        ];
+        let mut row = worktree_row(
+            "blocks-engine@fix-issue-855-blocks-engine",
+            worktree::WorktreeQueueCreateStatus::Failed,
+        );
+        row.command = owner_argv.clone();
+        let actions = cook_batch_next_actions(
+            &cook_batch_args(),
+            "issue-wave",
+            "blocked",
+            false,
+            false,
+            &worktree_output(vec![row]),
+        );
+        let command = &actions[0].command;
+
+        assert_eq!(command, &quote_args(&owner_argv));
+        assert_eq!(
+            homeboy_engine_primitives::shell::normalize_args(&vec![command.clone()]),
+            owner_argv,
+            "the rendered repair command must round-trip to the registered owner's argv"
+        );
+        assert!(!command.starts_with("homeboy homeboy "));
     }
 
     /// `fanout status|artifacts|resume` read a durable batch record that only

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1254,6 +1254,32 @@ pub fn worktree_provider_idempotency_key(intent: &WorktreeProviderCreateIntent) 
     )
 }
 
+/// Render the configured workspace owner's ensure command for an explicit
+/// lifecycle request. Callers can expose this as a repair action without
+/// assuming that Homeboy owns the workspace implementation.
+pub fn worktree_provider_lifecycle_ensure_argv_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    config: &HomeboyConfig,
+) -> Result<Vec<String>> {
+    let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
+    let provider = config
+        .worktree_providers
+        .get(&provider_id)
+        .expect("selected provider is configured");
+    let command = provider
+        .commands
+        .ensure
+        .as_ref()
+        .expect("selected lifecycle provider configures ensure");
+    Ok(expand_lifecycle_ensure_command(
+        command,
+        intent,
+        lifecycle,
+        &provision_idempotency_key(intent),
+    ))
+}
+
 /// Stable finalization key. A stale lease may cause multiple invocations, so
 /// providers must use this key to deduplicate their logical terminal effect.
 pub fn worktree_provider_finalization_idempotency_key(
@@ -3139,6 +3165,71 @@ mod tests {
                 .expect("list result mapping")
                 .items,
             "$.result.items"
+        );
+    }
+
+    #[test]
+    fn lifecycle_ensure_argv_uses_the_registered_workspace_owner() {
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "managed".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec!["false".to_string()]),
+                    resolve_not_found_exit_codes: vec![1],
+                    ensure: Some(vec![
+                        "workspace-owner".to_string(),
+                        "worktree".to_string(),
+                        "add".to_string(),
+                        "{repo}".to_string(),
+                        "{head}".to_string(),
+                        "--from={base}".to_string(),
+                        "--task-url={task_url}".to_string(),
+                        "--owner-run-ref={owner_run_ref}".to_string(),
+                    ]),
+                    ..WorktreeProviderCommands::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        config.settings.insert(
+            WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY.to_string(),
+            json!({ "managed": { "finalize": ["workspace-owner", "finalize"] } }),
+        );
+        let intent = WorktreeProviderCreateIntent {
+            handle: "blocks-engine@fix-12252".to_string(),
+            repo: "blocks-engine".to_string(),
+            base: "origin/trunk".to_string(),
+            head: "fix/12252".to_string(),
+            task_url: "https://example.test/issues/12252".to_string(),
+        };
+        let lifecycle = WorktreeProviderLifecycleIntent {
+            purpose: "agent_task_cook".to_string(),
+            owner_run_ref: "fanout-12252".to_string(),
+            cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+        };
+
+        let argv =
+            worktree_provider_lifecycle_ensure_argv_from_config(&intent, &lifecycle, &config)
+                .expect("registered owner repair argv");
+
+        assert_eq!(
+            argv,
+            vec![
+                "workspace-owner",
+                "worktree",
+                "add",
+                "blocks-engine",
+                "fix/12252",
+                "--from=origin/trunk",
+                "--task-url=https://example.test/issues/12252",
+                "--owner-run-ref=fanout-12252",
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- render the selected workspace lifecycle provider exact ensure argv
- preserve task, base, branch, and owner-run identity
- remove the duplicated executable prefix from fanout repair actions

Closes #12252

## Verification
- `cargo fmt --check`
- `cargo check`
- workspace-owner argv and shell round-trip tests

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed this change with parallel coding and review agents. Chris Huber reviewed and remains responsible for every line.