### PR TITLE
fix: let an exact-ref deploy assert the version it expects to install

### DIFF
--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -90,10 +90,25 @@ pub struct DeployArgs {
     )]
     pub release_set: Option<String>,
     /// Deploy an exact Git ref resolved from the declared component repository
+    ///
+    /// `--version` is deliberately NOT in the conflict set (#10648). The two
+    /// answer different questions: `--ref` selects immutable *source*, and
+    /// `--version` asserts the *content* of what that source builds. Recovering
+    /// a bad deploy needs both -- "deploy exactly this commit, and refuse before
+    /// touching the remote unless the package it produces embeds exactly this
+    /// version" -- and forcing a choice meant picking between source identity
+    /// and artifact identity, or writing a release-set manifest for a
+    /// one-component repair.
+    ///
+    /// They only looked mutually exclusive because `--version` doubles as a tag
+    /// selector. It cannot do that here: `resolve_deploy_tags` is already gated
+    /// on `!config.has_requested_refs()`, so with a ref requested the version
+    /// reaches `PreparedDeployArtifact::validate` as a pure assertion and never
+    /// selects anything.
     #[arg(
         long = "ref",
         value_name = "GIT_REF_OR_SHA",
-        conflicts_with_all = ["head", "tagged", "version", "outdated", "behind_upstream", "check"]
+        conflicts_with_all = ["head", "tagged", "outdated", "behind_upstream", "check"]
     )]
     pub requested_ref: Option<String>,
     /// Force local tag-based build/deploy, ignoring reusable release assets

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -331,12 +331,23 @@ fn deploy_parser_accepts_explicit_source_safety_overrides() {
     assert!(args.allow_downgrade);
 }
 
+/// `--version` is deliberately absent from this list (#10648).
+///
+/// It was here because `--version` doubles as a tag selector on the
+/// non-ref path, so it looked like one more way of choosing source. It is not:
+/// with a ref requested, `resolve_deploy_tags` is skipped entirely and the
+/// version reaches `PreparedDeployArtifact::validate` as an assertion about the
+/// package's contents. Selecting a commit and asserting what it builds are
+/// different questions, and recovery needs to ask both at once --
+/// `exact_ref_deploy_accepts_an_independent_expected_version` covers that.
+///
+/// Everything still listed here genuinely competes with `--ref` for source
+/// selection and must stay refused.
 #[test]
 fn deploy_ref_rejects_every_other_source_selector() {
     for conflicting in [
         vec!["--head"],
         vec!["--tagged"],
-        vec!["--version", "1.2.3"],
         vec!["--outdated"],
         vec!["--behind-upstream"],
         vec!["--check"],
@@ -474,4 +485,29 @@ fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
     };
     customize(&mut args);
     args
+}
+
+/// `--ref` selects immutable source; `--version` asserts what that source
+/// builds. Recovery needs both at once (#10648).
+#[test]
+fn exact_ref_deploy_accepts_an_independent_expected_version() {
+    let cli = Cli::try_parse_from([
+        "homeboy",
+        "deploy",
+        "--project",
+        "project-a",
+        "--component",
+        "component-a",
+        "--ref",
+        "v0.170.8",
+        "--version",
+        "0.170.8",
+    ])
+    .expect("--ref and --version answer different questions and must combine");
+
+    let Commands::Deploy(args) = cli.command else {
+        panic!("expected deploy command");
+    };
+    assert_eq!(args.requested_ref.as_deref(), Some("v0.170.8"));
+    assert_eq!(args.version.as_deref(), Some("0.170.8"));
 }


### PR DESCRIPTION
Fixes #10648.

## What was wrong

```sh
homeboy deploy <project> <component> --ref v0.170.8 --version 0.170.8
```

was refused as mutually exclusive. So recovering a bad deploy meant choosing:

- `--version` alone — asserts the version, but can select a stale local prepared artifact (the reported incident picked a `build/data-machine.zip` reporting `0.153.5`)
- `--ref` alone — selects immutable source, but cannot assert that what it builds embeds the expected version
- or write a release-set manifest for a one-component repair

None of those is the question being asked. **`--ref` selects immutable source; `--version` asserts what that source builds.** Recovery needs both.

## Why they looked mutually exclusive

Because `--version` does double duty — it is also a *tag selector* on the non-ref path.

It cannot do that alongside a ref. `resolve_deploy_tags` is already gated:

```rust
if !config.has_requested_refs() && !config.head && !config.skip_build {
    let resolved = resolve_deploy_tags(&local_build_components, config.expected_version.as_deref())?;
```

So with a ref requested the version never selects anything. It flows through `ComponentPayloadPreparationRequest` — which clears `requested_ref` precisely because the detached checkout is already the authoritative source — and reaches:

```rust
artifact.validate(&component.id, request.config.expected_version.as_deref())?;
```

a pure assertion that fails **before any remote mutation** when the packaged version disagrees.

**The plumbing already implemented the contract this issue asks for.** Only the clap conflict stood in the way, which is why the change is this small.

## On the test that pinned the old behaviour

`deploy_ref_rejects_every_other_source_selector` listed `--version` among "every other source selector" — the same conflation, in test form. I removed it from that list rather than adding a second test that contradicts it, and recorded why in the doc comment.

Everything that genuinely competes with `--ref` for source selection stays refused, and that is asserted:

| flag | still conflicts with `--ref` |
|---|---|
| `--head` | yes |
| `--tagged` | yes |
| `--outdated` | yes |
| `--behind-upstream` | yes |
| `--check` | yes |
| `--version` | **no — different question** |

## Verification

`cargo test -p homeboy-cli --lib deploy_test` — **23 passed, 0 failed**
`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean

New coverage: `exact_ref_deploy_accepts_an_independent_expected_version` asserts both values survive parsing and land on the right fields.

## Note

The issue also asks for a single identity envelope reporting ref, commit, artifact digest, embedded version and artifact source. That is a reporting change rather than a gating one and is not in this PR.

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix. Chris Huber remains responsible for the change.
