### PR TITLE
fix: repair the gate-layer measurement registry and close the action-pin hole

### DIFF
--- a/.github/validate-action-pin.sh
+++ b/.github/validate-action-pin.sh
@@ -33,8 +33,21 @@ fi
 
 mapfile -t pins < <(grep -oE 'uses: [A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/[A-Za-z0-9_.-]+@[0-9a-f]{40}' "${ci_workflow}" | sed 's/^uses: //')
 
+# Establish the population independently of the extractor above.
+#
+# "No pins found, nothing to verify" used to be decided by the same grep that
+# does the verifying, so a pattern that stopped matching reported a green having
+# checked nothing -- the #10706 shape exactly. Count reusable-workflow
+# references without caring how they are pinned, and require the two counts to
+# agree before an empty result may be read as an honest zero.
+references="$(grep -cE 'uses: [A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/' "${ci_workflow}" || true)"
+
 if [ "${#pins[@]}" -eq 0 ]; then
-  echo "action-pin: no SHA-pinned reusable workflows in ${ci_workflow}; nothing to verify"
+  if [ "${references}" -gt 0 ]; then
+    echo "::error::action-pin: ${ci_workflow} references ${references} reusable workflow(s) but none is pinned to a 40-character commit SHA, so this gate would pass having verified nothing. Pin each one to \`git rev-parse <ref>^{commit}\`, or update the extractor in $0 if the \`uses:\` syntax changed." >&2
+    exit 1
+  fi
+  echo "action-pin: ${ci_workflow} references no reusable workflows; nothing to verify"
   exit 0
 fi
 

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -344,20 +344,21 @@ struct GateLayerSite {
 /// Sorted by `(file, decision)`. Keep it that way.
 const GATE_LAYER_SITES: &[GateLayerSite] = &[
     GateLayerSite {
-        file: ".github/detect-stranded-release.sh",
-        decision: "exit 0",
-        basis: MeasurementBasis::ExplicitlySkipped,
+        file: ".github/canonicalize-checksum-sidecars.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
         renders_skip: false,
         fixture: None,
-        note: "NO FIXTURE: `finish` is the script's single exit and it always writes all four \
-               outputs, so a crash leaves them unset and release.yml's fallback supplies inert \
-               defaults. The one genuine no-measurement path -- `gh release list` failing -- \
-               already refuses to read its own failure as `nothing is published`, warns, and \
-               finishes empty (line 114). Its remaining soft spot is the empty `git tag --list` \
-               case: a shallow or tagless checkout is indistinguishable from a repo with no \
-               stranded tags, and both render `stranded-tag=`. That degrades to `no recovery`, \
-               never to a false release, so it is recorded rather than patched. Exercising it \
-               needs a fixture git repo plus a `gh` stub, which is why there is no fixture yet.",
+        note: "NO FIXTURE: both exits are refusals -- a sidecar carrying anything other than \
+               exactly one checksum record, and a record whose digest, name, or trailing content \
+               does not parse. A non-zero exit cannot manufacture a pass, so neither carries a \
+               measurement obligation of its own. The script's own green is not a decision this \
+               scan can see: it falls off the end of a `for` loop over `*.sha256`, and \
+               `shopt -s nullglob` means an empty asset directory rewrites nothing and exits 0. \
+               That emptiness is not laundered into a release, because \
+               `release-asset-completeness.sh` independently requires every declared sidecar to \
+               be present and non-empty before publication -- this script normalizes bytes, that \
+               one decides.",
     },
     GateLayerSite {
         file: ".github/release-asset-completeness.sh",
@@ -406,6 +407,49 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                Measurement::assess to bash: units>0 measured, units==0 with an empty configured \
                population is an honest zero (warn, pass), units==0 against a non-empty population \
                is Contradicted and a hard error.",
+    },
+    GateLayerSite {
+        file: ".github/validate-action-pin.sh",
+        decision: "exit \"${status}\"",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the per-pin verdict. `status` starts at 0 and each pin is classified \
+               individually against the GitHub API, so this exit is reached only after the loop \
+               ran over a population proven non-empty by the guard above. Only a positively \
+               identified tag object sets status=1; an unreadable ref warns and is reported \
+               `unverified` rather than valid, which is the deliberate soft spot -- a token \
+               without access to the pinned repo degrades every pin to unverified and still \
+               exits 0. That is recorded rather than patched because failing closed on an \
+               unreadable ref would make every fork PR unable to run CI. Exercising the loop \
+               needs a `gh` stub, which is why there is no fixture yet.",
+    },
+    GateLayerSite {
+        file: ".github/validate-action-pin.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::EmptyPopulation,
+        renders_skip: false,
+        fixture: Some("action_pin_refuses_a_green_when_it_extracted_no_pins_from_a_file_that_has_them"),
+        note: "The `nothing to verify` green. It used to be decided by the same grep that does \
+               the verifying: an extractor that stopped matching -- a reformatted `uses:` line, a \
+               changed pin syntax -- reported zero pins, printed `nothing to verify`, and passed \
+               having checked nothing. That is the #10706 shape in a gate whose whole job is to \
+               stop CI dying at startup. The population is now established independently, by \
+               counting reusable-workflow references without regard to how they are pinned. Zero \
+               references is an honest zero and still passes; references>0 with zero extracted \
+               pins is Contradicted and a hard error naming both counts.",
+    },
+    GateLayerSite {
+        file: ".github/validate-action-pin.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: Some("action_pin_fails_closed_on_a_missing_workflow_file"),
+        note: "Two refusals share this decision: the workflow file is absent, and the \
+               Contradicted case above. A non-zero exit cannot manufacture a pass, so it carries \
+               no measurement obligation of its own; it is registered because the scan keys on \
+               every exit in a gate script and an unregistered one is indistinguishable from an \
+               unexamined one.",
     },
     GateLayerSite {
         file: ".github/validate-required-gates.sh",
@@ -823,8 +867,8 @@ fn gate_layer_decision(relative: &str, line: &str) -> Option<String> {
     }
 
     // Rule 2 applies to gate scripts only. Indentation is not consulted: the
-    // single exit in `detect-stranded-release.sh` lives inside its `finish`
-    // helper, and that is still the script's verdict.
+    // refusals in `canonicalize-checksum-sidecars.sh` live inside a `for` loop
+    // and a brace group, and they are still the script's verdict.
     if relative.ends_with(".sh") && trimmed.starts_with("exit ") {
         return Some(trimmed.trim_end_matches(';').to_string());
     }
@@ -1399,8 +1443,8 @@ fn the_gate_layer_matcher_distinguishes_a_verdict_from_data() {
         Some("exit \"${failed}\"")
     );
     assert_eq!(
-        gate_layer_decision(".github/detect-stranded-release.sh", "  exit 0").as_deref(),
-        Some("exit 0")
+        gate_layer_decision(".github/canonicalize-checksum-sidecars.sh", "    exit 1").as_deref(),
+        Some("exit 1")
     );
     // A workflow step's early exit is carried by the outputs it wrote.
     assert!(gate_layer_decision(".github/workflows/release.yml", "            exit 0").is_none());

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -2298,3 +2298,82 @@ fn release_integrity_sweeper_guards_publications_the_pipeline_never_made() {
         "a failed un-publish must escalate with the manual command, never pass silently"
     );
 }
+
+/// Run the action-pin validator against a workflow fixture, with no network.
+///
+/// `PATH` is emptied of a real `gh` by pointing the script at a stub that always
+/// fails, so any case that reaches the per-pin loop is inconclusive rather than
+/// silently network-dependent. Both cases below refuse before that loop.
+fn action_pin(workflow_body: &str) -> (i32, String) {
+    let temp = tempfile::tempdir().expect("action-pin fixture dir");
+    let workflow = temp.path().join("workflow.yml");
+    std::fs::write(&workflow, workflow_body).expect("write workflow fixture");
+
+    let output = std::process::Command::new("bash")
+        .arg(".github/validate-action-pin.sh")
+        .env("ACTION_PIN_WORKFLOW", &workflow)
+        .env_remove("GITHUB_OUTPUT")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("action pin validator should run");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (output.status.code().unwrap_or(-1), combined)
+}
+
+/// The `nothing to verify` green must be an independently established zero.
+///
+/// It used to be decided by the same grep that does the verifying: an extractor
+/// that stopped matching reported zero pins, printed `nothing to verify`, and
+/// passed having checked nothing -- while `uses:` sat right there in the file.
+/// A gate whose job is to stop CI dying at startup cannot launder its own blind
+/// spot into a pass.
+#[test]
+fn action_pin_refuses_a_green_when_it_extracted_no_pins_from_a_file_that_has_them() {
+    // A reusable workflow that the SHA extractor cannot read.
+    let (code, out) = action_pin(
+        "jobs:\n  ci:\n    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2.11.21\n",
+    );
+    assert_ne!(
+        code, 0,
+        "a reusable-workflow reference the extractor cannot read must fail closed rather than \
+         report `nothing to verify`: {out}"
+    );
+    assert!(
+        out.contains("verified nothing"),
+        "the refusal must say what it could not establish: {out}"
+    );
+
+    // A genuinely empty population is still an honest zero.
+    let (code, out) = action_pin("jobs:\n  build:\n    runs-on: ubuntu-latest\n");
+    assert_eq!(
+        code, 0,
+        "a workflow with no reusable-workflow references has nothing to verify: {out}"
+    );
+}
+
+/// An absent workflow file is UNKNOWN, never `nothing to verify`.
+#[test]
+fn action_pin_fails_closed_on_a_missing_workflow_file() {
+    let temp = tempfile::tempdir().expect("action-pin fixture dir");
+    let missing = temp.path().join("does-not-exist.yml");
+
+    let output = std::process::Command::new("bash")
+        .arg(".github/validate-action-pin.sh")
+        .env("ACTION_PIN_WORKFLOW", &missing)
+        .env_remove("GITHUB_OUTPUT")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("action pin validator should run");
+
+    assert_ne!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "an unreadable workflow must fail closed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Refs #11932. Removes two of the failures currently reddening `main`.

## What was failing

Two measurement-registry tests have been failing on `main`:

```
these gate-layer decisions render a verdict but do not declare how they
established a measurement:
  .github/validate-action-pin.sh  ->  exit "${status}"
  .github/validate-action-pin.sh  ->  exit 0
  .github/validate-action-pin.sh  ->  exit 1

these GATE_LAYER_SITES entries no longer match a decision in the tree:
  .github/detect-stranded-release.sh  ->  exit 0
```

Three separate drifts, all in the same registry:

| script | what happened |
|---|---|
| `.github/detect-stranded-release.sh` | deleted by `2976848b5` (Aug 9); its registration was left behind |
| `.github/canonicalize-checksum-sidecars.sh` | arrived in `7b5cb497f` with two unregistered refusals |
| `.github/validate-action-pin.sh` | three unregistered decisions |

The third one was only visible locally — CI's shard never reached it, because the sort-order and stale-entry assertions fail first.

## Registering `exit 0` honestly meant fixing it first

`validate-action-pin.sh` had this:

```bash
mapfile -t pins < <(grep -oE 'uses: …@[0-9a-f]{40}' "${ci_workflow}" | sed 's/^uses: //')

if [ "${#pins[@]}" -eq 0 ]; then
  echo "action-pin: no SHA-pinned reusable workflows in ${ci_workflow}; nothing to verify"
  exit 0
fi
```

The "nothing to verify" green was decided by **the same grep that does the verifying**. An extractor that stopped matching — a reformatted `uses:` line, a changed pin syntax — reported zero pins and passed having checked nothing, while `uses:` sat right there in the file.

That is the #10706 shape, in a gate whose entire job is to stop CI dying at startup with zero jobs and no logs.

The population is now established independently, by counting reusable-workflow references without regard to how they are pinned:

| ci.yml contains | before | after |
|---|---|---|
| no reusable workflows | pass | pass (honest zero) |
| references, none SHA-pinned | **pass, verified nothing** | **fail, names both counts** |
| SHA-pinned references | verified | verified |

Verified against the real `.github/workflows/ci.yml`: still `exit=0`, `Extra-Chill/homeboy-action@3b20c221… is a commit`.

## Registrations

- **`exit "${status}"`** → `PerUnitEvaluation`. Reached only after a loop over a population the guard above proved non-empty. Registered without a fixture and it says so — exercising it needs a `gh` stub. Its deliberate soft spot is recorded too: an unreadable ref warns and reports `unverified` rather than failing, because failing closed there would leave every fork PR unable to run CI.
- **`exit 0`** → `EmptyPopulation`, now that the population has an independent source.
- **`exit 1`** → `Projection`. A non-zero exit cannot manufacture a pass.
- **`canonicalize-checksum-sidecars.sh exit 1`** → `Projection`. Both exits are refusals. Its green is not a decision this scan can see — it falls off the end of a `for` loop, and `shopt -s nullglob` means an empty asset directory rewrites nothing and exits 0. That emptiness is not laundered into a release, because `release-asset-completeness.sh` independently requires every declared sidecar before publication. This script normalizes bytes; that one decides.

## Fixtures

Two new tests in `tests/release_workflow_test.rs` execute the real script:

- `action_pin_refuses_a_green_when_it_extracted_no_pins_from_a_file_that_has_them` — covers both the Contradicted case and the honest zero
- `action_pin_fails_closed_on_a_missing_workflow_file`

## Also

The parser test and the rule-2 comment both used the deleted script as their example of an exit that is indented but still the script's verdict. Both now cite a live one.

## Verification

- `cargo test -p homeboy-engine-primitives --lib measurement` — **35 passed, 0 failed** (was 3 failed)
- `cargo test --test release_workflow_test` — **64 passed, 0 failed**
- `cargo check --workspace --tests -j2` — clean
- `cargo fmt --check` — clean

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix and its coverage. Chris Huber remains responsible for the change.
