### PR TITLE
Repair current-main provider-readiness compile gates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -175,7 +175,7 @@ fn immediate_provider_failure(
                 .as_deref()
                 .and_then(|expression| regex::Regex::new(expression).ok())
                 .map(|expression| expression.replace_all(&text, "[provider-error-ref]").into_owned())
-                .unwrap_or(text);
+                .unwrap_or_else(|| text.clone());
             let normalized = bounded_text(&normalized, IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT);
             ImmediateProviderFailure {
                 pattern_id: pattern.id.clone(),

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -6,7 +6,10 @@ use serde_json::{json, Value};
 use crate::agent_task_scheduler::AgentTaskPlan;
 use homeboy_core::{Error, Result};
 
-use super::command_runner::{run_provider_readiness_invocation, ProviderReadinessInvocationResult};
+use super::command_runner::{
+    run_provider_readiness_invocation, validate_provider_immediate_failure_patterns,
+    ProviderReadinessInvocationResult,
+};
 use super::resolution::select_provider;
 use super::AgentTaskExecutorProvider;
 


### PR DESCRIPTION
Closes #12301.

## Summary

- import the immediate-failure validator where runtime readiness invokes it
- retain the normalized provider failure source text across repeated pattern evaluation
- restore Linux and Windows compilation for the provider-readiness feature merged through #12299

The current-main rustfmt drift is visible in the same baseline CI run; this focused compiler repair lets GitHub CI report the remaining exact formatting surface before the follow-up formatting commit.

Evidence: https://github.com/Extra-Chill/homeboy/actions/runs/31700092804

## Verification

- `git diff --check origin/main...HEAD`
- GitHub CI is the authoritative Rust compile, Windows, warning, formatting, lint, audit, and test gate

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to inspect baseline CI failures, implement the focused compiler repair, and prepare this PR. Chris Huber remains responsible for every line.