### PR TITLE
test(audit): lower the suppression ceiling to the actual 1129

### DIFF
--- a/tests/audit_baseline_ratchet_test.rs
+++ b/tests/audit_baseline_ratchet_test.rs
@@ -46,7 +46,7 @@ use serde_json::Value;
 /// a ceiling, not a target: lower it whenever suppressions are retired, and
 /// never raise it. Raising this number is the one edit this test exists to make
 /// someone argue for in review.
-const AUDIT_BASELINE_CEILING: usize = 1130;
+const AUDIT_BASELINE_CEILING: usize = 1129;
 
 fn baseline_fingerprints() -> Vec<String> {
     let config: Value =


### PR DESCRIPTION
One line. It is the remaining thing blocking every homeboy release.

## Why this matters more than it looks

homeboy has published **no release since `v0.345.0`**. Every recent Release run dies the same way:

```
Test                     failure
Release Quality Policy   failure
Prepare Release          skipped
Create GitHub Release    skipped
```

Consumers install `version: latest`, which resolves through *published* releases, so everyone is pinned to a build that predates the changed-test drift fix (#12393), the inventory extension seam (#12396), and the macOS checksum fix (#12400).

The Test gate failure is exactly one assertion:

```
---- audit_baseline_ceiling_leaves_no_slack stdout ----
audit suppression baseline shrank — good. Now lock it in.

  ceiling: 1130
  actual:  1129   (-1)

Lower AUDIT_BASELINE_CEILING in tests/audit_baseline_ratchet_test.rs to 1129
in this same PR.
```

A suppression was retired — which is the good direction — without lowering the ceiling in the same PR. The ratchet deliberately refuses slack, since a ceiling above the real count is room for new suppressions to be added later without any test noticing.

## Verified

`baselines.audit.known_fingerprints` in `homeboy.json` on current `main`:

```
rows   : 1129
unique : 1129
```

`cargo test -p homeboy --test audit_baseline_ratchet_test` — **3 passed, 0 failed**:

```
test audit_baseline_ceiling_leaves_no_slack ... ok
test audit_baseline_may_only_shrink ... ok
test audit_baseline_rows_are_unique ... ok
```

The ceiling moves **down**, which is the only direction this test permits.
