### PR TITLE
Bound runner doctor SSH fallback

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -8,11 +8,21 @@ pub fn report(
     client: &SshClient,
     options: &RunnerDoctorOptions,
 ) -> RunnerDoctorOutput {
-    let _probe_limits = client.scoped_probe_limits(
-        std::time::Duration::from_secs(5),
-        std::time::Duration::from_secs(60),
-        "runner doctor",
-    );
+    let scoped = options.scope == RunnerDoctorScope::LabOffload;
+    let (per_probe, overall) = probe_limits(options.scope);
+    let _probe_limits = client.scoped_probe_limits(per_probe, overall, "runner doctor");
+    let ssh_execution = client.execute("printf ok");
+    if !ssh_execution.success || ssh_execution.stdout.trim() != "ok" {
+        return unreachable_report(runner_id, runner, server, ssh_execution);
+    }
+    let mut ssh_details = common::detail_map(&[]);
+    if homeboy::core::server::client::used_clean_ssh_session(&ssh_execution) {
+        ssh_details.insert(
+            "transport".to_string(),
+            "clean_session_fallback".to_string(),
+        );
+    }
+
     // Lab admission uses the live status projection, including the daemon's
     // typed freshness report. Doctor repair must make its decision from that
     // same observation rather than treating a reachable endpoint as ready.
@@ -42,23 +52,19 @@ pub fn report(
         .workspace_root
         .clone()
         .unwrap_or_else(|| ".".to_string());
-    let artifact_root = default_artifact_root(client);
+    let artifact_root = if scoped {
+        "~/.local/share/homeboy/artifacts".to_string()
+    } else {
+        default_artifact_root(client)
+    };
     let mut checks = Vec::new();
     let mut tools = BTreeMap::new();
 
-    checks.push(match client.execute("printf ok") {
-        output if output.success && output.stdout.trim() == "ok" => checks::ok(
-            "ssh.execution",
-            format!("SSH runner {} is reachable", runner_id),
-            None,
-        ),
-        output => checks::error(
-            "ssh.execution",
-            format!("SSH runner {} is not reachable", runner_id),
-            Some("Run `homeboy server status <server-id>` and verify host, user, port, identity_file, and network access".to_string()),
-            common::detail_map(&[("stderr", output.stderr.trim()), ("stdout", output.stdout.trim())]),
-        ),
-    });
+    checks.push(checks::ok_with_details(
+        "ssh.execution",
+        format!("SSH runner {} is reachable", runner_id),
+        ssh_details,
+    ));
 
     let homeboy_command = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
     let local_homeboy_identity = homeboy_product_identity::build_identity();
@@ -101,63 +107,87 @@ pub fn report(
         )
     });
 
