### PR TITLE
fix(cook): gate detached acceptance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -427,15 +427,20 @@ pub fn record_detached_cook_supervisor(cook_id: &str, job_id: &str) -> Result<()
     Ok(())
 }
 
-/// Terminalize a handoff parent once no child can materialize its first
-/// attempt. A previously requested cancellation remains authoritative.
+/// Terminalize a still-pending handoff parent once no child can materialize its
+/// first attempt. A redirected or terminal parent is authoritative evidence
+/// from a concurrent materialization or cancellation and is never rewritten.
 pub fn fail_detached_cook_handoff_parent(
     cook_id: &str,
     reason: &str,
 ) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
     let record = store::mutate_record(&cook_id, |record| {
-        if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id {
+        if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id
+            || record.state.is_terminal()
+            || record.metadata["detached_cook_handoff"]["state"] != "pending"
+            || store::read_cook_index(&cook_id).is_ok()
+        {
             return false;
         }
         let cancelled = record.state == AgentTaskRunState::Cancelled;
@@ -452,7 +457,9 @@ pub fn fail_detached_cook_handoff_parent(
         record.updated_at = Some(now_timestamp());
         true
     })?;
-    Ok(record.expect("detached handoff parent exists"))
+    // A protected parent is a successful no-op: it is the authoritative result
+    // of materialization or a prior terminal transition, not a missing parent.
+    Ok(record.unwrap_or(store::read_record(&cook_id)?))
 }
 
 fn complete_detached_cook_handoff_parent(cook_id: &str, attempt_run_id: &str) -> Result<()> {
@@ -461,16 +468,17 @@ fn complete_detached_cook_handoff_parent(cook_id: &str, attempt_run_id: &str) ->
     if store::read_record(&cook_id).is_err() {
         return Ok(());
     }
-    let _ = store::mutate_record(&cook_id, |record| {
-        if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id {
+    let _ = store::mutate_record_locked_without_terminal_projection(&cook_id, |record| {
+        if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id
+            || record.state.is_terminal()
+            || record.metadata["detached_cook_handoff"]["state"] != "pending"
+        {
             return false;
         }
         let metadata = record.ensure_metadata_object();
         metadata["detached_cook_handoff"]["state"] = json!("redirected");
         metadata["detached_cook_handoff"]["attempt_run_id"] = json!(attempt_run_id);
-        if !record.state.is_terminal() {
-            set_run_state(record, AgentTaskRunState::Succeeded);
-        }
+        set_run_state(record, AgentTaskRunState::Succeeded);
         record.updated_at = Some(now_timestamp());
         true
     })?;
@@ -3719,10 +3727,14 @@ pub fn record_cook_attempt(
     run_id: &str,
 ) -> Result<AgentTaskCookIndex> {
     let registration = homeboy_core::config::with_config_lock(|| {
-        record_cook_attempt_locked(cook_id, attempt, run_id)
+        let registration = record_cook_attempt_locked(cook_id, attempt, run_id)?;
+        // The index is the handoff's ownership proof. Redirect its placeholder
+        // while the index writer lock is held so an exit observer cannot fail
+        // the parent between index publication and this transition.
+        complete_detached_cook_handoff_parent(cook_id, run_id)?;
+        Ok(registration)
     })?;
     let index = registration.project_terminal_after_unlock()?;
-    complete_detached_cook_handoff_parent(cook_id, run_id)?;
     Ok(index)
 }
 
@@ -3734,6 +3746,21 @@ pub(crate) fn record_cook_attempt_locked(
 ) -> Result<CookAttemptRegistration> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
+    if let Ok(parent) = store::read_record(&cook_id) {
+        let handoff = &parent.metadata["detached_cook_handoff"];
+        if handoff["cook_id"] == cook_id
+            && (parent.state.is_terminal()
+                || handoff["cancellation_fence"]["state"] == "cancelled"
+                || (handoff["state"] != "pending" && handoff["state"] != "redirected"))
+        {
+            return Err(Error::validation_invalid_argument(
+                "cook_id",
+                "detached Cook handoff was cancelled or terminal before its attempt could materialize",
+                Some(cook_id),
+                None,
+            ));
+        }
+    }
     // Validate both durable ownership projections before changing either one.
     store::validate_cook_index_attempt(&cook_id, attempt, &run_id)?;
     let mut record = store::read_record(&run_id)?;

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -229,6 +229,20 @@ pub(super) fn mutate_record(
     Ok(record)
 }
 
+/// Mutate a record while the caller owns the config lock. Terminal authority is
+/// deliberately deferred to the caller's post-lock projection, matching
+/// [`write_record_locked_without_terminal_projection`].
+pub(super) fn mutate_record_locked_without_terminal_projection(
+    run_id: &str,
+    mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
+) -> Result<Option<AgentTaskRunRecord>> {
+    let mut record = read_record(run_id)?;
+    if !mutate(&mut record) {
+        return Ok(None);
+    }
+    write_record_locked_without_terminal_projection(&record).map(Some)
+}
+
 /// Commit the controller projection and child aggregate in one observation row.
 /// The JSON aggregate is a post-commit cache: readers use the committed row, so
 /// interruption before or after cache persistence exposes a complete state.

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -51,20 +51,13 @@ use crate::core::io::output_file::write_output_file;
 
 const HANDOFF_SCHEMA: &str = "homeboy/agent-task-cook-local-detach-handoff/v1";
 
-/// Bound on how long the launcher waits for the detached cook to publish its
-/// durable identity before reporting the handoff as still pending.
+/// Bound on how long the launcher waits for the detached cook to materialize
+/// its first executable attempt before reporting the handoff as pending.
 ///
-/// This wait is no longer load-bearing. The daemon submit returns a job id
-/// synchronously, and `record_detached_cook_handoff_parent` makes the cook id
-/// resolvable before a child even exists, so both handles in the envelope are
-/// addressable the moment it is printed. What the wait still buys is the
-/// *attempt* id, which genuinely does not exist until the cook materializes its
-/// first attempt and which no design can conjure synchronously.
-///
-/// It is kept at its historical default so no existing caller that reads
-/// `run_id` regresses, and it is now safe to set to `0`: a zero-wait envelope
-/// still names an addressable cook and an inspectable controller job, which was
-/// not true before the daemon owned the lifecycle.
+/// The placeholder and controller job make the Cook addressable before this
+/// boundary, but they do not prove the child has durable execution ownership.
+/// `accepted` is reserved for that later proof. A zero wait consequently emits
+/// a pending handoff, never an unproven acceptance.
 const DEFAULT_HANDOFF_TIMEOUT_MS: u64 = 30_000;
 const HANDOFF_POLL: Duration = Duration::from_millis(100);
 
@@ -270,15 +263,23 @@ pub(super) fn intercept_local_detached_cook(
             )
         },
     )?;
-    // The parent record and admitted controller job are the authoritative durable
-    // transition. Do not wait for a slow provider to materialize its first attempt.
-    let handoff = DetachedCookHandoff {
-        state: DetachedHandoffState::Accepted,
-        run_id: Some(cook_id.clone()),
-        waited_ms: 0,
-    };
-    crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), &cook_id);
     if cli.detach_after_handoff {
+        // Controller supervision makes the placeholder addressable, but
+        // acceptance requires the child to durably materialize its first
+        // executable attempt. Until then, callers receive an explicitly pending
+        // handoff instead of a success that could be followed by a zero-task
+        // terminal placeholder. Attached callers stream immediately; they do
+        // not receive a handoff acknowledgement to classify.
+        let handoff = await_durable_handoff(&cook_id, &mut child, handoff_timeout())?;
+        if handoff.state == DetachedHandoffState::ExitedBeforeHandoff {
+            return Err(Error::validation_invalid_argument(
+                "detach-after-handoff",
+                "detached Cook exited before materializing its first attempt",
+                Some(cook_id),
+                None,
+            ));
+        }
+        crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), &cook_id);
         let envelope = handoff_envelope(
             &cook_id,
             pid,
@@ -689,9 +690,9 @@ fn handoff_timeout() -> Duration {
     Duration::from_millis(millis)
 }
 
-/// Poll durable state until the detached cook is addressable, it dies, or the
-/// bound elapses. A launcher that returned before the record existed would hand
-/// back an id that `agent-task status` cannot yet resolve.
+/// Poll durable state until the detached cook materializes an executable
+/// attempt, it dies, or the bound elapses. The placeholder is addressable while
+/// pending; an index whose named attempt can be read proves durable ownership.
 ///
 /// Liveness is read from the child handle rather than from the pid. The
 /// detached cook is still this process's direct child until this process exits,
@@ -702,35 +703,77 @@ fn await_durable_handoff(
     cook_id: &str,
     child: &mut std::process::Child,
     timeout: Duration,
-) -> DetachedCookHandoff {
+) -> homeboy::core::Result<DetachedCookHandoff> {
     let started = Instant::now();
     loop {
-        if agent_task_lifecycle::cook_index_exists(cook_id).unwrap_or(false) {
-            let run_id = agent_task_lifecycle::cook_index(cook_id)
-                .ok()
-                .map(|index| index.latest_run_id);
-            return DetachedCookHandoff {
+        if let Some(run_id) = durable_attempt_id(cook_id) {
+            return Ok(DetachedCookHandoff {
                 state: DetachedHandoffState::Accepted,
-                run_id,
+                run_id: Some(run_id),
                 waited_ms: started.elapsed().as_millis() as u64,
-            };
+            });
         }
-        if matches!(child.try_wait(), Ok(Some(_)) | Err(_)) {
-            return DetachedCookHandoff {
-                state: DetachedHandoffState::ExitedBeforeHandoff,
-                run_id: None,
-                waited_ms: started.elapsed().as_millis() as u64,
-            };
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                // Process exit and index publication can cross. Re-read the
+                // durable ownership proof before failing, and let lifecycle
+                // reject a stale failure mutation if materialization wins this
+                // race afterward.
+                if let Some(run_id) = durable_attempt_id(cook_id) {
+                    return Ok(DetachedCookHandoff {
+                        state: DetachedHandoffState::Accepted,
+                        run_id: Some(run_id),
+                        waited_ms: started.elapsed().as_millis() as u64,
+                    });
+                }
+                agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                    cook_id,
+                    "detached Cook exited before materializing its first attempt",
+                )?;
+                if let Some(run_id) = durable_attempt_id(cook_id) {
+                    return Ok(DetachedCookHandoff {
+                        state: DetachedHandoffState::Accepted,
+                        run_id: Some(run_id),
+                        waited_ms: started.elapsed().as_millis() as u64,
+                    });
+                }
+                return Ok(DetachedCookHandoff {
+                    state: DetachedHandoffState::ExitedBeforeHandoff,
+                    run_id: None,
+                    waited_ms: started.elapsed().as_millis() as u64,
+                });
+            }
+            // An observation error is not proof that the child died. Preserve
+            // the pending contract and let durable supervision continue.
+            Err(_) => {
+                return Ok(DetachedCookHandoff {
+                    state: DetachedHandoffState::Pending,
+                    run_id: None,
+                    waited_ms: started.elapsed().as_millis() as u64,
+                });
+            }
+            Ok(None) => {}
         }
         if started.elapsed() >= timeout {
-            return DetachedCookHandoff {
+            return Ok(DetachedCookHandoff {
                 state: DetachedHandoffState::Pending,
                 run_id: None,
                 waited_ms: started.elapsed().as_millis() as u64,
-            };
+            });
         }
         std::thread::sleep(HANDOFF_POLL);
     }
+}
+
+/// Read the exact durable attempt an accepted handoff names. An index file on
+/// its own is not sufficient: a caller must be able to resolve the attempt it
+/// receives immediately.
+fn durable_attempt_id(cook_id: &str) -> Option<String> {
+    let run_id = agent_task_lifecycle::cook_index(cook_id)
+        .ok()?
+        .latest_run_id;
+    (!run_id.trim().is_empty() && agent_task_lifecycle::exact_record(&run_id).is_ok())
+        .then_some(run_id)
 }
 
 /// The launcher's only output: a bounded, machine-readable handoff naming the
