### PR TITLE
fix: derive child test names so a module move cannot silently disarm them

### DIFF
--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -1597,14 +1597,15 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let lease = acquire("parent", "lab").expect("parent acquires lease");
             let executable = std::env::current_exe().expect("resolve test executable");
+            let child_test = crate::test_support::harness_test_name(
+                module_path!(),
+                "authorized_child_process_acquires_lease",
+            );
             let mut child = Command::new(executable);
-            child.args([
-                "--ignored",
-                "--exact",
-                "core::runtime_promotion::tests::authorized_child_process_acquires_lease",
-            ]);
+            child.args(["--ignored", "--exact", &child_test]);
             lease.authorize_subprocess(&mut child);
-            assert!(child.status().expect("run authorized child").success());
+            let output = crate::test_support::run_child_test(&mut child, &child_test);
+            assert!(output.status.success());
         });
     }
 
@@ -1655,16 +1656,16 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let _lease = acquire("parent", "lab").expect("parent acquires lease");
             let executable = std::env::current_exe().expect("resolve test executable");
-            let status = Command::new(executable)
-                .args([
-                    "--ignored",
-                    "--exact",
-                    "core::runtime_promotion::tests::unrelated_child_process_is_denied",
-                ])
-                .env_remove(SUBPROCESS_LEASE_ENV)
-                .status()
-                .expect("run unrelated child");
-            assert!(status.success());
+            let child_test = crate::test_support::harness_test_name(
+                module_path!(),
+                "unrelated_child_process_is_denied",
+            );
+            let mut child = Command::new(executable);
+            child
+                .args(["--ignored", "--exact", &child_test])
+                .env_remove(SUBPROCESS_LEASE_ENV);
+            let output = crate::test_support::run_child_test(&mut child, &child_test);
+            assert!(output.status.success());
         });
     }
 

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1594,6 +1594,54 @@ pub fn home_env_guard() -> MutexGuard<'static, ()> {
     env_lock()
 }
 
+/// The libtest name of a test in `module_path`, for passing to `--exact`.
+///
+/// Several tests re-invoke their own binary to get a second process -- a lock
+/// holder, a lease claimant -- by naming the child test with `--exact`. Those
+/// names were written as string literals, and the crate extraction moved every
+/// module underneath them. A stale name does not error: libtest matches zero
+/// tests, prints `running 0 tests`, and exits 0. So the child appears to
+/// succeed while never running, and `assert!(status.success())` passes having
+/// proved nothing (#12373-adjacent; found via the one case that did fail,
+/// `daemon_operation_lock_recovers_after_owner_exits_without_drop`, whose parent
+/// waits on a file the child never writes).
+///
+/// Deriving the name removes the literal. libtest strips the crate segment from
+/// `module_path!()`, so `homeboy_core::daemon::daemon_test` is addressed as
+/// `daemon::daemon_test`.
+pub fn harness_test_name(module_path: &str, test: &str) -> String {
+    let module = module_path
+        .split_once("::")
+        .map(|(_crate_name, rest)| rest)
+        .unwrap_or(module_path);
+    format!("{module}::{test}")
+}
+
+/// Run one `#[ignore]`d test in this same binary as a child process, and prove
+/// it actually ran.
+///
+/// `status.success()` alone is not proof: a name that matches nothing also
+/// exits 0. The child's own summary line is the measurement.
+pub fn run_child_test(
+    command: &mut std::process::Command,
+    test_name: &str,
+) -> std::process::Output {
+    let output = command
+        .output()
+        .unwrap_or_else(|error| panic!("run child test {test_name}: {error}"));
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("running 0 tests"),
+        "child test `{test_name}` matched nothing, so the assertion on its exit status \
+         would have passed without executing anything:\n{combined}"
+    );
+    output
+}
+
 /// Serializes tests that mutate or capture process-global environment state.
 pub fn env_lock() -> MutexGuard<'static, ()> {
     home_lock().lock().unwrap_or_else(|e| e.into_inner())

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2124,7 +2124,10 @@ fn daemon_operation_lock_recovers_after_owner_exits_without_drop() {
         .with_file_name("operation-lock-holder.release");
     let mut child = Command::new(std::env::current_exe().expect("current test executable"))
         .arg("--exact")
-        .arg("daemon::daemon_test::daemon_operation_lock_recovers_after_owner_exits_without_drop")
+        .arg(crate::test_support::harness_test_name(
+            module_path!(),
+            "daemon_operation_lock_recovers_after_owner_exits_without_drop",
+        ))
         .arg("--nocapture")
         .env(HOLDER_ENV, "1")
         .spawn()


### PR DESCRIPTION
Refs #11932. Removes another failure from the currently-red `main` — and two silently vacuous tests that nobody was going to notice.

## What was wrong

Three tests re-invoke their own binary with `--exact <name>` to get a second process (a lock holder, a lease claimant). All three named the child with a **string literal** carrying a `core::` module prefix that the crate extraction removed.

A stale `--exact` name does not error. libtest matches zero tests, prints `running 0 tests`, and **exits 0**.

### Two passed while running nothing

```rust
child.args(["--ignored", "--exact",
    "core::runtime_promotion::tests::authorized_child_process_acquires_lease"]);
lease.authorize_subprocess(&mut child);
assert!(child.status().expect("run authorized child").success());
```

That assertion is true for *any* name, including one that addresses nothing. `authorized_child_reenters_only_its_parent_transaction` and `unrelated_process_without_capability_is_denied` were both green while the lease authorization and denial they exist to prove never executed.

### One failed loudly, and misleadingly

`daemon_operation_lock_recovers_after_owner_exits_without_drop` waits on a ready file the child never writes, then panics:

```
operation lock holder did not become ready
```

— a message describing a *lock* problem when the actual fault was a name that addressed nothing. That is the failure currently on `main`. Caught by running the parent with `--nocapture` and seeing the child report `running 0 tests`.

## The fix, in two parts

**Remove the instance.** Derive the name from `module_path!()`. libtest strips the crate segment, so `homeboy_core::daemon::daemon_test` is addressed as `daemon::daemon_test`, and any future module move carries the child name with it.

```rust
.arg(crate::test_support::harness_test_name(
    module_path!(),
    "daemon_operation_lock_recovers_after_owner_exits_without_drop",
))
```

**Remove the class.** `run_child_test` asserts the child did not print `running 0 tests` before the caller reads its exit status:

```
child test `runtime_promotion::tests::…` matched nothing, so the assertion on its
exit status would have passed without executing anything
```

`status.success()` alone is not proof of anything — the child's own summary line is the measurement.

## Verification

```
test daemon::daemon_test::daemon_operation_lock_recovers_after_owner_exits_without_drop ...
running 1 test
ok
test runtime_promotion::tests::authorized_child_reenters_only_its_parent_transaction ... ok
test runtime_promotion::tests::unrelated_process_without_capability_is_denied ... ok

test result: ok. 3 passed; 0 failed
```

Note `running 1 test` in the child — previously `running 0 tests`.

With the names fixed, both previously-vacuous tests execute their child logic and **pass**. The behaviour was correct all along; it simply was not being tested.

`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean. `run_child_test` is not unix-gated, since the two `runtime_promotion` callers are not either and the Windows compile job builds them.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix. Chris Huber remains responsible for the change.
