### PR TITLE
Bound and instrument worktree provider commands

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -97,6 +97,7 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -187,6 +187,7 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
@@ -291,6 +292,7 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -183,6 +183,7 @@ fn lookup_only_configured_provider_cannot_construct_a_promotion_adapter() {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4062,7 +4062,77 @@ where
         .transpose()?;
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     if cook_workspace_lookup_pending(&options.initial_plan) {
-        if let Err(error) = materialize_pending_cook_workspace(&mut options) {
+        report_cook_progress(
+            durable_observer,
+            &options.cook_id,
+            &options.initial_run_id,
+            "worktree_provider_lookup",
+            1,
+            Some("starting bounded provider workspace lookup"),
+        )?;
+        // Core owns process-tree supervision; Cook owns the durable lifecycle
+        // record. Keep that record live while the external provider command runs.
+        let (lookup_stop, lookup_wait) = mpsc::channel();
+        let lookup_cook_id = options.cook_id.clone();
+        let lookup_run_id = options.initial_run_id.clone();
+        let lookup_control =
+            homeboy_core::worktree_providers::WorktreeProviderCommandControl::default();
+        let heartbeat_control = lookup_control.clone();
+        let lookup_result = std::thread::scope(|scope| {
+            scope.spawn(move || {
+                let mut next_heartbeat = Instant::now() + COOK_HEARTBEAT_INTERVAL;
+                loop {
+                    match lookup_wait.recv_timeout(COOK_PROVIDER_TERMINAL_POLL_INTERVAL) {
+                        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    }
+                    if agent_task_lifecycle::status(&lookup_run_id)
+                        .ok()
+                        .is_some_and(|record| {
+                            record.state == agent_task_lifecycle::AgentTaskRunState::Cancelled
+                        })
+                    {
+                        heartbeat_control.cancel();
+                        break;
+                    }
+                    if Instant::now() >= next_heartbeat {
+                        next_heartbeat = Instant::now() + COOK_HEARTBEAT_INTERVAL;
+                        let _ = report_cook_progress(
+                            durable_observer,
+                            &lookup_cook_id,
+                            &lookup_run_id,
+                            "worktree_provider_lookup",
+                            1,
+                            Some("bounded provider workspace lookup is still running"),
+                        );
+                    }
+                }
+            });
+            let result = homeboy_core::worktree_providers::with_worktree_provider_command_control(
+                lookup_control,
+                || materialize_pending_cook_workspace(&mut options),
+            );
+            let _ = lookup_stop.send(());
+            result
+        });
+        if let Err(error) = lookup_result {
+            if agent_task_lifecycle::status(&options.initial_run_id)
+                .ok()
+                .is_some_and(|record| {
+                    record.state == agent_task_lifecycle::AgentTaskRunState::Cancelled
+                })
+            {
+                return Ok(cook_report(CookReportInput {
+                    cook_id: options.cook_id.clone(),
+                    status: CookStatus::Cancelled.as_str(),
+                    disposition: CookDisposition::Terminal,
+                    attempts: Vec::new(),
+                    finalization: None,
+                    stop_reason: Some(error.to_string()),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&options.initial_run_id),
+                }));
+            }
             let error = with_pre_execution_phase(error, "worktree_provider_lookup");
             record_pre_execution_failure(
                 &options.initial_plan,
@@ -5898,21 +5968,32 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
                 .metadata
                 .pointer("/cook_provision/worktree_provider_id")
                 .and_then(Value::as_str)
-        })
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "worktree_provider",
-                "pending Cook workspace lookup is missing its persisted provider identity",
-                Some(options.to_worktree.clone()),
-                None,
-            )
-        })?;
+        });
     let config = homeboy_core::defaults::load_config();
-    let identity = homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
-        &options.to_worktree,
-        provider_id,
-        &config,
-    )?;
+    let resolve = || {
+        match provider_id {
+        Some(provider_id) => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
+            &options.to_worktree,
+            provider_id,
+            &config,
+        ),
+        None => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(
+            &options.to_worktree,
+            &config,
+        ),
+    }
+    };
+    let identity = match resolve() {
+        Ok(identity) => identity,
+        Err(error)
+            if provider_id.is_none()
+                && error.details["worktree_provider_lookup"] == "not_found" =>
+        {
+            provision_pending_cook_workspace(options, &config)?;
+            resolve()?
+        }
+        Err(error) => return Err(error),
+    };
     if identity.handle != options.to_worktree {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
@@ -5979,6 +6060,35 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
         Value::String("existing".to_string());
     options.source_worktree_path = Some(target);
     agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
+}
+
+/// A deferred provider lookup can prove absence only after Cook owns a durable
+/// identity. In that case, execute the unchanged configured ensure contract and
+/// resolve its postcondition through the same provider boundary.
+fn provision_pending_cook_workspace(
+    options: &AgentTaskCookServiceOptions,
+    config: &homeboy_core::defaults::HomeboyConfig,
+) -> Result<()> {
+    let intent = &options.initial_plan.metadata["cook_provision"]["provision_intent"];
+    let required = |field: &str| {
+        intent.get(field).and_then(Value::as_str).filter(|value| !value.trim().is_empty()).ok_or_else(|| {
+            Error::validation_missing_argument(vec![format!(
+                "--{field} is required to create missing provider worktree `{}` after durable Cook admission",
+                options.to_worktree
+            )])
+        })
+    };
+    homeboy_core::worktree_providers::provision_apply_enabled_worktree_provider_from_config(
+        &homeboy_core::worktree_providers::WorktreeProviderCreateIntent {
+            handle: options.to_worktree.clone(),
+            repo: required("repo")?.to_string(),
+            base: required("base")?.to_string(),
+            head: required("head")?.to_string(),
+            task_url: required("task_url")?.to_string(),
+        },
+        config,
+    )?;
+    Ok(())
 }
 
 fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2894,6 +2894,7 @@ fn initial_cook_adopts_only_clean_issue_owned_unpushed_provider_worktree() {
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),
@@ -3000,6 +3001,7 @@ fn explicit_cook_workspace_bypasses_a_timed_out_provider_lookup() {
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 1,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.path().display().to_string()]),
@@ -3770,7 +3772,7 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
 
 #[cfg(unix)]
 #[test]
-fn cook_persists_pending_identity_when_safety_attestation_times_out() {
+fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_timeout() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -3824,19 +3826,12 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
         let workspace = workspace.canonicalize().expect("canonical workspace");
         let provider_dir = tempfile::tempdir().expect("provider directory");
         let provider = provider_dir.path().join("provider");
-        std::fs::write(
-            &provider,
-            format!(
-                "#!/bin/sh\nif test \"$1\" = safety; then sleep 1; else printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"pending-identity\",\"handle\":\"fixture@cook-slow-worktree-lookup\",\"path\":\"{}\",\"branch\":\"cook-slow-worktree-lookup\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'; fi\n",
-                workspace.display()
-            ),
-        )
-        .expect("write provider");
+        std::fs::write(&provider, format!("#!/bin/sh\nsleep 1\n")).expect("write provider");
         let mut permissions = std::fs::metadata(&provider)
             .expect("provider metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+        std::fs::set_permissions(&provider, permissions.clone()).expect("make provider executable");
 
         let mut config = homeboy_core::defaults::HomeboyConfig::default();
         config.worktree_providers.insert(
@@ -3846,6 +3841,7 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 25,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve_identity: Some(vec![
@@ -3879,24 +3875,20 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
         let cook_id = "cook-slow-worktree-lookup";
         let run_id = "cook-slow-worktree-lookup-run";
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
-        // Exercise normal local Cook: a retryable provider failure must retain
-        // the exact handle without persisting provider-owned diagnostics.
-        options.attempt_dispatcher = None;
+        // The provider identity is deliberately absent until durable admission.
+        // The detached dispatcher keeps the resumed Cook test focused on its
+        // durable retry and workspace lifecycle rather than local execution.
         options.initial_run_id = run_id.to_string();
+        options.max_attempts = 2;
         options.initial_plan.metadata["cook_provision"] = serde_json::json!({
-            "action": "attestation_pending",
+            "action": "lookup_pending",
             "kind": "provider",
             "handle": options.to_worktree,
-            "worktree_provider_id": "fixture",
-            "workspace_identity": {
-                "schema": "homeboy/worktree-provider-identity/v1", "provider_id": "fixture", "token": "pending-identity",
-                "handle": options.to_worktree, "path": workspace, "branch": "cook-slow-worktree-lookup", "primary": false,
-                "latency_ms": 1, "budget_ms": 25
-            }
         });
         let exact_handle = options.to_worktree.clone();
 
-        let result = run_cook(options, UnusedExecutor).expect("Cook records lookup failure");
+        let result =
+            run_cook(options.clone(), UnusedExecutor).expect("Cook records lookup failure");
 
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.cook_id, cook_id);
@@ -3918,9 +3910,23 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
             "transient"
         );
         assert_eq!(
-            record.metadata["pre_execution_failure"]["details"]["worktree_provider_split"],
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_lookup"],
             "timed_out"
         );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]
+                ["worktree_provider_call_classification"],
+            "timeout"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_phase"],
+            "worktree_provider_resolve_identity"
+        );
+        assert!(record.metadata["pre_execution_failure"]["details"]
+            ["worktree_provider_replay_command"]
+            .as_str()
+            .expect("replay command")
+            .contains(provider.to_string_lossy().as_ref()));
         let recipe = super::super::load_recipe(cook_id).expect("durable Cook identity");
         assert_eq!(recipe.attempts[0].run_id, run_id);
         let persisted_plan = agent_task_lifecycle::load_plan(run_id).expect("durable lookup plan");
@@ -3929,17 +3935,129 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
             exact_handle
         );
         assert_eq!(persisted_plan.tasks[0].workspace.root, None);
