### PR TITLE
feat(agent-task): classify immediate provider failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -69,7 +69,7 @@ pub use admission::{
 pub use catalog::*;
 pub use command_runner::{
     probe_provider_executor_resolves, provider_command_parts, run_provider_readiness_invocation,
-    ProviderExecutorResolution, ProviderReadinessInvocationResult,
+    validate_provider_immediate_failure_patterns, ProviderExecutorResolution, ProviderReadinessInvocationResult,
     PROVIDER_READINESS_RESULT_SCHEMA,
 };
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -412,6 +412,15 @@ fn validate_provider_runner_readiness_for_backend_with_diagnostics(
         }
     };
 
+    super::command_runner::validate_provider_immediate_failure_patterns(provider).map_err(|message| {
+        Error::validation_invalid_argument(
+            "immediate_failure_patterns",
+            format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+            Some(provider.backend.clone()),
+            None,
+        )
+    })?;
+
     provider_executable_env(provider).map_err(|error| {
         Error::validation_invalid_argument(
             "backend",

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -41,6 +41,9 @@ pub(super) const PROVIDER_TRANSIENT_MAX_ATTEMPTS: u32 = 3;
 /// (250ms, 500ms, ...). Keeps a single network blip from failing a whole cook
 /// task without introducing unbounded delay.
 const PROVIDER_TRANSIENT_BASE_BACKOFF_MS: u64 = 250;
+const IMMEDIATE_FAILURE_WINDOW: Duration = Duration::from_secs(10);
+const IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT: usize = 4 * 1024;
+const IMMEDIATE_FAILURE_ERROR_REF_LIMIT: usize = 8;
 
 /// Run the provider command with a bounded retry on transient provider/network
 /// failures.
@@ -57,11 +60,49 @@ pub(super) fn run_materialized_provider_command(
     execution_attempt: u32,
 ) -> AgentTaskOutcome {
     let mut retry_attempt = 1;
+    // This state belongs to one invocation's retry sequence. It cannot couple
+    // unrelated tasks that happen to use the same provider concurrently.
+    let mut prior_immediate_failure = None;
     loop {
+        let started = Instant::now();
         let mut outcome =
             run_materialized_provider_command_once(request, provider, run_id, execution_attempt);
         classify_provider_policy_denial(request, &mut outcome);
         classify_transient_provider_outcome(&mut outcome);
+
+        if let Some(failure) = immediate_provider_failure(provider, &outcome, started.elapsed()) {
+            if prior_immediate_failure.as_deref() == Some(failure.signature.as_str()) {
+                if outcome.failure_classification != Some(AgentTaskFailureClassification::Transient) {
+                    outcome.failure_classification = Some(AgentTaskFailureClassification::Provider);
+                }
+                outcome.diagnostics.push(AgentTaskDiagnostic {
+                    class: "agent_task.provider_immediate_failure_retry_suppressed".to_string(),
+                    message: format!(
+                        "provider '{}' repeated immediate '{}' failure; same-provider retry suppressed",
+                        provider.id, failure.pattern_id
+                    ),
+                    data: json!({
+                        "provider_id": provider.id,
+                        "backend": provider.backend,
+                        "failure_pattern": failure.pattern_id,
+                        "provider_error_refs": failure.error_refs,
+                        "retryable": false,
+                        "retryability_reason": "identical immediate provider failure repeated in this task/provider retry sequence",
+                        "log_lookup": failure.log_lookup,
+                        "fallback_action": failure.fallback_action,
+                        "scope": "task_provider_retry_sequence",
+                    }),
+                });
+                attach_runtime_tool_provenance(request, &mut outcome);
+                link_latest_executor_evidence(request, &mut outcome, run_id);
+                return outcome;
+            }
+            prior_immediate_failure = Some(failure.signature);
+            // The adapter declared this server-side failure retryable. Retain
+            // Homeboy's normal one-retry recovery path until the same signature
+            // proves it is not a transient blip.
+            outcome.failure_classification = Some(AgentTaskFailureClassification::Transient);
+        }
 
         let retryable = outcome_is_transient(&outcome);
         if !retryable || retry_attempt >= PROVIDER_TRANSIENT_MAX_ATTEMPTS {
@@ -82,6 +123,132 @@ pub(super) fn run_materialized_provider_command(
         }
         retry_attempt += 1;
     }
+}
+
+struct ImmediateProviderFailure {
+    pattern_id: String,
+    signature: String,
+    error_refs: Vec<String>,
+    log_lookup: String,
+    fallback_action: String,
+}
+
+fn immediate_provider_failure(
+    provider: &AgentTaskExecutorProvider,
+    outcome: &AgentTaskOutcome,
+    elapsed: Duration,
+) -> Option<ImmediateProviderFailure> {
+    if elapsed >= IMMEDIATE_FAILURE_WINDOW
+        || !matches!(outcome.status, AgentTaskOutcomeStatus::ProviderError | AgentTaskOutcomeStatus::Failed)
+        || !matches!(
+            outcome.failure_classification,
+            None
+                | Some(AgentTaskFailureClassification::Provider)
+                | Some(AgentTaskFailureClassification::Transient)
+        )
+    {
+        return None;
+    }
+    let text = provider_failure_text(outcome);
+    provider.immediate_failure_patterns.iter().find_map(|pattern| {
+        if !pattern.retryable || pattern.error_contains_any.is_empty() {
+            return None;
+        }
+        let matches = pattern.error_contains_any.iter().any(|needle| {
+            !needle.is_empty() && text.to_ascii_lowercase().contains(&needle.to_ascii_lowercase())
+        });
+        matches.then(|| {
+            let error_refs = pattern
+                .error_ref_pattern
+                .as_deref()
+                .and_then(|expression| regex::Regex::new(expression).ok())
+                .map(|expression| {
+                    expression
+                        .find_iter(&text)
+                        .take(IMMEDIATE_FAILURE_ERROR_REF_LIMIT)
+                        .map(|matched| matched.as_str().to_string())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let normalized = pattern
+                .error_ref_pattern
+                .as_deref()
+                .and_then(|expression| regex::Regex::new(expression).ok())
+                .map(|expression| expression.replace_all(&text, "[provider-error-ref]").into_owned())
+                .unwrap_or(text);
+            let normalized = bounded_text(&normalized, IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT);
+            ImmediateProviderFailure {
+                pattern_id: pattern.id.clone(),
+                signature: format!(
+                    "{}:{}:{}",
+                    provider.id,
+                    pattern.id,
+                    homeboy_engine_primitives::content_hash::sha256_hex(normalized.as_bytes())
+                ),
+                error_refs,
+                log_lookup: pattern.log_lookup.clone().unwrap_or_else(|| {
+                    "homeboy agent-task logs <run-id> --task <task-id>".to_string()
+                }),
+                fallback_action: pattern.fallback_action.clone().unwrap_or_else(|| {
+                    "Select another configured provider or pause until this provider is healthy."
+                        .to_string()
+                }),
+            }
+        })
+    })
+}
+
+/// Validate adapter-owned failure signatures before they can affect dispatch.
+/// Invalid regular expressions must be a visible manifest contract error, not
+/// a silent opt-out from retry suppression.
+pub fn validate_provider_immediate_failure_patterns(
+    provider: &AgentTaskExecutorProvider,
+) -> std::result::Result<(), String> {
+    for pattern in &provider.immediate_failure_patterns {
+        if pattern.id.trim().is_empty() || pattern.error_contains_any.iter().all(|value| value.trim().is_empty()) {
+            return Err("immediate failure patterns need an id and at least one non-empty error substring".to_string());
+        }
+        if let Some(expression) = &pattern.error_ref_pattern {
+            if expression.len() > 512 {
+                return Err(format!(
+                    "immediate failure pattern '{}' error_ref_pattern exceeds 512 bytes",
+                    pattern.id
+                ));
+            }
+            let expression = regex::Regex::new(expression).map_err(|error| {
+                format!("immediate failure pattern '{}' has invalid error_ref_pattern: {error}", pattern.id)
+            })?;
+            if expression.is_match("") {
+                return Err(format!(
+                    "immediate failure pattern '{}' error_ref_pattern must not match an empty string",
+                    pattern.id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn provider_failure_text(outcome: &AgentTaskOutcome) -> String {
+    let mut text = outcome.summary.clone().unwrap_or_default();
+    for diagnostic in &outcome.diagnostics {
+        text.push('\n');
+        text.push_str(&diagnostic.message);
+        text.push('\n');
+        text.push_str(&diagnostic.data.to_string());
+    }
+    text
+}
+
+fn bounded_text(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let mut start = text.len() - limit;
+    while !text.is_char_boundary(start) {
+        start += 1;
+    }
+    text[start..].to_string()
 }
 
 fn attach_runtime_tool_provenance(

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -118,6 +118,16 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
             }
         };
         let workspace_root = request.request.workspace.root.clone();
+        if let Err(message) = validate_provider_immediate_failure_patterns(&provider) {
+            return failure_outcome(
+                &request,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskFailureClassification::InvalidInput,
+                "agent_task.provider_immediate_failure_configuration_invalid",
+                format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                json!({ "provider_id": provider.id, "backend": provider.backend }),
+            );
+        }
         bind_workspace_permission_root(
             &mut request.request.executor,
             workspace_root.as_deref(),

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -28,8 +28,24 @@ pub fn preflight_plan_provider_runtime_readiness_with_providers(
             continue;
         };
         if provider.readiness_invocation.is_none() {
+            validate_provider_immediate_failure_patterns(provider).map_err(|message| {
+                Error::validation_invalid_argument(
+                    "immediate_failure_patterns",
+                    format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                    Some(provider.backend.clone()),
+                    None,
+                )
+            })?;
             continue;
         }
+        validate_provider_immediate_failure_patterns(provider).map_err(|message| {
+            Error::validation_invalid_argument(
+                "immediate_failure_patterns",
+                format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                Some(provider.backend.clone()),
+                None,
+            )
+        })?;
         let config = effective_provider_config(&task.executor.config, task.executor.model());
         let verdict = readiness_verdict(provider, &config, cache)?;
         if !verdict.ready {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/common.rs
@@ -40,6 +40,7 @@ pub(super) fn request(
         readiness_invocation: None,
         runner_sources: Vec::new(),
         dependency_failure_patterns: Vec::new(),
+        immediate_failure_patterns: Vec::new(),
         config_preflights: Vec::new(),
         lab_runtime_components: Vec::new(),
         timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery::default(),

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1300,6 +1300,136 @@ fn provider_exhausts_bounded_transient_retries() {
     let _ = fs::remove_file(&state_path);
 }
 
+#[test]
+fn repeated_immediate_adapter_classified_failure_opens_circuit_with_actionable_evidence() {
+    let state_path = unique_state_path("immediate-circuit");
+    let _ = fs::remove_file(&state_path);
+    let state = state_path.to_string_lossy().replace('\\', "\\\\");
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));let p='{state}';let n=0;try{{n=parseInt(fs.readFileSync(p,'utf8'))||0}}catch(e){{}}fs.writeFileSync(p,String(n+1));process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'provider_error',summary:'Unexpected server error. Check server logs for details. err_test123',failure_classification:'provider'}}));"
+        ))
+    );
+    let (request, mut provider) = request("task-immediate-circuit", command);
+    provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+        id: "server_error".to_string(),
+        error_contains_any: vec!["unexpected server error".to_string()],
+        retryable: true,
+        error_ref_pattern: Some(r"err_[A-Za-z0-9]+".to_string()),
+        log_lookup: Some("providerctl logs --error-ref <provider-error-ref>".to_string()),
+        fallback_action: Some("Select another configured provider.".to_string()),
+    }];
+
+    let outcome = run_provider_command(&request, &provider, None);
+
+    assert_eq!(fs::read_to_string(&state_path).expect("attempt count"), "2");
+    assert_eq!(outcome.failure_classification, Some(AgentTaskFailureClassification::Provider));
+    let diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "agent_task.provider_immediate_failure_retry_suppressed")
+        .expect("circuit diagnostic");
+    assert_eq!(diagnostic.data["provider_error_refs"], json!(["err_test123"]));
+    assert_eq!(diagnostic.data["retryable"], json!(false));
+    assert_eq!(diagnostic.data["log_lookup"], "providerctl logs --error-ref <provider-error-ref>");
+    assert_eq!(diagnostic.data["fallback_action"], "Select another configured provider.");
+    let _ = fs::remove_file(&state_path);
+}
+
+#[test]
+fn immediate_failure_suppression_is_scoped_to_one_task_provider_retry_sequence() {
+    let first_state = unique_state_path("immediate-first");
+    let second_state = unique_state_path("immediate-second");
+    let _ = fs::remove_file(&first_state);
+    let _ = fs::remove_file(&second_state);
+    for (task_id, state) in [("first", &first_state), ("second", &second_state)] {
+        let state = state.to_string_lossy().replace('\\', "\\\\");
+        let (request, mut provider) = request(task_id, format!("node {}", script(&format!(
+            "let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));let p='{state}';let n=0;try{{n=parseInt(fs.readFileSync(p,'utf8'))||0}}catch(e){{}}fs.writeFileSync(p,String(n+1));process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'provider_error',summary:'server unavailable',failure_classification:'provider'}}));"
+        ))));
+        provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+            id: "server".to_string(), error_contains_any: vec!["server unavailable".to_string()], retryable: true,
+            error_ref_pattern: None, log_lookup: None, fallback_action: None,
+        }];
+        let outcome = run_provider_command(&request, &provider, None);
+        assert!(outcome.diagnostics.iter().any(|d| d.class == "agent_task.provider_immediate_failure_retry_suppressed"));
+    }
+    assert_eq!(fs::read_to_string(&first_state).expect("first count"), "2");
+    assert_eq!(fs::read_to_string(&second_state).expect("second count"), "2");
+    let _ = fs::remove_file(&first_state);
+    let _ = fs::remove_file(&second_state);
+}
+
+#[test]
+fn invalid_immediate_failure_regex_is_rejected_before_dispatch() {
+    let (_, mut provider) = request("invalid-pattern", "node provider.js".to_string());
+    provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+        id: "bad".to_string(), error_contains_any: vec!["server".to_string()], retryable: true,
+        error_ref_pattern: Some("[".to_string()), log_lookup: None, fallback_action: None,
+    }];
+    let error = validate_provider_immediate_failure_patterns(&provider).expect_err("invalid regex");
+    assert!(error.contains("invalid error_ref_pattern"));
+}
+
+#[test]
+fn empty_matching_immediate_failure_regex_is_rejected_before_dispatch() {
+    let (_, mut provider) = request("empty-pattern", "node provider.js".to_string());
+    provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+        id: "empty".to_string(), error_contains_any: vec!["server".to_string()], retryable: true,
+        error_ref_pattern: Some(".*".to_string()), log_lookup: None, fallback_action: None,
+    }];
+    let error = validate_provider_immediate_failure_patterns(&provider).expect_err("empty match regex");
+    assert!(error.contains("must not match an empty string"));
+}
+
+#[test]
+fn immediate_failure_patterns_preserve_terminal_failure_classifications() {
+    let (_, mut provider) = request("terminal-pattern", "node provider.js".to_string());
+    provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+        id: "server".to_string(), error_contains_any: vec!["server error".to_string()], retryable: true,
+        error_ref_pattern: None, log_lookup: None, fallback_action: None,
+    }];
+    for classification in [
+        AgentTaskFailureClassification::PolicyDenied,
+        AgentTaskFailureClassification::RateLimited,
+        AgentTaskFailureClassification::InvalidInput,
+        AgentTaskFailureClassification::CapabilityMissing,
+        AgentTaskFailureClassification::ExecutionFailed,
+        AgentTaskFailureClassification::Timeout,
+        AgentTaskFailureClassification::Stalled,
+        AgentTaskFailureClassification::Unknown,
+    ] {
+        let outcome = AgentTaskOutcome {
+            status: AgentTaskOutcomeStatus::ProviderError,
+            summary: Some("server error".to_string()),
+            failure_classification: Some(classification),
+            ..Default::default()
+        };
+        assert!(immediate_provider_failure(&provider, &outcome, Duration::ZERO).is_none());
+    }
+}
+
+#[test]
+fn opencode_manifest_shaped_declaration_classifies_the_observed_server_failure() {
+    let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+        "id": "opencode.agent-task-executor",
+        "backend": "opencode",
+        "immediate_failure_patterns": [{
+            "id": "unexpected_server_error",
+            "error_contains_any": ["Unexpected server error. Check server logs for details."],
+            "retryable": true,
+            "error_ref_pattern": "err_[A-Za-z0-9]+",
+            "log_lookup": "opencode logs --error <provider-error-ref>",
+            "fallback_action": "Select another configured provider."
+        }]
+    })).expect("manifest-shaped provider");
+    let outcome = AgentTaskOutcome { status: AgentTaskOutcomeStatus::ProviderError, summary: Some("Unexpected server error. Check server logs for details. err_3a6d31e2".to_string()), ..Default::default() };
+    let failure = immediate_provider_failure(&provider, &outcome, Duration::from_secs(1)).expect("classified failure");
+    assert_eq!(failure.error_refs, vec!["err_3a6d31e2"]);
+    assert_eq!(failure.log_lookup, "opencode logs --error <provider-error-ref>");
+}
+
 fn selected_component_contract(
     slug: &str,
     path: &std::path::Path,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
@@ -263,6 +263,27 @@ fn provider_readiness_selector_mismatch_explains_runtime_provider_confusion() {
 }
 
 #[test]
+fn provider_readiness_rejects_invalid_immediate_failure_configuration_before_execution() {
+    let (_, mut provider) = request("task-a", "node provider.js".to_string());
+    provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
+        id: "invalid".to_string(),
+        error_contains_any: vec!["server error".to_string()],
+        retryable: true,
+        error_ref_pattern: Some("[".to_string()),
+        log_lookup: None,
+        fallback_action: None,
+    }];
+
+    let error = validate_provider_runner_readiness_for_backend_with_providers(
+        &[provider], "test", None,
+    )
+    .expect_err("invalid adapter configuration must fail pre-dispatch");
+
+    assert_eq!(error.details["field"], "immediate_failure_patterns");
+    assert!(error.message.contains("invalid error_ref_pattern"));
+}
+
+#[test]
 fn provider_selection_matches_unique_extension_alias() {
     let (_, mut provider) = request("task-a", "node provider.js".to_string());
     provider.id = "extension-a.provider".to_string();

--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -84,6 +84,10 @@ pub struct AgentTaskExecutorProvider {
     pub runner_sources: Vec<AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_failure_patterns: Vec<AgentTaskProviderDependencyFailurePattern>,
+    /// Adapter-owned classifications for failures that prove an otherwise
+    /// statically-ready provider cannot currently dispatch work.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub immediate_failure_patterns: Vec<AgentTaskProviderImmediateFailurePattern>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config_preflights: Vec<AgentTaskProviderConfigPreflight>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -289,6 +293,24 @@ pub struct AgentTaskProviderDependencyFailurePattern {
     pub remediation: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+/// A provider-specific failure signature that is safe to circuit-break when it
+/// repeats immediately. Homeboy owns the bounded retry/circuit policy; adapter
+/// manifests own the error semantics and operator-facing log lookup.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskProviderImmediateFailurePattern {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub error_contains_any: Vec<String>,
+    #[serde(default)]
+    pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_ref_pattern: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_lookup: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_action: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -12,8 +12,8 @@ use homeboy::agents::agent_tasks::promotion::{
     AgentTaskPromotionStatus,
 };
 use homeboy::agents::agent_tasks::provider::{
-    provider_credential_readiness, AgentTaskExecutorProvider, AgentTaskProviderCatalog,
-    AgentTaskProviderCredentialReadiness, ExtensionProviderAgentTaskExecutor,
+    provider_credential_readiness, resolve_provider_for_backend, AgentTaskExecutorProvider, AgentTaskProviderCatalog,
+    AgentTaskProviderCredentialReadiness, ExtensionProviderAgentTaskExecutor, ProviderResolution,
 };
 use homeboy::agents::agent_tasks::review_dossier::{
     homeboy_tool_disclosure, resolve_review_profile, validate_issue_reference,
@@ -1116,7 +1116,7 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
             0,
         ));
     }
