### PR TITLE
Root lifecycle record authority in explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -1,7 +1,41 @@
 use std::sync::{Arc, Barrier};
 
 use super::{succeeded_aggregate, test_plan};
-use crate::agent_task_lifecycle::AgentTaskLifecycleStore;
+use crate::agent_task_lifecycle::{
+    records::schemas, AgentTaskLabHandoff, AgentTaskLabHandoffAuthority, AgentTaskLabHandoffState,
+    AgentTaskLifecycleStore, AgentTaskRunRecord, AgentTaskRunState,
+};
+use homeboy_core::run_lifecycle_record::{RunExecutionState, RunLifecycleRecord};
+use serde_json::json;
+
+fn record(store: &AgentTaskLifecycleStore, run_id: &str, marker: &str) -> AgentTaskRunRecord {
+    let plan = test_plan();
+    AgentTaskRunRecord {
+        schema: schemas::RUN.to_string(),
+        run_id: run_id.to_string(),
+        plan_id: plan.plan_id,
+        state: AgentTaskRunState::Queued,
+        submitted_at: "2026-08-13T00:00:00Z".to_string(),
+        updated_at: None,
+        plan_path: store.controller_plan_path(run_id).display().to_string(),
+        aggregate_path: None,
+        totals: None,
+        tasks: Vec::new(),
+        artifact_refs: Vec::new(),
+        provider_handles: Vec::new(),
+        latest_executor_evidence: None,
+        lifecycle: RunLifecycleRecord::with_execution_state(RunExecutionState::Queued),
+        lab_handoff: None,
+        candidate_adoption: None,
+        adoption_run_id: None,
+        acceptance: None,
+        workspace_identity: None,
+        workspace_lifecycle_revision: 0,
+        workspace_owner_lease: None,
+        workspace_claim: None,
+        metadata: json!({ "store_marker": marker }),
+    }
+}
 
 #[test]
 fn lifecycle_stores_isolate_identical_ids_and_lock_domains() {
@@ -105,4 +139,88 @@ fn lifecycle_stores_isolate_identical_ids_and_lock_domains() {
                 .expect("right lock");
         });
     });
+}
+
+#[test]
+fn lifecycle_stores_isolate_same_run_record_writes_in_parallel() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let run_id = "same-record";
+    let barrier = Arc::new(Barrier::new(2));
+
+    std::thread::scope(|scope| {
+        let left_store = left.clone();
+        let left_barrier = Arc::clone(&barrier);
+        scope.spawn(move || {
+            left_barrier.wait();
+            left_store
+                .write_record(&record(&left_store, run_id, "left"))
+                .expect("left record");
+        });
+        let right_store = right.clone();
+        let right_barrier = Arc::clone(&barrier);
+        scope.spawn(move || {
+            right_barrier.wait();
+            right_store
+                .write_record(&record(&right_store, run_id, "right"))
+                .expect("right record");
+        });
+    });
+
+    assert_eq!(
+        left.read_record(run_id).unwrap().metadata["store_marker"],
+        "left"
+    );
+    assert_eq!(
+        right.read_record_bounded(run_id).unwrap().metadata["store_marker"],
+        "right"
+    );
+    assert_ne!(left.observation_db_path(), right.observation_db_path());
+}
+
+#[test]
+fn terminal_record_authority_is_written_only_below_its_lifecycle_root() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let run_id = "same-terminal-record";
+    let mut terminal = record(&left, run_id, "terminal");
+    terminal.state = AgentTaskRunState::Succeeded;
+    terminal.lifecycle = RunLifecycleRecord::with_execution_state(RunExecutionState::Succeeded);
+    terminal.lab_handoff = Some(AgentTaskLabHandoff {
+        state: AgentTaskLabHandoffState::Accepted,
+        authority: AgentTaskLabHandoffAuthority::RunnerDaemon,
+        runner_id: "runner-a".to_string(),
+        submission_key: None,
+        payload_fingerprint: None,
+        runner_job_id: Some("job-a".to_string()),
+        submitted_at: None,
+        acceptance_deadline_at: None,
+        accepted_at: Some("2026-08-13T00:00:01Z".to_string()),
+        expired_at: None,
+        workspace_identity: None,
+        workspace_lifecycle_revision: 0,
+        workspace_owner_lease: None,
+        workspace_claim: None,
+    });
+    terminal.metadata["remote_workspace"] = json!("/runner/workspace");
+
+    left.write_record(&terminal).expect("terminal record");
+
+    assert!(left_context
+        .data_dir()
+        .join("workspace-terminal-authority")
+        .join("by-run")
+        .read_dir()
+        .expect("left terminal index")
+        .next()
+        .is_some());
+    assert!(!right_context
+        .data_dir()
+        .join("workspace-terminal-authority")
+        .exists());
+    assert!(right.read_record(run_id).is_err());
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -39,6 +39,112 @@ struct WorkspaceTerminalAuthorityRelease {
     state: String,
 }
 
