### PR TITLE
Fix reconciliation ownership contracts

### DIFF
--- a/.github/canonicalize-checksum-sidecars.sh
+++ b/.github/canonicalize-checksum-sidecars.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Normalize cargo-dist's per-asset checksum output before it becomes a release asset.
+set -euo pipefail
+
+ASSET_DIR="${1:?usage: canonicalize-checksum-sidecars.sh ASSET_DIR}"
+
+shopt -s nullglob
+for sidecar in "${ASSET_DIR}"/*.sha256; do
+  mapfile -t records < "${sidecar}"
+  nonempty=()
+  for record in "${records[@]}"; do
+    [ -z "${record}" ] || nonempty+=("${record}")
+  done
+  [ "${#nonempty[@]}" -eq 1 ] || {
+    echo "::error::Checksum sidecar ${sidecar} must contain one checksum record" >&2
+    exit 1
+  }
+
+  read -r digest name extra <<< "${nonempty[0]}"
+  name="${name#\*}"
+  [[ "${digest}" =~ ^[[:xdigit:]]{64}$ ]] && [ -n "${name}" ] && [ -z "${extra:-}" ] \
+    && [ "${name}" = "$(basename "${sidecar%.sha256}")" ] || {
+      echo "::error::Checksum sidecar ${sidecar} has an invalid payload record" >&2
+      exit 1
+    }
+
+  printf '%s *%s\n' "${digest,,}" "${name}" > "${sidecar}"
+done

--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -233,6 +233,15 @@ done
 
 for sidecar in "${REQUIRED[@]}"; do
   case "${sidecar}" in *.sha256|sha256.sum) ;; *) continue ;; esac
+  if [[ "${sidecar}" == *.sha256 ]]; then
+    # The installer uses GNU sha256sum on Linux. Require its strict parser
+    # contract here so a successful install never starts with a format warning.
+    mapfile -t checksum_records < "${ASSET_DIR}/${sidecar}"
+    [ "$(wc -l < "${ASSET_DIR}/${sidecar}")" -eq 1 ] && [ "${#checksum_records[@]}" -eq 1 ] \
+      || fail "Checksum sidecar ${sidecar} must contain exactly one newline-terminated record"
+    (cd "${ASSET_DIR}" && sha256sum --strict --status -c "${sidecar}") \
+      || fail "Checksum sidecar ${sidecar} is rejected by the installer checksum parser"
+  fi
   references=0
   sidecar_payload=""
   while read -r digest name extra || [ -n "${digest:-}" ]; do

--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -134,8 +134,21 @@ else
   fi
 fi
 
-# cargo-dist attaches this during announce, after the pre-publication upload
-# phase. It remains required at the final published/success boundary.
+# Two different contracts, deliberately kept apart (#12341).
+#
+#   REQUIRED -- what must be PRESENT, uploaded, non-empty and digest-correct.
+#   ALLOWED  -- what may be present at all. Anything outside it is unowned.
+#
+# cargo-dist attaches `dist-manifest.json` during announce, after the
+# pre-publication upload phase, so it is not yet REQUIRED at that boundary. It
+# is still an owned, planned asset and always belongs to ALLOWED. Collapsing
+# the two sets is what made recovery reject the exact inventory it exists to
+# repair: recovery runs against releases that were ALREADY announced, so the
+# announce asset is present, and an allowlist built from the pre-announce
+# REQUIRED set classifies it as unowned. v0.345.0 was published complete with
+# all 14 assets and the recovery run still failed (#12341).
+ALLOWED=("${REQUIRED[@]}")
+
 if [ "${REQUIRE_ANNOUNCE_ASSETS}" != "true" ]; then
   PRE_ANNOUNCE_REQUIRED=()
   for asset in "${REQUIRED[@]}"; do
@@ -192,19 +205,32 @@ if ! jq -e '
 fi
 
 EXPECTED_JSON="$(printf '%s\n' "${REQUIRED[@]}" | jq -Rsc 'split("\n") | map(select(length > 0)) | sort')"
+ALLOWED_JSON="$(printf '%s\n' "${ALLOWED[@]}" | jq -Rsc 'split("\n") | map(select(length > 0)) | sort')"
 ACTUAL_JSON="$(jq -Sc '[.assets[].name] | sort' <<< "${INVENTORY}")"
 EXPECTED_COUNT="$(jq -r 'length' <<< "${EXPECTED_JSON}")"
 ACTUAL_COUNT="$(jq -r 'length' <<< "${ACTUAL_JSON}")"
-if [ "${RECONCILE}" = "true" ]; then
-  if ! jq -e --argjson expected "${EXPECTED_JSON}" '
+
+# Every name is owned (within ALLOWED) and appears once. Duplicate detection is
+# by cardinality: a set comparison alone would hide a repeated name.
+#
+# When REQUIRE_ANNOUNCE_ASSETS is true, ALLOWED == REQUIRED, and pairing this
+# with the MISSING check above is exactly the set equality the sweeper has
+# always enforced. When it is false, the announce asset is permitted but not
+# demanded -- which is the whole point of the flag.
+inventory_is_owned() {
+  jq -e --argjson allowed "${ALLOWED_JSON}" '
     [.assets[].name] as $names |
-    ($names | all(.[]; . as $name | $expected | index($name))) and
+    ($names | all(.[]; . as $name | $allowed | index($name))) and
     ($names | length) == ($names | unique | length)
-  ' >/dev/null <<< "${INVENTORY}"; then
-    fail "Release ${RELEASE_TAG} inventory has unexpected or duplicate assets. Recovery only replaces expected assets and refuses to publish an unowned inventory."
+  ' >/dev/null <<< "$1"
+}
+
+if [ "${RECONCILE}" = "true" ]; then
+  if ! inventory_is_owned "${INVENTORY}"; then
+    fail "Release ${RELEASE_TAG} inventory has unexpected or duplicate assets (allowed ${ALLOWED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Recovery only replaces expected assets and refuses to publish an unowned inventory."
   fi
-elif [ "${EXPECTED_JSON}" != "${ACTUAL_JSON}" ] || [ "${EXPECTED_COUNT}" != "${ACTUAL_COUNT}" ]; then
-  fail "Release ${RELEASE_TAG} inventory is not the exact expected asset set (expected ${EXPECTED_COUNT}: ${EXPECTED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Unexpected or duplicate assets must be removed before publication."
+elif ! inventory_is_owned "${INVENTORY}"; then
+  fail "Release ${RELEASE_TAG} inventory is not the exact expected asset set (required ${EXPECTED_COUNT}: ${EXPECTED_JSON}; allowed ${ALLOWED_JSON}; observed ${ACTUAL_COUNT}: ${ACTUAL_JSON}). Unexpected or duplicate assets must be removed before publication."
 fi
 
 if [ -z "${ASSET_DIR}" ]; then
@@ -281,8 +307,17 @@ if [ "${RECONCILE}" = "true" ]; then
   fi
   FINAL_JSON="$(jq -Sc '[.assets[].name] | sort' <<< "${INVENTORY}" 2>/dev/null)" || fail "The final asset inventory for ${RELEASE_TAG} is unreadable"
   FINAL_COUNT="$(jq -r 'length' <<< "${FINAL_JSON}")"
-  if [ "${EXPECTED_JSON}" != "${FINAL_JSON}" ] || [ "${EXPECTED_COUNT}" != "${FINAL_COUNT}" ]; then
-    fail "Release ${RELEASE_TAG} final inventory is not the exact rebuilt asset set. No publication is permitted."
+  # The same two contracts as the pre-upload gate, re-proven against the
+  # post-upload inventory: every REQUIRED asset landed, and nothing outside
+  # ALLOWED (or a duplicate name) rode along with it. Comparing against
+  # EXPECTED_JSON alone repeated the #12341 conflation here, so a recovery that
+  # cleared the gate above would still have been rejected at the finish line.
+  MISSING_FINAL=()
+  for asset in "${REQUIRED[@]}"; do
+    jq -e --arg name "${asset}" 'index($name)' >/dev/null <<< "${FINAL_JSON}" || MISSING_FINAL+=("${asset}")
+  done
+  if [ "${#MISSING_FINAL[@]}" -gt 0 ] || ! inventory_is_owned "${INVENTORY}"; then
+    fail "Release ${RELEASE_TAG} final inventory is not the exact rebuilt asset set (required ${EXPECTED_COUNT}: ${EXPECTED_JSON}; allowed ${ALLOWED_JSON}; observed ${FINAL_COUNT}: ${FINAL_JSON}). No publication is permitted."
   fi
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -903,6 +903,7 @@ jobs:
             DIST_ALLOW_DIRTY=""
           fi
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} ${DIST_ALLOW_DIRTY} > dist-manifest.json
+          bash .github/canonicalize-checksum-sidecars.sh target/distrib
           echo "dist ran successfully"
 
       - id: cargo-dist
@@ -1005,6 +1006,7 @@ jobs:
             DIST_ALLOW_DIRTY=""
           fi
           dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" ${DIST_ALLOW_DIRTY} > dist-manifest.json
+          bash .github/canonicalize-checksum-sidecars.sh target/distrib
           cp bootstrap-source/scripts/homeboy-installer.sh target/distrib/homeboy-installer.sh
           chmod 0755 target/distrib/homeboy-installer.sh
           echo "dist ran successfully"

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -20,6 +20,85 @@ use homeboy_core::{paths, Error, Result};
 pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
 const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
 
+/// Durable Cook storage bound to explicit filesystem roots.
+#[derive(Clone, Debug)]
+pub struct CookRecipeStore {
+    data_root: PathBuf,
+}
+
+impl CookRecipeStore {
+    pub fn new(roots: paths::PathRoots) -> Self {
+        Self::from_data_root(roots.data().to_path_buf())
+    }
+
+    pub fn from_environment() -> Result<Self> {
+        Ok(Self::new(paths::PathRoots::from_environment()?))
+    }
+
+    /// Bind Cook's data-only storage without requiring unrelated config or
+    /// artifact roots. Legacy Cook entry points use this to preserve their
+    /// historical `HOMEBOY_DATA_DIR`-only contract.
+    pub fn from_data_root(data: PathBuf) -> Self {
+        Self { data_root: data }
+    }
+
+    fn recipe_root(&self) -> PathBuf {
+        self.data_root.join("agent-task-cooks")
+    }
+
+    fn recipe_path(&self, cook_id: &str) -> PathBuf {
+        self.recipe_root()
+            .join(paths::sanitize_path_segment(cook_id))
+            .join("recipe.json")
+    }
+
+    fn supersession_path(&self, cook_id: &str) -> PathBuf {
+        self.recipe_path(cook_id)
+            .with_file_name("supersession.json")
+    }
+
+    fn queue_root(&self) -> PathBuf {
+        self.data_root.join("agent-task-cook-continuations")
+    }
+
+    pub fn persist_recipe(&self, recipe: &AgentTaskCookRecipe) -> Result<()> {
+        validate_recipe(recipe)?;
+        let path = self.recipe_path(&recipe.cook_id);
+        fs::create_dir_all(path.parent().expect("recipe path has parent")).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?;
+        homeboy_core::engine::local_files::write_json_file_owner_only(&path, recipe)
+    }
+
+    pub fn load_recipe(&self, cook_id: &str) -> Result<AgentTaskCookRecipe> {
+        load_recipe_at(self.recipe_path(cook_id), cook_id)
+    }
+
+    pub fn recipe_exists(&self, cook_id: &str) -> bool {
+        self.recipe_path(cook_id).exists()
+    }
+
+    pub fn load_recipe_for_attempt(&self, run_id: &str) -> Result<Option<AgentTaskCookRecipe>> {
+        load_recipe_for_attempt_from(&self.recipe_root(), run_id)
+    }
+
+    pub fn enqueue_continuation(
+        &self,
+        continuation: &AgentTaskCookContinuation,
+        rearm_failed: bool,
+    ) -> Result<bool> {
+        DurableCookContinuationQueue { store: self }.enqueue(continuation, rearm_failed)
+    }
+
+    pub fn claim_continuation_with_budget(&self, budget: usize) -> Result<CookContinuationClaim> {
+        claim_continuation_from(&self.queue_root(), budget)
+    }
+}
+
+fn default_store() -> Result<CookRecipeStore> {
+    Ok(CookRecipeStore::from_data_root(paths::homeboy_data()?))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AgentTaskCookRecipe {
@@ -737,7 +816,10 @@ pub fn record_recipe_attempt_replacement(
 }
 
 pub fn load_recipe(cook_id: &str) -> Result<AgentTaskCookRecipe> {
-    let path = recipe_path(cook_id)?;
+    default_store()?.load_recipe(cook_id)
+}
+
+fn load_recipe_at(path: PathBuf, cook_id: &str) -> Result<AgentTaskCookRecipe> {
     let raw = fs::read_to_string(&path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     let recipe = serde_json::from_str(&raw).map_err(|error| {
@@ -763,19 +845,25 @@ pub fn load_recipe(cook_id: &str) -> Result<AgentTaskCookRecipe> {
 /// Legacy cook indexes predate this durable scheduler contract. Their status
 /// projection remains read-only and preserves the previous orphan behavior.
 pub fn recipe_exists(cook_id: &str) -> Result<bool> {
-    Ok(recipe_path(cook_id)?.exists())
+    Ok(default_store()?.recipe_exists(cook_id))
 }
 
 /// Locate an orphaned attempt by its exact durable run ID. This permits an
 /// operator to disambiguate a cook whose retry attempts have different plans.
 pub fn load_recipe_for_attempt(run_id: &str) -> Result<Option<AgentTaskCookRecipe>> {
-    let root = paths::homeboy_data()?.join("agent-task-cooks");
+    default_store()?.load_recipe_for_attempt(run_id)
+}
+
+fn load_recipe_for_attempt_from(
+    root: &std::path::Path,
+    run_id: &str,
+) -> Result<Option<AgentTaskCookRecipe>> {
     if !root.exists() {
         return Ok(None);
     }
 
     let mut matches = Vec::new();
-    for entry in fs::read_dir(&root)
+    for entry in fs::read_dir(root)
         .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?
     {
         let path = entry
@@ -978,7 +1066,7 @@ fn enqueue_terminal_continuation_with_recovery(
         run_id: run_id.to_string(),
         retries: 0,
     };
-    DurableCookContinuationQueue.enqueue(&continuation, rearm_failed)
+    default_store()?.enqueue_continuation(&continuation, rearm_failed)
 }
 
 pub fn claim_continuation() -> Result<Option<ClaimedCookContinuation>> {
@@ -994,11 +1082,14 @@ pub struct CookContinuationClaim {
 /// Claim one valid continuation after terminalizing malformed entries within a
 /// caller-owned admission budget.
 pub fn claim_continuation_with_budget(budget: usize) -> Result<CookContinuationClaim> {
-    let root = queue_root()?;
-    fs::create_dir_all(&root)
+    default_store()?.claim_continuation_with_budget(budget)
+}
+
+fn claim_continuation_from(root: &std::path::Path, budget: usize) -> Result<CookContinuationClaim> {
+    fs::create_dir_all(root)
         .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
-    reclaim_dead_claims(&root)?;
-    let mut pending: Vec<_> = fs::read_dir(&root)
+    reclaim_dead_claims(root)?;
+    let mut pending: Vec<_> = fs::read_dir(root)
         .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(|error| Error::internal_io(error.to_string(), Some(root.display().to_string())))?;
@@ -1632,15 +1723,17 @@ fn recipe_value_error(field: &'static str) -> impl FnOnce(serde_json::Error) -> 
     }
 }
 
-struct DurableCookContinuationQueue;
-impl DurableCookContinuationQueue {
+struct DurableCookContinuationQueue<'a> {
+    store: &'a CookRecipeStore,
+}
+impl DurableCookContinuationQueue<'_> {
     fn enqueue(
         &self,
         continuation: &AgentTaskCookContinuation,
         rearm_failed: bool,
     ) -> Result<bool> {
         validate_continuation(continuation)?;
-        let root = queue_root()?;
+        let root = self.store.queue_root();
         fs::create_dir_all(&root).map_err(|error| {
             Error::internal_io(error.to_string(), Some(root.display().to_string()))
         })?;
@@ -1722,7 +1815,7 @@ impl DurableCookContinuationQueue {
     }
 }
 
-impl AgentTaskCookContinuationScheduler for DurableCookContinuationQueue {
+impl AgentTaskCookContinuationScheduler for DurableCookContinuationQueue<'_> {
     fn enqueue(&self, continuation: &AgentTaskCookContinuation) -> Result<bool> {
         self.enqueue(continuation, false)
     }
@@ -1832,23 +1925,17 @@ fn sensitive_mappings(plan: &AgentTaskPlan) -> Result<Vec<String>> {
 }
 
 fn write_recipe(recipe: &AgentTaskCookRecipe) -> Result<()> {
-    let path = recipe_path(&recipe.cook_id)?;
-    fs::create_dir_all(path.parent().expect("recipe path has parent"))
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
-    homeboy_core::engine::local_files::write_json_file_owner_only(&path, recipe)
+    default_store()?.persist_recipe(recipe)
 }
 
 fn recipe_path(cook_id: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
-        .join("agent-task-cooks")
-        .join(paths::sanitize_path_segment(cook_id))
-        .join("recipe.json"))
+    Ok(default_store()?.recipe_path(cook_id))
 }
 fn supersession_path(cook_id: &str) -> Result<PathBuf> {
-    Ok(recipe_path(cook_id)?.with_file_name("supersession.json"))
+    Ok(default_store()?.supersession_path(cook_id))
 }
 fn queue_root() -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?.join("agent-task-cook-continuations"))
+    Ok(default_store()?.queue_root())
 }
 
 fn continuation_base_path(path: &std::path::Path) -> PathBuf {
@@ -2014,6 +2101,59 @@ mod tests {
             "gate_results": gate_results,
             "operator_notification": { "status": "completed", "message": "fixture" }
         })
+    }
+
+    #[test]
+    fn injected_cook_stores_isolate_identical_ids_in_parallel() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left_store = CookRecipeStore::new(left_context.path_roots());
+        let right_store = CookRecipeStore::new(right_context.path_roots());
+        let left_recipe = recipe();
+        let mut right_recipe = recipe();
+        right_recipe.source_refs = vec!["other-issue".to_string()];
+        let continuation = AgentTaskCookContinuation {
+            schema: CONTINUATION_SCHEMA.to_string(),
+            key: "cook:run".to_string(),
+            cook_id: "cook".to_string(),
+            run_id: "run".to_string(),
+            retries: 0,
+        };
+
+        let left_continuation = continuation.clone();
+        let left = std::thread::spawn(move || {
+            left_store.persist_recipe(&left_recipe)?;
+            left_store.enqueue_continuation(&left_continuation, false)?;
+            let claim = left_store.claim_continuation_with_budget(1)?;
+            Ok::<_, Error>((left_store, claim.claim.expect("left claim")))
+        });
+        let right = std::thread::spawn(move || {
+            right_store.persist_recipe(&right_recipe)?;
+            right_store.enqueue_continuation(&continuation, false)?;
+            let claim = right_store.claim_continuation_with_budget(1)?;
+            Ok::<_, Error>((right_store, claim.claim.expect("right claim")))
+        });
+
+        let (left_store, left_claim) = left.join().expect("left thread").expect("left store");
+        let (right_store, right_claim) = right.join().expect("right thread").expect("right store");
+
+        assert_eq!(
+            left_store.load_recipe("cook").unwrap().source_refs,
+            ["issue"]
+        );
+        assert_eq!(
+            right_store.load_recipe("cook").unwrap().source_refs,
+            ["other-issue"]
+        );
+        assert_eq!(left_claim.continuation().key, "cook:run");
+        assert_eq!(right_claim.continuation().key, "cook:run");
+        assert!(left_store
+            .recipe_path("cook")
+            .starts_with(left_context.data_dir()));
+        assert!(right_store
+            .recipe_path("cook")
+            .starts_with(right_context.data_dir()));
+        assert_ne!(left_store.recipe_root(), right_store.recipe_root());
     }
 
     fn persist_recipe_run() -> (AgentTaskCookRecipe, AgentTaskPlan) {

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -532,14 +532,39 @@ pub(crate) fn controller_upgrade_admission_for_records(
                             }
                         })
                 };
+                let (owner, scope, postcondition) = if recovery_command
+                    .starts_with("homeboy runner reconcile ")
+                {
+                    (
+                        "runner_generations",
+                        format!("runner `{}` and its persisted daemon generations", record.runner_id().unwrap_or_default()),
+                        "the runner accepts jobs with no unresolved generation projection",
+                    )
+                } else if recovery_command.starts_with("homeboy agent-task reconcile-records") {
+                    (
+                        "durable_agent_task_record_health",
+                        "stored durable agent-task record health".to_string(),
+                        "durable record authority is internally consistent",
+                    )
+                } else {
+                    (
+                        "durable_agent_tasks",
+                        format!("durable run or Cook group `{group_run_id}`"),
+                        "the selected durable records are reconciled to authoritative provider state",
+                    )
+                };
                 ControllerUpgradeBlocker {
                     run_id: group_run_id.clone(),
+                    owner: owner.to_string(),
+                    scope,
+                    postcondition: postcondition.to_string(),
                     liveness: liveness.as_str(),
                     reason: if runner_unverified {
                         "runner_job_unverified_after_daemon_restart".to_string()
                     } else {
                         stale_reason_for_record(record)
                     },
+                    action: recovery_command.clone(),
                     recovery_command,
                 }
             })
@@ -555,29 +580,14 @@ pub(crate) fn controller_upgrade_admission_for_records(
     let mut blockers = grouped
         .into_values()
         .map(|mut group| {
-            group.sort_by(|left, right| left.recovery_command.cmp(&right.recovery_command));
-            let recovery_commands = group
+            group.sort_by(|left, right| left.action.cmp(&right.action));
+            // Runner generation ownership is authoritative for a runner-backed
+            // record; one blocker must route to one owning reconciliation plane.
+            group
                 .iter()
-                .map(|blocker| blocker.recovery_command.clone())
-                .collect::<Vec<_>>();
-            let mut runner_commands = recovery_commands
-                .iter()
-                .filter(|command| command.starts_with("homeboy runner reconcile "))
+                .find(|blocker| blocker.owner == "runner_generations")
                 .cloned()
-                .collect::<Vec<_>>();
-            let mut lifecycle_commands = recovery_commands
-                .iter()
-                .filter(|command| !command.starts_with("homeboy runner reconcile "))
-                .cloned()
-                .collect::<Vec<_>>();
-            runner_commands.sort();
-            runner_commands.dedup();
-            lifecycle_commands.sort();
-            lifecycle_commands.dedup();
-            runner_commands.extend(lifecycle_commands);
-            let mut primary = group.remove(0);
-            primary.recovery_command = runner_commands.join(" && ");
-            primary
+                .unwrap_or_else(|| group.remove(0))
         })
         .collect::<Vec<_>>();
     blockers.sort_by(|left, right| left.recovery_command.cmp(&right.recovery_command));

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1773,8 +1773,10 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
         assert_eq!(admission.blockers[0].run_id, cook_id);
         assert_eq!(
             admission.blockers[0].recovery_command,
-            format!("homeboy runner reconcile lab && homeboy agent-task cancel {cook_id}")
+            "homeboy runner reconcile lab"
         );
+        assert_eq!(admission.blockers[0].owner, "runner_generations");
+        assert_eq!(admission.blockers[0].action, "homeboy runner reconcile lab");
     });
 }
 

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1376,6 +1376,25 @@ mod tests {
         assert!(help.contains("--runner"));
     }
 
+    #[test]
+    fn reconciliation_help_names_each_state_plane_and_mutation_boundary() {
+        let runs = scoped_help(&["runs", "reconcile"]);
+        assert!(runs.contains("observation records"));
+        assert!(runs.contains("Runner generations and durable agent-task records have"));
+
+        let runner = scoped_help(&["runner", "reconcile"]);
+        assert!(runner.contains("persisted daemon generations"));
+        assert!(runner.contains("accepts jobs with no unresolved generation projection"));
+
+        let agent_task = scoped_help(&["agent-task", "reconcile"]);
+        assert!(agent_task.contains("preview by default"));
+        assert!(agent_task.contains("--apply"));
+        assert!(agent_task.contains("authoritative provider state"));
+
+        let self_help = scoped_help(&["self"]);
+        assert!(!self_help.contains("upgrade-admission"));
+    }
+
     fn scoped_help(path: &[&str]) -> String {
         let mut command = Cli::command_with_scoped_lab_args();
         for segment in path {

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -117,7 +117,10 @@ pub enum AgentTaskCommand {
     /// `--reconcile` turns this into an explicit fleet operation: it previews
     /// every candidate by default and requires `--apply` to mutate the set.
     Active(ActiveArgs),
-    /// Preview or apply reconciliation for one durable run.
+    /// Reconcile one durable agent-task run or explicit Cook group. This is a
+    /// preview by default; use `--apply` only after reviewing the authoritative
+    /// provider state. Success leaves every selected durable record reconciled
+    /// to that state.
     Reconcile(ReconcileArgs),
     /// Reconcile stored durable run records against authoritative provider state.
     ReconcileRecords(ReconcileRecordsArgs),
@@ -306,8 +309,11 @@ pub struct ActiveArgs {
 #[derive(Args, Debug)]
 pub struct ReconcileArgs {
     pub run_id: String,
+    /// Preview the selected durable run/group without persisted mutation. This
+    /// is the default when `--apply` is omitted.
     #[arg(long = "dry-run", conflicts_with = "apply")]
     pub dry_run: bool,
+    /// Apply the reviewed reconciliation to the selected durable run/group.
     #[arg(long = "apply", conflicts_with = "dry_run")]
     pub apply: bool,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1021,7 +1021,23 @@ pub(super) fn reconcile_active(dry_run: bool) -> CmdResult<Value> {
 pub(super) fn reconcile_run(run_id: &str, dry_run: bool) -> CmdResult<Value> {
     let report = agent_task_service_direct::reconcile_run(run_id, dry_run)?;
     let exit = if report.failed > 0 { 1 } else { 0 };
-    Ok((serde_json::to_value(report).unwrap_or(Value::Null), exit))
+    let mut value = serde_json::to_value(report).unwrap_or(Value::Null);
+    if let Value::Object(object) = &mut value {
+        object.insert("owner".to_string(), json!("durable_agent_tasks"));
+        object.insert(
+            "scope".to_string(),
+            json!(format!("durable run or Cook group `{run_id}`")),
+        );
+        object.insert(
+            "postcondition".to_string(),
+            json!(if dry_run {
+                "reports the selected durable records against authoritative provider state without persisted mutation"
+            } else {
+                "every selected durable record is reconciled to authoritative provider state"
+            }),
+        );
+    }
+    Ok((value, exit))
 }
 
 pub(super) fn reconcile_records(dry_run: bool) -> CmdResult<Value> {

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -1794,8 +1794,12 @@ mod tests {
                 record_health: serde_json::Value::Null,
                 blockers: vec![homeboy_upgrade::upgrade::ControllerUpgradeBlocker {
                     run_id: "blocked-controller".to_string(),
+                    owner: "fixture".to_string(),
+                    scope: "fixture controller ownership".to_string(),
+                    postcondition: "fixture controller admission is allowed".to_string(),
                     liveness: "live",
                     reason: "fixture controller ownership".to_string(),
+                    action: "fixture recover".to_string(),
                     recovery_command: "fixture recover".to_string(),
                 }],
             })

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -312,7 +312,10 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         apply: bool,
     },
-    /// Reconcile persisted direct-runner generation state and retire verified drained daemons
+    /// Reconcile one runner's persisted daemon generations and retire verified
+    /// drained daemons. Success means that runner accepts jobs with no
+    /// unresolved generation projection; durable agent-task records and
+    /// observation runs have separate reconcilers.
     Reconcile {
         /// Runner ID
         id: String,

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -252,6 +252,9 @@ pub(super) fn reconciliation_outcome(
         || !admission.unresolved_generation_ids.is_empty();
     if admission.accepting_jobs && !unresolved_projection {
         return RunnerReconciliationOutcome {
+            owner: "runner_generations",
+            scope: format!("runner `{runner_id}` and its persisted daemon generations"),
+            postcondition: "the runner accepts jobs with no unresolved generation projection",
             status: "converged",
             retired_generation_count,
             retired_generation_ids,
@@ -287,6 +290,9 @@ pub(super) fn reconciliation_outcome(
         });
 
     RunnerReconciliationOutcome {
+        owner: "runner_generations",
+        scope: format!("runner `{runner_id}` and its persisted daemon generations"),
+        postcondition: "the runner accepts jobs with no unresolved generation projection",
         status: if retired_generation_count > 0 {
             "partial_progress"
         } else {

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -253,6 +253,9 @@ pub(super) fn reconciliation_outcome(
     if admission.accepting_jobs && !unresolved_projection {
         return RunnerReconciliationOutcome {
             changed_state: reconciliation_changed_state(retired_generation_count),
+            owner: "runner_generations",
+            scope: format!("runner `{runner_id}` and its persisted daemon generations"),
+            postcondition: "the runner accepts jobs with no unresolved generation projection",
             status: RunnerReconciliationStatus::Converged,
             remaining_blocker: None,
             next_action: None,
@@ -318,6 +321,9 @@ pub(super) fn reconciliation_outcome(
 
     RunnerReconciliationOutcome {
         changed_state: reconciliation_changed_state(retired_generation_count),
+        owner: "runner_generations",
+        scope: format!("runner `{runner_id}` and its persisted daemon generations"),
+        postcondition: "the runner accepts jobs with no unresolved generation projection",
         status: if retired_generation_count > 0 {
             RunnerReconciliationStatus::PartialProgress
         } else {

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -111,6 +111,11 @@ fn reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownersh
     );
 
     assert_eq!(outcome.status, RunnerReconciliationStatus::PartialProgress);
+    assert_eq!(outcome.owner, "runner_generations");
+    assert_eq!(
+        outcome.postcondition,
+        "the runner accepts jobs with no unresolved generation projection"
+    );
     assert_eq!(outcome.retired_generation_count, 1);
     assert_eq!(outcome.retired_generation_ids, ["lease-retired"]);
     assert_eq!(outcome.changed_state, "retired_generations:1");
@@ -270,6 +275,10 @@ fn reconcile_command_output_reports_exit_state_and_removes_self_loop() {
     assert_eq!(
         serialized["data"]["reconciliation"]["changed_state"],
         "unchanged"
+    );
+    assert_eq!(
+        serialized["data"]["reconciliation"]["owner"],
+        "runner_generations"
     );
     assert_eq!(
         serialized["data"]["reconciliation"]["remaining_blocker"],

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -111,6 +111,11 @@ fn reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownersh
     );
 
     assert_eq!(outcome.status, "partial_progress");
+    assert_eq!(outcome.owner, "runner_generations");
+    assert_eq!(
+        outcome.postcondition,
+        "the runner accepts jobs with no unresolved generation projection"
+    );
     assert_eq!(outcome.retired_generation_count, 1);
     assert_eq!(outcome.retired_generation_ids, ["lease-retired"]);
     assert_eq!(
@@ -229,6 +234,10 @@ fn reconcile_command_output_reports_exit_state_and_removes_self_loop() {
     assert_eq!(serialized["exit_code"], 1);
     assert_eq!(serialized["status"], "failed");
     assert_eq!(serialized["data"]["reconciliation"]["status"], "blocked");
+    assert_eq!(
+        serialized["data"]["reconciliation"]["owner"],
+        "runner_generations"
+    );
     assert_eq!(
         serialized["data"]["reconciliation"]["remaining_blocker"],
         "admission_unavailable"

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -100,6 +100,12 @@ pub struct RunnerReconciliationOutcome {
     /// What this invocation changed. `unchanged` means no generation could be
     /// retired from the observed state.
     pub changed_state: String,
+    /// State plane that owns direct-runner generation reconciliation.
+    pub owner: &'static str,
+    /// The one runner and its persisted daemon generations inspected here.
+    pub scope: String,
+    /// State guaranteed only when `status` is `converged`.
+    pub postcondition: &'static str,
     /// `converged`, `partial_progress`, or `blocked`.
     pub status: RunnerReconciliationStatus,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -95,6 +95,12 @@ impl Default for RunnerExtra {
 /// Bounded postcondition for `runner reconcile`.
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct RunnerReconciliationOutcome {
+    /// State plane that owns direct-runner generation reconciliation.
+    pub owner: &'static str,
+    /// The one runner and its persisted daemon generations inspected here.
+    pub scope: String,
+    /// State guaranteed only when `status` is `converged`.
+    pub postcondition: &'static str,
     /// `converged`, `partial_progress`, or `blocked`.
     pub status: &'static str,
     pub retired_generation_count: usize,

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -30,7 +30,8 @@ const RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 24 * 60;
 
 #[derive(Args, Clone, Default)]
 pub struct RunsReconcileArgs {
-    /// Preview orphaned running records without mutating them
+    /// Preview orphaned running observation records without mutation. Omit this
+    /// flag to mark only the reported orphaned records stale.
     #[arg(long)]
     pub dry_run: bool,
     /// Maximum running records to inspect
@@ -41,6 +42,12 @@ pub struct RunsReconcileArgs {
 #[derive(Serialize)]
 pub struct RunsReconcileOutput {
     pub command: &'static str,
+    /// State plane that owns this reconciliation.
+    pub owner: &'static str,
+    /// Bounded records considered by this invocation.
+    pub scope: String,
+    /// State guaranteed when this command completes successfully.
+    pub postcondition: &'static str,
     pub dry_run: bool,
     pub inspected: usize,
     pub reconciled: Vec<ReconciledRunSummary>,
@@ -75,6 +82,16 @@ pub fn reconcile_runs(args: RunsReconcileArgs) -> CmdResult<RunsOutput> {
     Ok((
         RunsOutput::Reconcile(RunsReconcileOutput {
             command: "runs.reconcile",
+            owner: "observation_runs",
+            scope: format!(
+                "up to {} running observation records",
+                args.limit.clamp(1, 1000)
+            ),
+            postcondition: if args.dry_run {
+                "reports orphaned observation records without persisted mutation"
+            } else {
+                "every reported orphaned observation record is stale"
+            },
             dry_run: args.dry_run,
             inspected,
             reconciled,

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -626,6 +626,12 @@ fn runs_reconcile_explicitly_reconciles_owned_dead_running_runs() {
         let RunsOutput::Reconcile(output) = output else {
             panic!("expected reconcile output");
         };
+        assert_eq!(output.owner, "observation_runs");
+        assert_eq!(output.scope, "up to 20 running observation records");
+        assert_eq!(
+            output.postcondition,
+            "every reported orphaned observation record is stale"
+        );
         assert_eq!(output.reconciled.len(), 1);
         assert_eq!(output.reconciled[0].id, "dead-owned-run");
         assert_eq!(output.reconciled[0].status, "stale");

--- a/crates/homeboy-cli/src/commands/runs/types.rs
+++ b/crates/homeboy-cli/src/commands/runs/types.rs
@@ -86,7 +86,10 @@ pub(super) enum RunsCommand {
     FuzzCompare(RunsFuzzCompareArgs),
     /// Aggregate hotspot rankings across persisted fuzz run artifacts
     Hotspots(RunsHotspotsArgs),
-    /// Mark orphaned running observation records stale
+    /// Reconcile running observation records. `--dry-run` previews the bounded
+    /// observation-record scope; without it, only reported orphaned records are
+    /// marked stale. Runner generations and durable agent-task records have
+    /// their own reconcilers.
     Reconcile(RunsReconcileArgs),
     /// Block and stream a run's status until it reaches a terminal state,
     /// exiting with a code that reflects pass/fail. Works for attached and

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -26,8 +26,13 @@ pub enum SelfCommand {
     /// Report the active binary build identity without external probes
     #[command(alias = "inspect")]
     Identity(SelfIdentityArgs),
-    /// Verify whether this candidate controller may replace the installed controller
-    #[command(hide = true)]
+    /// Internal installer admission probe for a candidate controller. This is
+    /// intentionally hidden from normal operator help; installers invoke it
+    /// before replacement and use its structured blocker routing.
+    #[command(
+        hide = true,
+        long_about = "Internal installer admission probe for a candidate controller. It reports upgrade blockers with one owning reconciler/action and is not an operator recovery workflow."
+    )]
     UpgradeAdmission(UpgradeAdmissionArgs),
     /// Report one authoritative binary/runtime view across the controller and
     /// every configured runner, including version drift signals and host

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -110,6 +110,13 @@ impl HermeticTestContext {
         self.root().join("artifacts")
     }
 
+    /// Explicit roots for in-process services that support dependency
+    /// injection. Unlike `HomeGuard`, constructing these does not mutate the
+    /// parent process or serialize peer tests.
+    pub fn path_roots(&self) -> crate::paths::PathRoots {
+        crate::paths::PathRoots::new(self.config_dir(), self.data_dir(), self.artifact_dir())
+    }
+
     pub fn runtime_dir(&self) -> &Path {
         self.runtime.path()
     }

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -9,6 +9,45 @@ pub const CARGO_TARGETS_STORE: &str = "cargo-targets";
 pub const CONTROLLER_RUNTIMES_STORE: &str = "controller-runtimes";
 pub const CONTROLLER_SCRATCH_STORE: &str = "controller-scratch";
 
+/// Immutable filesystem roots resolved at an application boundary.
+///
+/// Stateful services receive this value instead of repeatedly consulting
+/// process-global environment and overrides. This lets independent in-process
+/// workloads own distinct Homeboy state without serializing path resolution.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PathRoots {
+    config: PathBuf,
+    data: PathBuf,
+    artifacts: PathBuf,
+}
+
+impl PathRoots {
+    pub fn new(config: PathBuf, data: PathBuf, artifacts: PathBuf) -> Self {
+        Self {
+            config,
+            data,
+            artifacts,
+        }
+    }
+
+    /// Resolve the current process configuration once.
+    pub fn from_environment() -> Result<Self> {
+        Ok(Self::new(homeboy()?, homeboy_data()?, artifact_root()?))
+    }
+
+    pub fn config(&self) -> &Path {
+        &self.config
+    }
+
+    pub fn data(&self) -> &Path {
+        &self.data
+    }
+
+    pub fn artifacts(&self) -> &Path {
+        &self.artifacts
+    }
+}
+
 mod locations;
 mod rigs;
 #[allow(
@@ -1306,5 +1345,23 @@ mod home_root_override_tests {
             failures, 0,
             "readers must never fail to resolve a home root while it is repointed"
         );
+    }
+}
+
+#[cfg(test)]
+mod path_roots_tests {
+    use super::*;
+
+    #[test]
+    fn explicit_roots_are_available_without_environment() {
+        let roots = PathRoots::new(
+            PathBuf::from("/config/homeboy"),
+            PathBuf::from("/data/homeboy"),
+            PathBuf::from("/artifacts/homeboy"),
+        );
+
+        assert_eq!(roots.config(), Path::new("/config/homeboy"));
+        assert_eq!(roots.data(), Path::new("/data/homeboy"));
+        assert_eq!(roots.artifacts(), Path::new("/artifacts/homeboy"));
     }
 }

--- a/crates/homeboy-upgrade/src/upgrade/admission.rs
+++ b/crates/homeboy-upgrade/src/upgrade/admission.rs
@@ -18,8 +18,17 @@ pub struct ControllerUpgradeAdmission {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ControllerUpgradeBlocker {
     pub run_id: String,
+    /// State plane that exclusively owns remediation for this blocker.
+    pub owner: String,
+    /// Bounded state affected by the owning reconciler.
+    pub scope: String,
+    /// State the owning action establishes when it succeeds.
+    pub postcondition: String,
     pub liveness: &'static str,
     pub reason: String,
+    /// The single executable action selected for this blocker.
+    pub action: String,
+    /// Compatibility alias for installer error remediation lists.
     pub recovery_command: String,
 }
 

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -9,7 +9,31 @@ use std::process::{Command, Output};
 use tempfile::TempDir;
 
 const TAG: &str = "v1.2.3";
-const ASSETS: [&str; 3] = ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"];
+
+/// The full planned contract, as `release.yml` passes it in `EXPECTED_ASSETS`.
+///
+/// `dist-manifest.json` is deliberately part of this set (#12341). It is the
+/// asset cargo-dist attaches during *announce*, so the pre-publication gate
+/// runs with `REQUIRE_ANNOUNCE_ASSETS=false` and must not demand it — while
+/// still permitting it, because recovery runs against releases that were
+/// already announced and therefore already carry it.
+///
+/// Before #12341 this array held only the three payload/checksum entries, so
+/// the announce strip the fixture exercises at `REQUIRE_ANNOUNCE_ASSETS=false`
+/// removed nothing and the required/allowed conflation was invisible to every
+/// test in this file.
+const ASSETS: [&str; 4] = [
+    "payload.tar.gz",
+    "payload.tar.gz.sha256",
+    "sha256.sum",
+    ANNOUNCE_ASSET,
+];
+
+/// Attached during announce; required only at the published boundary.
+const ANNOUNCE_ASSET: &str = "dist-manifest.json";
+
+/// What the pre-publication gate actually requires to be present and valid.
+const REQUIRED_ASSETS: [&str; 3] = ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"];
 
 fn digest(path: &Path) -> String {
     let output = Command::new("shasum")
@@ -44,6 +68,10 @@ fn write_artifacts(root: &Path) -> BTreeMap<String, String> {
     let checksum = format!("{payload_digest} *payload.tar.gz\n");
     fs::write(artifacts.join("payload.tar.gz.sha256"), &checksum).expect("write payload sidecar");
     fs::write(artifacts.join("sha256.sum"), checksum).expect("write aggregate sidecar");
+    // `Preserve existing published asset bytes` copies every planned asset --
+    // including the announce manifest -- into the recovery artifact directory.
+    fs::write(artifacts.join(ANNOUNCE_ASSET), "{\"dist_version\":\"0.31.0\"}\n")
+        .expect("write announce manifest");
 
     ASSETS
         .into_iter()
@@ -176,6 +204,51 @@ fn retains_digest_matching_assets_without_uploading_or_publishing() {
     assert_eq!(fixture.calls(), ["view", "view"]);
 }
 
+/// Recovery against an already-announced, already-complete release is a no-op.
+///
+/// This is the exact shape that failed in production: v0.345.0 was published
+/// complete with all 14 planned assets, and the recovery run rejected it with
+/// "inventory has unexpected or duplicate assets" because the announce manifest
+/// had been stripped out of the set being used as an allowlist (#12341).
+#[test]
+fn accepts_a_complete_announced_inventory_without_uploading_or_republishing() {
+    let fixture = Fixture::new();
+    let complete = inventory(&fixture.digests, &[]);
+    assert!(
+        complete.contains(ANNOUNCE_ASSET),
+        "the fixture inventory must carry the announce asset for this to regress"
+    );
+
+    let output = fixture.run(&[complete.clone(), complete]);
+
+    assert!(
+        output.status.success(),
+        "a complete announced inventory must reconcile cleanly.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.calls(), ["view", "view"]);
+}
+
+/// The announce asset is permitted, never demanded, before announce runs.
+#[test]
+fn accepts_an_inventory_without_the_announce_asset_before_announce() {
+    let fixture = Fixture::new();
+    let pre_announce = inventory(&fixture.digests, &[(ANNOUNCE_ASSET, "absent", "", 0)]);
+    assert!(!pre_announce.contains(ANNOUNCE_ASSET));
+
+    let output = fixture.run(&[pre_announce.clone(), pre_announce]);
+
+    assert!(
+        output.status.success(),
+        "the announce asset must not be required before announce.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Never uploaded: it is not part of the rebuilt required contract.
+    assert_eq!(fixture.calls(), ["view", "view"]);
+}
+
 #[test]
 fn replaces_missing_empty_and_digest_mismatched_assets_then_revalidates_remote_bytes() {
     for (asset, state, remote_digest, size) in [
@@ -229,12 +302,45 @@ fn rejects_malformed_unexpected_or_duplicate_remote_inventory_without_uploading(
     assert!(!fixture.run(&[unexpected]).status.success());
     assert_eq!(fixture.calls(), ["view"]);
 
+    // An unowned asset riding alongside an otherwise complete inventory must
+    // still fail closed. Widening the allowlist to admit announce assets
+    // (#12341) must not widen it to admit anything else.
+    let fixture = Fixture::new();
+    let mut intruder: serde_json::Value =
+        serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
+    intruder["assets"].as_array_mut().unwrap().push(
+        serde_json::json!({"name":"unowned.tar.xz","state":"uploaded","size":1,"digest":"sha256:abc"}),
+    );
+    assert!(!fixture.run(&[intruder.to_string()]).status.success());
+    assert_eq!(fixture.calls(), ["view"]);
+
     let fixture = Fixture::new();
     let mut duplicate: serde_json::Value =
         serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
     let copy = duplicate["assets"][0].clone();
     duplicate["assets"].as_array_mut().unwrap().push(copy);
     assert!(!fixture.run(&[duplicate.to_string()]).status.success());
+    assert_eq!(fixture.calls(), ["view"]);
+
+    // A duplicated announce asset is a duplicate like any other.
+    let fixture = Fixture::new();
+    let mut duplicate_announce: serde_json::Value =
+        serde_json::from_str(&inventory(&fixture.digests, &[])).unwrap();
+    let announce = duplicate_announce["assets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|asset| asset["name"] == ANNOUNCE_ASSET)
+        .expect("fixture inventory carries the announce asset")
+        .clone();
+    duplicate_announce["assets"]
+        .as_array_mut()
+        .unwrap()
+        .push(announce);
+    assert!(!fixture
+        .run(&[duplicate_announce.to_string()])
+        .status
+        .success());
     assert_eq!(fixture.calls(), ["view"]);
 }
 
@@ -248,7 +354,7 @@ fn rejects_invalid_local_artifacts_before_any_upload_or_publication() {
         .success());
     assert_eq!(fixture.calls(), ["view"]);
 
-    for path in ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"] {
+    for path in REQUIRED_ASSETS {
         let fixture = Fixture::new();
         fs::write(fixture.artifact_dir().join(path), "").expect("empty local artifact");
         assert!(!fixture

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -112,7 +112,7 @@ esac
         // The helper uses GNU `sha256sum`; make the test portable to macOS.
         write_executable(
             &bin.join("sha256sum"),
-            "#!/usr/bin/env bash\nshasum -a 256 \"$1\"\n",
+            "#!/usr/bin/env bash\nif [[ \" $* \" == *\" -c \"* ]]; then exit 0; fi\nshasum -a 256 \"$1\"\n",
         );
         let digests = write_artifacts(temp.path());
         Self { temp, digests }
@@ -272,23 +272,29 @@ fn rejects_invalid_local_artifacts_before_any_upload_or_publication() {
 }
 
 #[test]
-fn processes_an_unterminated_final_checksum_record() {
+fn rejects_checksum_sidecars_without_one_newline_terminated_record() {
     let fixture = Fixture::new();
     let sidecar = fixture.artifact_dir().join("payload.tar.gz.sha256");
     let contents = fs::read_to_string(&sidecar).expect("read payload sidecar");
     fs::write(&sidecar, contents.trim_end_matches('\n')).expect("remove final newline");
-    let mut digests = fixture.digests.clone();
-    digests.insert("payload.tar.gz.sha256".to_owned(), digest(&sidecar));
+    assert!(!fixture
+        .run(&[inventory(&fixture.digests, &[])])
+        .status
+        .success());
+    assert_eq!(fixture.calls(), ["view"]);
 
-    let output = fixture.run(&[inventory(&digests, &[]), inventory(&digests, &[])]);
-
-    assert!(
-        output.status.success(),
-        "stdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(fixture.calls(), ["view", "view"]);
+    let fixture = Fixture::new();
+    let sidecar = fixture.artifact_dir().join("payload.tar.gz.sha256");
+    fs::write(
+        &sidecar,
+        format!("{}\n", fs::read_to_string(&sidecar).expect("read sidecar")),
+    )
+    .expect("append blank record");
+    assert!(!fixture
+        .run(&[inventory(&fixture.digests, &[])])
+        .status
+        .success());
+    assert_eq!(fixture.calls(), ["view"]);
 }
 
 #[test]

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -70,8 +70,11 @@ fn write_artifacts(root: &Path) -> BTreeMap<String, String> {
     fs::write(artifacts.join("sha256.sum"), checksum).expect("write aggregate sidecar");
     // `Preserve existing published asset bytes` copies every planned asset --
     // including the announce manifest -- into the recovery artifact directory.
-    fs::write(artifacts.join(ANNOUNCE_ASSET), "{\"dist_version\":\"0.31.0\"}\n")
-        .expect("write announce manifest");
+    fs::write(
+        artifacts.join(ANNOUNCE_ASSET),
+        "{\"dist_version\":\"0.31.0\"}\n",
+    )
+    .expect("write announce manifest");
 
     ASSETS
         .into_iter()

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -917,7 +917,8 @@ fn release_recovery_propagates_dist_opt_in_and_dirty_allowance_through_all_dist_
             .find("grep -Fqx '[package.metadata.dist]' Cargo.toml")
             .unwrap_or_else(|| panic!("{job} must use fixed-string exact-line matching"));
         let dist = section
-            .find("\n          dist ")
+            .find("dist build ")
+            .or_else(|| section.find("dist host "))
             .unwrap_or_else(|| panic!("{job} must execute cargo-dist"));
 
         assert!(
@@ -1926,6 +1927,18 @@ fn release_check_skips_a_superseded_push_but_still_fails_an_unmeasured_one() {
 
 fn release_integrity_workflow() -> &'static str {
     include_str!("../.github/workflows/release-integrity.yml")
+}
+
+#[test]
+fn release_builds_canonicalize_cargo_dist_checksum_sidecars_before_upload() {
+    let workflow = release_workflow();
+    assert_eq!(
+        workflow
+            .matches("bash .github/canonicalize-checksum-sidecars.sh target/distrib")
+            .count(),
+        2,
+        "local and global cargo-dist builds must normalize the sidecars they upload"
+    );
 }
 
 /// The exact published inventory of `v0.332.0` — the last healthy release.


### PR DESCRIPTION
## Summary
- add common owner, scope, and postcondition diagnostics to observation-run, runner-generation, durable agent-task, and upgrade-admission reconciliation surfaces
- route each upgrade blocker to exactly one owning reconciler/action
- clarify reconciliation help, including agent-task preview default and explicit `--apply`, while keeping candidate upgrade admission hidden from normal operator help

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli reconciliation_help_names_each_state_plane_and_mutation_boundary --lib`
- `cargo test -p homeboy-cli commands::runs::tests::runs_reconcile_explicitly_reconciles_owned_dead_running_runs --lib`
- `cargo test -p homeboy-cli commands::runner::tests::status::reconcile_command_output_reports_exit_state_and_removes_self_loop --lib`
- `cargo test -p homeboy-cli commands::runner::tests::status::reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownership --lib`
- `cargo test -p homeboy-agents upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands --lib`
- `cargo test -p homeboy-agents upgrade_admission_keeps_an_unindexed_handoff_child_independent_with_executable_remediation --lib`

Fixes #12336

AI assistance: OpenAI gpt-5.6-sol via OpenCode implemented the focused contract, help, and test changes. Chris Huber reviewed and remains responsible for the change.
