### PR TITLE
fix: open a shell for interactive project SSH instead of exiting after cd

### DIFF
--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -128,17 +128,11 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                 Some(shell::quote_args(&args.command))
             };
 
-            // When project is resolved with base_path, auto-cd to project root
-            let effective_command = match (&result.project_id, &result.base_path, &command_string) {
-                // Project with base_path and command: cd to base_path then run command
-                (Some(_), Some(bp), Some(cmd)) => {
-                    Some(format!("cd {} && {}", shell::quote_path(bp), cmd))
-                }
-                // Project with base_path, no command: interactive shell starts in base_path
-                (Some(_), Some(bp), None) => Some(format!("cd {}", shell::quote_path(bp))),
-                // No project context or no base_path: use command as-is
-                _ => command_string.clone(),
-            };
+            let effective_command = effective_remote_command(
+                result.project_id.as_deref(),
+                result.base_path.as_deref(),
+                command_string.as_deref(),
+            );
 
             let mut client = SshClient::from_server(&result.server, &result.server_id)?;
             if let Some(ref user_override) = args.user {
@@ -341,9 +335,89 @@ fn ssh_failure_reason(success: bool, exit_code: i32) -> Option<String> {
     ))
 }
 
+/// Compose the remote command, rooting it at the project base path.
+///
+/// Extracted from `run` so the generated command is directly assertable
+/// (#10839). The interactive shape in particular could not be observed from a
+/// test while it was an inline `match` arm, which is how `cd <base_path>` --
+/// a command that exits immediately -- shipped as the "open a shell" case.
+fn effective_remote_command(
+    project_id: Option<&str>,
+    base_path: Option<&str>,
+    command: Option<&str>,
+) -> Option<String> {
+    match (project_id, base_path, command) {
+        // Project with base_path and command: cd to base_path then run command.
+        (Some(_), Some(bp), Some(cmd)) => Some(format!("cd {} && {}", shell::quote_path(bp), cmd)),
+        // Project with base_path, no command: interactive shell rooted at
+        // base_path.
+        //
+        // `cd <bp>` alone is a complete remote command, so ssh ran it, it
+        // succeeded, and the session ended -- reporting
+        // `remote_command_success` with no shell ever presented. Replace the
+        // process with the operator's shell so the session persists until they
+        // exit it.
+        //
+        // `exec` rather than a plain invocation so the shell's exit status is
+        // the session's. Not `-l`: a login shell re-runs the profile scripts,
+        // and one that cd's to $HOME would silently undo the base_path this
+        // command exists to apply. The pty requested for the interactive path
+        // is what makes the exec'd shell interactive.
+        (Some(_), Some(bp), None) => Some(format!(
+            "cd {} && exec \"${{SHELL:-/bin/sh}}\"",
+            shell::quote_path(bp)
+        )),
+        // No project context or no base_path: use the command as-is. A
+        // server-only session with no command stays None, so ssh opens its own
+        // login shell exactly as before.
+        _ => command.map(str::to_string),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `homeboy ssh <project>` must hand back a shell, not run `cd` and quit.
+    #[test]
+    fn interactive_project_ssh_execs_a_shell_after_changing_directory() {
+        let command = effective_remote_command(Some("wpcom-sandbox"), Some("/srv/app"), None)
+            .expect("a project with a base path must produce a remote command");
+
+        assert_eq!(command, "cd '/srv/app' && exec \"${SHELL:-/bin/sh}\"");
+        assert!(
+            command.contains("exec"),
+            "the session must replace itself with a shell rather than terminating \
+             after cd (#10839): {command}"
+        );
+        assert!(
+            !command.contains(" -l"),
+            "a login shell re-runs profile scripts that may cd away from the \
+             base path this command exists to apply: {command}"
+        );
+    }
+
+    /// Every other shape is unchanged.
+    #[test]
+    fn other_remote_command_shapes_are_untouched() {
+        assert_eq!(
+            effective_remote_command(Some("proj"), Some("/srv/app"), Some("ls -la")).as_deref(),
+            Some("cd '/srv/app' && ls -la")
+        );
+        // Server-only, no base path: the command passes through verbatim.
+        assert_eq!(
+            effective_remote_command(None, None, Some("uptime")).as_deref(),
+            Some("uptime")
+        );
+        // Server-only interactive: ssh opens its own login shell, as before.
+        assert_eq!(effective_remote_command(None, None, None), None);
+        // A project without a base path has nothing to cd to.
+        assert_eq!(
+            effective_remote_command(Some("proj"), None, Some("uptime")).as_deref(),
+            Some("uptime")
+        );
+        assert_eq!(effective_remote_command(Some("proj"), None, None), None);
+    }
 
     #[test]
     fn ssh_success_classification_does_not_depend_on_output() {

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -1003,3 +1003,39 @@ fn pid_is_alive(pid: libc::pid_t) -> bool {
         .map(crate::process::pid_is_running)
         .unwrap_or(false)
 }
+
+/// An interactive session carrying a remote command needs an explicit tty
+/// (#10839).
+///
+/// `homeboy ssh <project>` sends `cd <base_path> && exec "$SHELL"` so the
+/// session lands in the project root. ssh allocates a tty by default only when
+/// NO command is given, so without `-t` the exec'd shell comes up
+/// non-interactive: no prompt, no job control.
+#[test]
+fn an_interactive_session_carrying_a_command_requests_a_terminal() {
+    let server: Server =
+        serde_json::from_str(r#"{"host":"app.example.test","user":"deploy"}"#).expect("server");
+    let client = SshClient::from_server(&server, "app").expect("client");
+
+    let interactive = client.build_ssh_args(Some("cd '/srv/app' && exec \"$SHELL\""), true);
+    assert!(
+        interactive.contains(&"-t".to_string()),
+        "an interactive session with a command must request a tty: {interactive:?}"
+    );
+
+    // Non-interactive callers capture output and must never be handed a pty:
+    // it would merge stderr into stdout and echo input back into the capture.
+    let captured = client.build_ssh_args(Some("uptime"), false);
+    assert!(
+        !captured.contains(&"-t".to_string()),
+        "output-capturing callers must not be handed a pty: {captured:?}"
+    );
+
+    // A bare interactive session has no command, so ssh allocates the tty
+    // itself and the flag is unnecessary.
+    let bare = client.build_ssh_args(None, true);
+    assert!(
+        !bare.contains(&"-t".to_string()),
+        "ssh already allocates a tty when no command is given: {bare:?}"
+    );
+}

--- a/crates/homeboy-core/src/server/ssh_args.rs
+++ b/crates/homeboy-core/src/server/ssh_args.rs
@@ -134,6 +134,19 @@ fn client_connection_args(
         push_option(&mut args, "ServerAliveCountMax=3");
     }
 
+    // ssh allocates a TTY by default only when no remote command is given
+    // (#10839). An interactive session that carries one -- `cd <base_path> &&
+    // exec $SHELL` -- therefore gets no TTY, and the shell it execs would come
+    // up non-interactive, with no prompt and no job control. Ask for the
+    // terminal explicitly.
+    //
+    // Scoped to the interactive path: `interactive` is set by exactly one
+    // caller, `SshClient::execute_interactive`. Every non-interactive caller
+    // captures output and must not be handed a pty.
+    if options.interactive && options.command.is_some() {
+        args.push("-t".to_string());
+    }
+
     args
 }
 


### PR DESCRIPTION
Fixes #10839.

## What was wrong

`homeboy ssh <project>` sent `cd <base_path>` as the remote command. That is a *complete* command — ssh ran it, it succeeded, and the session ended. Homeboy reported `remote_command_success` with `command: null` and printed a JSON envelope, having never presented a shell.

```rust
// before
(Some(_), Some(bp), None) => Some(format!("cd {}", shell::quote_path(bp))),
```

## The fix has two halves

**1. Replace the process with a shell.**

```rust
(Some(_), Some(bp), None) => Some(format!(
    "cd {} && exec \"${{SHELL:-/bin/sh}}\"",
    shell::quote_path(bp)
)),
```

`exec` rather than a plain invocation, so the shell's exit status is the session's.

Deliberately **not** `-l`. A login shell re-runs the profile scripts, and one that `cd`s to `$HOME` would silently undo the base path this command exists to apply — turning a visible bug into an invisible one.

**2. Ask for a terminal.**

This is the half that is easy to miss. `ssh` allocates a tty by default **only when no remote command is given**. An interactive session that carries one would therefore exec a shell with no terminal: no prompt, no job control. So `-t` is now passed when a session is both interactive and carrying a command.

That condition is tightly scoped. `interactive` is set by exactly one caller — `SshClient::execute_interactive` — and every non-interactive caller captures output, where a pty would merge stderr into stdout and echo input back into the capture. A bare interactive session still lets ssh allocate the tty itself.

## Testability

The command construction moved out of `run` into `effective_remote_command`. It could not be observed from a test while it was an inline `match` arm — which is precisely how a command that exits immediately shipped as the "open a shell" case.

## Verification

`cargo test -p homeboy-cli --lib commands::ssh` — 7 passed
`cargo test -p homeboy-core --lib an_interactive_session` — 1 passed

- `interactive_project_ssh_execs_a_shell_after_changing_directory` — asserts the exact command, that it `exec`s, and that it is not a login shell
- `an_interactive_session_carrying_a_command_requests_a_terminal` — `-t` present for interactive+command, absent for output-capturing callers, absent for a bare interactive session
- `other_remote_command_shapes_are_untouched` — project+command still `cd`s first; server-only passes through verbatim; server-only interactive still resolves to `None` so ssh opens its own login shell exactly as before

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix and its coverage. Chris Huber remains responsible for the change.