+/// Terminal workspace authority rooted below one lifecycle store's data root.
+/// The layout remains private to this module.
+#[derive(Debug, Clone)]
+pub(crate) struct WorkspaceTerminalAuthorityStore {
+    root: PathBuf,
+    config_root: PathBuf,
+}
+
+impl WorkspaceTerminalAuthorityStore {
+    pub(crate) fn new(data_root: PathBuf, config_root: PathBuf) -> Self {
+        Self {
+            root: data_root.join("workspace-terminal-authority"),
+            config_root,
+        }
+    }
+
+    fn run_index_path(&self, run_id: &str) -> PathBuf {
+        let mut digest = Sha256::new();
+        digest.update(run_id.as_bytes());
+        self.root
+            .join("by-run")
+            .join(format!("{:x}.json", digest.finalize()))
+    }
+
+    fn receipt_path(&self, run_id: &str, runner_id: &str, remote_workspace: &str) -> PathBuf {
+        self.root.join(format!(
+            "{}.json",
+            authority_digest(run_id, runner_id, remote_workspace)
+        ))
+    }
+
+    fn release_path(&self, run_id: &str, runner_id: &str, remote_workspace: &str) -> PathBuf {
+        self.root.join(format!(
+            "{}.release.json",
+            authority_digest(run_id, runner_id, remote_workspace)
+        ))
+    }
+
+    pub(crate) fn persist_terminal_from_record(&self, record: &AgentTaskRunRecord) -> Result<()> {
+        if !record.state.is_terminal() {
+            return Ok(());
+        }
+        let Some(identity) = accepted_lab_runner_job_identity_from_record(record) else {
+            return Ok(());
+        };
+        let Some(remote_workspace) = record
+            .metadata
+            .get("remote_workspace")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return Ok(());
+        };
+        self.persist(WorkspaceTerminalAuthorityReceipt {
+            schema: WORKSPACE_TERMINAL_AUTHORITY_SCHEMA.to_string(),
+            run_id: record.run_id.clone(),
+            runner_id: identity.runner_id,
+            runner_job_id: identity.runner_job_id,
+            remote_workspace: remote_workspace.to_string(),
+        })
+    }
+
+    fn persist(&self, receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
+        let path = self.receipt_path(
+            &receipt.run_id,
+            &receipt.runner_id,
+            &receipt.remote_workspace,
+        );
+        let release_path = self.release_path(
+            &receipt.run_id,
+            &receipt.runner_id,
+            &receipt.remote_workspace,
+        );
+        homeboy_core::config::with_config_lock_at(&self.config_root, || {
+            if release_path.exists() {
+                read_release(
+                    &release_path,
+                    &receipt.run_id,
+                    &receipt.runner_id,
+                    &receipt.remote_workspace,
+                )?;
+                return Ok(());
+            }
+            if path.exists() {
+                let existing = read_receipt(&path)?;
+                if existing == receipt {
+                    return homeboy_core::engine::local_files::write_json_file_owner_only(
+                        &self.run_index_path(&receipt.run_id),
+                        &existing,
+                    );
+                }
+                return Err(Error::validation_invalid_argument(
+                    "workspace_terminal_authority",
+                    "workspace terminal authority receipt conflicts with existing immutable receipt",
+                    Some(path.display().to_string()), None,
+                ));
+            }
+            homeboy_core::engine::local_files::write_json_file_owner_only(&path, &receipt)?;
+            homeboy_core::engine::local_files::write_json_file_owner_only(
+                &self.run_index_path(&receipt.run_id),
+                &receipt,
+            )
+        })
+    }
+}
+
 fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> String {
     let mut digest = Sha256::new();
     digest.update(run_id.as_bytes());
@@ -50,105 +156,42 @@ fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> St
 }
 
 fn run_index_path(run_id: &str) -> Result<PathBuf> {
-    let mut digest = Sha256::new();
-    digest.update(run_id.as_bytes());
-    Ok(paths::homeboy_data()?
-        .join("workspace-terminal-authority")
-        .join("by-run")
-        .join(format!("{:x}.json", digest.finalize())))
+    Ok(
+        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
+            .run_index_path(run_id),
+    )
 }
 
 fn receipt_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
