### PR TITLE
Materialize Cook attempts with explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -462,26 +462,31 @@ pub fn fail_detached_cook_handoff_parent(
     Ok(record.unwrap_or(store::read_record(&cook_id)?))
 }
 
-fn complete_detached_cook_handoff_parent(cook_id: &str, attempt_run_id: &str) -> Result<()> {
+fn complete_detached_cook_handoff_parent_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    attempt_run_id: &str,
+) -> Result<()> {
     let cook_id = sanitize_run_id(cook_id);
     let attempt_run_id = sanitize_run_id(attempt_run_id);
-    if store::read_record(&cook_id).is_err() {
+    if lifecycle_store.read_record(&cook_id).is_err() {
         return Ok(());
     }
-    let _ = store::mutate_record_locked_without_terminal_projection(&cook_id, |record| {
-        if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id
-            || record.state.is_terminal()
-            || record.metadata["detached_cook_handoff"]["state"] != "pending"
-        {
-            return false;
-        }
-        let metadata = record.ensure_metadata_object();
-        metadata["detached_cook_handoff"]["state"] = json!("redirected");
-        metadata["detached_cook_handoff"]["attempt_run_id"] = json!(attempt_run_id);
-        set_run_state(record, AgentTaskRunState::Succeeded);
-        record.updated_at = Some(now_timestamp());
-        true
-    })?;
+    let _ =
+        lifecycle_store.mutate_record_locked_without_terminal_projection(&cook_id, |record| {
+            if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id
+                || record.state.is_terminal()
+                || record.metadata["detached_cook_handoff"]["state"] != "pending"
+            {
+                return false;
+            }
+            let metadata = record.ensure_metadata_object();
+            metadata["detached_cook_handoff"]["state"] = json!("redirected");
+            metadata["detached_cook_handoff"]["attempt_run_id"] = json!(attempt_run_id);
+            set_run_state(record, AgentTaskRunState::Succeeded);
+            record.updated_at = Some(now_timestamp());
+            true
+        })?;
     Ok(())
 }
 
@@ -3828,15 +3833,26 @@ pub fn record_cook_attempt(
     attempt: u32,
     run_id: &str,
 ) -> Result<AgentTaskCookIndex> {
-    let registration = homeboy_core::config::with_config_lock(|| {
-        let registration = record_cook_attempt_locked(cook_id, attempt, run_id)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_attempt_in_store(&lifecycle_store, cook_id, attempt, run_id)
+}
+
+pub(crate) fn record_cook_attempt_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+) -> Result<AgentTaskCookIndex> {
+    let registration = lifecycle_store.with_config_lock(|| {
+        let registration =
+            record_cook_attempt_locked_in_store(lifecycle_store, cook_id, attempt, run_id)?;
         // The index is the handoff's ownership proof. Redirect its placeholder
         // while the index writer lock is held so an exit observer cannot fail
         // the parent between index publication and this transition.
-        complete_detached_cook_handoff_parent(cook_id, run_id)?;
+        complete_detached_cook_handoff_parent_in_store(lifecycle_store, cook_id, run_id)?;
         Ok(registration)
     })?;
-    let index = registration.project_terminal_after_unlock()?;
+    let index = registration.project_terminal_after_unlock_in_store(lifecycle_store)?;
     Ok(index)
 }
 
@@ -3846,9 +3862,19 @@ pub(crate) fn record_cook_attempt_locked(
     attempt: u32,
     run_id: &str,
 ) -> Result<CookAttemptRegistration> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_attempt_locked_in_store(&lifecycle_store, cook_id, attempt, run_id)
+}
+
+fn record_cook_attempt_locked_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+) -> Result<CookAttemptRegistration> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
-    if let Ok(parent) = store::read_record(&cook_id) {
+    if let Ok(parent) = lifecycle_store.read_record(&cook_id) {
         let handoff = &parent.metadata["detached_cook_handoff"];
         if handoff["cook_id"] == cook_id
             && (parent.state.is_terminal()
@@ -3864,8 +3890,8 @@ pub(crate) fn record_cook_attempt_locked(
         }
     }
     // Validate both durable ownership projections before changing either one.
-    store::validate_cook_index_attempt(&cook_id, attempt, &run_id)?;
-    let mut record = store::read_record(&run_id)?;
+    lifecycle_store.validate_cook_index_attempt(&cook_id, attempt, &run_id)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
     let recorded_cook_id = record.metadata.get("cook_id").and_then(Value::as_str);
     let recorded_attempt = record.metadata.get("cook_attempt").and_then(Value::as_u64);
     if recorded_cook_id.is_some_and(|value| value != cook_id)
@@ -3882,7 +3908,7 @@ pub(crate) fn record_cook_attempt_locked(
     let metadata = record.ensure_metadata_object();
     metadata.insert("cook_id".to_string(), json!(&cook_id));
     metadata.insert("cook_attempt".to_string(), json!(attempt));
-    if let Ok(parent) = store::read_record(&cook_id) {
+    if let Ok(parent) = lifecycle_store.read_record(&cook_id) {
         if let Some(supervisor) = parent.metadata["detached_cook_handoff"]
             .get("supervisor_job_id")
             .cloned()
@@ -3896,16 +3922,17 @@ pub(crate) fn record_cook_attempt_locked(
             );
         }
     }
-    let committed = store::write_record_locked_without_terminal_projection(&record)?;
+    let committed = lifecycle_store.write_record_locked_without_terminal_projection(&record)?;
     // Completion can precede Cook registration during handoff recovery. Re-read
     // its persisted aggregate after the Cook identity is durable, then commit the
     // attempt and substantive pointer in the same index write.
-    let candidate = store::read_aggregate(&committed.run_id)
+    let candidate = lifecycle_store
+        .read_aggregate(&committed.run_id)
         .ok()
         .and_then(|aggregate| {
             substantive_candidate_from_aggregate(&committed.run_id, attempt, &aggregate, None)
         });
-    let index = store::write_cook_index_attempt_locked(
+    let index = lifecycle_store.write_cook_index_attempt_locked(
         &cook_id,
         attempt,
         &committed.run_id,
@@ -3925,7 +3952,15 @@ pub(crate) struct CookAttemptRegistration {
 
 impl CookAttemptRegistration {
     pub(crate) fn project_terminal_after_unlock(self) -> Result<AgentTaskCookIndex> {
-        store::project_terminal_record_after_unlock(&self.run_id)?;
+        let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+        self.project_terminal_after_unlock_in_store(&lifecycle_store)
+    }
+
+    pub(crate) fn project_terminal_after_unlock_in_store(
+        self,
+        lifecycle_store: &AgentTaskLifecycleStore,
+    ) -> Result<AgentTaskCookIndex> {
+        lifecycle_store.project_terminal_record_after_unlock(&self.run_id)?;
         Ok(self.index)
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -15,7 +15,7 @@
 use serde_json::Value;
 
 use crate::agent_task::AgentTaskExecutor;
-use crate::agent_task_lifecycle;
+use crate::agent_task_lifecycle::{self, AgentTaskLifecycleStore};
 use crate::agent_task_scheduler::AgentTaskPlan;
 use homeboy_core::cook_status::CookDisposition;
 use homeboy_core::{Error, Result};
@@ -33,19 +33,36 @@ use super::AgentTaskRunResult;
 pub(crate) fn materialize_initial_cook_attempt(
     options: &AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    let store = CookRecipeStore::from_current_data_root()?;
-    materialize_initial_cook_attempt_with_store(&store, options)
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    materialize_initial_cook_attempt_with_store_and_lifecycle(
+        &recipe_store,
+        &lifecycle_store,
+        options,
+    )
 }
 
 pub(crate) fn materialize_initial_cook_attempt_with_store(
     store: &CookRecipeStore,
     options: &AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    materialize_cook_attempt_with_store(
-        store,
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    materialize_initial_cook_attempt_with_store_and_lifecycle(store, &lifecycle_store, options)
+}
+
+fn materialize_initial_cook_attempt_with_store_and_lifecycle(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+) -> Result<()> {
+    materialize_cook_attempt_with_stores_and_runtime(
+        recipe_store,
+        lifecycle_store,
         &options.cook_id,
         &options.initial_run_id,
         &options.initial_plan,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        production_runtime_admission(lifecycle_store),
     )
 }
 
@@ -57,8 +74,17 @@ pub(crate) fn materialize_cook_attempt(
     run_id: &str,
     plan: &AgentTaskPlan,
 ) -> Result<()> {
-    let store = CookRecipeStore::from_current_data_root()?;
-    materialize_cook_attempt_with_store(&store, cook_id, run_id, plan)
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    materialize_cook_attempt_with_stores_and_runtime(
+        &recipe_store,
+        &lifecycle_store,
+        cook_id,
+        run_id,
+        plan,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        production_runtime_admission(&lifecycle_store),
+    )
 }
 
 pub(crate) fn materialize_cook_attempt_with_store(
@@ -67,26 +93,94 @@ pub(crate) fn materialize_cook_attempt_with_store(
     run_id: &str,
     plan: &AgentTaskPlan,
 ) -> Result<()> {
-    if agent_task_lifecycle::run_record_exists(run_id)? {
-        return ensure_cook_attempt_index(store, cook_id, run_id);
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    materialize_cook_attempt_with_stores_and_runtime(
+        store,
+        &lifecycle_store,
+        cook_id,
+        run_id,
+        plan,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        production_runtime_admission(&lifecycle_store),
+    )
+}
+
+/// Materialize an immutable Cook recipe attempt into explicitly rooted lifecycle
+/// storage. Detached handoff parents are supported only when they share this
+/// lifecycle store; a parent in another root is never consulted.
+pub(crate) fn materialize_cook_attempt_with_stores_and_admission(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    admit_runtime: impl FnOnce(&str) -> Result<Value>,
+) -> Result<()> {
+    materialize_cook_attempt_with_stores_and_runtime(
+        recipe_store,
+        lifecycle_store,
+        cook_id,
+        run_id,
+        plan,
+        None,
+        admit_runtime,
+    )
+}
+
+fn materialize_cook_attempt_with_stores_and_runtime(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    admission_status: Option<&dyn Fn(&str) -> Option<Value>>,
+    admit_runtime: impl FnOnce(&str) -> Result<Value>,
+) -> Result<()> {
+    if lifecycle_store.record_exists(run_id)? {
+        return ensure_cook_attempt_index(recipe_store, lifecycle_store, cook_id, run_id);
     }
-    match agent_task_lifecycle::submit_plan(plan, Some(run_id)) {
-        Ok(_) => ensure_cook_attempt_index(store, cook_id, run_id),
+    let submission = match admission_status {
+        Some(project) => lifecycle_store.submit_plan_with_runtime_admission_status(
+            plan,
+            run_id,
+            project,
+            admit_runtime,
+        ),
+        None => lifecycle_store.submit_plan_with_runtime_admission(plan, run_id, admit_runtime),
+    };
+    match submission {
+        Ok(_) => ensure_cook_attempt_index(recipe_store, lifecycle_store, cook_id, run_id),
         Err(error) => {
             // `submit_plan` persists admission failures before returning them.
-            if agent_task_lifecycle::run_record_exists(run_id)? {
-                ensure_cook_attempt_index(store, cook_id, run_id)?;
+            if lifecycle_store.record_exists(run_id)? {
+                ensure_cook_attempt_index(recipe_store, lifecycle_store, cook_id, run_id)?;
             }
             Err(error)
         }
     }
 }
 
+fn production_runtime_admission(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> impl FnOnce(&str) -> Result<Value> + '_ {
+    move |run_id| {
+        homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(run_id, || {
+            Ok(lifecycle_store.read_record(run_id)?.state.is_terminal())
+        })
+        .map(|admission| admission.runtime)
+    }
+}
+
 /// Complete the second half of initial-attempt materialization after a crash.
 /// The recipe and run record are independent durable writes, so their exact
 /// identities must agree before repairing the alias/index projection.
-fn ensure_cook_attempt_index(store: &CookRecipeStore, cook_id: &str, run_id: &str) -> Result<()> {
-    let recipe = store.load_recipe(cook_id)?;
+fn ensure_cook_attempt_index(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    run_id: &str,
+) -> Result<()> {
+    let recipe = recipe_store.load_recipe(cook_id)?;
     let attempt = recipe
         .attempts
         .iter()
@@ -99,7 +193,7 @@ fn ensure_cook_attempt_index(store: &CookRecipeStore, cook_id: &str, run_id: &st
                 None,
             )
         })?;
-    let record = agent_task_lifecycle::exact_record(run_id)?;
+    let record = lifecycle_store.read_record(run_id)?;
     if let Some(cook_id) = record.metadata.get("cook_id").and_then(Value::as_str) {
         if cook_id != recipe.cook_id {
             return Err(Error::validation_invalid_argument(
@@ -120,8 +214,15 @@ fn ensure_cook_attempt_index(store: &CookRecipeStore, cook_id: &str, run_id: &st
             ));
         }
     }
-    super::cook_recipe::validate_recipe_attempt_record(&recipe, &attempt.run_id, &record)?;
-    agent_task_lifecycle::record_cook_attempt(&recipe.cook_id, attempt.attempt, &attempt.run_id)
+    let controller_plan = lifecycle_store.read_controller_plan(run_id)?;
+    super::cook_recipe::validate_recipe_attempt_record_with_controller_plan(
+        &recipe,
+        &attempt.run_id,
+        &record,
+        &controller_plan,
+    )?;
+    lifecycle_store
+        .record_cook_attempt(&recipe.cook_id, attempt.attempt, &attempt.run_id)
         .map(|_| ())
 }
 
@@ -436,4 +537,194 @@ fn terminal_provider_execution(
             backend: terminal.backend.clone(),
             model: terminal.model.clone(),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::agent_task_lifecycle::AgentTaskLifecycleStore;
+    use crate::agent_task_service::cook_recipe::{
+        AgentTaskCookRecipe, AgentTaskCookRecipeAttempt, COOK_RECIPE_SCHEMA,
+    };
+
+    fn recipe(cook_id: &str, run_id: &str, plan: AgentTaskPlan) -> AgentTaskCookRecipe {
+        AgentTaskCookRecipe {
+            schema: COOK_RECIPE_SCHEMA.to_string(),
+            cook_id: cook_id.to_string(),
+            attempts: vec![AgentTaskCookRecipeAttempt {
+                attempt: 1,
+                run_id: run_id.to_string(),
+                plan: plan.clone(),
+            }],
+            promotion_transport: serde_json::json!({}),
+            gate_policy: serde_json::json!({}),
+            retry_budget: serde_json::json!({}),
+            finalization: serde_json::json!({}),
+            source_refs: vec![format!("{cook_id}-source")],
+            runtime_generation: "test".to_string(),
+            sensitive_mappings: Vec::new(),
+            harvest_context: Default::default(),
+        }
+    }
+
+    fn plan(plan_id: &str, marker: &str) -> AgentTaskPlan {
+        AgentTaskPlan::new(
+            plan_id,
+            vec![AgentTaskRequest {
+                schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                task_id: "task".to_string(),
+                group_key: None,
+                parent_plan_id: None,
+                executor: AgentTaskExecutor {
+                    backend: "test".to_string(),
+                    selector: None,
+                    runtime_selection: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    model: None,
+                    config: Value::Null,
+                },
+                instructions: marker.to_string(),
+                inputs: Value::Null,
+                source_refs: Vec::new(),
+                workspace: AgentTaskWorkspace::default(),
+                component_contracts: Vec::new(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits::default(),
+                expected_artifacts: Vec::new(),
+                artifact_declarations: Vec::new(),
+                output_declarations: Vec::new(),
+                runtime_tools: Vec::new(),
+                metadata: Value::Null,
+            }],
+        )
+    }
+
+    #[test]
+    fn explicit_stores_materialize_identical_cook_attempts_in_parallel() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left_recipe_store = CookRecipeStore::new(left_context.path_roots());
+        let right_recipe_store = CookRecipeStore::new(right_context.path_roots());
+        let left_lifecycle_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+        let right_lifecycle_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+        let cook_id = "same-cook";
+        let run_id = "same-run";
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mut left_plan = plan("left-plan", "left");
+        left_plan.metadata = serde_json::json!({ "store": "left" });
+        let mut right_plan = plan("right-plan", "right");
+        right_plan.metadata = serde_json::json!({ "store": "right" });
+        left_recipe_store
+            .persist_recipe(&recipe(cook_id, run_id, left_plan.clone()))
+            .expect("persist left recipe");
+        right_recipe_store
+            .persist_recipe(&recipe(cook_id, run_id, right_plan.clone()))
+            .expect("persist right recipe");
+
+        std::thread::scope(|scope| {
+            let left_barrier = Arc::clone(&barrier);
+            let left_recipe_store = left_recipe_store.clone();
+            let left_lifecycle_store = left_lifecycle_store.clone();
+            scope.spawn(move || {
+                materialize_cook_attempt_with_stores_and_admission(
+                    &left_recipe_store,
+                    &left_lifecycle_store,
+                    cook_id,
+                    run_id,
+                    &left_plan,
+                    |_| {
+                        left_barrier.wait();
+                        Ok(serde_json::json!({ "store": "left" }))
+                    },
+                )
+                .expect("materialize left");
+            });
+            let right_barrier = Arc::clone(&barrier);
+            let right_recipe_store = right_recipe_store.clone();
+            let right_lifecycle_store = right_lifecycle_store.clone();
+            scope.spawn(move || {
+                materialize_cook_attempt_with_stores_and_admission(
+                    &right_recipe_store,
+                    &right_lifecycle_store,
+                    cook_id,
+                    run_id,
+                    &right_plan,
+                    |_| {
+                        right_barrier.wait();
+                        Ok(serde_json::json!({ "store": "right" }))
+                    },
+                )
+                .expect("materialize right");
+            });
+        });
+
+        assert_eq!(
+            left_lifecycle_store
+                .read_controller_plan(run_id)
+                .unwrap()
+                .plan_id,
+            "left-plan"
+        );
+        assert_eq!(
+            right_lifecycle_store
+                .read_controller_plan(run_id)
+                .unwrap()
+                .plan_id,
+            "right-plan"
+        );
+        assert_eq!(
+            left_lifecycle_store.read_record(run_id).unwrap().metadata["controller_runtime"]
+                ["store"],
+            "left"
+        );
+        assert_eq!(
+            right_lifecycle_store.read_record(run_id).unwrap().metadata["controller_runtime"]
+                ["store"],
+            "right"
+        );
+        assert_eq!(
+            left_lifecycle_store
+                .read_cook_index(cook_id)
+                .unwrap()
+                .latest_run_id,
+            run_id
+        );
+        assert_eq!(
+            right_lifecycle_store
+                .read_cook_index(cook_id)
+                .unwrap()
+                .latest_run_id,
+            run_id
+        );
+        assert!(left_lifecycle_store
+            .cook_index_path(cook_id)
+            .starts_with(left_context.data_dir()));
+        assert!(right_lifecycle_store
+            .cook_index_path(cook_id)
+            .starts_with(right_context.data_dir()));
+        assert_ne!(
+            left_lifecycle_store.cook_index_path(cook_id),
+            right_lifecycle_store.cook_index_path(cook_id)
+        );
+        assert_eq!(
+            left_recipe_store.load_recipe(cook_id).unwrap().attempts[0]
+                .plan
+                .plan_id,
+            "left-plan"
+        );
+        assert_eq!(
+            right_recipe_store.load_recipe(cook_id).unwrap().attempts[0]
+                .plan
+                .plan_id,
+            "right-plan"
+        );
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1064,6 +1064,16 @@ pub fn validate_recipe_attempt_record(
     run_id: &str,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<()> {
+    let controller_plan = agent_task_lifecycle::load_controller_plan(run_id)?;
+    validate_recipe_attempt_record_with_controller_plan(recipe, run_id, record, &controller_plan)
+}
+
+pub(crate) fn validate_recipe_attempt_record_with_controller_plan(
+    recipe: &AgentTaskCookRecipe,
+    run_id: &str,
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+    controller_plan: &AgentTaskPlan,
+) -> Result<()> {
     let attempt = recipe
         .attempts
         .iter()
@@ -1100,7 +1110,6 @@ pub fn validate_recipe_attempt_record(
             ]),
         ));
     }
-    let controller_plan = agent_task_lifecycle::load_controller_plan(run_id)?;
     let plan_identity_matches = controller_plan.tasks.len() == attempt.plan.tasks.len()
         && attempt.plan.tasks.iter().all(|expected| {
             controller_plan

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -110,6 +110,24 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub(crate) fn submit_plan_with_runtime_admission_status(
+        &self,
+        plan: &AgentTaskPlan,
+        run_id: &str,
+        admission_status: &dyn Fn(&str) -> Option<Value>,
+        admit_runtime: impl FnOnce(&str) -> Result<Value>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::submit_plan_with_runtime_admission_in_store(
+            self,
+            plan,
+            Some(run_id),
+            None,
+            None,
+            Some(admission_status),
+            admit_runtime,
+        )
+    }
+
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
         ObservationStore::open_initialized_at(self.observation_db_path())
     }
@@ -157,6 +175,33 @@ impl AgentTaskLifecycleStore {
         write_cook_index_attempt_in_store(self, cook_id, attempt, run_id, recorded_at, candidate)
     }
 
+    pub(crate) fn write_cook_index_attempt_locked(
+        &self,
+        cook_id: &str,
+        attempt: u32,
+        run_id: &str,
+        recorded_at: String,
+        candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
+    ) -> Result<AgentTaskCookIndex> {
+        write_cook_index_attempt_locked_in_store(
+            self,
+            cook_id,
+            attempt,
+            run_id,
+            recorded_at,
+            candidate,
+        )
+    }
+
+    pub(crate) fn validate_cook_index_attempt(
+        &self,
+        cook_id: &str,
+        attempt: u32,
+        run_id: &str,
+    ) -> Result<()> {
+        validate_cook_index_attempt_in_store(self, cook_id, attempt, run_id)
+    }
+
     pub fn read_cook_index(&self, cook_id: &str) -> Result<AgentTaskCookIndex> {
         read_cook_index_in_store(self, cook_id)
     }
@@ -167,6 +212,26 @@ impl AgentTaskLifecycleStore {
 
     pub fn read_record(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_in_store(self, run_id)
+    }
+
+    /// Check this store for one exact durable run identity without Cook alias
+    /// resolution.
+    pub fn record_exists(&self, run_id: &str) -> Result<bool> {
+        Ok(self
+            .open_observation_initialized()?
+            .get_run(run_id)?
+            .is_some())
+    }
+
+    /// Register a Cook attempt using this store's record, lock, index, and
+    /// terminal-projection roots.
+    pub fn record_cook_attempt(
+        &self,
+        cook_id: &str,
+        attempt: u32,
+        run_id: &str,
+    ) -> Result<AgentTaskCookIndex> {
+        super::lifecycle_ops::record_cook_attempt_in_store(self, cook_id, attempt, run_id)
     }
 
     pub fn read_record_bounded(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -715,7 +780,7 @@ fn write_cook_index_attempt_locked_in_store(
 ) -> Result<AgentTaskCookIndex> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
-    validate_cook_index_attempt(&cook_id, attempt, &run_id)?;
+    validate_cook_index_attempt_in_store(store, &cook_id, attempt, &run_id)?;
     let path = store.cook_index_path(&cook_id);
     let mut index = if path.exists() {
         read_json(&path)?
@@ -914,9 +979,18 @@ pub(super) fn record_exists_readonly(run_id: &str) -> Result<bool> {
 }
 
 pub(super) fn validate_cook_index_attempt(cook_id: &str, attempt: u32, run_id: &str) -> Result<()> {
+    validate_cook_index_attempt_in_store(&default_store()?, cook_id, attempt, run_id)
+}
+
+fn validate_cook_index_attempt_in_store(
+    store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+) -> Result<()> {
     let cook_id = sanitize_run_id(cook_id);
     let run_id = sanitize_run_id(run_id);
-    let path = cook_index_path(&cook_id)?;
+    let path = store.cook_index_path(&cook_id);
     if !path.exists() {
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- add dual-store Cook attempt materialization using explicit recipe and lifecycle stores
- root submission, exact record reads, controller-plan validation, Cook registration, indexes, locks, and terminal projection
- preserve detached handoff behavior when its parent shares the supplied lifecycle store
- retain production controller-admission metadata while keeping explicit materialization ambient-free
- prove identical Cook/run IDs materialize concurrently with divergent plans across independent roots

This establishes the first complete recipe+lifecycle Cook boundary. Full `run_cook_with_stores` remains deferred until downstream retry/status/operation-claim paths can carry the lifecycle store honestly.

## Verification
- `cargo test -p homeboy-agents explicit_stores_materialize_identical_cook_attempts_in_parallel --locked`
- `cargo test -p homeboy-agents cook_pre_execution --locked`
- `cargo test -p homeboy-agents record_cook_attempt --locked`
- `cargo check -p homeboy-agents --tests --locked`
- `git diff --check`

Advances #7505.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to map the dual-store materialization boundary, implement rooted Cook registration, review production compatibility, add parallel isolation coverage, and run verification. Chris Huber reviewed and remains responsible for the change.