### PR TITLE
fix(cook): canonicalize continuation commands

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1280,7 +1280,7 @@ pub fn persist_notification_route(
 ///
 /// The route a caller supplied is bound to the launching *thread*
 /// (`notification_route::current`), which a process that did not launch the
-/// cook — `cook --continue`, controller adoption, claimed continuation — never
+/// cook — `cook-continue`, controller adoption, claimed continuation — never
 /// inherits. It is also persisted on the durable record by
 /// [`persist_notification_route`], and that copy survives the process. This is
 /// the same durable read the daemon completion backstop and `runs watch`

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -64,7 +64,7 @@ fn should_deliver(kind: NotifyEventKind, has_explicit_route: bool) -> bool {
 ///
 /// `notification_route::current()` is a **thread-local**, so it only answers in
 /// the process and on the thread that accepted `--notification-route`. A cook
-/// resumed elsewhere — `cook --continue`, controller adoption, a claimed
+/// resumed elsewhere — `cook-continue`, controller adoption, a claimed
 /// continuation — starts with an empty one, which silently downgraded the whole
 /// arc: `Started`/`Progress` were dropped by `should_deliver`, and the terminal
 /// event went to the ambient default transport instead of the thread that
@@ -93,7 +93,7 @@ fn should_deliver(kind: NotifyEventKind, has_explicit_route: bool) -> bool {
 ///
 /// The durable fallback is not made redundant by environment propagation. It
 /// covers resumption paths that inherit neither argv nor environment from the
-/// launching process — `cook --continue`, controller adoption, a claimed
+/// launching process — `cook-continue`, controller adoption, a claimed
 /// continuation — so both remain load-bearing.
 fn effective_route(run_id: &str) -> Option<NotificationRoute> {
     notification_route::current()

--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -52,7 +52,7 @@ fn failure_context() -> AgentTaskCookFailureContext {
         recovery_reason: "the durable recipe is intact".to_string(),
         legal_actions: vec![AgentTaskCookRecoveryAction {
             action: "continue".to_string(),
-            command: "homeboy agent-task cook --continue cook-abc".to_string(),
+            command: "homeboy agent-task cook-continue cook-abc".to_string(),
         }],
         next_actions: vec![AgentTaskCookRecoveryAction {
             action: "diagnose".to_string(),
@@ -97,7 +97,7 @@ fn failed_cook_forwards_its_own_legal_recovery_commands() {
         "{commands:?}"
     );
     assert!(
-        commands.contains(&"homeboy agent-task cook --continue cook-abc"),
+        commands.contains(&"homeboy agent-task cook-continue cook-abc"),
         "{commands:?}"
     );
     assert!(payload
@@ -377,7 +377,7 @@ fn resumed_terminal_delivery_uses_the_durable_route_and_stays_deduplicated() {
 #[test]
 fn a_cook_resumed_in_a_new_process_recovers_its_route_from_the_durable_record() {
     // #11115: `notification_route::current()` is a thread-local, so a
-    // process that did not launch the cook (`cook --continue`, controller
+    // process that did not launch the cook (`cook-continue`, controller
     // adoption, claimed continuation) has none. Without the durable
     // fallback the whole arc degrades: Started/Progress are dropped and the
     // terminal event lands on the ambient default transport instead of the

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -24,6 +24,7 @@ use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::run_lifecycle_status::RunLifecycleStatus;
 use homeboy_core::{Error, Result};
+use homeboy_engine_primitives::shell::quote_arg;
 
 use super::cook_activity::{CookActivityProbe, CookProviderActivity};
 use super::cook_baseline::{
@@ -58,6 +59,34 @@ use super::AgentTaskRunResult;
 /// controller finishes promoting and records the result within it; a crashed
 /// controller's lease elapses so a resumed pass can reconcile and continue.
 const PROMOTION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Render the public CLI continuation route.
+///
+/// Cook IDs deliberately preserve normal current-attempt selection, while
+/// attempt IDs preserve exact lifecycle lineage for recovery. `executable`
+/// permits a controller-pinned runtime to own the continuation without
+/// changing the public command shape.
+pub fn cook_continue_command(
+    executable: Option<&str>,
+    cook_or_attempt_id: &str,
+    rearm: bool,
+    artifact_id: Option<&str>,
+) -> String {
+    let executable = executable.unwrap_or("homeboy");
+    let mut command = format!(
+        "{} agent-task cook-continue {}",
+        quote_arg(executable),
+        quote_arg(cook_or_attempt_id)
+    );
+    if rearm {
+        command.push_str(" --rearm");
+    }
+    if let Some(artifact_id) = artifact_id {
+        command.push_str(" --artifact-id ");
+        command.push_str(&quote_arg(artifact_id));
+    }
+    command
+}
 
 /// Durable operation key for the promotion of one cook attempt. Promotion is
 /// one-per-`run_id`, so the run id is the stable operation identity (#8357).
@@ -488,7 +517,7 @@ fn promote_with_operation_claim(
                 "promotion_operation",
                 "operation_in_progress",
                 Some(operation_key),
-                Some(vec![format!("homeboy agent-task cook-continue {run_id}")]),
+                Some(vec![cook_continue_command(None, run_id, false, None)]),
             );
             error.details["claim"] = serde_json::to_value(claim).unwrap_or(Value::Null);
             Err(error)
@@ -5760,8 +5789,8 @@ fn trusted_initial_cook_workspace(
             "clean unpushed provider checkout cannot be trusted for initial Cook adoption",
             Some(options.to_worktree.clone()),
             Some(vec![format!(
-                "Adopt or continue this exact Cook with: homeboy agent-task cook-continue {}",
-                options.cook_id
+                "Adopt or continue this exact Cook with: {}",
+                cook_continue_command(None, &options.cook_id, false, None)
             )]),
         );
         if !clean {
@@ -5791,8 +5820,8 @@ fn trusted_initial_cook_workspace(
             "explicitly targeted provider worktree is not owned by this Cook task",
             Some(options.to_worktree.clone()),
             Some(vec![format!(
-                "Continue the owning Cook with: homeboy agent-task cook-continue {}",
-                options.cook_id
+                "Continue the owning Cook with: {}",
+                cook_continue_command(None, &options.cook_id, false, None)
             )]),
         ));
     }
@@ -5810,8 +5839,8 @@ fn trusted_initial_cook_workspace(
             "provider resolved a different checkout than the explicitly targeted Cook checkout",
             Some(options.to_worktree.clone()),
             Some(vec![format!(
-                "Continue the owning Cook with: homeboy agent-task cook-continue {}",
-                options.cook_id
+                "Continue the owning Cook with: {}",
+                cook_continue_command(None, &options.cook_id, false, None)
             )]),
         ));
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -803,7 +803,7 @@ pub(crate) fn moving_base_recovery_for_run_with_store(
             // Recoveries written before scoped continuation used `run-next`.
             // The run ID remains authoritative, so expose the safe command
             // without requiring an unsafe migration of historical records.
-            recovery.continuation = format!("homeboy agent-task cook-continue {run_id}");
+            recovery.continuation = super::cook_continue_command(None, run_id, false, None);
             Ok(Some(recovery))
         })
 }
@@ -841,7 +841,7 @@ pub(crate) fn moving_base_recovery_from_promotion(
         blocker: String::new(),
         // This recovery belongs to one immutable Cook attempt. `run-next` is a
         // global scheduler operation and must never be offered as its recovery.
-        continuation: format!("homeboy agent-task cook-continue {run_id}"),
+        continuation: super::cook_continue_command(None, run_id, false, None),
         base_movements: 0,
     }
 }
@@ -3437,15 +3437,13 @@ fn cook_recovery_actions(
         actions.extend(ambiguous_artifact_ids.into_iter().map(|artifact_id| {
             super::AgentTaskCookRecoveryAction {
                 action: "resume_with_artifact".to_string(),
-                command: format!(
-                    "homeboy agent-task cook-continue {run_id} --rearm --artifact-id {artifact_id}"
-                ),
+                command: super::cook_continue_command(None, run_id, true, Some(&artifact_id)),
             }
         }));
     } else if continuation_eligible {
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "resume".to_string(),
-            command: format!("homeboy agent-task cook-continue {run_id}"),
+            command: super::cook_continue_command(None, run_id, false, None),
         });
     }
     let next_actions = actions.clone();

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1166,7 +1166,8 @@ pub fn reconcile_recipe_attempt_for_continuation(
             ),
             Some(run_id.to_string()),
             Some(vec![format!(
-                "Retry `homeboy agent-task cook-continue {run_id}` after the runner artifact can be harvested."
+                "Retry `{}` after the runner artifact can be harvested.",
+                super::cook_continue_command(None, run_id, false, None)
             )]),
         )
         .with_retryable(true));

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -844,8 +844,8 @@ fn retryable_cook_attempt(
             "retryable pre-provider failure is not owned by its durable Cook recipe",
             Some(source.run_id.clone()),
             Some(vec![format!(
-                "Continue the owning Cook with: homeboy agent-task cook-continue {}",
-                cook_id
+                "Continue the owning Cook with: {}",
+                super::cook_continue_command(None, cook_id, false, None)
             )]),
         ));
     };

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -21,6 +21,7 @@ use homeboy::extension::{
     list_summaries_with, load_all_extensions, CliConfig,
     ExtensionManifest as InstalledExtensionManifest, ExtensionReadinessMode, ExtensionSummary,
 };
