### PR TITLE
fix: give hermetic tests an executable temp root instead of unsetting TMPDIR

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2331,6 +2331,89 @@ mod tests {
         );
     }
 
+    /// The runner must hand the test a temp root it can execute from (#12345).
+    ///
+    /// It used to `unset TMPDIR TMP TEMP`, dropping every test onto the shared
+    /// system `/tmp`. On a host that mounts `/tmp` noexec that is not a loud
+    /// failure: bash's PATH search calls `access(X_OK)`, Linux fails it on a
+    /// noexec mount, so a mock executable written into the temp dir is SKIPPED
+    /// and the REAL binary further down PATH runs instead. The test then
+    /// asserts against the real tool's output without ever reporting that its
+    /// fixture did not exist.
+    ///
+    /// Pinned host-independently by the TMPDIR value, not by probing /tmp: on a
+    /// host where /tmp happens to be executable the old behavior would pass an
+    /// execution-only check, and the regression would stay invisible exactly
+    /// where CI runs.
+    #[cfg(unix)]
+    #[test]
+    fn hermetic_runner_provides_an_executable_temp_root() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root");
+        let runner = workspace.join("scripts/nextest-hermetic-test-environment.sh");
+
+        let output = Command::new("sh")
+            .arg(&runner)
+            .args([
+                "sh",
+                "-c",
+                // Report the root, then prove an executable written into it
+                // actually runs.
+                r#"printf 'tmpdir=%s\ntmp=%s\ntemp=%s\n' "$TMPDIR" "$TMP" "$TEMP"
+                   printf '#!/bin/sh\necho fixture-executed\n' > "$TMPDIR/fixture"
+                   chmod +x "$TMPDIR/fixture"
+                   "$TMPDIR/fixture""#,
+            ])
+            // The caller's environment must not decide the answer. CI exports
+            // no TMPDIR, which is the case that regressed.
+            .env_remove("TMPDIR")
+            .env_remove("TMP")
+            .env_remove("TEMP")
+            .output()
+            .expect("run hermetic test runner");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let tmpdir = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("tmpdir="))
+            .expect("the runner must export TMPDIR");
+
+        assert!(
+            !tmpdir.is_empty(),
+            "TMPDIR must be set; unsetting it silently falls back to the shared \
+             system /tmp: {stdout}"
+        );
+        assert!(
+            Path::new(tmpdir).starts_with(workspace.join("target")),
+            "the temp root must live under this workspace's target directory, \
+             which is proven exec-capable because cargo runs test binaries from \
+             it. Got {tmpdir:?}"
+        );
+        for spelling in ["tmp=", "temp="] {
+            let value = stdout
+                .lines()
+                .find_map(|line| line.strip_prefix(spelling))
+                .unwrap_or_default();
+            assert_eq!(
+                value, tmpdir,
+                "all three temp spellings must name the same root, or code \
+                 reading {spelling} lands somewhere else than code reading TMPDIR"
+            );
+        }
+        assert!(
+            stdout.contains("fixture-executed"),
+            "an executable written into the temp root must run: {stdout}\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !Path::new(tmpdir).exists(),
+            "the per-invocation temp root must be removed when the test exits, \
+             or it accumulates under target/: {tmpdir}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn hermetic_runner_reaps_descendants_after_a_panicking_test_binary() {

--- a/scripts/nextest-hermetic-test-environment.sh
+++ b/scripts/nextest-hermetic-test-environment.sh
@@ -10,12 +10,56 @@ unset CARGO_TARGET_DIR
 # owns its runtime root, so inheriting the controller's makes fixture state land
 # outside each test's isolated home.
 unset HOMEBOY_RUNTIME_TMPDIR
-unset TMPDIR TMP TEMP
+
+# Give the test a PRIVATE temp root rather than unsetting TMPDIR (#12345).
+#
+# Unsetting it did not isolate anything. It handed every test the shared system
+# `/tmp` -- the least isolated directory on the machine -- and silently assumed
+# that directory is executable.
+#
+# On a host that mounts /tmp noexec, a fixture that writes a mock executable
+# into its temp dir cannot run it, and the failure mode is not an error. Bash's
+# PATH search calls access(X_OK); Linux fails that on a noexec mount, so bash
+# SKIPS the mock and invokes the real binary further down PATH. The test does
+# not report a missing mock -- it quietly talks to the real tool and asserts
+# against whatever that returns. `tests/release_asset_completeness_test.rs`
+# failed all 7 of its cases that way, reporting a GitHub release lookup error
+# for a tag that never existed.
+#
+# The root lives under this workspace's `target/`, resolved from this script's
+# own location so it does not depend on the caller's working directory or on
+# the shape of the command being run.
+#
+# `target/` is the right filesystem by construction: cargo builds test binaries
+# there and executes them from there, so if a test can run at all, that
+# filesystem can host an executable fixture. No probing and no assumption.
+#
+# One root per invocation. Cargo's runner is invoked per test binary, and under
+# nextest's process-per-test execution per test, so this is strictly more
+# isolation than the shared /tmp it replaces, not less.
+hermetic_script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+hermetic_tmp_parent="$(CDPATH= cd -- "$hermetic_script_dir/.." && pwd)/target/.test-tmp"
+if ! mkdir -p "$hermetic_tmp_parent"; then
+    echo "hermetic test environment: cannot create the temp root at $hermetic_tmp_parent" >&2
+    exit 1
+fi
+TMPDIR="$(mktemp -d "$hermetic_tmp_parent/run.XXXXXX")"
+export TMPDIR
+# All three spellings must name the same root. Code reading TMP or TEMP must not
+# land somewhere else than code reading TMPDIR.
+TMP="$TMPDIR"
+TEMP="$TMPDIR"
+export TMP TEMP
 
 # Cargo's runner is the last parent guaranteed to receive cancellation when a
 # test binary is interrupted. A Perl parent uses waitpid(WNOHANG), rather than
 # a shell `wait` held open by inherited descriptors, then reaps the test group.
 # Homeboy test daemons deliberately stay in this group instead of daemonizing.
+#
+# It also owns the temp root above: this script `exec`s into it, so an EXIT trap
+# here would never fire, and an accumulating per-test directory under `target/`
+# would be a disk leak. Set HOMEBOY_TEST_KEEP_TMPDIR=1 to retain it for
+# debugging.
 exec perl -MPOSIX=setsid,WNOHANG -e '
     my $child = fork();
     die "fork: $!\n" unless defined $child;
@@ -23,6 +67,13 @@ exec perl -MPOSIX=setsid,WNOHANG -e '
         setsid() or die "setsid: $!\n";
         exec @ARGV or die "exec: $!\n";
     }
