### PR TITLE
fix: use cargo-dist archive layout in installer

### DIFF
--- a/scripts/homeboy-installer.sh
+++ b/scripts/homeboy-installer.sh
@@ -38,21 +38,22 @@ else
 fi
 
 (cd "$TMP_DIR" && tar -xJf "$ASSET" 2>/dev/null || tar -xf "$ASSET")
-if [ ! -f "$TMP_DIR/homeboy" ]; then
+EXTRACTED_BIN="$TMP_DIR/${ASSET%.tar.xz}/homeboy"
+if [ ! -f "$EXTRACTED_BIN" ]; then
   echo "Expected extracted binary named homeboy" >&2
   exit 1
 fi
-chmod 0755 "$TMP_DIR/homeboy"
+chmod 0755 "$EXTRACTED_BIN"
 
 # The staged candidate owns admission; any failure exits before the installed
 # controller is written. Its report binds the candidate decision to legacy identity.
 LEGACY_IDENTITY="$("$BIN_PATH" self identity 2>/dev/null || "$BIN_PATH" --version 2>/dev/null || printf 'unavailable')"
-"$TMP_DIR/homeboy" self upgrade-admission --legacy-identity "$LEGACY_IDENTITY"
+"$EXTRACTED_BIN" self upgrade-admission --legacy-identity "$LEGACY_IDENTITY"
 
 if [ "${HOMEBOY_INSTALL_USE_SUDO:-false}" != true ] && { [ -w "$BIN_PATH" ] || [ -w "$BIN_DIR" ]; }; then
-  install -m 0755 "$TMP_DIR/homeboy" "$TMP_BIN"
+  install -m 0755 "$EXTRACTED_BIN" "$TMP_BIN"
   mv "$TMP_BIN" "$BIN_PATH"
 else
-  sudo install -m 0755 "$TMP_DIR/homeboy" "$TMP_BIN"
+  sudo install -m 0755 "$EXTRACTED_BIN" "$TMP_BIN"
   sudo mv "$TMP_BIN" "$BIN_PATH"
 fi

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -46,7 +46,11 @@ fn run_installer(
     );
     write_executable(
         &tools.join("tar"),
-        "#!/bin/sh\ncp \"$HOMEBOY_TEST_CANDIDATE\" homeboy\n",
+        "#!/bin/sh\nmkdir -p \"$HOMEBOY_TEST_ARCHIVE_DIR\"\ncp \"$HOMEBOY_TEST_CANDIDATE\" \"$HOMEBOY_TEST_ARCHIVE_DIR/homeboy\"\n",
+    );
+    write_executable(
+        &tools.join("uname"),
+        "#!/bin/sh\ncase \"$1\" in -s) printf 'Linux\\n' ;; -m) printf 'x86_64\\n' ;; esac\n",
     );
     write_executable(
         &tools.join("sudo"),
@@ -63,6 +67,10 @@ fn run_installer(
         .env("HOMEBOY_TEST_EVIDENCE", &evidence)
         .env("HOMEBOY_TEST_EVENTS", &events)
         .env("HOMEBOY_TEST_BIN_DIR", &install_dir)
+        .env(
+            "HOMEBOY_TEST_ARCHIVE_DIR",
+            "homeboy-x86_64-unknown-linux-gnu",
+        )
         .env("PATH", format!("{}:/usr/bin:/bin", tools.display()));
     if force_sudo {
         command.env("HOMEBOY_INSTALL_USE_SUDO", "true");
@@ -80,7 +88,7 @@ fn installer_admits_a_staged_candidate_and_preserves_bytes_on_admission_failure(
     assert!(allowed.status.success(), "{allowed:?}");
     assert!(installed.contains("upgrade-admission"));
     assert!(evidence.contains("legacy-controller-identity"));
-    assert!(evidence.contains("/homeboy"));
+    assert!(evidence.contains("/homeboy-x86_64-unknown-linux-gnu/homeboy"));
 
     for exit_code in [1, 70] {
         let (blocked, installed, evidence, _) = run_installer(exit_code, true, false);


### PR DESCRIPTION
Fixes #12306

The installer now stages the binary from cargo-dist's versioned archive directory (`${ASSET%.tar.xz}/homeboy`) rather than expecting a root-level binary. The installer integration fixture materializes the real nested archive shape and asserts the candidate path used for admission.

Tests:
- `cargo test --test homeboy_installer_test`
- `cargo fmt --check`
- `shellcheck -S warning scripts/homeboy-installer.sh`

AI assistance: OpenAI gpt-5.6-sol via OpenCode was used to inspect the installer/test contract, implement the scoped fix, and run verification. Chris remains responsible for every line.