### PR TITLE
fix: fail closed instead of silently destroying a remote file on write

### DIFF
--- a/crates/homeboy-cli/src/commands/file/args.rs
+++ b/crates/homeboy-cli/src/commands/file/args.rs
@@ -42,6 +42,9 @@ pub(crate) enum FileCommand {
         project_id: String,
         /// Remote file path
         path: String,
+        /// Permit an empty write, truncating the destination to zero bytes
+        #[arg(long)]
+        allow_empty: bool,
         // Apply the destructive write. Without this flag, prints a plan only.
         // Shared plan-default mutation group (#11139).
         #[command(flatten)]

--- a/crates/homeboy-cli/src/commands/file/mod.rs
+++ b/crates/homeboy-cli/src/commands/file/mod.rs
@@ -18,6 +18,7 @@ use args::{EditArgs, FileCommand};
 
 use homeboy::core::context::require_project_base_path;
 use homeboy::core::engine::{command, executor, shell};
+use homeboy::core::error::{Error, Result};
 use homeboy::core::project::files;
 use homeboy::core::server::transfer::{self, TransferConfig, TransferOutput};
 use homeboy::core::{join_remote_path, project};
@@ -50,9 +51,10 @@ pub fn run(args: FileArgs) -> CmdResult<FileCommandOutput> {
         FileCommand::Write {
             project_id,
             path,
+            allow_empty,
             mutation,
         } => {
-            let (out, code) = write(&project_id, &path, mutation.is_apply())?;
+            let (out, code) = write(&project_id, &path, mutation.is_apply(), allow_empty)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Mkdir {
@@ -207,8 +209,38 @@ fn read(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     ))
 }
 
-fn write(project_id: &str, path: &str, apply: bool) -> CmdResult<FileOutput> {
+/// Refuse an empty write unless the operator asked for one (#10816).
+///
+/// `files::write` sends `cat > path << 'EOF'`, and the redirect truncates the
+/// destination the moment the shell opens it -- before a single byte of content
+/// is transferred. So an empty payload is not a no-op, it is a deletion that
+/// reports `success: true`. A piped invocation whose producer wrote nothing
+/// destroyed an existing remote file exactly this way.
+///
+/// Truncation is a legitimate thing to want, so this is a guard rather than a
+/// prohibition: `--allow-empty` states the intent explicitly. The default is
+/// the safe one because the destructive reading of an empty stdin is almost
+/// never what the caller meant.
+///
+/// Checked before the dry-run branch too: a plan that does not surface this
+/// refusal would tell the operator the write is fine, and they would then run
+/// the same command with `--apply`.
+fn require_nonempty_write(content: &str, allow_empty: bool, path: &str) -> Result<()> {
+    if !content.is_empty() || allow_empty {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "stdin",
+        "refusing to write 0 bytes: the destination would be truncated to an empty \
+         file. Pass --allow-empty if truncating is what you intend.",
+        Some(path.to_string()),
+        None,
+    ))
+}
+
+fn write(project_id: &str, path: &str, apply: bool, allow_empty: bool) -> CmdResult<FileOutput> {
     let content = files::read_stdin()?;
+    require_nonempty_write(&content, allow_empty, path)?;
     if !apply {
         let project = project::load(project_id)?;
         let project_base_path = require_project_base_path(project_id, &project)?;

--- a/crates/homeboy-core/src/project/files.rs
+++ b/crates/homeboy-core/src/project/files.rs
@@ -282,7 +282,31 @@ fn write_content_command(quoted_path: &str, content: &str) -> String {
         command.push_str(&format!("\ntruncate -s -1 {quoted_path}"));
     }
 
+    // Measure the destination and emit the count as the command's last line
+    // (#10816). `bytes_written` used to be `content.len()` -- the length of what
+    // we MEANT to send, echoed back without ever asking the remote. That number
+    // is identical whether every byte landed or none did, so it could not
+    // distinguish a completed write from a truncated one.
+    command.push_str(&format!(
+        "\nprintf '{WRITTEN_BYTES_MARKER}%s\\n' \"$(wc -c < {quoted_path})\""
+    ));
+
     command
+}
+
+/// Sentinel prefixing the verified byte count on the write command's last line.
+///
+/// Distinctive enough that content echoed by a remote shell profile cannot be
+/// mistaken for the measurement.
+const WRITTEN_BYTES_MARKER: &str = "__homeboy_written_bytes__=";
+
+/// Read back the byte count the remote actually measured.
+fn parse_written_bytes(stdout: &str) -> Option<usize> {
+    stdout
+        .lines()
+        .rev()
+        .find_map(|line| line.trim().strip_prefix(WRITTEN_BYTES_MARKER))
+        .and_then(|count| count.trim().parse().ok())
 }
 
 /// Write content to file.
@@ -294,10 +318,35 @@ pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult>
     let output = execute_for_project(&project, &command)?;
     command::require_success(output.success, &output.stderr, "WRITE")?;
 
+    // Fail closed on a short write. `cat > path` truncates the destination when
+    // the shell opens the redirect, so a transfer that dies partway leaves a
+    // damaged file behind AND exits 0. Reporting success there is what let an
+    // empty write present as a completed one (#10816).
+    let Some(bytes_written) = parse_written_bytes(&output.stdout) else {
+        return Err(Error::internal_io(
+            format!(
+                "wrote {} bytes to {full_path} but the remote did not report a byte \
+                 count, so the write could not be verified",
+                content.len()
+            ),
+            Some("write".to_string()),
+        ));
+    };
+    if bytes_written != content.len() {
+        return Err(Error::internal_io(
+            format!(
+                "short write to {full_path}: sent {} bytes, destination holds {bytes_written}. \
+                 The file has already been modified and may be truncated; restore it before retrying.",
+                content.len()
+            ),
+            Some("write".to_string()),
+        ));
+    }
+
     Ok(WriteResult {
         base_path: Some(project_base_path),
         path: full_path,
-        bytes_written: content.len(),
+        bytes_written,
     })
 }
 
@@ -675,6 +724,48 @@ mod tests {
         assert_eq!(matches[0].file, "/tmp/file.txt");
         assert_eq!(matches[0].line, 3);
         assert_eq!(matches[0].content, "needle");
+    }
+
+    /// The write must measure the destination, not restate its own intent
+    /// (#10816).
+    #[test]
+    fn the_write_command_measures_the_destination_it_wrote() {
+        let command = write_content_command("'/srv/app/config.php'", "hello\n");
+
+        assert!(
+            command.contains("wc -c < '/srv/app/config.php'"),
+            "the write must read the destination size back: {command}"
+        );
+        assert!(
+            command.trim_end().ends_with('"'),
+            "the measurement must be the last thing the command does, so a \
+             failure earlier in the pipeline cannot be reported as a completed \
+             write: {command}"
+        );
+    }
+
+    /// `bytes_written` is only meaningful if it came from the remote.
+    #[test]
+    fn written_bytes_are_read_from_the_marked_measurement_line() {
+        assert_eq!(
+            parse_written_bytes("__homeboy_written_bytes__=42\n"),
+            Some(42)
+        );
+        // A remote shell profile can print a banner before the command runs.
+        assert_eq!(
+            parse_written_bytes("Welcome to prod\n17\n__homeboy_written_bytes__=42\n"),
+            Some(42)
+        );
+        // The written content itself may contain digits, or even look like a
+        // count. Only the marked line is the measurement.
+        assert_eq!(parse_written_bytes("42\n"), None);
+        // No measurement at all is UNKNOWN, never zero.
+        assert_eq!(parse_written_bytes(""), None);
+        assert_eq!(parse_written_bytes("__homeboy_written_bytes__=\n"), None);
+        assert_eq!(
+            parse_written_bytes("__homeboy_written_bytes__=oops\n"),
+            None
+        );
     }
 
     #[test]

--- a/tests/commands/file_test.rs
+++ b/tests/commands/file_test.rs
@@ -284,3 +284,30 @@ fn file_edit_force_allows_first_replacement_when_pattern_has_multiple_matches() 
         "thread\nneedle"
     );
 }