-    if args.validate_readiness {
+    let validated_provider = if args.validate_readiness {
         // Fall back to the configured default backend the same way Cook selection
         // does, so readiness validation does not demand a flag that policy already
         // answers. `default_backend_for_component` resolves component, then
@@ -1142,7 +1142,13 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
             &backend,
             args.selector.as_deref(),
         )?;
-    }
+        match resolve_provider_for_backend(&all_providers, &backend, args.selector.as_deref()) {
+            ProviderResolution::Resolved(provider) => Some((backend, provider.id.clone())),
+            _ => None,
+        }
+    } else {
+        None
+    };
 
     // Default to the requested backend's slice. Dumping the whole multi-backend
     // catalog (every backend's providers, identity catalog, dispatch layers, and
@@ -1169,6 +1175,12 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
         .cloned()
         .collect::<Vec<_>>();
     let providers: &[AgentTaskExecutorProvider] = &filtered_providers;
+    let validated_provider_identity = validated_provider.as_ref();
+    let validated_provider = validated_provider_identity.and_then(|(_, provider_id)| {
+        all_providers
+            .iter()
+            .find(|provider| &provider.id == provider_id)
+    });
     let fallback_sources =
         homeboy::agents::agent_tasks::provider::provider_secret_sources_for_providers(providers);
 
