### PR TITLE
Reconcile exact Cook lifecycle records

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -42,6 +42,15 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
     )))
 }
 
+/// Cancel one literal durable record without resolving a Cook alias.
+///
+/// Grouped lifecycle recovery uses this boundary after it has explicitly
+/// selected every parent/attempt record to mutate. Alias-aware cancellation is
+/// intentionally broader because it follows an advancing Cook index.
+pub fn cancel_exact_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
+    cancel_resolved_run(&sanitize_run_id(run_id), reason)
+}
+
 fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
     // Cook IDs are stable aliases. Match status and logs by following an
     // materialized attempt once one exists; before then the handoff parent is

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2681,8 +2681,27 @@ pub fn status_with_options(
     run_id: &str,
     options: AgentTaskStatusOptions,
 ) -> Result<AgentTaskStatusOutcome> {
+    status_with_options_inner(run_id, options, false)
+}
+
+/// Reconcile one literal durable record without following a Cook alias. Scoped
+/// repair uses this when a logical Cook id has both a handoff parent and an
+/// attempt, because each record is independently authoritative evidence.
+pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
+    Ok(status_with_options_inner(run_id, AgentTaskStatusOptions::default(), true)?.record)
+}
+
+fn status_with_options_inner(
+    run_id: &str,
+    options: AgentTaskStatusOptions,
+    exact: bool,
+) -> Result<AgentTaskStatusOutcome> {
     let requested_run_id = sanitize_run_id(run_id);
-    let resolved_run_id = resolve_run_id(run_id)?;
+    let resolved_run_id = if exact {
+        requested_run_id.clone()
+    } else {
+        resolve_run_id(run_id)?
+    };
     let _ = reconcile_deferred_candidate(&resolved_run_id)?;
     let mut record = store::read_record(&resolved_run_id)?;
     if let Ok(admission) = homeboy_core::controller_runtime::admission_status(&record.run_id) {
@@ -2929,7 +2948,7 @@ pub fn status_with_options(
             }
         }
     }
-    if requested_run_id != record.run_id {
+    if !exact && requested_run_id != record.run_id {
         if let Ok(index) = store::read_cook_index(&requested_run_id) {
             project_cook_alias_adoption(&mut record, &index)?;
             let metadata = record.ensure_metadata_object();
@@ -4134,6 +4153,65 @@ fn substantive_candidate_in_aggregate(
 /// index entry. Recovery must inspect historical source attempts directly.
 pub fn exact_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     store::read_record(&sanitize_run_id(run_id))
+}
+
+/// Return the exact durable records a reconciliation request owns. A Cook id
+/// with a materialized detached-handoff parent names both that parent and its
+/// current attempt; an exact attempt remains scoped to itself.
+pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
+    let requested = sanitize_run_id(run_id);
+    let mut run_ids = vec![requested.clone()];
+
+    if let Ok(parent) = store::read_record(&requested) {
+        if let Some(attempt_run_id) = parent
+            .metadata
+            .pointer("/detached_cook_handoff/attempt_run_id")
+            .and_then(Value::as_str)
+        {
+            let attempt_run_id = sanitize_run_id(attempt_run_id);
+            let attempt = store::read_record(&attempt_run_id)?;
+            let attempt_cook_id = attempt.metadata.get("cook_id").and_then(Value::as_str);
+            if attempt_cook_id != Some(requested.as_str()) {
+                return Err(Error::validation_invalid_argument(
+                    "detached_cook_handoff.attempt_run_id",
+                    "detached Cook handoff attempt does not belong to its parent Cook",
+                    Some(attempt_run_id),
+                    None,
+                ));
+            }
+            let index = store::read_cook_index(&requested).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "detached_cook_handoff.attempt_run_id",
+                    "detached Cook handoff attempt has no Cook index authority",
+                    Some(attempt.run_id.clone()),
+                    None,
+                )
+            })?;
+            if !index
+                .attempts
+                .iter()
+                .any(|entry| entry.run_id == attempt.run_id)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "detached_cook_handoff.attempt_run_id",
+                    "detached Cook handoff attempt is absent from its Cook index",
+                    Some(attempt.run_id),
+                    None,
+                ));
+            }
+            // The handoff binds this repair to its accepted child. A later
+            // index retry is a separate attempt and remains out of scope.
+            run_ids.push(attempt.run_id);
+        } else if let Ok(index) = store::read_cook_index(&requested) {
+            run_ids.push(index.latest_run_id);
+        }
+    } else if let Ok(index) = store::read_cook_index(&requested) {
+        run_ids[0] = index.latest_run_id;
+    }
+
+    run_ids.sort();
+    run_ids.dedup();
+    Ok(run_ids)
 }
 
 /// Resolve a caller-supplied identifier to the durable run it addresses.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -13,7 +13,7 @@ use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use crate::agent_task_service::reconcile_stale_active_runs;