+use homeboy_agents::agent_task_service::cook_continue_command;
 use homeboy_core::extension_readiness::READY_CHECK_SKIPPED_REASON;
 use homeboy_upgrade::upgrade;
 
@@ -1208,11 +1209,7 @@ fn guard_fanout_resume_runtime(cli: &Cli) -> homeboy::core::Result<()> {
 }
 
 fn pinned_cook_continue_command(pinned: &std::path::Path, cook_id: &str) -> String {
-    format!(
-        "{} agent-task cook-continue {}",
-        homeboy::core::engine::shell::quote_arg(&pinned.to_string_lossy()),
-        homeboy::core::engine::shell::quote_arg(cook_id),
-    )
+    cook_continue_command(Some(&pinned.to_string_lossy()), cook_id, false, None)
 }
 
 fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1154,6 +1154,30 @@ mod tests {
     }
 
     #[test]
+    fn generated_cook_continuation_commands_parse_against_the_live_cli() {
+        use homeboy_agents::agent_task_service::cook_continue_command;
+
+        for command in [
+            cook_continue_command(None, "cook-1", false, None),
+            cook_continue_command(None, "cook-1-attempt-2", false, None),
+            cook_continue_command(None, "cook-1-attempt-2", true, None),
+            cook_continue_command(None, "cook-1-attempt-2", true, Some("selected patch")),
+            cook_continue_command(
+                Some("/tmp/controller runtimes/homeboy"),
+                "cook-1-attempt-2",
+                false,
+                None,
+            ),
+        ] {
+            let argv =
+                shlex::split(&command).expect("generated continuation command must be shell-safe");
+            Cli::try_parse_from(&argv).unwrap_or_else(|error| {
+                panic!("generated Cook continuation command failed to parse: {command}\n{error}")
+            });
+        }
+    }
+
+    #[test]
     fn core_command_docs_do_not_drift_from_registry() {
         let root = workspace_root();
         let registered_docs = crate::command_contract::COMMAND_SPECS

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
+use homeboy::agents::agent_task_service as agent_task_service_direct;
 use homeboy::agents::agent_tasks::dispatch_service;
 use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::agents::agent_tasks::provider;
@@ -619,7 +620,7 @@ fn cook_terminal_continuation_status(
             "continuation_pending",
             serde_json::json!({
                 "action": "await_continuation_claim",
-                "command": format!("homeboy agent-task cook-continue {run_id}"),
+                "command": agent_task_service_direct::cook_continue_command(None, run_id, false, None),
             }),
         ),
         agent_task_service::CookContinuationState::Claimed => (
@@ -633,7 +634,7 @@ fn cook_terminal_continuation_status(
             "continuation_recovery_required",
             serde_json::json!({
                 "action": "rearm_failed_continuation",
-                "command": format!("homeboy agent-task cook-continue {run_id} --rearm"),
+                "command": agent_task_service_direct::cook_continue_command(None, run_id, true, None),
             }),
         ),
         agent_task_service::CookContinuationState::Completed => (
@@ -758,7 +759,9 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
         );
         report.insert(
             "continuation_command".to_string(),
-            serde_json::json!(format!("homeboy agent-task cook-continue {run_id}")),
+            serde_json::json!(agent_task_service_direct::cook_continue_command(
+                None, &run_id, false, None
+            )),
         );
     }
     value

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -443,7 +443,7 @@ fn recipe_only_status(run_or_cook_id: &str, exact: bool) -> homeboy::core::Resul
         "provider_executions_consumed": 0,
         "guidance": {
             "action": "materialize_recipe_attempt",
-            "command": format!("homeboy agent-task cook-continue {}", attempt.run_id),
+            "command": agent_task_service_direct::cook_continue_command(None, &attempt.run_id, false, None),
             "message": "The immutable Cook recipe is durable but its lifecycle record is absent. Continue the exact attempt to materialize the controller lifecycle before provider work."
         }
     })))
