### PR TITLE
fix(runner): report reconcile convergence outcome

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -19,10 +19,10 @@ use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
     RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOperatorSummary, RunnerOutput,
-    RunnerReconciliationOutcome, RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics,
-    RunnerStatusInspection, RunnerStatusUnavailable, RunnerToolDiagnostics, RunnerTruncation,
-    RunnerWorkflowBinaryGuidance, RuntimeDiagnostic, RuntimePackageOutput, RuntimeProbeValue,
-    SelectedRuntimeOutput,
+    RunnerReconciliationOutcome, RunnerReconciliationStatus, RunnerRuntimeDiagnostics,
+    RunnerRuntimePackageDiagnostics, RunnerStatusInspection, RunnerStatusUnavailable,
+    RunnerToolDiagnostics, RunnerTruncation, RunnerWorkflowBinaryGuidance, RuntimeDiagnostic,
+    RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
 };
 
 const DEFAULT_STATUS_SESSION_LIMIT: usize = 20;
@@ -211,7 +211,7 @@ pub(super) fn reconcile_output(
     );
     let reconciliation =
         reconciliation_outcome(id, retired_generation_ids, &report, &admission_summary);
-    let exit_code = if reconciliation.status == "converged" {
+    let exit_code = if reconciliation.status == RunnerReconciliationStatus::Converged {
         0
     } else {
         1
@@ -252,51 +252,109 @@ pub(super) fn reconciliation_outcome(
         || !admission.unresolved_generation_ids.is_empty();
     if admission.accepting_jobs && !unresolved_projection {
         return RunnerReconciliationOutcome {
-            status: "converged",
-            retired_generation_count,
-            retired_generation_ids,
+            changed_state: reconciliation_changed_state(retired_generation_count),
+            status: RunnerReconciliationStatus::Converged,
             remaining_blocker: None,
             next_action: None,
+            retry_predicate: None,
+            retired_generation_count,
+            retired_generation_ids,
         };
     }
 
-    let remaining_blocker = if unresolved_projection {
-        "unresolved_generation_projection".to_string()
-    } else if !admission.connected {
-        "runner_disconnected".to_string()
-    } else if !admission.daemon_fresh {
-        daemon_freshness_blocker(report)
-    } else if !admission.daemon_compatible {
-        "daemon_compatibility".to_string()
-    } else if admission.blocking_generation.is_some() {
-        "retained_generation_ownership".to_string()
-    } else {
-        "admission_unavailable".to_string()
-    };
     let reconcile_command = format!("homeboy runner reconcile {}", shell_arg(runner_id));
-    let next_action = admission
-        .next_action
-        .as_ref()
-        .filter(|action| *action != &reconcile_command)
-        .cloned()
-        .or_else(|| {
-            Some(format!(
-                "homeboy runner status {} --full",
-                shell_arg(runner_id)
-            ))
-        });
+    let (remaining_blocker, next_action, retry_predicate) = if unresolved_projection {
+        (
+            "unresolved_generation_projection".to_string(),
+            format!("homeboy runner status {} --full", shell_arg(runner_id)),
+            "a fresh authoritative generation projection resolves every retained count".to_string(),
+        )
+    } else if !admission.connected {
+        (
+            "runner_disconnected".to_string(),
+            reconciliation_remediation(&reconcile_command, admission, report)
+                .unwrap_or_else(|| format!("homeboy runner connect {}", shell_arg(runner_id))),
+            "the runner reconnects and publishes a current daemon session".to_string(),
+        )
+    } else if !admission.daemon_fresh {
+        (
+            daemon_freshness_blocker(report),
+            reconciliation_remediation(&reconcile_command, admission, report).unwrap_or_else(
+                || {
+                    format!(
+                        "homeboy runner doctor {} --scope lab-offload",
+                        shell_arg(runner_id)
+                    )
+                },
+            ),
+            "daemon_fresh=true after the selected daemon repair completes".to_string(),
+        )
+    } else if !admission.daemon_compatible {
+        (
+            "daemon_compatibility".to_string(),
+            reconciliation_remediation(&reconcile_command, admission, report).unwrap_or_else(
+                || {
+                    format!(
+                        "homeboy runner doctor {} --scope lab-offload",
+                        shell_arg(runner_id)
+                    )
+                },
+            ),
+            "daemon_compatible=true after the selected daemon identity is repaired".to_string(),
+        )
+    } else if admission.blocking_generation.is_some() {
+        (
+            "retained_generation_ownership".to_string(),
+            format!("homeboy runner job list {} --active", shell_arg(runner_id)),
+            "the retained generation has no authoritative active job owners".to_string(),
+        )
+    } else {
+        (
+            "admission_unavailable".to_string(),
+            format!("homeboy runner status {} --full", shell_arg(runner_id)),
+            "an authoritative active-job view is available".to_string(),
+        )
+    };
 
     RunnerReconciliationOutcome {
+        changed_state: reconciliation_changed_state(retired_generation_count),
         status: if retired_generation_count > 0 {
-            "partial_progress"
+            RunnerReconciliationStatus::PartialProgress
         } else {
-            "blocked"
+            RunnerReconciliationStatus::Blocked
         },
+        remaining_blocker: Some(remaining_blocker),
+        next_action: Some(next_action),
+        retry_predicate: Some(retry_predicate),
         retired_generation_count,
         retired_generation_ids,
-        remaining_blocker: Some(remaining_blocker),
-        next_action,
     }
+}
+
+fn reconciliation_changed_state(retired_generation_count: usize) -> String {
+    if retired_generation_count == 0 {
+        "unchanged".to_string()
+    } else {
+        format!("retired_generations:{retired_generation_count}")
+    }
+}
+
+fn reconciliation_remediation(
+    reconcile_command: &str,
+    admission: &homeboy::runner::runners::RunnerAdmissionSummary,
+    report: &homeboy::runner::runners::RunnerStatusReport,
+) -> Option<String> {
+    admission
+        .next_action
+        .as_ref()
+        .filter(|action| action.as_str() != reconcile_command)
+        .cloned()
+        .or_else(|| {
+            report
+                .admission_action()
+                .map(|action| action.render_command())
+                .filter(|action| action != reconcile_command)
+        })
 }
 
 fn daemon_freshness_blocker(report: &homeboy::runner::runners::RunnerStatusReport) -> String {

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -21,7 +21,7 @@ use super::super::status::{
     runner_artifact_feature_diagnostics, runner_followups, runner_followups_with_admission,
     runner_status_operator_commands, selected_admission_summary,
 };
-use super::super::types::RunnerConnectionOutput;
+use super::super::types::{RunnerConnectionOutput, RunnerReconciliationStatus};
 use crate::cli_surface::Cli;
 use crate::commands::utils::response::{
     cli_response_for_json_result_for_command, map_cmd_result_to_json,
@@ -110,9 +110,10 @@ fn reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownersh
         &admission,
     );
 
-    assert_eq!(outcome.status, "partial_progress");
+    assert_eq!(outcome.status, RunnerReconciliationStatus::PartialProgress);
     assert_eq!(outcome.retired_generation_count, 1);
     assert_eq!(outcome.retired_generation_ids, ["lease-retired"]);
+    assert_eq!(outcome.changed_state, "retired_generations:1");
     assert_eq!(
         outcome.remaining_blocker.as_deref(),
         Some("daemon_version_mismatch")
@@ -120,6 +121,10 @@ fn reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownersh
     assert_eq!(
         outcome.next_action.as_deref(),
         Some("homeboy runner refresh-homeboy homeboy-lab --reconnect")
+    );
+    assert_eq!(
+        outcome.retry_predicate.as_deref(),
+        Some("daemon_fresh=true after the selected daemon repair completes")
     );
 }
 
@@ -132,8 +137,9 @@ fn reconcile_reports_unchanged_blocked_state_without_self_recommendation() {
     let outcome =
         reconciliation_outcome("homeboy-lab", Vec::new(), &connected_report(), &admission);
 
-    assert_eq!(outcome.status, "blocked");
+    assert_eq!(outcome.status, RunnerReconciliationStatus::Blocked);
     assert_eq!(outcome.retired_generation_count, 0);
+    assert_eq!(outcome.changed_state, "unchanged");
     assert_eq!(
         outcome.remaining_blocker.as_deref(),
         Some("unresolved_generation_projection")
@@ -141,6 +147,10 @@ fn reconcile_reports_unchanged_blocked_state_without_self_recommendation() {
     assert_eq!(
         outcome.next_action.as_deref(),
         Some("homeboy runner status homeboy-lab --full")
+    );
+    assert_eq!(
+        outcome.retry_predicate.as_deref(),
+        Some("a fresh authoritative generation projection resolves every retained count")
     );
 }
 
@@ -153,10 +163,38 @@ fn reconcile_reports_ready_admission_as_converged() {
     let outcome =
         reconciliation_outcome("homeboy-lab", Vec::new(), &connected_report(), &admission);
 
-    assert_eq!(outcome.status, "converged");
+    assert_eq!(outcome.status, RunnerReconciliationStatus::Converged);
     assert_eq!(outcome.retired_generation_count, 0);
+    assert_eq!(outcome.changed_state, "unchanged");
     assert_eq!(outcome.remaining_blocker, None);
     assert_eq!(outcome.next_action, None);
+    assert_eq!(outcome.retry_predicate, None);
+}
+
+#[test]
+fn reconcile_retained_owner_requires_owner_settlement_before_retry() {
+    let mut admission = admission_fixture();
+    admission.blocking_generation = Some("lease-retained".to_string());
+    admission.admission_blocking_job_ids = vec!["job-retained".to_string()];
+    admission.next_action = Some("homeboy runner reconcile homeboy-lab".to_string());
+
+    let outcome =
+        reconciliation_outcome("homeboy-lab", Vec::new(), &connected_report(), &admission);
+
+    assert_eq!(outcome.status, RunnerReconciliationStatus::Blocked);
+    assert_eq!(outcome.changed_state, "unchanged");
+    assert_eq!(
+        outcome.remaining_blocker.as_deref(),
+        Some("retained_generation_ownership")
+    );
+    assert_eq!(
+        outcome.next_action.as_deref(),
+        Some("homeboy runner job list homeboy-lab --active")
+    );
+    assert_eq!(
+        outcome.retry_predicate.as_deref(),
+        Some("the retained generation has no authoritative active job owners")
+    );
 }
 
 #[test]
@@ -170,7 +208,7 @@ fn reconcile_does_not_converge_when_admission_accepts_with_unresolved_projection
     let outcome =
         reconciliation_outcome("homeboy-lab", Vec::new(), &connected_report(), &admission);
 
-    assert_eq!(outcome.status, "blocked");
+    assert_eq!(outcome.status, RunnerReconciliationStatus::Blocked);
     assert_eq!(
         outcome.remaining_blocker.as_deref(),
         Some("unresolved_generation_projection")
@@ -230,6 +268,10 @@ fn reconcile_command_output_reports_exit_state_and_removes_self_loop() {
     assert_eq!(serialized["status"], "failed");
     assert_eq!(serialized["data"]["reconciliation"]["status"], "blocked");
     assert_eq!(
+        serialized["data"]["reconciliation"]["changed_state"],
+        "unchanged"
+    );
+    assert_eq!(
         serialized["data"]["reconciliation"]["remaining_blocker"],
         "admission_unavailable"
     );
@@ -238,6 +280,14 @@ fn reconcile_command_output_reports_exit_state_and_removes_self_loop() {
         .is_none_or(|commands| commands
             .iter()
             .all(|command| command["command"] != "homeboy runner reconcile homeboy-lab")));
+    assert_eq!(
+        serialized["data"]["reconciliation"]["next_action"],
+        "homeboy runner status homeboy-lab --full"
+    );
+    assert_eq!(
+        serialized["data"]["reconciliation"]["retry_predicate"],
+        "an authoritative active-job view is available"
+    );
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -21,6 +21,12 @@ use crate::commands::utils::response::CommandActionableMetadata;
 #[derive(Debug, Serialize)]
 pub struct RunnerExtra {
     pub variant: &'static str,
+    /// Postcondition of a mutating generation reconciliation. This is distinct
+    /// from the command envelope: only `converged` restores runner admission.
+    /// It intentionally precedes status detail so compact output leads with the
+    /// operation's changed state, remaining blocker, and next action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconciliation: Option<RunnerReconciliationOutcome>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_lab_runner: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,10 +35,6 @@ pub struct RunnerExtra {
     pub managed_followups: Vec<LabFollowup>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection: Option<RunnerConnectionOutput>,
-    /// Postcondition of a mutating generation reconciliation. This is distinct
-    /// from the command envelope: only `converged` restores runner admission.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reconciliation: Option<RunnerReconciliationOutcome>,
     /// The compact authoritative "ready now / safe to rotate" answer. Leads the
     /// status output; the full generation inventory below is detail behind it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,16 +97,32 @@ impl Default for RunnerExtra {
 /// Bounded postcondition for `runner reconcile`.
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct RunnerReconciliationOutcome {
+    /// What this invocation changed. `unchanged` means no generation could be
+    /// retired from the observed state.
+    pub changed_state: String,
     /// `converged`, `partial_progress`, or `blocked`.
-    pub status: &'static str,
-    pub retired_generation_count: usize,
-    /// IDs retired by this reconciliation operation under the generation lock.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub retired_generation_ids: Vec<String>,
+    pub status: RunnerReconciliationStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remaining_blocker: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
+    /// The observation that must change before retrying this same operation can
+    /// make additional progress. This prevents an unbounded self-recommendation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_predicate: Option<String>,
+    pub retired_generation_count: usize,
+    /// IDs retired by this reconciliation operation under the generation lock.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub retired_generation_ids: Vec<String>,
+}
+
+/// Terminality of a `runner reconcile` result.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerReconciliationStatus {
+    Converged,
+    PartialProgress,
+    Blocked,
 }
 
 /// The bounded inspection state for a registry-wide status response.

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -809,6 +809,12 @@ generations that have been verified as drained. Use the remediation command
 reported by `homeboy runner status` after it has established that no active work
 still belongs to the generation.
 
+The command succeeds only when its postcondition has converged: the runner is
+accepting jobs and has no unresolved generation projection. A non-converged
+result exits non-zero and reports `changed_state`, the remaining blocker, one
+different executable action, and the concrete predicate that must become true
+before another reconcile can make progress.
+
 ### `disconnect`
 
 ```sh


### PR DESCRIPTION
## Summary
- report typed converged, partial-progress, and blocked reconcile postconditions
- fail unresolved admission and provide a distinct remediation plus retry predicate
- cover no-progress, retirement progress, version/lease blockers, retained ownership, and ready convergence

## Verification
- `cargo test -p homeboy-cli commands::runner::tests::status`
- `cargo fmt --check`

Fixes #12218

AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented the typed outcome contract, tests, documentation, and verification. Chris Huber reviewed and owns this change.