### PR TITLE
Retain candidate-producing model evidence

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_config.rs
@@ -711,6 +711,18 @@ pub struct AgentTaskProviderRotationAttempt {
     pub selector: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// The model supplied by the operator before policy resolution. It remains
+    /// stable across rotation attempts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_model: Option<String>,
+    /// The model selected for this dispatched attempt. `model` remains its
+    /// compatibility projection for existing evidence readers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempted_model: Option<String>,
+    /// The concrete model reported by the provider that produced this
+    /// attempt's candidate or outcome.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_producing_model: Option<String>,
     pub status: AgentTaskOutcomeStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_classification: Option<AgentTaskFailureClassification>,

--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -7,7 +7,7 @@ use crate::agent_task_review_dossier::{
 use homeboy_core::error::{Error, Result};
 use homeboy_core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use homeboy_core::proof::HomeboyProof;
-use homeboy_core::run_lifecycle_record::RunLifecycleRecord;
+use homeboy_core::run_lifecycle_record::{ProviderRuntimeState, RunLifecycleRecord};
 
 pub const AGENT_TASK_PR_FINALIZATION_SCHEMA: &str = "homeboy/agent-task-pr-finalization/v1";
 pub const AGENT_TASK_PR_FINALIZATION_OUTCOME_SCHEMA: &str =
@@ -1046,6 +1046,8 @@ fn durable_model(lifecycle: &RunLifecycleRecord) -> Result<String> {
     let model = lifecycle
         .provider_runtime
         .iter()
+        .rev()
+        .filter(|runtime| runtime.state == ProviderRuntimeState::Succeeded)
         .find_map(|runtime| {
             runtime
                 .metadata

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1176,6 +1176,56 @@ fn durable_finalization_requires_successful_provider_run_and_hydrates_model() {
 }
 
 #[test]
+fn durable_finalization_discloses_terminal_successful_model_after_same_backend_rotation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(rotated_lifecycle(
+            "opencode",
+            "openai/gpt-5.6-sol",
+            "opencode",
+            "openai/gpt-5.6-terra",
+        )),
+        gate_proof: Some(successful_gate_proof()),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+
+    let report = finalize_pr_with_backend(finalization_options, &mut backend)
+        .expect("successful rotated run finalizes");
+
+    assert_eq!(
+        report.review_dossier.ai_assistance.model,
+        "openai/gpt-5.6-terra"
+    );
+}
+
+#[test]
+fn durable_finalization_discloses_terminal_successful_model_after_cross_backend_rotation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(rotated_lifecycle(
+            "opencode",
+            "openai/gpt-5.6-sol",
+            "claude-code",
+            "anthropic/claude-sonnet-4",
+        )),
+        gate_proof: Some(successful_gate_proof()),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+
+    let report = finalize_pr_with_backend(finalization_options, &mut backend)
+        .expect("successful rotated run finalizes");
+
+    assert_eq!(
+        report.review_dossier.ai_assistance.model,
+        "anthropic/claude-sonnet-4"
+    );
+}
+
+#[test]
 fn finalization_keeps_internal_durable_refs_for_operators_but_not_reviewers() {
     let internal_ref = "homeboy://agent-task/run/run-9568/artifacts#task=cook&artifact=patch";
     let reviewer_ref = "https://github.com/Extra-Chill/homeboy/issues/9568";
@@ -1286,7 +1336,7 @@ fn durable_finalization_accepts_only_authenticated_pre_provider_candidate_adopti
         .push(ProviderRuntimeLifecycle {
             task_id: "task".to_string(),
             backend: "opencode".to_string(),
-            state: ProviderRuntimeState::Failed,
+            state: ProviderRuntimeState::Succeeded,
             stream_uri: None,
             external_runtime_ids: Vec::new(),
             metadata: json!({ "evidence_source": "canonical_executor_outcome" }),
@@ -2011,6 +2061,34 @@ fn successful_lifecycle(model: &str) -> RunLifecycleRecord {
         }],
         ..RunLifecycleRecord::default()
     }
+}
+
+fn rotated_lifecycle(
+    attempted_backend: &str,
+    attempted_model: &str,
+    producing_backend: &str,
+    producing_model: &str,
+) -> RunLifecycleRecord {
+    let mut lifecycle = successful_lifecycle(producing_model);
+    lifecycle.provider_runtime = vec![
+        ProviderRuntimeLifecycle {
+            task_id: "task".to_string(),
+            backend: attempted_backend.to_string(),
+            state: ProviderRuntimeState::Succeeded,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: json!({ "model": attempted_model }),
+        },
+        ProviderRuntimeLifecycle {
+            task_id: "task".to_string(),
+            backend: producing_backend.to_string(),
+            state: ProviderRuntimeState::Succeeded,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: json!({ "model": producing_model }),
+        },
+    ];
+    lifecycle
 }
 
 fn generic_executor_lifecycle(state: ProviderRuntimeState, model: &str) -> RunLifecycleRecord {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -71,11 +71,12 @@ pub(crate) fn latest_executor_evidence(
         request.component_contracts.clone()
     };
 
+    let (backend, selector, model) = terminal_executor_identity(outcome, request);
     Some(AgentTaskLatestExecutorEvidence {
         task_id: task_id.clone(),
-        backend: request.executor.backend.clone(),
-        selector: request.executor.selector.clone(),
-        model: request.executor.model.clone(),
+        backend,
+        selector,
+        model,
         input_ref: AgentTaskEvidenceRef {
             kind: "executor-input".to_string(),
             uri: format!("{base}/plan#task={task_id}"),
@@ -103,6 +104,40 @@ pub(crate) fn latest_executor_evidence(
         typed_artifact_expectations: typed_artifact_expectations(request),
         component_contracts,
     })
+}
+
+fn terminal_executor_identity(
+    outcome: &AgentTaskOutcome,
+    request: &AgentTaskRequest,
+) -> (String, Option<String>, Option<String>) {
+    let rotated = outcome
+        .metadata
+        .pointer("/provider_rotation/attempts")
+        .and_then(|attempts| {
+            serde_json::from_value::<
+                Vec<crate::agent_task_scheduler::AgentTaskProviderRotationAttempt>,
+            >(attempts.clone())
+            .ok()
+        })
+        .and_then(|attempts| attempts.into_iter().last());
+    match rotated {
+        Some(attempt) => (
+            attempt.backend,
+            attempt.selector,
+            attempt
+                .candidate_producing_model
+                .or(attempt.attempted_model)
+                .or(attempt.model),
+        ),
+        None => (
+            request.executor.backend.clone(),
+            request.executor.selector.clone(),
+            outcome
+                .selected_model()
+                .map(str::to_string)
+                .or_else(|| request.executor.model.clone()),
+        ),
+    }
 }
 
 pub(crate) fn runtime_component_paths(request: &AgentTaskRequest) -> Vec<String> {
@@ -192,8 +227,15 @@ pub(crate) fn tasks_for_aggregate(
             } else if let Some(outcome) = outcome {
                 task.state = task_state_for_outcome_status(outcome.status);
             }
-            if let Some(model) = outcome.and_then(|outcome| outcome.selected_model()) {
-                task.model = Some(model.to_string());
+            if let Some(outcome) = outcome {
+                let (backend, selector, model) = terminal_executor_identity(outcome, request);
+                task.backend = backend;
+                task.selector = selector;
+                task.model = model;
+                task.provider_ref = task
+                    .selector
+                    .as_ref()
+                    .map(|selector| format!("{}:{selector}", task.backend));
             }
             task
         })

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1838,6 +1838,33 @@ fn completed_run_exposes_latest_executor_input_output_and_expectations() {
         }];
 
         let mut aggregate = succeeded_aggregate(&plan);
+        aggregate.outcomes[0].metadata = json!({
+            "model": "openai/gpt-5.6-terra",
+            "provider_rotation": {
+                "attempts": [{
+                    "attempt": 1,
+                    "rotation_index": 0,
+                    "backend": "sandbox",
+                    "selector": "fixture",
+                    "model": "gpt-fixture",
+                    "requested_model": "gpt-fixture",
+                    "attempted_model": "gpt-fixture",
+                    "candidate_producing_model": "gpt-fixture",
+                    "status": "provider_error",
+                    "failure_classification": "provider"
+                }, {
+                    "attempt": 2,
+                    "rotation_index": 1,
+                    "backend": "opencode",
+                    "selector": "opencode.agent-task-executor",
+                    "model": "openai/gpt-5.6-terra",
+                    "requested_model": "gpt-fixture",
+                    "attempted_model": "openai/gpt-5.6-terra",
+                    "candidate_producing_model": "openai/gpt-5.6-terra",
+                    "status": "succeeded"
+                }]
+            }
+        });
         aggregate.outcomes[0].outputs = json!({
             "provider_run_result": {
                 "run_id": "provider-run-123",
@@ -1854,9 +1881,17 @@ fn completed_run_exposes_latest_executor_input_output_and_expectations() {
         let artifact_report = artifacts("run-evidence").expect("artifacts loaded");
 
         assert_eq!(evidence.task_id, "task-a");
-        assert_eq!(evidence.backend, "sandbox");
-        assert_eq!(evidence.selector.as_deref(), Some("fixture"));
-        assert_eq!(evidence.model.as_deref(), Some("gpt-fixture"));
+        assert_eq!(evidence.backend, "opencode");
+        assert_eq!(
+            evidence.selector.as_deref(),
+            Some("opencode.agent-task-executor")
+        );
+        assert_eq!(evidence.model.as_deref(), Some("openai/gpt-5.6-terra"));
+        assert_eq!(record.tasks[0].backend, "opencode");
+        assert_eq!(
+            record.tasks[0].model.as_deref(),
+            Some("openai/gpt-5.6-terra")
+        );
         assert_eq!(
             evidence.provider_run_id.as_deref(),
             Some("provider-run-123")

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1028,6 +1028,13 @@ where
                                 running_task.candidate_artifacts,
                                 &outcome,
                             );
+                            if request.metadata["model_selection"]["requested"].is_null() {
+                                if !request.metadata.is_object() {
+                                    request.metadata = serde_json::json!({});
+                                }
+                                request.metadata["model_selection"]["requested"] =
+                                    serde_json::json!(request.executor.model());
+                            }
                             AgentTaskScheduleSupport::apply_rotation_entry(
                                 &mut request,
                                 entry,
@@ -1040,9 +1047,11 @@ where
                                 AgentTaskState::Queued,
                                 next_attempt,
                                 Some(format!(
-                                    "provider rotation queued: entry {} of {}",
+                                    "provider rotation queued: entry {} of {}; backend={}, model={}",
                                     running_task.rotation_index + 1,
-                                    policy.entries.len()
+                                    policy.entries.len(),
+                                    request.executor.backend,
+                                    request.executor.model().unwrap_or("not recorded")
                                 )),
                             ));
                             queued.push_back(ScheduledTask {
@@ -1271,6 +1280,9 @@ pub(crate) fn persist_resolved_provider_model(
         "model_identity".to_string(),
         serde_json::json!({
             "requested": requested,
+            "attempted": resolved,
+            "candidate_producing": provider_reported,
+            // Retained for consumers of the previous outcome metadata shape.
             "resolved": resolved,
             "provider_reported": provider_reported,
             "actual": provider_reported,

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1364,6 +1364,13 @@ impl AgentTaskScheduleSupport {
             backend: request.executor.backend.clone(),
             selector: request.executor.selector.clone(),
             model: request.executor.model().map(str::to_string),
+            requested_model: request.metadata["model_selection"]["requested"]
+                .as_str()
+                .filter(|model| !model.trim().is_empty())
+                .map(str::to_string)
+                .or_else(|| request.executor.model().map(str::to_string)),
+            attempted_model: request.executor.model().map(str::to_string),
+            candidate_producing_model: outcome.selected_model().map(str::to_string),
             status: outcome.status,
             failure_classification: outcome.failure_classification,
             summary: outcome.summary.clone(),

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -27,6 +27,8 @@ fn provider_reported_model_is_retained_separately_from_requested_and_resolved_mo
         outcome.metadata["model_identity"],
         json!({
             "requested": "openai/gpt-5.6-sol",
+            "attempted": "openai/gpt-5.6-terra",
+            "candidate_producing": "openai/gpt-5.6-terra",
             "resolved": "openai/gpt-5.6-terra",
             "provider_reported": "openai/gpt-5.6-terra",
             "actual": "openai/gpt-5.6-terra",

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -20,6 +20,34 @@ mod provider_rotation_tests {
         patch: String,
     }
 
+    struct ProviderReportedRotationExecutor {
+        calls: AtomicUsize,
+    }
+
+    impl AgentTaskExecutorAdapter for ProviderReportedRotationExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut result = outcome(
+                request.task_id,
+                if call == 0 {
+                    AgentTaskOutcomeStatus::ProviderError
+                } else {
+                    AgentTaskOutcomeStatus::Succeeded
+                },
+            );
+            if call == 0 {
+                result.failure_classification = Some(AgentTaskFailureClassification::Provider);
+            } else {
+                result.metadata = json!({ "model": "openai/gpt-5.6-actual" });
+            }
+            result
+        }
+    }
+
     impl AgentTaskExecutorAdapter for AdoptionExecutor {
         fn execute(
             &self,
@@ -195,6 +223,7 @@ mod provider_rotation_tests {
         let calls = Arc::clone(&executor.calls);
         let scheduler = AgentTaskScheduler::new(executor);
         let mut plan = plan_with_tasks(1);
+        plan.tasks[0].executor.model = Some("primary-model".to_string());
         plan.options.rotation = Some(rotation_policy(vec![
             AgentTaskProviderRotationEntry {
                 backend: Some("fallback-backend-a".to_string()),
@@ -240,18 +269,79 @@ mod provider_rotation_tests {
         assert_eq!(attempts.len(), 2);
         assert_eq!(attempts[0]["attempt"], 1);
         assert_eq!(attempts[0]["backend"], "test");
+        assert_eq!(attempts[0]["requested_model"], "primary-model");
+        assert_eq!(attempts[0]["attempted_model"], "primary-model");
         assert_eq!(attempts[0]["failure_classification"], "provider");
         assert_eq!(attempts[0]["status"], "provider_error");
         assert_eq!(attempts[1]["attempt"], 2);
         assert_eq!(attempts[1]["backend"], "fallback-backend-a");
+        assert_eq!(attempts[1]["requested_model"], "primary-model");
+        assert_eq!(attempts[1]["attempted_model"], "fallback-model-a");
+        assert!(attempts[1].get("candidate_producing_model").is_none());
         assert_eq!(attempts[1]["status"], "succeeded");
         assert_eq!(
             aggregate.outcomes[0].metadata["execution_budget"]["executions_used"], 2,
             "only dispatched provider attempts consume the execution budget"
         );
         assert!(aggregate.events.iter().any(|event| {
-            event.message.as_deref() == Some("provider rotation queued: entry 1 of 2")
+            event.message.as_deref()
+                == Some("provider rotation queued: entry 1 of 2; backend=fallback-backend-a, model=fallback-model-a")
         }));
+    }
+
+    #[test]
+    fn same_backend_model_rotation_announces_and_records_the_producing_model() {
+        let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
+        let scheduler = AgentTaskScheduler::new(executor);
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].executor.backend = "opencode".to_string();
+        plan.tasks[0].executor.model = Some("openai/gpt-5.6-sol".to_string());
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: Some("opencode".to_string()),
+            model: Some("openai/gpt-5.6-terra".to_string()),
+            ..Default::default()
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        let attempts = aggregate.outcomes[0]
+            .metadata
+            .pointer("/provider_rotation/attempts")
+            .and_then(Value::as_array)
+            .expect("rotation attempts evidence");
+        assert_eq!(attempts[1]["backend"], "opencode");
+        assert_eq!(attempts[1]["requested_model"], "openai/gpt-5.6-sol");
+        assert_eq!(attempts[1]["attempted_model"], "openai/gpt-5.6-terra");
+        assert!(attempts[1].get("candidate_producing_model").is_none());
+        assert!(aggregate.events.iter().any(|event| {
+            event.message.as_deref()
+                == Some("provider rotation queued: entry 1 of 1; backend=opencode, model=openai/gpt-5.6-terra")
+        }));
+    }
+
+    #[test]
+    fn rotation_records_a_provider_reported_model_that_differs_from_the_attempted_model() {
+        let scheduler = AgentTaskScheduler::new(ProviderReportedRotationExecutor {
+            calls: AtomicUsize::new(0),
+        });
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].executor.model = Some("openai/gpt-5.6-sol".to_string());
+        plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
+            backend: Some("opencode".to_string()),
+            model: Some("openai/gpt-5.6-terra".to_string()),
+            ..Default::default()
+        }]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        let attempt = &aggregate.outcomes[0].metadata["provider_rotation"]["attempts"][1];
+        assert_eq!(attempt["attempted_model"], "openai/gpt-5.6-terra");
+        assert_eq!(
+            attempt["candidate_producing_model"],
+            "openai/gpt-5.6-actual"
+        );
     }
 
     #[test]
@@ -696,7 +786,8 @@ mod provider_rotation_tests {
             "the rotated provider receives a new scratch root"
         );
         assert!(aggregate.events.iter().any(|event| {
-            event.message.as_deref() == Some("provider rotation queued: entry 1 of 1")
+            event.message.as_deref()
+                == Some("provider rotation queued: entry 1 of 1; backend=fallback-backend-a, model=not recorded")
         }));
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -279,9 +279,9 @@ pub(crate) fn provider_rotation_attempts(
 }
 
 pub(crate) struct TerminalExecutorIdentity {
-    backend: String,
-    selector: Option<String>,
-    model: Option<String>,
+    pub(crate) backend: String,
+    pub(crate) selector: Option<String>,
+    pub(crate) model: Option<String>,
 }
 
 pub(crate) fn terminal_executor_identity(
@@ -302,7 +302,10 @@ pub(crate) fn terminal_executor_identity(
         let terminal = TerminalExecutorIdentity {
             backend: attempt.backend,
             selector: attempt.selector,
-            model: attempt.model,
+            model: attempt
+                .candidate_producing_model
+                .or(attempt.attempted_model)
+                .or(attempt.model),
         };
         if durable_provider_executions.is_some() {
             let durable = terminal_provider_execution(outcome, durable_provider_executions)?;

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2384,7 +2384,11 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
                 None,
             )
         })?;
-    let model = outcome.selected_model();
+    let terminal = super::cook_pre_execution::terminal_executor_identity(&outcome, &plan, None);
+    let model = terminal
+        .as_ref()
+        .and_then(|identity| identity.model.as_deref())
+        .or_else(|| outcome.selected_model());
     let requested_model = outcome.metadata["model_identity"]["requested"].as_str();
     let resolved_model = outcome.metadata["model_identity"]["resolved"].as_str();
     let provider_reported_model = outcome.metadata["model_identity"]["provider_reported"].as_str();
@@ -2421,7 +2425,10 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
             &outcome.outputs,
         )?
         .filter(|form| form.validate().is_ok()),
-        tool: task.executor.backend.clone(),
+        tool: terminal
+            .as_ref()
+            .map(|identity| identity.backend.clone())
+            .unwrap_or_else(|| task.executor.backend.clone()),
         model: model.map(str::to_string),
         review_form_only: task.inputs["cook_loop"]["review_form_required"] == true,
     })


### PR DESCRIPTION
## Summary

- distinguish requested, attempted, and provider-reported producing models
- announce backend/model rotation before execution
- attribute canonical candidate and PR disclosure to the terminal successful producer
- preserve legacy model fields for compatibility

## Verification

- `cargo test -p homeboy-agents provider_rotation --lib` (18 passed)
- `cargo test -p homeboy-agents durable_finalization --lib` (11 passed)
- same- and cross-backend disclosure tests
- `cargo fmt --check`

Closes #12249.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol implemented typed rotation evidence and final disclosure attribution with same/cross-backend tests. Chris Huber reviewed and owns every change.
