### PR TITLE
fix: assert the status label the summary actually renders

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -5887,7 +5887,17 @@ mod tests {
             "homeboy agent-task review agent-task-durable-patch"
         );
         assert_eq!(full["liveness"], compact["liveness"]);
-        assert!(full_rendered.contains("Subject state: succeeded"));
+        // The summary labels the SUBJECT's lifecycle state as `Status:`, which is
+        // the contract `status_summary_labels_the_subject_lifecycle_state` pins
+        // by rendering every state including `failed`. There is no
+        // `Subject state:` line and there never was -- that label appears
+        // nowhere in the renderer, so this assertion could not pass on any
+        // revision. `subject_state` is the JSON envelope field added by
+        // bbc90c2b7; the human summary carries the same value under `Status:`.
+        assert!(
+            full_rendered.contains("Status: succeeded"),
+            "{full_rendered}"
+        );
         assert!(full_rendered.contains("Patch candidates: 1 non-empty / 0 empty"));
         assert!(full_rendered.contains("Changed files: 7"));
         assert!(!full_rendered.contains("no_patch_produced"));
@@ -5923,7 +5933,12 @@ mod tests {
         assert_eq!(status["execution_states"]["gate"]["state"], "failed");
         assert_eq!(status["cook"]["publication"], "blocked");
         assert_eq!(subject_exit_code(&status, true), 1);
-        assert!(rendered.contains("Subject state: gate_failed"));
+        // `Status:` is the subject's lifecycle state, not the status query's
+        // outcome -- see the note in
+        // `default_status_projects_durable_patch_candidate_for_rendering_and_actions`.
+        // A terminal gate failure must surface here even though the provider
+        // succeeded, which is the whole point of this test.
+        assert!(rendered.contains("Status: gate_failed"), "{rendered}");
         assert!(rendered.contains("Candidate state: promoted_gate_failed"));
         assert!(rendered.contains("Cook: gate_failed (publication blocked)"));
         assert!(rendered.contains("Next: homeboy agent-task diagnose cook-attempt-1 --full"));


### PR DESCRIPTION
Refs #12377. `commands::agent_task`: **443 passed / 2 failed → 445 passed, 0 failed.**

With the leakage in that module fixed by #12388, two genuine defects became visible underneath it. This is both of them.

## What was wrong

```
assertion failed: full_rendered.contains("Subject state: succeeded")
```

`Subject state:` appears **nowhere in the renderer** — a tree-wide grep finds it only in these two assertions. Neither could have passed on any revision. Both were merged red, and until now the surrounding leakage made that invisible.

## What the summary actually renders

```
Agent task status              Agent task status
Status: succeeded              Status: gate_failed
Run: agent-task-durable-patch  Run: cook-attempt-1
```

The subject's lifecycle state is labelled `Status:`. That is already the pinned contract — `status_summary_labels_the_subject_lifecycle_state` renders every state, **including `failed`**, and asserts `Status: {state}`. So the line is definitively the *subject's* state, not the status query's outcome, which is exactly the property these two tests exist to check.

`subject_state` is the JSON envelope field added by `bbc90c2b7` when query and subject status were separated (`commands/utils/response.rs:32`). The human summary carries the same value under `Status:`. The tests were written against a label that was planned but never landed.

## The fix

Assert the rendered label, and print the summary on failure so the next mismatch names itself instead of being a bare `assertion failed: contains(...)`.

The intent of each test is preserved exactly:

- `default_status_projects_durable_patch_candidate_for_rendering_and_actions` still proves a durable patch candidate renders as succeeded
- `terminal_cook_gate_failure_overrides_successful_provider_status` still proves a terminal gate failure surfaces even though the provider succeeded

## Why not rename the label instead

Renaming `Status:` to `Subject state:` would be a product change to operator-facing output, and it would contradict `status_summary_labels_the_subject_lifecycle_state`, which pins the current label deliberately. If the rename is wanted it belongs in its own change with that test updated alongside — not smuggled in under a red-test fix.

## Verification

- `cargo test -p homeboy-cli --lib commands::agent_task::status::tests` — 38 passed, 0 failed
- `cargo test -p homeboy-cli --lib commands::agent_task` — **445 passed, 0 failed**
- `cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean

## AI assistance

Claude (chubes-bot) diagnosed and wrote the fix. Chris Huber remains responsible for the change.
