### PR TITLE
fix: validate installer archive members

### DIFF
--- a/scripts/homeboy-installer.sh
+++ b/scripts/homeboy-installer.sh
@@ -37,12 +37,55 @@ else
   [ "$expected" = "$actual" ]
 fi
 
-(cd "$TMP_DIR" && tar -xJf "$ASSET" 2>/dev/null || tar -xf "$ASSET")
-EXTRACTED_BIN="$TMP_DIR/${ASSET%.tar.xz}/homeboy"
-if [ ! -f "$EXTRACTED_BIN" ]; then
-  echo "Expected extracted binary named homeboy" >&2
+CANDIDATE="${ASSET%.tar.xz}/homeboy"
+MEMBERS="$(tar -tJf "$TMP_DIR/$ASSET" 2>/dev/null || tar -tf "$TMP_DIR/$ASSET")" || {
+  echo "Unable to list release archive" >&2
+  exit 1
+}
+CANDIDATE_COUNT=0
+while IFS= read -r member; do
+  member="${member#./}"
+  case "$member" in
+    '' | /* | ../* | */../* | */.. | *//*)
+      echo "Release archive contains an unsafe member path" >&2
+      exit 1
+      ;;
+  esac
+  case "$member" in
+    homeboy | */homeboy)
+      if [ "$member" = "$CANDIDATE" ]; then
+        CANDIDATE_COUNT=$((CANDIDATE_COUNT + 1))
+      else
+        echo "Release archive contains an additional homeboy candidate" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done <<EOF
+$MEMBERS
+EOF
+if [ "$CANDIDATE_COUNT" -ne 1 ]; then
+  echo "Release archive must contain exactly one homeboy candidate" >&2
   exit 1
 fi