-    let system = SystemProbe {
-        os: common::remote_line(client, "uname -s").unwrap_or_else(|| "unknown".to_string()),
-        arch: common::remote_line(client, "uname -m").unwrap_or_else(|| "unknown".to_string()),
-        kernel: common::remote_line(client, "uname -r"),
+    let system = if scoped {
+        SystemProbe::default()
+    } else {
+        SystemProbe {
+            os: common::remote_line(client, "uname -s").unwrap_or_else(|| "unknown".to_string()),
+            arch: common::remote_line(client, "uname -m").unwrap_or_else(|| "unknown".to_string()),
+            kernel: common::remote_line(client, "uname -r"),
+        }
     };
-    checks.push(checks::ok(
-        "system",
-        format!("{} {} runner detected", system.os, system.arch),
-        None,
-    ));
+    if !scoped {
+        checks.push(checks::ok(
+            "system",
+            format!("{} {} runner detected", system.os, system.arch),
+            None,
+        ));
+    }
 
-    let cpu = CpuProbe {
+    let cpu = if scoped {
+        CpuProbe::default()
+    } else {
+        CpuProbe {
         count: common::remote_line(client, "getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null")
             .and_then(|value| value.parse::<usize>().ok())
             .unwrap_or(1),
+    }
     };
-    checks.push(checks::ok(
-        "cpu",
-        format!("{} CPU cores detected", cpu.count),
-        None,
-    ));
-
-    let memory = probes::remote_memory_probe(client);
-    checks.push(match &memory {
-        Some(memory) => checks::ok(
-            "memory",
-            format!("{} MB RAM detected", memory.total_mb),
+    if !scoped {
+        checks.push(checks::ok(
+            "cpu",
+            format!("{} CPU cores detected", cpu.count),
             None,
-        ),
-        None => checks::warning(
-            "memory",
-            "RAM totals could not be detected".to_string(),
-            Some("Ensure /proc/meminfo or sysctl is available on the remote runner".to_string()),
-        ),
-    });
+        ));
+    }
 
-    let disk = probes::remote_disk_probe(client, &workspace_root);
-    checks.push(match &disk {
-        Some(disk) => checks::ok(
-            "disk.workspace_root",
-            format!("{} MB available at workspace root", disk.available_mb),
-            None,
-        ),
-        None => checks::warning(
-            "disk.workspace_root",
-            "Workspace disk capacity could not be detected".to_string(),
-            Some("Ensure df is available on the remote runner".to_string()),
-        ),
-    });
+    let memory = (!scoped)
+        .then(|| probes::remote_memory_probe(client))
+        .flatten();
+    if !scoped {
+        checks.push(match &memory {
+            Some(memory) => checks::ok(
+                "memory",
+                format!("{} MB RAM detected", memory.total_mb),
+                None,
+            ),
+            None => checks::warning(
+                "memory",
+                "RAM totals could not be detected".to_string(),
+                Some(
+                    "Ensure /proc/meminfo or sysctl is available on the remote runner".to_string(),
+                ),
+            ),
+        });
+    }
 
-    for spec in probes::tool_specs(runner) {
-        if spec.id == "homeboy" {
-            continue;
+    let disk = (!scoped)
+        .then(|| probes::remote_disk_probe(client, &workspace_root))
+        .flatten();
+    if !scoped {
+        checks.push(match &disk {
+            Some(disk) => checks::ok(
+                "disk.workspace_root",
+                format!("{} MB available at workspace root", disk.available_mb),
+                None,
+            ),
+            None => checks::warning(
+                "disk.workspace_root",
+                "Workspace disk capacity could not be detected".to_string(),
+                Some("Ensure df is available on the remote runner".to_string()),
+            ),
+        });
+    }
+
+    if !scoped {
+        for spec in probes::tool_specs(runner) {
+            if spec.id == "homeboy" {
+                continue;
+            }
+            let probe = probes::remote_tool_probe(client, &spec.command, &spec.version_args);
+            checks.push(checks::tool_check(spec.clone(), &probe));
+            tools.insert(spec.id.to_string(), probe);
         }
-        let probe = probes::remote_tool_probe(client, &spec.command, &spec.version_args);
-        checks.push(checks::tool_check(spec.clone(), &probe));
-        tools.insert(spec.id.to_string(), probe);
     }
 
     for command in normalized_required_tools(&options.required_tools) {
@@ -168,43 +198,61 @@ pub fn report(
     }
 
     let mut declared_tools = BTreeMap::new();
-    for (source, specs) in probes::declared_tool_specs_by_source() {
-        let mut source_tools = BTreeMap::new();
-        for spec in specs {
-            let probe = probes::remote_tool_probe(client, &spec.command, &spec.version_args);
-            source_tools.insert(spec.id.clone(), probe.clone());
-            tools.entry(spec.id.clone()).or_insert(probe);
+    if !scoped {
+        for (source, specs) in probes::declared_tool_specs_by_source() {
+            let mut source_tools = BTreeMap::new();
+            for spec in specs {
+                let probe = probes::remote_tool_probe(client, &spec.command, &spec.version_args);
+                source_tools.insert(spec.id.clone(), probe.clone());
+                tools.entry(spec.id.clone()).or_insert(probe);
+            }
+            declared_tools.insert(source, source_tools);
         }
-        declared_tools.insert(source, source_tools);
     }
 
     let playwright = probes::tool_available(&tools, "playwright");
-    let browser_ready = probes::remote_browser_ready(client);
-    let display_ready = probes::remote_display_ready(client);
-    let xvfb_ready = probes::remote_xvfb_ready(client);
+    let browser_ready = (!scoped)
+        .then(|| probes::remote_browser_ready(client))
+        .unwrap_or(false);
+    let display_ready = (!scoped)
+        .then(|| probes::remote_display_ready(client))
+        .unwrap_or(false);
+    let xvfb_ready = (!scoped)
+        .then(|| probes::remote_xvfb_ready(client))
+        .unwrap_or(false);
     let headed_browser_ready = probes::headed_browser_ready(display_ready, xvfb_ready);
-    checks.push(checks::playwright_check(playwright, browser_ready));
-    checks.push(checks::headed_browser_check(
-        headed_browser_ready,
-        display_ready,
-        xvfb_ready,
-    ));
+    if !scoped {
+        checks.push(checks::playwright_check(playwright, browser_ready));
+        checks.push(checks::headed_browser_check(
+            headed_browser_ready,
+            display_ready,
+            xvfb_ready,
+        ));
+    }
 
-    let workspace_writable = probes::remote_path_writable(client, &workspace_root);
-    checks.push(checks::path_writable_check(
-        "workspace.writable",
-        workspace_writable,
-        Path::new(&workspace_root),
-        "Make the remote workspace root writable by the runner user",
-    ));
+    let workspace_writable = (!scoped)
+        .then(|| probes::remote_path_writable(client, &workspace_root))
+        .unwrap_or(false);
+    if !scoped {
+        checks.push(checks::path_writable_check(
+            "workspace.writable",
+            workspace_writable,
+            Path::new(&workspace_root),
+            "Make the remote workspace root writable by the runner user",
+        ));
+    }
 
-    let artifact_store_available = probes::remote_artifact_store_available(client, &artifact_root);
-    checks.push(checks::path_writable_check(
-        "artifact_store.available",
-        artifact_store_available,
-        Path::new(&artifact_root),
-        "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
-    ));
+    let artifact_store_available = (!scoped)
+        .then(|| probes::remote_artifact_store_available(client, &artifact_root))
+        .unwrap_or(false);
+    if !scoped {
+        checks.push(checks::path_writable_check(
+            "artifact_store.available",
+            artifact_store_available,
+            Path::new(&artifact_root),
+            "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
+        ));
+    }
 
     if options.scope == RunnerDoctorScope::LabOffload {
         checks.extend(probes::lab_homeboy_path_checks(
@@ -332,6 +380,34 @@ pub fn report(
             .and_then(|status| status.daemon_freshness.clone()),
         admission_summary: persisted_status.as_ref().and_then(admission_summary),
         repairs: Vec::new(),
+    }
+}
+
+pub(super) fn probe_limits(scope: RunnerDoctorScope) -> (std::time::Duration, std::time::Duration) {
+    match scope {
+        RunnerDoctorScope::LabOffload => (
+            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(20),
+        ),
+        RunnerDoctorScope::General | RunnerDoctorScope::SecretEnv => (
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(60),
+        ),
+    }
+}
+
+pub(super) fn unreachable_report(
+    runner_id: &str,
+    runner: &Runner,
+    server: &Server,
+    output: homeboy::core::server::CommandOutput,
+) -> RunnerDoctorOutput {
+    RunnerDoctorOutput {
+        variant: "doctor", command: "runner.doctor", runner_id: runner_id.to_string(),
+        runner: runner_summary("ssh", Some(runner), Some(server)), status: RunnerDoctorStatus::Error,
+        capabilities: RunnerCapabilities::default(), resources: RunnerResources::default(),
+        checks: vec![checks::error("ssh.execution", format!("SSH runner {} is not reachable", runner_id), Some("Run `homeboy server status <server-id>` and verify host, user, port, identity_file, and network access".to_string()), common::detail_map(&[("stderr", output.stderr.trim()), ("stdout", output.stdout.trim())]))],
+        secret_env_migration: None, diagnostics: Some(types::RunnerDoctorDiagnostics { status: "partial", completed_checks: 1, timed_out_probes: Vec::new() }), daemon_recovery: None, admission_summary: None, repairs: Vec::new(),
     }
 }
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -211,6 +211,61 @@ fn remote_default_artifact_root_rejects_empty_home() {
 }
 
 #[test]
+fn unreachable_transport_report_is_terminal_and_has_no_daemon_evidence() {
+    let runner = Runner {
+        id: "lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: Some("lab".to_string()),
+        workspace_root: None,
+        settings: server::RunnerSettings::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: server::RunnerPolicy::default(),
+    };
+    let server = server::Server {
+        id: "lab".to_string(),
+        aliases: Vec::new(),
+        host: "example.test".to_string(),
+        user: "runner".to_string(),
+        port: 22,
+        identity_file: None,
+        kind: None,
+        auth: None,
+        env: Default::default(),
+        runner: None,
+    };
+    let output = homeboy::core::server::CommandOutput {
+        stdout: String::new(),
+        stderr: "mm_send_fd: sendmsg(0): Message too long".to_string(),
+        success: false,
+        exit_code: 255,
+        timed_out: false,
+        child_resource: None,
+    };
+
+    let report = remote::unreachable_report("lab", &runner, &server, output);
+
+    assert_eq!(report.status, RunnerDoctorStatus::Error);
+    assert_eq!(report.checks.len(), 1);
+    assert_eq!(report.checks[0].id, "ssh.execution");
+    assert!(report.daemon_recovery.is_none());
+    assert!(report.admission_summary.is_none());
+    assert_eq!(report.diagnostics.expect("diagnostics").completed_checks, 1);
+}
+
+#[test]
+fn lab_offload_uses_a_bounded_probe_envelope() {
+    assert_eq!(
+        remote::probe_limits(RunnerDoctorScope::LabOffload),
+        (
+            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(20),
+        )
+    );
+}
+
+#[test]
 fn disconnected_lab_doctor_reuses_daemon_recovery_envelope() {
     let recovery = homeboy::core::daemon::DaemonFreshnessReport {
         fresh: false,

--- a/crates/homeboy-core/src/server/client/mod.rs
+++ b/crates/homeboy-core/src/server/client/mod.rs
@@ -26,6 +26,7 @@ pub use local_exec::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,
     execute_local_command_stderr_passthrough_with_timeout,
 };
+pub use ssh_client::used_clean_ssh_session;
 
 pub struct SshClient {
     pub host: String,

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -182,6 +182,15 @@ impl SshClient {
     }
 
     pub(crate) fn build_ssh_args(&self, command: Option<&str>, interactive: bool) -> Vec<String> {
+        self.build_ssh_args_with_multiplexing(command, interactive, false)
+    }
+
+    fn build_ssh_args_with_multiplexing(
+        &self,
+        command: Option<&str>,
+        interactive: bool,
+        disable_multiplexing: bool,
+    ) -> Vec<String> {
         client_ssh_args(
             self,
             SshArgOptions {
@@ -189,6 +198,7 @@ impl SshClient {
                 batch_mode: true,
                 connect_timeout: true,
                 keepalive: true,
+                disable_multiplexing,
                 port_flag: Some(SshPortFlag::Lowercase),
                 command,
                 ..SshArgOptions::default()
@@ -552,7 +562,21 @@ impl SshClient {
         timeout: Duration,
     ) -> CommandOutput {
         let remote_command = wrap_timed_remote_command(command);
-        let args = self.build_ssh_args(Some(&remote_command), false);
+        self.execute_ssh_with_timeout_and_multiplexing(&remote_command, stdin, timeout, false)
+    }
+
+    fn execute_ssh_with_timeout_and_multiplexing(
+        &self,
+        remote_command: &str,
+        stdin: Option<&[u8]>,
+        timeout: Duration,
+        disable_multiplexing: bool,
+    ) -> CommandOutput {
+        let args = self.build_ssh_args_with_multiplexing(
+            Some(remote_command),
+            false,
+            disable_multiplexing,
+        );
         let mut cmd = Command::new("ssh");
         cmd.args(&args)
             .stdout(Stdio::piped())
@@ -720,7 +744,24 @@ impl ProbeLimits {
                 child_resource: None,
             };
         }
-        let output = client.execute_with_timeout(command, timeout);
+        let started = Instant::now();
+        let mut output = client.execute_with_timeout(command, timeout);
+        if is_ssh_mux_message_too_long(&output) {
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if !remaining.is_zero() {
+                output = client.execute_ssh_with_timeout_and_multiplexing(
+                    &wrap_timed_remote_command(&client.prepend_env(command)),
+                    None,
+                    remaining,
+                    true,
+                );
+                if output.success {
+                    output.stderr.push_str(
+                        "Homeboy diagnostic probe bypassed the SSH control socket after mux overflow.\n",
+                    );
+                }
+            }
+        }
         if output.timed_out {
             self.record_timeout(command, reason_code);
         }
@@ -742,6 +783,20 @@ impl ProbeLimits {
             });
         }
     }
+}
+
+pub fn is_ssh_mux_message_too_long(output: &CommandOutput) -> bool {
+    !output.success
+        && output
+            .stderr
+            .to_ascii_lowercase()
+            .contains("mm_send_fd: sendmsg(0): message too long")
+}
+
+pub fn used_clean_ssh_session(output: &CommandOutput) -> bool {
+    output
+        .stderr
+        .contains("Homeboy diagnostic probe bypassed the SSH control socket after mux overflow.")
 }
 
 pub(super) fn execute_command_with_stdin_timeout(
@@ -911,6 +966,37 @@ mod bounded_probe_tests {
         let output = client.execute("printf unreachable");
 
         assert!(!output.success);
+    }
+
+    #[test]
+    fn mux_message_too_long_is_classified_for_clean_session_retry() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: "mux_client_request_session: read from master failed: Broken pipe\nmm_send_fd: sendmsg(0): Message too long".to_string(),
+            success: false,
+            exit_code: 255,
+            timed_out: false,
+            child_resource: None,
+        };
+
+        assert!(is_ssh_mux_message_too_long(&output));
+    }
+
+    #[test]
+    fn clean_session_fallback_does_not_reuse_the_control_socket() {
+        let mut client = localhost_client();
+        client.is_local = false;
+        client.auth = Some(ManagedSshSession {
+            control_path: "/tmp/homeboy-control".to_string(),
+            persist: "1h".to_string(),
+            persist_source: crate::server::ManagedSshSessionPersistSource::Configured,
+        });
+
+        let args = client.build_ssh_args_with_multiplexing(Some("printf ok"), false, true);
+
+        assert!(args.contains(&"ControlMaster=no".to_string()));
+        assert!(args.contains(&"ControlPath=none".to_string()));
+        assert!(!args.iter().any(|arg| arg.contains("/tmp/homeboy-control")));
     }
 }
 


### PR DESCRIPTION
## Summary
- Bound `runner doctor --scope lab-offload` to targeted probes.
- Retry the exact OpenSSH mux-overflow signature once through a clean session.
- Keep reachability and daemon evidence consistent after transport failure.

Closes #12308.

## Verification
- `cargo test -p homeboy-core mux_message_too_long_is_classified_for_clean_session_retry`
- `cargo test -p homeboy-cli lab_offload_uses_a_bounded_probe_envelope`
- `cargo fmt --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed the change and tests. Chris Huber reviewed and remains responsible for every line.
