### PR TITLE
fix(test): restore provider fixture compilation

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -1277,6 +1277,7 @@ fn cook_cwd_matching_external_handle_never_invokes_a_sleeping_resolver() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
@@ -1382,6 +1383,7 @@ fn cook_cwd_rejects_a_mismatched_external_provider_handle_before_dispatch() {
                 kind: homeboy::core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
                 lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy::core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),


### PR DESCRIPTION
## Summary

- restore clean `homeboy-cli` test compilation after the worktree-provider mutation timeout became required
- give both resolver-focused fixtures the standard 30-second mutation timeout while preserving their 10-second lookup timeout

Fixes #12425.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib commands::agent_task::tests::dispatch::cook_cwd_matching_external_handle_never_invokes_a_sleeping_resolver`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the clean-worktree compiler failure, traced it to the #12349 aggregate change, implemented the fixture repair, and ran focused verification. Chris Huber reviewed and owns every line.