-        assert_eq!(
-            persisted_plan.metadata["cook_provision"]["workspace_identity"]["token"],
-            "pending-identity"
-        );
+        assert!(persisted_plan.metadata["cook_provision"]["workspace_identity"].is_null());
         assert!(persisted_plan.tasks[0]
             .metadata
             .get("cook_workspace_identity")
             .is_none());
-        let retry = agent_task_lifecycle::retry(run_id, Some("cook-slow-worktree-lookup-retry"))
-            .expect("lookup timeout remains retryable");
-        assert_eq!(retry.metadata["retry_of"], run_id);
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nif test \"$1\" = identity; then printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"recovered-identity\",\"handle\":\"fixture@cook-slow-worktree-lookup\",\"path\":\"{}\",\"branch\":\"cook-slow-worktree-lookup\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'; else printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-safety/v1\",\"identity_token\":\"recovered-identity\",\"observed_at\":\"2026-01-01T00:00:00Z\",\"dirty\":false,\"unpushed\":false,\"fresh\":true,\"latency_ms\":0,\"budget_ms\":0}}'; fi\n",
+                workspace.display()
+            ),
+        )
+        .expect("recover provider");
+        std::fs::set_permissions(&provider, permissions).expect("restore executable provider");
+
+        let retry = crate::agent_task_service::retry(run_id, None, false, false)
+            .expect("reserve a Cook-owned retry successor");
+        assert_eq!(retry.record.metadata["retry_of"], run_id);
+        assert_eq!(retry.record.metadata["cook_id"], cook_id);
+        assert_eq!(retry.record.metadata["cook_attempt"], 2);
+        let recipe = super::super::load_recipe(cook_id).expect("same Cook recipe owns retry");
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].run_id, retry.record.run_id);
+
+        let mut resumed_options = super::super::reconstruct_options_with_dispatcher(
+            &recipe,
+            Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+        )
+        .expect("reconstruct Cook-owned retry");
+        resumed_options.initial_run_id = retry.record.run_id.clone();
+        resumed_options.initial_plan =
+            agent_task_lifecycle::load_plan(&retry.record.run_id).expect("load durable retry plan");
+        let resumed = run_cook(resumed_options, UnusedExecutor)
+            .expect("same Cook retry materializes its recovered provider workspace");
+        assert_eq!(resumed.value.cook_id, cook_id);
+        let resumed_plan =
+            agent_task_lifecycle::load_plan(&retry.record.run_id).expect("materialized retry plan");
+        assert_eq!(
+            resumed_plan.tasks[0].workspace.root.as_deref(),
+            Some(workspace.to_str().expect("utf8 workspace"))
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn review_12349_deferred_lookup_cancellation_preserves_cancelled_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let marker = provider_dir.path().join("started");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!("#!/bin/sh\ntouch '{}'\nsleep 5\n", marker.display()),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve_identity: Some(vec![
+                        provider.display().to_string(),
+                        "token=provider-secret-must-not-persist".to_string(),
+                    ]),
+                    attest_safety: Some(vec!["true".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save config");
+
+        let cook_id = "review-12349-cancelled-lookup";
+        let run_id = "review-12349-cancelled-lookup-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending", "kind": "provider", "handle": options.to_worktree,
+            "worktree_provider_id": "fixture",
+        });
+
+        let cook = std::thread::spawn(move || run_cook(options, UnusedExecutor));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while !marker.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            marker.exists(),
+            "provider lookup started before cancellation"
+        );
+        agent_task_lifecycle::cancel_run(run_id, Some("review cancellation"))
+            .expect("cancel durable lookup run");
+
+        let result = cook
+            .join()
+            .expect("Cook thread joins")
+            .expect("Cook returns cancellation report");
+        assert_eq!(result.value.status, "cancelled");
+        let record = agent_task_lifecycle::status(run_id).expect("cancelled durable record");
+        assert_eq!(
+            record.state,
+            agent_task_lifecycle::AgentTaskRunState::Cancelled
+        );
+        assert!(record.metadata["pre_execution_failure"].is_null());
+        assert!(!record
+            .metadata
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
     });
 }
 
@@ -3947,6 +4065,7 @@ fn cook_persists_pending_identity_when_safety_attestation_times_out() {
 #[test]
 fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::Mutex;
 
     homeboy_core::test_support::with_isolated_home(|_| {
         let provider_dir = tempfile::tempdir().expect("provider directory");
@@ -3965,6 +4084,7 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 25,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve_identity: Some(vec![
@@ -3988,7 +4108,17 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
             "worktree_provider_id": "fixture",
         });
 
-        let result = run_cook(options, UnusedExecutor).expect("Cook records split lookup timeout");
+        let phases = Arc::new(Mutex::new(Vec::new()));
+        let observed_phases = Arc::clone(&phases);
+        let observer = move |event: &CookProgressEvent<'_>| {
+            observed_phases
+                .lock()
+                .expect("phase lock")
+                .push((event.phase.to_string(), event.detail.map(str::to_string)));
+            Ok(())
+        };
+        let result = run_cook_with_durable_observer(options, UnusedExecutor, &observer)
+            .expect("Cook records split lookup timeout");
         assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("durable timeout record");
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
@@ -4001,6 +4131,24 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
             record.metadata["pre_execution_failure"]["details"]["worktree_provider_id"],
             "fixture"
         );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]
+                ["worktree_provider_call_classification"],
+            "timeout"
+        );
+        assert!(record.metadata["pre_execution_failure"]["details"]
+            ["worktree_provider_replay_command"]
+            .as_str()
+            .expect("replay command")
+            .contains(provider.to_string_lossy().as_ref()));
+        assert!(phases
+            .lock()
+            .expect("phase lock")
+            .iter()
+            .any(|(phase, detail)| {
+                phase == "worktree_provider_lookup"
+                    && detail.as_deref() == Some("starting bounded provider workspace lookup")
+            }));
         let recipe = super::super::load_recipe(cook_id).expect("durable recipe");
         assert_eq!(
             recipe.attempts[0].plan.metadata["cook_provision"]["worktree_provider_id"],
@@ -4129,6 +4277,7 @@ fn split_only_provider_is_authoritative_without_source_override_or_legacy_comman
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve_identity: Some(vec![
@@ -4252,6 +4401,7 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![script.display().to_string(), "{handle}".to_string()]),
@@ -4394,6 +4544,7 @@ fn pending_repo_only_lookup_rejects_provider_workspace_from_another_repository()
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
@@ -9636,6 +9787,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4709,6 +4709,7 @@ mod tests {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -827,6 +827,28 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
     }
 
     let config = defaults::load_config();
+    // A command provider's answer is external, bounded, and retryable. Preserve
+    // the complete creation intent in the Cook plan and resolve it only after
+    // Cook has materialized its durable recipe/run identity.
+    if config.worktree_providers.values().any(|provider| {
+        provider.enabled
+            && provider.apply_enabled
+            && (provider.commands.resolve_identity.is_some()
+                || provider.commands.resolve.is_some()
+                || provider.commands.list.is_some())
+    }) {
+        return Ok(serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": to_worktree,
+            "provision_intent": {
+                "repo": args.dispatch.repo,
+                "base": args.base,
+                "head": args.head,
+                "task_url": args.dispatch.task_url,
+            },
+        }));
+    }
     match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(to_worktree, &config) {
         Ok(identity) => {
             homeboy::core::worktree_providers::validate_task_worktree_root(

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -917,6 +917,7 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -981,7 +982,7 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
 
 #[cfg(unix)]
 #[test]
-fn cook_resolves_existing_provider_destination_without_creation_metadata() {
+fn cook_defers_existing_provider_destination_lookup_until_durable_admission() {
     use std::os::unix::fs::PermissionsExt;
 
     with_isolated_home(|_| {
@@ -1031,6 +1032,7 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
@@ -1066,11 +1068,10 @@ fn cook_resolves_existing_provider_destination_without_creation_metadata() {
         ]))
         .expect("repo-only Cook retains its requested repository expectation");
         let provision = super::super::run::provision_cook_destination(&args)
-            .expect("existing provider destination resolves without creation fields");
+            .expect("provider destination lookup is deferred until durable Cook admission");
 
-        assert_eq!(provision["action"], "existing");
-        assert_eq!(provision["provider"], "fixture");
-        assert_eq!(provision["path"], destination.display().to_string());
+        assert_eq!(provision["action"], "lookup_pending");
+        assert_eq!(provision["handle"], "fixture@existing");
     });
 }
 
@@ -1127,6 +1128,7 @@ fn cook_cwd_is_authoritative_when_provider_lookup_times_out() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 1,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),
@@ -1284,7 +1286,7 @@ fn cook_rejects_an_inactive_managed_destination_before_provider_execution() {
 
 #[cfg(unix)]
 #[test]
-fn cook_rejects_immediately_resolved_provider_destination_from_another_repository() {
+fn cook_defers_foreign_provider_destination_validation_until_durable_admission() {
     use std::os::unix::fs::PermissionsExt;
 
     with_isolated_home(|_| {
@@ -1339,6 +1341,7 @@ fn cook_rejects_immediately_resolved_provider_destination_from_another_repositor
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
@@ -1372,18 +1375,16 @@ fn cook_rejects_immediately_resolved_provider_destination_from_another_repositor
             "--no-finalize".to_string(),
         ]))
         .expect("persist generic repo expectation");
-        let error = super::super::run::provision_cook_destination(&args)
-            .expect_err("foreign immediate provider checkout is rejected before plan creation");
-        assert!(error
-            .message
-            .contains("does not match the requested Cook repository"));
-        assert!(!error.message.contains("provider-secret"));
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("provider destination validation is deferred until Cook is durable");
+        assert_eq!(provision["action"], "lookup_pending");
+        assert_eq!(provision["handle"], "fixture@foreign");
     });
 }
 
 #[cfg(unix)]
 #[test]
-fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_metadata() {
+fn cook_defers_provider_lookup_failures_until_durable_admission() {
     use std::os::unix::fs::PermissionsExt;
 
     with_isolated_home(|_| {
@@ -1412,6 +1413,7 @@ fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_meta
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "resolve".to_string()]),
@@ -1444,12 +1446,9 @@ fn cook_does_not_collapse_provider_lookup_failures_into_missing_destination_meta
             "fixture@missing".to_string(),
             "--no-finalize".to_string(),
         ]);
-        let error = super::super::run::provision_cook_destination(&args)
-            .expect_err("provider lookup failure is not a missing destination");
-
-        assert!(error
-            .message
-            .contains("provider `fixture` resolve command failed"));
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("provider lookup failure is deferred until Cook is durable");
+        assert_eq!(provision["action"], "lookup_pending");
         assert!(!ensured.exists(), "failed lookup must not run ensure");
     });
 }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -628,6 +628,7 @@ fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -938,6 +939,7 @@ fn cook_continue_selects_a_recoverable_candidate_without_provider_redispatch() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -551,6 +551,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),
@@ -915,6 +916,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -2420,6 +2420,7 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -2668,6 +2668,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_preview: Some(vec![script, "dry_run".to_string()]),
@@ -2730,6 +2731,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -455,15 +455,22 @@ pub struct WorktreeProviderConfig {
     pub apply_enabled: bool,
     #[serde(default)]
     pub commands: WorktreeProviderCommands,
-    /// Maximum time allowed for a provider's read-only `list` or `resolve`
-    /// command. This is intentionally separate from mutating provider actions.
+    /// Maximum time allowed for a read-only provider lookup, identity, or safety
+    /// command.
     #[serde(
         default = "default_worktree_provider_lookup_timeout_ms",
         deserialize_with = "deserialize_worktree_provider_lookup_timeout_ms"
     )]
     pub lookup_timeout_ms: u64,
-    /// Maximum output retained from a provider's read-only `list` or `resolve`
-    /// command. The configured result mapping receives the complete JSON payload.
+    /// Maximum time allowed for a mutating provider ensure or finalization
+    /// command. The default preserves the prior fixed 30-second bound.
+    #[serde(
+        default = "default_worktree_provider_mutation_timeout_ms",
+        deserialize_with = "deserialize_worktree_provider_mutation_timeout_ms"
+    )]
+    pub mutation_timeout_ms: u64,
+    /// Maximum output retained from one provider command. The configured result
+    /// mapping receives the complete JSON payload.
     #[serde(
         default = "default_worktree_provider_lookup_output_limit_bytes",
         deserialize_with = "deserialize_worktree_provider_lookup_output_limit_bytes"
@@ -478,6 +485,9 @@ pub struct WorktreeProviderConfig {
 const DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 10_000;
 const MIN_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 1;
 const MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS: u64 = 300_000;
+const DEFAULT_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS: u64 = 30_000;
+const MIN_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS: u64 = 1;
+const MAX_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS: u64 = 900_000;
 const DEFAULT_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS: u64 = 30_000;
 const MIN_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS: u64 = 1;
 const MAX_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS: u64 = 300_000;
@@ -487,6 +497,10 @@ const MAX_WORKTREE_PROVIDER_LOOKUP_OUTPUT_LIMIT_BYTES: usize = 64 * 1024 * 1024;
 
 fn default_worktree_provider_lookup_timeout_ms() -> u64 {
     DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
+}
+
+fn default_worktree_provider_mutation_timeout_ms() -> u64 {
+    DEFAULT_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS
 }
 
 fn default_worktree_provider_cleanup_timeout_ms() -> u64 {
@@ -518,6 +532,31 @@ pub fn validate_worktree_provider_lookup_timeout_ms(
     } else {
         Err(format!(
             "lookup_timeout_ms must be between {MIN_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS} and {MAX_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS} milliseconds"
+        ))
+    }
+}
+
+fn deserialize_worktree_provider_mutation_timeout_ms<'de, D>(
+    deserializer: D,
+) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let timeout_ms = u64::deserialize(deserializer)?;
+    validate_worktree_provider_mutation_timeout_ms(timeout_ms).map_err(serde::de::Error::custom)?;
+    Ok(timeout_ms)
+}
+
+pub fn validate_worktree_provider_mutation_timeout_ms(
+    timeout_ms: u64,
+) -> std::result::Result<(), String> {
+    if (MIN_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS..=MAX_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS)
+        .contains(&timeout_ms)
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "mutation_timeout_ms must be between {MIN_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS} and {MAX_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS} milliseconds"
         ))
     }
 }
