### PR TITLE
Fix fresh runner capabilities after doctor

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -74,6 +74,10 @@ pub fn run_with_options(
         repair::apply(&target, &options, &mut report);
     }
 
+    // Doctor probes the runner directly. Its observation supersedes any
+    // process-local capability answer, so the next execution preflight probes
+    // the exact command environment rather than replaying stale remediation.
+    runner::observe_runner_capabilities(runner_id);
     report.status = checks::overall_status(&report.checks);
     let exit_code = report.status.operational_exit_code();
     Ok((report, exit_code))

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -239,6 +239,7 @@ pub(crate) use connection::{
     configured_runner_homeboy_build_identity, configured_runner_homeboy_handshake_evidence,
     daemon_lab_handoff_capabilities, status_for_admission,
 };
+pub use runner_probe_gate::observe_runner_capabilities;
 #[allow(
     dead_code,
     reason = "Runner upgrades support explicit orchestration paths."

--- a/crates/homeboy-lab-runner/src/runner_probe_gate.rs
+++ b/crates/homeboy-lab-runner/src/runner_probe_gate.rs
@@ -255,6 +255,13 @@ pub fn invalidate_runner_probes(runner_id: &str) {
     gate.slots.retain(|key, _| !key.starts_with(&prefix));
 }
 
+/// Record that a separate live observation has superseded cached capability
+/// answers. The next admission preflight re-probes its own execution
+/// environment instead of turning an older answer into remediation.
+pub fn observe_runner_capabilities(runner_id: &str) {
+    invalidate_runner_probes(runner_id);
+}
+
 /// Releases a runner's probe slot when dropped, including on panic.
 struct ProbePermit {
     budget: Arc<RunnerBudget>,
@@ -638,6 +645,49 @@ mod tests {
 
         // Only the invalidated runner re-probed.
         assert_eq!(connections.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn fresh_doctor_observation_forces_the_next_refresh_preflight_to_reprobe() {
+        let _serialized = serialized();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let probe = |answer: &str| {
+            let connections = Arc::clone(&connections);
+            deduplicated_probe("lab", "capabilities", "refresh-homeboy", move || {
+                connections.fetch_add(1, Ordering::SeqCst);
+                Ok(answer.to_string())
+            })
+            .expect("capability answer")
+        };
+
+        // A previous capability probe reported the tools absent. Doctor then
+        // observes the runner directly and invalidates that stale inventory.
+        assert_eq!(probe("missing"), "missing");
+        observe_runner_capabilities("lab");
+
+        assert_eq!(probe("present"), "present");
+        assert_eq!(connections.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn unchanged_inventory_remains_cached_until_a_live_observation_arrives() {
+        let _serialized = serialized();
+        let connections = Arc::new(AtomicUsize::new(0));
+
+        let first: String = deduplicated_probe("lab", "capabilities", "refresh-homeboy", || {
+            connections.fetch_add(1, Ordering::SeqCst);
+            Ok("missing".to_string())
+        })
+        .expect("stale capability answer");
+        let cached: String = deduplicated_probe("lab", "capabilities", "refresh-homeboy", || {
+            connections.fetch_add(1, Ordering::SeqCst);
+            Ok("present".to_string())
+        })
+        .expect("cached capability answer");
+
+        assert_eq!(first, "missing");
+        assert_eq!(cached, "missing");
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -17,7 +17,6 @@
 
 pub use crate::daemon_repair_codes;
 pub use crate::peer_session_maintenance;
-pub use crate::runner_capability_inventory;
 pub use crate::{
     apply_change_artifact, apply_workspace_patch, broker_auth_store_path,
     broker_submit_token_for_runner, broker_token_from_env, close_reconnected_job_log_owner,
@@ -82,6 +81,7 @@ pub use crate::{
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
     RunnerWorkspaceUpdateOptions, RunnerWorkspaceUpdateOutput, RuntimeMaterializationStatus,
 };
+pub use crate::{observe_runner_capabilities, runner_capability_inventory};
 
 // Registry CRUD entry points.
 pub use crate::{


### PR DESCRIPTION
## Summary
- invalidate a runner's process-local capability probes after `runner doctor` completes
- preserve short-lived caching for unchanged runner inventories
- cover doctor-observation-to-refresh-preflight reprobe behavior

## Validation
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner runner_probe_gate`
- `cargo test -p homeboy-cli commands::runner::doctor`
- `cargo check -p homeboy-cli`

Fixes #12310

## AI assistance
OpenAI gpt-5.6-sol via OpenCode inspected the existing worktree, traced the runner capability cache and doctor/preflight paths, ran focused validation, and prepared this PR. Chris Huber reviewed and owns the change.