### PR TITLE
fix: separate required and allowed asset contracts in release recovery

### DIFF
--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -134,8 +134,21 @@ else
   fi
 fi
 
-# cargo-dist attaches this during announce, after the pre-publication upload
-# phase. It remains required at the final published/success boundary.
+# Two different contracts, deliberately kept apart (#12341).
+#
+#   REQUIRED -- what must be PRESENT, uploaded, non-empty and digest-correct.
+#   ALLOWED  -- what may be present at all. Anything outside it is unowned.
+#
+# cargo-dist attaches `dist-manifest.json` during announce, after the
+# pre-publication upload phase, so it is not yet REQUIRED at that boundary. It
+# is still an owned, planned asset and always belongs to ALLOWED. Collapsing
+# the two sets is what made recovery reject the exact inventory it exists to
+# repair: recovery runs against releases that were ALREADY announced, so the
+# announce asset is present, and an allowlist built from the pre-announce
+# REQUIRED set classifies it as unowned. v0.345.0 was published complete with
+# all 14 assets and the recovery run still failed (#12341).
+ALLOWED=("${REQUIRED[@]}")
+
 if [ "${REQUIRE_ANNOUNCE_ASSETS}" != "true" ]; then
   PRE_ANNOUNCE_REQUIRED=()
   for asset in "${REQUIRED[@]}"; do
@@ -192,19 +205,32 @@ if ! jq -e '
 fi
 
 EXPECTED_JSON="$(printf '%s\n' "${REQUIRED[@]}" | jq -Rsc 'split("\n") | map(select(length > 0)) | sort')"
+ALLOWED_JSON="$(printf '%s\n' "${ALLOWED[@]}" | jq -Rsc 'split("\n") | map(select(length > 0)) | sort')"
 ACTUAL_JSON="$(jq -Sc '[.assets[].name] | sort' <<< "${INVENTORY}")"
 EXPECTED_COUNT="$(jq -r 'length' <<< "${EXPECTED_JSON}")"
 ACTUAL_COUNT="$(jq -r 'length' <<< "${ACTUAL_JSON}")"
-if [ "${RECONCILE}" = "true" ]; then
-  if ! jq -e --argjson expected "${EXPECTED_JSON}" '
+
+# Every name is owned (within ALLOWED) and appears once. Duplicate detection is
+# by cardinality: a set comparison alone would hide a repeated name.
+#
+# When REQUIRE_ANNOUNCE_ASSETS is true, ALLOWED == REQUIRED, and pairing this
+# with the MISSING check above is exactly the set equality the sweeper has
+# always enforced. When it is false, the announce asset is permitted but not
+# demanded -- which is the whole point of the flag.
+inventory_is_owned() {
+  jq -e --argjson allowed "${ALLOWED_JSON}" '
     [.assets[].name] as $names |
-    ($names | all(.[]; . as $name | $expected | index($name))) and
+    ($names | all(.[]; . as $name | $allowed | index($name))) and
     ($names | length) == ($names | unique | length)
-  ' >/dev/null <<< "${INVENTORY}"; then
-    fail "Release ${RELEASE_TAG} inventory has unexpected or duplicate assets. Recovery only replaces expected assets and refuses to publish an unowned inventory."
+  ' >/dev/null <<< "$1"
+}
+
+if [ "${RECONCILE}" = "true" ]; then
+  if ! inventory_is_owned "${INVENTORY}"; then
+    fail "Release ${RELEASE_TAG} inventory has unexpected or duplicate assets (allowed ${ALLOWED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Recovery only replaces expected assets and refuses to publish an unowned inventory."
   fi
-elif [ "${EXPECTED_JSON}" != "${ACTUAL_JSON}" ] || [ "${EXPECTED_COUNT}" != "${ACTUAL_COUNT}" ]; then
-  fail "Release ${RELEASE_TAG} inventory is not the exact expected asset set (expected ${EXPECTED_COUNT}: ${EXPECTED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Unexpected or duplicate assets must be removed before publication."
+elif ! inventory_is_owned "${INVENTORY}"; then
+  fail "Release ${RELEASE_TAG} inventory is not the exact expected asset set (required ${EXPECTED_COUNT}: ${EXPECTED_JSON}; allowed ${ALLOWED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Unexpected or duplicate assets must be removed before publication."
 fi
 
 if [ -z "${ASSET_DIR}" ]; then