+    my $discard_tmpdir = sub {
+        return if $ENV{HOMEBOY_TEST_KEEP_TMPDIR};
+        my $tmpdir = $ENV{TMPDIR};
+        # Only ever remove the directory this script created.
+        return unless defined $tmpdir && $tmpdir =~ m{/\.test-tmp/run\.[^/]+$};
+        system("rm", "-rf", "--", $tmpdir);
+    };
     my $cleanup = sub {
         # A clean test leaves no process in its private group. Avoid charging
         # nextest process-per-test execution a grace period in that case.
@@ -36,10 +87,17 @@ exec perl -MPOSIX=setsid,WNOHANG -e '
         }
         waitpid $child, 0;
     };
-    $SIG{HUP} = $SIG{INT} = $SIG{TERM} = sub { $cleanup->(); exit 143; };
+    $SIG{HUP} = $SIG{INT} = $SIG{TERM} = sub {
+        $cleanup->();
+        # Only after the process group is gone: a surviving descendant could
+        # still be writing into the temp root.
+        $discard_tmpdir->();
+        exit 143;
+    };
     my $status;
     while (($status = waitpid $child, WNOHANG) == 0) { select undef, undef, undef, 0.05; }
     my $exit = $?;
     $cleanup->();
+    $discard_tmpdir->();
     exit($exit >> 8);
 ' -- "$@"