-        .join("workspace-terminal-authority")
-        .join(format!(
-            "{}.json",
-            authority_digest(run_id, runner_id, remote_workspace)
-        )))
+    Ok(
+        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
+            .receipt_path(run_id, runner_id, remote_workspace),
+    )
 }
 
 fn release_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
-        .join("workspace-terminal-authority")
-        .join(format!(
-            "{}.release.json",
-            authority_digest(run_id, runner_id, remote_workspace)
-        )))
+    Ok(
+        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
+            .release_path(run_id, runner_id, remote_workspace),
+    )
 }
 
 pub(crate) fn persist_terminal_from_record(record: &AgentTaskRunRecord) -> Result<()> {
-    if !record.state.is_terminal() {
-        return Ok(());
-    }
-    let Some(identity) = accepted_lab_runner_job_identity_from_record(record) else {
-        return Ok(());
-    };
-    let Some(remote_workspace) = record
-        .metadata
-        .get("remote_workspace")
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-    else {
-        return Ok(());
-    };
-    let receipt = WorkspaceTerminalAuthorityReceipt {
-        schema: WORKSPACE_TERMINAL_AUTHORITY_SCHEMA.to_string(),
-        run_id: record.run_id.clone(),
-        runner_id: identity.runner_id,
-        runner_job_id: identity.runner_job_id,
-        remote_workspace: remote_workspace.to_string(),
-    };
-    persist_workspace_terminal_authority(receipt)
+    WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
+        .persist_terminal_from_record(record)
 }
 
 fn persist_workspace_terminal_authority(receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
-    let path = receipt_path(
-        &receipt.run_id,
-        &receipt.runner_id,
-        &receipt.remote_workspace,
-    )?;
-    let release_path = release_path(
-        &receipt.run_id,
-        &receipt.runner_id,
-        &receipt.remote_workspace,
-    )?;
-    homeboy_core::config::with_config_lock(|| {
-        if release_path.exists() {
-            read_release(
-                &release_path,
-                &receipt.run_id,
-                &receipt.runner_id,
-                &receipt.remote_workspace,
-            )?;
-            return Ok(());
-        }
-        if path.exists() {
-            let existing: WorkspaceTerminalAuthorityReceipt =
-                serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
-                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
-                })?)
-                .map_err(|error| {
-                    Error::internal_json(error.to_string(), Some(path.display().to_string()))
-                })?;
-            if existing == receipt {
-                return homeboy_core::engine::local_files::write_json_file_owner_only(
-                    &run_index_path(&receipt.run_id)?,
-                    &existing,
-                );
-            }
-            return Err(Error::validation_invalid_argument(
-                "workspace_terminal_authority",
-                "workspace terminal authority receipt conflicts with existing immutable receipt",
-                Some(path.display().to_string()),
-                None,
-            ));
-        }
-        homeboy_core::engine::local_files::write_json_file_owner_only(&path, &receipt)?;
-        homeboy_core::engine::local_files::write_json_file_owner_only(
-            &run_index_path(&receipt.run_id)?,
-            &receipt,
-        )
-    })
+    WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?).persist(receipt)
+}
+
+fn read_receipt(path: &std::path::Path) -> Result<WorkspaceTerminalAuthorityReceipt> {
+    serde_json::from_slice(
+        &std::fs::read(path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        })?,
+    )
+    .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1180,9 +1180,13 @@ fn composite_error(message: &str, failures: Vec<String>) -> Error {
 }
 
 fn store() -> Result<WorkspaceClaimStore> {
-    Ok(WorkspaceClaimStore::new(
-        paths::homeboy_data()?.join("agent-task-workspace-claims"),
-    ))
+    Ok(workspace_claim_store_at(paths::homeboy_data()?))
+}
+
+/// Construct the controller-local claim authority below an explicit lifecycle
+/// data root. Lifecycle commits use this rather than resolving ambient paths.
+pub(crate) fn workspace_claim_store_at(data_root: std::path::PathBuf) -> WorkspaceClaimStore {
+    WorkspaceClaimStore::new(data_root.join("agent-task-workspace-claims"))
 }
 
 /// Return the durable controller binding for a workspace-owning run. Callers