+
+/// An empty write is a deletion, so it must be asked for explicitly (#10816).
+///
+/// `files::write` sends `cat > path << 'EOF'`. The redirect truncates the
+/// destination the moment the shell opens it, before any content is
+/// transferred, so writing zero bytes destroys the file rather than doing
+/// nothing. A piped invocation whose producer emitted nothing wiped an existing
+/// remote file exactly this way and returned `success: true` with
+/// `bytes_written: 0`.
+#[test]
+fn an_empty_write_is_refused_unless_explicitly_allowed() {
+    let refusal = super::require_nonempty_write("", false, "config.php")
+        .expect_err("an empty write must not be permitted by default");
+    let rendered = format!("{refusal:?}");
+    assert!(
+        rendered.contains("--allow-empty"),
+        "the refusal must name the flag that expresses the intent: {rendered}"
+    );
+
+    // Truncating is legitimate when it is what the operator asked for.
+    super::require_nonempty_write("", true, "config.php")
+        .expect("--allow-empty must permit truncation");
+
+    // Content of any size is unaffected by the guard.
+    super::require_nonempty_write("x", false, "config.php")
+        .expect("a non-empty write must not be blocked");
+}


### PR DESCRIPTION
Refs #10816. Fixes the data-loss half; see "Deliberately not in scope" below.

