### PR TITLE
fix(cook): canonicalize completion recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1126,21 +1126,15 @@ impl AgentTaskCookReport {
     /// Project the Cook's end-to-end PR completion separately from provider
     /// output and raw legacy status strings.
     pub fn completion(&self) -> Option<AgentTaskCookCompletion> {
-        let candidate_produced = self
-            .selected_candidate
-            .as_ref()
-            .is_some_and(|candidate| !candidate["incomplete"].as_bool().unwrap_or(false));
         let finalization_requested = !matches!(
             self.status.as_str(),
             "green_no_finalize" | "intentional_no_change"
         );
         cook_completion(
-            candidate_produced,
+            self.selected_candidate.as_ref(),
             finalization_requested,
             self.finalization.as_ref(),
-            self.selected_candidate
-                .as_ref()
-                .and_then(|candidate| candidate["run_id"].as_str()),
+            self.latest_run_id.as_deref(),
         )
     }
 }
@@ -1161,15 +1155,35 @@ pub fn cook_finalization_is_pr_receipt(finalization: &Value) -> bool {
 /// Project durable candidate and publication facts for both immediate Cook
 /// reports and record readers.
 pub fn cook_completion(
-    candidate_produced: bool,
+    selected_candidate: Option<&Value>,
     finalization_requested: bool,
     finalization: Option<&Value>,
-    recovery_run_id: Option<&str>,
+    finalization_run_id: Option<&str>,
 ) -> Option<AgentTaskCookCompletion> {
+    let candidate_produced = canonical_candidate_produced(selected_candidate);
+    let canonical_finalization = canonical_candidate_finalization(
+        selected_candidate,
+        finalization,
+        finalization_run_id,
+    );
+    // A report can carry a receipt before the Cook index is available. Once a
+    // canonical selection exists, however, only that selected attempt owns the
+    // completion receipt; a newer non-substantive attempt cannot replace it.
+    let finalization = canonical_finalization
+        .as_ref()
+        .or_else(|| {
+            selected_candidate
+                .is_none_or(|candidate| candidate["cook_id"].as_str().is_none())
+                .then_some(finalization)
+                .flatten()
+        });
     let pr_finalized = finalization.is_some_and(cook_finalization_is_pr_receipt);
+    let recovery_run_id = (!pr_finalized && finalization_requested)
+        .then(|| canonical_finalization_recovery_run_id(selected_candidate))
+        .flatten();
     let state = if pr_finalized {
         "pr_finalized"
-    } else if candidate_produced && finalization_requested {
+    } else if recovery_run_id.is_some() {
         "candidate_awaiting_finalization"
     } else if candidate_produced {
         "candidate_produced"
@@ -1191,6 +1205,140 @@ pub fn cook_completion(
         state,
         next_action,
     })
+}
+
+/// A candidate selection is substantive only when the controller named the
+/// immutable task and patch artifact it selected. The legacy fallback selection
+/// leaves those fields empty for empty, unknown, and conflicting attempts.
+fn canonical_candidate_produced(selected_candidate: Option<&Value>) -> bool {
+    let Some(candidate) = selected_candidate else {
+        return false;
+    };
+    candidate["incomplete"] != true
+        && candidate["run_id"].as_str().is_some_and(|value| !value.is_empty())
+        && candidate["selected_task_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+        && candidate["selected_artifact_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+}
+
+/// Recovery needs the exact selected immutable artifact, a finalizable promotion,
+/// required-gate evidence accepted by the Cook recipe, and reviewer metadata.
+fn canonical_finalization_recovery_run_id(selected_candidate: Option<&Value>) -> Option<String> {
+    if !canonical_candidate_produced(selected_candidate) {
+        return None;
+    }
+    let candidate = selected_candidate?;
+    let run_id = candidate["run_id"].as_str()?;
+    let task_id = candidate["selected_task_id"].as_str()?;
+    let artifact_id = candidate["selected_artifact_id"].as_str()?;
+    let cook_id = candidate["cook_id"].as_str()?;
+    let recipe = super::cook_recipe::load_recipe(cook_id).ok()?;
+    let options = super::cook_recipe::reconstruct_adoption_options(&recipe).ok()?;
+    let promotion = super::cook_promotion::persisted_promotion_for_attempt(run_id)
+        .ok()
+        .flatten()?;
+    let recovery_run_id = super::cook_promotion::canonical_cook_recovery_run_id(cook_id)?;
+    if !canonical_finalization_eligible(
+        &promotion,
+        options.gates.accept_inherited_failures,
+        review_form_from_aggregate(
+            &agent_task_lifecycle::read_attempt_aggregate(&recovery_run_id).ok()?,
+        )
+        .ok()
+        .flatten()
+        .is_some_and(|form| form.validate().is_ok()),
+    )
+        || promotion.source.run_id.as_deref() != Some(run_id)
+        || promotion.source.task_id != task_id
+        || promotion.patch_artifact.id != artifact_id
+        || promotion.patch_artifact.sha256.as_deref().is_none_or(str::is_empty)
+    {
+        return None;
+    }
+    Some(recovery_run_id)
+}
+
+fn canonical_finalization_eligible(
+    promotion: &AgentTaskPromotionReport,
+    accept_inherited_failures: bool,
+    has_valid_review_form: bool,
+) -> bool {
+    matches!(
+        promotion.status,
+        AgentTaskPromotionStatus::Applied | AgentTaskPromotionStatus::GateFailed
+    ) && promotion.finalization_eligible(accept_inherited_failures)
+        && has_valid_review_form
+}
+
+/// Read finalization from the canonical selected attempt or its authenticated
+/// form-only continuation. An exact status read may target a later attempt, but
+/// only a continuation that carries this candidate's verified promotion may own
+/// its reviewer-metadata receipt.
+pub(crate) fn canonical_candidate_finalization(
+    selected_candidate: Option<&Value>,
+    inspected_finalization: Option<&Value>,
+    inspected_run_id: Option<&str>,
+) -> Option<Value> {
+    if !canonical_candidate_produced(selected_candidate) {
+        return None;
+    }
+    let candidate = selected_candidate?;
+    let cook_id = candidate["cook_id"].as_str()?;
+    let run_id = candidate["run_id"].as_str()?;
+    if inspected_run_id == Some(run_id) {
+        if let Some(finalization) = inspected_finalization {
+            return Some(finalization.clone());
+        }
+    }
+    let record = agent_task_lifecycle::exact_record(run_id).ok()?;
+    if record.metadata["cook_id"].as_str() == Some(cook_id) {
+        if let Some(finalization) = record.metadata.get("cook_finalization") {
+            return Some(finalization.clone());
+        }
+    }
+    let recipe = super::cook_recipe::load_recipe(cook_id).ok()?;
+    for attempt in recipe.attempts.iter().rev() {
+        if attempt.run_id == run_id {
+            continue;
+        }
+        let Ok(record) = agent_task_lifecycle::exact_record(&attempt.run_id) else {
+            continue;
+        };
+        if record.metadata["cook_id"].as_str() != Some(cook_id)
+            || !review_form_attempt_is_ready_for_cook_continuation(&attempt.plan, &record).ok()?
+        {
+            continue;
+        }
+        let Some(promotion) = super::cook_promotion::persisted_promotion_for_attempt(&attempt.run_id)
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+        if promotion
+            .provenance
+            .pointer("/cook_follow_up/source_run_id")
+            .and_then(Value::as_str)
+            != Some(run_id)
+        {
+            continue;
+        }
+        if let Some(finalization) = record.metadata.get("cook_finalization") {
+            return Some(finalization.clone());
+        }
+    }
+    None
+}
+
+/// Resolve the controller-owned candidate selection for a Cook alias. Callers
+/// that publish or recover must use this instead of ranking attempt history.
+pub(crate) fn canonical_cook_candidate(cook_id: &str) -> Option<Value> {
+    agent_task_lifecycle::select_cook_candidate(cook_id)
+        .ok()
+        .and_then(|selection| serde_json::to_value(selection).ok())
 }
 
 /// `skip_serializing_if` predicate for a borrowed slice field.
@@ -1742,11 +1890,13 @@ mod run_lifecycle_projection_tests {
     }
 
     #[test]
-    fn candidate_without_requested_pr_finalization_is_not_a_completed_cook() {
+    fn candidate_without_canonical_finalization_evidence_is_not_recoverable() {
         let mut candidate = report("completed", CookDisposition::Terminal);
         candidate.selected_candidate = Some(serde_json::json!({
             "run_id": "cook-projection-attempt-1",
             "incomplete": false,
+            "selected_task_id": "task-1",
+            "selected_artifact_id": "patch-1",
         }));
 
         let serialized = serde_json::to_value(&candidate).expect("serialize");
@@ -1756,22 +1906,19 @@ mod run_lifecycle_projection_tests {
         );
         assert_eq!(
             serialized["completion"]["state"],
-            "candidate_awaiting_finalization"
+            "candidate_produced"
         );
         assert_eq!(serialized["completion"]["pr_finalized"], false);
-        assert_eq!(
-            serialized["completion"]["next_action"]["command"],
-            "homeboy agent-task finalize-pr --recover cook-projection-attempt-1"
-        );
+        assert!(serialized["completion"].get("next_action").is_none());
 
         let batch = cook_batch_result(
             "batch-projection".to_string(),
             vec![cell("completed", Some(candidate))],
         );
-        assert_eq!(batch.value.succeeded, 0);
-        assert_eq!(batch.value.failed, 1);
-        assert_eq!(batch.value.status, "failed");
-        assert_eq!(batch.exit_code, 1);
+        assert_eq!(batch.value.succeeded, 1);
+        assert_eq!(batch.value.failed, 0);
+        assert_eq!(batch.value.status, "succeeded");
+        assert_eq!(batch.exit_code, 0);
     }
 
     #[test]
@@ -1780,6 +1927,8 @@ mod run_lifecycle_projection_tests {
         candidate.selected_candidate = Some(serde_json::json!({
             "run_id": "cook-projection-attempt-1",
             "incomplete": false,
+            "selected_task_id": "task-1",
+            "selected_artifact_id": "patch-1",
         }));
         candidate.finalization = Some(serde_json::json!({
             "status": "review_ready",
@@ -1798,6 +1947,8 @@ mod run_lifecycle_projection_tests {
         candidate.selected_candidate = Some(serde_json::json!({
             "run_id": "cook-projection-attempt-1",
             "incomplete": false,
+            "selected_task_id": "task-1",
+            "selected_artifact_id": "patch-1",
         }));
         // Legacy receipts can establish that finalization was attempted, but
         // cannot establish publication without the PR identity.
@@ -1806,8 +1957,121 @@ mod run_lifecycle_projection_tests {
         }));
 
         let completion = candidate.completion().expect("candidate completion");
-        assert_eq!(completion.state, "candidate_awaiting_finalization");
+        assert_eq!(completion.state, "candidate_produced");
         assert!(!completion.pr_finalized);
+    }
+
+    #[test]
+    fn empty_unknown_and_conflicting_selections_never_produce_candidates() {
+        for candidate in [
+            serde_json::json!({"run_id": "run", "incomplete": false}),
+            serde_json::json!({"run_id": "", "incomplete": false, "selected_task_id": "task", "selected_artifact_id": "patch"}),
+            serde_json::json!({"run_id": "run", "incomplete": true, "selected_task_id": "task", "selected_artifact_id": "patch"}),
+        ] {
+            assert!(
+                cook_completion(Some(&candidate), true, None, None).is_none(),
+                "non-canonical selection cannot advertise a candidate or recovery"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_candidate_without_green_finalization_evidence_has_no_recovery_action() {
+        let candidate = serde_json::json!({
+            "run_id": "failed-provider-run",
+            "incomplete": false,
+            "selected_task_id": "task",
+            "selected_artifact_id": "patch",
+        });
+
+        let completion = cook_completion(Some(&candidate), true, None, None)
+            .expect("canonical candidate is reported without treating it as publishable");
+
+        assert_eq!(completion.state, "candidate_produced");
+        assert!(completion.next_action.is_none());
+    }
+
+    #[test]
+    fn canonical_selection_rejects_a_newer_attempt_receipt() {
+        let candidate = serde_json::json!({
+            "cook_id": "cook",
+            "run_id": "older-canonical-run",
+            "incomplete": false,
+            "selected_task_id": "task",
+            "selected_artifact_id": "patch",
+        });
+        let newer_receipt = serde_json::json!({"status": "review_ready", "pr_number": 12291});
+
+        assert!(
+            canonical_candidate_finalization(
+                Some(&candidate),
+                Some(&newer_receipt),
+                Some("newer-non-substantive-run"),
+            )
+            .is_none(),
+            "a receipt on an exact newer non-substantive attempt cannot finalize the older candidate"
+        );
+    }
+
+    #[test]
+    fn canonical_selection_uses_its_own_inspected_receipt() {
+        let candidate = serde_json::json!({
+            "cook_id": "cook",
+            "run_id": "canonical-run",
+            "incomplete": false,
+            "selected_task_id": "task",
+            "selected_artifact_id": "patch",
+        });
+        let receipt = serde_json::json!({"status": "review_ready", "pr_number": 12291});
+
+        assert_eq!(
+            canonical_candidate_finalization(Some(&candidate), Some(&receipt), Some("canonical-run")),
+            Some(receipt)
+        );
+    }
+
+    #[test]
+    fn finalized_canonical_candidate_does_not_reopen_finalization_recovery() {
+        let receipt = serde_json::json!({"status": "review_ready", "pr_number": 12291});
+        let completion = cook_completion(None, true, Some(&receipt), None)
+            .expect("receipt produces terminal completion");
+
+        assert_eq!(completion.state, "pr_finalized");
+        assert!(completion.next_action.is_none());
+    }
+
+    #[test]
+    fn unbound_finalization_receipt_does_not_make_a_cook_exit_successfully() {
+        let mut report = report("review_ready", CookDisposition::Terminal);
+        report.latest_run_id = Some("newer-attempt".to_string());
+        report.selected_candidate = Some(serde_json::json!({
+            "cook_id": "cook",
+            "run_id": "older-canonical-attempt",
+            "incomplete": false,
+            "selected_task_id": "task",
+            "selected_artifact_id": "patch",
+        }));
+        report.finalization = Some(serde_json::json!({
+            "status": "review_ready",
+            "pr_number": 12291,
+        }));
+
+        assert_eq!(cook_report_exit_code(&report), 1);
+    }
+
+    #[test]
+    fn a_pr_receipt_remains_completed_without_reloading_candidate_evidence() {
+        let completion = cook_completion(
+            None,
+            true,
+            Some(&serde_json::json!({"status": "review_ready", "pr_number": 12291})),
+            None,
+        )
+        .expect("durable PR receipt completes Cook publication");
+
+        assert_eq!(completion.state, "pr_finalized");
+        assert!(completion.pr_finalized);
+        assert!(completion.next_action.is_none());
     }
 }
 
@@ -2581,25 +2845,21 @@ fn child_finalization_value(cell: &AgentTaskCookBatchCellReport) -> Value {
 }
 
 fn cook_report_exit_code(report: &AgentTaskCookReport) -> i32 {
-    // A review-ready or already-finalized cook is a success; anything the cook
-    // could not carry to a green, finalized state is a non-zero resume result
-    // the operator must still act on.
-    match CookStatus::from_status(&report.status) {
-        status if status.is_success_exit() => 0,
-        _ => {
-            if report
-                .finalization
-                .as_ref()
-                .and_then(|value| value.get("status"))
-                .and_then(Value::as_str)
-                .is_some_and(|status| matches!(status, "review_ready" | "draft_published"))
-            {
-                0
-            } else {
-                1
-            }
-        }
+    let finalization_requested = !matches!(
+        report.status.as_str(),
+        "green_no_finalize" | "intentional_no_change"
+    );
+    if finalization_requested {
+        return report
+            .completion()
+            .is_some_and(|completion| completion.pr_finalized)
+            .then_some(0)
+            .unwrap_or(1);
     }
+    CookStatus::from_status(&report.status)
+        .is_success_exit()
+        .then_some(0)
+        .unwrap_or(1)
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -3059,7 +3319,7 @@ fn adopted_attempt_is_ready_for_cook_continuation(
     Ok(None)
 }
 
-fn review_form_attempt_is_ready_for_cook_continuation(
+pub(crate) fn review_form_attempt_is_ready_for_cook_continuation(
     plan: &AgentTaskPlan,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<bool> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -35,7 +35,11 @@ use crate::agent_task_review_dossier::{
 };
 use homeboy_core::{config, Error, Result};
 
-use super::cook::{AgentTaskCookAttemptReport, AgentTaskCookReport, AgentTaskCookServiceOptions};
+use super::cook::{
+    canonical_candidate_finalization, canonical_cook_candidate, cook_finalization_is_pr_receipt,
+    review_form_attempt_is_ready_for_cook_continuation, AgentTaskCookAttemptReport,
+    AgentTaskCookReport, AgentTaskCookServiceOptions,
+};
 use super::AgentTaskRunResult;
 
 pub fn source_worktree_path(cwd: Option<String>, workspace: Option<String>) -> Option<PathBuf> {
@@ -1797,30 +1801,10 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     {
         run_or_cook_id.to_string()
     } else {
-        let mut applied_run_id = None;
-        for attempt in recipe.attempts.iter().rev() {
-            if persisted_promotion_for_attempt(&attempt.run_id)?.is_some_and(|promotion| {
-                // #11460 stopped flattening an explicitly accepted inherited
-                // baseline failure into Applied, so selecting only on Applied
-                // made recovery unable to find the very attempt it exists to
-                // recover. Selection is permissive on purpose: finalization
-                // still enforces finalization_eligible against the cook's own
-                // accept_inherited_failures, so a candidate the operator has
-                // not accepted still fails there, with its specific reason
-                // instead of "no attempt with an applied promotion".
-                let outcome = promotion.gate_outcome();
-                outcome.status == AgentTaskPromotionStatus::Applied
-                    || (outcome.status == AgentTaskPromotionStatus::GateFailed
-                        && promotion.finalization_eligible(true))
-            }) {
-                applied_run_id = Some(attempt.run_id.clone());
-                break;
-            }
-        }
-        applied_run_id.ok_or_else(|| {
+        canonical_cook_recovery_run_id(&recipe.cook_id).ok_or_else(|| {
             Error::validation_invalid_argument(
                 "run_or_cook_id",
-                "durable Cook recipe has no attempt with an applied promotion",
+                "durable Cook has no canonical promotable candidate",
                 Some(run_or_cook_id.to_string()),
                 None,
             )
@@ -1867,6 +1851,37 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
     }
     Ok(value)
+}
+
+pub(crate) fn canonical_cook_recovery_run_id(cook_id: &str) -> Option<String> {
+    let candidate = canonical_cook_candidate(cook_id)
+        .filter(|candidate| candidate["incomplete"] != true)
+        ?;
+    let source_run_id = candidate["run_id"].as_str()?.to_string();
+    if source_run_id.is_empty() {
+        return None;
+    }
+    let recipe = super::cook_recipe::load_recipe(cook_id).ok()?;
+    for attempt in recipe.attempts.iter().rev() {
+        let Ok(record) = agent_task_lifecycle::exact_record(&attempt.run_id) else {
+            continue;
+        };
+        if review_form_attempt_is_ready_for_cook_continuation(&attempt.plan, &record).ok()?
+            && persisted_promotion_for_attempt(&attempt.run_id)
+                .ok()
+                .flatten()
+                .is_some_and(|promotion| {
+                    promotion
+                        .provenance
+                        .pointer("/cook_follow_up/source_run_id")
+                        .and_then(Value::as_str)
+                        == Some(source_run_id.as_str())
+                })
+        {
+            return Some(attempt.run_id.clone());
+        }
+    }
+    Some(source_run_id)
 }
 
 /// Recover a standalone manual-finalization record. Unlike Cook attempts, a
@@ -1924,6 +1939,11 @@ fn completed_finalization_receipt_for_recovery(
     recipe: &super::cook_recipe::AgentTaskCookRecipe,
     run_or_cook_id: &str,
 ) -> Result<Option<Value>> {
+    if run_or_cook_id == recipe.cook_id {
+        let selected_candidate = canonical_cook_candidate(&recipe.cook_id);
+        let receipt = canonical_candidate_finalization(selected_candidate.as_ref(), None, None);
+        return Ok(receipt.filter(cook_finalization_is_pr_receipt));
+    }
     let run_ids = if recipe
         .attempts
         .iter()

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10,6 +10,7 @@ use super::super::cook_adoption::{
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
     canonical_cook_patch_artifact_id, cook_finalization_options, cook_promotion_argv, cook_report,
+    canonical_cook_recovery_run_id,
     finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
     moving_base_recovery_for_run, moving_base_recovery_from_promotion, moving_base_recovery_report,
     next_moving_base_recovery, persist_manual_finalization_intent,
@@ -7281,6 +7282,56 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             AgentTaskCookLoopStatus::GreenCompleted
         );
         let follow_up_run_id = &result.value.attempts[1].run_id;
+        let selected_candidate = result
+            .value
+            .selected_candidate
+            .as_ref()
+            .expect("source patch remains the canonical candidate");
+        assert_eq!(selected_candidate["run_id"], run_id);
+        assert_eq!(
+            result.value.completion().expect("in-process completion").state,
+            "pr_finalized",
+            "the form-only continuation owns the canonical source candidate receipt"
+        );
+        let source_record = agent_task_lifecycle::exact_record(run_id).expect("source record");
+        assert_eq!(
+            cook_completion(
+                Some(selected_candidate),
+                true,
+                source_record.metadata.get("cook_finalization"),
+                Some(run_id),
+            )
+            .expect("exact source status completion")
+            .state,
+            "pr_finalized",
+            "exact source status resolves the bound form-only receipt"
+        );
+        agent_task_lifecycle::rewrite_record_for_test(follow_up_run_id, |record| {
+            record.metadata
+                .as_object_mut()
+                .expect("record metadata object")
+                .remove("cook_finalization");
+        })
+        .expect("remove form-only receipt");
+        let awaiting = result.value.completion().expect("recoverable completion");
+        assert_eq!(awaiting.state, "candidate_awaiting_finalization");
+        assert_eq!(
+            awaiting.next_action.expect("recovery action").command,
+            format!("homeboy agent-task finalize-pr --recover {follow_up_run_id}"),
+            "the bound form-only continuation owns failed-finalization recovery"
+        );
+        let unrelated_run_id = format!("{cook_id}-unrelated-continuation");
+        super::super::record_recipe_attempt(cook_id, 3, &unrelated_run_id, &options.initial_plan)
+            .expect("persist unrelated recipe attempt");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&unrelated_run_id))
+            .expect("persist unrelated attempt record");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 3, &unrelated_run_id)
+            .expect("link unrelated attempt");
+        assert_eq!(
+            canonical_cook_recovery_run_id(cook_id).as_deref(),
+            Some(follow_up_run_id.as_str()),
+            "an unrelated newer continuation cannot replace the bound form-only recovery owner"
+        );
         let follow_up_promotion = persisted_promotion_for_attempt(follow_up_run_id)
             .unwrap()
             .expect("form-only continuation carries promoted candidate");
@@ -8377,6 +8428,12 @@ fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run
             });
         })
         .expect("persist promotion provenance");
+        agent_task_lifecycle::record_promotion(
+            latest_run_id,
+            serde_json::to_value(promotion(latest_run_id))
+                .expect("serialize newer otherwise eligible promotion"),
+        )
+        .expect("persist unrelated newer promotion");
 
         let report = cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
@@ -8400,6 +8457,11 @@ fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run
             options.initial_plan.tasks[0].task_id
         );
         assert_eq!(provenance["selected_artifact_id"], "candidate");
+        assert_eq!(
+            canonical_cook_recovery_run_id(cook_id).as_deref(),
+            Some(selected_run_id),
+            "Cook alias recovery follows the canonical older candidate rather than a newer unrelated eligible promotion"
+        );
         assert_eq!(provenance["applied_promotion"]["identity"], "candidate-sha");
         assert_eq!(
             provenance["applied_promotion"]["destination"],
@@ -8408,6 +8470,18 @@ fn cook_report_emits_selected_candidate_provenance_without_redefining_latest_run
         assert_eq!(
             provenance["applied_promotion"]["fingerprint"],
             "candidate-fingerprint"
+        );
+        let finalized = serde_json::json!({ "status": "review_ready", "pr_number": 12291 });
+        agent_task_lifecycle::record_cook_finalization(selected_run_id, finalized.clone())
+            .expect("persist selected candidate receipt");
+        assert_eq!(
+            canonical_candidate_finalization(
+                Some(&provenance),
+                Some(&serde_json::json!({ "status": "review_ready", "pr_number": 99999 })),
+                Some(latest_run_id),
+            ),
+            Some(finalized),
+            "exact status for a newer non-substantive attempt resolves the canonical candidate receipt"
         );
     });
 }
@@ -9100,6 +9174,36 @@ fn promotion_with_existing_path(run_id: &str, path: &std::path::Path) -> AgentTa
     promotion.target.path = Some(path.clone());
     promotion.provenance["worktree_path"] = serde_json::json!(path);
     promotion
+}
+
+#[test]
+fn canonical_completion_accepts_green_and_recipe_authorized_inherited_gate_evidence() {
+    let mut green = promotion("canonical-green");
+    green.patch_artifact.sha256 = Some("canonical-sha".to_string());
+    assert!(canonical_finalization_eligible(&green, false, true));
+
+    let mut inherited = green.clone();
+    inherited.status = AgentTaskPromotionStatus::GateFailed;
+    inherited.deterministic_gates[0].status =
+        crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure;
+    inherited.deterministic_gates[0].exit_code = 1;
+    inherited.deterministic_gates[0].baseline_comparison = Some(
+        crate::agent_task_gate::AgentTaskGateBaselineComparison {
+            base_ref: "main".to_string(),
+            exit_code: 1,
+            failure_fingerprint: "inherited".to_string(),
+            matches_candidate_failure: true,
+            result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+        },
+    );
+    assert!(canonical_finalization_eligible(&inherited, true, true));
+    assert!(!canonical_finalization_eligible(&inherited, false, true));
+}
+
+#[test]
+fn canonical_completion_requires_a_valid_review_form() {
+    let green = promotion("canonical-missing-review-form");
+    assert!(!canonical_finalization_eligible(&green, false, false));
 }
 
 fn tracked_promotion_continuation_options(

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1487,15 +1487,18 @@ fn attach_cook_completion(value: &mut Value, record: &AgentTaskRunRecord) {
     let Ok(Some(recipe)) = agent_task_service::load_recipe_for_attempt(&record.run_id) else {
         return;
     };
-    let candidate_produced = record
+    let selected_candidate = record
         .metadata
-        .pointer("/latest_promotion/patch_artifact/sha256")
+        .get("cook_id")
         .and_then(Value::as_str)
-        .is_some();
+        .and_then(|cook_id| agent_task_service_direct::select_cook_candidate(cook_id).ok())
+        .and_then(|selection| serde_json::to_value(selection).ok());
     let finalization_requested = recipe.finalization["no_finalize"] != true;
     if let Some(completion) = agent_task_service_direct::cook_completion(
-        candidate_produced,
+        selected_candidate.as_ref(),
         finalization_requested,
+        // `cook_completion` resolves this receipt from the selected candidate
+        // whenever selection exists. This fallback only serves pre-index reports.
         record.metadata.get("cook_finalization"),
         Some(&record.run_id),
     ) {


### PR DESCRIPTION
## Summary
- derive Cook completion, exit status, and recovery guidance from one canonical candidate model
- prevent empty/unknown/conflicting candidates and unbound receipts from advertising finalization
- preserve green, accepted-inherited-failure, and authenticated form-only recovery
- make Cook-alias recovery choose the canonical candidate rather than newest eligible work

Closes #12291.

## Verification
- `git diff --check`
- Rust compilation and tests are delegated to GitHub CI

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding agents implemented and independently reviewed canonical completion and recovery behavior. Chris Huber directed the work and owns every line.