### PR TITLE
Fix canonical release checksum sidecars

### DIFF
--- a/.github/canonicalize-checksum-sidecars.sh
+++ b/.github/canonicalize-checksum-sidecars.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Normalize cargo-dist's per-asset checksum output before it becomes a release asset.
+set -euo pipefail
+
+ASSET_DIR="${1:?usage: canonicalize-checksum-sidecars.sh ASSET_DIR}"
+
+shopt -s nullglob
+for sidecar in "${ASSET_DIR}"/*.sha256; do
+  mapfile -t records < "${sidecar}"
+  nonempty=()
+  for record in "${records[@]}"; do
+    [ -z "${record}" ] || nonempty+=("${record}")
+  done
+  [ "${#nonempty[@]}" -eq 1 ] || {
+    echo "::error::Checksum sidecar ${sidecar} must contain one checksum record" >&2
+    exit 1
+  }
+
+  read -r digest name extra <<< "${nonempty[0]}"
+  name="${name#\*}"
+  [[ "${digest}" =~ ^[[:xdigit:]]{64}$ ]] && [ -n "${name}" ] && [ -z "${extra:-}" ] \
+    && [ "${name}" = "$(basename "${sidecar%.sha256}")" ] || {
+      echo "::error::Checksum sidecar ${sidecar} has an invalid payload record" >&2
+      exit 1
+    }
+
+  printf '%s *%s\n' "${digest,,}" "${name}" > "${sidecar}"
+done

--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -233,6 +233,15 @@ done
 
 for sidecar in "${REQUIRED[@]}"; do
   case "${sidecar}" in *.sha256|sha256.sum) ;; *) continue ;; esac
+  if [[ "${sidecar}" == *.sha256 ]]; then
+    # The installer uses GNU sha256sum on Linux. Require its strict parser
+    # contract here so a successful install never starts with a format warning.
+    mapfile -t checksum_records < "${ASSET_DIR}/${sidecar}"
+    [ "$(wc -l < "${ASSET_DIR}/${sidecar}")" -eq 1 ] && [ "${#checksum_records[@]}" -eq 1 ] \
+      || fail "Checksum sidecar ${sidecar} must contain exactly one newline-terminated record"
+    (cd "${ASSET_DIR}" && sha256sum --strict --status -c "${sidecar}") \
+      || fail "Checksum sidecar ${sidecar} is rejected by the installer checksum parser"
+  fi
   references=0
   sidecar_payload=""
   while read -r digest name extra || [ -n "${digest:-}" ]; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -903,6 +903,7 @@ jobs:
             DIST_ALLOW_DIRTY=""
           fi
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} ${DIST_ALLOW_DIRTY} > dist-manifest.json
+          bash .github/canonicalize-checksum-sidecars.sh target/distrib
           echo "dist ran successfully"
 
       - id: cargo-dist
@@ -1005,6 +1006,7 @@ jobs:
             DIST_ALLOW_DIRTY=""
           fi
           dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" ${DIST_ALLOW_DIRTY} > dist-manifest.json
+          bash .github/canonicalize-checksum-sidecars.sh target/distrib
           cp bootstrap-source/scripts/homeboy-installer.sh target/distrib/homeboy-installer.sh
           chmod 0755 target/distrib/homeboy-installer.sh
           echo "dist ran successfully"

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -112,7 +112,7 @@ esac
         // The helper uses GNU `sha256sum`; make the test portable to macOS.
         write_executable(
             &bin.join("sha256sum"),
-            "#!/usr/bin/env bash\nshasum -a 256 \"$1\"\n",
+            "#!/usr/bin/env bash\nif [[ \" $* \" == *\" -c \"* ]]; then exit 0; fi\nshasum -a 256 \"$1\"\n",
         );
         let digests = write_artifacts(temp.path());
         Self { temp, digests }
@@ -272,23 +272,29 @@ fn rejects_invalid_local_artifacts_before_any_upload_or_publication() {
 }
 
 #[test]
-fn processes_an_unterminated_final_checksum_record() {
+fn rejects_checksum_sidecars_without_one_newline_terminated_record() {
     let fixture = Fixture::new();
     let sidecar = fixture.artifact_dir().join("payload.tar.gz.sha256");
     let contents = fs::read_to_string(&sidecar).expect("read payload sidecar");
     fs::write(&sidecar, contents.trim_end_matches('\n')).expect("remove final newline");
-    let mut digests = fixture.digests.clone();
-    digests.insert("payload.tar.gz.sha256".to_owned(), digest(&sidecar));
+    assert!(!fixture
+        .run(&[inventory(&fixture.digests, &[])])
+        .status
+        .success());
+    assert_eq!(fixture.calls(), ["view"]);
 
-    let output = fixture.run(&[inventory(&digests, &[]), inventory(&digests, &[])]);
-
-    assert!(
-        output.status.success(),
-        "stdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(fixture.calls(), ["view", "view"]);
+    let fixture = Fixture::new();
+    let sidecar = fixture.artifact_dir().join("payload.tar.gz.sha256");
+    fs::write(
+        &sidecar,
+        format!("{}\n", fs::read_to_string(&sidecar).expect("read sidecar")),
+    )
+    .expect("append blank record");
+    assert!(!fixture
+        .run(&[inventory(&fixture.digests, &[])])
+        .status
+        .success());
+    assert_eq!(fixture.calls(), ["view"]);
 }
 
 #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -917,7 +917,8 @@ fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_
             .find("grep -Fqx '[package.metadata.dist]' Cargo.toml")
             .unwrap_or_else(|| panic!("{job} must use fixed-string exact-line matching"));
         let dist = section
-            .find("\n          dist ")
+            .find("dist build ")
+            .or_else(|| section.find("dist host "))
             .unwrap_or_else(|| panic!("{job} must execute cargo-dist"));
 
         assert!(
@@ -1926,6 +1927,18 @@ fn release_check_skips_a_superseded_push_but_still_fails_an_unmeasured_one() {
 
 fn release_integrity_workflow() -> &'static str {
     include_str!("../.github/workflows/release-integrity.yml")
+}
+
+#[test]
+fn release_builds_canonicalize_cargo_dist_checksum_sidecars_before_upload() {
+    let workflow = release_workflow();
+    assert_eq!(
+        workflow
+            .matches("bash .github/canonicalize-checksum-sidecars.sh target/distrib")
+            .count(),
+        2,
+        "local and global cargo-dist builds must normalize the sidecars they upload"
+    );
 }
 
 /// The exact published inventory of `v0.332.0` — the last healthy release.


### PR DESCRIPTION
## Summary
- normalize cargo-dist per-asset checksum sidecars to one canonical record and one newline before upload
- reject blank, malformed, and unterminated per-asset sidecars with the strict GNU sha256sum parser used by supported Linux installers
- cover the release producer and gate contract

Fixes #12338

## Verification
- `cargo fmt --check`
- `cargo test --test release_asset_completeness_test --test release_workflow_test`
- `bash -n .github/canonicalize-checksum-sidecars.sh`
- `bash -n .github/release-asset-completeness.sh`
- `git diff --check`

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the release producer and installer parser contract, implement the sidecar normalization and strict gate, and run focused verification. Chris Huber remains responsible for every line.