@@ -1236,11 +1248,10 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
             // not dispatchable reports the credential it is missing here so the
             // remediation survives the `--full` serde presentation too (#11479).
             "credential_readiness": credential_readiness_report(&shown_providers),
-            "readiness_validation": {
-                "validated": args.validate_readiness,
-                "backend": args.backend,
-                "selector": args.selector,
-            },
+            "readiness_validation": readiness_validation_projection(
+                validated_provider_identity,
+                validated_provider,
+            ),
             "diagnostics": shown_diagnostics,
             "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_with_fallbacks(&args.secret_env, &fallback_sources),
         }),
@@ -1314,6 +1325,28 @@ fn compact_provider(provider: &AgentTaskExecutorProvider) -> Value {
         "reason": readiness.reason().map(|value| bounded_text(&value, DEFAULT_TEXT_LIMIT)),
         "default_backend": provider.default_backend,
         "capabilities": provider.capabilities.iter().take(8).map(|value| bounded_text(value, 96)).collect::<Vec<_>>(),
+    })
+}
+
+fn live_dispatch_readiness(provider: Option<&AgentTaskExecutorProvider>) -> &'static str {
+    provider
+        .filter(|provider| provider.readiness_invocation.is_some())
+        .map(|_| "validated")
+        .unwrap_or("unverified")
+}
+
+fn readiness_validation_projection(
+    identity: Option<&(String, String)>,
+    provider: Option<&AgentTaskExecutorProvider>,
+) -> Value {
+    serde_json::json!({
+        "validated": identity.is_some(),
+        "effective_backend": identity.map(|(backend, _)| backend),
+        "effective_provider_id": identity.map(|(_, provider_id)| provider_id),
+        // Catalog discovery proves static configuration only. A live dispatch
+        // probe is opt-in because providers own its request.
+        "static_configuration": "declared",
+        "live_dispatch": live_dispatch_readiness(provider),
     })
 }
 
