### PR TITLE
Enforce monotonic runner recovery guidance

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
+++ b/crates/homeboy-cli/src/commands/runner/controller_ancestry.rs
@@ -37,13 +37,19 @@ const PROBE: &str = "controller_git_ancestry";
 /// an unbounded subprocess transcript.
 const MAX_DETAIL_CHARS: usize = 400;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CommitAncestry {
+    Ancestor,
+    NotAncestor,
+    Unavailable,
+}
+
 /// Is `older` an ancestor of `newer` in the controller's ambient checkout?
 ///
-/// Returns `false` when the question cannot be answered, which is the same
-/// conservative answer as "no": the caller falls back to the controller's own
-/// refresh ref. When the probe could not run at all, the reason is recorded as
-/// a degradation rather than printed or discarded.
-pub(super) fn commits_are_ancestral(older: &str, newer: &str) -> bool {
+/// An unavailable probe remains distinct from a real "not an ancestor" answer:
+/// recovery guidance must not turn an unknown build relationship into a
+/// potentially downgrading controller refresh.
+pub(super) fn commits_are_ancestral(older: &str, newer: &str) -> CommitAncestry {
     // `output()` captures both child streams. `status()` would inherit them and
     // print git's `fatal:` line straight past the structured envelope.
     ancestry_from_probe(
@@ -56,9 +62,9 @@ pub(super) fn commits_are_ancestral(older: &str, newer: &str) -> bool {
 /// Classify a completed probe. Split from the spawn so the "answered false"
 /// versus "could not answer" distinction is deterministically testable without
 /// depending on the machine's git or working directory.
-fn ancestry_from_probe(probe: std::io::Result<std::process::Output>) -> bool {
+fn ancestry_from_probe(probe: std::io::Result<std::process::Output>) -> CommitAncestry {
     match probe {
-        Ok(output) if output.status.success() => true,
+        Ok(output) if output.status.success() => CommitAncestry::Ancestor,
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stderr = stderr.trim();
@@ -67,12 +73,14 @@ fn ancestry_from_probe(probe: std::io::Result<std::process::Output>) -> bool {
             // diagnostic on stderr means the probe itself could not run.
             if !stderr.is_empty() {
                 record_unavailable(stderr);
+                CommitAncestry::Unavailable
+            } else {
+                CommitAncestry::NotAncestor
             }
-            false
         }
         Err(error) => {
             record_unavailable(&format!("git could not be executed: {error}"));
-            false
+            CommitAncestry::Unavailable
         }
     }
 }
@@ -151,7 +159,7 @@ mod tests {
         ));
 
         assert!(
-            !answer,
+            answer == CommitAncestry::Unavailable,
             "an unanswerable ancestry probe must not claim ancestry"
         );
         let degradations = readonly_probe::take_degradations();
@@ -174,10 +182,13 @@ mod tests {
     fn a_plain_non_ancestor_answer_records_nothing() {
         readonly_probe::take_degradations();
 
-        assert!(!ancestry_from_probe(probe(1, "")));
+        assert_eq!(
+            ancestry_from_probe(probe(1, "")),
+            CommitAncestry::NotAncestor
+        );
         assert!(readonly_probe::take_degradations().is_empty());
 
-        assert!(ancestry_from_probe(probe(0, "")));
+        assert_eq!(ancestry_from_probe(probe(0, "")), CommitAncestry::Ancestor);
         assert!(readonly_probe::take_degradations().is_empty());
     }
 
@@ -185,10 +196,13 @@ mod tests {
     fn a_missing_git_binary_is_reported_rather_than_swallowed() {
         readonly_probe::take_degradations();
 
-        assert!(!ancestry_from_probe(Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "no such file or directory",
-        ))));
+        assert_eq!(
+            ancestry_from_probe(Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no such file or directory",
+            ))),
+            CommitAncestry::Unavailable
+        );
 
         let degradations = readonly_probe::take_degradations();
         assert_eq!(degradations.len(), 1);

--- a/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
+++ b/crates/homeboy-cli/src/commands/runner/refresh_plan.rs
@@ -382,10 +382,14 @@ fn lab_homeboy_provenance_from_parts(
         purpose: "configured runner executable used for runner jobs and daemon refresh operations",
     };
 
-    let controller_refresh_ref = controller_identity
-        .git_commit
-        .clone()
-        .unwrap_or_else(|| format!("v{}", controller_identity.version));
+    let inspect_runner = shell_join(&[
+        "homeboy",
+        "runner",
+        "doctor",
+        runner_id,
+        "--scope",
+        "lab-offload",
+    ]);
     let mut diagnostics = Vec::new();
     if controller_identity.git_dirty == Some(true) {
         diagnostics.push(LabHomeboyProvenanceDiagnostic {
@@ -414,24 +418,7 @@ fn lab_homeboy_provenance_from_parts(
                         .unwrap_or("unknown")
                 ),
                 action: format!(
-                    "run `{}`; if active jobs are still running, wait for them or inspect with `{}` before reconnecting",
-                    shell_join(&[
-                        "homeboy",
-                        "runner",
-                        "refresh-homeboy",
-                        runner_id,
-                        "--ref",
-                        &controller_refresh_ref,
-                        "--reconnect"
-                    ]),
-                    shell_join(&[
-                        "homeboy",
-                        "runner",
-                        "doctor",
-                        runner_id,
-                        "--scope",
-                        "lab-offload"
-                    ])
+                    "inspect exact controller and active-daemon build identities with `{inspect_runner}` before selecting a refresh target; use --allow-downgrade only for an intentional rollback"
                 ),
             });
         } else if active_daemon
@@ -451,16 +438,7 @@ fn lab_homeboy_provenance_from_parts(
                         .unwrap_or("unknown")
                 ),
                 action: format!(
-                    "run `{}`; same-version build drift can be intentional for origin/main-style runner builds, but Lab proof should use matching controller and runner identities",
-                    shell_join(&[
-                        "homeboy",
-                        "runner",
-                        "refresh-homeboy",
-                        runner_id,
-                        "--ref",
-                        &controller_refresh_ref,
-                        "--reconnect"
-                    ])
+                    "inspect exact controller and active-daemon build identities with `{inspect_runner}`; same-version drift has no safe refresh target until ancestry is verified"
                 ),
             });
         }
@@ -497,7 +475,15 @@ fn lab_homeboy_provenance_from_parts(
                 "runner_stale_daemon"
             },
             message: stale_daemon.message.clone(),
-            action: stale_daemon.refresh_command.clone(),
+            action: stale_daemon
+                .safe_recovery_commands()
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| {
+                    format!(
+                        "inspect exact runner build identities with `{inspect_runner}` before selecting a refresh target"
+                    )
+                }),
         });
     }
 
@@ -1174,7 +1160,8 @@ mod tests {
             .contains("executes the runner job"));
         assert!(provenance.diagnostics[1]
             .action
-            .contains("homeboy runner refresh-homeboy lab-runner --ref controller123 --reconnect"));
+            .contains("inspect exact controller and active-daemon build identities"));
+        assert!(!provenance.diagnostics[1].action.contains("refresh-homeboy"));
         assert!(provenance.diagnostics[1]
             .action
             .contains("homeboy runner doctor lab-runner --scope lab-offload"));
@@ -1214,10 +1201,11 @@ mod tests {
         );
         assert!(provenance.diagnostics[0]
             .action
-            .contains("origin/main-style runner builds"));
+            .contains("same-version drift has no safe refresh target"));
         assert!(provenance.diagnostics[0]
             .action
-            .contains("homeboy runner refresh-homeboy lab-runner --ref controller123 --reconnect"));
+            .contains("homeboy runner doctor lab-runner --scope lab-offload"));
+        assert!(!provenance.diagnostics[0].action.contains("refresh-homeboy"));
     }
 
     #[test]
