### PR TITLE
fix(release): keep the macOS checksum step within bash 3.2

### DIFF
--- a/.github/canonicalize-checksum-sidecars.sh
+++ b/.github/canonicalize-checksum-sidecars.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 # Normalize cargo-dist's per-asset checksum output before it becomes a release asset.
+#
+# This runs on every release target, including macOS. macOS ships bash 3.2, so
+# bash 4+ builtins are unavailable here no matter what the Linux runners have:
+# `mapfile` aborts the job with `command not found` (exit 127), and `${var,,}`
+# is a bad substitution. Both were used below, which failed both Darwin builds,
+# skipped `Create GitHub Release`, and left the already-pushed tag orphaned --
+# homeboy published no release for v0.345.1 through v0.345.5 as a result.
+#
+# Keep this script POSIX-ish and bash-3.2-clean.
 set -euo pipefail
 
 ASSET_DIR="${1:?usage: canonicalize-checksum-sidecars.sh ASSET_DIR}"
 
 shopt -s nullglob
 for sidecar in "${ASSET_DIR}"/*.sha256; do
-  mapfile -t records < "${sidecar}"
+  # bash 3.2 has no `mapfile`. The `|| [ -n "${line}" ]` keeps a final line that
+  # is not newline-terminated, which `mapfile` would also have retained.
   nonempty=()
-  for record in "${records[@]}"; do
-    [ -z "${record}" ] || nonempty+=("${record}")
-  done
+  while IFS= read -r line || [ -n "${line}" ]; do
+    [ -z "${line}" ] || nonempty+=("${line}")
+  done < "${sidecar}"
+
   [ "${#nonempty[@]}" -eq 1 ] || {
     echo "::error::Checksum sidecar ${sidecar} must contain one checksum record" >&2
     exit 1
@@ -24,5 +35,7 @@ for sidecar in "${ASSET_DIR}"/*.sha256; do
       exit 1
     }
 
-  printf '%s *%s\n' "${digest,,}" "${name}" > "${sidecar}"
+  # bash 3.2 has no `${var,,}` case expansion.
+  digest_lower="$(printf '%s' "${digest}" | tr '[:upper:]' '[:lower:]')"
+  printf '%s *%s\n' "${digest_lower}" "${name}" > "${sidecar}"
 done

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1941,6 +1941,54 @@ fn release_builds_canonicalize_cargo_dist_checksum_sidecars_before_upload() {
     );
 }
 
+/// Release builds run on macOS, which ships bash 3.2. A bash 4+ builtin in a
+/// script that executes there is not a style question: `mapfile` aborted both
+/// Darwin builds with exit 127, `Create GitHub Release` was skipped, and the
+/// tag had already been pushed — so v0.345.1 through v0.345.5 exist as tags
+/// with no published release, and every consumer pinned to `latest` stayed on
+/// v0.345.0.
+///
+/// Scoped to scripts that actually run on a macOS runner.
+/// `canonicalize-checksum-sidecars.sh` runs in `build-local-artifacts`, whose
+/// `runs-on` is `${{ matrix.runner }}` and therefore includes Darwin.
+/// `release-asset-completeness.sh` runs only on `ubuntu-*`, so its bash 4 use
+/// is legitimate and deliberately not covered here.
+///
+/// Pin the absence, because the Linux runners cannot observe this failure.
+#[test]
+fn macos_release_shell_scripts_avoid_bash_4_only_constructs() {
+    const MACOS_SCRIPTS: &[(&str, &str)] = &[(
+        ".github/canonicalize-checksum-sidecars.sh",
+        include_str!("../.github/canonicalize-checksum-sidecars.sh"),
+    )];
+
+    // (needle, why it is unavailable on macOS bash 3.2)
+    const BASH_4_ONLY: &[(&str, &str)] = &[
+        ("mapfile", "`mapfile` is a bash 4 builtin"),
+        ("readarray", "`readarray` is a bash 4 builtin"),
+        ("declare -A", "associative arrays are bash 4"),
+        ("local -A", "associative arrays are bash 4"),
+        (",,}", "`${var,,}` case expansion is bash 4"),
+        ("^^}", "`${var^^}` case expansion is bash 4"),
+    ];
+
+    for (path, source) in MACOS_SCRIPTS {
+        // Comments explain which constructs are unavailable and why, so they
+        // name them on purpose. Only executable lines are checked.
+        let code: String = source
+            .lines()
+            .filter(|line| !line.trim_start().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for (needle, reason) in BASH_4_ONLY {
+            assert!(
+                !code.contains(needle),
+                "{path} uses `{needle}`, but {reason} and this script runs on macOS bash 3.2"
+            );
+        }
+    }
+}
+
 /// The exact published inventory of `v0.332.0` — the last healthy release.
 const HEALTHY_RELEASE_ASSETS: &[&str] = &[
     "dist-manifest.json",


### PR DESCRIPTION
**homeboy has published no release since `v0.345.0`.** Tags `v0.345.1`–`v0.345.5` exist with no GitHub Release behind them.

Consumers install `version: latest`, which resolves through *published releases*, so every consumer has been pinned to a ten-hour-old build. Nothing merged since has reached anyone — including the changed-test drift fix (#12393) that #12365 depends on.

## Cause

`canonicalize-checksum-sidecars.sh` runs in `build-local-artifacts`, whose `runs-on` is `${{ matrix.runner }}` — which includes Darwin. macOS ships **bash 3.2**, which has neither `mapfile` nor `${var,,}`.

Both Darwin builds died immediately:

```
.github/canonicalize-checksum-sidecars.sh: line 9: mapfile: command not found
##[error]Process completed with exit code 127
```

Job graph from run [31744332187](https://github.com/Extra-Chill/homeboy/actions/runs/31744332187):

```
Prepare Release                    success   <- tag already pushed here
build (x86_64-unknown-linux-gnu)   success
build (aarch64-unknown-linux-gnu)  success
build (aarch64-apple-darwin)       failure   <- mapfile
build (x86_64-apple-darwin)        failure   <- mapfile
build-global-artifacts             skipped
Create GitHub Release              skipped
Verify GitHub Release published    failure
```

`Prepare Release` pushes the tag *before* the builds, which is why the tags are orphaned rather than simply absent.

## Fix

- `mapfile -t records < "$sidecar"` → a `while IFS= read -r` loop. The `|| [ -n "$line" ]` guard keeps a final line with no trailing newline, which `mapfile` would also have retained.
- `${digest,,}` → `tr '[:upper:]' '[:lower:]'`.

Verified behaviourally identical on six cases:

| case | result |
|---|---|
| uppercase digest | lowercased |
| sidecar with no trailing newline | record retained |
| leading/trailing blank lines | ignored |
| two records | rejected |
| non-hex digest | rejected |
| filename mismatch | rejected |

## Regression pin

`macos_release_shell_scripts_avoid_bash_4_only_constructs` asserts the absence of `mapfile`, `readarray`, `declare -A`, `local -A`, `${var,,}`, `${var^^}` in scripts that execute on a macOS runner. The Linux runners **cannot** observe this class of failure, so a static pin is the only thing that can catch it.

Comment lines are stripped before checking, since the script's comments name these constructs deliberately to explain why they are absent.

`release-asset-completeness.sh` is **deliberately out of scope** — it runs only on `ubuntu-*` (`host` job and `release-integrity.yml`'s `audit` job), where its `declare -A` / `mapfile` / `${digest,,}` are legitimate.

## The other release blocker

This unblocks the Darwin path, but it is not the only thing stopping releases. Several recent runs fail earlier, at `Release Quality Policy`, because the `Test` gate is red on main:

```
31755661319 a9bcb65b2  test=failure
31751835418 666be3cae  test=failure
31751801758 05a2ca3ec  test=failure
31750894508 80a9e313c  test=failure
```

That is the known red main (#12226, #11897, #11932) and needs fixing separately before releases actually flow again.

## Verification

- `cargo fmt --check` — clean
- `cargo check --workspace --tests -j2` — clean
- `cargo test --test release_workflow_test` — **65 passed, 0 failed**