+
+CANDIDATE_DETAILS="$(tar -tvJf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -tvf "$TMP_DIR/$ASSET" "$CANDIDATE")" || {
+  echo "Unable to inspect release candidate" >&2
+  exit 1
+}
+case "$CANDIDATE_DETAILS" in
+  -*) ;;
+  *)
+    echo "Release archive candidate must be a regular file" >&2
+    exit 1
+    ;;
+esac
+
+EXTRACTED_BIN="$TMP_DIR/homeboy"
+(tar -xJOf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -xOf "$TMP_DIR/$ASSET" "$CANDIDATE") > "$EXTRACTED_BIN" || {
+  echo "Unable to extract release candidate" >&2
+  exit 1
+}
 chmod 0755 "$EXTRACTED_BIN"
 
 # The staged candidate owns admission; any failure exits before the installed

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -3,6 +3,19 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
+const TARGET: &str = "homeboy-x86_64-unknown-linux-gnu";
+
+#[derive(Clone, Copy)]
+enum ArchiveFixture {
+    Valid,
+    MissingCandidate,
+    AdditionalCandidate,
+    Traversal,
+    Absolute,
+    SymlinkCandidate,
+    HardlinkCandidate,
+}
+
 fn write_executable(path: &Path, contents: &str) {
     fs::write(path, contents).expect("write executable");
     let mut permissions = fs::metadata(path).expect("metadata").permissions();
@@ -10,7 +23,62 @@ fn write_executable(path: &Path, contents: &str) {
     fs::set_permissions(path, permissions).expect("set executable permissions");
 }
 
+fn archive(root: &Path, destination: &Path, fixture: ArchiveFixture) {
+    let target = root.join(TARGET);
+    fs::create_dir_all(&target).expect("target directory");
+    let candidate = target.join("homeboy");
+    write_executable(
+        &candidate,
+        "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = upgrade-admission ]; then\n  printf '%s|%s\\n' \"$0\" \"$4\" > \"$HOMEBOY_TEST_EVIDENCE\"\n  printf 'admission\\n' >> \"$HOMEBOY_TEST_EVENTS\"\n  exit ${HOMEBOY_TEST_CANDIDATE_EXIT:-0}\nfi\nexit 64\n",
+    );
+
+    let mut entries = vec![TARGET.to_string()];
+    let mut transform = None;
+    match fixture {
+        ArchiveFixture::Valid => {}
+        ArchiveFixture::MissingCandidate => {
+            fs::remove_file(&candidate).expect("remove candidate");
+            fs::write(target.join("not-homeboy"), "not a candidate").expect("write fixture");
+        }
+        ArchiveFixture::AdditionalCandidate => {
+            let additional = root.join("other");
+            fs::create_dir_all(&additional).expect("additional directory");
+            write_executable(&additional.join("homeboy"), "#!/bin/sh\nexit 0\n");
+            entries.push("other".to_string());
+        }
+        ArchiveFixture::Traversal | ArchiveFixture::Absolute => {
+            fs::remove_dir_all(&target).expect("remove target");
+            fs::write(root.join("payload"), "unsafe").expect("write payload");
+            entries = vec!["payload".to_string()];
+            transform = Some(match fixture {
+                ArchiveFixture::Traversal => ",^payload$,../payload,",
+                ArchiveFixture::Absolute => ",^payload$,/payload,",
+                _ => unreachable!(),
+            });
+        }
+        ArchiveFixture::SymlinkCandidate => {
+            fs::remove_file(&candidate).expect("remove candidate");
+            std::os::unix::fs::symlink("elsewhere", &candidate).expect("symlink candidate");
+        }
+        ArchiveFixture::HardlinkCandidate => {
+            let original = root.join("original");
+            fs::rename(&candidate, &original).expect("move candidate");
+            fs::hard_link(&original, &candidate).expect("hardlink candidate");
+            entries = vec!["original".to_string(), TARGET.to_string()];
+        }
+    }
+
+    let mut command = Command::new("tar");
+    command.args(["-cJf"]).arg(destination).arg("-C").arg(root);
+    if let Some(transform) = transform {
+        command.arg("-s").arg(transform);
+    }
+    command.args(entries);
+    assert!(command.status().expect("create archive").success());
+}
+
 fn run_installer(
+    fixture: ArchiveFixture,
     candidate_exit: i32,
     legacy_installed: bool,
     force_sudo: bool,
@@ -22,13 +90,9 @@ fn run_installer(
     let installed = install_dir.join("homeboy");
     let evidence = temp.path().join("admission-evidence");
     let events = temp.path().join("events");
-    let candidate = temp.path().join("candidate");
-    write_executable(
-        &candidate,
-        &format!(
-            "#!/bin/sh\nif [ \"$1\" = self ] && [ \"$2\" = upgrade-admission ]; then\n  printf '%s|%s\\n' \"$0\" \"$4\" > \"$HOMEBOY_TEST_EVIDENCE\"\n  printf 'admission\\n' >> \"$HOMEBOY_TEST_EVENTS\"\n  exit {candidate_exit}\nfi\nexit 64\n"
-        ),
-    );
+    let archive_path = temp.path().join("homeboy.tar.xz");
+    let archive_root = temp.path().join("archive-root");
+    archive(&archive_root, &archive_path, fixture);
     if legacy_installed {
         fs::create_dir_all(&install_dir).expect("install directory");
         write_executable(
@@ -38,15 +102,11 @@ fn run_installer(
     }
     write_executable(
         &tools.join("curl"),
-        "#!/bin/sh\nout=\nfor arg in \"$@\"; do [ \"$previous\" = -o ] && out=\"$arg\"; previous=\"$arg\"; done\ncase \"$out\" in *.sha256) printf 'unused  homeboy.tar.xz\\n' > \"$out\" ;; *) : > \"$out\" ;; esac\n",
+        "#!/bin/sh\nout=\nfor arg in \"$@\"; do [ \"$previous\" = -o ] && out=\"$arg\"; previous=\"$arg\"; done\ncase \"$out\" in *.sha256) printf 'unused  homeboy.tar.xz\\n' > \"$out\" ;; *) cp \"$HOMEBOY_TEST_ARCHIVE\" \"$out\" ;; esac\n",
     );
     write_executable(
         &tools.join("sha256sum"),
         "#!/bin/sh\nprintf 'homeboy.tar.xz: OK\\n'\n",
-    );
-    write_executable(
-        &tools.join("tar"),
-        "#!/bin/sh\nmkdir -p \"$HOMEBOY_TEST_ARCHIVE_DIR\"\ncp \"$HOMEBOY_TEST_CANDIDATE\" \"$HOMEBOY_TEST_ARCHIVE_DIR/homeboy\"\n",
     );
     write_executable(
         &tools.join("uname"),
@@ -63,14 +123,11 @@ fn run_installer(
             "/scripts/homeboy-installer.sh"
         ))
         .env("HOMEBOY_INSTALL_PATH", &installed)
-        .env("HOMEBOY_TEST_CANDIDATE", &candidate)
+        .env("HOMEBOY_TEST_ARCHIVE", &archive_path)
+        .env("HOMEBOY_TEST_CANDIDATE_EXIT", candidate_exit.to_string())
         .env("HOMEBOY_TEST_EVIDENCE", &evidence)
         .env("HOMEBOY_TEST_EVENTS", &events)
         .env("HOMEBOY_TEST_BIN_DIR", &install_dir)
-        .env(
-            "HOMEBOY_TEST_ARCHIVE_DIR",
-            "homeboy-x86_64-unknown-linux-gnu",
-        )
         .env("PATH", format!("{}:/usr/bin:/bin", tools.display()));
     if force_sudo {
         command.env("HOMEBOY_INSTALL_USE_SUDO", "true");
@@ -84,14 +141,18 @@ fn run_installer(
 
 #[test]
 fn installer_admits_a_staged_candidate_and_preserves_bytes_on_admission_failure() {
-    let (allowed, installed, evidence, _) = run_installer(0, true, false);
+    let (allowed, installed, evidence, _) = run_installer(ArchiveFixture::Valid, 0, true, false);
     assert!(allowed.status.success(), "{allowed:?}");
     assert!(installed.contains("upgrade-admission"));
     assert!(evidence.contains("legacy-controller-identity"));
-    assert!(evidence.contains("/homeboy-x86_64-unknown-linux-gnu/homeboy"));
+    assert!(evidence
+        .split('|')
+        .next()
+        .is_some_and(|candidate| candidate.ends_with("/homeboy")));
 
     for exit_code in [1, 70] {
-        let (blocked, installed, evidence, _) = run_installer(exit_code, true, false);
+        let (blocked, installed, evidence, _) =
+            run_installer(ArchiveFixture::Valid, exit_code, true, false);
         assert!(!blocked.status.success());
         assert!(installed.contains("legacy-controller-identity"));
         assert!(evidence.contains("legacy-controller-identity"));
@@ -100,7 +161,7 @@ fn installer_admits_a_staged_candidate_and_preserves_bytes_on_admission_failure(
 
 #[test]
 fn installer_creates_a_first_install_parent_before_staging_the_replacement() {
-    let (output, installed, evidence, _) = run_installer(0, false, false);
+    let (output, installed, evidence, _) = run_installer(ArchiveFixture::Valid, 0, false, false);
 
     assert!(output.status.success(), "{output:?}");
     assert!(installed.contains("upgrade-admission"));
@@ -109,7 +170,7 @@ fn installer_creates_a_first_install_parent_before_staging_the_replacement() {
 
 #[test]
 fn installer_uses_privileged_atomic_replacement_after_staged_admission() {
-    let (output, installed, evidence, events) = run_installer(0, true, true);
+    let (output, installed, evidence, events) = run_installer(ArchiveFixture::Valid, 0, true, true);
 
     assert!(output.status.success(), "{output:?}");
     assert!(installed.contains("upgrade-admission"));
@@ -118,4 +179,22 @@ fn installer_uses_privileged_atomic_replacement_after_staged_admission() {
         events.lines().collect::<Vec<_>>(),
         ["admission", "sudo:install", "sudo:mv"]
     );
+}
+
+#[test]
+fn installer_rejects_unsafe_or_ambiguous_archive_members_before_admission() {
+    for fixture in [
+        ArchiveFixture::MissingCandidate,
+        ArchiveFixture::AdditionalCandidate,
+        ArchiveFixture::Traversal,
+        ArchiveFixture::Absolute,
+        ArchiveFixture::SymlinkCandidate,
+        ArchiveFixture::HardlinkCandidate,
+    ] {
+        let (output, installed, evidence, events) = run_installer(fixture, 0, true, false);
+        assert!(!output.status.success(), "{output:?}");
+        assert!(installed.contains("legacy-controller-identity"));
+        assert!(evidence.is_empty());
+        assert!(events.is_empty());
+    }
 }


### PR DESCRIPTION
Fixes #12306

The installer now lists and validates archive members before extraction, requires exactly one regular `homeboy` candidate at cargo-dist's target directory, and streams only that member into the staged candidate. It rejects traversal, absolute and duplicate-path entries, missing or additional executable candidates, and symlink or hardlink candidates before upgrade admission.

Tests:
- `cargo test --test homeboy_installer_test`
- `cargo fmt --check`
- `shellcheck -S warning scripts/homeboy-installer.sh`

AI assistance: OpenAI `gpt-5.6-sol` via OpenCode was used to review the installer contract, implement the archive-member validation, add fixture coverage, and run verification. Chris Huber remains responsible for every line.