@@ -1536,7 +1579,8 @@ mod tests {
                 .spawn()
                 .expect("spawn slow preparation fixture");
 
-            let handoff = await_durable_handoff(cook_id, &mut child, Duration::from_millis(5));
+            let handoff = await_durable_handoff(cook_id, &mut child, Duration::from_millis(5))
+                .expect("observe bounded pending handoff");
 
             assert_eq!(handoff.state, DetachedHandoffState::Pending);
             assert_eq!(
@@ -1563,6 +1607,179 @@ mod tests {
     }
 
     #[test]
+    fn a_materialized_attempt_is_the_boundary_for_accepted_handoff() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-materialized-acceptance";
+            let attempt_id = "cook-materialized-acceptance-attempt-1";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pending handoff parent");
+            let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+                "materialized-acceptance-attempt",
+                Vec::new(),
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some(attempt_id))
+                .expect("persist executable attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id)
+                .expect("publish durable Cook attempt ownership");
+            let mut child = Command::new("sh")
+                .args(["-c", "sleep 30"])
+                .spawn()
+                .expect("spawn live detached child");
+
+            let handoff = await_durable_handoff(cook_id, &mut child, Duration::from_millis(0))
+                .expect("observe materialized handoff");
+
+            assert_eq!(handoff.state, DetachedHandoffState::Accepted);
+            assert_eq!(handoff.run_id.as_deref(), Some(attempt_id));
+            terminate_and_reap_detached_child(&mut child);
+        });
+    }
+
+    #[test]
+    fn materialization_lock_first_makes_exit_failure_a_non_panicking_no_op() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-materialized-parent-preserved";
+            let attempt_id = "cook-materialized-parent-preserved-attempt-1";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pending handoff parent");
+            let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+                "materialized-parent-preserved-attempt",
+                Vec::new(),
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some(attempt_id))
+                .expect("persist executable attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id)
+                .expect("publish durable Cook attempt ownership");
+
+            agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                cook_id,
+                "stale detached child exit observation",
+            )
+            .expect("protected materialized parent makes exit failure a no-op");
+
+            let parent = agent_task_lifecycle::exact_record(cook_id)
+                .expect("read materialized handoff parent");
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["state"],
+                "redirected"
+            );
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["attempt_run_id"],
+                attempt_id
+            );
+            assert_ne!(
+                parent.metadata["detached_cook_handoff"]["reason"],
+                "stale detached child exit observation"
+            );
+        });
+    }
+
+    #[test]
+    fn exit_lock_first_blocks_later_attempt_materialization() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-exit-before-materialization";
+            let attempt_id = "cook-exit-before-materialization-attempt-1";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pending handoff parent");
+            let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+                "exit-before-materialization-attempt",
+                Vec::new(),
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some(attempt_id))
+                .expect("persist attempt before ownership arbitration");
+
+            agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                cook_id,
+                "detached Cook exited before materializing its first attempt",
+            )
+            .expect("exit wins the handoff arbitration");
+
+            assert!(
+                agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id).is_err(),
+                "a terminal exit winner must prevent later index publication"
+            );
+            let parent = agent_task_lifecycle::exact_record(cook_id)
+                .expect("read exit-winning handoff parent");
+            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Failed);
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["state"],
+                "exited_before_handoff"
+            );
+            assert!(
+                !agent_task_lifecycle::cook_index_exists(cook_id)
+                    .expect("exit winner left no Cook index"),
+                "a failed placeholder cannot coexist with an accepted Cook alias"
+            );
+        });
+    }
+
+    #[test]
+    fn cancellation_lock_first_blocks_later_attempt_materialization() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-cancel-before-materialization";
+            let attempt_id = "cook-cancel-before-materialization-attempt-1";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pending handoff parent");
+            let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+                "cancel-before-materialization-attempt",
+                Vec::new(),
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some(attempt_id))
+                .expect("persist attempt before ownership arbitration");
+
+            let cancelled = agent_task_lifecycle::cancel_run(cook_id, None)
+                .expect("cancellation wins the handoff arbitration");
+            assert_eq!(cancelled.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+
+            assert!(
+                agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id).is_err(),
+                "a cancelled parent must prevent attempt and index publication"
+            );
+            let parent = agent_task_lifecycle::exact_record(cook_id)
+                .expect("read cancellation-winning handoff parent");
+            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["cancellation_fence"]["state"],
+                "cancelled"
+            );
+            assert!(
+                !agent_task_lifecycle::cook_index_exists(cook_id)
+                    .expect("cancel winner left no Cook index"),
+                "a cancelled placeholder cannot resurrect a Cook alias"
+            );
+        });
+    }
+
+    #[test]
+    fn materialization_lock_first_remains_cancel_resolvable() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-materialized-before-cancel";
+            let attempt_id = "cook-materialized-before-cancel-attempt-1";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pending handoff parent");
+            let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
+                "materialized-before-cancel-attempt",
+                Vec::new(),
+            );
+            agent_task_lifecycle::submit_plan(&plan, Some(attempt_id))
+                .expect("persist executable attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id)
+                .expect("materialization wins the handoff arbitration");
+
+            let cancelled = agent_task_lifecycle::cancel_run(cook_id, None)
+                .expect("Cook alias resolves to its materialized attempt");
+            assert_eq!(cancelled.run_id, attempt_id);
+            assert_eq!(cancelled.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+            assert_eq!(
+                agent_task_lifecycle::exact_record(attempt_id)
+                    .expect("read materialized cancelled attempt")
+                    .state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+        });
+    }
+
+    #[test]
     fn a_dead_detached_process_is_never_reported_as_an_accepted_handoff() {
         crate::test_support::with_isolated_home(|_| {
             let cook_id = "cook-never-submitted";
@@ -1573,21 +1790,25 @@ mod tests {
                 .spawn()
                 .expect("spawn a child that exits immediately");
 
-            let handoff =
-                await_durable_handoff(cook_id, &mut child, std::time::Duration::from_millis(5_000));
+            let handoff = await_durable_handoff(
+                cook_id,
+                &mut child,
+                std::time::Duration::from_millis(5_000),
+            )
+            .expect("observe exited handoff");
 
             assert_eq!(handoff.state, DetachedHandoffState::ExitedBeforeHandoff);
             assert_eq!(handoff.run_id, None);
-            agent_task_lifecycle::fail_detached_cook_handoff_parent(
-                cook_id,
-                "detached Cook exited before materializing its first attempt",
-            )
-            .expect("terminalize exited handoff");
+            let parent = agent_task_lifecycle::exact_record(cook_id)
+                .expect("the observer terminalizes the exited handoff parent");
+            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Failed);
             assert_eq!(
-                agent_task_lifecycle::exact_record(cook_id)
-                    .expect("read exited handoff parent")
-                    .state,
-                agent_task_lifecycle::AgentTaskRunState::Failed
+                parent.metadata["detached_cook_handoff"]["state"],
+                "exited_before_handoff"
+            );
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["reason"],
+                "detached Cook exited before materializing its first attempt"
             );
         });
     }

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -9,7 +9,8 @@ use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary
 ///
 /// Every case in this file asserts what an invocation settles *before* any
 /// worktree or provider resolution: a contradictory combination is rejected,
