### PR TITLE
fix: keep the hermetic temp root outside the repository, and unbusy two provider fixtures

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -1105,13 +1105,20 @@ fn cook_cwd_is_authoritative_when_provider_lookup_times_out() {
         })
         .expect("register linked worktree");
 
-        let provider = tempfile::NamedTempFile::new().expect("provider file");
-        std::fs::write(provider.path(), "#!/bin/sh\nsleep 2\n").expect("write provider");
-        let mut permissions = std::fs::metadata(provider.path())
+        // `into_temp_path` closes the write handle. A `NamedTempFile` keeps one
+        // open for its whole lifetime, and Linux refuses to `execve` a file that
+        // any process still holds open for writing -- ETXTBSY, surfaced as
+        // "Text file busy (os error 26)". The file stays alive and still
+        // self-deletes; only the descriptor goes away.
+        let provider = tempfile::NamedTempFile::new()
+            .expect("provider file")
+            .into_temp_path();
+        std::fs::write(&provider, "#!/bin/sh\nsleep 2\n").expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
             .expect("provider metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
         let mut config = homeboy::core::defaults::HomeboyConfig::default();
         config.worktree_providers.insert(
             "timeout".to_string(),
@@ -1122,7 +1129,7 @@ fn cook_cwd_is_authoritative_when_provider_lookup_times_out() {
                 lookup_timeout_ms: 1,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
-                    resolve: Some(vec![provider.path().display().to_string()]),
+                    resolve: Some(vec![provider.display().to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: None,
@@ -1303,20 +1310,27 @@ fn cook_rejects_immediately_resolved_provider_destination_from_another_repositor
             .status()
             .expect("create linked worktree")
             .success());
-        let provider = tempfile::NamedTempFile::new().expect("provider file");
+        // `into_temp_path` closes the write handle. A `NamedTempFile` keeps one
+        // open for its whole lifetime, and Linux refuses to `execve` a file that
+        // any process still holds open for writing -- ETXTBSY, surfaced as
+        // "Text file busy (os error 26)". The file stays alive and still
+        // self-deletes; only the descriptor goes away.
+        let provider = tempfile::NamedTempFile::new()
+            .expect("provider file")
+            .into_temp_path();
         std::fs::write(
-            provider.path(),
+            &provider,
             format!(
                 "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@foreign\",\"path\":\"{}\",\"branch\":\"fix/foreign\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
                 destination.display()
             ),
         )
         .expect("write provider");
-        let mut permissions = std::fs::metadata(provider.path())
+        let mut permissions = std::fs::metadata(&provider)
             .expect("provider metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(provider.path(), permissions).expect("make provider executable");
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
         let mut config = homeboy::core::defaults::HomeboyConfig::default();
         config.worktree_providers.insert(
             "fixture".to_string(),
@@ -1327,10 +1341,7 @@ fn cook_rejects_immediately_resolved_provider_destination_from_another_repositor
                 lookup_timeout_ms: 10_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
-                    resolve: Some(vec![
-                        provider.path().display().to_string(),
-                        "{handle}".to_string(),
-                    ]),
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2331,7 +2331,8 @@ mod tests {
         );
     }
 
-    /// The runner must hand the test a temp root it can execute from (#12345).
+    /// The runner must hand the test a temp root it can execute from (#12345),
+    /// and that root must not sit inside the repository (#12377).
     ///
     /// It used to `unset TMPDIR TMP TEMP`, dropping every test onto the shared
     /// system `/tmp`. On a host that mounts `/tmp` noexec that is not a loud
@@ -2341,13 +2342,19 @@ mod tests {
     /// asserts against the real tool's output without ever reporting that its
     /// fixture did not exist.
     ///
+    /// The first fix put the root under `target/`, which is exec-capable by
+    /// construction but is inside a git checkout -- and code that walks up
+    /// looking for a repository root then escapes the temp directory and finds
+    /// the real one. So the root is now a PROBED system temp directory, and
+    /// `target/` is only the last resort. The runner reports which it chose.
+    ///
     /// Pinned host-independently by the TMPDIR value, not by probing /tmp: on a
     /// host where /tmp happens to be executable the old behavior would pass an
     /// execution-only check, and the regression would stay invisible exactly
     /// where CI runs.
     #[cfg(unix)]
     #[test]
-    fn hermetic_runner_provides_an_executable_temp_root() {
+    fn hermetic_runner_provides_an_executable_temp_root_outside_the_repository() {
         let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .and_then(Path::parent)
@@ -2359,9 +2366,8 @@ mod tests {
             .args([
                 "sh",
                 "-c",
-                // Report the root, then prove an executable written into it
-                // actually runs.
-                r#"printf 'tmpdir=%s\ntmp=%s\ntemp=%s\n' "$TMPDIR" "$TMP" "$TEMP"
+                r#"printf 'tmpdir=%s\ntmp=%s\ntemp=%s\nsource=%s\n' \
+                     "$TMPDIR" "$TMP" "$TEMP" "$HOMEBOY_TEST_TMP_SOURCE"
                    printf '#!/bin/sh\necho fixture-executed\n' > "$TMPDIR/fixture"
                    chmod +x "$TMPDIR/fixture"
                    "$TMPDIR/fixture""#,
@@ -2375,29 +2381,24 @@ mod tests {
             .expect("run hermetic test runner");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let tmpdir = stdout
-            .lines()
-            .find_map(|line| line.strip_prefix("tmpdir="))
-            .expect("the runner must export TMPDIR");
+        let field = |name: &str| {
+            stdout
+                .lines()
+                .find_map(|line| line.strip_prefix(name))
+                .unwrap_or_default()
+                .to_string()
+        };
+        let tmpdir = field("tmpdir=");
 
         assert!(
             !tmpdir.is_empty(),
             "TMPDIR must be set; unsetting it silently falls back to the shared \
              system /tmp: {stdout}"
         );
-        assert!(
-            Path::new(tmpdir).starts_with(workspace.join("target")),
-            "the temp root must live under this workspace's target directory, \
-             which is proven exec-capable because cargo runs test binaries from \
-             it. Got {tmpdir:?}"
-        );
         for spelling in ["tmp=", "temp="] {
-            let value = stdout
-                .lines()
-                .find_map(|line| line.strip_prefix(spelling))
-                .unwrap_or_default();
             assert_eq!(
-                value, tmpdir,
+                field(spelling),
+                tmpdir,
                 "all three temp spellings must name the same root, or code \
                  reading {spelling} lands somewhere else than code reading TMPDIR"
             );
@@ -2407,10 +2408,28 @@ mod tests {
             "an executable written into the temp root must run: {stdout}\n{}",
             String::from_utf8_lossy(&output.stderr)
         );
+        assert_ne!(
+            Path::new(&tmpdir).parent(),
+            Some(Path::new("/tmp")),
+            "the root must be private to this invocation, not the shared system \
+             temp directory itself: {tmpdir}"
+        );
+
+        // The in-tree fallback exists for hosts where nothing else can execute.
+        // Wherever a system temp directory works, the root must stay outside the
+        // checkout -- a temp workspace nested in a git repo is not equivalent to
+        // one in /tmp, because repository-root walks escape it (#12377).
+        if field("source=") == "system" {
+            assert!(
+                !Path::new(&tmpdir).starts_with(workspace),
+                "a probed system temp root must not live inside the repository: {tmpdir}"
+            );
+        }
+
         assert!(
-            !Path::new(tmpdir).exists(),
+            !Path::new(&tmpdir).exists(),
             "the per-invocation temp root must be removed when the test exits, \
-             or it accumulates under target/: {tmpdir}"
+             or it accumulates: {tmpdir}"
         );
     }
 

--- a/scripts/nextest-hermetic-test-environment.sh
+++ b/scripts/nextest-hermetic-test-environment.sh
@@ -26,19 +26,52 @@ unset HOMEBOY_RUNTIME_TMPDIR
 # failed all 7 of its cases that way, reporting a GitHub release lookup error
 # for a tag that never existed.
 #
-# The root lives under this workspace's `target/`, resolved from this script's
-# own location so it does not depend on the caller's working directory or on
-# the shape of the command being run.
+# The root is a system temp directory that is PROVEN executable, chosen by
+# actually running a script from it rather than assuming.
 #
-# `target/` is the right filesystem by construction: cargo builds test binaries
-# there and executes them from there, so if a test can run at all, that
-# filesystem can host an executable fixture. No probing and no assumption.
-#
-# One root per invocation. Cargo's runner is invoked per test binary, and under
-# nextest's process-per-test execution per test, so this is strictly more
-# isolation than the shared /tmp it replaces, not less.
-hermetic_script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-hermetic_tmp_parent="$(CDPATH= cd -- "$hermetic_script_dir/.." && pwd)/target/.test-tmp"
+# It must live outside the repository. `target/` is tempting -- cargo runs test
+# binaries from there, so it is exec-capable by construction -- but a temp
+# workspace nested inside a git checkout is not equivalent to one in /tmp: code
+# that walks up looking for a repository root escapes the temp directory and
+# finds the real one. That regressed
+# `from_spec_dispatch_defaults_replace_stale_cwd_in_snapshot_workspace`, which
+# resolved its isolated workspace to the homeboy checkout itself. `target/` is
+# kept only as a last resort, for a host where no system temp directory can
+# execute anything at all.
+hermetic_exec_probe() {
+    probe_dir="$1"
+    [ -d "$probe_dir" ] && [ -w "$probe_dir" ] || return 1
+    probe="${probe_dir}/.homeboy-exec-probe.$$"
+    printf '#!/bin/sh\nexit 0\n' > "$probe" 2>/dev/null || return 1
+    if chmod +x "$probe" 2>/dev/null && "$probe" 2>/dev/null; then
+        rm -f "$probe"
+        return 0
+    fi
+    rm -f "$probe"
+    return 1
+}
+
+hermetic_workspace_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+hermetic_tmp_parent=""
+for hermetic_candidate in "${TMPDIR:-/tmp}" /tmp /var/tmp /dev/shm; do
+    if hermetic_exec_probe "$hermetic_candidate"; then
+        hermetic_tmp_parent="$hermetic_candidate"
+        break
+    fi
+done
+hermetic_tmp_source=system
+if [ -z "$hermetic_tmp_parent" ]; then
+    # Nothing on this host can execute from a system temp directory. Fall back
+    # into the tree, which cargo has already proven executable, and accept that
+    # repository-root walks will see the checkout.
+    hermetic_tmp_parent="${hermetic_workspace_root}/target/.test-tmp"
+    hermetic_tmp_source=in_tree
+fi
+# Which root was chosen, so a test can assert the preference held rather than
+# hard-coding a location that is only correct on some hosts.
+HOMEBOY_TEST_TMP_SOURCE="$hermetic_tmp_source"
+export HOMEBOY_TEST_TMP_SOURCE
+hermetic_tmp_parent="${hermetic_tmp_parent}/.homeboy-test-tmp"
 if ! mkdir -p "$hermetic_tmp_parent"; then
     echo "hermetic test environment: cannot create the temp root at $hermetic_tmp_parent" >&2
     exit 1
@@ -74,7 +107,7 @@ exec perl -MPOSIX=setsid,WNOHANG -e '
         return if $ENV{HOMEBOY_TEST_KEEP_TMPDIR};
         my $tmpdir = $ENV{TMPDIR};
         # Only ever remove the directory this script created.
-        return unless defined $tmpdir && $tmpdir =~ m{/\.test-tmp/run\.[^/]+$};
+        return unless defined $tmpdir && $tmpdir =~ m{/\.homeboy-test-tmp/run\.[^/]+$};
         system("rm", "-rf", "--", $tmpdir);
     };
     my $cleanup = sub {


### PR DESCRIPTION
Refs #12377. `commands::agent_task::tests::dispatch`: **37 passed / 3 failed → 40 passed**.

Three fixes. The first is a regression I introduced in #12369 and should land quickly.

## 1. The hermetic temp root moves back out of the repository

#12369 put it under `target/`, reasoning that cargo runs test binaries from there so it is exec-capable by construction. That reasoning was sound and the conclusion was still wrong: **a temp workspace nested inside a git checkout is not equivalent to one in `/tmp`.** Code that walks up looking for a repository root escapes the temp directory and finds the real one.

```
assertion `left == right` failed
  left:  "/var/lib/datamachine/workspace/homeboy@…"          <- the real checkout
 right:  "/var/lib/datamachine/workspace/homeboy@…/target/.test-tmp/run.DxBZIY/.tmpTcOhqP"
```

`from_spec_dispatch_defaults_replace_stale_cwd_in_snapshot_workspace` resolved its isolated workspace to the homeboy checkout itself.

The root is now a system temp directory **proven executable by running a script from it** — preferring the inherited `TMPDIR`, then `/tmp`, `/var/tmp`, `/dev/shm`. `target/` remains only as a last resort for a host where nothing else can execute at all.

The runner exports `HOMEBOY_TEST_TMP_SOURCE=system|in_tree` so the test can assert *the preference held* rather than hard-coding a location that is only correct on some hosts:

```rust
if field("source=") == "system" {
    assert!(!Path::new(&tmpdir).starts_with(workspace), …);
}
```

Cost: ~7ms per invocation on a host whose `/tmp` is noexec (two probes); less where the first candidate works. The existing clean-exit timing guard still passes.

## 2. `NamedTempFile` cannot host an executable fixture

Two provider fixtures were built with `NamedTempFile`, which keeps a **write descriptor open for the whole lifetime of the value**. Linux refuses to `execve` a file any process still holds open for writing:

```
worktree provider `fixture` resolve command could not start: Text file busy (os error 26)
```

So `cook_rejects_immediately_resolved_provider_destination_from_another_repository` got ETXTBSY instead of the repository mismatch it asserts on. `into_temp_path()` closes the descriptor while keeping the file and its self-deletion.

### The same bug was hiding a second test in plain sight

`cook_cwd_is_authoritative_when_provider_lookup_times_out` was **green while its provider never executed**. Its assertion holds whether the lookup times out *or* fails to start, so a passing test proved nothing about timeouts. It now actually runs the sleeping provider.

That one was not on any failure list and would not have been found by chasing red tests.

## 3. A test that never passed

`cook_explicit_repo_skips_unrelated_portable_git_enrichment` was written 2026-08-12 — **ten days after** #11241 (2026-08-02) made `--task-url` mandatory whenever `--to-worktree` is omitted. It calls `resolve_cook_destination` without one, so it was refused before reaching the identity enrichment its timing assertion exists to measure. Every sibling test in the file already passes `--task-url`; this one now matches.

## Verification

- `commands::agent_task::tests::dispatch` — **40 passed, 0 failed**
- `cargo test -p homeboy-core --lib hermetic_runner` — 4 passed
- `cargo test --test release_asset_completeness_test` — 10 passed (the original #12345 case still holds)
- `cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean

## Still open in the cluster

`controller_run` and `lifecycle` failures remain and have a different cause — the fixture executor never receives a request (`expect("provider saw request")`). Not a temp-file or argument issue. Tracked in #12377.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fixes. Chris Huber remains responsible for the change.
