### PR TITLE
Root agent-task plan submission in lifecycle stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -9,8 +9,19 @@ pub fn record_pre_execution_failure(
     phase: &str,
     error: &Error,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_pre_execution_failure_in_store(&lifecycle_store, run_id, plan, phase, error)
+}
+
+pub(crate) fn record_pre_execution_failure_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    phase: &str,
+    error: &Error,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let mut record = store::read_record(&run_id)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
 
     // A transport/handoff error that arrives AFTER a provider attempt was
     // already dispatched (or completed) on a runner is not a pre-execution
@@ -21,7 +32,7 @@ pub fn record_pre_execution_failure(
     // controller reconciliation can adopt the completed candidate without
     // rerunning the provider.
     if record.has_recorded_provider_progress() {
-        return record_transport_follow_up_failure(record, phase, error);
+        return record_transport_follow_up_failure_in_store(lifecycle_store, record, phase, error);
     }
 
     let task_count = plan.tasks.len();
@@ -65,7 +76,8 @@ pub fn record_pre_execution_failure(
             ..AgentTaskQueueStatus::default()
         },
     };
-    let mut failed_record = record_aggregate(&mut record, plan, &aggregate)?;
+    let mut failed_record =
+        record_aggregate_in_store(lifecycle_store, &mut record, plan, &aggregate)?;
     let runner_id = failed_record.runner_id().map(str::to_string);
     let metadata = failed_record.ensure_metadata_object();
     if retryable {
@@ -93,7 +105,7 @@ pub fn record_pre_execution_failure(
             })).collect::<Vec<_>>(),
         }),
     );
-    store::write_record(&failed_record)?;
+    lifecycle_store.write_record(&failed_record)?;
     Ok(failed_record)
 }
 
@@ -105,6 +117,16 @@ pub fn record_pre_execution_failure(
 /// rerunning the provider. The failure stays `retryable` so recovery is
 /// attempted, and never regresses a terminal candidate to `Failed`.
 fn record_transport_follow_up_failure(
+    record: AgentTaskRunRecord,
+    phase: &str,
+    error: &Error,
+) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_transport_follow_up_failure_in_store(&lifecycle_store, record, phase, error)
+}
+
+fn record_transport_follow_up_failure_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     mut record: AgentTaskRunRecord,
     phase: &str,
     error: &Error,
@@ -129,7 +151,7 @@ fn record_transport_follow_up_failure(
     // must not be reaped as a clean success when its follow-up failed.
     metadata.insert("candidate_preserved".to_string(), json!(true));
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -644,7 +666,17 @@ pub(crate) fn record_aggregate(
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,
 ) -> Result<AgentTaskRunRecord> {
-    let aggregate_path = store::aggregate_path(&record.run_id)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_aggregate_in_store(&lifecycle_store, record, plan, aggregate)
+}
+
+pub(crate) fn record_aggregate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Result<AgentTaskRunRecord> {
+    let aggregate_path = lifecycle_store.aggregate_path(&record.run_id);
     apply_aggregate_to_record(
         record,
         plan,
@@ -689,13 +721,22 @@ pub(crate) fn record_aggregate(
     }
     crate::controller_scratch::register_outcome_resources(&record.run_id, &aggregate.outcomes)?;
     crate::controller_scratch::finalize_run(&record.run_id)?;
-    store::write_aggregate_and_record(record, aggregate)?;
-    record_terminal_artifact_projection(record, aggregate)?;
+    lifecycle_store.write_aggregate_and_record(record, aggregate)?;
+    record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
     update_cook_candidate_after_completion(record, aggregate, None)?;
     Ok(record.clone())
 }
 
 pub(crate) fn record_terminal_artifact_projection(
+    record: &mut AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_terminal_artifact_projection_in_store(&lifecycle_store, record, aggregate)
+}
+
+fn record_terminal_artifact_projection_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
@@ -724,7 +765,7 @@ pub(crate) fn record_terminal_artifact_projection(
                         },
                     }),
                 );
-                return store::write_record(record);
+                return lifecycle_store.write_record(record);
             }
         }
     }
@@ -754,7 +795,7 @@ pub(crate) fn record_terminal_artifact_projection(
             );
         }
     }