-/// and a locally-detached Cook is handed off (#11476).
+/// and a locally-detached Cook either materializes executable ownership or
+/// reports an honest rejection (#11476, #12290).
 ///
 /// `HermeticTestContext::command` owns the complete isolation contract — HOME,
 /// XDG config and data roots, artifact root, runtime and temp dirs — and strips
@@ -175,14 +176,15 @@ fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
     assert!(!stderr.contains("worktree provider"));
 }
 
-/// `--placement local --detach-after-handoff` is served, not rejected (#11476).
+/// A local detached Cook whose child exits before attempt materialization is
+/// rejected rather than falsely accepted (#12290).
 ///
-/// The launcher hands the Cook to a process in its own session and returns a
-/// bounded handoff naming the durable handle. It performs no worktree or
-/// provider resolution itself — that belongs to the detached cook — so this
-/// still asserts the fast, work-free return the old rejection guaranteed.
+/// The launcher hands the Cook to a process in its own session, then observes
+/// whether it materializes the durable attempt. It performs no worktree or
+/// provider resolution itself, so this still asserts the fast failure boundary
+/// the old rejection guaranteed.
 #[test]
-fn cook_detaches_local_placement_instead_of_rejecting_it() {
+fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materialization() {
     let context = HermeticTestContext::new();
     let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
     command
@@ -195,6 +197,8 @@ fn cook_detaches_local_placement_instead_of_rejecting_it() {
             "--detach-after-handoff",
             "agent-task",
             "cook",
+            "--run-id",
+            "local-detach-exits-before-attempt",
             "--backend",
             "fixture",
             "--prompt",
@@ -207,56 +211,150 @@ fn cook_detaches_local_placement_instead_of_rejecting_it() {
     let output = bounded_output(command);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "{stdout}");
+    assert!(!output.status.success(), "{stdout}");
     assert!(
         !stdout.contains("cannot detach after handoff with --placement local"),
         "{stdout}"
     );
     assert!(!stdout.contains("worktree provider"), "{stdout}");
-
-    // The envelope is the last thing the launcher writes, so parse from the
-    // first object brace rather than assuming stdout holds nothing else.
-    let envelope_start = stdout
-        .find('{')
-        .unwrap_or_else(|| panic!("handoff envelope is present\n{stdout}"));
-    let envelope: serde_json::Value = serde_json::from_str(stdout[envelope_start..].trim())
-        .unwrap_or_else(|error| panic!("handoff envelope is JSON: {error}\n{stdout}"));
-    assert_eq!(
-        envelope["schema"], "homeboy/agent-task-cook-local-detach-handoff/v1",
+    assert!(
+        stdout.contains("detached Cook exited before materializing its first attempt"),
         "{stdout}"
     );
-    assert_eq!(envelope["placement"], "local", "{stdout}");
-    assert_eq!(envelope["detached"], true, "{stdout}");
-    let cook_id = envelope["cook_id"]
+    let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    status.args([
+        "agent-task",
+        "status",
+        "local-detach-exits-before-attempt",
+        "--full",
+    ]);
+    let status = bounded_output(status);
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status.status.success(), "{status_stdout}");
+    assert!(status_stdout.contains("\"state\": \"failed\""), "{status_stdout}");
+    assert!(
+        status_stdout.contains("\"tasks\": []")
+            && status_stdout.contains("\"max_attempts\": 0")
+            && status_stdout.contains("\"exited_before_handoff\""),
+        "{status_stdout}"
+    );
+}
+
+/// A successful local detach exposes accepted only after the child has written
+/// an attempt that status can resolve, rather than merely its zero-task parent.
+#[test]
+fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
+    let context = HermeticTestContext::new();
+    let (_checkout_guard, checkout) =
+        homeboy_core::test_support::shared_committed_git_repo_fixture("local-detach-acceptance");
+    let mut register = context.command(TestBinary::HomeboyFixture);
+    register.args([
+        "component",
+        "create",
+        "--local-path",
+        checkout.to_str().expect("checkout path"),
+    ]);
+    let registered = bounded_output(register);
+    assert!(
+        registered.status.success(),
+        "register component: {}",
+        String::from_utf8_lossy(&registered.stdout)
+    );
+    let task_worktree = context.root().join("local-detach-acceptance-worktree");
+    homeboy_core::test_support::run_git_fixture_command(
+        &checkout,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "local-detach-acceptance",
+            task_worktree.to_str().expect("task worktree path"),
+        ],
+    );
+    std::fs::write(
+        context.config_dir().join("homeboy.json"),
+        r#"{"retention":{"reconstructable_artifact_reserve_bytes":0}}"#,
+    )
+    .expect("disable host-capacity admission for fixture worktree");
+    let cook_id = "local-detach-materializes-attempt";
+    let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    command.args([
+        "--placement",
+        "local",
+        "--detach-after-handoff",
+        "agent-task",
+        "cook",
+        "--run-id",
+        cook_id,
+        "--repo",
+        "local-detach-acceptance",
+        "--backend",
+        "fixture",
+        "--prompt",
+        "materialize a deterministic local attempt",
+        "--cwd",
+        task_worktree.to_str().expect("task worktree path"),
+        "--to-worktree",
+        task_worktree.to_str().expect("task worktree path"),
+        "--verify",
+        "true",
+        "--max-attempts",
+        "1",
+        "--no-finalize",
+    ]);
+    let output = bounded_output(command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "{stdout}");
+    let handoff: serde_json::Value = serde_json::from_str(
+        &stdout[stdout
+            .find('{')
+            .unwrap_or_else(|| panic!("handoff envelope is present\n{stdout}"))..],
+    )
+    .unwrap_or_else(|error| panic!("handoff envelope is JSON: {error}\n{stdout}"));
+    assert_eq!(handoff["handoff"]["state"], "accepted", "{stdout}");
+    let attempt_id = handoff["run_id"]
         .as_str()
-        .unwrap_or_else(|| panic!("handoff names a cook id\n{stdout}"));
-    assert!(!cook_id.is_empty(), "{stdout}");
-    assert_eq!(
-        envelope["status_command"],
-        format!("homeboy agent-task status {cook_id}"),
-        "{stdout}"
-    );
-    for operation in ["status", "logs", "cancel"] {
-        let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
-        command.args(["agent-task", operation, cook_id]);
-        let output = bounded_output(command);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            output.status.success()
-                || (operation == "cancel" && stdout.contains("already terminal")),
-            "{operation} must resolve the returned detached Cook id: {stdout}"
-        );
-    }
-    let pid = envelope["pid"]
-        .as_u64()
-        .unwrap_or_else(|| panic!("handoff names the detached pid\n{stdout}"));
-    assert!(pid > 0, "{stdout}");
+        .unwrap_or_else(|| panic!("accepted handoff names an attempt\n{stdout}"))
+        .to_string();
+    assert_ne!(attempt_id, cook_id, "{stdout}");
+    let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    status.args(["agent-task", "status", &attempt_id, "--full"]);
+    let status = bounded_output(status);
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status.status.success(), "{status_stdout}");
+    assert!(status_stdout.contains(&attempt_id), "{status_stdout}");
+    assert!(!status_stdout.contains("\"tasks\": []"), "{status_stdout}");
 
