### PR TITLE
Honor daemon candidate state directories

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -34,9 +34,9 @@ use super::{
 const TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV: &str = "HOMEBOY_TEST_KEEP_DAEMON_IN_PROCESS_GROUP";
 
 /// Enumerate foreground daemon processes without inferring ownership from a
-/// command substring. A candidate is an owner only when its explicit HOME
-/// environment resolves to this durable store and its executable is the active
-/// binary; absent evidence remains ambiguous.
+/// command substring. A candidate is an owner only when its explicit state
+/// store resolves to this durable store and its executable is the active binary;
+/// absent evidence remains ambiguous.
 pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonProcessCandidate>> {
     // macOS cannot expose another process's environment through `ps`, so a live
     // operator daemon has no durable-store evidence there. Test harnesses opt
@@ -69,9 +69,14 @@ pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonPr
         .lines()
         .filter_map(|line| parse_daemon_process_candidate(line, jobs_path, current_exe.as_deref()))
         .map(|mut candidate| {
-            if let Some(store) = process_durable_store_path(candidate.pid) {
-                candidate.durable_store_path = Some(store.display().to_string());
-                candidate.ownership = classify_candidate_store(&candidate, jobs_path, &store);
+            if matches!(
+                command_state_dir(&candidate.cmdline),
+                CommandStateDir::Absent
+            ) {
+                if let Some(store) = process_durable_store_path(candidate.pid) {
+                    candidate.durable_store_path = Some(store.display().to_string());
+                    candidate.ownership = classify_candidate_store(&candidate, jobs_path, &store);
+                }
             }
             if test_namespace && candidate.durable_store_path.as_deref() != jobs_path.to_str() {
                 candidate.ownership = DaemonProcessOwnership::Unrelated;
@@ -277,17 +282,28 @@ fn parse_daemon_process_candidate(
         .collect::<Vec<_>>()
         .windows(2)
         .find_map(|pair| (pair[0] == "--addr").then(|| pair[1].to_string()));
-    let state_dir = cmdline
-        .split_whitespace()
-        .find_map(|part| part.strip_prefix(crate::paths::DAEMON_STATE_DIR_ENV))
-        .and_then(|value| value.strip_prefix('='))
-        .filter(|value| !value.trim().is_empty());
-    let home = cmdline
-        .split_whitespace()
-        .find_map(|part| part.strip_prefix("HOME="));
-    let durable_store_path = state_dir
-        .map(|state_dir| Path::new(state_dir).join("jobs.json"))
-        .or_else(|| home.map(|home| Path::new(home).join(".config/homeboy/daemon/jobs.json")));
+    let durable_store_path = match command_state_dir(&cmdline) {
+        CommandStateDir::Proven(state_dir) => Some(durable_store_path(Path::new(state_dir))),
+        // `ps` command text cannot preserve an argv boundary inside a quoted or
+        // whitespace-bearing path. Do not substitute a lower-priority store.
+        CommandStateDir::Ambiguous => None,
+        CommandStateDir::Absent => match command_environment_value(
+            &cmdline,
+            &executable,
+            crate::paths::DAEMON_STATE_DIR_ENV,
+        ) {
+            CommandTextValue::Proven(state_dir) => Some(durable_store_path(Path::new(state_dir))),
+            CommandTextValue::Ambiguous => None,
+            CommandTextValue::Absent => {
+                match command_environment_value(&cmdline, &executable, "HOME") {
+                    CommandTextValue::Proven(home) => Some(durable_store_path(
+                        &Path::new(home).join(".config/homeboy/daemon"),
+                    )),
+                    CommandTextValue::Absent | CommandTextValue::Ambiguous => None,
+                }
+            }
+        },
+    };
     let executable_matches = current_exe.is_some_and(|current| {
         Path::new(&executable).canonicalize().ok().as_deref() == Some(current)
     });
@@ -316,12 +332,96 @@ fn command_has_daemon_serve(cmdline: &str) -> bool {
         .any(|arguments| arguments == ["daemon", "serve"])
 }
 
+enum CommandStateDir<'a> {
+    Absent,
+    Proven(&'a str),
+    Ambiguous,
+}
+
+enum CommandTextValue<'a> {
+    Absent,
+    Proven(&'a str),
+    Ambiguous,
+}
+
+fn command_state_dir(cmdline: &str) -> CommandStateDir<'_> {
+    let arguments = cmdline.split_whitespace().collect::<Vec<_>>();
+    let Some((index, argument)) = arguments
+        .iter()
+        .enumerate()
+        .find(|(_, argument)| **argument == "--state-dir" || argument.starts_with("--state-dir="))
+    else {
+        return CommandStateDir::Absent;
+    };
+
+    let value = if *argument == "--state-dir" {
+        arguments.get(index + 1).copied()
+    } else {
+        argument.strip_prefix("--state-dir=")
+    };
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return CommandStateDir::Ambiguous;
+    };
+
+    // `ps` renders argv as whitespace-delimited text. A state-dir is exact only
+    // at the end of that rendering and without shell quoting or escaping.
+    if index + if *argument == "--state-dir" { 2 } else { 1 } != arguments.len()
+        || value.contains(['\'', '"', '\\'])
+    {
+        CommandStateDir::Ambiguous
+    } else {
+        CommandStateDir::Proven(value)
+    }
+}
+
+fn command_environment_value<'a>(
+    cmdline: &'a str,
+    executable: &str,
+    key: &str,
+) -> CommandTextValue<'a> {
+    let arguments = cmdline.split_whitespace().collect::<Vec<_>>();
+    let Some((index, value)) = arguments.iter().enumerate().find_map(|(index, argument)| {
+        argument
+            .strip_prefix(key)
+            .and_then(|value| value.strip_prefix('='))
+            .map(|value| (index, value))
+    }) else {
+        return CommandTextValue::Absent;
+    };
+    if value.trim().is_empty() || value.contains(['\'', '"', '\\']) {
+        return CommandTextValue::Ambiguous;
+    }
+
+    // `ps` renders the environment and argv as whitespace-delimited text. The
+    // assignment is trustworthy only when its following command boundary is
+    // proven by the executable field; otherwise it may be a path fragment.
+    match arguments[index + 1..]
+        .iter()
+        .find(|argument| !argument.contains('='))
+    {
+        Some(command) if *command == executable => CommandTextValue::Proven(value),
+        Some(_) | None => CommandTextValue::Ambiguous,
+    }
+}
+
+fn durable_store_path(state_dir: &Path) -> PathBuf {
+    state_dir.join("jobs.json")
+}
+
+fn normalize_durable_store_path(store: &Path) -> PathBuf {
+    let parent = store.parent().expect("jobs file has a parent");
+    parent
+        .canonicalize()
+        .map(|parent| parent.join("jobs.json"))
+        .unwrap_or_else(|_| store.to_path_buf())
+}
+
 fn classify_candidate_store(
     candidate: &DaemonProcessCandidate,
     jobs_path: &Path,
     store: &Path,
 ) -> DaemonProcessOwnership {
-    if store != jobs_path {
+    if normalize_durable_store_path(store) != normalize_durable_store_path(jobs_path) {
         DaemonProcessOwnership::Unrelated
     } else if candidate.build_identity.is_some() {
         DaemonProcessOwnership::Owning
@@ -344,11 +444,11 @@ fn process_durable_store_path(pid: u32) -> Option<PathBuf> {
     };
     assignment(crate::paths::DAEMON_STATE_DIR_ENV)
         .filter(|value| !value.is_empty())
-        .map(|value| Path::new(value).join("jobs.json"))
+        .map(|value| durable_store_path(Path::new(value)))
         .or_else(|| {
             assignment("HOME")
                 .filter(|value| !value.is_empty())
-                .map(|value| Path::new(value).join(".config/homeboy/daemon/jobs.json"))
+                .map(|value| durable_store_path(&Path::new(value).join(".config/homeboy/daemon")))
         })
 }
 

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -392,6 +392,143 @@ fn daemon_process_attribution_matches_explicit_state_directory_store() {
 }
 
 #[test]
+fn daemon_process_attribution_keeps_whitespace_environment_assignments_ambiguous() {
+    let root = tempfile::tempdir().expect("state root");
+    let state_dir = root.path().join("state directory");
+    let home = root.path().join("home directory");
+    std::fs::create_dir(&state_dir).expect("state directory");
+    std::fs::create_dir(&home).expect("home directory");
+    let executable = std::env::current_exe().expect("current executable");
+
+    for assignment in [
+        format!("HOMEBOY_DAEMON_STATE_DIR={}", state_dir.display()),
+        format!("HOME={}", home.display()),
+    ] {
+        let line = format!(
+            "4243 {} {} {} daemon serve --addr 127.0.0.1:7421",
+            executable.display(),
+            assignment,
+            executable.display(),
+        );
+        let candidate = super::parse_daemon_process_candidate(
+            &line,
+            &state_dir.join("jobs.json"),
+            Some(&executable),
+        )
+        .expect("candidate");
+        assert_eq!(
+            candidate.ownership,
+            super::super::DaemonProcessOwnership::Ambiguous,
+            "{assignment}"
+        );
+        assert_eq!(candidate.durable_store_path, None, "{assignment}");
+    }
+}
+
+#[test]
+fn daemon_process_attribution_matches_state_directory_argument() {
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let jobs = state_dir.path().join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+
+    for state_dir_argument in [
+        format!("--state-dir {}", state_dir.path().display()),
+        format!("--state-dir={}", state_dir.path().display()),
+    ] {
+        let line = format!(
+            "4243 {} {} daemon serve --addr 127.0.0.1:7421 {}",
+            executable.display(),
+            executable.display(),
+            state_dir_argument,
+        );
+        let candidate = super::parse_daemon_process_candidate(&line, &jobs, Some(&executable))
+            .expect("candidate");
+        assert_eq!(
+            candidate.ownership,
+            super::super::DaemonProcessOwnership::Owning,
+            "{state_dir_argument}"
+        );
+        assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+    }
+}
+
+#[test]
+fn daemon_process_attribution_keeps_whitespace_state_directory_arguments_ambiguous() {
+    let root = tempfile::tempdir().expect("state root");
+    let state_dir = root.path().join("state directory");
+    std::fs::create_dir(&state_dir).expect("state directory");
+    let jobs = state_dir.join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+
+    for state_dir_argument in [
+        format!("--state-dir {}", state_dir.display()),
+        format!("--state-dir={}", state_dir.display()),
+        format!("--state-dir \"{}\"", state_dir.display()),
+        format!("--state-dir=\"{}\"", state_dir.display()),
+    ] {
+        let line = format!(
+            "4243 {} {} daemon serve {}",
+            executable.display(),
+            executable.display(),
+            state_dir_argument,
+        );
+        let candidate = super::parse_daemon_process_candidate(&line, &jobs, Some(&executable))
+            .expect("candidate");
+        assert_eq!(
+            candidate.ownership,
+            super::super::DaemonProcessOwnership::Ambiguous,
+            "{state_dir_argument}"
+        );
+        assert_eq!(candidate.durable_store_path, None, "{state_dir_argument}");
+    }
+}
+
+#[test]
+fn daemon_process_attribution_keeps_same_state_directory_argument_ambiguous_without_binary_proof() {
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let jobs = state_dir.path().join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} {} daemon serve --state-dir {}",
+        executable.display(),
+        executable.display(),
+        state_dir.path().display(),
+    );
+
+    let candidate = super::parse_daemon_process_candidate(&line, &jobs, None).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Ambiguous
+    );
+    assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
+fn daemon_process_attribution_state_directory_argument_overrides_environment_and_home() {
+    let home = tempfile::tempdir().expect("home");
+    let environment_state_dir = tempfile::tempdir().expect("environment state directory");
+    let argument_state_dir = tempfile::tempdir().expect("argument state directory");
+    let jobs = argument_state_dir.path().join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} HOME={} HOMEBOY_DAEMON_STATE_DIR={} {} daemon serve --state-dir {}",
+        executable.display(),
+        home.path().display(),
+        environment_state_dir.path().display(),
+        executable.display(),
+        argument_state_dir.path().display(),
+    );
+
+    let candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, Some(&executable)).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Owning
+    );
+    assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
 fn daemon_process_attribution_proves_explicit_different_state_directory_unrelated() {
     let home = tempfile::tempdir().expect("home");
     let other_state_dir = tempfile::tempdir().expect("other state directory");
@@ -403,6 +540,32 @@ fn daemon_process_attribution_proves_explicit_different_state_directory_unrelate
         home.path().display(),
         other_state_dir.path().display(),
         executable.display()
+    );
+
+    let candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, Some(&executable)).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Unrelated
+    );
+    assert_eq!(
+        candidate.durable_store_path.as_deref(),
+        other_state_dir.path().join("jobs.json").to_str()
+    );
+}
+
+#[test]
+fn daemon_process_attribution_proves_state_directory_argument_different_store_unrelated() {
+    let home = tempfile::tempdir().expect("home");
+    let other_state_dir = tempfile::tempdir().expect("other state directory");
+    let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4244 {} HOME={} {} daemon serve --state-dir={}",
+        executable.display(),
+        home.path().display(),
+        executable.display(),
+        other_state_dir.path().display(),
     );
 
     let candidate =


### PR DESCRIPTION
## Summary
- Attribute daemon candidates using explicit `daemon serve --state-dir` arguments.
- Preserve CLI argument precedence over environment and HOME fallback.
- Fail closed when process-text argument or environment boundaries are ambiguous.

Closes #12311.

## Verification
- `cargo test -p homeboy-core daemon_process_attribution` (10 tests)
- `cargo fmt --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed the change and tests. Chris Huber reviewed and remains responsible for every line.