+use crate::agent_task_service::{reconcile_run, reconcile_stale_active_runs};
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
@@ -1032,7 +1032,7 @@ fn foreground_terminal_daemon_projection_finishes_success_and_failure_runs_once(
 }
 
 #[test]
-fn stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controller_projection() {
+fn scoped_reconcile_repairs_authoritative_terminal_runner_projection_idempotently() {
     with_isolated_home(|_| {
         let run_id = "cook-9773-attempt-1-caller-loss";
         let plan = test_plan();
@@ -1068,7 +1068,7 @@ fn stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controlle
         .expect("persist stale local controller projection");
         assert!(store::read_aggregate(run_id).is_err());
 
-        let report = reconcile_stale_active_runs(false).expect("reconcile stale projection");
+        let report = reconcile_run(run_id, false).expect("reconcile stale projection");
         assert_eq!(report.considered, 0);
         assert_eq!(report.reconciled, 0);
 
@@ -1086,7 +1086,7 @@ fn stale_reconcile_imports_terminal_runner_aggregate_before_cancelling_controlle
             .iter()
             .any(|evidence| evidence.kind == "executor-input"));
 
-        let repeated = reconcile_stale_active_runs(false).expect("idempotent terminal reconcile");
+        let repeated = reconcile_run(run_id, false).expect("idempotent terminal reconcile");
         assert_eq!(repeated.considered, 0);
         assert_eq!(
             status(run_id).expect("terminal state retained").state,

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -4,6 +4,7 @@
 use crate::agent_task::{AgentTaskRequest, AgentTaskSourceRef};
 use crate::agent_task_lifecycle::{self, AgentTaskRecordHealthSummary, AgentTaskRunRecord};
 use crate::agent_task_scheduler::AgentTaskState;
+use std::collections::{BTreeMap, BTreeSet};
 // `agent-task active` treats a `Running` record that has gone this long without
 // an `updated_at` heartbeat as suspect even when its owner process/runner-job
 // liveness cannot be disproven (#5682). Shared with `activity` so the two
@@ -457,7 +458,33 @@ pub(crate) fn controller_upgrade_admission_for_records(
     now: chrono::DateTime<chrono::Utc>,
 ) -> ControllerUpgradeAdmission {
     let summary = liveness_summary_for_records(records, now);
-    let blockers = records
+    let mut parent_by_attempt = BTreeMap::new();
+    let mut invalid_handoff_parents = BTreeSet::new();
+    for record in records {
+        if let Some(attempt) = record
+            .metadata
+            .pointer("/detached_cook_handoff/attempt_run_id")
+            .and_then(serde_json::Value::as_str)
+        {
+            let linked_attempt = records.iter().find(|candidate| candidate.run_id == attempt);
+            let belongs_to_parent = linked_attempt
+                .and_then(|candidate| candidate.metadata.get("cook_id"))
+                .and_then(serde_json::Value::as_str)
+                == Some(record.run_id.as_str());
+            let indexed = agent_task_lifecycle::cook_index(&record.run_id)
+                .ok()
+                .is_some_and(|index| index.attempts.iter().any(|entry| entry.run_id == attempt));
+            if belongs_to_parent && indexed {
+                parent_by_attempt.insert(attempt, &record.run_id);
+            } else {
+                // Do not prescribe the parent alias here: scoped reconciliation
+                // correctly rejects an untrusted handoff link. The record-health
+                // primitive is executable and owns repairing malformed authority.
+                invalid_handoff_parents.insert(record.run_id.as_str());
+            }
+        }
+    }
+    let mut blockers = records
         .iter()
         .filter_map(|record| {
             let liveness =
@@ -470,14 +497,22 @@ pub(crate) fn controller_upgrade_admission_for_records(
                         | AgentTaskLiveness::Unreconciled
                 );
             (!matches!(liveness, AgentTaskLiveness::Stale) || runner_unverified).then(|| {
-                let recovery_command = record
-                    .runner_id()
-                    .map(|runner| format!("homeboy runner reconcile {runner}"))
-                    .unwrap_or_else(|| {
-                        format!("homeboy agent-task reconcile {} --dry-run", record.run_id)
-                    });
+                let group_run_id = parent_by_attempt
+                    .get(record.run_id.as_str())
+                    .copied()
+                    .unwrap_or(&record.run_id);
+                let recovery_command = if invalid_handoff_parents.contains(record.run_id.as_str()) {
+                    "homeboy agent-task reconcile-records --dry-run".to_string()
+                } else {
+                    record
+                        .runner_id()
+                        .map(|runner| format!("homeboy runner reconcile {runner}"))
+                        .unwrap_or_else(|| {
+                            format!("homeboy agent-task reconcile {group_run_id} --dry-run")
+                        })
+                };
                 ControllerUpgradeBlocker {
-                    run_id: record.run_id.clone(),
+                    run_id: group_run_id.clone(),
                     liveness: liveness.as_str(),
                     reason: if runner_unverified {
                         "runner_job_unverified_after_daemon_restart".to_string()
@@ -488,7 +523,44 @@ pub(crate) fn controller_upgrade_admission_for_records(
                 }
             })
         })
-        .collect();
+        .collect::<Vec<_>>();
+    let mut grouped = BTreeMap::<String, Vec<ControllerUpgradeBlocker>>::new();
+    for blocker in blockers.drain(..) {
+        grouped
+            .entry(blocker.run_id.clone())
+            .or_default()
+            .push(blocker);
+    }
+    let mut blockers = grouped
+        .into_values()
+        .map(|mut group| {
+            group.sort_by(|left, right| left.recovery_command.cmp(&right.recovery_command));
+            let recovery_commands = group
+                .iter()
+                .map(|blocker| blocker.recovery_command.clone())
+                .collect::<Vec<_>>();
+            let mut runner_commands = recovery_commands
+                .iter()
+                .filter(|command| command.starts_with("homeboy runner reconcile "))
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut lifecycle_commands = recovery_commands
+                .iter()
+                .filter(|command| !command.starts_with("homeboy runner reconcile "))
+                .cloned()
+                .collect::<Vec<_>>();
+            runner_commands.sort();
+            runner_commands.dedup();
+            lifecycle_commands.sort();
+            lifecycle_commands.dedup();
+            runner_commands.extend(lifecycle_commands);
+            let mut primary = group.remove(0);
+            primary.recovery_command = runner_commands.join(" && ");
+            primary
+        })
+        .collect::<Vec<_>>();
+    blockers.sort_by(|left, right| left.recovery_command.cmp(&right.recovery_command));
+    blockers.dedup_by(|left, right| left.recovery_command == right.recovery_command);
     ControllerUpgradeAdmission {
         schema: "homeboy/controller-upgrade-admission/v1",
         active: summary.active,

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -19,6 +19,12 @@ pub struct AgentTaskReconcileReport {
     pub schema: &'static str,
     /// `fleet` for the explicit bulk operation or `run:<id>` for a scoped repair.
     pub scope: String,
+    /// The identifier supplied by the caller. It remains distinct from a Cook
+    /// alias's exact attempt ids so recovery output cannot hide what was asked.
+    pub requested_run_id: Option<String>,
+    /// Exact durable records inspected by a scoped operation.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub resolved_run_ids: Vec<String>,
     /// `preview` unless the caller supplied explicit `--apply` authorization.
     pub authorization: &'static str,
     /// `true` when no records were actually mutated (preview mode).
@@ -172,6 +178,8 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
     Ok(AgentTaskReconcileReport {
         schema: "homeboy/agent-task-reconcile/v1",
         scope: "fleet".to_string(),
+        requested_run_id: None,
+        resolved_run_ids: Vec::new(),
         authorization: if dry_run { "preview" } else { "explicit-apply" },
         dry_run,
         considered: runs.len(),
@@ -186,108 +194,112 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
 /// reconciliation: a state or ownership change becomes a no-op rather than a
 /// reason to inspect or mutate any other record (#10001).
 pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileReport> {
-    let authoritative = agent_task_lifecycle::status(run_id)?;
-    let resolved_run_id = authoritative.run_id.clone();
-    let source = authoritative
-        .runner_id()
-        .map(|runner_id| format!("runner:{runner_id}"))
-        .unwrap_or_else(|| "local".to_string());
-    let candidate = discover_runs(AgentTaskDiscoveryFilter::Active)?
-        .runs
-        .into_iter()
-        .find(|run| run.run_id == resolved_run_id);
-
+    let requested_run_id = run_id.to_string();
+    let resolved_run_ids = agent_task_lifecycle::reconcile_scope_run_ids(run_id)?;
     let mut runs = Vec::new();
     let mut reconciled = 0;
     let mut failed = 0;
-    match candidate {
-        Some(run) if run.liveness.is_some_and(AgentTaskLiveness::is_reconcilable) => {
-            let liveness = run.liveness.expect("checked reconcilable liveness");
-            // Re-read immediately before apply. A newly-live runner or a changed
-            // owner is authoritative and turns this scoped request into a no-op.
-            let refreshed = agent_task_lifecycle::status(&resolved_run_id)?;
-            let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
-                .runs
-                .into_iter()
-                .find(|run| run.run_id == resolved_run_id)
-                .and_then(|run| run.liveness)
-                .is_some_and(AgentTaskLiveness::is_reconcilable);
-            if refreshed.state.is_terminal() || !still_reconcilable {
-                runs.push(AgentTaskReconcileRun {
-                    run_id: resolved_run_id,
-                    liveness,
-                    source: run.source,
-                    authoritative_state: refreshed.state,
-                    stale_reason: run.stale_reason,
-                    action: "no-op",
-                    error: None,
-                });
-            } else if dry_run {
-                runs.push(AgentTaskReconcileRun {
-                    run_id: resolved_run_id,
-                    liveness,
-                    source: run.source,
-                    authoritative_state: refreshed.state,
-                    stale_reason: run.stale_reason,
-                    action: "would-reconcile",
-                    error: None,
-                });
-            } else {
-                let reason = run
-                    .stale_reason
-                    .clone()
-                    .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
-                match agent_task_lifecycle::cancel_run(&resolved_run_id, Some(&reason)) {
-                    Ok(record) => {
-                        reconciled += 1;
-                        runs.push(AgentTaskReconcileRun {
-                            run_id: resolved_run_id,
-                            liveness,
-                            source: run.source,
-                            authoritative_state: record.state,
-                            stale_reason: run.stale_reason,
-                            action: "reconciled",
-                            error: None,
-                        });
-                    }
-                    Err(error) => {
-                        failed += 1;
-                        runs.push(AgentTaskReconcileRun {
-                            run_id: resolved_run_id,
-                            liveness,
-                            source: run.source,
-                            authoritative_state: refreshed.state,
-                            stale_reason: run.stale_reason,
-                            action: "failed",
-                            error: Some(error.message),
-                        });
+    for resolved_run_id in &resolved_run_ids {
+        let authoritative = agent_task_lifecycle::exact_status(resolved_run_id)?;
+        let source = authoritative
+            .runner_id()
+            .map(|runner_id| format!("runner:{runner_id}"))
+            .unwrap_or_else(|| "local".to_string());
+        let candidate = discover_runs(AgentTaskDiscoveryFilter::Active)?
+            .runs
+            .into_iter()
+            .find(|run| run.run_id == *resolved_run_id);
+        match candidate {
+            Some(run) if run.liveness.is_some_and(AgentTaskLiveness::is_reconcilable) => {
+                let liveness = run.liveness.expect("checked reconcilable liveness");
+                // Re-read immediately before apply. A newly-live runner or a changed
+                // owner is authoritative and turns this scoped request into a no-op.
+                let refreshed = agent_task_lifecycle::exact_status(resolved_run_id)?;
+                let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
+                    .runs
+                    .into_iter()
+                    .find(|run| run.run_id == *resolved_run_id)
+                    .and_then(|run| run.liveness)
+                    .is_some_and(AgentTaskLiveness::is_reconcilable);
+                if refreshed.state.is_terminal() || !still_reconcilable {
+                    runs.push(AgentTaskReconcileRun {
+                        run_id: resolved_run_id.clone(),
+                        liveness,
+                        source: run.source,
+                        authoritative_state: refreshed.state,
+                        stale_reason: run.stale_reason,
+                        action: "no-op",
+                        error: None,
+                    });
+                } else if dry_run {
+                    runs.push(AgentTaskReconcileRun {
+                        run_id: resolved_run_id.clone(),
+                        liveness,
+                        source: run.source,
+                        authoritative_state: refreshed.state,
+                        stale_reason: run.stale_reason,
+                        action: "would-reconcile",
+                        error: None,
+                    });
+                } else {
+                    let reason = run
+                        .stale_reason
+                        .clone()
+                        .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
+                    match agent_task_lifecycle::cancel_exact_run(resolved_run_id, Some(&reason)) {
+                        Ok(record) => {
+                            reconciled += 1;
+                            runs.push(AgentTaskReconcileRun {
+                                run_id: resolved_run_id.clone(),
+                                liveness,
+                                source: run.source,
+                                authoritative_state: record.state,
+                                stale_reason: run.stale_reason,
+                                action: "reconciled",
+                                error: None,
+                            });
+                        }
+                        Err(error) => {
+                            failed += 1;
+                            runs.push(AgentTaskReconcileRun {
+                                run_id: resolved_run_id.clone(),
+                                liveness,
+                                source: run.source,
+                                authoritative_state: refreshed.state,
+                                stale_reason: run.stale_reason,
+                                action: "failed",
+                                error: Some(error.message),
+                            });
+                        }
                     }
                 }
             }
+            Some(run) => runs.push(AgentTaskReconcileRun {
+                run_id: resolved_run_id.clone(),
+                liveness: run.liveness.unwrap_or(AgentTaskLiveness::Active),
+                source: run.source,
+                authoritative_state: authoritative.state,
+                stale_reason: run.stale_reason,
+                action: "no-op",
+                error: None,
+            }),
+            None => runs.push(AgentTaskReconcileRun {
+                run_id: resolved_run_id.clone(),
+                liveness: AgentTaskLiveness::Active,
+                source,
+                authoritative_state: authoritative.state,
+                stale_reason: None,
+                action: "no-op",
+                error: None,
+            }),
         }
-        Some(run) => runs.push(AgentTaskReconcileRun {
-            run_id: resolved_run_id,
-            liveness: run.liveness.unwrap_or(AgentTaskLiveness::Active),
-            source: run.source,
-            authoritative_state: authoritative.state,
-            stale_reason: run.stale_reason,
-            action: "no-op",
-            error: None,
-        }),
-        None => runs.push(AgentTaskReconcileRun {
-            run_id: resolved_run_id,
-            liveness: AgentTaskLiveness::Active,
-            source,
-            authoritative_state: authoritative.state,
-            stale_reason: None,
-            action: "no-op",
-            error: None,
-        }),
     }
 
     Ok(AgentTaskReconcileReport {
         schema: "homeboy/agent-task-reconcile/v1",
-        scope: format!("run:{}", authoritative.run_id),
+        scope: format!("run:{requested_run_id}"),
+        requested_run_id: Some(requested_run_id),
+        resolved_run_ids,
         authorization: if dry_run { "preview" } else { "explicit-apply" },
         dry_run,
         considered: runs.iter().filter(|run| run.action != "no-op").count(),

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1518,6 +1518,216 @@ fn scoped_reconcile_applies_only_the_inspected_run_and_preserves_other_stale_rec
 }
 
 #[test]
+fn scoped_reconcile_keeps_exact_attempts_separate_and_expands_cook_aliases_to_their_parent() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-reconcile-alias";
+        let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            // Model the durable parent/attempt link while both projections are
+            // stale, before normal handoff completion terminalizes the parent.
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_id);
+        })
+        .expect("link stale parent projection");
+        for run_id in [cook_id, attempt_id.as_str()] {
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+                record.metadata["runner_pid"] = serde_json::json!(u32::MAX);
+                if record.run_id == attempt_id {
+                    record.metadata["cook_id"] = serde_json::json!(cook_id);
+                }
+            })
+            .expect("stale record");
+        }
+        index_cook_attempt(cook_id, &attempt_id);
+
+        let exact = reconcile_run(&attempt_id, true).expect("exact attempt preview");
+        assert_eq!(exact.scope, format!("run:{attempt_id}"));
+        assert_eq!(exact.resolved_run_ids, vec![attempt_id.clone()]);
+        assert_eq!(exact.runs.len(), 1);
+
+        let alias = reconcile_run(cook_id, true).expect("logical Cook preview");
+        assert_eq!(alias.scope, format!("run:{cook_id}"));
+        assert_eq!(alias.requested_run_id.as_deref(), Some(cook_id));
+        assert_eq!(
+            alias.resolved_run_ids,
+            vec![cook_id.to_string(), attempt_id.clone()]
+        );
+        assert_eq!(alias.runs.len(), 2);
+
+        let applied = reconcile_run(cook_id, false).expect("logical Cook apply");
+        assert_eq!(applied.reconciled, 2, "{applied:?}");
+        assert!(applied.runs.iter().all(|run| run.action == "reconciled"));
+        for run_id in [cook_id, attempt_id.as_str()] {
+            assert_eq!(
+                agent_task_lifecycle::exact_record(run_id)
+                    .expect("exact durable record")
+                    .state,
+                AgentTaskRunState::Cancelled,
+                "{run_id} must be cancelled through its own exact record"
+            );
+        }
+    });
+}
+
+#[test]
+fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-upgrade-alias";
+        let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_id);
+        })
+        .expect("link parent");
+        for run_id in [cook_id, attempt_id.as_str()] {
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+                if record.run_id == cook_id {
+                    record.metadata["runner_pid"] = serde_json::json!(std::process::id());
+                } else {
+                    record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+                    record.updated_at = None;
+                    record.metadata["cook_id"] = serde_json::json!(cook_id);
+                    record.metadata["runner_id"] = serde_json::json!("lab");
+                    record.metadata["runner_job_id"] = serde_json::json!("stale-job");
+                }
+            })
+            .expect("live linked record");
+        }
+        index_cook_attempt(cook_id, &attempt_id);
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].run_id, cook_id);
+        assert_eq!(
+            admission.blockers[0].recovery_command,
+            format!(
+                "homeboy runner reconcile lab && homeboy agent-task reconcile {cook_id} --dry-run"
+            )
+        );
+    });
+}
+
+#[test]
+fn scoped_reconcile_rejects_a_parent_child_link_with_disagreeing_cook_identity() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-reconcile-parent";
+        let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_id);
+        })
+        .expect("link parent");
+        agent_task_lifecycle::rewrite_record_for_test(&attempt_id, |record| {
+            record.metadata["cook_id"] = serde_json::json!("other-cook");
+        })
+        .expect("write disagreement");
+        index_cook_attempt(cook_id, &attempt_id);
+
+        let error = reconcile_run(cook_id, true).expect_err("reject mismatched child identity");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("does not belong"));
+    });
+}
+
+#[test]
+fn scoped_reconcile_rejects_a_parent_child_link_without_cook_index_authority() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-reconcile-unindexed";
+        let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_id);
+        })
+        .expect("link parent");
+        agent_task_lifecycle::rewrite_record_for_test(&attempt_id, |record| {
+            record.metadata["cook_id"] = serde_json::json!(cook_id);
+        })
+        .expect("write matching Cook identity");
+
+        let error = reconcile_run(cook_id, true).expect_err("reject unindexed child link");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("no Cook index authority"));
+    });
+}
+
+#[test]
+fn upgrade_admission_keeps_an_unindexed_handoff_child_independent_with_executable_remediation() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-upgrade-unindexed";
+        let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+            record.metadata["runner_pid"] = serde_json::json!(std::process::id());
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_id);
+        })
+        .expect("unindexed parent link");
+        agent_task_lifecycle::rewrite_record_for_test(&attempt_id, |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Running);
+            record.metadata["runner_pid"] = serde_json::json!(std::process::id());
+            record.metadata["cook_id"] = serde_json::json!(cook_id);
+        })
+        .expect("unindexed child");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 2);
+        assert!(admission.blockers.iter().any(|blocker| {
+            blocker.run_id == cook_id
+                && blocker.recovery_command == "homeboy agent-task reconcile-records --dry-run"
+        }));
+        assert!(admission.blockers.iter().any(|blocker| {
+            blocker.run_id == attempt_id
+                && blocker.recovery_command
+                    == format!("homeboy agent-task reconcile {attempt_id} --dry-run")
+        }));
+        assert!(agent_task_lifecycle::reconcile_record_health(true).is_ok());
+    });
+}
+
+#[test]
+fn scoped_reconcile_uses_validated_handoff_child_not_later_index_attempt() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-reconcile-accepted-child";
+        let attempt_one = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        let attempt_two = agent_task_lifecycle::cook_attempt_run_id(cook_id, 2);
+        agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
+        for run_id in [&attempt_one, &attempt_two] {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("attempt");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.metadata["cook_id"] = serde_json::json!(cook_id);
+            })
+            .expect("record Cook identity");
+        }
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            record.metadata["detached_cook_handoff"]["attempt_run_id"] =
+                serde_json::json!(&attempt_one);
+        })
+        .expect("bind accepted child");
+        index_cook_attempts(cook_id, &attempt_one, &attempt_two);
+
+        let scope = agent_task_lifecycle::reconcile_scope_run_ids(cook_id).expect("scope");
+        assert_eq!(scope, vec![cook_id.to_string(), attempt_one]);
+        assert!(!scope.contains(&attempt_two));
+    });
+}
+
+#[test]
 fn scoped_reconcile_is_a_no_op_when_the_owner_becomes_live_after_preview() {
     with_isolated_home(|_| {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-owner-changed"))
@@ -2491,4 +2701,29 @@ fn discovery_plan() -> AgentTaskPlan {
     plan.tasks[0].workspace.root = Some("/tmp/homeboy".to_string());
     plan.tasks[0].workspace.slug = Some("homeboy".to_string());
     plan
+}
+
+fn index_cook_attempt(cook_id: &str, run_id: &str) {
+    index_cook_attempts(cook_id, run_id, run_id);
+}
+
+fn index_cook_attempts(cook_id: &str, first_run_id: &str, latest_run_id: &str) {
+    agent_task_lifecycle::replace_cook_index_for_test(&agent_task_lifecycle::AgentTaskCookIndex {
+        schema: "homeboy/agent-task-cook-index/v1".to_string(),
+        cook_id: cook_id.to_string(),
+        latest_run_id: latest_run_id.to_string(),
+        latest_substantive_candidate: None,
+        attempts: [first_run_id, latest_run_id]
+            .into_iter()
+            .enumerate()
+            .map(
+                |(index, run_id)| agent_task_lifecycle::AgentTaskCookIndexAttempt {
+                    attempt: (index + 1) as u32,
+                    run_id: run_id.to_string(),
+                    recorded_at: chrono::Utc::now().to_rfc3339(),
+                },
+            )
+            .collect(),
+    })
+    .expect("index Cook attempt");
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -829,8 +829,9 @@ pub(super) fn reconcile_active(dry_run: bool) -> CmdResult<Value> {
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), exit))
 }
 
-/// `agent-task reconcile <run-id>` always addresses exactly one durable run.
-/// It previews by default; `--apply` is the explicit operator authorization.
+/// `agent-task reconcile <run-id>` addresses one exact record or the explicit
+/// parent/attempt group named by a logical Cook ID. It previews by default;
+/// `--apply` is the explicit operator authorization.
 pub(super) fn reconcile_run(run_id: &str, dry_run: bool) -> CmdResult<Value> {
     let report = agent_task_service_direct::reconcile_run(run_id, dry_run)?;
     let exit = if report.failed > 0 { 1 } else { 0 };


### PR DESCRIPTION
## Summary

- separate exact lifecycle mutation from logical Cook alias resolution
- reconcile authoritative parent/attempt groups only with Cook-index authority
- repair terminal runner projections idempotently
- deduplicate admission recovery without grouping malformed links

## Verification

- exact attempt and parent/child scope tests
- terminal runner projection repair/idempotence test
- malformed/unindexed handoff remediation tests
- `cargo check -p homeboy-agents`
- `cargo fmt --check`

Closes #12246.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol implemented exact reconciliation boundaries, authority validation, admission deduplication, and deterministic lifecycle tests. Chris Huber reviewed and owns every change.