-    // Never leave a detached process behind a test. An unresolvable destination
-    // normally kills it well before this, so this is belt-and-braces cleanup.
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    // Cancel through the durable Cook alias, then wait on the returned attempt.
+    // The controller job owns process-tree termination and reaping; this keeps
+    // the fixture from leaking its detached child across hermetic teardown.
+    let mut cancel = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    cancel.args(["agent-task", "cancel", cook_id]);
+    let cancelled = bounded_output(cancel);
+    let cancelled_stdout = String::from_utf8_lossy(&cancelled.stdout);
+    assert!(
+        cancelled.status.success() || cancelled_stdout.contains("already terminal"),
+        "cancel detached Cook: {cancelled_stdout}"
+    );
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+        status.args(["agent-task", "status", &attempt_id, "--full"]);
+        let status = bounded_output(status);
+        let status_stdout = String::from_utf8_lossy(&status.stdout);
+        assert!(status.status.success(), "{status_stdout}");
+        let terminal = serde_json::from_str::<serde_json::Value>(&status_stdout)
+            .ok()
+            .and_then(|status| status.pointer("/data/state").and_then(serde_json::Value::as_str))
+            .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
+        if terminal {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "detached Cook did not terminalize after cancellation: {status_stdout}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
     }
 }
 
@@ -511,14 +609,11 @@ fn detached_cook_admission_does_not_schedule_unrelated_recovery_records() {
         "Cook admission must not wait for stale daemon recovery"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "{stdout}");
