### PR TITLE
fix(audit): prune stale observe fingerprint

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -743,7 +743,6 @@
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/execution.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/replay.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/issues.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/observe.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/bench.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/trace.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runner/types.rs::ConstantBypassLiteral",


### PR DESCRIPTION
## Summary
- remove the obsolete `commands/observe.rs` constant-bypass fingerprint left by the Trace migration
- leave `commands/trace/passive.rs` unblessed so current findings are evaluated normally

Closes #12265.

## Evidence
- Current-main failure: https://github.com/Extra-Chill/homeboy/actions/runs/31653758550
- `jq empty homeboy.json` passes
- `git diff --check` passes
- Local `homeboy review audit` was deferred by the resource-policy guard because the machine was warm and no Lab runner was ready; GitHub CI is the runtime verification surface

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode traced the stale row, made the focused baseline edit, and verified the JSON and diff. Chris Huber reviewed and owns the change.