## What was wrong

`homeboy file write` could truncate an existing remote file to zero bytes and report success:

```sh
printf "non-empty content" | homeboy file write <project> <existing-file> --apply
```
```json
{"success": true, "status": "succeeded",
 "data": {"operation": "write", "bytes_written": 0, "success": true}}
```

The destination was left empty. Two independent defects had to line up for that, and both are fixed here.

### 1. An empty payload is not a no-op — it is a deletion

`files::write` sends:

```sh
cat > /path/to/file << 'EOF'
...
EOF
```

The redirect truncates the destination **the moment the shell opens it**, before a single byte of content is transferred. So a producer that emitted nothing did not skip the write — it destroyed the file.

Empty writes are now refused by default. Truncating is a legitimate thing to want, so this is a guard rather than a prohibition — `--allow-empty` states the intent:

```
refusing to write 0 bytes: the destination would be truncated to an empty file.
Pass --allow-empty if truncating is what you intend.
```

The guard runs **before** the dry-run branch. A plan that hid the refusal would tell the operator the write was fine, and they would then re-run the identical command with `--apply`.

### 2. `bytes_written` never asked the remote anything

It was `content.len()` — the length of what we *meant* to send, echoed straight back. That value is identical whether every byte landed or none did, so it could not distinguish a completed write from a truncated one. It was also, per the issue, *"the only indication that the operation had failed semantically"* — a field that structurally cannot detect the failure it was being read as evidence of.

The write now measures the destination as its last action and reports that:

```sh
printf '__homeboy_written_bytes__=%s\n' "$(wc -c < '/path/to/file')"
```

- count disagrees with content length → error naming both, and warning the file has **already** been modified
- no measurement at all → UNKNOWN, which fails; it never degrades to zero
- the marker is distinctive so a remote shell banner or the file's own content cannot be misread as the measurement

## Verification

- `cargo test -p homeboy-core --lib project::files` — 10 passed
- `cargo test -p homeboy-cli --lib file_test` — 15 passed
- `cargo check -p homeboy-cli -p homeboy-core --tests` — clean

New coverage:

- `an_empty_write_is_refused_unless_explicitly_allowed` — refused by default, permitted with the flag, non-empty unaffected
- `the_write_command_measures_the_destination_it_wrote` — pins that the measurement exists and is **last**, so a failure earlier in the pipeline cannot be reported as a completed write
- `written_bytes_are_read_from_the_marked_measurement_line` — shell banners, digit-bearing content, empty and malformed counts

## Deliberately not in scope

The issue also asks for an atomic temp-file write plus rename, so a transfer that dies partway preserves the destination instead of leaving it damaged. That changes ownership and permission semantics on the destination inode — `cat >` writes through the existing file and keeps its mode, `mv` replaces it — and deserves its own change rather than riding along here. Leaving #10816 open for it.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix and its coverage. Chris Huber remains responsible for the change.
