### PR TITLE
test(controller-runtime): own the fixture warmth a digest count depends on

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -2697,6 +2697,27 @@ fn register_test_fixture_candidate(source: &Path, candidate: &Path, expected_dig
 #[cfg(not(all(unix, any(test, feature = "test-support"))))]
 fn register_test_fixture_candidate(_source: &Path, _candidate: &Path, _expected_digest: &str) {}
 
+/// Resolve the test-support controller fixture's digest once, up front.
+///
+/// Pin validation consults that fixture, and its digest cache is process-wide
+/// and deliberately not cleared between tests. A test that measures digest
+/// computations therefore has to decide whether the fixture is warm rather than
+/// inherit the answer from whichever tests ran before it — otherwise it passes
+/// under `cargo test` and fails under nextest, which gives every test its own
+/// process (#12226).
+///
+/// Best effort: with no fixture configured there is nothing to warm, and the
+/// caller's measurement is unaffected.
+#[cfg(all(unix, test))]
+fn warm_test_controller_fixture_digest() {
+    let Some(source) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) else {
+        return;
+    };
+    let source = PathBuf::from(source);
+    crate::test_support::ensure_test_controller_fixture(&source);
+    let _ = test_controller_fixture_digest(&source);
+}
+
 fn required_runtime_string<'a>(runtime: &'a Value, pointer: &str, label: &str) -> Result<&'a str> {
     runtime
         .pointer(pointer)
@@ -4060,6 +4081,16 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         crate::test_support::with_isolated_home(|_| {
+            // `pin_executable` validates the pin it publishes, and validation
+            // resolves the test-support controller fixture's digest. That
+            // fixture cache is process-wide state this test does not own, so
+            // warm it deliberately: the count below is meant to measure
+            // publication, not whether a neighbouring test happened to warm the
+            // fixture first. Leaving it to chance is why this passed under
+            // `cargo test` and failed under nextest, which runs every test in
+            // its own process (#12226).
+            warm_test_controller_fixture_digest();
+
             EXECUTABLE_DIGESTS
                 .get_or_init(|| Mutex::new(BTreeMap::new()))
                 .lock()


### PR DESCRIPTION
Item 2 of #12226, and the sole remaining failure on the shard that runs `homeboy-core`.

## Problem

`publishing_a_pin_seeds_the_digest_its_validation_needs` asserts publication computes exactly two digests — the source and the staged copy. Run alone it observes three:

```
assertion `left == right` failed: publication reads the source and the staged copy, and nothing else
  left: 3   right: 2
```

Reproduced on **unmodified `main`**, so this is not a regression from #12237.

## Root cause

Instrumenting `executable_digest` shows exactly which three files get hashed:

```
DIGESTPROBE /tmp/.../homeboy                                  # the fake controller source   (expected)
DIGESTPROBE /var/tmp/.../controller-runtimes/.../.homeboy-... # the staged copy              (expected)
DIGESTPROBE /var/tmp/.../homeboy-controller-fixture           # the test-support fixture     (not expected)
```

`pin_executable` validates the pin it publishes, and validation resolves the **test-support controller fixture's** digest. That cache (`TEST_CONTROLLER_FIXTURE_DIGESTS`) is process-wide and deliberately *not* cleared between tests — the test clears `EXECUTABLE_DIGESTS` but has no ownership of this one.

So the third computation appears only when no earlier test has warmed the fixture. Under `cargo test` a neighbour always has; under **nextest, which gives every test its own process**, none ever does. The assertion was measuring publication *plus* the ambient state of a cache the test does not own.

This is the same shape as the failure #12237 fixed, and the second confirmed instance of #12226 item 2.

## Change

Warm the fixture digest explicitly before resetting the counter, so the measurement covers publication alone and is identical under both runners.

The assertion itself is **unchanged**. It still pins the behaviour it was written for — that publication seeds the digest its validation needs rather than re-reading the destination — and the warming happens before the counter reset, so it cannot mask a real regression in that behaviour.

## Verification

| | alone (nextest condition) | in the `controller_runtime` group |
|---|---|---|
| `main` | FAILED (`left: 3, right: 2`) | ok |
| this PR | **ok** | ok |

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --tests -j2` — clean
- Group failure set diffed against unmodified `origin/main` in the same worktree: **byte-identical**, 9 either way. Those 9 are `noexec /tmp` artifacts on my host (they write fake controller binaries to a temp dir and exec them), unrelated and unchanged.

## Remaining on #12226

Item 3 (audit corpus needing `homeboy-action`'s `Install extension` step) and the `homeboy-cli` agent-task lifecycle failures.

Worth flagging for whoever takes those: an assertion on an exact count of a **process-wide counter** cannot be hermetic unless the test owns that counter's entire lifetime. This PR gives the test that ownership, but the pattern is inherently fragile and may deserve a different measurement seam rather than more warming calls.