### PR TITLE
Restore Rust 1.95 formatting on current main

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -116,8 +116,9 @@ use catalog::{
 };
 #[cfg(test)]
 use command_runner::{
-    is_transient_provider_error, provider_command_env, render_provider_command_display,
-    run_provider_command, run_provider_command_once, PROVIDER_TRANSIENT_MAX_ATTEMPTS,
+    immediate_provider_failure, is_transient_provider_error, provider_command_env,
+    render_provider_command_display, run_provider_command, run_provider_command_once,
+    PROVIDER_TRANSIENT_MAX_ATTEMPTS,
 };
 #[cfg(test)]
 use fixtures::fixture_artifact;

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -69,8 +69,8 @@ pub use admission::{
 pub use catalog::*;
 pub use command_runner::{
     probe_provider_executor_resolves, provider_command_parts, run_provider_readiness_invocation,
-    validate_provider_immediate_failure_patterns, ProviderExecutorResolution, ProviderReadinessInvocationResult,
-    PROVIDER_READINESS_RESULT_SCHEMA,
+    validate_provider_immediate_failure_patterns, ProviderExecutorResolution,
+    ProviderReadinessInvocationResult, PROVIDER_READINESS_RESULT_SCHEMA,
 };
 pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub use credential_readiness::{

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -412,14 +412,19 @@ fn validate_provider_runner_readiness_for_backend_with_diagnostics(
         }
     };
 
-    super::command_runner::validate_provider_immediate_failure_patterns(provider).map_err(|message| {
-        Error::validation_invalid_argument(
-            "immediate_failure_patterns",
-            format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
-            Some(provider.backend.clone()),
-            None,
-        )
-    })?;
+    super::command_runner::validate_provider_immediate_failure_patterns(provider).map_err(
+        |message| {
+            Error::validation_invalid_argument(
+                "immediate_failure_patterns",
+                format!(
+                    "provider '{}' has invalid immediate failure configuration: {message}",
+                    provider.id
+                ),
+                Some(provider.backend.clone()),
+                None,
+            )
+        },
+    )?;
 
     provider_executable_env(provider).map_err(|error| {
         Error::validation_invalid_argument(

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -134,7 +134,7 @@ struct ImmediateProviderFailure {
     fallback_action: String,
 }
 
-fn immediate_provider_failure(
+pub(super) fn immediate_provider_failure(
     provider: &AgentTaskExecutorProvider,
     outcome: &AgentTaskOutcome,
     elapsed: Duration,

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -72,7 +72,8 @@ pub(super) fn run_materialized_provider_command(
 
         if let Some(failure) = immediate_provider_failure(provider, &outcome, started.elapsed()) {
             if prior_immediate_failure.as_deref() == Some(failure.signature.as_str()) {
-                if outcome.failure_classification != Some(AgentTaskFailureClassification::Transient) {
+                if outcome.failure_classification != Some(AgentTaskFailureClassification::Transient)
+                {
                     outcome.failure_classification = Some(AgentTaskFailureClassification::Provider);
                 }
                 outcome.diagnostics.push(AgentTaskDiagnostic {
@@ -139,45 +140,57 @@ fn immediate_provider_failure(
     elapsed: Duration,
 ) -> Option<ImmediateProviderFailure> {
     if elapsed >= IMMEDIATE_FAILURE_WINDOW
-        || !matches!(outcome.status, AgentTaskOutcomeStatus::ProviderError | AgentTaskOutcomeStatus::Failed)
+        || !matches!(
+            outcome.status,
+            AgentTaskOutcomeStatus::ProviderError | AgentTaskOutcomeStatus::Failed
+        )
         || !matches!(
             outcome.failure_classification,
-            None
-                | Some(AgentTaskFailureClassification::Provider)
+            None | Some(AgentTaskFailureClassification::Provider)
                 | Some(AgentTaskFailureClassification::Transient)
         )
     {
         return None;
     }
     let text = provider_failure_text(outcome);
-    provider.immediate_failure_patterns.iter().find_map(|pattern| {
-        if !pattern.retryable || pattern.error_contains_any.is_empty() {
-            return None;
-        }
-        let matches = pattern.error_contains_any.iter().any(|needle| {
-            !needle.is_empty() && text.to_ascii_lowercase().contains(&needle.to_ascii_lowercase())
-        });
-        matches.then(|| {
-            let error_refs = pattern
-                .error_ref_pattern
-                .as_deref()
-                .and_then(|expression| regex::Regex::new(expression).ok())
-                .map(|expression| {
-                    expression
-                        .find_iter(&text)
-                        .take(IMMEDIATE_FAILURE_ERROR_REF_LIMIT)
-                        .map(|matched| matched.as_str().to_string())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let normalized = pattern
-                .error_ref_pattern
-                .as_deref()
-                .and_then(|expression| regex::Regex::new(expression).ok())
-                .map(|expression| expression.replace_all(&text, "[provider-error-ref]").into_owned())
-                .unwrap_or_else(|| text.clone());
-            let normalized = bounded_text(&normalized, IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT);
-            ImmediateProviderFailure {
+    provider
+        .immediate_failure_patterns
+        .iter()
+        .find_map(|pattern| {
+            if !pattern.retryable || pattern.error_contains_any.is_empty() {
+                return None;
+            }
+            let matches = pattern.error_contains_any.iter().any(|needle| {
+                !needle.is_empty()
+                    && text
+                        .to_ascii_lowercase()
+                        .contains(&needle.to_ascii_lowercase())
+            });
+            matches.then(|| {
+                let error_refs = pattern
+                    .error_ref_pattern
+                    .as_deref()
+                    .and_then(|expression| regex::Regex::new(expression).ok())
+                    .map(|expression| {
+                        expression
+                            .find_iter(&text)
+                            .take(IMMEDIATE_FAILURE_ERROR_REF_LIMIT)
+                            .map(|matched| matched.as_str().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let normalized = pattern
+                    .error_ref_pattern
+                    .as_deref()
+                    .and_then(|expression| regex::Regex::new(expression).ok())
+                    .map(|expression| {
+                        expression
+                            .replace_all(&text, "[provider-error-ref]")
+                            .into_owned()
+                    })
+                    .unwrap_or_else(|| text.clone());
+                let normalized = bounded_text(&normalized, IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT);
+                ImmediateProviderFailure {
                 pattern_id: pattern.id.clone(),
                 signature: format!(
                     "{}:{}:{}",
@@ -194,8 +207,8 @@ fn immediate_provider_failure(
                         .to_string()
                 }),
             }
+            })
         })
-    })
 }
 
 /// Validate adapter-owned failure signatures before they can affect dispatch.
@@ -205,8 +218,16 @@ pub fn validate_provider_immediate_failure_patterns(
     provider: &AgentTaskExecutorProvider,
 ) -> std::result::Result<(), String> {
     for pattern in &provider.immediate_failure_patterns {
-        if pattern.id.trim().is_empty() || pattern.error_contains_any.iter().all(|value| value.trim().is_empty()) {
-            return Err("immediate failure patterns need an id and at least one non-empty error substring".to_string());
+        if pattern.id.trim().is_empty()
+            || pattern
+                .error_contains_any
+                .iter()
+                .all(|value| value.trim().is_empty())
+        {
+            return Err(
+                "immediate failure patterns need an id and at least one non-empty error substring"
+                    .to_string(),
+            );
         }
         if let Some(expression) = &pattern.error_ref_pattern {
             if expression.len() > 512 {
@@ -216,7 +237,10 @@ pub fn validate_provider_immediate_failure_patterns(
                 ));
             }
             let expression = regex::Regex::new(expression).map_err(|error| {
-                format!("immediate failure pattern '{}' has invalid error_ref_pattern: {error}", pattern.id)
+                format!(
+                    "immediate failure pattern '{}' has invalid error_ref_pattern: {error}",
+                    pattern.id
+                )
             })?;
             if expression.is_match("") {
                 return Err(format!(

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -126,11 +126,11 @@ pub(super) fn run_materialized_provider_command(
     }
 }
 
-struct ImmediateProviderFailure {
+pub(super) struct ImmediateProviderFailure {
     pattern_id: String,
     signature: String,
-    error_refs: Vec<String>,
-    log_lookup: String,
+    pub(super) error_refs: Vec<String>,
+    pub(super) log_lookup: String,
     fallback_action: String,
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -124,7 +124,10 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
                 AgentTaskOutcomeStatus::Failed,
                 AgentTaskFailureClassification::InvalidInput,
                 "agent_task.provider_immediate_failure_configuration_invalid",
-                format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                format!(
+                    "provider '{}' has invalid immediate failure configuration: {message}",
+                    provider.id
+                ),
                 json!({ "provider_id": provider.id, "backend": provider.backend }),
             );
         }

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -34,7 +34,10 @@ pub fn preflight_plan_provider_runtime_readiness_with_providers(
             validate_provider_immediate_failure_patterns(provider).map_err(|message| {
                 Error::validation_invalid_argument(
                     "immediate_failure_patterns",
-                    format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                    format!(
+                        "provider '{}' has invalid immediate failure configuration: {message}",
+                        provider.id
+                    ),
                     Some(provider.backend.clone()),
                     None,
                 )
@@ -44,7 +47,10 @@ pub fn preflight_plan_provider_runtime_readiness_with_providers(
         validate_provider_immediate_failure_patterns(provider).map_err(|message| {
             Error::validation_invalid_argument(
                 "immediate_failure_patterns",
-                format!("provider '{}' has invalid immediate failure configuration: {message}", provider.id),
+                format!(
+                    "provider '{}' has invalid immediate failure configuration: {message}",
+                    provider.id
+                ),
                 Some(provider.backend.clone()),
                 None,
             )

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1324,16 +1324,30 @@ fn repeated_immediate_adapter_classified_failure_opens_circuit_with_actionable_e
     let outcome = run_provider_command(&request, &provider, None);
 
     assert_eq!(fs::read_to_string(&state_path).expect("attempt count"), "2");
-    assert_eq!(outcome.failure_classification, Some(AgentTaskFailureClassification::Provider));
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::Provider)
+    );
     let diagnostic = outcome
         .diagnostics
         .iter()
-        .find(|diagnostic| diagnostic.class == "agent_task.provider_immediate_failure_retry_suppressed")
+        .find(|diagnostic| {
+            diagnostic.class == "agent_task.provider_immediate_failure_retry_suppressed"
+        })
         .expect("circuit diagnostic");
-    assert_eq!(diagnostic.data["provider_error_refs"], json!(["err_test123"]));
+    assert_eq!(
+        diagnostic.data["provider_error_refs"],
+        json!(["err_test123"])
+    );
     assert_eq!(diagnostic.data["retryable"], json!(false));
-    assert_eq!(diagnostic.data["log_lookup"], "providerctl logs --error-ref <provider-error-ref>");
-    assert_eq!(diagnostic.data["fallback_action"], "Select another configured provider.");
+    assert_eq!(
+        diagnostic.data["log_lookup"],
+        "providerctl logs --error-ref <provider-error-ref>"
+    );
+    assert_eq!(
+        diagnostic.data["fallback_action"],
+        "Select another configured provider."
+    );
     let _ = fs::remove_file(&state_path);
 }
 
@@ -1349,14 +1363,24 @@ fn immediate_failure_suppression_is_scoped_to_one_task_provider_retry_sequence()
             "let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));let p='{state}';let n=0;try{{n=parseInt(fs.readFileSync(p,'utf8'))||0}}catch(e){{}}fs.writeFileSync(p,String(n+1));process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'provider_error',summary:'server unavailable',failure_classification:'provider'}}));"
         ))));
         provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
-            id: "server".to_string(), error_contains_any: vec!["server unavailable".to_string()], retryable: true,
-            error_ref_pattern: None, log_lookup: None, fallback_action: None,
+            id: "server".to_string(),
+            error_contains_any: vec!["server unavailable".to_string()],
+            retryable: true,
+            error_ref_pattern: None,
+            log_lookup: None,
+            fallback_action: None,
         }];
         let outcome = run_provider_command(&request, &provider, None);
-        assert!(outcome.diagnostics.iter().any(|d| d.class == "agent_task.provider_immediate_failure_retry_suppressed"));
+        assert!(outcome
+            .diagnostics
+            .iter()
+            .any(|d| d.class == "agent_task.provider_immediate_failure_retry_suppressed"));
     }
     assert_eq!(fs::read_to_string(&first_state).expect("first count"), "2");
-    assert_eq!(fs::read_to_string(&second_state).expect("second count"), "2");
+    assert_eq!(
+        fs::read_to_string(&second_state).expect("second count"),
+        "2"
+    );
     let _ = fs::remove_file(&first_state);
     let _ = fs::remove_file(&second_state);
 }
@@ -1365,8 +1389,12 @@ fn immediate_failure_suppression_is_scoped_to_one_task_provider_retry_sequence()
 fn invalid_immediate_failure_regex_is_rejected_before_dispatch() {
     let (_, mut provider) = request("invalid-pattern", "node provider.js".to_string());
     provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
-        id: "bad".to_string(), error_contains_any: vec!["server".to_string()], retryable: true,
-        error_ref_pattern: Some("[".to_string()), log_lookup: None, fallback_action: None,
+        id: "bad".to_string(),
+        error_contains_any: vec!["server".to_string()],
+        retryable: true,
+        error_ref_pattern: Some("[".to_string()),
+        log_lookup: None,
+        fallback_action: None,
     }];
     let error = validate_provider_immediate_failure_patterns(&provider).expect_err("invalid regex");
     assert!(error.contains("invalid error_ref_pattern"));
@@ -1376,10 +1404,15 @@ fn invalid_immediate_failure_regex_is_rejected_before_dispatch() {
 fn empty_matching_immediate_failure_regex_is_rejected_before_dispatch() {
     let (_, mut provider) = request("empty-pattern", "node provider.js".to_string());
     provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
-        id: "empty".to_string(), error_contains_any: vec!["server".to_string()], retryable: true,
-        error_ref_pattern: Some(".*".to_string()), log_lookup: None, fallback_action: None,
+        id: "empty".to_string(),
+        error_contains_any: vec!["server".to_string()],
+        retryable: true,
+        error_ref_pattern: Some(".*".to_string()),
+        log_lookup: None,
+        fallback_action: None,
     }];
-    let error = validate_provider_immediate_failure_patterns(&provider).expect_err("empty match regex");
+    let error =
+        validate_provider_immediate_failure_patterns(&provider).expect_err("empty match regex");
     assert!(error.contains("must not match an empty string"));
 }
 
@@ -1387,8 +1420,12 @@ fn empty_matching_immediate_failure_regex_is_rejected_before_dispatch() {
 fn immediate_failure_patterns_preserve_terminal_failure_classifications() {
     let (_, mut provider) = request("terminal-pattern", "node provider.js".to_string());
     provider.immediate_failure_patterns = vec![AgentTaskProviderImmediateFailurePattern {
-        id: "server".to_string(), error_contains_any: vec!["server error".to_string()], retryable: true,
-        error_ref_pattern: None, log_lookup: None, fallback_action: None,
+        id: "server".to_string(),
+        error_contains_any: vec!["server error".to_string()],
+        retryable: true,
+        error_ref_pattern: None,
+        log_lookup: None,
+        fallback_action: None,
     }];
     for classification in [
         AgentTaskFailureClassification::PolicyDenied,
@@ -1423,11 +1460,22 @@ fn opencode_manifest_shaped_declaration_classifies_the_observed_server_failure()
             "log_lookup": "opencode logs --error <provider-error-ref>",
             "fallback_action": "Select another configured provider."
         }]
-    })).expect("manifest-shaped provider");
-    let outcome = AgentTaskOutcome { status: AgentTaskOutcomeStatus::ProviderError, summary: Some("Unexpected server error. Check server logs for details. err_3a6d31e2".to_string()), ..Default::default() };
-    let failure = immediate_provider_failure(&provider, &outcome, Duration::from_secs(1)).expect("classified failure");
+    }))
+    .expect("manifest-shaped provider");
+    let outcome = AgentTaskOutcome {
+        status: AgentTaskOutcomeStatus::ProviderError,
+        summary: Some(
+            "Unexpected server error. Check server logs for details. err_3a6d31e2".to_string(),
+        ),
+        ..Default::default()
+    };
+    let failure = immediate_provider_failure(&provider, &outcome, Duration::from_secs(1))
+        .expect("classified failure");
     assert_eq!(failure.error_refs, vec!["err_3a6d31e2"]);
-    assert_eq!(failure.log_lookup, "opencode logs --error <provider-error-ref>");
+    assert_eq!(
+        failure.log_lookup,
+        "opencode logs --error <provider-error-ref>"
+    );
 }
 
 fn selected_component_contract(

--- a/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
@@ -274,10 +274,9 @@ fn provider_readiness_rejects_invalid_immediate_failure_configuration_before_exe
         fallback_action: None,
     }];
 
-    let error = validate_provider_runner_readiness_for_backend_with_providers(
-        &[provider], "test", None,
-    )
-    .expect_err("invalid adapter configuration must fail pre-dispatch");
+    let error =
+        validate_provider_runner_readiness_for_backend_with_providers(&[provider], "test", None)
+            .expect_err("invalid adapter configuration must fail pre-dispatch");
 
     assert_eq!(error.details["field"], "immediate_failure_patterns");
     assert!(error.message.contains("invalid error_ref_pattern"));

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1161,22 +1161,17 @@ pub fn cook_completion(
     finalization_run_id: Option<&str>,
 ) -> Option<AgentTaskCookCompletion> {
     let candidate_produced = canonical_candidate_produced(selected_candidate);
-    let canonical_finalization = canonical_candidate_finalization(
-        selected_candidate,
-        finalization,
-        finalization_run_id,
-    );
+    let canonical_finalization =
+        canonical_candidate_finalization(selected_candidate, finalization, finalization_run_id);
     // A report can carry a receipt before the Cook index is available. Once a
     // canonical selection exists, however, only that selected attempt owns the
     // completion receipt; a newer non-substantive attempt cannot replace it.
-    let finalization = canonical_finalization
-        .as_ref()
-        .or_else(|| {
-            selected_candidate
-                .is_none_or(|candidate| candidate["cook_id"].as_str().is_none())
-                .then_some(finalization)
-                .flatten()
-        });
+    let finalization = canonical_finalization.as_ref().or_else(|| {
+        selected_candidate
+            .is_none_or(|candidate| candidate["cook_id"].as_str().is_none())
+            .then_some(finalization)
+            .flatten()
+    });
     let pr_finalized = finalization.is_some_and(cook_finalization_is_pr_receipt);
     let recovery_run_id = (!pr_finalized && finalization_requested)
         .then(|| canonical_finalization_recovery_run_id(selected_candidate))
@@ -1215,7 +1210,9 @@ fn canonical_candidate_produced(selected_candidate: Option<&Value>) -> bool {
         return false;
     };
     candidate["incomplete"] != true
-        && candidate["run_id"].as_str().is_some_and(|value| !value.is_empty())
+        && candidate["run_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
         && candidate["selected_task_id"]
             .as_str()
             .is_some_and(|value| !value.is_empty())
@@ -1250,11 +1247,14 @@ fn canonical_finalization_recovery_run_id(selected_candidate: Option<&Value>) ->
         .ok()
         .flatten()
         .is_some_and(|form| form.validate().is_ok()),
-    )
-        || promotion.source.run_id.as_deref() != Some(run_id)
+    ) || promotion.source.run_id.as_deref() != Some(run_id)
         || promotion.source.task_id != task_id
         || promotion.patch_artifact.id != artifact_id
-        || promotion.patch_artifact.sha256.as_deref().is_none_or(str::is_empty)
+        || promotion
+            .patch_artifact
+            .sha256
+            .as_deref()
+            .is_none_or(str::is_empty)
     {
         return None;
     }
@@ -1312,9 +1312,10 @@ pub(crate) fn canonical_candidate_finalization(
         {
             continue;
         }
-        let Some(promotion) = super::cook_promotion::persisted_promotion_for_attempt(&attempt.run_id)
-            .ok()
-            .flatten()
+        let Some(promotion) =
+            super::cook_promotion::persisted_promotion_for_attempt(&attempt.run_id)
+                .ok()
+                .flatten()
         else {
             continue;
         };
@@ -1904,10 +1905,7 @@ mod run_lifecycle_projection_tests {
             serialized["status"], "completed",
             "legacy status is preserved"
         );
-        assert_eq!(
-            serialized["completion"]["state"],
-            "candidate_produced"
-        );
+        assert_eq!(serialized["completion"]["state"], "candidate_produced");
         assert_eq!(serialized["completion"]["pr_finalized"], false);
         assert!(serialized["completion"].get("next_action").is_none());
 
@@ -2025,7 +2023,11 @@ mod run_lifecycle_projection_tests {
         let receipt = serde_json::json!({"status": "review_ready", "pr_number": 12291});
 
         assert_eq!(
-            canonical_candidate_finalization(Some(&candidate), Some(&receipt), Some("canonical-run")),
+            canonical_candidate_finalization(
+                Some(&candidate),
+                Some(&receipt),
+                Some("canonical-run")
+            ),
             Some(receipt)
         );
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1854,9 +1854,8 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
 }
 
 pub(crate) fn canonical_cook_recovery_run_id(cook_id: &str) -> Option<String> {
-    let candidate = canonical_cook_candidate(cook_id)
-        .filter(|candidate| candidate["incomplete"] != true)
-        ?;
+    let candidate =
+        canonical_cook_candidate(cook_id).filter(|candidate| candidate["incomplete"] != true)?;
     let source_run_id = candidate["run_id"].as_str()?.to_string();
     if source_run_id.is_empty() {
         return None;

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9,16 +9,15 @@ use super::super::cook_adoption::{
 };
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
-    canonical_cook_patch_artifact_id, cook_finalization_options, cook_promotion_argv, cook_report,
-    canonical_cook_recovery_run_id,
-    finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
-    moving_base_recovery_for_run, moving_base_recovery_from_promotion, moving_base_recovery_report,
-    next_moving_base_recovery, persist_manual_finalization_intent,
-    persist_manual_finalization_receipt, persisted_promotion_for_attempt,
-    prepare_manual_finalization_identity, record_replacement_gate_proof,
-    recover_cook_pr_with_backend, recover_moving_base_cook_candidate,
-    refreshed_moving_base_recovery, selected_candidate_task_id, CookReportInput,
-    MovingBaseCookRecovery,
+    canonical_cook_patch_artifact_id, canonical_cook_recovery_run_id, cook_finalization_options,
+    cook_promotion_argv, cook_report, finalize_cook_pr_with_backend,
+    finalize_or_load_cook_pr_with_backend, moving_base_recovery_for_run,
+    moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
+    persist_manual_finalization_intent, persist_manual_finalization_receipt,
+    persisted_promotion_for_attempt, prepare_manual_finalization_identity,
+    record_replacement_gate_proof, recover_cook_pr_with_backend,
+    recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
+    CookReportInput, MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::persist_initial_recipe;
 use super::*;
@@ -7407,7 +7406,11 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             .expect("source patch remains the canonical candidate");
         assert_eq!(selected_candidate["run_id"], run_id);
         assert_eq!(
-            result.value.completion().expect("in-process completion").state,
+            result
+                .value
+                .completion()
+                .expect("in-process completion")
+                .state,
             "pr_finalized",
             "the form-only continuation owns the canonical source candidate receipt"
         );
@@ -7425,7 +7428,8 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
             "exact source status resolves the bound form-only receipt"
         );
         agent_task_lifecycle::rewrite_record_for_test(follow_up_run_id, |record| {
-            record.metadata
+            record
+                .metadata
                 .as_object_mut()
                 .expect("record metadata object")
                 .remove("cook_finalization");
@@ -9305,15 +9309,14 @@ fn canonical_completion_accepts_green_and_recipe_authorized_inherited_gate_evide
     inherited.deterministic_gates[0].status =
         crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure;
     inherited.deterministic_gates[0].exit_code = 1;
-    inherited.deterministic_gates[0].baseline_comparison = Some(
-        crate::agent_task_gate::AgentTaskGateBaselineComparison {
+    inherited.deterministic_gates[0].baseline_comparison =
+        Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
             base_ref: "main".to_string(),
             exit_code: 1,
             failure_fingerprint: "inherited".to_string(),
             matches_candidate_failure: true,
             result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
-        },
-    );
+        });
     assert!(canonical_finalization_eligible(&inherited, true, true));
     assert!(!canonical_finalization_eligible(&inherited, false, true));
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -77,10 +77,20 @@ pub struct StatusArgs {
     #[arg(long)]
     pub watch: bool,
     /// Delay between status reads while following. Accepts ms, s, m, h, or d.
-    #[arg(long, default_value = "5s", value_name = "DURATION", requires = "watch")]
+    #[arg(
+        long,
+        default_value = "5s",
+        value_name = "DURATION",
+        requires = "watch"
+    )]
     pub interval: String,
     /// Total time to follow before returning the latest partial status. Accepts ms, s, m, h, or d.
-    #[arg(long, default_value = "30m", value_name = "DURATION", requires = "watch")]
+    #[arg(
+        long,
+        default_value = "30m",
+        value_name = "DURATION",
+        requires = "watch"
+    )]
     pub timeout: String,
 }
 
@@ -276,8 +286,15 @@ mod tests {
     #[test]
     fn status_watch_uses_bounded_duration_flags() {
         let cli = Cli::try_parse_from([
-            "homeboy", "agent-task", "status", "run-a", "--watch", "--interval", "250ms",
-            "--timeout", "2m",
+            "homeboy",
+            "agent-task",
+            "status",
+            "run-a",
+            "--watch",
+            "--interval",
+            "250ms",
+            "--timeout",
+            "2m",
         ])
         .expect("watch status parses");
         let Commands::AgentTask(agent_task) = cli.command else {
@@ -290,11 +307,21 @@ mod tests {
         assert_eq!(args.interval, "250ms");
         assert_eq!(args.timeout, "2m");
         assert!(Cli::try_parse_from([
-            "homeboy", "agent-task", "status", "run-a", "--interval", "1s",
+            "homeboy",
+            "agent-task",
+            "status",
+            "run-a",
+            "--interval",
+            "1s",
         ])
         .is_err());
         assert!(Cli::try_parse_from([
-            "homeboy", "agent-task", "status", "run-a", "--timeout", "1m",
+            "homeboy",
+            "agent-task",
+            "status",
+            "run-a",
+            "--timeout",
+            "1m",
         ])
         .is_err());
     }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -12,8 +12,9 @@ use homeboy::agents::agent_tasks::promotion::{
     AgentTaskPromotionStatus,
 };
 use homeboy::agents::agent_tasks::provider::{
-    provider_credential_readiness, resolve_provider_for_backend, AgentTaskExecutorProvider, AgentTaskProviderCatalog,
-    AgentTaskProviderCredentialReadiness, ExtensionProviderAgentTaskExecutor, ProviderResolution,
+    provider_credential_readiness, resolve_provider_for_backend, AgentTaskExecutorProvider,
+    AgentTaskProviderCatalog, AgentTaskProviderCredentialReadiness,
+    ExtensionProviderAgentTaskExecutor, ProviderResolution,
 };
 use homeboy::agents::agent_tasks::review_dossier::{
     homeboy_tool_disclosure, resolve_review_profile, validate_issue_reference,
@@ -2119,7 +2120,10 @@ mod tests {
             "readiness_invocation": { "argv": ["true"] }
         }))
         .expect("provider");
-        let identity = ("resolved-backend".to_string(), "resolved.provider".to_string());
+        let identity = (
+            "resolved-backend".to_string(),
+            "resolved.provider".to_string(),
+        );
 
         let projection = readiness_validation_projection(Some(&identity), Some(&provider));
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -34,7 +34,7 @@ use crate::commands::utils::response::{
     CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,
 };
 use crate::commands::utils::watch::{
-    parse_duration, watch_loop, WatchConfig, WatchConclusion, WatchPoller, WatchResult,
+    parse_duration, watch_loop, WatchConclusion, WatchConfig, WatchPoller, WatchResult,
     TIMEOUT_EXIT_CODE,
 };
 
@@ -297,7 +297,8 @@ impl StatusWatchProgress {
             self.changes.len() >= STATUS_WATCH_CHANGE_LIMIT,
         ));
         if self.changes.len() < STATUS_WATCH_CHANGE_LIMIT {
-            self.changes.push(json!({ "poll": poll, "status": snapshot }));
+            self.changes
+                .push(json!({ "poll": poll, "status": snapshot }));
         } else {
             self.omitted += 1;
         }
@@ -305,10 +306,11 @@ impl StatusWatchProgress {
 }
 
 fn emit_status_change_event(snapshot: &Value, poll: u64, retained_limit_reached: bool) -> String {
-    let run_id = snapshot
-        .get("run_id")
-        .and_then(Value::as_str)
-        .or_else(|| snapshot.pointer("/identity/resolved_run_id").and_then(Value::as_str));
+    let run_id = snapshot.get("run_id").and_then(Value::as_str).or_else(|| {
+        snapshot
+            .pointer("/identity/resolved_run_id")
+            .and_then(Value::as_str)
+    });
     serde_json::to_string(&json!({
         "schema": "homeboy/agent-task-status-watch-event/v1",
         "event": "status_changed",
@@ -375,7 +377,9 @@ fn watch_status_output(
     let (latest, status_exit) = result.item;
     let continuation = format!(
         "homeboy agent-task status {} --watch --interval {} --timeout {}",
-        quote_arg(&args.run_id), args.interval, args.timeout
+        quote_arg(&args.run_id),
+        args.interval,
+        args.timeout
     );
     let output = json!({
         "schema": "homeboy/agent-task-status-watch/v1",
@@ -2175,9 +2179,11 @@ mod watch_tests {
         let mut progress = StatusWatchProgress::default();
         let mut emitted = Vec::new();
         for poll in 1..=(STATUS_WATCH_CHANGE_LIMIT as u64 + 2) {
-            progress.observe(&json!({ "run_id": "run-1", "state": "running", "progress": poll }), poll, |line| {
-                emitted.push(line)
-            });
+            progress.observe(
+                &json!({ "run_id": "run-1", "state": "running", "progress": poll }),
+                poll,
+                |line| emitted.push(line),
+            );
         }
         let terminal_poll = STATUS_WATCH_CHANGE_LIMIT as u64 + 3;
         progress.observe(
@@ -2192,8 +2198,12 @@ mod watch_tests {
         let first_overflow: Value = serde_json::from_str(&emitted[STATUS_WATCH_CHANGE_LIMIT])
             .expect("first overflow event");
         assert_eq!(first_overflow["poll"], STATUS_WATCH_CHANGE_LIMIT as u64 + 1);
-        assert_eq!(first_overflow["latest"]["progress"], STATUS_WATCH_CHANGE_LIMIT as u64 + 1);
-        let overflow: Value = serde_json::from_str(emitted.last().unwrap()).expect("overflow event");
+        assert_eq!(
+            first_overflow["latest"]["progress"],
+            STATUS_WATCH_CHANGE_LIMIT as u64 + 1
+        );
+        let overflow: Value =
+            serde_json::from_str(emitted.last().unwrap()).expect("overflow event");
         assert_eq!(overflow["retained_limit_reached"], true);
         assert_eq!(overflow["state"], "succeeded");
         assert_eq!(overflow["poll"], terminal_poll);
@@ -2255,7 +2265,11 @@ mod watch_tests {
         assert_eq!(exit, TIMEOUT_EXIT_CODE);
         assert_eq!(output["latest"]["state"], "running");
         assert_eq!(output["changes"].as_array().unwrap().len(), 2);
-        assert_eq!(emitted.len(), 2, "progress was emitted before timeout returned");
+        assert_eq!(
+            emitted.len(),
+            2,
+            "progress was emitted before timeout returned"
+        );
         let queued: Value = serde_json::from_str(&emitted[0]).expect("queued event");
         let running: Value = serde_json::from_str(&emitted[1]).expect("running event");
         assert_eq!(queued["state"], "queued");

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -473,9 +473,9 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
                 full: true,
                 no_runner_probe: false,
                 strict_subject_exit: false,
-            watch: false,
-            interval: "5s".to_string(),
-            timeout: "30m".to_string(),
+                watch: false,
+                interval: "5s".to_string(),
+                timeout: "30m".to_string(),
             })
             .expect("resumed Cook status")
             .0["metadata"]["worktree_provision"]["action"],

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -1700,7 +1700,10 @@ mod tests {
             );
             let parent = agent_task_lifecycle::exact_record(cook_id)
                 .expect("read exit-winning handoff parent");
-            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Failed);
+            assert_eq!(
+                parent.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
             assert_eq!(
                 parent.metadata["detached_cook_handoff"]["state"],
                 "exited_before_handoff"
@@ -1729,7 +1732,10 @@ mod tests {
 
             let cancelled = agent_task_lifecycle::cancel_run(cook_id, None)
                 .expect("cancellation wins the handoff arbitration");
-            assert_eq!(cancelled.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+            assert_eq!(
+                cancelled.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
 
             assert!(
                 agent_task_lifecycle::record_cook_attempt(cook_id, 1, attempt_id).is_err(),
@@ -1737,7 +1743,10 @@ mod tests {
             );
             let parent = agent_task_lifecycle::exact_record(cook_id)
                 .expect("read cancellation-winning handoff parent");
-            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+            assert_eq!(
+                parent.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
             assert_eq!(
                 parent.metadata["detached_cook_handoff"]["cancellation_fence"]["state"],
                 "cancelled"
@@ -1769,7 +1778,10 @@ mod tests {
             let cancelled = agent_task_lifecycle::cancel_run(cook_id, None)
                 .expect("Cook alias resolves to its materialized attempt");
             assert_eq!(cancelled.run_id, attempt_id);
-            assert_eq!(cancelled.state, agent_task_lifecycle::AgentTaskRunState::Cancelled);
+            assert_eq!(
+                cancelled.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
             assert_eq!(
                 agent_task_lifecycle::exact_record(attempt_id)
                     .expect("read materialized cancelled attempt")
@@ -1790,18 +1802,18 @@ mod tests {
                 .spawn()
                 .expect("spawn a child that exits immediately");
 
-            let handoff = await_durable_handoff(
-                cook_id,
-                &mut child,
-                std::time::Duration::from_millis(5_000),
-            )
-            .expect("observe exited handoff");
+            let handoff =
+                await_durable_handoff(cook_id, &mut child, std::time::Duration::from_millis(5_000))
+                    .expect("observe exited handoff");
 
             assert_eq!(handoff.state, DetachedHandoffState::ExitedBeforeHandoff);
             assert_eq!(handoff.run_id, None);
             let parent = agent_task_lifecycle::exact_record(cook_id)
                 .expect("the observer terminalizes the exited handoff parent");
-            assert_eq!(parent.state, agent_task_lifecycle::AgentTaskRunState::Failed);
+            assert_eq!(
+                parent.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
             assert_eq!(
                 parent.metadata["detached_cook_handoff"]["state"],
                 "exited_before_handoff"

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -2960,7 +2960,10 @@ mod tests {
             let result = run_main_test_workflow(&component, source.path(), args, &run_dir)
                 .expect("missing producer output is a test result");
 
-            assert!(marker.exists(), "inventory producer must run despite zero selected tests");
+            assert!(
+                marker.exists(),
+                "inventory producer must run despite zero selected tests"
+            );
             assert_eq!(result.status, "failed");
             assert_eq!(result.exit_code, 1);
             assert_eq!(result.runner_exit_code, Some(0));
@@ -3078,8 +3081,17 @@ Path(os.environ["HOMEBOY_TEST_INVENTORY_FILE"]).write_text(json.dumps(inventory)
             assert_eq!(result.status, "passed");
             assert_eq!(result.exit_code, 0);
             assert_eq!(result.runner_exit_code, Some(0));
-            assert_eq!(result.test_inventory.as_ref().map(|inventory| inventory.test_count), Some(1));
-            assert!(published.is_file(), "validated inventory must publish to the requested path");
+            assert_eq!(
+                result
+                    .test_inventory
+                    .as_ref()
+                    .map(|inventory| inventory.test_count),
+                Some(1)
+            );
+            assert!(
+                published.is_file(),
+                "validated inventory must publish to the requested path"
+            );
             assert_eq!(
                 serde_json::from_slice::<TestInventoryEvidence>(
                     &std::fs::read(&published).expect("published inventory")
@@ -3139,7 +3151,10 @@ Path(os.environ["HOMEBOY_TEST_INVENTORY_FILE"]).write_text(json.dumps(inventory)
             assert_eq!(result.status, "passed");
             assert_eq!(result.exit_code, 0);
             assert_eq!(result.runner_exit_code, None);
-            assert!(!marker.exists(), "normal zero scope must not invoke the runner");
+            assert!(
+                !marker.exists(),
+                "normal zero scope must not invoke the runner"
+            );
         });
     }
 

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -352,8 +352,9 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
                 status
                     .pointer("/data/state")
                     .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
             })
-            .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
+            .is_some_and(|state| matches!(state.as_str(), "succeeded" | "failed" | "cancelled"));
         if terminal {
             break;
         }

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -231,7 +231,10 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
     let status = bounded_output(status);
     let status_stdout = String::from_utf8_lossy(&status.stdout);
     assert!(status.status.success(), "{status_stdout}");
-    assert!(status_stdout.contains("\"state\": \"failed\""), "{status_stdout}");
+    assert!(
+        status_stdout.contains("\"state\": \"failed\""),
+        "{status_stdout}"
+    );
     assert!(
         status_stdout.contains("\"tasks\": []")
             && status_stdout.contains("\"max_attempts\": 0")
@@ -345,7 +348,11 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
         assert!(status.status.success(), "{status_stdout}");
         let terminal = serde_json::from_str::<serde_json::Value>(&status_stdout)
             .ok()
-            .and_then(|status| status.pointer("/data/state").and_then(serde_json::Value::as_str))
+            .and_then(|status| {
+                status
+                    .pointer("/data/state")
+                    .and_then(serde_json::Value::as_str)
+            })
             .is_some_and(|state| matches!(state, "succeeded" | "failed" | "cancelled"));
         if terminal {
             break;


### PR DESCRIPTION
Closes #12303.

## Summary

- apply the exact Rust 1.95 formatter output reported by GitHub CI for current-main formatting debt
- preserve the compiler repair merged through #12302
- restore the required `Rustfmt` gate before refreshing the pending PR queue

Formatting was reconstructed against the exact CI checkout and applied three-way to current `main`; no behavior changes are intended.

Evidence: https://github.com/Extra-Chill/homeboy/actions/runs/31700092804/job/94446935801

## Verification

- `git diff --check origin/main...HEAD`
- GitHub CI is the authoritative Rust 1.95 formatting, compile, Windows, warning, lint, audit, and test gate

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to reconstruct the completed GitHub CI formatter patch, preserve the current-main compiler fix during three-way application, and prepare this PR. Chris Huber remains responsible for every line.