@@ -1015,6 +1054,10 @@ mod tests {
             DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
         );
         assert_eq!(
+            config.worktree_providers["fixture"].mutation_timeout_ms,
+            DEFAULT_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS
+        );
+        assert_eq!(
             config.worktree_providers["fixture"]
                 .commands
                 .cleanup_preview_timeout_ms,
@@ -1036,6 +1079,14 @@ mod tests {
                 .pointer("/worktree_providers/fixture/lookup_timeout_ms"),
             Some(&serde_json::json!(
                 DEFAULT_WORKTREE_PROVIDER_LOOKUP_TIMEOUT_MS
+            ))
+        );
+        assert_eq!(
+            serde_json::to_value(&config)
+                .expect("config serializes")
+                .pointer("/worktree_providers/fixture/mutation_timeout_ms"),
+            Some(&serde_json::json!(
+                DEFAULT_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS
             ))
         );
         assert_eq!(
@@ -1072,6 +1123,25 @@ mod tests {
                 .to_string()
                 .contains("lookup_timeout_ms must be between"));
         }
+
+        for timeout_ms in [0, MAX_WORKTREE_PROVIDER_MUTATION_TIMEOUT_MS + 1] {
+            let error = serde_json::from_value::<HomeboyConfig>(serde_json::json!({
+                "worktree_providers": {"fixture": {"mutation_timeout_ms": timeout_ms}}
+            }))
+            .expect_err("out-of-range mutation timeout is invalid");
+            assert!(error
+                .to_string()
+                .contains("mutation_timeout_ms must be between"));
+        }
+
+        let config: HomeboyConfig = serde_json::from_value(serde_json::json!({
+            "worktree_providers": {"fixture": {"mutation_timeout_ms": 540_000}}
+        }))
+        .expect("DMC's 540-second ensure budget is valid");
+        assert_eq!(
+            config.worktree_providers["fixture"].mutation_timeout_ms,
+            540_000
+        );
 
         for field in ["cleanup_preview_timeout_ms", "cleanup_apply_timeout_ms"] {
             for timeout_ms in [0, MAX_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS + 1] {

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1695,6 +1695,7 @@ fn queue_create_uses_provider_lifecycle_with_per_child_metadata() {
                 kind: crate::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: crate::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1,5 +1,8 @@
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -55,14 +58,41 @@ const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_secs(5);
 const PROVIDER_CLEANUP_HEARTBEAT: Duration = Duration::from_millis(100);
 const PROVIDER_CLEANUP_OUTPUT_LIMIT: usize = 64 * 1024;
 #[cfg(not(test))]
-const PROVIDER_ENSURE_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(test)]
-const PROVIDER_ENSURE_TIMEOUT: Duration = Duration::from_secs(3);
-const PROVIDER_LOOKUP_OUTPUT_LIMIT: usize = 64 * 1024;
-#[cfg(not(test))]
 const PROVIDER_LOOKUP_HEARTBEAT: Duration = Duration::from_millis(100);
 #[cfg(test)]
 const PROVIDER_LOOKUP_HEARTBEAT: Duration = Duration::from_millis(1);
+
+/// Cancellation is scoped to the controller thread issuing provider commands.
+/// This keeps provider supervision generic while letting a durable owner stop
+/// an isolated process group when its own lifecycle is cancelled.
+#[derive(Clone, Default)]
+pub struct WorktreeProviderCommandControl(Arc<AtomicBool>);
+
+impl WorktreeProviderCommandControl {
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+thread_local! {
+    static PROVIDER_COMMAND_CONTROL: RefCell<Option<WorktreeProviderCommandControl>> = const { RefCell::new(None) };
+}
+
+pub fn with_worktree_provider_command_control<T>(
+    control: WorktreeProviderCommandControl,
+    run: impl FnOnce() -> T,
+) -> T {
+    PROVIDER_COMMAND_CONTROL.with(|active| {
+        let previous = active.replace(Some(control));
+        let result = run();
+        active.replace(previous);
+        result
+    })
+}
 
 #[derive(Debug, Clone)]
 pub struct WorktreeProviderCleanupOptions {
@@ -452,6 +482,18 @@ pub fn resolve_apply_enabled_worktree_provider_by_id_from_config(
             None,
         );
         error.details["worktree_provider_lookup"] = Value::String("not_found".to_string());
+        let command = provider
+            .commands
+            .resolve
+            .as_ref()
+            .or(provider.commands.list.as_ref())
+            .expect("provider resolve or list command was selected");
+        let operation = if provider.commands.resolve.is_some() {
+            "resolve"
+        } else {
+            "list"
+        };
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "not_found");
         error
     })?;
     validate_provider_handle(provider_id, &worktree, None, None)?;
@@ -1046,6 +1088,7 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
                 })?;
                 run_provider_ensure_command(
                     &resolution.provider_id,
+                    provider,
                     &expand_lifecycle_ensure_command(
                         command,
                         intent,
@@ -1148,7 +1191,7 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
             Some(vec![format!("Create it with: {rendered_command}")]),
         ));
     }
-    run_provider_ensure_command(provider_id, &command)?;
+    run_provider_ensure_command(provider_id, provider, &command)?;
     let resolution =
         resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
             .map_err(mark_bootstrap_postcondition_failure)?;
@@ -1236,7 +1279,7 @@ pub fn finalize_apply_enabled_worktree_provider_from_config(
                 .replace("{lifecycle_state}", disposition.lifecycle_state())
         })
         .collect::<Vec<_>>();
-    run_provider_ensure_command(&resolution.provider_id, &command)?;
+    run_provider_mutation_command(&resolution.provider_id, provider, &command, "finalize")?;
     Ok(WorktreeProviderFinalization {
         provider_id: resolution.provider_id.clone(),
         handle: resolution.worktree.handle.clone(),
@@ -1336,82 +1379,84 @@ fn render_provider_command(command: &[String]) -> String {
         .join(" ")
 }
 
-fn run_provider_ensure_command(provider_id: &str, command: &[String]) -> Result<()> {
+fn run_provider_ensure_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+) -> Result<()> {
+    run_provider_mutation_command(provider_id, provider, command, "ensure")
+}
+
+fn run_provider_mutation_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    operation: &str,
+) -> Result<()> {
     if let Some(argument) = command.iter().find(|argument| argument.contains('{')) {
-        return Err(Error::validation_invalid_argument(
+        return Err(provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "command",
             "worktree_providers.commands",
             format!(
                 "worktree provider `{provider_id}` command contains an unresolved placeholder: {argument}"
             ),
-            Some(provider_id.to_string()),
-            None,
+            false,
         ));
     }
-    let Some((program, args)) = command
-        .split_first()
-        .filter(|(program, _)| !program.trim().is_empty())
-    else {
-        return Err(Error::validation_invalid_argument(
-            "worktree_providers.commands.ensure",
-            format!("worktree provider `{provider_id}` ensure command must include an executable"),
-            Some(provider_id.to_string()),
-            None,
-        ));
-    };
-    let mut process = Command::new(program);
-    process
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    crate::engine::command::isolate_process_tree(&mut process);
-    let mut child = process.spawn().map_err(|error| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            format!("worktree provider `{provider_id}` ensure command could not start: {error}"),
-            Some(provider_id.to_string()),
-            None,
-        )
-    })?;
-    let output = crate::engine::command::wait_with_bounded_output_supervised(
-        &mut child,
-        PROVIDER_LOOKUP_OUTPUT_LIMIT,
-        PROVIDER_ENSURE_TIMEOUT,
-        Duration::from_millis(100),
-        || false,
-        |_, _| Ok(()),
-    )
-    .map_err(|error| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            format!(
-                "worktree provider `{provider_id}` ensure command could not be supervised: {error}"
-            ),
-            Some(provider_id.to_string()),
-            None,
-        )
-    })?;
+    let timeout = provider_mutation_timeout(provider)?;
+    let output_limit = provider_lookup_output_limit(provider)?;
+    let supervised = run_bounded_provider_lookup_command(
+        provider_id,
+        command,
+        operation,
+        timeout,
+        output_limit,
+    )?;
+    let elapsed_ms = supervised.elapsed_ms;
+    let output = supervised.output;
     if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
-        return Err(Error::validation_invalid_argument(
+        let classification = match output.termination {
+            crate::engine::command::SupervisedCommandTermination::Cancelled => "cancelled",
+            crate::engine::command::SupervisedCommandTermination::TimedOut
+            | crate::engine::command::SupervisedCommandTermination::NoProgress => "timeout",
+            crate::engine::command::SupervisedCommandTermination::Completed => unreachable!(),
+        };
+        return Err(provider_lookup_error(
+            provider_id,
+            command,
+                operation,
+            classification,
             "to_worktree",
             format!(
-                "worktree provider `{provider_id}` ensure command timed out after {} ms",
-                PROVIDER_ENSURE_TIMEOUT.as_millis()
+                "worktree provider `{provider_id}` {operation} command {classification} after {elapsed_ms} ms (configured provider budget: {} ms)",
+                timeout.as_millis()
             ),
-            Some(provider_id.to_string()),
-            Some(vec![
-                "Refresh or repair the configured workspace provider, then retry the operation."
-                    .to_string(),
-            ]),
+            classification == "timeout" || classification == "cancelled",
         ));
     }
-    let output = output.output.into_output();
+    let output = output.output;
+    if output.capture.stdout.truncated || output.capture.stderr.truncated {
+        return Err(provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "malformed",
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes"),
+            false,
+        ));
+    }
+    let output = output.into_output();
     if output.status.success() {
         return Ok(());
     }
-    Err(Error::validation_invalid_argument_with_evidence(
+    let mut error = Error::validation_invalid_argument_with_evidence(
         "to_worktree",
         format!(
-            "worktree provider `{provider_id}` ensure command failed with {}",
+            "worktree provider `{provider_id}` {operation} command failed with {}",
             output
                 .status
                 .code()
@@ -1421,7 +1466,9 @@ fn run_provider_ensure_command(provider_id: &str, command: &[String]) -> Result<
         Some(provider_id.to_string()),
         None,
         Some(provider_command_evidence(command, &output)),
-    ))
+    );
+    annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
+    Err(error)
 }
 
 fn resolve_worktree_provider_with_policy_from_config(
@@ -1522,6 +1569,9 @@ fn resolve_worktree_provider_with_policy_from_config(
         ]),
     );
     error.details["worktree_provider_lookup"] = Value::String("not_found".to_string());
+    error.details["worktree_provider_call_classification"] = Value::String("not_found".to_string());
+    error.details["worktree_provider_phase"] =
+        Value::String("worktree_provider_lookup".to_string());
     Err(error)
 }
 
