### PR TITLE
fix: assert the rig toolchain PATH contract instead of a borrowed provider

### DIFF
--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -1114,25 +1114,71 @@ mod tests {
         });
     }
 
+    /// The toolchain PATH is forwarded from the rig provider, never fabricated.
+    ///
+    /// This used to assert only `PATH.is_some()`. That was true while this code
+    /// reached into rig directly, but `0f2193b78` put a provider registry
+    /// between them, and this crate does not depend on `homeboy-rig` and so can
+    /// never register one. The assertion became unsatisfiable in its own test
+    /// binary: it could only pass by borrowing a provider some other test had
+    /// registered into the process-global slot, which is the leak, not the
+    /// contract.
+    ///
+    /// The contract at this layer is conditional forwarding, so both directions
+    /// are asserted against a stub.
     #[test]
-    fn build_exec_env_includes_toolchain_path() {
-        let env = build_exec_env(
-            "fixture-extension",
-            None,
-            None,
-            "{}",
-            Some("/tmp/ext"),
-            None,
-            None,
-            None,
+    fn build_exec_env_forwards_the_rig_toolchain_path_only_when_a_provider_supplies_one() {
+        use homeboy_core::rig_toolchain_provider::{
+            register_rig_toolchain_provider, RigToolchainProvider,
+        };
+        use std::ffi::OsString;
+
+        struct StubToolchain(Option<OsString>);
+        impl RigToolchainProvider for StubToolchain {
+            fn command_step_path(&self, _rig_id: Option<&str>) -> Option<OsString> {
+                self.0.clone()
+            }
+        }
+
+        fn exec_env_path() -> Option<String> {
+            build_exec_env(
+                "fixture-extension",
+                None,
+                None,
+                "{}",
+                Some("/tmp/ext"),
+                None,
+                None,
+                None,
+            )
+            .into_iter()
+            .find(|(key, _)| key == "PATH")
+            .map(|(_, value)| value)
+        }
+
+        // The provider slot is process-global, so this must not race another
+        // test reading PATH out of the same slot.
+        let _lock = homeboy_core::test_support::env_lock();
+
+        register_rig_toolchain_provider(Box::new(StubToolchain(Some(OsString::from(
+            "/rig/toolchain/bin",
+        )))));
+        assert_eq!(
+            exec_env_path().as_deref(),
+            Some("/rig/toolchain/bin"),
+            "a registered rig toolchain must reach the extension environment verbatim"
         );
 
-        let path = env
-            .iter()
-            .find(|(k, _)| k == "PATH")
-            .map(|(_, v)| v.clone());
-
-        assert!(path.is_some(), "expected extension env to include PATH");
+        // Restored to the no-provider behaviour on the way out: a provider that
+        // supplies nothing is indistinguishable from the default no-op, so this
+        // leaves the slot semantically where it found it.
+        register_rig_toolchain_provider(Box::new(StubToolchain(None)));
+        assert_eq!(
+            exec_env_path(),
+            None,
+            "with no toolchain to forward, PATH must be left to the OS rather than \
+             invented -- an empty or fabricated PATH would hide the host's own"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refs #11932. Removes one of the failures currently reddening `main`.

## What was wrong

```
thread 'execution::tests::build_exec_env_includes_toolchain_path' panicked at
crates/homeboy-extension/src/execution.rs:1135:9:
expected extension env to include PATH
```

The test asserted only that the extension environment contains a `PATH`. That was true while this code reached into rig directly — but `0f2193b78` ("sever stay-in-core rig edges") put a provider registry between them:

```rust
if let Some(path) = homeboy_core::rig_toolchain_provider::command_step_path(None) {
    env.push(("PATH".to_string(), path.to_string_lossy().to_string()));
}
```

`homeboy-extension` does not depend on `homeboy-rig`, and the only caller of `register_rig_toolchain_provider` lives in `homeboy-rig/src/provider.rs`. So this crate **can never register a provider**. With none registered the registry falls back to a no-op returning `None`, and `build_exec_env` correctly pushes no `PATH`.

The assertion was therefore unsatisfiable in its own test binary. It could pass only by borrowing a provider that some *other* test had written into the process-global slot — which is a leak, not a contract, and it fails on CI where that ordering does not hold.

## The fix

Assert what this layer actually owns: **conditional forwarding**, in both directions, against a stub.

| provider supplies | required behaviour |
|---|---|
| `/rig/toolchain/bin` | reaches the extension environment verbatim |
| nothing | `PATH` is left alone, not invented |

The second direction matters as much as the first: fabricating an empty `PATH` would mask the host's own.

The stub is registered under `homeboy_core::test_support::env_lock()`, because the provider slot is process-global and this test must not race another reading `PATH` out of it. On the way out it leaves a provider that supplies nothing — semantically indistinguishable from the default no-op — so the slot ends where it was found.

## Verification

`cargo test -p homeboy-extension --lib build_exec_env` — **3 passed, 0 failed**
`cargo check -p homeboy-extension --tests` — clean
`cargo fmt --check` — clean

## Note on the other extension failure

`inventory_mode_publishes_valid_producer_output_for_an_empty_changed_scope` also failed on the same CI shard, but it **passes locally on this branch**, so it is environment-dependent rather than a broken assertion. Not touched here.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix. Chris Huber remains responsible for the change.