@@ -281,8 +307,17 @@ if [ "${RECONCILE}" = "true" ]; then
   fi
   FINAL_JSON="$(jq -Sc '[.assets[].name] | sort' <<< "${INVENTORY}" 2>/dev/null)" || fail "The final asset inventory for ${RELEASE_TAG} is unreadable"
   FINAL_COUNT="$(jq -r 'length' <<< "${FINAL_JSON}")"
-  if [ "${EXPECTED_JSON}" != "${FINAL_JSON}" ] || [ "${EXPECTED_COUNT}" != "${FINAL_COUNT}" ]; then
-    fail "Release ${RELEASE_TAG} final inventory is not the exact rebuilt asset set. No publication is permitted."
+  # The same two contracts as the pre-upload gate, re-proven against the
+  # post-upload inventory: every REQUIRED asset landed, and nothing outside
+  # ALLOWED (or a duplicate name) rode along with it. Comparing against
+  # EXPECTED_JSON alone repeated the #12341 conflation here, so a recovery that
+  # cleared the gate above would still have been rejected at the finish line.
+  MISSING_FINAL=()
+  for asset in "${REQUIRED[@]}"; do
+    jq -e --arg name "${asset}" 'index($name)' >/dev/null <<< "${FINAL_JSON}" || MISSING_FINAL+=("${asset}")
+  done
+  if [ "${#MISSING_FINAL[@]}" -gt 0 ] || ! inventory_is_owned "${INVENTORY}"; then
+    fail "Release ${RELEASE_TAG} final inventory is not the exact rebuilt asset set (required ${EXPECTED_COUNT}: ${EXPECTED_JSON}; allowed ${ALLOWED_JSON}; observed ${FINAL_COUNT}: ${FINAL_JSON}). No publication is permitted."
   fi
 fi
 

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -9,7 +9,31 @@ use std::process::{Command, Output};
 use tempfile::TempDir;
 
 const TAG: &str = "v1.2.3";
