### PR TITLE
fix(runner): bootstrap stale refresh over diagnostic SSH

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -456,9 +456,12 @@ pub fn refresh_homeboy_binary(
 
     let runner = load(&plan.runner_id)?;
     let previous_homeboy_path = runner.settings.homeboy_path.clone();
-    let connection_status = super::status(&plan.runner_id)?;
-    let disconnected_ssh = runner.kind == RunnerKind::Ssh && !connection_status.connected;
-    let exec_options = refresh_execution_options(&plan, required_commands, disconnected_ssh);
+    let admission = super::runner_admission_snapshot(&plan.runner_id)?;
+    let connection_status = admission.status.clone();
+    let execution_route = refresh_execution_route(&runner, &admission)?;
+    let diagnostic_ssh_bootstrap = execution_route.uses_diagnostic_ssh();
+    let exec_options =
+        refresh_execution_options(&plan, required_commands, diagnostic_ssh_bootstrap);
     let (exec_output, exit_code) = exec_with_status_snapshot(
         &plan.runner_id,
         exec_options,
@@ -563,7 +566,7 @@ pub fn refresh_homeboy_binary(
     // persisted after the candidate has been verified, whether or not this
     // invocation also replaces the active daemon.
     let ancestry_failure = RefCell::new(None);
-    let bootstrap = if disconnected_ssh {
+    let bootstrap = if diagnostic_ssh_bootstrap {
         ssh_bootstrap_promote_with(
             &plan,
             || Ok(exec_output.stdout.clone()),
@@ -581,7 +584,7 @@ pub fn refresh_homeboy_binary(
                             ancestry_checkout.as_deref(),
                             older,
                             newer,
-                            disconnected_ssh,
+                            diagnostic_ssh_bootstrap,
                             &connection_status,
                         );
                         match result {
@@ -637,7 +640,7 @@ pub fn refresh_homeboy_binary(
                         ancestry_checkout.as_deref(),
                         older,
                         newer,
-                        disconnected_ssh,
+                        diagnostic_ssh_bootstrap,
                         &connection_status,
                     );
                     match result {
@@ -942,7 +945,7 @@ pub fn refresh_homeboy_binary(
                             error.message,
                         )),
                         bootstrap_provenance: Some(refresh_bootstrap_provenance(
-                            disconnected_ssh,
+                            diagnostic_ssh_bootstrap,
                             &plan,
                             &bootstrap,
                             &identity,
@@ -999,7 +1002,7 @@ pub fn refresh_homeboy_binary(
                         daemon_identity_verification.err().as_deref(),
                     )),
                     bootstrap_provenance: Some(refresh_bootstrap_provenance(
-                        disconnected_ssh,
+                        diagnostic_ssh_bootstrap,
                         &plan,
                         &bootstrap,
                         &identity,
@@ -1057,7 +1060,7 @@ pub fn refresh_homeboy_binary(
                             Some(readiness_error.message.as_str()),
                         )),
                         bootstrap_provenance: Some(refresh_bootstrap_provenance(
-                            disconnected_ssh,
+                            diagnostic_ssh_bootstrap,
                             &plan,
                             &bootstrap,
                             &identity,
@@ -1112,7 +1115,7 @@ pub fn refresh_homeboy_binary(
             reconnect_deferred: None,
             failure: None,
             bootstrap_provenance: Some(HomeboyBootstrapProvenance {
-                transport: if disconnected_ssh {
+                transport: if diagnostic_ssh_bootstrap {
                     "ssh_bootstrap"
                 } else {
                     "daemon"
@@ -1126,7 +1129,7 @@ pub fn refresh_homeboy_binary(
                     .and_then(Value::as_str)
                     .map(str::to_string),
                 binary_identity: identity,
-                timeout_ms: disconnected_ssh
+                timeout_ms: diagnostic_ssh_bootstrap
                     .then_some(DISCONNECTED_SSH_REFRESH_TIMEOUT.as_millis()),
                 config_fields_changed: updated_fields.clone(),
             }),
@@ -1605,6 +1608,48 @@ fn refresh_execution_options(
         timeout: disconnected_ssh.then_some(DISCONNECTED_SSH_REFRESH_TIMEOUT),
         ..Default::default()
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefreshExecutionRoute {
+    Daemon,
+    DiagnosticSsh,
+}
+
+impl RefreshExecutionRoute {
+    fn uses_diagnostic_ssh(self) -> bool {
+        self == Self::DiagnosticSsh
+    }
+}
+
+/// A disconnected SSH runner has no daemon to rotate, so retain its diagnostic
+/// refresh route. A connected incompatible daemon may use that route only when
+/// the shared admission projection proves rotation is safe.
+fn refresh_execution_route(
+    runner: &super::Runner,
+    admission: &super::RunnerAdmissionSnapshot,
+) -> Result<RefreshExecutionRoute> {
+    if runner.kind != RunnerKind::Ssh {
+        return Ok(RefreshExecutionRoute::Daemon);
+    }
+    if !admission.summary.connected {
+        return Ok(RefreshExecutionRoute::DiagnosticSsh);
+    }
+    if admission.summary.daemon_compatible {
+        return Ok(RefreshExecutionRoute::Daemon);
+    }
+    if admission.summary.safe_to_rotate {
+        return Ok(RefreshExecutionRoute::DiagnosticSsh);
+    }
+    Err(Error::validation_invalid_argument(
+        "reconnect",
+        format!(
+            "runner `{}` cannot bootstrap over diagnostic SSH until its authoritative admission snapshot permits daemon rotation",
+            runner.id
+        ),
+        Some(runner.id.clone()),
+        admission.summary.next_action.clone().map(|action| vec![action]),
+    ))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -2,10 +2,11 @@
 
 use super::*;
 use crate::{
-    RunnerActiveJobState, RunnerExecMode, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport,
+    RunnerActiveJobState, RunnerAdmissionSnapshot, RunnerExecMode, RunnerSessionState,
+    RunnerStaleDaemonWarning, RunnerStatusReport,
 };
 use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
+use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
 use homeboy_core::test_support;
 
 /// Environment variables that redirect Cargo's output directory. A nested Cargo
@@ -1698,6 +1699,97 @@ fn disconnected_ssh_refresh_dispatches_the_existing_script_with_bounded_transpor
             .expect("preflight")
             .required_commands,
         vec!["bash", "git", "cargo"]
+    );
+}
+
+fn stale_daemon_admission_snapshot(
+    active_job_count: usize,
+    lease_id: Option<&str>,
+    pid: Option<u32>,
+) -> RunnerAdmissionSnapshot {
+    let mut status = refreshed_daemon_status(true, Some("homeboy 0.1.0+stale"));
+    status.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "lab",
+        "old".to_string(),
+        "current".to_string(),
+        None,
+        Some("current".to_string()),
+    ));
+    status.daemon_freshness = Some(DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(DaemonStaleReasonCode::VersionMismatch),
+        restartable: true,
+        lease_id: lease_id.map(str::to_string),
+        pid,
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: None,
+        daemon_build_identity: None,
+        runtime_paths: None,
+        active_jobs: active_job_count,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    });
+    status.active_job_count = active_job_count;
+    status.active_job_state = RunnerActiveJobState::Available;
+    RunnerAdmissionSnapshot::from_status_and_generations(status, Vec::new(), Vec::new())
+}
+
+#[test]
+fn refresh_routing_preserves_disconnected_ssh_execution_and_fences_unsafe_stale_daemons() {
+    let runner = crate::Runner {
+        id: "lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: None,
+        workspace_root: None,
+        settings: Default::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: Default::default(),
+    };
+    let disconnected = RunnerAdmissionSnapshot::from_status_and_generations(
+        refreshed_daemon_status(false, None),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let route = refresh_execution_route(&runner, &disconnected)
+        .expect("disconnected SSH refresh retains diagnostic execution");
+    let options = refresh_execution_options(
+        &ssh_bootstrap_plan(),
+        vec!["bash".to_string()],
+        route.uses_diagnostic_ssh(),
+    );
+    assert!(options.allow_diagnostic_ssh);
+
+    let unsafe_stale = stale_daemon_admission_snapshot(1, Some("lease-current"), Some(1));
+    let error = refresh_execution_route(&runner, &unsafe_stale)
+        .expect_err("connected stale daemon with active work remains fenced");
+    assert_eq!(error.code.as_str(), "validation.invalid_argument");
+    assert!(error.message.contains("permits daemon rotation"));
+
+    let ambiguous_stale = stale_daemon_admission_snapshot(0, None, None);
+    assert!(refresh_execution_route(&runner, &ambiguous_stale).is_err());
+}
+
+#[test]
+fn diagnostic_ssh_bootstrap_preflight_requires_remote_materialization_tools() {
+    let options = refresh_execution_options(
+        &ssh_bootstrap_plan(),
+        vec!["bash".to_string(), "git".to_string(), "cargo".to_string()],
+        true,
+    );
+
+    assert_eq!(
+        options
+            .capability_preflight
+            .expect("diagnostic SSH capability preflight")
+            .required_commands,
+        ["bash", "git", "cargo"],
+        "diagnostic SSH must probe the remote shell before materialization"
     );
 }
 


### PR DESCRIPTION
## Summary

- route stale connected daemon refresh through diagnostic SSH only when the canonical admission snapshot says rotation is safe
- preserve the existing disconnected diagnostic refresh path
- preflight actual remote `bash`, `git`, and `cargo` capabilities before materialization

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- 97 focused `homeboy_refresh` tests passed
- regression coverage for stale-idle bootstrap, active jobs, retained generations, ambiguous ownership, disconnected refresh, and missing SSH tools

Closes #12367

Depends on and is based on the merged admission contract from #12407.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented and independently reviewed the diagnostic SSH bootstrap routing, shared safety predicate integration, and regression tests. Chris Huber reviewed and owns every line.