@@ -1288,13 +1292,20 @@ pub(crate) fn release_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Resu
 }
 
 pub(crate) fn renew_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
+    renew_record_workspace_owner_in_store(&store()?, record)
+}
+
+pub(crate) fn renew_record_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<()> {
     if record.state.is_terminal() {
         return Ok(());
     }
     let Some(lease) = record.workspace_owner_lease.as_ref() else {
         return Ok(());
     };
-    let renewed = renew_local_workspace_owner(lease)?;
+    let renewed = store.renew_owner(lease, LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS, now_ms())?;
     record.workspace_lifecycle_revision = renewed.lifecycle_revision;
     record.workspace_owner_lease = Some(renewed);
     Ok(())
@@ -1352,9 +1363,16 @@ pub(crate) fn require_record_workspace_owner(record: &AgentTaskRunRecord) -> Res
 }
 
 pub(crate) fn release_terminal_record_workspace_owner(record: &AgentTaskRunRecord) -> Result<()> {
+    release_terminal_record_workspace_owner_in_store(&store()?, record)
+}
+
+pub(crate) fn release_terminal_record_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    record: &AgentTaskRunRecord,
+) -> Result<()> {
     if record.state.is_terminal() {
         if let Some(lease) = record.workspace_owner_lease.as_ref() {
-            release_local_workspace_owner(lease)?;
+            store.release_owner(lease, now_ms())?;
         }
     }
     Ok(())

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -21,9 +21,8 @@ use homeboy_core::{build_identity, paths, Error, ErrorCode, Result};
 
 /// Durable agent-task lifecycle storage bound to immutable filesystem roots.
 ///
-/// Record writes are intentionally outside this first boundary: renewing the
-/// workspace owner, persisting terminal workspace authority, and updating the
-/// observation row must move together in a later atomic migration.
+/// Record writes keep workspace owner renewal, terminal workspace authority,
+/// and observation projection bound to the same roots.
 #[derive(Clone, Debug)]
 pub struct AgentTaskLifecycleStore {
     roots: paths::PathRoots,
@@ -81,6 +80,10 @@ impl AgentTaskLifecycleStore {
         self.roots.data().join("homeboy.sqlite")
     }
 
+    fn data_root(&self) -> PathBuf {
+        self.roots.data().to_path_buf()
+    }
+
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
         ObservationStore::open_initialized_at(self.observation_db_path())
     }
@@ -134,6 +137,110 @@ impl AgentTaskLifecycleStore {
 
     pub fn cook_index_exists(&self, cook_id: &str) -> bool {
         self.cook_index_path(cook_id).exists()
+    }
+
+    pub fn read_record(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
+        read_record_in_store(self, run_id)
+    }
+
+    pub fn read_record_bounded(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
+        read_record_bounded_in_store(self, run_id)
+    }
+
+    pub fn write_record(&self, record: &AgentTaskRunRecord) -> Result<()> {
+        self.write_record_with_aggregate(
+            record,
+            read_mirrored_aggregate_in_store(self, &record.run_id)?,
+        )
+    }
+
+    /// Persist a record while the caller owns this store's config lock. Terminal
+    /// authority is intentionally projected only after that lock is released.
+    pub(crate) fn write_record_locked_without_terminal_projection(
+        &self,
+        record: &AgentTaskRunRecord,
+    ) -> Result<AgentTaskRunRecord> {
+        write_record_with_aggregate_without_workspace_authority(
+            self,
+            record,
+            read_mirrored_aggregate_in_store(self, &record.run_id)?,
+        )
+    }
+
+    pub fn mutate_record(
+        &self,
+        run_id: &str,
+        mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
+    ) -> Result<Option<AgentTaskRunRecord>> {
+        let record = self.with_config_lock(|| {
+            self.mutate_record_locked_without_terminal_projection(run_id, mutate)
+        })?;
+        if let Some(record) = record.as_ref() {
+            self.project_terminal_record_after_unlock(&record.run_id)?;
+        }
+        Ok(record)
+    }
+
+    pub(crate) fn mutate_record_locked_without_terminal_projection(
+        &self,
+        run_id: &str,
+        mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
+    ) -> Result<Option<AgentTaskRunRecord>> {
+        let mut record = self.read_record(run_id)?;
+        if !mutate(&mut record) {
+            return Ok(None);
+        }
+        self.write_record_locked_without_terminal_projection(&record)
+            .map(Some)
+    }
+
+    /// Complete terminal projection after the record lock has been released:
+    /// receipt first, then the workspace owner lease.
+    pub(crate) fn project_terminal_record_after_unlock(&self, run_id: &str) -> Result<()> {
+        let record = self.read_record(run_id)?;
+        super::workspace_authority::WorkspaceTerminalAuthorityStore::new(
+            self.data_root(),
+            self.roots.config().to_path_buf(),
+        )
+        .persist_terminal_from_record(&record)
+        .and_then(|_| {
+            super::workspace_claims::release_terminal_record_workspace_owner_in_store(
+                &super::workspace_claims::workspace_claim_store_at(self.data_root()),
+                &record,
+            )
+        })
+    }
+
+    pub fn write_aggregate_and_record(
+        &self,
+        record: &AgentTaskRunRecord,
+        aggregate: &AgentTaskAggregate,
+    ) -> Result<PathBuf> {
+        self.write_record_with_aggregate(record, Some(aggregate.clone()))?;
+        #[cfg(test)]
+        if INTERRUPT_AFTER_TERMINAL_COMMIT.swap(false, Ordering::SeqCst) {
+            return Err(Error::internal_io(
+                "injected interruption after terminal lifecycle commit",
+                Some(record.run_id.clone()),
+            ));
+        }
+        self.write_aggregate(&record.run_id, aggregate)
+    }
+
+    fn write_record_with_aggregate(
+        &self,
+        record: &AgentTaskRunRecord,
+        aggregate: Option<AgentTaskAggregate>,
+    ) -> Result<()> {
+        let mut record = record.clone();
+        super::workspace_claims::renew_record_workspace_owner_in_store(
+            &super::workspace_claims::workspace_claim_store_at(self.data_root()),
+            &mut record,
+        )?;
+        let committed = self.with_config_lock(|| {
+            write_record_with_aggregate_without_workspace_authority(self, &record, aggregate)
+        })?;
+        self.project_terminal_record_after_unlock(&committed.run_id)
     }
 }
 
@@ -349,7 +456,7 @@ pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
 }
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
-    write_record_with_aggregate(record, read_mirrored_aggregate(&record.run_id)?)
+    default_store()?.write_record(record)
 }
 
 /// Persist a record while the caller owns the config lock. Terminal workspace