@@ -1559,14 +1609,41 @@ fn run_provider_identity_command(
     if split_identity_not_owned(&payload) {
         return Ok(None);
     }
-    let identity: WorktreeProviderExactIdentity = serde_json::from_value(payload).map_err(|error| Error::validation_invalid_argument("worktree_providers.commands.resolve_identity", format!("worktree provider `{provider_id}` returned an invalid identity envelope: {error}"), Some(provider_id.to_string()), None))?;
+    let identity: WorktreeProviderExactIdentity = serde_json::from_value(payload).map_err(|error| {
+        provider_lookup_error(
+            provider_id,
+            &command,
+            "resolve_identity",
+            "malformed",
+            "worktree_providers.commands.resolve_identity",
+            format!("worktree provider `{provider_id}` returned an invalid identity envelope: {error}"),
+            false,
+        )
+    })?;
     if identity.schema != "homeboy/worktree-provider-identity/v1"
         || identity.provider_id != provider_id
         || identity.token.trim().is_empty()
     {
-        return Err(Error::validation_invalid_argument("worktree_providers.commands.resolve_identity", format!("worktree provider `{provider_id}` returned an unsupported or incomplete identity envelope"), Some(provider_id.to_string()), None));
+        return Err(provider_lookup_error(
+            provider_id,
+            &command,
+            "resolve_identity",
+            "malformed",
+            "worktree_providers.commands.resolve_identity",
+            format!("worktree provider `{provider_id}` returned an unsupported or incomplete identity envelope"),
+            false,
+        ));
     }
-    validate_split_identity(provider_id, handle, &identity)?;
+    validate_split_identity(provider_id, handle, &identity).map_err(|mut error| {
+        annotate_provider_lookup_error(
+            &mut error,
+            provider_id,
+            &command,
+            "resolve_identity",
+            "malformed",
+        );
+        error
+    })?;
     Ok(Some(WorktreeProviderExactIdentity {
         latency_ms,
         budget_ms,
@@ -1655,12 +1732,30 @@ fn run_provider_safety_command(
         .collect::<Vec<_>>();
     let (payload, latency_ms, budget_ms) =
         run_provider_split_command(provider_id, provider, &command, "attest_safety")?;
-    let safety: WorktreeProviderSafetyAttestation = serde_json::from_value(payload).map_err(|error| Error::validation_invalid_argument("worktree_providers.commands.attest_safety", format!("worktree provider `{provider_id}` returned an invalid safety envelope: {error}"), Some(provider_id.to_string()), None))?;
+    let safety: WorktreeProviderSafetyAttestation = serde_json::from_value(payload).map_err(|error| {
+        provider_lookup_error(
+            provider_id,
+            &command,
+            "attest_safety",
+            "malformed",
+            "worktree_providers.commands.attest_safety",
+            format!("worktree provider `{provider_id}` returned an invalid safety envelope: {error}"),
+            false,
+        )
+    })?;
     if safety.schema != "homeboy/worktree-provider-safety/v1"
         || safety.identity_token.trim().is_empty()
         || safety.observed_at.trim().is_empty()
     {
-        return Err(Error::validation_invalid_argument("worktree_providers.commands.attest_safety", format!("worktree provider `{provider_id}` returned an unsupported or incomplete safety envelope"), Some(provider_id.to_string()), None));
+        return Err(provider_lookup_error(
+            provider_id,
+            &command,
+            "attest_safety",
+            "malformed",
+            "worktree_providers.commands.attest_safety",
+            format!("worktree provider `{provider_id}` returned an unsupported or incomplete safety envelope"),
+            false,
+        ));
     }
     Ok(WorktreeProviderSafetyAttestation {
         latency_ms,
@@ -1677,55 +1772,76 @@ fn run_provider_split_command(
 ) -> Result<(Value, u128, u128)> {
     let timeout = provider_lookup_timeout(provider)?;
     let output_limit = provider_lookup_output_limit(provider)?;
-    let (program, args) = command.split_first().filter(|(program, _)| !program.trim().is_empty()).ok_or_else(|| Error::validation_invalid_argument("worktree_providers.commands", format!("worktree provider `{provider_id}` {operation} command must include an executable"), Some(provider_id.to_string()), None))?;
-    let mut process = Command::new(program);
-    process
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    crate::engine::command::isolate_process_tree(&mut process);
-    let mut child = process.spawn().map_err(|error| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            format!(
-                "worktree provider `{provider_id}` {operation} command could not start: {error}"
-            ),
-            Some(provider_id.to_string()),
-            None,
-        )
-    })?;
-    let started = std::time::Instant::now();
-    let supervised = crate::engine::command::wait_with_bounded_output_supervised(&mut child, output_limit, timeout, Duration::from_millis(100), || false, |_, _| Ok(())).map_err(|error| Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command could not be supervised: {error}"), Some(provider_id.to_string()), None))?;
-    let elapsed_ms = started.elapsed().as_millis();
-    if supervised.termination != crate::engine::command::SupervisedCommandTermination::Completed {
-        let mut error = Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured safety/identity budget: {} ms)", timeout.as_millis()), Some(provider_id.to_string()), None);
+    let supervised = run_bounded_provider_lookup_command(
+        provider_id,
+        command,
+        operation,
+        timeout,
+        output_limit,
+    )?;
+    let elapsed_ms = supervised.elapsed_ms;
+    let output = supervised.output;
+    if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
+        let cancelled =
+            output.termination == crate::engine::command::SupervisedCommandTermination::Cancelled;
+        let outcome = if cancelled { "cancelled" } else { "timed out" };
+        let mut error = Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command {outcome} after {elapsed_ms} ms (configured safety/identity budget: {} ms)", timeout.as_millis()), Some(provider_id.to_string()), None);
         error.retryable = Some(true);
         // Preserve the established deferred-Cook contract so split resolver
         // timeouts create the same durable lookup_pending state as legacy ones.
-        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_lookup"] =
+            Value::String(if cancelled { "cancelled" } else { "timed_out" }.to_string());
         error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
         error.details["worktree_provider_operation"] = Value::String(operation.to_string());
         error.details["worktree_provider_split_operation"] = Value::String(operation.to_string());
-        error.details["worktree_provider_split"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_split"] =
+            Value::String(if cancelled { "cancelled" } else { "timed_out" }.to_string());
         error.details["latency_ms"] = Value::from(elapsed_ms as u64);
         error.details["budget_ms"] = Value::from(timeout.as_millis() as u64);
+        annotate_provider_lookup_error(
+            &mut error,
+            provider_id,
+            command,
+            operation,
+            if cancelled { "cancelled" } else { "timeout" },
+        );
         return Err(error);
     }
-    let output = supervised.output;
+    let output = output.output;
     if output.capture.stdout.truncated {
-        return Err(Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes"), Some(provider_id.to_string()), None));
+        return Err(provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "malformed",
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes"),
+            false,
+        ));
     }
     let output = output.into_output();
     if !output.status.success() {
-        return Err(Error::validation_invalid_argument_with_evidence(
+        let mut error = Error::validation_invalid_argument_with_evidence(
             "to_worktree",
             format!("worktree provider `{provider_id}` {operation} command failed"),
             Some(provider_id.to_string()),
             None,
             Some(provider_command_evidence(command, &output)),
-        ));
+        );
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
+        return Err(error);
     }
-    let payload = serde_json::from_slice(&output.stdout).map_err(|error| Error::validation_invalid_argument("to_worktree", format!("worktree provider `{provider_id}` {operation} command returned invalid JSON: {error}"), Some(provider_id.to_string()), None))?;
+    let payload = serde_json::from_slice(&output.stdout).map_err(|error| {
+        provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "malformed",
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command returned invalid JSON: {error}"),
+            false,
+        )
+    })?;
     Ok((payload, elapsed_ms, timeout.as_millis()))
 }
 
@@ -1783,7 +1899,7 @@ fn retry_resolve_path_timeouts(
                     "observed_total_elapsed_ms": u64::try_from(started.elapsed().as_millis())
                         .unwrap_or(u64::MAX),
                     "attempts": timed_out_attempts,
-                    "replay_command": crate::redaction::redact_argv_shell_display(&command),
+                    "replay_command": crate::redaction::redact_argv_shell_display(command),
                 });
                 return Err(error);
             }
@@ -1835,58 +1951,23 @@ fn run_provider_lookup_command(
 ) -> Result<Vec<WorktreeProviderHandle>> {
     let timeout = provider_lookup_timeout(provider)?;
     let output_limit = provider_lookup_output_limit(provider)?;
-    let (program, args) = command
-        .split_first()
-        .filter(|(program, _)| !program.trim().is_empty())
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                format!("worktree_providers.commands.{operation}"),
-                format!(
-                    "worktree provider `{provider_id}` {operation} command must include an executable"
-                ),
-                Some(provider_id.to_string()),
-                None,
-            )
-        })?;
-    let mut process = Command::new(program);
-    process
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    crate::engine::command::isolate_process_tree(&mut process);
-    let mut child = process.spawn().map_err(|error| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            format!(
-                "worktree provider `{provider_id}` {operation} command could not start: {error}"
-            ),
-            Some(provider_id.to_string()),
-            None,
-        )
-    })?;
-    let started = std::time::Instant::now();
-    let output = crate::engine::command::wait_with_bounded_output_supervised(
-        &mut child,
-        output_limit,
+    let supervised = run_bounded_provider_lookup_command(
+        provider_id,
+        command,
+        operation,
         timeout,
-        PROVIDER_LOOKUP_HEARTBEAT,
-        || false,
-        |_, _| Ok(()),
-    )
-    .map_err(|error| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            format!("worktree provider `{provider_id}` {operation} command could not be supervised: {error}"),
-            Some(provider_id.to_string()),
-            None,
-        )
-    })?;
-    let elapsed_ms = started.elapsed().as_millis();
+        output_limit,
+    )?;
+    let elapsed_ms = supervised.elapsed_ms;
+    let output = supervised.output;
     if output.termination != crate::engine::command::SupervisedCommandTermination::Completed {
+        let cancelled =
+            output.termination == crate::engine::command::SupervisedCommandTermination::Cancelled;
+        let outcome = if cancelled { "cancelled" } else { "timed out" };
         let mut error = Error::validation_invalid_argument(
             "to_worktree",
             format!(
-                "worktree provider `{provider_id}` {operation} command timed out after {elapsed_ms} ms (configured lookup_timeout_ms: {})",
+                "worktree provider `{provider_id}` {operation} command {outcome} after {elapsed_ms} ms (configured lookup_timeout_ms: {})",
                 timeout.as_millis()
             ),
             Some(provider_id.to_string()),
@@ -1899,17 +1980,32 @@ fn run_provider_lookup_command(
         // invalid. Preserve that distinction for durable callers instead of
         // turning provider latency into an input error.
         error.retryable = Some(true);
-        error.details["worktree_provider_lookup"] = Value::String("timed_out".to_string());
+        error.details["worktree_provider_lookup"] =
+            Value::String(if cancelled { "cancelled" } else { "timed_out" }.to_string());
         error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
         error.details["worktree_provider_operation"] = Value::String(operation.to_string());
         error.details["lookup_timeout_ms"] = Value::from(timeout.as_millis() as u64);
         error.details["latency_ms"] = Value::from(elapsed_ms as u64);
-        error.details["provider_lookup_timeout_kind"] = Value::String("supervision".to_string());
+        error.details["provider_lookup_timeout_kind"] = Value::String(
+            if cancelled {
+                "cancellation"
+            } else {
+                "supervision"
+            }
+            .to_string(),
+        );
+        annotate_provider_lookup_error(
+            &mut error,
+            provider_id,
+            command,
+            operation,
+            if cancelled { "cancelled" } else { "timeout" },
+        );
         return Err(error);
     }
     let output = output.output;
     if output.capture.stdout.truncated {
-        return Err(Error::validation_invalid_argument(
+        let mut error = Error::validation_invalid_argument(
             "to_worktree",
             format!(
                 "worktree provider `{provider_id}` {operation} command output exceeded configured lookup_output_limit_bytes: {output_limit} (received {} bytes)",
@@ -1919,7 +2015,9 @@ fn run_provider_lookup_command(
             Some(vec![
                 "Increase the provider lookup_output_limit_bytes within its configured bound, then retry the operation.".to_string(),
             ]),
-        ));
+        );
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "malformed");
+        return Err(error);
     }
     let output = output.into_output();
     if !output.status.success() {
@@ -1930,7 +2028,7 @@ fn run_provider_lookup_command(
         {
             return Ok(Vec::new());
         }
-        return Err(Error::validation_invalid_argument_with_evidence(
+        let mut error = Error::validation_invalid_argument_with_evidence(
             "to_worktree",
             format!(
                 "worktree provider `{provider_id}` {operation} command failed with {}",
@@ -1943,16 +2041,19 @@ fn run_provider_lookup_command(
             Some(provider_id.to_string()),
             None,
             Some(provider_command_evidence(command, &output)),
-        ));
+        );
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
+        return Err(error);
     }
     let value: Value = serde_json::from_slice(&output.stdout).map_err(|error| {
-        Error::validation_invalid_argument(
+        provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "malformed",
             "to_worktree",
-            format!(
-                "worktree provider `{provider_id}` {operation} command returned invalid JSON: {error}"
-            ),
-            Some(provider_id.to_string()),
-            None,
+            format!("worktree provider `{provider_id}` {operation} command returned invalid JSON: {error}"),
+            false,
         )
     })?;
     if let Some(attribution) = provider_failed_lookup_timeout_attribution(&value) {
@@ -1975,6 +2076,7 @@ fn run_provider_lookup_command(
         // Persist only this fixed, redacted timeout classification.
         error.details["provider_timeout_attribution"] =
             serde_json::to_value(attribution).expect("fixed timeout attribution serializes");
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "timeout");
         return Err(error);
     }
     let mapping = provider.list_result_mapping.as_ref().ok_or_else(|| {
@@ -1987,7 +2089,10 @@ fn run_provider_lookup_command(
             None,
         )
     })?;
-    map_provider_list_result(provider_id, mapping, &value)
+    map_provider_list_result(provider_id, mapping, &value).map_err(|mut error| {
+        annotate_provider_lookup_error(&mut error, provider_id, command, operation, "malformed");
+        error
+    })
 }
 
 #[derive(Serialize)]
@@ -2026,6 +2131,19 @@ fn provider_lookup_timeout(provider: &WorktreeProviderConfig) -> Result<Duration
     Ok(Duration::from_millis(provider.lookup_timeout_ms))
 }
 
+fn provider_mutation_timeout(provider: &WorktreeProviderConfig) -> Result<Duration> {
+    defaults::validate_worktree_provider_mutation_timeout_ms(provider.mutation_timeout_ms)
+        .map_err(|message| {
+            Error::validation_invalid_argument(
+                "worktree_providers.mutation_timeout_ms",
+                message,
+                Some(provider.mutation_timeout_ms.to_string()),
+                None,
+            )
+        })?;
+    Ok(Duration::from_millis(provider.mutation_timeout_ms))
+}
+
 fn provider_lookup_output_limit(provider: &WorktreeProviderConfig) -> Result<usize> {
     defaults::validate_worktree_provider_lookup_output_limit_bytes(
         provider.lookup_output_limit_bytes,
@@ -2041,16 +2159,130 @@ fn provider_lookup_output_limit(provider: &WorktreeProviderConfig) -> Result<usi
     Ok(provider.lookup_output_limit_bytes)
 }
 
+struct BoundedProviderLookupCommand {
+    output: crate::engine::command::SupervisedCommandOutput,
+    elapsed_ms: u128,
+}
+
+/// Run one provider command in its own process group with its operation-specific
+/// configured bound. This prevents an external provider from leaving Cook
+/// waiting silently or retaining descendants on timeout.
+fn run_bounded_provider_lookup_command(
+    provider_id: &str,
+    command: &[String],
+    operation: &str,
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<BoundedProviderLookupCommand> {
+    let (program, args) = command
+        .split_first()
+        .filter(|(program, _)| !program.trim().is_empty())
+        .ok_or_else(|| {
+            provider_lookup_error(
+                provider_id,
+                command,
+                operation,
+                "command",
+                &format!("worktree_providers.commands.{operation}"),
+                format!("worktree provider `{provider_id}` {operation} command must include an executable"),
+                false,
+            )
+        })?;
+    let mut process = Command::new(program);
+    process
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::engine::command::isolate_process_tree(&mut process);
+    let mut child = process.spawn().map_err(|error| {
+        provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "command",
+            "to_worktree",
+            format!(
+                "worktree provider `{provider_id}` {operation} command could not start: {error}"
+            ),
+            false,
+        )
+    })?;
+    let started = std::time::Instant::now();
+    let output = crate::engine::command::wait_with_bounded_output_supervised(
+        &mut child,
+        output_limit,
+        timeout,
+        PROVIDER_LOOKUP_HEARTBEAT,
+        || {
+            PROVIDER_COMMAND_CONTROL.with(|active| {
+                active
+                    .borrow()
+                    .as_ref()
+                    .is_some_and(WorktreeProviderCommandControl::is_cancelled)
+            })
+        },
+        |_, _| Ok(()),
+    )
+    .map_err(|error| {
+        provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "command",
+            "to_worktree",
+            format!("worktree provider `{provider_id}` {operation} command could not be supervised: {error}"),
+            false,
+        )
+    })?;
+    Ok(BoundedProviderLookupCommand {
+        output,
+        elapsed_ms: started.elapsed().as_millis(),
+    })
+}
+
+fn provider_lookup_error(
+    provider_id: &str,
+    command: &[String],
+    operation: &str,
+    classification: &str,
+    field: &str,
+    message: String,
+    retryable: bool,
+) -> Error {
+    let mut error =
+        Error::validation_invalid_argument(field, message, Some(provider_id.to_string()), None);
+    error.retryable = retryable.then_some(true);
+    annotate_provider_lookup_error(&mut error, provider_id, command, operation, classification);
+    error
+}
+
+fn annotate_provider_lookup_error(
+    error: &mut Error,
+    provider_id: &str,
+    command: &[String],
+    operation: &str,
+    classification: &str,
+) {
+    error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+    error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+    error.details["worktree_provider_call_classification"] =
+        Value::String(classification.to_string());
+    error.details["worktree_provider_phase"] =
+        Value::String(format!("worktree_provider_{operation}"));
+    error.details["worktree_provider_replay_command"] =
+        Value::String(crate::redaction::redact_argv_shell_display(command));
+}
+
 fn provider_command_evidence(command: &[String], output: &std::process::Output) -> CommandEvidence {
     let (stdout, stdout_truncated) = bounded_provider_output(&output.stdout);
     let (stderr, stderr_truncated) = bounded_provider_output(&output.stderr);
     CommandEvidence {
-        command: command.join(" "),
+        command: crate::redaction::redact_argv_shell_display(command),
         cwd: None,
         location: Some("local".to_string()),
         exit_code: output.status.code().unwrap_or(-1),
-        stdout,
-        stderr,
+        stdout: crate::redaction::redact_string(&stdout),
+        stderr: crate::redaction::redact_string(&stderr),
         truncated: stdout_truncated || stderr_truncated,
     }
 }
@@ -3194,6 +3426,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec!["false".to_string()]),
@@ -3285,6 +3518,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![
@@ -3432,6 +3666,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 ensure: Some(vec![fake_provider_script_body(&format!(
@@ -3497,6 +3732,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![script.display().to_string(), "resolve".to_string()]),
@@ -3572,6 +3808,7 @@ mod tests {
                 apply_enabled: true,
                 commands: WorktreeProviderCommands::default(),
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 list_result_mapping: None,
             },
@@ -3830,6 +4067,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -3921,6 +4159,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -4015,6 +4254,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -4028,7 +4268,7 @@ mod tests {
                 list_result_mapping: Some(worktrees_mapping()),
             },
         );
-        for handle in ["auth", "malformed"] {
+        for (handle, classification) in [("auth", "command"), ("malformed", "malformed")] {
             let error = provision_apply_enabled_worktree_provider_from_config(
                 &WorktreeProviderCreateIntent {
                     handle: handle.to_string(),
@@ -4041,6 +4281,15 @@ mod tests {
             )
             .expect_err("lookup failure is not absence");
             assert!(error.message.contains("provider `fixture` resolve command"));
+            assert_eq!(
+                error.details["worktree_provider_call_classification"],
+                classification
+            );
+            assert_eq!(error.details["worktree_provider_id"], "fixture");
+            assert!(error.details["worktree_provider_replay_command"]
+                .as_str()
+                .expect("replay command")
+                .contains(script.to_string_lossy().as_ref()));
         }
         assert!(
             !ensured.exists(),
@@ -4063,6 +4312,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_preview: Some(vec![script, "preview".to_string()]),
@@ -4207,6 +4457,7 @@ mod tests {
                     kind: WorktreeProviderKind::Command,
                     apply_enabled: false,
                     lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
                     lookup_output_limit_bytes: 64 * 1024,
                     commands: WorktreeProviderCommands {
                         cleanup_preview: Some(vec![script]),
@@ -4238,6 +4489,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 cleanup_preview_timeout_ms: 25,
@@ -4289,6 +4541,7 @@ mod tests {
                     kind: WorktreeProviderKind::Command,
                     apply_enabled: false,
                     lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
                     lookup_output_limit_bytes: 64 * 1024,
                     commands: WorktreeProviderCommands {
                         cleanup_preview: Some(vec![script]),
@@ -4323,6 +4576,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 cleanup_preview: Some(vec![script]),
@@ -4388,6 +4642,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),
@@ -4422,6 +4677,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script, "apply".to_string()]),
@@ -4459,6 +4715,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![script, "{handle}".to_string()]),
@@ -4491,6 +4748,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
@@ -4523,6 +4781,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
@@ -4557,6 +4816,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve_path: Some(vec![script, "{path}".to_string()]),
@@ -4585,6 +4845,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve_path: Some(vec![
@@ -4633,6 +4894,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve_path: Some(vec![script, "{path}".to_string()]),
@@ -4656,6 +4918,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 25,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands::default(),
             list_result_mapping: Some(worktrees_mapping()),
@@ -4699,6 +4962,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 4_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve_path: Some(vec![script, "{path}".to_string()]),
@@ -4725,6 +4989,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 25,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands::default(),
             list_result_mapping: Some(worktrees_mapping()),
@@ -4776,6 +5041,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 25,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script.to_string_lossy().to_string()]),
@@ -4791,6 +5057,14 @@ mod tests {
         assert_eq!(error.retryable, Some(true));
         assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
         assert_eq!(error.details["worktree_provider_operation"], "list");
+        assert_eq!(
+            error.details["worktree_provider_call_classification"],
+            "timeout"
+        );
+        assert!(error.details["worktree_provider_replay_command"]
+            .as_str()
+            .expect("replay command")
+            .contains(script.to_string_lossy().as_ref()));
     }
 
     #[test]
@@ -4809,9 +5083,14 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
-                    resolve: Some(vec![script, "{handle}".to_string()]),
+                    resolve: Some(vec![
+                        script,
+                        "{handle}".to_string(),
+                        "token=secret".to_string(),
+                    ]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(worktrees_mapping()),
@@ -4823,6 +5102,18 @@ mod tests {
         assert_eq!(error.details["worktree_provider_lookup"], "timed_out");
         assert_eq!(error.details["worktree_provider_operation"], "resolve");
         assert_eq!(
+            error.details["worktree_provider_call_classification"],
+            "timeout"
+        );
+        assert_eq!(
+            error.details["worktree_provider_phase"],
+            "worktree_provider_resolve"
+        );
+        assert!(error.details["worktree_provider_replay_command"]
+            .as_str()
+            .expect("replay command")
+            .contains("[REDACTED]"));
+        assert_eq!(
             error.details["provider_timeout_attribution"],
             json!({ "error_code": "git_command_timeout" })
         );
@@ -4832,6 +5123,162 @@ mod tests {
             .contains("provider-secret-must-not-persist"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn ensure_uses_the_configured_provider_bound_and_typed_evidence() {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(&script, "#!/bin/sh\nsleep 1\n").expect("write provider");
+        make_executable(&script);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 1,
+            mutation_timeout_ms: 25,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands::default(),
+            list_result_mapping: None,
+        };
+
+        let error = run_provider_ensure_command(
+            "fixture",
+            &provider,
+            &[
+                script.to_string_lossy().to_string(),
+                "token=secret".to_string(),
+            ],
+        )
+        .expect_err("ensure is supervised by the configured provider budget");
+
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(error.details["worktree_provider_operation"], "ensure");
+        assert_eq!(
+            error.details["worktree_provider_call_classification"],
+            "timeout"
+        );
+        assert_eq!(
+            error.details["worktree_provider_phase"],
+            "worktree_provider_ensure"
+        );
+        assert!(error.details["worktree_provider_replay_command"]
+            .as_str()
+            .expect("replay command")
+            .contains("[REDACTED]"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_mutation_evidence_redacts_command_and_output_secrets() {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'stdout_token=provider-secret-must-not-persist\\n'\nprintf 'stderr_token=provider-secret-must-not-persist\\n' >&2\nexit 1\n",
+        )
+        .expect("write provider");
+        make_executable(&script);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands::default(),
+            list_result_mapping: None,
+        };
+
+        let error = run_provider_mutation_command(
+            "fixture",
+            &provider,
+            &[
+                script.to_string_lossy().to_string(),
+                "token=provider-secret-must-not-persist".to_string(),
+            ],
+            "finalize",
+        )
+        .expect_err("failed provider mutation returns evidence");
+
+        assert_eq!(error.details["worktree_provider_operation"], "finalize");
+        assert_eq!(
+            error.details["worktree_provider_phase"],
+            "worktree_provider_finalize"
+        );
+        assert!(error.details["command_evidence"]["command"]
+            .as_str()
+            .expect("command evidence")
+            .contains("[REDACTED]"));
+        assert!(!error
+            .details
+            .to_string()
+            .contains("provider-secret-must-not-persist"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn malformed_split_provider_results_have_typed_redacted_replay_evidence() {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(&script, "#!/bin/sh\nprintf '%s\\n' '{\"schema\":false}'\n")
+            .expect("write provider");
+        make_executable(&script);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands::default(),
+            list_result_mapping: None,
+        };
+
+        for (operation, result) in [
+            (
+                "resolve_identity",
+                run_provider_identity_command(
+                    "fixture",
+                    &provider,
+                    &[
+                        script.to_string_lossy().to_string(),
+                        "token=provider-secret-must-not-persist".to_string(),
+                    ],
+                    "fixture@target",
+                )
+                .map(|_| ()),
+            ),
+            (
+                "attest_safety",
+                run_provider_safety_command(
+                    "fixture",
+                    &provider,
+                    &[
+                        script.to_string_lossy().to_string(),
+                        "token=provider-secret-must-not-persist".to_string(),
+                    ],
+                    "provider-secret-must-not-persist",
+                )
+                .map(|_| ()),
+            ),
+        ] {
+            let error = result.expect_err("malformed split response is rejected");
+            assert_eq!(error.details["worktree_provider_operation"], operation);
+            assert_eq!(
+                error.details["worktree_provider_call_classification"],
+                "malformed"
+            );
+            assert!(error.details["worktree_provider_replay_command"]
+                .as_str()
+                .expect("replay command")
+                .contains("[REDACTED]"));
+            assert!(!error
+                .details
+                .to_string()
+                .contains("provider-secret-must-not-persist"));
+        }
+    }
+
     #[test]
     fn path_resolution_does_not_retry_a_provider_reported_timeout() {
         let provider = WorktreeProviderConfig {
@@ -4839,6 +5286,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 25,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands::default(),
             list_result_mapping: Some(worktrees_mapping()),
@@ -4888,6 +5336,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![script, "{handle}".to_string()]),
@@ -4914,6 +5363,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 5_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![script, "{handle}".to_string()]),
@@ -4948,6 +5398,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 128 * 1024,
             commands: WorktreeProviderCommands {
                 resolve: Some(vec![script, "{handle}".to_string()]),
@@ -5001,6 +5452,7 @@ mod tests {
                     kind: WorktreeProviderKind::Command,
                     apply_enabled: false,
                     lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
                     lookup_output_limit_bytes: 64 * 1024,
                     commands: WorktreeProviderCommands::default(),
                     list_result_mapping: None,
@@ -5043,6 +5495,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![resolve, "{handle}".to_string()]),
@@ -5094,6 +5547,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![script, "{handle}".to_string()]),
@@ -5135,6 +5589,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: false,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     list: Some(vec![script]),
@@ -5295,6 +5750,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     resolve: Some(vec![
@@ -5680,6 +6136,7 @@ mod tests {
                 kind: WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: WorktreeProviderCommands {
                     cleanup_apply: Some(vec![script]),
@@ -5877,6 +6334,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: true,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands::default(),
             list_result_mapping: None,
@@ -5905,6 +6363,7 @@ mod tests {
             kind: WorktreeProviderKind::Command,
             apply_enabled: false,
             lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
             lookup_output_limit_bytes: 64 * 1024,
             commands: WorktreeProviderCommands {
                 list: Some(vec![script]),

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -122,6 +122,7 @@ mod lab_source_path_tests {
                     kind: defaults::WorktreeProviderKind::Command,
                     apply_enabled: false,
                     lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
                     lookup_output_limit_bytes: 64 * 1024,
                     commands: defaults::WorktreeProviderCommands {
                         list: Some(vec![script.display().to_string()]),

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -714,6 +714,7 @@ mod tests {
                         ..Default::default()
                     },
                     lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
                     lookup_output_limit_bytes: 64 * 1024,
                     list_result_mapping: Some(
                         homeboy_core::defaults::WorktreeProviderListResultMapping {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,7 +33,23 @@ the higher-level system model and core/extension boundary, see
 - `triage` — Triage priority-label configuration.
 - `agent_task` — Default backend, secret sources, provider rotation policy, and optional independently signed acceptance verification for agent-task dispatch. `acceptance_verifier` uses controller-owned `trust: { kind: hmac_sha256, key_id, key_env }`; Homeboy removes `key_env` from the verifier subprocess, verifies its base64 HMAC-SHA-256 over the canonical verdict binding, and stores the signature plus key ID with the durable run record.
 - `notifications` — Notification delivery policy for route-less completed operations.
-- `worktree_providers` — External worktree lifecycle providers keyed by provider ID. `lookup_timeout_ms` bounds read-only `list` and `resolve` commands. `resolve_path` gets one immediate retry after a supervised timeout, for a maximum of two attempts; all other completed and failed lookup outcomes retain their normal semantics. `commands.cleanup_preview_timeout_ms` and `commands.cleanup_apply_timeout_ms` independently bound cleanup preview and apply commands (each defaults to 30,000 milliseconds). A command provider that sets `commands.list` must also set `list_result_mapping`: JSONPath selectors for `items`, `handle`, `path`, `branch`, `dirty`, `unpushed`, and `primary`. `items` must resolve to one array; each item selector must resolve to exactly one value of its required type (strings for handle/path/branch, booleans for safety values). Homeboy does not infer response envelopes or safety values. Purpose-owned callers require `enabled`, `apply_enabled`, `commands.ensure`, and `settings.worktree_provider_lifecycle.<provider-id>.finalize`. They can use argv-only `commands.ensure` placeholders `{purpose}`, `{owner_run_ref}`, and `{cleanup_policy}`; the lifecycle finalizer expands `{handle}`, `{purpose}`, `{owner_run_ref}`, `{cleanup_policy}`, `{disposition}`, and stable `{idempotency_key}`. Providers must deduplicate finalization effects by that key because a stale lease may retry the invocation; this is not process-level exactly-once fencing.
+- `worktree_providers` — External worktree lifecycle providers keyed by provider ID. `lookup_timeout_ms` bounds read-only `list`, `resolve`, exact-identity, and safety commands (default: 10,000 milliseconds). `mutation_timeout_ms` bounds `ensure` and lifecycle finalization commands (default: 30,000 milliseconds; maximum: 900,000 milliseconds). `resolve_path` gets one immediate retry after a supervised timeout, for a maximum of two attempts; all other completed and failed lookup outcomes retain their normal semantics. `commands.cleanup_preview_timeout_ms` and `commands.cleanup_apply_timeout_ms` independently bound cleanup preview and apply commands (each defaults to 30,000 milliseconds). A command provider that sets `commands.list` must also set `list_result_mapping`: JSONPath selectors for `items`, `handle`, `path`, `branch`, `dirty`, `unpushed`, and `primary`. `items` must resolve to one array; each item selector must resolve to exactly one value of its required type (strings for handle/path/branch, booleans for safety values). Homeboy does not infer response envelopes or safety values. Purpose-owned callers require `enabled`, `apply_enabled`, `commands.ensure`, and `settings.worktree_provider_lifecycle.<provider-id>.finalize`. They can use argv-only `commands.ensure` placeholders `{purpose}`, `{owner_run_ref}`, and `{cleanup_policy}`; the lifecycle finalizer expands `{handle}`, `{purpose}`, `{owner_run_ref}`, `{cleanup_policy}`, `{disposition}`, and stable `{idempotency_key}`. Providers must deduplicate finalization effects by that key because a stale lease may retry the invocation; this is not process-level exactly-once fencing.
+
+Example provider with a nine-minute ensure/finalize budget while retaining short lookups:
+
+```json
+{
+  "worktree_providers": {
+    "workspace-service": {
+      "lookup_timeout_ms": 10000,
+      "mutation_timeout_ms": 540000,
+      "commands": {
+        "ensure": ["workspace-service", "ensure", "{handle}"]
+      }
+    }
+  }
+}
+```
 - `github_hosts` — Host-scoped environment for `gh` subprocesses, keyed by GitHub hostname. Component-level `github.hosts` entries override these global defaults.
 - `settings` — Generic extension and executor settings, addressed through `/settings/...`.
 - `release_gate` — Routing safety policy for release-gate hot commands.


### PR DESCRIPTION
## Summary
- defer exact-handle lookup until durable Cook admission and resume the same Cook on retry
- supervise provider lookup and mutation operations with typed phases, heartbeats, cancellation, bounded output, and redacted replay evidence
- add compatible operation-specific lookup and mutation budgets, including nine-minute provider mutations

## Verification
- `cargo test -p homeboy-core worktree_provider --lib` (64 passed)
- `cargo test -p homeboy-agents review_12349 --lib`
- `cargo test -p homeboy-cli cook_defers_ --lib`
- `cargo check --workspace`
- `cargo fmt --check`

Closes #12349

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented, reviewed, rebased, and verified the provider boundary. Chris Huber directed the work and remains responsible for every line.