### PR DESCRIPTION
Fixes #12345.

## What was wrong

The cargo test runner did:

```sh
unset TMPDIR TMP TEMP
```

That did not isolate anything. It handed every test the **shared system `/tmp`** — the least isolated directory on the machine — and silently assumed it is executable.

On a host that mounts `/tmp` `noexec`, a fixture that writes a mock executable into its temp dir cannot run it, and **the failure mode is not an error**. Bash's PATH search calls `access(X_OK)`; Linux fails that on a noexec mount, so bash *skips* the mock and invokes the **real** binary further down PATH. The test never reports a missing fixture — it quietly talks to the real tool and asserts against whatever that returns.

`tests/release_asset_completeness_test.rs` failed all 7 of its cases exactly that way, reporting a GitHub release lookup failure for a tag that never existed, because its mock `gh` was skipped in favour of the real one.

Demonstrated directly, same fixture, same command:

```
$ env -u TMPDIR sh scripts/nextest-hermetic-test-environment.sh ./fixture   # before
TMPDIR=
Work seamlessly with GitHub from the command line.     <- the REAL gh

$ env -u TMPDIR sh scripts/nextest-hermetic-test-environment.sh ./fixture   # after
TMPDIR=/…/target/.test-tmp/run.QpB1B4
MOCK_RAN
```

## The fix

Point `TMPDIR` at a per-invocation root under this workspace's `target/`, resolved from the script's own location so it does not depend on the caller's working directory or on the shape of the command being run.

`target/` is the right filesystem **by construction**: cargo builds test binaries there and executes them from there, so if a test can run at all, that filesystem can host an executable fixture. No probing and no assumption.

`TMP` and `TEMP` are set to the same root, so code reading either cannot land somewhere other than code reading `TMPDIR`.

The perl parent owns cleanup — this script `exec`s into it, so an EXIT trap would never fire and a per-test directory under `target/` would be a disk leak. Removal happens only **after the process group is gone** (a surviving descendant could still be writing there) and only for paths matching what this script created. `HOMEBOY_TEST_KEEP_TMPDIR=1` retains it for debugging.

This is **strictly more** isolation than the shared `/tmp` it replaces, not less: cargo invokes the runner per test binary, and under nextest's process-per-test execution, per test.

## Impact

| | before | after |
|---|---|---|
| `cargo test --test release_asset_completeness_test` | **0 passed, 7 failed** | **10 passed, 0 failed** |

No manual `TMPDIR` override in either case.

## Cost

| | 20 invocations |
|---|---|
| before | 1366ms |
| after | 1419ms |

~2.6ms per invocation. The existing `hermetic_runner_clean_exits_do_not_pay_descendant_cleanup_grace_period` guard (4 runs under 1s) still passes with room to spare, and all three existing hermetic-runner tests are unaffected.

## On the regression test

`hermetic_runner_provides_an_executable_temp_root` pins the **TMPDIR value**, not execution.

That is deliberate. An execution-only check passes under the old behaviour on any host where `/tmp` happens to be executable — including CI — which would leave the regression invisible exactly where it is checked. Worse: verifying this locally as root, the old script *still* printed `fixture-executed`, because `$TMPDIR/fixture` expanded to `/fixture` and root could write there. Asserting the value is the only host-independent guard.

Confirmed to fail against the old script and pass against the new one.

## Scope note

This does not fix the currently-red `main`. The two process-reaping failures on CI (`normal_completion_reaps_descendants_before_collecting_output`, `bounded_output_timeout_reaps_term_resistant_descendants`) pass locally both with and without this change, so they are CI-environment flakes and belong to #12008. This fixes the silent-fixture-fallthrough class only.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix and its coverage. Chris Huber remains responsible for the change.
