### PR TITLE
fix(store): isolate lifecycle opens from artifact maintenance

### DIFF
--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -129,7 +129,7 @@ impl AgentTaskLifecycleStore {
     }
 
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
-        ObservationStore::open_initialized_at(self.observation_db_path())
+        ObservationStore::open_initialized_for_lifecycle_at(self.observation_db_path())
     }
 
     pub fn open_observation_readonly(&self) -> Result<ObservationStore> {
@@ -712,7 +712,7 @@ pub(super) fn inject_raw_record_metadata_for_corruption_test(
     run_id: &str,
     inject: impl FnOnce(&mut Value),
 ) -> Result<()> {
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_initialized_for_lifecycle()?;
     let mut run = store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -975,7 +975,7 @@ pub(super) fn update_cook_index(
 }
 
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {
-    Ok(ObservationStore::open_initialized()?
+    Ok(ObservationStore::open_initialized_for_lifecycle()?
         .get_run(run_id)?
         .is_some())
 }
@@ -1029,7 +1029,7 @@ fn validate_cook_index_attempt_in_store(
 }
 
 pub(super) fn record_lacks_typed_metadata(run_id: &str) -> Result<bool> {
-    Ok(ObservationStore::open_initialized()?
+    Ok(ObservationStore::open_initialized_for_lifecycle()?
         .get_run(run_id)?
         .is_some_and(|run| run.metadata_json.get("agent_task_run").is_none()))
 }
@@ -1050,7 +1050,7 @@ const RETRY_SUCCESSOR_SCAN_LIMIT: usize = 256;
 /// retry. The page is therefore read with an explicit truncation signal and a
 /// truncated lineage fails loudly rather than answering wrongly (#11177).
 pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTaskRunRecord>> {
-    let page = ObservationStore::open_initialized()?.list_runs_by_retry_of_page(
+    let page = ObservationStore::open_initialized_for_lifecycle()?.list_runs_by_retry_of_page(
         "agent-task",
         source_run_id,
         RETRY_SUCCESSOR_SCAN_LIMIT,

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::{params, OptionalExtension};
 use sha2::{Digest, Sha256};
@@ -124,51 +125,62 @@ impl ObservationStore {
     /// Backfill the stable opaque handle for legacy rows. The source identity is
     /// immutable (`run_id`, `artifact.id`), and the unique index makes a hash
     /// collision a hard integrity failure instead of resolving another artifact.
-    pub(super) fn backfill_artifact_handles(&self) -> Result<()> {
-        let mut statement = self.connection.prepare(
-            "SELECT id, run_id, metadata_json FROM artifacts WHERE artifact_handle IS NULL OR failure_diagnostic IS NULL",
-        ).map_err(sqlite_error("read artifact handle backfill rows"))?;
-        let rows = statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                ))
-            })
-            .map_err(sqlite_error("query artifact handle backfill rows"))?;
-        for row in rows {
-            let (id, run_id, metadata_json) =
-                row.map_err(sqlite_error("collect artifact handle backfill rows"))?;
-            let handle = artifact_handle(&run_id, &id);
-            let metadata = serde_json::from_str::<serde_json::Value>(&metadata_json)
-                .unwrap_or(serde_json::Value::Null);
-            let diagnostic =
-                i64::from(metadata["failure_diagnostic"] == serde_json::Value::Bool(true));
-            let rank = metadata["failure_diagnostic_rank"]
-                .as_u64()
-                .unwrap_or_default()
-                .to_string();
-            let updated = self.connection.execute(
-                "UPDATE artifacts SET artifact_handle = COALESCE(artifact_handle, ?1), failure_diagnostic = ?2, failure_diagnostic_rank = ?3 WHERE id = ?4 AND run_id = ?5",
-                params![handle, diagnostic, rank, id, run_id],
-            ).map_err(sqlite_error("backfill artifact handle"))?;
-            if updated == 0 {
-                continue;
-            }
-        }
-        // Verify the index's collision boundary explicitly. This remains useful
-        // for stores created during a partial/manual migration.
-        let collisions: i64 = self.connection.query_row(
-            "SELECT COUNT(*) FROM (SELECT artifact_handle FROM artifacts WHERE artifact_handle IS NOT NULL GROUP BY artifact_handle HAVING COUNT(*) > 1)",
-            [], |row| row.get(0),
-        ).map_err(sqlite_error("verify artifact handle collisions"))?;
-        if collisions != 0 {
-            return Err(Error::internal_unexpected(
-                "artifact handle collision detected",
-            ));
-        }
-        Ok(())
+    pub(super) fn backfill_artifact_handles_with_retry(
+        &self,
+        mut on_retry: impl FnMut(),
+    ) -> Result<()> {
+        // This maintenance work uses its own zero-timeout connection. Retrying
+        // a five-second SQLite busy handler would turn the bounded retry policy
+        // into a roughly thirty-second startup stall.
+        let connection = schema::open_maintenance_connection(&self.path)?;
+        execute_with_retry_inner(
+            "backfill artifact handles".to_string(),
+            SQLITE_WRITE_MAX_ATTEMPTS,
+            SQLITE_WRITE_BASE_BACKOFF_MS,
+            |_, backoff_ms| {
+                on_retry();
+                std::thread::sleep(Duration::from_millis(backoff_ms));
+            },
+            &mut || {
+                // Keep the read and updates in one retryable transaction. In
+                // rollback-journal mode a read-to-write upgrade
+                // can fail after another writer commits; retrying only UPDATE
+                // would leave that failure outside the recovery boundary.
+                let tx = connection.unchecked_transaction()?;
+                let mut statement = tx.prepare(
+                    "SELECT id, run_id, metadata_json FROM artifacts WHERE artifact_handle IS NULL OR failure_diagnostic IS NULL OR failure_diagnostic_rank IS NULL",
+                )?;
+                let rows = statement
+                    .query_map([], |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                        ))
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                drop(statement);
+
+                for (id, run_id, metadata_json) in rows {
+                    let metadata = serde_json::from_str::<serde_json::Value>(&metadata_json)
+                        .unwrap_or(serde_json::Value::Null);
+                    let diagnostic =
+                        i64::from(metadata["failure_diagnostic"] == serde_json::Value::Bool(true));
+                    let rank = metadata["failure_diagnostic_rank"]
+                        .as_u64()
+                        .unwrap_or_default()
+                        .to_string();
+                    // Only fill diagnostics if their source metadata is still
+                    // the snapshot we read. A concurrent metadata update must
+                    // never receive values derived from an older row.
+                    tx.execute(
+                        "UPDATE artifacts SET artifact_handle = COALESCE(artifact_handle, ?1), failure_diagnostic = CASE WHEN metadata_json = ?4 THEN COALESCE(failure_diagnostic, ?2) ELSE failure_diagnostic END, failure_diagnostic_rank = CASE WHEN metadata_json = ?4 THEN COALESCE(failure_diagnostic_rank, ?3) ELSE failure_diagnostic_rank END WHERE id = ?5 AND run_id = ?6",
+                        params![artifact_handle(&run_id, &id), diagnostic, rank, metadata_json, id, run_id],
+                    )?;
+                }
+                tx.commit()
+            },
+        )
     }
     /// Publish a run and all of its filesystem artifacts as one reader-visible unit.
     ///
@@ -420,15 +432,33 @@ impl ObservationStore {
             .collect()
     }
 
+    pub(super) fn reconcile_unfinished_artifact_publications_with_retry(
+        &self,
+        mut on_retry: impl FnMut(),
+    ) -> Result<()> {
+        let connection = schema::open_maintenance_connection(&self.path)?;
+        execute_with_retry_inner(
+            "reconcile unfinished artifact publications".to_string(),
+            SQLITE_WRITE_MAX_ATTEMPTS,
+            SQLITE_WRITE_BASE_BACKOFF_MS,
+            |_, backoff_ms| {
+                on_retry();
+                std::thread::sleep(Duration::from_millis(backoff_ms));
+            },
+            &mut || Self::reconcile_unfinished_artifact_publications_on(&connection),
+        )
+    }
+
     /// Remove only expired publication-token paths. Final paths are immutable
     /// and token-scoped, so reclaiming an expired owner can never remove bytes
     /// selected by a competing publisher for the same logical artifact.
-    pub(super) fn reconcile_unfinished_artifact_publications(&self) -> Result<()> {
+    fn reconcile_unfinished_artifact_publications_on(
+        connection: &rusqlite::Connection,
+    ) -> rusqlite::Result<()> {
         let now = chrono::Utc::now().timestamp_millis();
-        let mut statement = self
-            .connection
-            .prepare("SELECT publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms FROM artifact_publication_intents WHERE lease_expires_at_ms IS NULL OR lease_expires_at_ms < ?1")
-            .map_err(sqlite_error("read unfinished artifact publications"))?;
+        let mut statement = connection.prepare(
+            "SELECT publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms FROM artifact_publication_intents WHERE lease_expires_at_ms IS NULL OR lease_expires_at_ms < ?1",
+        )?;
         let paths = statement
             .query_map([now], |row| {
                 Ok((
@@ -439,9 +469,9 @@ impl ObservationStore {
                     row.get::<_, Option<String>>(4)?,
                     row.get::<_, Option<i64>>(5)?,
                 ))
-            })
-            .map_err(sqlite_error("query unfinished artifact publications"))?;
-        let paths = collect_rows(paths, "collect unfinished artifact publications")?;
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(statement);
         for (
             publication_id,
             artifact_id,
@@ -454,10 +484,10 @@ impl ObservationStore {
             // Revocation is the ownership boundary: delete the exact snapshot
             // first. A renewal that wins changes its lease and this CAS deletes
             // nothing, so this recovery pass must not touch either path.
-            let claimed = self.connection.execute(
+            let claimed = connection.execute(
                 "DELETE FROM artifact_publication_intents WHERE publication_id = ?1 AND artifact_id = ?2 AND ((owner_token IS NULL AND ?3 IS NULL) OR owner_token = ?3) AND ((lease_expires_at_ms IS NULL AND ?4 IS NULL) OR lease_expires_at_ms = ?4) AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms < ?5)",
                 params![publication_id, artifact_id, owner_token, lease_expires_at, now],
-            ).map_err(sqlite_error("claim expired artifact publication"))?;
+            )?;
             if claimed == 1 {
                 remove_publication_path(Path::new(&staging_path));
                 remove_publication_path(Path::new(&final_path));
@@ -2117,6 +2147,8 @@ mod tests {
     use crate::observation::{ArtifactViewerLink, NewRunRecord};
     use crate::test_support::with_isolated_home;
     use std::collections::BTreeSet;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     /// The preflight gates every publication path, so a healthy filesystem must
     /// stay silently healthy. A capacity gate that fails closed on a machine
@@ -2502,7 +2534,7 @@ mod tests {
     }
 
     #[test]
-    fn opening_store_recovers_unfinished_journaled_finalization() {
+    fn bounded_reconciliation_recovers_unfinished_journaled_finalization() {
         with_isolated_home(|home| {
             let database = home.path().join("observation.sqlite");
             let store = ObservationStore::open_initialized_at(&database).expect("store");
@@ -2516,8 +2548,10 @@ mod tests {
             ).expect("journal intent");
             drop(store);
 
-            let recovered =
-                ObservationStore::open_initialized_at(&database).expect("recover store");
+            let recovered = ObservationStore::open_initialized_at(&database).expect("reopen store");
+            recovered
+                .reconcile_unfinished_artifact_publications_with_retry(|| {})
+                .expect("reconcile expired publication");
             assert!(!staging.exists());
             assert!(!final_path.exists());
             let intents: i64 = recovered
@@ -2533,7 +2567,123 @@ mod tests {
     }
 
     #[test]
-    fn opening_store_reclaims_v10_null_lease_intent_as_stale() {
+    fn lifecycle_open_does_not_wait_for_rollback_writer_maintenance_lock() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let setup = schema::open_connection(&database).expect("open schema");
+            schema::apply_migrations(&setup).expect("apply schema");
+            setup
+                .execute_batch("PRAGMA journal_mode=DELETE;")
+                .expect("use rollback journal mode");
+            setup
+                .execute(
+                    "INSERT INTO runs(id, kind, started_at, status, metadata_json) VALUES ('retry-run', 'agent-task', '2026-01-01T00:00:00Z', 'running', '{}')",
+                    [],
+                )
+                .expect("persist retry identity");
+            let staging = home.path().join("locked.staging");
+            let final_path = home.path().join("locked.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            fs::write(&final_path, b"finalized before crash").expect("final bytes");
+            setup.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('locked', 'artifact', ?1, ?2, 'dead-owner', 0)",
+                params![staging.display().to_string(), final_path.display().to_string()],
+            ).expect("journal intent");
+            drop(setup);
+
+            let writer = rusqlite::Connection::open(&database).expect("open locking connection");
+            writer
+                .execute_batch("BEGIN IMMEDIATE;")
+                .expect("hold rollback writer lock");
+            let (opened_tx, opened_rx) = mpsc::sync_channel(1);
+            let opener = std::thread::spawn(move || {
+                opened_tx.send(ObservationStore::open_initialized_for_lifecycle_at(
+                    &database,
+                ))
+            });
+
+            let opened = opened_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("lifecycle open must not wait for maintenance lock")
+                .expect("lifecycle open succeeds while maintenance is deferred");
+            assert!(opened
+                .get_run("retry-run")
+                .expect("read retry identity")
+                .is_some());
+            drop(opened);
+            writer
+                .execute_batch("COMMIT;")
+                .expect("release writer lock");
+            opener
+                .join()
+                .expect("lifecycle opener joined")
+                .expect("lifecycle open result sent");
+        });
+    }
+
+    #[test]
+    fn reconciliation_eventually_recovers_after_a_rollback_writer_lock() {
+        with_isolated_home(|home| {
+            let database = home.path().join("observation.sqlite");
+            let connection = schema::open_connection(&database).expect("open schema");
+            schema::apply_migrations(&connection).expect("apply schema");
+            connection
+                .execute_batch("PRAGMA journal_mode=DELETE;")
+                .expect("use rollback journal mode");
+            let store = ObservationStore {
+                connection,
+                path: database.clone(),
+                readonly: false,
+            };
+            let staging = home.path().join("retry.staging");
+            let final_path = home.path().join("retry.final");
+            fs::write(&staging, b"staged").expect("staging bytes");
+            fs::write(&final_path, b"finalized before crash").expect("final bytes");
+            store.connection.execute(
+                "INSERT INTO artifact_publication_intents(publication_id, artifact_id, staging_path, final_path, owner_token, lease_expires_at_ms) VALUES ('retry', 'artifact', ?1, ?2, 'dead-owner', 0)",
+                params![staging.display().to_string(), final_path.display().to_string()],
+            ).expect("journal intent");
+            let writer = rusqlite::Connection::open(&database).expect("open locking connection");
+            writer
+                .execute_batch("BEGIN IMMEDIATE;")
+                .expect("hold rollback writer lock");
+
+            let (retry_started_tx, retry_started_rx) = mpsc::sync_channel(0);
+            let (release_retry_tx, release_retry_rx) = mpsc::sync_channel(0);
+            let worker = std::thread::spawn(move || {
+                store.reconcile_unfinished_artifact_publications_with_retry(|| {
+                    retry_started_tx.send(()).expect("report retry");
+                    release_retry_rx.recv().expect("release retry");
+                })
+            });
+            retry_started_rx
+                .recv()
+                .expect("reconciliation attempted while locked");
+            writer
+                .execute_batch("COMMIT;")
+                .expect("release writer lock");
+            release_retry_tx.send(()).expect("resume reconciliation");
+            worker
+                .join()
+                .expect("reconciliation worker joined")
+                .expect("reconciliation recovers after lock release");
+
+            assert!(!staging.exists());
+            assert!(!final_path.exists());
+            let check = rusqlite::Connection::open(database).expect("open check connection");
+            let intents: i64 = check
+                .query_row(
+                    "SELECT COUNT(*) FROM artifact_publication_intents WHERE publication_id = 'retry'",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("count recovered intents");
+            assert_eq!(intents, 0);
+        });
+    }
+
+    #[test]
+    fn bounded_reconciliation_reclaims_v10_null_lease_intent_as_stale() {
         with_isolated_home(|home| {
             let database = home.path().join("observation.sqlite");
             let store = ObservationStore::open_initialized_at(&database).expect("store");
@@ -2547,14 +2697,18 @@ mod tests {
             ).expect("legacy intent");
             drop(store);
 
-            ObservationStore::open_initialized_at(&database).expect("reopen migrated store");
+            let reopened =
+                ObservationStore::open_initialized_at(&database).expect("reopen migrated store");
+            reopened
+                .reconcile_unfinished_artifact_publications_with_retry(|| {})
+                .expect("reconcile legacy publication");
             assert!(!staging.exists());
             assert!(!final_path.exists());
         });
     }
 
     #[test]
-    fn opening_second_store_preserves_a_live_publication_lease() {
+    fn bounded_reconciliation_preserves_a_live_publication_lease() {
         with_isolated_home(|home| {
             let database = home.path().join("observation.sqlite");
             let store = ObservationStore::open_initialized_at(&database).expect("store");
@@ -2567,6 +2721,9 @@ mod tests {
             ).expect("journal live intent");
 
             let second = ObservationStore::open_initialized_at(&database).expect("second store");
+            second
+                .reconcile_unfinished_artifact_publications_with_retry(|| {})
+                .expect("reconcile live publication");
             assert!(staging.exists());
             let intents: i64 = second.connection.query_row(
                 "SELECT COUNT(*) FROM artifact_publication_intents WHERE publication_id = 'live'", [], |row| row.get(0),
@@ -2592,6 +2749,9 @@ mod tests {
             // Simulate a publisher paused past its lease while a second store
             // reclaims its exact intent and the already-renamed bytes.
             let reclaimer = ObservationStore::open_initialized_at(&database).expect("reclaimer");
+            reclaimer
+                .reconcile_unfinished_artifact_publications_with_retry(|| {})
+                .expect("reconcile expired publication");
             assert!(!staging.exists());
             assert!(!final_path.exists());
             let tx = reclaimer

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -54,7 +54,26 @@ impl ObservationStore {
     }
 
     pub fn open_initialized_at(path: impl Into<PathBuf>) -> Result<Self> {
-        let path = path.into();
+        Self::open_initialized_at_with_maintenance(path.into(), true)
+    }
+
+    /// Open a store for lifecycle and retry state transitions.
+    ///
+    /// Schema initialization remains synchronous, but report-only artifact
+    /// maintenance is deferred to a later normal open. This keeps durable retry
+    /// identity available while another process owns SQLite's writer lock.
+    pub fn open_initialized_for_lifecycle() -> Result<Self> {
+        Self::open_initialized_for_lifecycle_at(database_path()?)
+    }
+
+    pub fn open_initialized_for_lifecycle_at(path: impl Into<PathBuf>) -> Result<Self> {
+        Self::open_initialized_at_with_maintenance(path.into(), false)
+    }
+
+    fn open_initialized_at_with_maintenance(
+        path: PathBuf,
+        maintain_artifacts: bool,
+    ) -> Result<Self> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 Error::internal_io(
@@ -71,8 +90,14 @@ impl ObservationStore {
             path,
             readonly: false,
         };
-        store.backfill_artifact_handles()?;
-        store.reconcile_unfinished_artifact_publications()?;
+        if maintain_artifacts {
+            // Evidence projections expose opaque handles and failure ranks, so
+            // they only receive a store after bounded maintenance completes.
+            // Failure is returned to the caller and the next normal open
+            // deterministically retries; no detached work can be lost.
+            store.reconcile_unfinished_artifact_publications_with_retry(|| {})?;
+            store.backfill_artifact_handles_with_retry(|| {})?;
+        }
         Ok(store)
     }
 

--- a/crates/homeboy-core/src/observation/store/schema.rs
+++ b/crates/homeboy-core/src/observation/store/schema.rs
@@ -418,9 +418,19 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     // store running in rollback-journal mode with materially different
     // concurrency behaviour and nobody told, so the next "database is locked"
     // report has no way to reach its own cause.
+    // Journal tuning is optional maintenance, so it must not consume the
+    // lifecycle connection's normal busy budget before migrations or callers.
+    connection
+        .busy_timeout(Duration::ZERO)
+        .map_err(sqlite_error(
+            "bound observation journal maintenance timeout",
+        ))?;
     for warning in apply_journal_pragmas(&connection) {
         warn_pragma_once(&warning);
     }
+    connection
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(sqlite_error("restore observation store busy timeout"))?;
     enforce_foreign_keys(&connection)?;
     Ok(connection)
 }
@@ -520,6 +530,22 @@ pub(crate) fn open_bounded_writer_connection(path: &Path) -> Result<Connection> 
         .busy_timeout(WRITE_TIMEOUT)
         .map_err(sqlite_error(
             "configure bounded observation scheduler store",
+        ))?;
+    enforce_foreign_keys(&connection)?;
+    Ok(connection)
+}
+
+/// Open a connection for best-effort store maintenance. It bypasses the normal
+/// five-second busy handler so its explicit bounded retry is the whole wait.
+pub(crate) fn open_maintenance_connection(path: &Path) -> Result<Connection> {
+    let connection = Connection::open(path).map_err(sqlite_error(format!(
+        "open observation maintenance store {}",
+        path.display()
+    )))?;
+    connection
+        .busy_timeout(Duration::ZERO)
+        .map_err(sqlite_error(
+            "configure observation maintenance busy timeout",
         ))?;
     enforce_foreign_keys(&connection)?;
     Ok(connection)

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -202,6 +202,141 @@ mod store_init_tests {
     }
 
     #[test]
+    fn artifact_handle_backfill_recovers_after_a_transient_writer_lock() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let path = store::database_path().expect("database path");
+            std::fs::create_dir_all(path.parent().expect("database parent"))
+                .expect("create database parent");
+            let connection = super::super::schema::open_connection(&path).expect("open schema");
+            super::super::schema::apply_migrations(&connection).expect("apply schema");
+            drop(connection);
+            let writer = rusqlite::Connection::open(&path).expect("open locking connection");
+            writer
+                .execute_batch("PRAGMA journal_mode=DELETE;")
+                .expect("use rollback journal mode");
+            let store = ObservationStore {
+                connection: rusqlite::Connection::open(&path).expect("open test store"),
+                path: path.clone(),
+                readonly: false,
+            };
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+            let artifact_id = "legacy-artifact";
+            writer
+                .execute(
+                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
+                    rusqlite::params![artifact_id, run.id],
+                )
+                .expect("insert legacy artifact");
+            writer
+                .execute_batch("BEGIN EXCLUSIVE;")
+                .expect("hold writer lock");
+
+            let (retry_started_tx, retry_started_rx) = std::sync::mpsc::sync_channel(0);
+            let (release_retry_tx, release_retry_rx) = std::sync::mpsc::sync_channel(0);
+            let worker = std::thread::spawn(move || {
+                store.backfill_artifact_handles_with_retry(|| {
+                    retry_started_tx.send(()).expect("report retry");
+                    release_retry_rx.recv().expect("release retry");
+                })
+            });
+            retry_started_rx
+                .recv()
+                .expect("backfill attempted while locked");
+            writer
+                .execute_batch("COMMIT;")
+                .expect("release writer lock");
+            release_retry_tx.send(()).expect("resume backfill");
+
+            worker
+                .join()
+                .expect("backfill worker joined")
+                .expect("backfill recovers after lock release");
+
+            let check = rusqlite::Connection::open(path).expect("open check connection");
+            let (handle, diagnostic, rank): (String, i64, String) = check
+                .query_row(
+                    "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = ?1",
+                    [artifact_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .expect("read backfilled artifact");
+            assert!(handle.starts_with("ah_"));
+            assert_eq!(diagnostic, 0);
+            assert_eq!(rank, "0");
+        });
+    }
+
+    #[test]
+    fn artifact_handle_backfill_does_not_replace_materialized_diagnostic_metadata() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("initialize store");
+            let run = store
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+            store
+                .connection
+                .execute(
+                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":1}', '2026-01-01T00:00:00Z', NULL, 0, '99')",
+                    rusqlite::params!["materialized-artifact", run.id],
+                )
+                .expect("insert partially backfilled artifact");
+
+            store
+                .backfill_artifact_handles_with_retry(|| {})
+                .expect("backfill artifact handle");
+
+            let (handle, diagnostic, rank): (String, i64, String) = store
+                .connection
+                .query_row(
+                    "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = 'materialized-artifact'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .expect("read backfilled artifact");
+            assert!(handle.starts_with("ah_"));
+            assert_eq!(diagnostic, 0);
+            assert_eq!(rank, "99");
+        });
+    }
+
+    #[test]
+    fn normal_open_backfills_artifact_handles_before_a_bounded_projection() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let path = store::database_path().expect("database path");
+            let lifecycle = ObservationStore::open_initialized_for_lifecycle_at(&path)
+                .expect("initialize lifecycle store");
+            let run = lifecycle
+                .start_run(sample_run("test", "homeboy"))
+                .expect("start run");
+            lifecycle
+                .connection
+                .execute(
+                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES ('legacy-projection-artifact', ?1, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":2}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
+                    [run.id.as_str()],
+                )
+                .expect("insert legacy artifact");
+            drop(lifecycle);
+
+            let store = ObservationStore::open_initialized().expect("normal open backfills");
+            let projection = store
+                .bounded_artifact_projection_for_runs(&[run.id], 10)
+                .expect("project backfilled artifact");
+
+            assert_eq!(projection.artifacts.len(), 1);
+            assert!(projection.artifacts[0].id.starts_with("ah_"));
+            assert_eq!(
+                projection.diagnostic_handle,
+                Some(projection.artifacts[0].id.clone())
+            );
+        });
+    }
+
+    #[test]
     fn migration_from_version_8_preserves_artifacts_and_adds_query_indexes() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();
@@ -253,6 +388,25 @@ mod store_init_tests {
                     mime TEXT,
                     metadata_json TEXT NOT NULL DEFAULT '{}',
                     created_at TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                );
+                CREATE TABLE findings (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                );
+                CREATE TABLE triage_items (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                );
+                CREATE TABLE trace_runs (
+                    run_id TEXT PRIMARY KEY,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                );
+                CREATE TABLE trace_spans (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
                     FOREIGN KEY(run_id) REFERENCES runs(id)
                 );
                 INSERT INTO runs(id) VALUES ('run-1'), ('run-2');


### PR DESCRIPTION
## Summary

- add an explicit lifecycle store open path that preserves schema setup while avoiding non-critical artifact maintenance locks
- keep normal evidence opens synchronously enforcing bounded reconciliation and artifact-handle prerequisites
- make backfill transaction retries complete, bounded, idempotent, and stale-write safe

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- 108 observation-store tests passed
- focused lifecycle lock, concurrent retry identity/no-duplicate, rollback-journal, stale-write, and projection-backfill tests

Closes #12384

## AI assistance

OpenAI gpt-5.6-sol via OpenCode diagnosed the SQLite lifecycle contention, implemented and independently reviewed the split open contract and bounded maintenance behavior, and added concurrency tests. Chris Huber reviewed and owns every line.