@@ -357,17 +464,12 @@ pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
 pub(super) fn write_record_locked_without_terminal_projection(
     record: &AgentTaskRunRecord,
 ) -> Result<AgentTaskRunRecord> {
-    write_record_with_aggregate_without_workspace_authority(
-        record,
-        read_mirrored_aggregate(&record.run_id)?,
-    )
+    default_store()?.write_record_locked_without_terminal_projection(record)
 }
 
 /// Complete terminal projection from committed lifecycle truth after unlocking.
 pub(super) fn project_terminal_record_after_unlock(run_id: &str) -> Result<()> {
-    let record = read_record(run_id)?;
-    super::workspace_authority::persist_terminal_from_record(&record)
-        .and_then(|_| super::release_terminal_record_workspace_owner(&record))
+    default_store()?.project_terminal_record_after_unlock(run_id)
 }
 
 /// Serialize a record read-modify-write so independent lifecycle projections do
@@ -376,23 +478,7 @@ pub(super) fn mutate_record(
     run_id: &str,
     mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
 ) -> Result<Option<AgentTaskRunRecord>> {
-    let record = homeboy_core::config::with_config_lock(|| {
-        let mut record = read_record(run_id)?;
-        if !mutate(&mut record) {
-            return Ok(None);
-        }
-        let committed = write_record_with_aggregate_without_workspace_authority(
-            &record,
-            read_mirrored_aggregate(&record.run_id)?,
-        )?;
-        Ok(Some(committed))
-    })?;
-    if let Some(record) = record.as_ref() {
-        // Terminal authority has its own config lock. Persist it after releasing
-        // the record mutation lock so a terminal update cannot self-deadlock.
-        super::workspace_authority::persist_terminal_from_record(record)?;
-    }
-    Ok(record)
+    default_store()?.mutate_record(run_id, mutate)
 }
 
 /// Mutate a record while the caller owns the config lock. Terminal authority is