@@ -2059,6 +2092,42 @@ mod tests {
             assert_eq!(provider_status(&provider), "available");
             assert!(compact_provider(&provider)["reason"].is_null());
         });
+    }
+
+    #[test]
+    fn live_dispatch_readiness_uses_the_resolved_provider_only() {
+        let mut probed: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "probed", "backend": "test", "readiness_invocation": { "argv": ["true"] }
+        }))
+        .expect("probed provider");
+        let unprobed: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "unprobed", "backend": "test"
+        }))
+        .expect("unprobed provider");
+
+        assert_eq!(live_dispatch_readiness(Some(&probed)), "validated");
+        assert_eq!(live_dispatch_readiness(Some(&unprobed)), "unverified");
+        assert_eq!(live_dispatch_readiness(None), "unverified");
+        probed.readiness_invocation = None;
+        assert_eq!(live_dispatch_readiness(Some(&probed)), "unverified");
+    }
+
+    #[test]
+    fn readiness_validation_reports_effective_identity_not_raw_arguments() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "resolved.provider", "backend": "resolved-backend",
+            "readiness_invocation": { "argv": ["true"] }
+        }))
+        .expect("provider");
+        let identity = ("resolved-backend".to_string(), "resolved.provider".to_string());
+
+        let projection = readiness_validation_projection(Some(&identity), Some(&provider));
+
+        assert_eq!(projection["effective_backend"], "resolved-backend");
+        assert_eq!(projection["effective_provider_id"], "resolved.provider");
+        assert_eq!(projection["live_dispatch"], "validated");
+        assert!(projection.get("backend").is_none());
+        assert!(projection.get("selector").is_none());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/secrets/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/secrets/tests/mod.rs
@@ -99,6 +99,7 @@ pub(super) fn fixture_provider_with_example_defaults_at(path: &str) -> AgentTask
         readiness_invocation: None,
         runner_sources: Vec::new(),
         dependency_failure_patterns: Vec::new(),
+        immediate_failure_patterns: Vec::new(),
         config_preflights: Vec::new(),
         lab_runtime_components: Vec::new(),
         timeout_artifact_discovery: Default::default(),


### PR DESCRIPTION
## Summary
- add adapter-owned immediate-failure declarations with strict validation
- distinguish static readiness from resolved-provider live validation
- stop identical same-task provider retries after one recovery attempt
- preserve terminal classification precedence and isolate retry state per dispatch sequence
- expose bounded error references, log guidance, and fallback actions

Closes #12293.

Companion adapter activation: the `homeboy-extensions` PR from `feat/12293-opencode-failure-classification`.

## Verification
- `git diff --check`
- Rust compilation and tests are delegated to GitHub CI

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding agents implemented and independently reviewed the generic provider contract and retry behavior. Chris Huber directed the work and owns every line.