-const ASSETS: [&str; 3] = ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"];
+
+/// The full planned contract, as `release.yml` passes it in `EXPECTED_ASSETS`.
+///
+/// `dist-manifest.json` is deliberately part of this set (#12341). It is the
+/// asset cargo-dist attaches during *announce*, so the pre-publication gate
+/// runs with `REQUIRE_ANNOUNCE_ASSETS=false` and must not demand it — while
+/// still permitting it, because recovery runs against releases that were
+/// already announced and therefore already carry it.
+///
+/// Before #12341 this array held only the three payload/checksum entries, so
+/// the announce strip the fixture exercises at `REQUIRE_ANNOUNCE_ASSETS=false`
+/// removed nothing and the required/allowed conflation was invisible to every
+/// test in this file.
+const ASSETS: [&str; 4] = [
+    "payload.tar.gz",
+    "payload.tar.gz.sha256",
+    "sha256.sum",
+    ANNOUNCE_ASSET,
+];
+
+/// Attached during announce; required only at the published boundary.
+const ANNOUNCE_ASSET: &str = "dist-manifest.json";
+
+/// What the pre-publication gate actually requires to be present and valid.
+const REQUIRED_ASSETS: [&str; 3] = ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"];
 
 fn digest(path: &Path) -> String {
     let output = Command::new("shasum")
@@ -44,6 +68,10 @@ fn write_artifacts(root: &Path) -> BTreeMap<String, String> {
     let checksum = format!("{payload_digest} *payload.tar.gz\n");
     fs::write(artifacts.join("payload.tar.gz.sha256"), &checksum).expect("write payload sidecar");
     fs::write(artifacts.join("sha256.sum"), checksum).expect("write aggregate sidecar");
+    // `Preserve existing published asset bytes` copies every planned asset --
+    // including the announce manifest -- into the recovery artifact directory.
+    fs::write(artifacts.join(ANNOUNCE_ASSET), "{\"dist_version\":\"0.31.0\"}\n")
+        .expect("write announce manifest");
 
     ASSETS
         .into_iter()
@@ -176,6 +204,51 @@ fn retains_digest_matching_assets_without_uploading_or_publishing() {
     assert_eq!(fixture.calls(), ["view", "view"]);
 }
 
+/// Recovery against an already-announced, already-complete release is a no-op.
+///
+/// This is the exact shape that failed in production: v0.345.0 was published
+/// complete with all 14 planned assets, and the recovery run rejected it with
+/// "inventory has unexpected or duplicate assets" because the announce manifest
+/// had been stripped out of the set being used as an allowlist (#12341).
+#[test]
+fn accepts_a_complete_announced_inventory_without_uploading_or_republishing() {
+    let fixture = Fixture::new();
+    let complete = inventory(&fixture.digests, &[]);
+    assert!(
+        complete.contains(ANNOUNCE_ASSET),
+        "the fixture inventory must carry the announce asset for this to regress"
+    );
+
+    let output = fixture.run(&[complete.clone(), complete]);
+
+    assert!(
+        output.status.success(),
+        "a complete announced inventory must reconcile cleanly.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.calls(), ["view", "view"]);
+}
+
+/// The announce asset is permitted, never demanded, before announce runs.
+#[test]
+fn accepts_an_inventory_without_the_announce_asset_before_announce() {
+    let fixture = Fixture::new();
+    let pre_announce = inventory(&fixture.digests, &[(ANNOUNCE_ASSET, "absent", "", 0)]);
+    assert!(!pre_announce.contains(ANNOUNCE_ASSET));
+
+    let output = fixture.run(&[pre_announce.clone(), pre_announce]);
+
+    assert!(
+        output.status.success(),
+        "the announce asset must not be required before announce.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Never uploaded: it is not part of the rebuilt required contract.
+    assert_eq!(fixture.calls(), ["view", "view"]);
+}
+
 #[test]
 fn replaces_missing_empty_and_digest_mismatched_assets_then_revalidates_remote_bytes() {
     for (asset, state, remote_digest, size) in [
@@ -229,12 +302,45 @@ fn rejects_malformed_unexpected_or_duplicate_remote_inventory_without_uploading(
     assert!(!fixture.run(&[unexpected]).status.success());
     assert_eq!(fixture.calls(), ["view"]);
 
+    // An unowned asset riding alongside an otherwise complete inventory must
+    // still fail closed. Widening the allowlist to admit announce assets
+    // (#12341) must not widen it to admit anything else.
+    let fixture = Fixture::new();
+    let mut intruder: serde_json::Value =
+        serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
+    intruder["assets"].as_array_mut().unwrap().push(
+        serde_json::json!({"name":"unowned.tar.xz","state":"uploaded","size":1,"digest":"sha256:abc"}),
+    );
+    assert!(!fixture.run(&[intruder.to_string()]).status.success());
+    assert_eq!(fixture.calls(), ["view"]);
+
     let fixture = Fixture::new();
     let mut duplicate: serde_json::Value =
         serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
     let copy = duplicate["assets"][0].clone();
     duplicate["assets"].as_array_mut().unwrap().push(copy);
     assert!(!fixture.run(&[duplicate.to_string()]).status.success());
+    assert_eq!(fixture.calls(), ["view"]);
+
+    // A duplicated announce asset is a duplicate like any other.
+    let fixture = Fixture::new();
+    let mut duplicate_announce: serde_json::Value =
+        serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
+    let announce = duplicate_announce["assets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|asset| asset["name"] == ANNOUNCE_ASSET)
+        .expect("fixture inventory carries the announce asset")
+        .clone();
+    duplicate_announce["assets"]
+        .as_array_mut()
+        .unwrap()
+        .push(announce);
+    assert!(!fixture
+        .run(&[duplicate_announce.to_string()])
+        .status
+        .success());
     assert_eq!(fixture.calls(), ["view"]);
 }
 
@@ -248,7 +354,7 @@ fn rejects_invalid_local_artifacts_before_any_upload_or_publication() {
         .success());
     assert_eq!(fixture.calls(), ["view"]);
 
-    for path in ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"] {
+    for path in REQUIRED_ASSETS {
         let fixture = Fixture::new();
         fs::write(fixture.artifact_dir().join(path), "").expect("empty local artifact");
         assert!(!fixture

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -70,8 +70,11 @@ fn write_artifacts(root: &Path) -> BTreeMap<String, String> {
     fs::write(artifacts.join("sha256.sum"), checksum).expect("write aggregate sidecar");
     // `Preserve existing published asset bytes` copies every planned asset --
     // including the announce manifest -- into the recovery artifact directory.
-    fs::write(artifacts.join(ANNOUNCE_ASSET), "{\"dist_version\":\"0.31.0\"}\n")
-        .expect("write announce manifest");
+    fs::write(
+        artifacts.join(ANNOUNCE_ASSET),
+        "{\"dist_version\":\"0.31.0\"}\n",
+    )
+    .expect("write announce manifest");
 
     ASSETS
         .into_iter()


### PR DESCRIPTION
Fixes #12341.

## What was wrong

Release recovery could not succeed against a release that had already been announced — which is every release recovery exists to repair.

`release.yml:1198` invokes the completeness gate with `REQUIRE_ANNOUNCE_ASSETS=false`, because at the pre-publication boundary cargo-dist has run `--steps=upload` but not `announce`, so `dist-manifest.json` is not yet *required*. That was implemented by **removing the asset from `REQUIRED`** — and `REQUIRED` was then reused as an exhaustive allowlist for the "no unexpected or duplicate assets" check. "Not required yet" was silently promoted to "not permitted."

v0.345.0 was published **complete** at `16:09:32Z` with all 14 planned assets and correct digests. The recovery run at `16:22` rejected exactly that inventory:

```
::error::Release v0.345.0 inventory has unexpected or duplicate assets.
```

`verify-published` then reported the opposite of the truth about a live release — *"the tag exists with no GitHub Release"*. 17 of the last 28 `main` Release runs are red.

## The fix

Split the two contracts that were collapsed into one:

| set | meaning |
|---|---|
| `REQUIRED` | must be present, uploaded, non-empty, digest-correct |
| `ALLOWED` | may be present at all — anything else is unowned |

Announce assets leave `REQUIRED` before announce and stay in `ALLOWED`.

The same conflation appeared a **second time** in the reconcile finalization (old lines 282-286), which compared the post-upload inventory to `REQUIRED` for exact equality. A recovery that cleared the first gate would still have been rejected at the finish line. It now proves the same two properties.

When `REQUIRE_ANNOUNCE_ASSETS=true` the two sets are identical, so pairing the ownership check with the existing `MISSING` check is exactly the set equality the `release-integrity.yml` sweeper has always enforced.

## Verification

Reproduced against `origin/main` and confirmed fixed, driving the real script with a mock `gh`:

| inventory | main | this PR |
|---|---|---|
| complete, announced (the v0.345.0 shape) | ❌ rejected | ✅ passes, zero uploads |
| pre-announce, manifest absent | ✅ | ✅ |
| unowned asset present | ❌ fails closed | ❌ fails closed |
| duplicate announce asset | ❌ fails closed | ❌ fails closed |
| required payload missing | uploads, then fails closed | uploads, then fails closed |

Sweeper path (`REQUIRE_ANNOUNCE_ASSETS=true`, no reconcile) verified byte-identical in behavior before and after across complete / missing-manifest / rogue-extra inventories.

`cargo check --workspace --tests -j2` clean.

## Why no test caught it

`tests/release_asset_completeness_test.rs` declared the entire fixture contract as three payload/checksum entries and no announce asset. The fixture *sets* `REQUIRE_ANNOUNCE_ASSETS=false`, so the strip branch ran — but with nothing to strip it was a **no-op in every test in the file**. The branch was exercised; its actual effect never was.

`dist-manifest.json` is now part of the fixture contract, plus two new tests for the announced-complete and pre-announce cases and two more for fail-closed behavior on unowned and duplicated announce assets.

Against the unfixed script **5 of the 9 tests fail**; all 9 pass against this one.

## Note for local reviewers

These tests cannot pass on a host with a `noexec` `/tmp`. `scripts/nextest-hermetic-test-environment.sh` does `unset TMPDIR TMP TEMP`, so `tempfile::tempdir()` falls back to `/tmp`, and the fixture's mock `gh` cannot be executed — bash skips it and silently invokes the real `gh`. Same binary, unchanged: 7 failed with `TMPDIR` unset, 7 passed with it set. Unrelated to this change and not a CI problem, but it makes the whole file look broken locally. Filing separately.

## AI assistance

Claude (chubes-bot) diagnosed the workflow evidence, wrote the fix and the regression coverage. Chris Huber remains responsible for the change.