@@ -402,11 +488,7 @@ pub(super) fn mutate_record_locked_without_terminal_projection(
     run_id: &str,
     mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
 ) -> Result<Option<AgentTaskRunRecord>> {
-    let mut record = read_record(run_id)?;
-    if !mutate(&mut record) {
-        return Ok(None);
-    }
-    write_record_locked_without_terminal_projection(&record).map(Some)
+    default_store()?.mutate_record_locked_without_terminal_projection(run_id, mutate)
 }
 
 /// Commit the controller projection and child aggregate in one observation row.
@@ -416,15 +498,7 @@ pub(super) fn write_aggregate_and_record(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<PathBuf> {
-    write_record_with_aggregate(record, Some(aggregate.clone()))?;
-    #[cfg(test)]
-    if INTERRUPT_AFTER_TERMINAL_COMMIT.swap(false, Ordering::SeqCst) {
-        return Err(Error::internal_io(
-            "injected interruption after terminal lifecycle commit",
-            Some(record.run_id.clone()),
-        ));
-    }
-    write_aggregate(&record.run_id, aggregate)
+    default_store()?.write_aggregate_and_record(record, aggregate)
 }
 
 #[cfg(test)]
@@ -437,23 +511,8 @@ pub(super) fn interrupt_after_terminal_commit_for_test() {
     INTERRUPT_AFTER_TERMINAL_COMMIT.store(true, Ordering::SeqCst);
 }
 
-fn write_record_with_aggregate(
-    record: &AgentTaskRunRecord,
-    aggregate: Option<AgentTaskAggregate>,
-) -> Result<()> {
-    let mut record = record.clone();
-    // Every durable scheduler/provider/controller heartbeat passes through this
-    // write boundary. Renew before persisting so the record carries the exact
-    // store-issued epoch rather than an optimistic local timestamp.
-    super::renew_record_workspace_owner(&mut record)?;
-    let committed = homeboy_core::config::with_config_lock(|| {
-        write_record_with_aggregate_without_workspace_authority(&record, aggregate)
-    })?;
-    super::workspace_authority::persist_terminal_from_record(&committed)
-        .and_then(|_| super::release_terminal_record_workspace_owner(&committed))
-}
-
 fn write_record_with_aggregate_without_workspace_authority(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<AgentTaskRunRecord> {
@@ -464,7 +523,7 @@ fn write_record_with_aggregate_without_workspace_authority(
             Some(record.run_id.clone()),
         ));
     }
-    let store = ObservationStore::open_initialized()?;
+    let store = lifecycle_store.open_observation_initialized()?;
     let existing_metadata = store
         .get_run(&record.run_id)?
         .map(|run| run.metadata_json)
@@ -504,7 +563,14 @@ fn write_record_with_aggregate_without_workspace_authority(
 }
 
 pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let store = ObservationStore::open_initialized()?;
+    default_store()?.read_record(run_id)
+}
+
+fn read_record_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let store = lifecycle_store.open_observation_initialized()?;
     let run = store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -519,7 +585,14 @@ pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// Read one durable record under the observation store's read-only busy budget.
 /// Inspection must not initialize, migrate, or contend like a writer.
 pub(super) fn read_record_bounded(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let store = ObservationStore::open_readonly()?;
+    default_store()?.read_record_bounded(run_id)
+}
+
+fn read_record_bounded_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let store = lifecycle_store.open_observation_readonly()?;
     let run = store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",


### PR DESCRIPTION
## Summary
- add store-owned agent-task record reads, writes, mutations, and aggregate commits
- bind observation rows, workspace-owner renewal/release, terminal workspace receipts, and config locks to one `AgentTaskLifecycleStore`
- preserve ambient lifecycle APIs as current-environment compatibility adapters
- make terminal mutation projection complete receipt persistence before owner release
- prove parallel same-run-ID records and terminal receipts stay isolated by explicit root

## Verification
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::lifecycle_store:: --locked` (3 passed)
- `cargo test -p homeboy-agents terminal_lab_record_persists_from_inside_a_config_lock_section --locked`
- `cargo check -p homeboy-agents --tests --locked`
- `git diff --check`

Full workspace compilation was intentionally skipped because the workspace began this slice critically low on disk; targeted package compilation and authority regressions are green.

Advances #7505.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to map the record/lease/terminal-authority saga, implement explicit-root routing, add isolation coverage, diagnose fixture validation, and run verification. Chris Huber reviewed and remains responsible for the change.