-    store::write_record(record)
+    lifecycle_store.write_record(record)
 }
 
 /// Replace runner-local file references with controller-resolvable aggregate

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -928,7 +928,6 @@ impl RuntimeAdmissionEvidence for homeboy_core::controller_runtime::RuntimeAdmis
     }
 }
 
-#[cfg(test)]
 impl RuntimeAdmissionEvidence for Value {
     fn runtime(&self) -> Value {
         self.clone()
@@ -946,10 +945,14 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
-    submit_plan_with_runtime_admission_on_runner(
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    submit_plan_with_runtime_admission_in_store(
+        &lifecycle_store,
         plan,
         requested_run_id,
         execution_runner_id(),
+        None,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         admit_runtime,
     )
 }
@@ -964,11 +967,14 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
-    submit_plan_with_runtime_admission_on_runner_with_metadata(
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    submit_plan_with_runtime_admission_in_store(
+        &lifecycle_store,
         plan,
         requested_run_id,
         execution_runner_id,
         None,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         admit_runtime,
     )
 }
@@ -984,6 +990,32 @@ where
     F: FnOnce(&str) -> Result<A>,
     A: RuntimeAdmissionEvidence,
 {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    submit_plan_with_runtime_admission_in_store(
+        &lifecycle_store,
+        plan,
+        requested_run_id,
+        execution_runner_id,
+        submission_metadata,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        admit_runtime,
+    )
+}
+
+pub(crate) fn submit_plan_with_runtime_admission_in_store<F, A>(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+    execution_runner_id: Option<String>,
+    submission_metadata: Option<serde_json::Map<String, Value>>,
+    admission_status: Option<&dyn Fn(&str) -> Option<Value>>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce(&str) -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
+    let workspace_claim_store = lifecycle_store.workspace_claim_store();
     let mut normalized_plan = plan.clone();
     if normalized_plan.workspace_identity.is_none() {
         normalized_plan.workspace_identity = identity_for_plan(&normalized_plan)?;
@@ -992,8 +1024,11 @@ where
         .map(sanitize_run_id)
         .unwrap_or_else(default_run_id);
     if let Some(identity) = normalized_plan.workspace_identity.clone() {
-        normalized_plan.workspace_owner_lease =
-            Some(register_local_workspace_owner(identity, &run_id)?);
+        normalized_plan.workspace_owner_lease = Some(register_local_workspace_owner_in_store(
+            &workspace_claim_store,
+            identity,
+            &run_id,
+        )?);
         normalized_plan.workspace_lifecycle_revision = normalized_plan
             .workspace_owner_lease
             .as_ref()
@@ -1001,11 +1036,11 @@ where
             .lifecycle_revision;
     }
     let plan = &normalized_plan;
-    let plan_path = match store::write_plan(&run_id, plan) {
+    let plan_path = match lifecycle_store.write_controller_plan(&run_id, plan) {
         Ok(path) => path,
         Err(error) => {
             if let Some(lease) = plan.workspace_owner_lease.as_ref() {
-                let _ = release_local_workspace_owner(lease);
+                let _ = release_local_workspace_owner_in_store(&workspace_claim_store, lease);
             }
             return Err(error);
         }
@@ -1110,7 +1145,7 @@ where
         metadata,
     };
     let mut preserved_controller_runtime = None;
-    if let Ok(existing) = store::read_record(&run_id) {
+    if let Ok(existing) = lifecycle_store.read_record(&run_id) {
         // A runner may re-submit the plan after the controller reserved a
         // side-effect claim. Claims are durable exactly-once ownership, not
         // plan-derived state, so replacing the record must retain them.
@@ -1177,14 +1212,14 @@ where
             record.workspace_owner_lease = existing.workspace_owner_lease;
         }
     }
-    require_record_workspace_owner(&record)?;
-    store::write_record(&record)?;
+    require_record_workspace_owner_in_store(&workspace_claim_store, &record)?;
+    lifecycle_store.write_record(&record)?;
 
     // The queue is durable independently of this foreground controller. Status
     // and cancellation can therefore resolve a waiter after a restart.
-    if let Ok(admission) = homeboy_core::controller_runtime::admission_status(&run_id) {
+    if let Some(admission) = admission_status.and_then(|project| project(&run_id)) {
         record.metadata["controller_admission"] = admission;
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
 
     match admit_runtime(&run_id) {
@@ -1192,7 +1227,7 @@ where
             // The admission claim checks this state under the queue lock. Read
             // it once more before recording runtime provenance or dispatching
             // any provider work in case cancellation won immediately after.
-            if let Ok(cancelled) = store::read_record(&run_id) {
+            if let Ok(cancelled) = lifecycle_store.read_record(&run_id) {
                 if cancelled.state.is_terminal() {
                     return Ok(cancelled);
                 }
@@ -1210,20 +1245,26 @@ where
                     [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
                     admission.runtime();
             }
-            store::write_record(&record)?;
+            lifecycle_store.write_record(&record)?;
         }
         Err(error) => {
             // Cancellation is persisted before removing a queue entry. Do not
             // overwrite that terminal lifecycle state with a synthetic
             // pre-execution admission failure when the waiter wakes up.
-            if let Ok(cancelled) = store::read_record(&run_id) {
+            if let Ok(cancelled) = lifecycle_store.read_record(&run_id) {
                 if cancelled.state == AgentTaskRunState::Cancelled
                     || cancelled.metadata["controller_admission_cancellation_requested"] == true
                 {
                     return Ok(cancelled);
                 }
             }
-            record_pre_execution_failure(&run_id, plan, "controller_admission", &error)?;
+            record_pre_execution_failure_in_store(
+                lifecycle_store,
+                &run_id,
+                plan,
+                "controller_admission",
+                &error,
+            )?;
             return Err(error);
         }
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -181,6 +181,64 @@ fn lifecycle_stores_isolate_same_run_record_writes_in_parallel() {
 }
 
 #[test]
+fn lifecycle_stores_submit_identical_run_ids_without_ambient_runtime() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let run_id = "same-submission";
+    let barrier = Arc::new(Barrier::new(2));
+
+    let mut left_plan = test_plan();
+    left_plan.plan_id = "left-submission-plan".to_string();
+    let mut right_plan = test_plan();
+    right_plan.plan_id = "right-submission-plan".to_string();
+
+    std::thread::scope(|scope| {
+        let left_store = left.clone();
+        let left_barrier = Arc::clone(&barrier);
+        scope.spawn(move || {
+            left_barrier.wait();
+            left_store
+                .submit_plan_with_runtime_admission(&left_plan, run_id, |_| {
+                    Ok(json!({ "store": "left" }))
+                })
+                .expect("submit left plan");
+        });
+        let right_store = right.clone();
+        let right_barrier = Arc::clone(&barrier);
+        scope.spawn(move || {
+            right_barrier.wait();
+            right_store
+                .submit_plan_with_runtime_admission(&right_plan, run_id, |_| {
+                    Ok(json!({ "store": "right" }))
+                })
+                .expect("submit right plan");
+        });
+    });
+
+    let left_record = left.read_record(run_id).expect("read left record");
+    let right_record = right.read_record(run_id).expect("read right record");
+    assert_eq!(
+        left.read_controller_plan(run_id).unwrap().plan_id,
+        "left-submission-plan"
+    );
+    assert_eq!(
+        right.read_controller_plan(run_id).unwrap().plan_id,
+        "right-submission-plan"
+    );
+    assert_eq!(left_record.plan_id, "left-submission-plan");
+    assert_eq!(right_record.plan_id, "right-submission-plan");
+    assert_eq!(left_record.metadata["controller_runtime"]["store"], "left");
+    assert_eq!(
+        right_record.metadata["controller_runtime"]["store"],
+        "right"
+    );
+    assert!(left_record.metadata.get("controller_admission").is_none());
+    assert!(right_record.metadata.get("controller_admission").is_none());
+}
+
+#[test]
 fn terminal_record_authority_is_written_only_below_its_lifecycle_root() {
     let left_context = homeboy_core::test_support::HermeticTestContext::new();
     let right_context = homeboy_core::test_support::HermeticTestContext::new();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1277,6 +1277,19 @@ pub(crate) fn register_local_workspace_owner(
     )
 }
 
+pub(crate) fn register_local_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    workspace: WorkspaceIdentity,
+    run_id: &str,
+) -> Result<WorkspaceOwnerLease> {
+    store.register_owner(
+        workspace,
+        run_id,
+        LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS,
+        now_ms(),
+    )
+}
+
 pub(crate) fn renew_local_workspace_owner(
     lease: &WorkspaceOwnerLease,
 ) -> Result<WorkspaceOwnerLease> {
@@ -1287,8 +1300,22 @@ pub(crate) fn validate_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Res
     store()?.validate_owner(lease, now_ms())
 }
 
+pub(crate) fn validate_local_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    lease: &WorkspaceOwnerLease,
+) -> Result<bool> {
+    store.validate_owner(lease, now_ms())
+}
+
 pub(crate) fn release_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Result<()> {
     store()?.release_owner(lease, now_ms())
+}
+
+pub(crate) fn release_local_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    lease: &WorkspaceOwnerLease,
+) -> Result<()> {
+    store.release_owner(lease, now_ms())
 }
 
 pub(crate) fn renew_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
@@ -1335,6 +1362,13 @@ pub(crate) fn ensure_record_workspace_owner(record: &mut AgentTaskRunRecord) -> 
 }
 
 pub(crate) fn require_record_workspace_owner(record: &AgentTaskRunRecord) -> Result<()> {
+    require_record_workspace_owner_in_store(&store()?, record)
+}
+
+pub(crate) fn require_record_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    record: &AgentTaskRunRecord,
+) -> Result<()> {
     let Some(identity) = record.workspace_identity.as_ref() else {
         return Ok(());
     };
@@ -1350,7 +1384,7 @@ pub(crate) fn require_record_workspace_owner(record: &AgentTaskRunRecord) -> Res
     if lease.workspace != *identity
         || lease.owner_id != record.run_id
         || lease.lifecycle_revision != record.workspace_lifecycle_revision
-        || !validate_local_workspace_owner(lease)?
+        || !validate_local_workspace_owner_in_store(store, lease)?
     {
         return Err(Error::validation_invalid_argument(
             "workspace_owner_lease",

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -84,6 +84,32 @@ impl AgentTaskLifecycleStore {
         self.roots.data().to_path_buf()
     }
 
+    pub(crate) fn workspace_claim_store(
+        &self,
+    ) -> homeboy_core::workspace_claim::WorkspaceClaimStore {
+        super::workspace_claims::workspace_claim_store_at(self.data_root())
+    }
+
+    /// Submit an exact run identity using this store's durable lifecycle roots.
+    /// The admission callback supplies runtime evidence without coupling tests to
+    /// the ambient controller runtime.
+    pub fn submit_plan_with_runtime_admission(
+        &self,
+        plan: &AgentTaskPlan,
+        run_id: &str,
+        admit_runtime: impl FnOnce(&str) -> Result<Value>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::submit_plan_with_runtime_admission_in_store(
+            self,
+            plan,
+            Some(run_id),
+            None,
+            None,
+            None,
+            admit_runtime,
+        )
+    }
+
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
         ObservationStore::open_initialized_at(self.observation_db_path())
     }


### PR DESCRIPTION
## Summary
- add explicit-store agent-task submission with injected runtime admission evidence
- bind plans, records, admission failures, and workspace-owner authority to one `AgentTaskLifecycleStore`
- preserve production submission behavior through current-environment adapters, including controller admission-status projection
- keep explicit-store submissions free of ambient controller-runtime reads
- prove identical run IDs submit concurrently into independent roots

This is the submission prerequisite for threading recipe and lifecycle stores together through Cook materialization. `run_cook_with_stores` remains deferred until its first lifecycle write can stay rooted.

## Verification
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::lifecycle_store:: --locked` (4 passed)
- `cargo test -p homeboy-agents submit_plan --locked` (2 passed)
- `cargo check -p homeboy-agents --tests --locked`
- `git diff --check`

Advances #7505.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to map Cook submission dependencies, implement rooted submission, add parallel isolation coverage, and run verification. Chris Huber reviewed and remains responsible for the change.