@@ -1240,6 +1228,44 @@ mod tests {
         assert!(provenance.diagnostics[0]
             .action
             .contains("homeboy runner doctor lab-runner --scope lab-offload"));
+    }
+
+    #[test]
+    fn homeboy_provenance_suppresses_an_unverified_persisted_refresh_command() {
+        let warning = RunnerStaleDaemonWarning::new(
+            "lab-runner",
+            "0.265.0".to_string(),
+            "0.265.0".to_string(),
+            Some("homeboy 0.265.0+aaaaaaaa".to_string()),
+            Some("homeboy 0.265.0+bbbbbbbb".to_string()),
+        );
+        let provenance = lab_homeboy_provenance_from_parts(
+            "lab-runner",
+            clean_controller_identity(),
+            Some("/controller/homeboy".to_string()),
+            Some("/runner/homeboy".to_string()),
+            Some(LabHomeboyBinaryIdentity {
+                role: "active_daemon",
+                owner: "runner",
+                path: None,
+                version: Some("0.265.0".to_string()),
+                build_identity: Some("homeboy 0.265.0+aaaaaaaa".to_string()),
+                dirty: None,
+                purpose: "test daemon",
+            }),
+            Some(&warning),
+            None,
+        );
+
+        let diagnostic = provenance
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "runner_stale_daemon")
+            .expect("stale daemon diagnostic");
+        assert!(diagnostic
+            .action
+            .contains("inspect exact runner build identities"));
+        assert!(!diagnostic.action.contains("--ref bbbbbbbb"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -14,7 +14,7 @@ use homeboy::runner::runners::{
 };
 
 use super::super::CmdResult;
-use super::controller_ancestry::commits_are_ancestral;
+use super::controller_ancestry::{commits_are_ancestral, CommitAncestry};
 use super::types::{
     LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
     RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
@@ -102,7 +102,9 @@ pub(super) fn status(
                 id: Some(id.to_string()),
                 extra: RunnerExtra {
                     admission_summary,
-                    connection: Some(RunnerConnectionOutput::Status(Box::new(report))),
+                    connection: Some(RunnerConnectionOutput::Status(Box::new(
+                        sanitized_status_for_output(report),
+                    ))),
                     generation_inventory,
                     preferred_lab_runner,
                     selected_lab_runner,
@@ -174,7 +176,10 @@ pub(super) fn status(
         RunnerOutput {
             command: "runner.status".to_string(),
             extra: RunnerExtra {
-                sessions,
+                sessions: sessions
+                    .into_iter()
+                    .map(sanitized_status_for_output)
+                    .collect(),
                 inspection: Some(inspection),
                 preferred_lab_runner,
                 selected_lab_runner,
@@ -224,7 +229,9 @@ pub(super) fn reconcile_output(
             extra: RunnerExtra {
                 admission_summary: Some(admission_summary),
                 reconciliation: Some(reconciliation),
-                connection: Some(RunnerConnectionOutput::Status(Box::new(report.clone()))),
+                connection: Some(RunnerConnectionOutput::Status(Box::new(
+                    sanitized_status_for_output(report.clone()),
+                ))),
                 generation_inventory,
                 operator_hints: runner_status_operator_hints(&report),
                 // Reconcile has already consumed the current evidence. A repeat
@@ -544,10 +551,10 @@ fn selected_lab_runner_status(
         return Ok(None);
     };
     let runner_config = runner::load(runner_id)?;
-    let status = match status {
+    let status = sanitized_status_for_output(match status {
         Some(status) => status,
         None => runner::status(runner_id)?,
-    };
+    });
     let configured_executable = runner_config
         .settings
         .homeboy_path
@@ -617,9 +624,28 @@ pub(super) fn lab_runner_homeboy_output(
     configured_executable: &str,
     status: &RunnerStatusReport,
 ) -> LabRunnerHomeboyOutput {
-    let materialization =
+    lab_runner_homeboy_output_with_recovery_guidance(
+        runner_id,
+        configured_executable,
+        status,
+        recovery_refresh_guidance(status),
+    )
+}
+
+fn lab_runner_homeboy_output_with_recovery_guidance(
+    runner_id: &str,
+    configured_executable: &str,
+    status: &RunnerStatusReport,
+    guidance: RecoveryRefreshGuidance,
+) -> LabRunnerHomeboyOutput {
+    let mut materialization =
         RuntimeMaterializationStatus::for_homeboy_runner(runner_id, configured_executable, status);
-    let stale_daemon = status.stale_daemon.as_ref();
+    let refresh_command = recovery_refresh_command(&shell_arg(runner_id), guidance);
+    materialization.stale_daemon_refresh_command = refresh_command.clone();
+    let stale_daemon = status
+        .stale_daemon
+        .as_ref()
+        .and_then(|warning| stale_daemon_output(warning, refresh_command));
     let binary_roles: Vec<_> = materialization
         .binary_sources
         .iter()
@@ -644,7 +670,7 @@ pub(super) fn lab_runner_homeboy_output(
         job_command_binary_build_identity: materialization.job_command_binary_build_identity,
         stale_daemon_severity: materialization.stale_daemon_severity.map(str::to_string),
         stale_daemon_refresh_command: materialization.stale_daemon_refresh_command,
-        stale_daemon: stale_daemon.and_then(|warning| serde_json::to_value(warning).ok()),
+        stale_daemon,
         version_drift: materialization.version_drift,
         command_availability_checks: lab_command_availability_checks(configured_executable),
         artifact_features: runner_artifact_feature_diagnostics(
@@ -1175,15 +1201,16 @@ fn lab_runner_homeboy_refresh_commands(
     status: &RunnerStatusReport,
 ) -> Vec<String> {
     let runner_arg = shell_arg(runner_id);
-    let refresh_ref = recovery_refresh_ref(status);
-    vec![
-        format!(
-            "homeboy runner refresh-homeboy {runner_arg} --ref {} --reconnect",
-            refresh_ref
-        ),
+    let mut commands = Vec::new();
+    if let Some(command) = recovery_refresh_command(&runner_arg, recovery_refresh_guidance(status))
+    {
+        commands.push(command);
+    }
+    commands.extend([
         format!("homeboy runner disconnect {runner_arg}"),
         format!("homeboy runner connect {runner_arg}"),
-    ]
+    ]);
+    commands
 }
 
 pub(super) fn runner_followups(
@@ -1195,19 +1222,26 @@ pub(super) fn runner_followups(
         return followups;
     };
     let runner_arg = shell_arg(runner_id);
+    if let Some(command) = recovery_refresh_command(
+        &runner_arg,
+        status.map(recovery_refresh_guidance).unwrap_or_else(|| {
+            RecoveryRefreshGuidance::IdentityDrift {
+                controller: homeboy_product_identity::build_identity().git_commit,
+                runner: "unavailable".to_string(),
+            }
+        }),
+    ) {
+        followups.push(LabFollowup {
+            label: "refresh_homeboy".to_string(),
+            command,
+            purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.".to_string(),
+        });
+    }
     followups.extend([
         LabFollowup {
             label: "doctor".to_string(),
             command: format!("homeboy runner doctor {runner_arg} --scope lab-offload"),
             purpose: "Probe runner tools, workspace writability, artifact storage, and Lab offload readiness.".to_string(),
-        },
-        LabFollowup {
-            label: "refresh_homeboy".to_string(),
-            command: format!(
-                "homeboy runner refresh-homeboy {runner_arg} --ref {} --reconnect",
-                status.map_or_else(controller_refresh_ref, recovery_refresh_ref)
-            ),
-            purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.".to_string(),
         },
         LabFollowup {
             label: "env".to_string(),
@@ -1290,27 +1324,16 @@ pub(crate) fn selected_admission_summary(
     selected_status.map(|report| report.admission_summary(0))
 }
 
-fn controller_refresh_ref() -> String {
-    homeboy_product_identity::build_identity()
-        .git_commit
-        .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
-}
-
-/// Preserve a verified runner descendant rather than using an older controller
-/// revision to regenerate its recovery command.
-fn recovery_refresh_ref(status: &RunnerStatusReport) -> String {
+/// Select only a refresh whose exact immutable commit is proven monotonic.
+fn recovery_refresh_guidance(status: &RunnerStatusReport) -> RecoveryRefreshGuidance {
     let controller = homeboy_product_identity::build_identity();
-    let Some(controller_commit) = controller.git_commit.as_deref() else {
-        return controller_refresh_ref();
-    };
     let runner_commit = status
         .session
         .as_ref()
         .and_then(|session| session.homeboy_build_identity.as_deref())
         .and_then(build_identity_commit);
-    recovery_refresh_ref_with(
-        &controller_refresh_ref(),
-        controller_commit,
+    recovery_refresh_guidance_with(
+        controller.git_commit.as_deref(),
         runner_commit,
         commits_are_ancestral,
     )
@@ -1323,20 +1346,83 @@ fn build_identity_commit(identity: &str) -> Option<&str> {
         .then_some(commit)
 }
 
-fn recovery_refresh_ref_with(
-    controller_ref: &str,
-    controller_commit: &str,
+#[derive(Debug, PartialEq, Eq)]
+enum RecoveryRefreshGuidance {
+    Refresh(String),
+    IdentityDrift {
+        controller: Option<String>,
+        runner: String,
+    },
+}
+
+fn recovery_refresh_command(runner_arg: &str, guidance: RecoveryRefreshGuidance) -> Option<String> {
+    match guidance {
+        RecoveryRefreshGuidance::Refresh(refresh_ref) => Some(format!(
+            "homeboy runner refresh-homeboy {runner_arg} --ref {refresh_ref} --reconnect"
+        )),
+        RecoveryRefreshGuidance::IdentityDrift { .. } => None,
+    }
+}
+
+fn sanitized_status_for_output(mut report: RunnerStatusReport) -> RunnerStatusReport {
+    report.stale_daemon = report
+        .stale_daemon
+        .as_ref()
+        .map(homeboy::runner::runners::RunnerStaleDaemonWarning::sanitized_for_output);
+    report
+}
+
+fn stale_daemon_output(
+    warning: &homeboy::runner::runners::RunnerStaleDaemonWarning,
+    refresh_command: Option<String>,
+) -> Option<serde_json::Value> {
+    let mut warning = serde_json::to_value(warning.sanitized_for_output()).ok()?;
+    let fields = warning.as_object_mut()?;
+    if let Some(refresh_command) = refresh_command {
+        fields.insert("refresh_command".to_string(), refresh_command.into());
+    } else {
+        fields.remove("refresh_command");
+    }
+    Some(warning)
+}
+
+fn recovery_refresh_guidance_with(
+    controller_commit: Option<&str>,
     runner_commit: Option<&str>,
-    mut is_ancestor: impl FnMut(&str, &str) -> bool,
-) -> String {
-    match runner_commit {
-        Some(runner_commit)
-            if runner_commit != controller_commit
-                && is_ancestor(controller_commit, runner_commit) =>
-        {
-            runner_commit.to_string()
-        }
-        _ => controller_ref.to_string(),
+    mut ancestry: impl FnMut(&str, &str) -> CommitAncestry,
+) -> RecoveryRefreshGuidance {
+    let Some(runner_commit) = runner_commit else {
+        return RecoveryRefreshGuidance::IdentityDrift {
+            controller: controller_commit.map(str::to_string),
+            runner: "unavailable".to_string(),
+        };
+    };
+    let Some(controller_commit) = controller_commit else {
+        return RecoveryRefreshGuidance::IdentityDrift {
+            controller: None,
+            runner: runner_commit.to_string(),
+        };
+    };
+    if runner_commit == controller_commit {
+        return RecoveryRefreshGuidance::Refresh(controller_commit.to_string());
+    }
+    match ancestry(controller_commit, runner_commit) {
+        CommitAncestry::Ancestor => RecoveryRefreshGuidance::Refresh(runner_commit.to_string()),
+        CommitAncestry::NotAncestor => match ancestry(runner_commit, controller_commit) {
+            CommitAncestry::Ancestor => {
+                RecoveryRefreshGuidance::Refresh(controller_commit.to_string())
+            }
+            CommitAncestry::NotAncestor | CommitAncestry::Unavailable => {
+                RecoveryRefreshGuidance::IdentityDrift {
+                    controller: Some(controller_commit.to_string()),
+                    runner: runner_commit.to_string(),
+                }
+            }
+        },
+        CommitAncestry::Unavailable => RecoveryRefreshGuidance::IdentityDrift {
+            controller: Some(controller_commit.to_string()),
+            runner: runner_commit.to_string(),
+        },
     }
 }
 
@@ -1497,11 +1583,20 @@ pub(super) fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<S
     if report.stale_daemon.is_some() {
         let mut materialization =
             RuntimeMaterializationStatus::for_homeboy_runner(&report.runner_id, "homeboy", report);
-        materialization.stale_daemon_refresh_command =
-            lab_runner_homeboy_refresh_commands(&report.runner_id, report)
-                .into_iter()
-                .next();
+        materialization.stale_daemon_refresh_command = recovery_refresh_command(
+            &shell_arg(&report.runner_id),
+            recovery_refresh_guidance(report),
+        );
         hints.extend(materialization.stale_daemon_hint());
+    }
+    if let RecoveryRefreshGuidance::IdentityDrift { controller, runner } =
+        recovery_refresh_guidance(report)
+    {
+        hints.push(format!(
+            "Runner `{}` reports exact Homeboy build drift: controller={} runner={runner}. Recovery will not recommend refresh-homeboy until ancestry is verified; use `--allow-downgrade` only for an intentional rollback.",
+            report.runner_id,
+            controller.as_deref().unwrap_or("unavailable"),
+        ));
     }
     match session.mode {
         RunnerTunnelMode::DirectSsh => {
@@ -1543,6 +1638,16 @@ fn reverse_runner_status_hints(
 
 pub(super) fn runner_status_operator_commands(
     report: &RunnerStatusReport,
+) -> Vec<RunnerOperatorCommand> {
+    runner_status_operator_commands_with_recovery_guidance(
+        report,
+        recovery_refresh_guidance(report),
+    )
+}
+
+fn runner_status_operator_commands_with_recovery_guidance(
+    report: &RunnerStatusReport,
+    guidance: RecoveryRefreshGuidance,
 ) -> Vec<RunnerOperatorCommand> {
     let Some(session) = report.session.as_ref() else {
         return Vec::new();
@@ -1677,18 +1782,18 @@ pub(super) fn runner_status_operator_commands(
         });
     }
 
-    if let Some(warning) = report.stale_daemon.as_ref() {
-        let refresh_command = lab_runner_homeboy_refresh_commands(&report.runner_id, report)
-            .into_iter()
-            .next()
-            .unwrap_or_else(|| warning.refresh_command.clone());
-        commands.push(RunnerOperatorCommand {
+    if report.stale_daemon.is_some() {
+        if let Some(refresh_command) =
+            recovery_refresh_command(&shell_arg(&report.runner_id), guidance)
+        {
+            commands.push(RunnerOperatorCommand {
             scope: "daemon_refresh",
             runner_id: report.runner_id.clone(),
             job_id: None,
             command: refresh_command,
             description: "Restart the active runner daemon so the control plane uses the configured job command binary.".to_string(),
         });
+        }
     }
 
     if let Some(freshness) = report.daemon_freshness.as_ref().filter(|freshness| {
@@ -1746,14 +1851,19 @@ mod tests {
             .expect("stale daemon hint");
         assert!(hint.contains("severity=warning"));
         assert!(hint.contains("active daemon control plane"));
-        assert!(hint.contains("homeboy 0.259.0+daemon"));
+        assert!(hint.contains(&format!(
+            "homeboy 0.259.0+{}",
+            homeboy_product_identity::build_identity()
+                .git_commit
+                .expect("test build has an immutable controller commit")
+        )));
         assert!(hint.contains("job command binary"));
         assert!(hint.contains("homeboy 0.262.0+binary"));
         let job_binary_refresh = format!(
             "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
             homeboy_product_identity::build_identity()
                 .git_commit
-                .unwrap_or_else(|| format!("v{}", homeboy_product_identity::product_version()))
+                .expect("test build has an immutable controller commit")
         );
         assert!(hint.contains(&job_binary_refresh));
 
@@ -1768,8 +1878,10 @@ mod tests {
     }
 
     #[test]
-    fn active_refresh_guidance_uses_the_controller_commit_when_known() {
-        let expected = controller_refresh_ref();
+    fn active_refresh_guidance_uses_an_immutable_controller_commit_when_known() {
+        let expected = homeboy_product_identity::build_identity()
+            .git_commit
+            .expect("test build has an immutable controller commit");
         let report = stale_daemon_report();
         let commands = lab_runner_homeboy_refresh_commands("homeboy-lab", &report);
         let followups = runner_followups(Some("homeboy-lab"), Some(&report));
@@ -1812,28 +1924,186 @@ mod tests {
         let newer_runner = "c7367571a217";
         let runner_identity = "homeboy 0.320.0+c7367571a217";
 
-        let refresh_ref = recovery_refresh_ref_with(
-            post_tag_controller,
-            post_tag_controller,
+        let guidance = recovery_refresh_guidance_with(
+            Some(post_tag_controller),
             build_identity_commit(runner_identity),
-            |older, newer| older == post_tag_controller && newer == newer_runner,
+            |older, newer| {
+                (older == post_tag_controller && newer == newer_runner)
+                    .then_some(CommitAncestry::Ancestor)
+                    .unwrap_or(CommitAncestry::NotAncestor)
+            },
         );
 
-        assert_eq!(refresh_ref, newer_runner);
+        assert_eq!(
+            guidance,
+            RecoveryRefreshGuidance::Refresh(newer_runner.to_string())
+        );
     }
 
     #[test]
-    fn recovery_guidance_does_not_select_an_unverified_runner_build() {
+    fn recovery_guidance_surfaces_same_semver_drift_without_a_refresh_command() {
         let controller = "99ec629c04ca";
         let runner = "c7367571a217";
 
+        let guidance = recovery_refresh_guidance_with(Some(controller), Some(runner), |_, _| {
+            CommitAncestry::Unavailable
+        });
         assert_eq!(
-            recovery_refresh_ref_with(controller, controller, Some(runner), |_, _| false),
-            controller
+            guidance,
+            RecoveryRefreshGuidance::IdentityDrift {
+                controller: Some(controller.to_string()),
+                runner: runner.to_string(),
+            }
+        );
+        assert!(recovery_refresh_command("homeboy-lab", guidance).is_none());
+    }
+
+    #[test]
+    fn recovery_guidance_uses_the_controller_exact_commit_only_when_it_is_newer() {
+        let controller = "7e29bde24e00";
+        let runner = "93bc3e103459";
+
+        assert_eq!(
+            recovery_refresh_guidance_with(Some(controller), Some(runner), |older, newer| {
+                (older == runner && newer == controller)
+                    .then_some(CommitAncestry::Ancestor)
+                    .unwrap_or(CommitAncestry::NotAncestor)
+            }),
+            RecoveryRefreshGuidance::Refresh(controller.to_string())
+        );
+    }
+
+    #[test]
+    fn recovery_guidance_withholds_refresh_when_the_controller_commit_is_absent() {
+        assert_eq!(
+            recovery_refresh_guidance_with(None, Some("7e29bde24e00"), |_, _| {
+                CommitAncestry::Ancestor
+            }),
+            RecoveryRefreshGuidance::IdentityDrift {
+                controller: None,
+                runner: "7e29bde24e00".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn recovery_guidance_withholds_mutable_version_tags_without_a_runner_commit() {
+        let guidance = recovery_refresh_guidance_with(Some("93bc3e103459"), None, |_, _| {
+            CommitAncestry::Ancestor
+        });
+
+        assert_eq!(
+            guidance,
+            RecoveryRefreshGuidance::IdentityDrift {
+                controller: Some("93bc3e103459".to_string()),
+                runner: "unavailable".to_string(),
+            }
+        );
+        assert!(recovery_refresh_command("homeboy-lab", guidance).is_none());
+    }
+
+    #[test]
+    fn identity_drift_never_leaks_the_legacy_daemon_refresh_command() {
+        let mut report = stale_daemon_report();
+        report
+            .session
+            .as_mut()
+            .expect("session")
+            .homeboy_build_identity = Some("homeboy 0.342.0+7e29bde24e00".to_string());
+        report
+            .stale_daemon
+            .as_mut()
+            .expect("stale daemon")
+            .refresh_command =
+            "homeboy runner refresh-homeboy homeboy-lab --ref 93bc3e103459 --reconnect".to_string();
+        let guidance = RecoveryRefreshGuidance::IdentityDrift {
+            controller: Some("93bc3e103459".to_string()),
+            runner: "7e29bde24e00".to_string(),
+        };
+
+        let commands = runner_status_operator_commands_with_recovery_guidance(&report, guidance);
+        assert!(commands
+            .iter()
+            .all(|command| command.scope != "daemon_refresh"));
+
+        let output = lab_runner_homeboy_output_with_recovery_guidance(
+            "homeboy-lab",
+            "/opt/homeboy",
+            &report,
+            RecoveryRefreshGuidance::IdentityDrift {
+                controller: Some("93bc3e103459".to_string()),
+                runner: "7e29bde24e00".to_string(),
+            },
+        );
+        let serialized = serde_json::to_value(output).expect("serialize output");
+        assert!(serialized.get("stale_daemon_refresh_command").is_none());
+        assert!(serialized["stale_daemon"].get("refresh_command").is_none());
+        assert!(serialized["stale_daemon"]
+            .get("recovery_commands")
+            .is_none());
+        assert!(!serialized
+            .to_string()
+            .contains("--ref 93bc3e103459 --reconnect"));
+
+        let report = sanitized_status_for_output(report);
+        let serialized = serde_json::to_value(report).expect("serialize full status");
+        assert!(serialized["stale_daemon"].get("refresh_command").is_none());
+        assert!(!serialized
+            .to_string()
+            .contains("--ref 93bc3e103459 --reconnect"));
+
+        let nested = serde_json::json!({ "selected_lab_runner": { "status": serialized } });
+        assert!(nested["selected_lab_runner"]["status"]["stale_daemon"]
+            .get("refresh_command")
+            .is_none());
+        assert!(!nested
+            .to_string()
+            .contains("--ref 93bc3e103459 --reconnect"));
+    }
+
+    #[test]
+    fn verified_recovery_keeps_the_safe_daemon_refresh_command() {
+        let mut report = stale_daemon_report();
+        report
+            .session
+            .as_mut()
+            .expect("session")
+            .homeboy_build_identity = Some("homeboy 0.259.0+7e29bde24e00".to_string());
+        report.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "homeboy 0.259.0".to_string(),
+            "homeboy 0.262.0".to_string(),
+            Some("homeboy 0.259.0+7e29bde24e00".to_string()),
+            Some("homeboy 0.262.0+7e29bde24e00".to_string()),
+        ));
+        let refresh = "homeboy runner refresh-homeboy homeboy-lab --ref 7e29bde24e00 --reconnect";
+        let commands = runner_status_operator_commands_with_recovery_guidance(
+            &report,
+            RecoveryRefreshGuidance::Refresh("7e29bde24e00".to_string()),
+        );
+        assert!(commands
+            .iter()
+            .any(|command| { command.scope == "daemon_refresh" && command.command == refresh }));
+
+        let output = lab_runner_homeboy_output_with_recovery_guidance(
+            "homeboy-lab",
+            "/opt/homeboy",
+            &report,
+            RecoveryRefreshGuidance::Refresh("7e29bde24e00".to_string()),
+        );
+        let serialized = serde_json::to_value(output).expect("serialize output");
+        assert_eq!(serialized["stale_daemon_refresh_command"], refresh);
+        assert_eq!(serialized["stale_daemon"]["refresh_command"], refresh);
+        assert_eq!(
+            serialized["stale_daemon"]["recovery_commands"],
+            serde_json::json!([refresh])
         );
     }
 
     fn stale_daemon_report() -> RunnerStatusReport {
+        let controller_commit = homeboy_product_identity::build_identity()
+            .git_commit
+            .expect("test build has an immutable controller commit");
         RunnerStatusReport {
             runner_id: "homeboy-lab".to_string(),
             connected: true,
@@ -1854,7 +2124,7 @@ mod tests {
                 remote_daemon_pid: Some(23456),
                 remote_daemon_lease_id: Some("lease-23456".to_string()),
                 homeboy_version: "homeboy 0.259.0".to_string(),
-                homeboy_build_identity: Some("homeboy 0.259.0+daemon".to_string()),
+                homeboy_build_identity: Some(format!("homeboy 0.259.0+{controller_commit}")),
                 connected_at: "2026-06-26T00:00:00Z".to_string(),
                 worker_identity: None,
                 worker_pid: None,
@@ -1865,7 +2135,7 @@ mod tests {
                 "homeboy-lab",
                 "homeboy 0.259.0".to_string(),
                 "homeboy 0.262.0".to_string(),
-                Some("homeboy 0.259.0+daemon".to_string()),
+                Some(format!("homeboy 0.259.0+{controller_commit}")),
                 Some("homeboy 0.262.0+binary".to_string()),
             )),
             configured_job_binary_build_identity: None,

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -1160,11 +1160,8 @@ fn runner_homeboy_status_distinguishes_daemon_and_job_binary_roles() {
     assert_eq!(output.active_daemon_version.as_deref(), Some("0.262.0"));
 }
 
-/// A dirty controller alongside a genuinely version-skewed runner: the skew is
-/// the reportable fact and keeps its runner-side recovery. The controller's
-/// dirty tree only removes the *stronger* exact-commit proof, so it must not
-/// rename the finding or replace the remediation with `homeboy upgrade
-/// --force` (#11101).
+/// A dirty controller alongside a genuinely version-skewed runner keeps the
+/// skew visible, but has no immutable target for a mutating refresh.
 #[test]
 fn compact_status_names_runner_version_skew_when_the_controller_is_dirty() {
     let report = RunnerStatusReport {
@@ -1257,16 +1254,15 @@ fn compact_status_names_runner_version_skew_when_the_controller_is_dirty() {
         .risk
         .iter()
         .any(|risk| risk.contains("homeboy 0.321.1+configured-dirty")));
-    // The remediation converges the runner, which is what is actually skewed.
-    // Telling an operator with uncommitted work to reinstall the controller
-    // answers a question nobody asked.
-    assert!(summary.next_action.contains("refresh-homeboy"));
+    // Exact ancestry is unavailable, so inspection preserves the skew evidence
+    // without recommending a potentially downgrading runner mutation.
+    assert!(summary
+        .next_action
+        .contains("homeboy runner status homeboy-lab"));
+    assert!(!summary.next_action.contains("refresh-homeboy"));
     assert!(!summary.next_action.contains("upgrade --force"));
     let warning = report.stale_daemon.as_ref().expect("stale daemon warning");
-    assert_eq!(
-        warning.recovery_commands,
-        vec!["homeboy runner refresh-homeboy homeboy-lab --ref configured --reconnect".to_string()]
-    );
+    assert!(warning.safe_recovery_commands().is_empty());
     assert_eq!(
         warning.compatibility_reason,
         Some("controller_configured_version_skew")
@@ -1298,10 +1294,10 @@ fn compact_status_names_runner_version_skew_when_the_controller_is_dirty() {
 fn runner_status_actions_preserve_runner_ids_for_every_admission_state() {
     let cases = [
         ("disconnected", disconnected_report(), None),
-        ("stale", stale_report(), Some("c8a6673b6abc")),
+        ("stale", stale_report(), None),
         ("active-job", active_job_report(), None),
         ("connected", connected_report(), None),
-        ("version-skew", version_skew_report(), Some("c8a6673b6abc")),
+        ("version-skew", version_skew_report(), None),
     ];
 
     for (state, report, pinned_ref) in cases {
@@ -1313,6 +1309,15 @@ fn runner_status_actions_preserve_runner_ids_for_every_admission_state() {
             assert_rendered_runner_action_parses(state, compact_action, pinned_ref);
         }
         assert_rendered_runner_action_parses(state, &operator.next_action, pinned_ref);
+        if matches!(state, "stale" | "version-skew") {
+            assert!(!operator.next_action.contains("refresh-homeboy"), "{state}");
+            assert!(report
+                .stale_daemon
+                .as_ref()
+                .expect("stale warning")
+                .safe_recovery_commands()
+                .is_empty());
+        }
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -819,20 +819,14 @@ fn same_version_different_controller_build_is_incompatible_and_truthful() {
     );
     assert!(warning.message.contains("configured job command binary"));
     assert!(warning.message.contains("controller"));
-    assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --ref controller --reconnect --allow-downgrade"]
-    );
-    assert!(!warning.refresh_command.contains("--ref configured"));
-    let diagnostics = serde_json::to_value(&warning).expect("serialize controller build skew");
+    assert!(warning.safe_recovery_commands().is_empty());
+    let diagnostics = serde_json::to_value(warning.sanitized_for_output())
+        .expect("serialize controller build skew");
     assert_eq!(
         diagnostics["mismatch_predicate"],
         "controller_build_commit != job_command_binary_build_commit"
     );
-    assert_eq!(
-        diagnostics["recovery_commands"][0],
-        "homeboy runner refresh-homeboy homeboy-lab --ref controller --reconnect --allow-downgrade"
-    );
+    assert!(diagnostics.get("recovery_commands").is_none());
 }
 
 #[test]
@@ -869,7 +863,8 @@ fn controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions()
         false,
     );
 
-    let dirty_diagnostics = serde_json::to_value(&dirty).expect("serialize dirty controller");
+    let dirty_diagnostics =
+        serde_json::to_value(dirty.sanitized_for_output()).expect("serialize dirty controller");
     // A dirty controller cannot compare; that is not a claim about the runner,
     // so it must not serialize as a staleness predicate (#11101).
     assert_eq!(
@@ -883,24 +878,18 @@ fn controller_dirty_and_version_skew_serialize_distinct_predicates_and_actions()
     // "Your working tree is dirty" has no correct automated remediation, and
     // `homeboy upgrade --force` is a destructive answer to a question nobody
     // asked. Offer none rather than the wrong one.
-    assert!(dirty_diagnostics["recovery_commands"]
-        .as_array()
-        .expect("serialized recovery command list")
-        .is_empty());
+    assert!(dirty_diagnostics.get("recovery_commands").is_none());
     assert!(!dirty.message.contains("upgrade --force"));
     assert!(dirty.message.contains("dirty working tree"));
     assert!(dirty.message.contains("unavailable, not failed"));
 
-    let version_diagnostics =
-        serde_json::to_value(&version_skew).expect("serialize controller version skew");
+    let version_diagnostics = serde_json::to_value(version_skew.sanitized_for_output())
+        .expect("serialize controller version skew");
     assert_eq!(
         version_diagnostics["mismatch_predicate"],
         "controller_version != job_command_binary_version"
     );
-    assert!(version_diagnostics["recovery_commands"]
-        .as_array()
-        .expect("serialized recovery command list")
-        .is_empty());
+    assert!(version_diagnostics.get("recovery_commands").is_none());
 }
 
 fn controller_identity(
@@ -1233,23 +1222,18 @@ fn unverifiable_identity_warning_is_actionable_without_claiming_a_mismatch() {
     assert!(warning.message.contains("could not be verified"));
     assert!(!warning.message.contains("different Homeboy build"));
     assert!(warning.message.contains("/opt/homeboy self identity"));
-    assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --reconnect"]
-    );
-    let diagnostics = serde_json::to_value(&warning).expect("serialize unverifiable identity");
+    assert!(warning.safe_recovery_commands().is_empty());
+    let diagnostics = serde_json::to_value(warning.sanitized_for_output())
+        .expect("serialize unverifiable identity");
     assert_eq!(
         diagnostics["mismatch_predicate"],
         "immutable_build_identity(active_daemon_control_plane_build_identity) && immutable_build_identity(job_command_binary_build_identity) == false"
     );
-    assert_eq!(
-        diagnostics["recovery_commands"][0],
-        "homeboy runner refresh-homeboy homeboy-lab --reconnect"
-    );
+    assert!(diagnostics.get("recovery_commands").is_none());
 }
 
 #[test]
-fn stale_daemon_warning_includes_explicit_refresh_recovery_command() {
+fn stale_daemon_warning_with_unverified_ref_withholds_refresh_recovery_command() {
     let warning = RunnerStaleDaemonWarning::new(
         "homeboy-lab",
         "homeboy 0.201.3".to_string(),
@@ -1280,21 +1264,14 @@ fn stale_daemon_warning_includes_explicit_refresh_recovery_command() {
         warning.job_command_binary_build_identity.as_deref(),
         Some("homeboy 0.204.0+new")
     );
-    assert_eq!(
-        warning.refresh_command,
-        "homeboy runner refresh-homeboy homeboy-lab --ref new --reconnect"
-    );
     assert!(warning.message.contains("daemon control plane"));
     assert!(warning.message.contains("job command binary"));
     assert!(warning.message.contains("active jobs are drained"));
-    assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --ref new --reconnect"]
-    );
-    assert_ne!(
-        warning.refresh_command,
-        "homeboy runner refresh-homeboy homeboy-lab --ref v0.1.0 --reconnect"
-    );
+    assert!(warning.safe_recovery_commands().is_empty());
+    let diagnostics =
+        serde_json::to_value(warning.sanitized_for_output()).expect("serialize stale warning");
+    assert!(diagnostics.get("refresh_command").is_none());
+    assert!(diagnostics.get("recovery_commands").is_none());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/daemon_repair.rs
+++ b/crates/homeboy-lab-runner/src/daemon_repair.rs
@@ -42,11 +42,6 @@ pub(crate) use codes::{
     RUNNER_RECONCILE_LEASELESS_ORPHANS, RUNNER_REFRESH_HOMEBOY, STALE_DAEMON_RECOVERY,
 };
 
-/// A step known only as text. Nothing may execute it implicitly.
-pub(crate) fn step(code: &str, command: String) -> DaemonRepairStep {
-    DaemonRepairStep::text(code, command)
-}
-
 /// A step whose argv is authoritative; its text is rendered from the action.
 pub(crate) fn action_step(code: &str, action: ExecutableAction) -> DaemonRepairStep {
     DaemonRepairStep::executable(code, action)
@@ -306,8 +301,8 @@ mod tests {
             // survive the crossing: `homeboy daemon stop` on the controller
             // stops the controller's daemon.
             repair_plan: vec![
-                step("daemon_stop", "homeboy daemon stop".to_string()),
-                step("daemon_start", "homeboy daemon start".to_string()),
+                DaemonRepairStep::text("daemon_stop", "homeboy daemon stop".to_string()),
+                DaemonRepairStep::text("daemon_start", "homeboy daemon start".to_string()),
             ],
         }
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -325,10 +325,7 @@ pub(crate) fn lab_runner_homeboy_metadata(
     // recovery avoids dispatch telling an operator to reinstall the runner's
     // already-incompatible configured binary (#11360).
     let refresh_commands = runner_homeboy_refresh_commands(runner_id, status);
-    let primary_remediation_command = refresh_commands
-        .first()
-        .cloned()
-        .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id));
+    let primary_remediation_command = refresh_commands.first().cloned();
     let topology_recovery_command = primary_remediation_command.clone();
     let controller_binary = std::env::current_exe()
         .ok()
@@ -345,8 +342,8 @@ pub(crate) fn lab_runner_homeboy_metadata(
         "job_command_binary_version": stale_daemon.map(|warning| warning.job_command_binary_version.clone()),
         "job_command_binary_build_identity": stale_daemon.and_then(|warning| warning.job_command_binary_build_identity.clone()),
         "stale_daemon_severity": stale_daemon.map(|warning| warning.severity),
-        "stale_daemon_refresh_command": stale_daemon.map(|warning| warning.refresh_command.clone()),
-        "stale_daemon": status.stale_daemon,
+        "stale_daemon_refresh_command": primary_remediation_command,
+        "stale_daemon": stale_daemon.map(RunnerStaleDaemonWarning::sanitized_for_output),
         "version_drift": lab_runner_homeboy_version_drift(status),
         "primary_remediation_command": primary_remediation_command,
         "topology_recovery_command": topology_recovery_command,
@@ -812,20 +809,19 @@ pub(crate) fn stale_runner_homeboy_error(
                 homeboy_product_identity::product_version()
             )
         });
-    let refresh = refresh_commands.join(" && ");
     let mut tried = Vec::new();
-    tried.push(format!(
-        "One-command topology recovery: {}",
-        refresh_commands
-            .first()
-            .cloned()
-            .unwrap_or_else(|| runner_homeboy_align_to_controller_command(runner_id))
-    ));
-    tried.extend([
-        format!("Reconnect runner `{runner_id}` before retrying Lab offload: {refresh}"),
-        format!("If the runner binary itself is stale, refresh or select a clean runner binary with `{}`.", runner_homeboy_align_to_controller_command(runner_id)),
-        "Use --placement local only if you intentionally want to bypass Lab offload and run locally.".to_string(),
-    ]);
+    if let Some(refresh) = refresh_commands.first() {
+        tried.push(format!("One-command topology recovery: {refresh}"));
+        tried.push(format!(
+            "Reconnect runner `{runner_id}` before retrying Lab offload: {}",
+            refresh_commands.join(" && ")
+        ));
+    } else {
+        tried.push(format!(
+            "Runner `{runner_id}` has no ancestry-verified refresh target. Inspect exact build identities and recover only with an explicit rollback authorization when intended."
+        ));
+    }
+    tried.push("Use --placement local only if you intentionally want to bypass Lab offload and run locally.".to_string());
     Error::validation_invalid_argument(
         "runner",
         format!(
@@ -837,22 +833,14 @@ pub(crate) fn stale_runner_homeboy_error(
 }
 
 pub(crate) fn runner_homeboy_refresh_commands(
-    runner_id: &str,
+    _runner_id: &str,
     status: &RunnerStatusReport,
 ) -> Vec<String> {
-    let commands = status
+    status
         .stale_daemon
         .as_ref()
-        .map(|warning| warning.recovery_commands.clone())
-        .unwrap_or_default();
-    if !commands.is_empty() {
-        return commands;
-    }
-    vec![
-        runner_homeboy_align_to_controller_command(runner_id),
-        format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
-        format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
-    ]
+        .map(RunnerStaleDaemonWarning::safe_recovery_commands)
+        .unwrap_or_default()
 }
 
 pub(crate) fn runner_homeboy_align_to_controller_command(runner_id: &str) -> String {

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -580,17 +580,7 @@ fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
         "homeboy 0.0.0+test"
     );
     assert_eq!(metadata["version_drift"], true);
-    assert_eq!(
-        metadata["refresh_commands"],
-        serde_json::json!([
-            format!(
-                "homeboy runner refresh-homeboy 'homeboy lab' --ref {} --reconnect",
-                expected_controller_refresh_ref()
-            ),
-            "homeboy runner disconnect 'homeboy lab'",
-            "homeboy runner connect 'homeboy lab'"
-        ])
-    );
+    assert_eq!(metadata["refresh_commands"], serde_json::json!([]));
     assert_eq!(
         metadata["upgrade_command"],
         "homeboy upgrade --force --upgrade-runner 'homeboy lab'"
@@ -623,15 +613,12 @@ fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
         .message
         .contains(homeboy_product_identity::product_version()));
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried.iter().any(
-        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )))
-    ));
+    assert!(tried.iter().all(|hint| hint
+        .as_str()
+        .is_some_and(|hint| !hint.contains("refresh-homeboy"))));
     assert!(tried.iter().any(|hint| hint
         .as_str()
-        .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
+        .is_some_and(|hint| hint.contains("no ancestry-verified refresh target"))));
 }
 
 /// Build a reverse-connected status whose runner session reports `version`.
@@ -734,17 +721,22 @@ fn newer_runner_than_controller_points_to_controller_convergence_first() {
         "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
         expected_controller_refresh_ref()
     );
-    assert_eq!(metadata["primary_remediation_command"], expected);
-    assert_eq!(metadata["topology_recovery_command"], expected);
+    assert_eq!(
+        metadata["primary_remediation_command"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        metadata["topology_recovery_command"],
+        serde_json::Value::Null
+    );
     assert!(metadata["controller_binary"].as_str().is_some());
     assert_eq!(metadata["local_upgrade_command"], "homeboy upgrade");
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
     assert!(tried
-        .first()
-        .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains(&expected)));
+        .iter()
+        .all(|hint| hint.as_str().is_some_and(|hint| !hint.contains(&expected))));
 }
 
 #[test]
@@ -763,21 +755,14 @@ fn newer_stale_daemon_control_plane_points_to_controller_convergence_first() {
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
     assert_eq!(
         metadata["primary_remediation_command"],
-        format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )
+        serde_json::Value::Null
     );
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried
-        .first()
-        .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains("refresh-homeboy")));
-    assert!(tried.iter().any(|hint| hint
+    assert!(tried.iter().all(|hint| hint
         .as_str()
-        .is_some_and(|hint| hint.contains("One-command topology recovery"))));
+        .is_some_and(|hint| !hint.contains("refresh-homeboy"))));
 }
 
 #[test]
@@ -787,21 +772,14 @@ fn older_runner_than_controller_points_to_runner_refresh_first() {
     let metadata = lab_runner_homeboy_metadata("homeboy-lab", "homeboy", &status);
     assert_eq!(
         metadata["primary_remediation_command"],
-        format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )
+        serde_json::Value::Null
     );
 
     let err = stale_runner_homeboy_error("homeboy-lab", "homeboy", &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried
-        .first()
-        .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        ))));
+    assert!(tried.iter().all(|hint| hint
+        .as_str()
+        .is_some_and(|hint| !hint.contains("refresh-homeboy"))));
 }
 
 #[test]
@@ -813,24 +791,18 @@ fn configured_runner_binary_drift_still_converges_to_the_controller() {
 
     assert_eq!(
         metadata["primary_remediation_command"],
-        format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )
+        serde_json::Value::Null
     );
     assert_eq!(
         metadata["topology_recovery_command"],
-        metadata["primary_remediation_command"]
+        serde_json::Value::Null
     );
 
     let err = stale_runner_homeboy_error("homeboy-lab", configured, &status);
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried.iter().any(
-        |hint| hint.as_str().is_some_and(|hint| hint.contains(&format!(
-            "homeboy runner refresh-homeboy homeboy-lab --ref {} --reconnect",
-            expected_controller_refresh_ref()
-        )))
-    ));
+    assert!(tried.iter().all(|hint| hint
+        .as_str()
+        .is_some_and(|hint| !hint.contains("refresh-homeboy"))));
 }
 
 #[test]
@@ -870,12 +842,9 @@ fn cook_metadata_reuses_the_doctor_recovery_action_for_controller_skew() {
     );
     assert_eq!(
         metadata["primary_remediation_command"],
-        doctor_action.render_command()
+        serde_json::Value::Null
     );
-    assert_eq!(
-        metadata["refresh_commands"][0],
-        doctor_action.render_command()
-    );
+    assert_eq!(metadata["refresh_commands"], serde_json::json!([]));
 }
 
 #[test]
@@ -1107,14 +1076,12 @@ fn stale_runner_homeboy_error_blocks_offload_with_reconnect_guidance() {
         .message
         .contains("malformed or misleading provider output"));
     let tried = err.details["tried"].as_array().expect("tried hints");
-    assert!(tried
-        .first()
-        .and_then(|hint| hint.as_str())
-        .is_some_and(|hint| hint
-            .contains("homeboy runner refresh-homeboy 'homeboy lab' --ref new --reconnect")));
+    assert!(tried.iter().all(|hint| hint
+        .as_str()
+        .is_some_and(|hint| !hint.contains("refresh-homeboy"))));
     assert!(tried.iter().any(|hint| hint
         .as_str()
-        .is_some_and(|hint| hint.contains("refresh or select a clean runner binary"))));
+        .is_some_and(|hint| hint.contains("no ancestry-verified refresh target"))));
 }
 
 fn higher_minor_version() -> String {
@@ -1164,24 +1131,43 @@ fn runner_homeboy_metadata_carries_stale_daemon_details() {
         metadata["stale_daemon"]["job_command_binary_build_identity"],
         "homeboy 0.229.11+new"
     );
-    // The explicit refresh owns the reconnect, so the recovery command avoids
-    // a redundant disconnect/connect loop.
-    let expected_refresh = "homeboy runner refresh-homeboy lab --ref new --reconnect";
-    assert_eq!(
-        metadata["stale_daemon"]["refresh_command"],
-        expected_refresh
-    );
+    assert!(metadata["stale_daemon"].get("refresh_command").is_none());
     assert_eq!(metadata["stale_daemon_severity"], "warning");
-    assert_eq!(metadata["stale_daemon_refresh_command"], expected_refresh);
+    assert_eq!(
+        metadata["stale_daemon_refresh_command"],
+        serde_json::Value::Null
+    );
     assert_eq!(metadata["job_command_binary_version"], "homeboy 0.229.11");
     assert_eq!(
         metadata["job_command_binary_build_identity"],
         "homeboy 0.229.11+new"
     );
-    assert_eq!(
-        metadata["refresh_commands"],
-        serde_json::json!([expected_refresh])
-    );
+    assert_eq!(metadata["refresh_commands"], serde_json::json!([]));
+}
+
+#[test]
+fn exact_active_daemon_target_remains_available_in_metadata_and_offload_error() {
+    let mut status = reverse_status("lab");
+    status.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "lab",
+        "0.264.0".to_string(),
+        "0.265.0".to_string(),
+        Some("homeboy 0.265.0+aaaaaaaa".to_string()),
+        Some("homeboy 0.265.0+aaaaaaaa".to_string()),
+    ));
+    let refresh = "homeboy runner refresh-homeboy lab --ref aaaaaaaa --reconnect";
+
+    let metadata = lab_runner_homeboy_metadata("lab", "homeboy", &status);
+    assert_eq!(metadata["stale_daemon_refresh_command"], refresh);
+    assert_eq!(metadata["stale_daemon"]["refresh_command"], refresh);
+    assert_eq!(metadata["refresh_commands"], serde_json::json!([refresh]));
+
+    let error = stale_runner_homeboy_error("lab", "homeboy", &status);
+    assert!(error.details["tried"].as_array().is_some_and(|tried| {
+        tried
+            .iter()
+            .any(|hint| hint.as_str().is_some_and(|hint| hint.contains(refresh)))
+    }));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/selection.rs
@@ -219,13 +219,6 @@ fn explicit_connected_stale_runner_preserves_drift_diagnosis_and_recovery() {
         Some(&status),
         vec![availability.clone()],
     );
-    let refresh = status
-        .stale_daemon
-        .as_ref()
-        .expect("stale daemon warning")
-        .refresh_command
-        .clone();
-
     assert!(error.message.contains("cannot accept jobs"));
     assert_eq!(
         error.details["runner_availability"]["reasons"],
@@ -240,11 +233,17 @@ fn explicit_connected_stale_runner_preserves_drift_diagnosis_and_recovery() {
         error.details["runner_status"]["stale_daemon"]["job_command_binary_version"],
         "homeboy 0.229.11"
     );
-    assert_eq!(error.details["stale_daemon_recovery_command"], refresh);
+    assert_eq!(
+        error.details["stale_daemon_recovery_command"],
+        serde_json::Value::Null
+    );
+    assert!(error.details["runner_status"]["stale_daemon"]
+        .get("refresh_command")
+        .is_none());
     assert!(error.details["tried"][0]
         .as_str()
         .expect("recovery hint")
-        .contains(&refresh));
+        .contains("Wait for an active Lab runner job"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -11,8 +11,8 @@ use homeboy_core::{Error, ErrorCode, Result};
 
 use super::{
     default_lab_runner_availability, load, status, LabOffloadCommand, LabRunnerGateMode,
-    RunnerActiveJobSource, RunnerAvailability, RunnerConnectReport, RunnerStatusReport,
-    RunnerTunnelMode,
+    RunnerActiveJobSource, RunnerAvailability, RunnerConnectReport, RunnerStaleDaemonWarning,
+    RunnerStatusReport, RunnerTunnelMode,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1113,7 +1113,7 @@ pub(super) fn lab_runner_availability_error(
 
     let stale_daemon_recovery = selected_status
         .and_then(|status| status.stale_daemon.as_ref())
-        .map(|warning| warning.refresh_command.clone());
+        .and_then(|warning| warning.safe_recovery_commands().into_iter().next());
     let mut tried = vec![
         "Wait for an active Lab runner job to finish, then retry.".to_string(),
         "Choose another available runner with --runner <runner-id>.".to_string(),
@@ -1138,11 +1138,20 @@ pub(super) fn lab_runner_availability_error(
                 "eligible": eligible,
                 "reasons": reasons,
             },
-            "runner_status": selected_status,
+            "runner_status": selected_status.map(sanitized_status_for_output),
             "stale_daemon_recovery_command": stale_daemon_recovery,
             "tried": tried,
         }),
     )
+}
+
+fn sanitized_status_for_output(status: &RunnerStatusReport) -> RunnerStatusReport {
+    let mut status = status.clone();
+    status.stale_daemon = status
+        .stale_daemon
+        .as_ref()
+        .map(RunnerStaleDaemonWarning::sanitized_for_output);
+    status
 }
 
 fn connect_runner_for_offload(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
@@ -1415,24 +1424,18 @@ fn daemon_repair_steps(runner_id: &str, status: &RunnerStatusReport) -> Vec<Daem
         return report.repair_plan.clone();
     }
     if let Some(warning) = status.stale_daemon.as_ref() {
-        // The warning renders its own text from argv, so a step keeps the
-        // action alongside the string instead of forcing a consumer to
-        // reconstruct one from the other. A recovery with no typed form (an
-        // older warning, or one whose command came from the runner rather than
-        // from a builder) degrades to text and is surfaced, not executed.
         let steps: Vec<_> = warning
-            .recovery_steps()
+            .safe_recovery_actions()
             .into_iter()
-            .map(|(command, action)| match action {
-                Some(action) => {
-                    daemon_repair::action_step(daemon_repair::STALE_DAEMON_RECOVERY, action)
-                }
-                None => daemon_repair::step(daemon_repair::STALE_DAEMON_RECOVERY, command),
-            })
+            .map(|action| daemon_repair::action_step(daemon_repair::STALE_DAEMON_RECOVERY, action))
             .collect();
         if !steps.is_empty() {
             return steps;
         }
+        return vec![daemon_repair::action_step(
+            daemon_repair::RUNNER_DIAGNOSE,
+            daemon_repair::diagnose_action(runner_id),
+        )];
     }
     daemon_repair::reconnect_plan(runner_id)
 }
@@ -1784,15 +1787,14 @@ mod daemon_repair_step_tests {
     }
 
     #[test]
-    fn stale_daemon_recovery_commands_become_typed_steps() {
+    fn stale_daemon_recovery_uses_only_an_exact_safe_typed_action() {
         let warning = RunnerStaleDaemonWarning::new(
             "homeboy-lab",
             "homeboy 0.218.0".to_string(),
             "homeboy 0.219.0".to_string(),
-            Some("homeboy 0.218.0+old".to_string()),
+            Some("homeboy 0.218.0+new".to_string()),
             Some("homeboy 0.219.0+new".to_string()),
         );
-        let expected = warning.recovery_commands.clone();
         let report = status_report("homeboy-lab", None, Some(warning));
 
         let steps = daemon_repair_steps("homeboy-lab", &report);
@@ -1802,11 +1804,34 @@ mod daemon_repair_step_tests {
                 .iter()
                 .map(|step| step.command.clone())
                 .collect::<Vec<_>>(),
-            expected
+            ["homeboy runner refresh-homeboy homeboy-lab --ref new --reconnect"]
         );
         assert!(steps
             .iter()
             .all(|step| step.code == daemon_repair::STALE_DAEMON_RECOVERY));
+        assert!(daemon_repair_action("homeboy-lab", &report).is_some());
+    }
+
+    #[test]
+    fn stale_daemon_with_unverified_ref_offers_only_read_only_inspection() {
+        let warning = RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            "homeboy 0.218.0".to_string(),
+            "homeboy 0.219.0".to_string(),
+            Some("homeboy 0.218.0+old".to_string()),
+            Some("homeboy 0.219.0+new".to_string()),
+        );
+        let report = status_report("homeboy-lab", None, Some(warning));
+
+        let steps = daemon_repair_steps("homeboy-lab", &report);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].code, daemon_repair::RUNNER_DIAGNOSE);
+        assert_eq!(
+            steps[0].command,
+            "homeboy runner doctor homeboy-lab --scope lab-offload"
+        );
+        assert!(!daemon_repair_command("homeboy-lab", &report).contains("refresh-homeboy"));
+        assert!(daemon_repair_action("homeboy-lab", &report).is_none());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::session::{RunnerSession, RunnerStatusReport};
+use super::session::{RunnerSession, RunnerStaleDaemonWarning, RunnerStatusReport};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RunnerBinarySource {
@@ -89,7 +89,9 @@ impl RuntimeMaterializationStatus {
                 .and_then(|warning| warning.job_command_binary_build_identity.clone()),
             stale_daemon_severity: stale_daemon.map(|warning| warning.severity),
             stale_daemon_refresh_command: stale_daemon
-                .map(|warning| warning.refresh_command.clone()),
+                .map(RunnerStaleDaemonWarning::safe_recovery_commands)
+                .filter(|commands| !commands.is_empty())
+                .map(|commands| commands.join(" && ")),
             version_drift,
         }
     }

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -965,7 +965,7 @@ impl RunnerStatusReport {
             }
         }
         if let Some(warning) = &self.stale_daemon {
-            warning.primary_recovery_action()
+            warning.safe_recovery_actions().into_iter().next()
         } else if !self.is_connected() {
             Some(crate::daemon_repair::connect_action(&self.runner_id))
         } else if self.active_job_state != RunnerActiveJobState::Available {
@@ -1800,12 +1800,14 @@ pub struct RunnerStaleDaemonWarning {
     pub active_daemon_control_plane_build_identity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_command_binary_build_identity: Option<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub refresh_command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stale_runtime_paths: Vec<RunnerStaleRuntimePath>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_runtime_paths: Vec<RunnerChangedRuntimePath>,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub recovery_commands: Vec<String>,
     /// Argv for `recovery_commands`, in the same order.
     ///
@@ -1837,6 +1839,53 @@ pub struct RunnerChangedRuntimePath {
 }
 
 impl RunnerStaleDaemonWarning {
+    /// Recovery commands safe to publish to an operator or machine consumer.
+    ///
+    /// Persisted command text is evidence, not authority. A refresh is exposed
+    /// only when its typed immutable ref equals the observed daemon commit or
+    /// git proves it is a descendant; unknown and divergent histories have no
+    /// mutating recovery recommendation.
+    pub fn safe_recovery_commands(&self) -> Vec<String> {
+        self.safe_recovery_actions()
+            .into_iter()
+            .map(|action| action.render_command())
+            .collect()
+    }
+
+    /// Typed mutating actions authorized by the same monotonic contract as the
+    /// published command projection. Callers must not reconstruct actions from
+    /// persisted command text.
+    pub(crate) fn safe_recovery_actions(&self) -> Vec<ExecutableAction> {
+        let Some(active) = self
+            .active_daemon_control_plane_build_identity
+            .as_deref()
+            .and_then(build_identity_commit)
+        else {
+            return Vec::new();
+        };
+        self.recovery_actions
+            .iter()
+            .filter_map(|action| {
+                let target = action
+                    .args
+                    .windows(2)
+                    .find_map(|args| (args[0] == "--ref").then(|| args[1].as_str()))?;
+                (target == active || commits_are_ancestral(&active, target)).then(|| action.clone())
+            })
+            .collect()
+    }
+
+    /// Remove persisted recovery text that has not passed the monotonic output
+    /// contract before embedding this warning in a broader serialized report.
+    pub fn sanitized_for_output(&self) -> Self {
+        let mut warning = self.clone();
+        let commands = self.safe_recovery_commands();
+        warning.refresh_command = commands.join(" && ");
+        warning.recovery_commands = commands;
+        warning.recovery_actions.clear();
+        warning
+    }
+
     pub fn new(
         runner_id: &str,
         session_homeboy_version: String,
@@ -2035,18 +2084,6 @@ impl RunnerStaleDaemonWarning {
         self.recovery_actions = actions;
     }
 
-    /// The first recovery step expressed as an executable action.
-    ///
-    /// Older persisted warnings can have only `refresh_command`. Preserve that
-    /// serialized command, including a pinned ref, by tokenizing it into argv
-    /// instead of replacing it with a newly composed recovery command.
-    fn primary_recovery_action(&self) -> Option<ExecutableAction> {
-        self.recovery_actions
-            .first()
-            .cloned()
-            .or_else(|| action_from_refresh_command(&self.refresh_command))
-    }
-
     /// Fold the controller↔runner comparison into this warning.
     ///
     /// `controller_identity_unverifiable` means the controller cannot name the
@@ -2138,18 +2175,6 @@ impl RunnerStaleDaemonWarning {
             }
         }
         self
-    }
-
-    /// Each recovery command paired with its argv, in order.
-    ///
-    /// The argv is `None` only when this warning's recovery has no typed form,
-    /// which is the one case a consumer must surface rather than execute.
-    pub(crate) fn recovery_steps(&self) -> Vec<(String, Option<ExecutableAction>)> {
-        self.recovery_commands
-            .iter()
-            .enumerate()
-            .map(|(index, command)| (command.clone(), self.recovery_actions.get(index).cloned()))
-            .collect()
     }
 
     pub(crate) fn recovery_ref(&self) -> Option<String> {
@@ -2258,39 +2283,6 @@ fn redact_runtime_value(value: &str) -> String {
     homeboy_core::redaction::RedactionPolicy::default().redact_env_value(value)
 }
 
-fn action_from_refresh_command(command: &str) -> Option<ExecutableAction> {
-    if command.trim().is_empty() {
-        return None;
-    }
-    if let Some(argv) = shlex::split(command) {
-        if let Some((program, args)) = argv.split_first() {
-            if program == "homeboy"
-                && !args
-                    .iter()
-                    .any(|arg| matches!(arg.as_str(), "&&" | ";" | "|"))
-            {
-                return Some(ExecutableAction::new(
-                    "runner.stale_recovery",
-                    "recover stale runner daemon",
-                    program,
-                    args.iter().cloned(),
-                    ActionSafety::Mutating,
-                ));
-            }
-        }
-    }
-    // Preserve a legacy chained recovery verbatim. Its shell form is already
-    // the published recovery contract; wrapping it avoids silently selecting a
-    // new, unpinned command when no typed steps were persisted.
-    Some(ExecutableAction::new(
-        "runner.stale_recovery",
-        "recover stale runner daemon",
-        "sh",
-        ["-lc", command],
-        ActionSafety::Mutating,
-    ))
-}
-
 /// The recovery for an identity-drifted runner daemon, as argv.
 ///
 /// A rendered string is derived from this; nothing derives argv from a string.
@@ -2330,6 +2322,19 @@ fn recovery_ref(
         }
         None => None,
     }
+}
+
+fn build_identity_commit(identity: &str) -> Option<String> {
+    homeboy_upgrade::upgrade::parse_build_identity_display(identity)
+        .filter(|identity| identity.git_dirty != Some(true))
+        .and_then(|identity| identity.git_commit)
+}
+
+fn commits_are_ancestral(older: &str, newer: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["merge-base", "--is-ancestor", older, newer])
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 fn same_homeboy_version(left: &str, right: &str) -> bool {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -8,7 +8,6 @@ use homeboy_lab_runner_contract::RunnerKind;
 use homeboy_upgrade::upgrade::version_is_newer;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
-use homeboy_upgrade::upgrade::RunnerDaemonDriftEntry;
 use homeboy_upgrade::upgrade::RunnerUpgradeEntry;
 use std::path::Path;
 
@@ -940,13 +939,7 @@ fn refresh_managed_immutable_runner(
     let (extensions_synced, extensions_skipped, extensions_failed) =
         sync_runner_extensions(runner, &homeboy_path, extension_updates, exec);
     let admission_ready = managed_immutable_admission_ready(&reconciled);
-    let stale_daemon = reconciled
-        .stale_daemon
-        .map(|warning| RunnerDaemonDriftEntry {
-            session_homeboy_version: warning.session_homeboy_version,
-            current_homeboy_version: warning.current_homeboy_version,
-            recovery_commands: warning.recovery_commands,
-        });
+    let stale_daemon = reconciled.stale_daemon.map(runner_daemon_drift_entry);
     let success = new_version.is_some()
         && admission_ready
         && stale_daemon.is_none()

--- a/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/reporting.rs
@@ -30,11 +30,18 @@ pub fn runner_stale_daemon(
         .ok()?
         .stale_daemon
         .filter(|warning| !warning.is_unverified())?;
-    Some(RunnerDaemonDriftEntry {
+    Some(runner_daemon_drift_entry(warning))
+}
+
+pub(super) fn runner_daemon_drift_entry(
+    warning: crate::RunnerStaleDaemonWarning,
+) -> RunnerDaemonDriftEntry {
+    let recovery_commands = warning.safe_recovery_commands();
+    RunnerDaemonDriftEntry {
         session_homeboy_version: warning.session_homeboy_version,
         current_homeboy_version: warning.current_homeboy_version,
-        recovery_commands: warning.recovery_commands,
-    })
+        recovery_commands,
+    }
 }
 
 #[expect(
@@ -112,7 +119,7 @@ pub fn runner_upgrade_final_detail(
     if let Some(stale_daemon) = stale_daemon {
         let remediation = stale_daemon.recovery_commands.join(" && ");
         let remediation = if remediation.is_empty() {
-            "homeboy runner disconnect <runner> && homeboy runner connect <runner>".to_string()
+            "inspect exact daemon and runner build identities before selecting a refresh target; use --allow-downgrade only for an intentional rollback".to_string()
         } else {
             remediation
         };

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_a.rs
@@ -7,10 +7,67 @@ use homeboy_core::build_identity;
 use homeboy_upgrade::upgrade::current_version;
 use homeboy_upgrade::upgrade::ExtensionUpgradeEntry;
 use homeboy_upgrade::upgrade::InstallMethod;
+use homeboy_upgrade::upgrade::RunnerDaemonDriftEntry;
 use std::cell::RefCell;
 use std::path::Path;
 thread_local! {
     static LOCAL_VERSION_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+#[test]
+fn upgrade_reporting_and_reconciliation_omit_unverified_persisted_refresh_refs() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "lab",
+        "0.264.0".to_string(),
+        "0.265.0".to_string(),
+        Some("homeboy 0.264.0+aaaaaaaa".to_string()),
+        Some("homeboy 0.265.0+bbbbbbbb".to_string()),
+    );
+
+    let report = runner_stale_daemon(&ssh_runner("lab", None), &|_| {
+        let mut status = runner_status("lab")?;
+        status.stale_daemon = Some(warning.clone());
+        Ok(status)
+    })
+    .expect("stale daemon report");
+    let reconciled = runner_daemon_drift_entry(warning);
+
+    assert!(report.recovery_commands.is_empty());
+    assert!(reconciled.recovery_commands.is_empty());
+    let detail = runner_upgrade_final_detail(
+        "lab",
+        "upgrade result".to_string(),
+        "homeboy",
+        None,
+        None,
+        None,
+        Some(&RunnerDaemonDriftEntry {
+            session_homeboy_version: "0.264.0".to_string(),
+            current_homeboy_version: "0.265.0".to_string(),
+            recovery_commands: report.recovery_commands,
+        }),
+        &[],
+        &[],
+    );
+    assert!(detail.contains("inspect exact daemon and runner build identities"));
+    assert!(!detail.contains("--ref bbbbbbbb"));
+}
+
+#[test]
+fn upgrade_reporting_preserves_an_exact_safe_refresh_ref() {
+    let warning = RunnerStaleDaemonWarning::new(
+        "lab",
+        "0.264.0".to_string(),
+        "0.265.0".to_string(),
+        Some("homeboy 0.264.0+aaaaaaaa".to_string()),
+        Some("homeboy 0.265.0+aaaaaaaa".to_string()),
+    );
+
+    let report = runner_daemon_drift_entry(warning);
+    assert_eq!(
+        report.recovery_commands,
+        ["homeboy runner refresh-homeboy lab --ref aaaaaaaa --reconnect"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Require immutable exact-build ancestry before generating runner refresh guidance.
- Centralize sanitized recovery commands/actions and remove unsafe persisted-command fallbacks across CLI, Lab metadata, selection, upgrade, and executable repair surfaces.
- Preserve explicit rollback guidance when monotonic ancestry cannot be proven.

Closes #9088.

## Verification
- `cargo test -p homeboy-cli runner::tests::status --no-fail-fast` (29 tests)
- `cargo test -p homeboy-lab-runner daemon_repair_step_tests --lib`
- `cargo test -p homeboy-lab-runner lab_selection::placement_readiness_tests --lib`
- `cargo test -p homeboy-lab-runner upgrade_runners::tests --lib`
- `cargo check -p homeboy-cli -p homeboy-lab-runner`
- `cargo fmt --check`

Two unrelated pre-existing connection tests remain red when running the broader connection module; both reproduce on `origin/main` and do not traverse stale-warning recovery authorization.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented the change, performed repeated adversarial reviews of every output/action surface, and added deterministic regression coverage. Chris Huber reviewed and remains responsible for every line.