@@ -498,9 +498,8 @@ fn attach_cook_notification_delivery(
         return;
     };
     if outcome.get("status").and_then(Value::as_str) != Some("delivered") {
-        outcome["retry_command"] = Value::String(format!(
-            "homeboy agent-task cook --continue {}",
-            quote_arg(cook_id)
+        outcome["retry_command"] = Value::String(agent_task_service_direct::cook_continue_command(
+            None, cook_id, false, None,
         ));
     }
     if outcome.get("status").and_then(Value::as_str) == Some("not_configured") {
@@ -5089,7 +5088,7 @@ fn cook_continuation_action(record: &AgentTaskRunRecord) -> homeboy::core::Resul
 fn cook_continuation_command(run_id: &str) -> CommandNextAction {
     CommandNextAction::new(
         "resume the authenticated Cook continuation",
-        format!("homeboy agent-task cook-continue {}", quote_arg(run_id)),
+        agent_task_service_direct::cook_continue_command(None, run_id, false, None),
     )
     .with_kind(CommandNextActionKind::Repair)
 }
@@ -5650,7 +5649,7 @@ mod tests {
                     "route_classification": "explicit",
                     "status": "failed",
                     "error_class": "transport_spawn_failed",
-                    "retry_command": "homeboy agent-task cook --continue cook-1",
+                    "retry_command": "homeboy agent-task cook-continue cook-1",
                     "raw_destination": "must-not-appear"
                 }
             }),
@@ -5660,7 +5659,7 @@ mod tests {
         assert_eq!(summary["notification_delivery"]["status"], "failed");
         assert_eq!(
             summary["notification_delivery"]["retry_command"],
-            "homeboy agent-task cook --continue cook-1"
+            "homeboy agent-task cook-continue cook-1"
         );
         assert!(summary["notification_delivery"]
             .get("raw_destination")

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -52,7 +52,7 @@ A run resolves its destination in this order, most explicit first:
 1. Explicit `--notification-transport` and `--notification-route` CLI values.
 2. `HOMEBOY_NOTIFICATION_TRANSPORT` and `HOMEBOY_NOTIFICATION_ROUTE`.
 3. The route persisted on the durable run record, which is what lets a run
-   resumed in another process — `cook --continue`, controller adoption, a
+   resumed in another process — `cook-continue`, controller adoption, a
    claimed continuation — keep reporting to the destination that launched it.
 
 Homeboy sets both environment variables on the child processes it spawns when a


### PR DESCRIPTION
## Summary

- centralize Cook continuation command rendering behind one canonical builder
- route reports, status, diagnose, notifications, workspace errors, and pinned-runtime recovery through the live `agent-task cook-continue` CLI contract
- shell-quote executable paths and identifiers and update stale recovery documentation

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- focused CLI parser coverage for generated normal, exact-attempt, rearm, artifact, and pinned-runtime commands
- moving-base, notification, status, diagnose, and Cook-report continuation tests

Closes #12383

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented and independently reviewed the canonical command builder, updated call sites and tests, and ran focused verification. Chris Huber reviewed and owns every line.