-    let handoff_start = stdout
-        .find('{')
-        .unwrap_or_else(|| panic!("Cook handoff is durable output\n{stdout}"));
-    let handoff: serde_json::Value = serde_json::from_str(stdout[handoff_start..].trim())
-        .unwrap_or_else(|error| panic!("Cook handoff is JSON: {error}\n{stdout}"));
-    assert_eq!(handoff["detached"], true, "{stdout}");
-    assert!(handoff["cook_id"].as_str().is_some_and(|id| !id.is_empty()));
+    assert!(!output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("detached Cook exited before materializing its first attempt"),
+        "{stdout}"
+    );
 
     let store = ObservationStore::open_initialized_at(&database).expect("reopen fixture store");
     assert!(store
@@ -535,13 +630,6 @@ fn detached_cook_admission_does_not_schedule_unrelated_recovery_records() {
         })
         .expect("list recovery children")
         .is_empty());
-
-    #[cfg(unix)]
-    if let Some(pid) = handoff["pid"].as_u64() {
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGKILL);
-        }
-    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- delay local detached Cook acceptance until a readable first attempt is durably indexed
- atomically arbitrate materialization against child exit and cancellation
- preserve pending status for observation errors and bounded materialization waits
- add realistic detached success, exit-first, materialization-first, and cancellation race coverage

Closes #12290.

## Verification
- `git diff --check`
- Rust compilation and tests are delegated to GitHub CI

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding agents implemented and independently reviewed the lifecycle repair and race coverage. Chris Huber directed the work and owns every line.