### PR TITLE
fix(runner): bound connect failure evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "glob",
  "glob-match",
  "homeboy-agents",
+ "homeboy-artifact-ref-contract",
  "homeboy-core",
  "homeboy-engine-primitives",
  "homeboy-extension",

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -885,6 +885,38 @@ impl ObservationStore {
             .map_err(sqlite_error("commit terminal run retention"))
     }
 
+    /// Discard a run whose observation could not be completed. Terminal runs
+    /// are deliberately preserved for retention instead.
+    pub fn discard_running_run(&self, run_id: &str) -> Result<bool> {
+        validate_required("run_id", run_id)?;
+        let tx = self
+            .connection
+            .unchecked_transaction()
+            .map_err(sqlite_error("begin running run rollback"))?;
+        let running: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1 AND status = 'running')",
+                [run_id],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_error("read running run rollback eligibility"))?;
+        if !running {
+            return Ok(false);
+        }
+        for table in RUN_OWNED_CHILD_TABLES {
+            tx.execute(&format!("DELETE FROM {table} WHERE run_id = ?1"), [run_id])
+                .map_err(sqlite_error(format!("delete running run {table}")))?;
+        }
+        tx.execute(
+            "DELETE FROM runs WHERE id = ?1 AND status = 'running'",
+            [run_id],
+        )
+        .map_err(sqlite_error("delete running run"))?;
+        tx.commit()
+            .map_err(sqlite_error("commit running run rollback"))?;
+        Ok(true)
+    }
+
     pub fn list_runs_started_since(&self, started_at: &str) -> Result<Vec<RunRecord>> {
         validate_required("started_at", started_at)?;
         let mut statement = self

--- a/crates/homeboy-lab-runner/Cargo.toml
+++ b/crates/homeboy-lab-runner/Cargo.toml
@@ -23,6 +23,7 @@ homeboy-agents = { version = "0.1.0", path = "../homeboy-agents" }
 homeboy-fuzz = { version = "0.1.0", path = "../homeboy-fuzz" }
 homeboy-product-identity = { version = "0.1.0", path = "../homeboy-product-identity" }
 homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-lab-runner-contract" }
+homeboy-artifact-ref-contract = { version = "0.1.0", path = "../contracts/homeboy-artifact-ref-contract" }
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "string"] }

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -1334,20 +1334,27 @@ fn connect_with_orphan_adoption_and_live_lease(
                     registry_lock_held: false,
                     daemon_recovery_capabilities,
                 })
-                .map_err(Error::internal_unexpected)
             },
-        )
-        .map_err(|error| error.message),
+        ),
     };
     let Ok(daemon) = daemon else {
+        let error = daemon.err().expect("failed daemon connection has an error");
+        let failure_evidence_ref = error
+            .details
+            .get("failure_evidence_ref")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok());
         let (mut report, exit_code) = failed_connect_after_recovery(
             runner_id,
             session_path,
             RunnerFailureKind::DaemonStartupFailure,
-            daemon.err().unwrap(),
+            error.message,
             leaseless_recovery,
             recovery_evidence,
         );
+        if let Some(evidence) = report.failure_evidence.as_mut() {
+            evidence.failure_evidence_ref = failure_evidence_ref;
+        }
         attach_state_loss_recovery(&mut report, state_loss_recovery);
         return Ok((report, exit_code));
     };

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -1,8 +1,12 @@
 use super::*;
 use crate::daemon_repair;
+use crate::session::RunnerConnectFailureEvidenceRef;
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRecoveryEvidence};
 use homeboy_lab_runner_contract::LabCapabilityVersion;
+use serde_json::json;
+use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -991,7 +995,24 @@ pub(super) struct RemoteDaemonEnsureRequest<'a> {
 
 pub(super) fn ensure_remote_daemon(
     request: RemoteDaemonEnsureRequest<'_>,
-) -> std::result::Result<RemoteDaemon, String> {
+) -> homeboy_core::Result<RemoteDaemon> {
+    ensure_remote_daemon_inner(request).map_err(|error| match error {
+        RemoteDaemonEnsureError::Other(message) => {
+            homeboy_core::Error::internal_unexpected(message)
+        }
+        RemoteDaemonEnsureError::EnsureRunning(failure) => {
+            let mut error = homeboy_core::Error::internal_unexpected(failure.message);
+            error.details = serde_json::to_value(&failure.evidence_ref)
+                .map(|reference| json!({ "failure_evidence_ref": reference }))
+                .unwrap_or(Value::Null);
+            error
+        }
+    })
+}
+
+fn ensure_remote_daemon_inner(
+    request: RemoteDaemonEnsureRequest<'_>,
+) -> std::result::Result<RemoteDaemon, RemoteDaemonEnsureError> {
     let RemoteDaemonEnsureRequest {
         client,
         homeboy,
@@ -1010,10 +1031,10 @@ pub(super) fn ensure_remote_daemon(
     probe_remote_daemon_endpoint(client, &mut status, Some(runner_id));
     if let Some(lease_id) = orphan_lease_id {
         if let Some(fence) = admission_fence {
-            return Err(format!(
+            return Err(RemoteDaemonEnsureError::Other(format!(
                 "runner `{runner_id}` generation `{}` has {} unresolved active job(s); refusing orphan adoption before terminal job evidence is available",
                 fence.generation, fence.active_job_count,
-            ));
+            )));
         }
         if status.stale_reason_code == Some(DaemonStaleReasonCode::PidDead)
             && status
@@ -1022,14 +1043,19 @@ pub(super) fn ensure_remote_daemon(
                 .and_then(|daemon| daemon.lease_id.as_deref())
                 == Some(lease_id)
         {
-            return remote_daemon_adopt_orphan(client, homeboy, lease_id, confirmed_no_pid_job_ids);
+            return Ok(remote_daemon_adopt_orphan(
+                client,
+                homeboy,
+                lease_id,
+                confirmed_no_pid_job_ids,
+            )?);
         }
     }
     if !confirmed_no_pid_job_ids.is_empty() {
-        return Err(
+        return Err(RemoteDaemonEnsureError::Other(
             "--confirm-untracked-child-dead applies only when the remote daemon reports the exact requested lease as PID-dead"
                 .to_string(),
-        );
+        ));
     }
     // The real runner id, not a `<runner-id>` placeholder: this report now
     // carries an executable repair plan, and a plan naming a command that does
@@ -1064,7 +1090,7 @@ pub(super) fn ensure_remote_daemon(
                 replacement_operation_id,
                 registry_lock_held,
             )?;
-            remote_daemon_ensure_running(client, homeboy, replacement_operation_id)
+            remote_daemon_ensure_running(client, homeboy, runner_id, replacement_operation_id)
         }
         RemoteDaemonConnectAction::ReplaceIdleStale
         | RemoteDaemonConnectAction::ReplaceUnhealthyExactOwner => {
@@ -1091,8 +1117,13 @@ pub(super) fn ensure_remote_daemon(
                 .expect("replacement requires lease");
             remote_daemon_force_stop(client, homeboy, lease_id)?;
             let replacement =
-                remote_daemon_ensure_running(client, homeboy, replacement_operation_id)?;
-            verify_remote_daemon_replacement(client, homeboy, &replacement, configured_identity)
+                remote_daemon_ensure_running(client, homeboy, runner_id, replacement_operation_id)?;
+            Ok(verify_remote_daemon_replacement(
+                client,
+                homeboy,
+                &replacement,
+                configured_identity,
+            )?)
         }
     }
 }
@@ -1844,18 +1875,19 @@ pub(super) fn remote_daemon_active_jobs(data: &Value) -> usize {
         .unwrap_or(0)
 }
 
-pub(super) fn remote_daemon_ensure_running(
+fn remote_daemon_ensure_running(
     client: &SshClient,
     homeboy: &str,
+    runner_id: &str,
     replacement_operation_id: Option<&str>,
-) -> std::result::Result<RemoteDaemon, String> {
+) -> std::result::Result<RemoteDaemon, RemoteDaemonEnsureError> {
     let command = remote_daemon_ensure_running_command(homeboy, replacement_operation_id);
     let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
     if !output.success {
-        return Err(command_failure_message(
+        return Err(RemoteDaemonEnsureError::Other(command_failure_message(
             "remote daemon ensure-running failed",
             &output,
-        ));
+        )));
     }
     let envelope = parse_envelope(&output.stdout).map_err(|err| {
         format!(
@@ -1864,9 +1896,14 @@ pub(super) fn remote_daemon_ensure_running(
         )
     })?;
     if !envelope.success {
-        return Err(format!(
-            "remote daemon ensure-running failed: {}",
-            envelope.error.unwrap_or(Value::Null)
+        return Err(RemoteDaemonEnsureError::EnsureRunning(
+            summarize_ensure_running_failure(
+                runner_id,
+                &command,
+                envelope.error.as_ref().unwrap_or(&Value::Null),
+                &output.stderr,
+                None,
+            ),
         ));
     }
     let data = envelope
@@ -1890,6 +1927,275 @@ pub(super) fn remote_daemon_ensure_running(
         build_identity: None,
         inspected_freshness: None,
     })
+}
+
+const ENSURE_RUNNING_FAILURE_SCHEMA_VERSION: u8 = 1;
+pub(super) const MAX_CANDIDATE_EXEMPLAR_BYTES: usize = 256;
+pub(super) const MAX_CANDIDATE_EXEMPLARS: usize = 3;
+const MAX_BLOCKER_BYTES: usize = 256;
+const MAX_NEXT_ACTION_BYTES: usize = 256;
+// Includes every bounded field and the durable evidence URI, so truncation
+// cannot remove the reference from a rendered failure envelope.
+pub(super) const MAX_ENSURE_RUNNING_FAILURE_MESSAGE_BYTES: usize = 1400;
+
+#[derive(Debug, Clone)]
+pub(super) struct EnsureRunningFailure {
+    pub(super) message: String,
+    pub(super) evidence_ref: Option<RunnerConnectFailureEvidenceRef>,
+}
+
+enum RemoteDaemonEnsureError {
+    Other(String),
+    EnsureRunning(EnsureRunningFailure),
+}
+
+impl From<String> for RemoteDaemonEnsureError {
+    fn from(message: String) -> Self {
+        Self::Other(message)
+    }
+}
+
+/// Keep control-plane output small while preserving the complete redacted
+/// remote envelope in the configured durable artifact root.
+pub(super) fn summarize_ensure_running_failure(
+    runner_id: &str,
+    command: &str,
+    error: &Value,
+    stderr: &str,
+    store: Option<&homeboy_core::observation::ObservationStore>,
+) -> EnsureRunningFailure {
+    let policy = homeboy_core::redaction::RedactionPolicy::default();
+    let error = policy.redact_json(error);
+    let details = error.get("details").unwrap_or(&Value::Null);
+    let classification = details
+        .get("classification")
+        .and_then(Value::as_str)
+        .or_else(|| error.get("code").and_then(Value::as_str))
+        .unwrap_or("remote_daemon_ensure_running_failure");
+    let candidates = details
+        .get("candidates")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let candidate_count = details
+        .get("candidate_count")
+        .and_then(Value::as_u64)
+        .and_then(|count| usize::try_from(count).ok())
+        .unwrap_or(candidates.len());
+    let blocker = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("remote daemon ensure-running returned an error");
+    let next_action = details
+        .get("safe_next_action")
+        .and_then(Value::as_str)
+        .or_else(|| error.get("hint").and_then(Value::as_str))
+        .unwrap_or("Retry the exact runner connect command after inspecting daemon status.");
+    let artifact_ref = store
+        .map(|store| {
+            persist_ensure_running_failure_evidence_in(store, runner_id, command, &error, stderr)
+        })
+        .unwrap_or_else(|| {
+            persist_ensure_running_failure_evidence(runner_id, command, &error, stderr)
+        })
+        .ok();
+    let candidates = bounded_candidate_exemplars(candidates);
+    let evidence = artifact_ref
+        .as_ref()
+        .map(|reference| reference.uri.as_str())
+        .unwrap_or("unavailable");
+    let message = format!(
+        "remote daemon ensure-running failed summary_v{} classification={} candidate_count={} blocker={} next_action={} candidates={} evidence_ref={}",
+        ENSURE_RUNNING_FAILURE_SCHEMA_VERSION,
+        truncate_utf8(classification, 96),
+        candidate_count,
+        truncate_utf8(blocker, MAX_BLOCKER_BYTES),
+        truncate_utf8(next_action, MAX_NEXT_ACTION_BYTES),
+        candidates, truncate_utf8(evidence, 256),
+    );
+    EnsureRunningFailure {
+        message: truncate_utf8(&message, MAX_ENSURE_RUNNING_FAILURE_MESSAGE_BYTES),
+        evidence_ref: artifact_ref,
+    }
+}
+
+pub(super) fn bounded_candidate_exemplars(candidates: &[Value]) -> String {
+    let mut seen = BTreeSet::new();
+    let mut exemplars = Vec::new();
+    let mut bytes = 0;
+    for candidate in candidates {
+        let rendered =
+            serde_json::to_string(candidate).unwrap_or_else(|_| "<unserializable>".to_string());
+        if !seen.insert(rendered.clone()) {
+            continue;
+        }
+        let separator = usize::from(!exemplars.is_empty());
+        if exemplars.len() == MAX_CANDIDATE_EXEMPLARS
+            || bytes + separator >= MAX_CANDIDATE_EXEMPLAR_BYTES - 2
+        {
+            break;
+        }
+        let available = MAX_CANDIDATE_EXEMPLAR_BYTES - 2 - bytes - separator;
+        let rendered = truncate_utf8(&rendered, available);
+        bytes += separator + rendered.len();
+        exemplars.push(rendered);
+    }
+    format!("[{}]", exemplars.join(","))
+}
+
+fn persist_ensure_running_failure_evidence(
+    runner_id: &str,
+    command: &str,
+    error: &Value,
+    stderr: &str,
+) -> homeboy_core::Result<RunnerConnectFailureEvidenceRef> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    persist_ensure_running_failure_evidence_in(&store, runner_id, command, error, stderr)
+}
+
+pub(super) fn persist_ensure_running_failure_evidence_in(
+    store: &homeboy_core::observation::ObservationStore,
+    runner_id: &str,
+    command: &str,
+    error: &Value,
+    stderr: &str,
+) -> homeboy_core::Result<RunnerConnectFailureEvidenceRef> {
+    let command = homeboy_core::redaction::redact_string(command);
+    let stderr = homeboy_core::redaction::redact_string(stderr);
+    let evidence = json!({
+        "schema_version": ENSURE_RUNNING_FAILURE_SCHEMA_VERSION,
+        "kind": "remote_daemon_ensure_running_failure",
+        "runner_id": runner_id,
+        "remote_command": command,
+        "remote_envelope": error,
+        "remote_stderr": stderr,
+    });
+    let file = tempfile::NamedTempFile::new().map_err(homeboy_core::Error::from)?;
+    serde_json::to_writer(file.as_file(), &evidence)?;
+    let run = store.start_run(
+        homeboy_core::observation::NewRunRecord::builder("runner_connect_failure")
+            .metadata(json!({
+                "runner_id": runner_id,
+                "controller_id": crate::connection::controller_id(),
+                "failure_kind": "remote_daemon_ensure_running",
+            }))
+            .build(),
+    )?;
+    let artifact = match store.record_artifact_with_metadata(
+        &run.id,
+        "remote_daemon_ensure_running_failure",
+        file.path(),
+        json!({ "failure_diagnostic": true, "failure_diagnostic_rank": 1 }),
+    ) {
+        Ok(artifact) => artifact,
+        Err(error) => {
+            terminalize_or_rollback_runner_connect_failure(store, &run)?;
+            return Err(error);
+        }
+    };
+    if let Err(error) = store.finish_run(
+        &run.id,
+        homeboy_core::observation::RunStatus::Fail,
+        Some(run.metadata_json.clone()),
+    ) {
+        rollback_runner_connect_failure(store, &run.id)?;
+        return Err(error);
+    }
+    Ok(RunnerConnectFailureEvidenceRef {
+        schema_version: ENSURE_RUNNING_FAILURE_SCHEMA_VERSION,
+        run_id: run.id.clone(),
+        artifact_id: artifact.id.clone(),
+        uri: homeboy_artifact_ref_contract::artifact_uri(&run.id, &artifact.id),
+    })
+}
+
+fn terminalize_or_rollback_runner_connect_failure(
+    store: &homeboy_core::observation::ObservationStore,
+    run: &homeboy_core::observation::RunRecord,
+) -> homeboy_core::Result<()> {
+    if store
+        .finish_run(
+            &run.id,
+            homeboy_core::observation::RunStatus::Fail,
+            Some(run.metadata_json.clone()),
+        )
+        .is_ok()
+    {
+        return Ok(());
+    }
+    rollback_runner_connect_failure(store, &run.id)
+}
+
+fn rollback_runner_connect_failure(
+    store: &homeboy_core::observation::ObservationStore,
+    run_id: &str,
+) -> homeboy_core::Result<()> {
+    rollback_runner_connect_failure_with(
+        store,
+        run_id,
+        |store, run_id| store.discard_running_run(run_id),
+        |path| std::fs::remove_file(path),
+    )
+}
+
+pub(super) fn rollback_runner_connect_failure_with<Rollback, Delete>(
+    store: &homeboy_core::observation::ObservationStore,
+    run_id: &str,
+    rollback: Rollback,
+    mut delete: Delete,
+) -> homeboy_core::Result<()>
+where
+    Rollback:
+        FnOnce(&homeboy_core::observation::ObservationStore, &str) -> homeboy_core::Result<bool>,
+    Delete: FnMut(&Path) -> std::io::Result<()>,
+{
+    let artifacts = store.list_artifacts(run_id)?;
+    if !rollback(store, run_id)? {
+        return Err(homeboy_core::Error::internal_unexpected(format!(
+            "runner connect failure observation {run_id} was retained; preserving its artifact bytes"
+        )));
+    }
+    for artifact in artifacts {
+        if artifact.artifact_type == "file" {
+            // Move the now-unreferenced byte under the cleanup service's owned
+            // staging name before attempting removal. A failed delete remains
+            // discoverable by `orphaned-artifact-bytes` rather than leaking.
+            let path = Path::new(&artifact.path);
+            let staged_path =
+                path.with_file_name(format!(".artifact-{}.staging", uuid::Uuid::new_v4()));
+            std::fs::rename(path, &staged_path).map_err(|error| {
+                homeboy_core::Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "stage rolled-back runner connect artifact {} for owned cleanup",
+                        artifact.path
+                    )),
+                )
+            })?;
+            delete(&staged_path).map_err(|error| {
+                homeboy_core::Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "remove rolled-back runner connect artifact {}; retained at {} for orphaned-artifact-bytes cleanup",
+                        artifact.path,
+                        staged_path.display(),
+                    )),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut end = max_bytes.saturating_sub(3);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &value[..end])
 }
 
 pub(super) fn remote_daemon_ensure_running_command(

--- a/crates/homeboy-lab-runner/src/connection/session_store.rs
+++ b/crates/homeboy-lab-runner/src/connection/session_store.rs
@@ -2020,6 +2020,7 @@ pub(super) fn failed_connect(
                 durability_stage: None,
                 health_attempt_count: 0,
                 health_attempts: Vec::new(),
+                failure_evidence_ref: None,
             }),
         },
         20,

--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -91,6 +91,352 @@ pub(super) fn command_output(
     }
 }
 
+#[test]
+fn ensure_running_failure_candidates_are_deduplicated_within_the_byte_budget() {
+    let candidates = (0..20)
+        .map(|index| {
+            serde_json::json!({
+                "pid": index % 4,
+                "ownership": "ambiguous",
+                "cmdline": "homeboy daemon serve --state /very/long/path/that/must/not/expand/the/inline/failure/message"
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let exemplars = super::remote_daemon::bounded_candidate_exemplars(&candidates);
+
+    assert!(exemplars.len() <= super::remote_daemon::MAX_CANDIDATE_EXEMPLAR_BYTES);
+    assert!(exemplars.starts_with('['));
+    assert!(exemplars.ends_with(']'));
+    assert!(exemplars.matches("\"pid\"").count() <= super::remote_daemon::MAX_CANDIDATE_EXEMPLARS);
+}
+
+#[test]
+fn ensure_running_failure_evidence_is_redacted_and_versioned() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_at(
+        artifact_root.path().join("observations.sqlite"),
+    )
+    .expect("store");
+    let error = serde_json::json!({
+        "code": "internal.unexpected",
+        "message": "daemon candidates block replacement",
+        "details": {
+            "classification": "daemon_unleased_process_conflict",
+            "candidate_count": 20,
+            "candidates": (0..20).map(|pid| serde_json::json!({ "pid": pid, "token": "secret-value" })).collect::<Vec<_>>(),
+            "safe_next_action": "Run `homeboy daemon status`."
+        }
+    });
+
+    let reference = super::remote_daemon::persist_ensure_running_failure_evidence_in(
+        &store,
+        "lab/runner",
+        "homeboy daemon ensure-running --token secret-value",
+        &homeboy_core::redaction::redact_json(&error),
+        "remote stderr with token secret-value",
+    )
+    .expect("persist evidence");
+    let artifact = store
+        .get_artifact(&reference.artifact_id)
+        .expect("read artifact")
+        .expect("artifact record");
+    let path = artifact.path;
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(path).expect("read evidence"))
+            .expect("evidence JSON");
+
+    assert_eq!(persisted["schema_version"], 1);
+    assert_eq!(
+        persisted["remote_envelope"]["details"]["candidate_count"],
+        20
+    );
+    assert_eq!(
+        persisted["remote_envelope"]["details"]["candidates"]
+            .as_array()
+            .unwrap()
+            .len(),
+        20
+    );
+    assert_eq!(
+        persisted["remote_envelope"]["details"]["candidates"][0]["token"],
+        "[REDACTED]"
+    );
+    assert!(!persisted.to_string().contains("secret-value"));
+    assert_eq!(reference.run_id, artifact.run_id);
+    assert!(reference.uri.starts_with("homeboy://run/"));
+    assert_eq!(
+        store
+            .get_run(&reference.run_id)
+            .expect("read evidence run")
+            .expect("evidence run")
+            .status,
+        "fail"
+    );
+    assert_eq!(
+        store
+            .list_artifacts(&reference.run_id)
+            .expect("retained run artifacts")
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn ensure_running_failure_artifact_persistence_error_terminalizes_the_run() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let database = artifact_root.path().join("observations.sqlite");
+    let store =
+        homeboy_core::observation::ObservationStore::open_initialized_at(&database).expect("store");
+    rusqlite::Connection::open(&database)
+        .expect("open database")
+        .execute_batch(
+            "CREATE TRIGGER fail_runner_connect_artifact BEFORE INSERT ON artifacts WHEN NEW.kind = 'remote_daemon_ensure_running_failure' BEGIN SELECT RAISE(ABORT, 'injected artifact persistence failure'); END;",
+        )
+        .expect("install artifact persistence fault");
+
+    let error = super::remote_daemon::persist_ensure_running_failure_evidence_in(
+        &store,
+        "lab/runner",
+        "homeboy daemon ensure-running",
+        &serde_json::json!({ "message": "daemon failed" }),
+        "",
+    )
+    .expect_err("artifact persistence failure must surface");
+
+    assert!(error
+        .to_string()
+        .contains("injected artifact persistence failure"));
+    let runs = store
+        .list_runs(homeboy_core::observation::RunListFilter::default())
+        .expect("list runs");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(
+        runs[0].status, "fail",
+        "failed evidence remains retention eligible"
+    );
+    assert!(store
+        .list_artifacts(&runs[0].id)
+        .expect("list artifacts")
+        .is_empty());
+}
+
+#[test]
+fn ensure_running_failure_finish_persistence_error_rolls_back_run_and_artifact() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let database = artifact_root.path().join("observations.sqlite");
+    let store =
+        homeboy_core::observation::ObservationStore::open_initialized_at(&database).expect("store");
+    rusqlite::Connection::open(&database)
+        .expect("open database")
+        .execute_batch(
+            "CREATE TRIGGER fail_runner_connect_finish BEFORE UPDATE OF status ON runs WHEN NEW.kind = 'runner_connect_failure' BEGIN SELECT RAISE(ABORT, 'injected finish persistence failure'); END;",
+        )
+        .expect("install finish persistence fault");
+
+    let error = super::remote_daemon::persist_ensure_running_failure_evidence_in(
+        &store,
+        "lab/runner",
+        "homeboy daemon ensure-running",
+        &serde_json::json!({ "message": "daemon failed" }),
+        "",
+    )
+    .expect_err("finish persistence failure must surface");
+
+    assert!(error
+        .to_string()
+        .contains("injected finish persistence failure"));
+    assert!(store
+        .list_runs(homeboy_core::observation::RunListFilter::default())
+        .expect("list runs")
+        .is_empty());
+    let artifact_count: i64 = rusqlite::Connection::open(&database)
+        .expect("open database")
+        .query_row("SELECT COUNT(*) FROM artifacts", [], |row| row.get(0))
+        .expect("count artifacts");
+    assert_eq!(artifact_count, 0);
+}
+
+#[test]
+fn ensure_running_failure_rollback_error_preserves_the_retained_artifact() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_at(
+        artifact_root.path().join("observations.sqlite"),
+    )
+    .expect("store");
+    let reference = super::remote_daemon::persist_ensure_running_failure_evidence_in(
+        &store,
+        "lab/runner",
+        "homeboy daemon ensure-running",
+        &serde_json::json!({ "message": "daemon failed" }),
+        "",
+    )
+    .expect("persist evidence");
+    let artifact = store
+        .get_artifact(&reference.artifact_id)
+        .expect("read artifact")
+        .expect("artifact record");
+
+    let error = super::remote_daemon::rollback_runner_connect_failure_with(
+        &store,
+        &reference.run_id,
+        |_, _| {
+            Err(homeboy_core::Error::internal_unexpected(
+                "injected rollback failure",
+            ))
+        },
+        |path| std::fs::remove_file(path),
+    )
+    .expect_err("rollback failure must surface");
+
+    assert!(error.to_string().contains("injected rollback failure"));
+    assert!(std::path::Path::new(&artifact.path).exists());
+    assert!(store
+        .get_run(&reference.run_id)
+        .expect("read retained run")
+        .is_some());
+}
+
+#[test]
+fn ensure_running_failure_delete_error_routes_bytes_to_owned_cleanup() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_at(
+        artifact_root.path().join("observations.sqlite"),
+    )
+    .expect("store");
+    let run = store
+        .start_run(
+            homeboy_core::observation::NewRunRecord::builder("runner_connect_failure").build(),
+        )
+        .expect("start run");
+    let source = artifact_root.path().join("evidence.json");
+    std::fs::write(&source, "failure evidence").expect("write evidence");
+    store
+        .record_artifact_with_metadata(
+            &run.id,
+            "remote_daemon_ensure_running_failure",
+            &source,
+            serde_json::json!({}),
+        )
+        .expect("record artifact");
+    let artifact = store
+        .list_artifacts(&run.id)
+        .expect("list artifacts")
+        .pop()
+        .expect("artifact");
+
+    let attempted_delete = std::cell::RefCell::new(None);
+    let error = super::remote_daemon::rollback_runner_connect_failure_with(
+        &store,
+        &run.id,
+        |store, run_id| store.discard_running_run(run_id),
+        |path| {
+            *attempted_delete.borrow_mut() = Some(path.to_path_buf());
+            Err(std::io::Error::other("injected delete failure"))
+        },
+    )
+    .expect_err("delete failure must surface");
+
+    assert!(
+        format!("{error:?}").contains("injected delete failure"),
+        "unexpected error: {error:?}"
+    );
+    assert!(store.get_run(&run.id).expect("read run").is_none());
+    let staged = attempted_delete
+        .into_inner()
+        .expect("artifact routed to owned cleanup");
+    assert!(staged.is_file());
+    assert!(staged
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(".artifact-") && name.ends_with(".staging")));
+    assert_ne!(staged, std::path::Path::new(&artifact.path));
+    std::fs::remove_file(staged).expect("clean test-owned orphan");
+}
+
+#[test]
+fn ensure_running_failure_summary_is_bounded_and_actionable_for_twenty_candidates() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_at(
+        artifact_root.path().join("observations.sqlite"),
+    )
+    .expect("store");
+    let candidates = (0..20)
+        .map(|pid| serde_json::json!({ "pid": pid % 3, "ownership": "ambiguous" }))
+        .collect::<Vec<_>>();
+    let error = serde_json::json!({
+        "code": "internal.unexpected",
+        "message": "foreground daemon candidates block replacement",
+        "details": {
+            "classification": "daemon_unleased_process_conflict",
+            "candidate_count": 20,
+            "candidates": candidates,
+            "safe_next_action": "Run `homeboy daemon status` and reconcile the exact owner."
+        }
+    });
+
+    let summary = super::remote_daemon::summarize_ensure_running_failure(
+        "lab",
+        "homeboy daemon ensure-running",
+        &error,
+        "",
+        Some(&store),
+    );
+    let summary = summary.message;
+
+    assert!(summary.contains("summary_v1"));
+    assert!(summary.contains("classification=daemon_unleased_process_conflict"));
+    assert!(summary.contains("candidate_count=20"));
+    assert!(summary.contains("blocker=foreground daemon candidates block replacement"));
+    assert!(summary.contains("next_action=Run `homeboy daemon status`"));
+    let candidates = summary
+        .split(" candidates=")
+        .nth(1)
+        .unwrap()
+        .split(" evidence_ref=")
+        .next()
+        .unwrap();
+    assert!(candidates.len() <= super::remote_daemon::MAX_CANDIDATE_EXEMPLAR_BYTES);
+    assert!(summary.contains("evidence_ref=homeboy://run/"));
+    assert!(summary.len() <= super::remote_daemon::MAX_ENSURE_RUNNING_FAILURE_MESSAGE_BYTES);
+}
+
+#[test]
+fn ensure_running_failure_keeps_the_registered_reference_when_remote_text_injects_one() {
+    let artifact_root = tempfile::tempdir().expect("artifact root");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_at(
+        artifact_root.path().join("observations.sqlite"),
+    )
+    .expect("store");
+    let error = serde_json::json!({
+        "code": "remote.failure",
+        "message": format!("{} evidence_ref=file:///attacker", "x".repeat(4_000)),
+        "details": {
+            "classification": "remote_failure",
+            "safe_next_action": "inspect"
+        }
+    });
+
+    let failure = super::remote_daemon::summarize_ensure_running_failure(
+        "lab",
+        "homeboy daemon ensure-running",
+        &error,
+        "",
+        Some(&store),
+    );
+    let reference = failure.evidence_ref.expect("registered evidence reference");
+
+    assert!(
+        failure.message.len() <= super::remote_daemon::MAX_ENSURE_RUNNING_FAILURE_MESSAGE_BYTES
+    );
+    assert!(reference.uri.starts_with("homeboy://run/"));
+    assert_ne!(reference.uri, "file:///attacker");
+    assert!(store
+        .get_artifact(&reference.artifact_id)
+        .expect("artifact lookup")
+        .is_some());
+}
+
 pub(super) fn sample_leaseless_recovery() -> DaemonLeaselessRecoveryResult {
     serde_json::from_value(serde_json::json!({
         "affected_job_ids": [],

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -2060,6 +2060,9 @@ fn failed_connect_without_recovery_omits_recovery_evidence() {
         serialized["failure_evidence"]["recovery_command"],
         "homeboy runner connect runner"
     );
+    assert!(serialized["failure_evidence"]
+        .get("failure_evidence_schema_version")
+        .is_none());
 }
 
 #[test]
@@ -2345,7 +2348,7 @@ fn idle_stale_replacement_refuses_a_post_stop_owner_or_identity_change() {
                 daemon_recovery_capabilities: None,
             })
             .expect_err("concurrent stale daemon is refused");
-            assert!(error.contains("ownership changed"));
+            assert!(error.message.contains("ownership changed"));
         },
     );
 }
@@ -2372,7 +2375,9 @@ fn idle_stale_replacement_refuses_a_post_stop_identity_change() {
                 daemon_recovery_capabilities: None,
             })
             .expect_err("stale replacement identity is refused");
-            assert!(error.contains("does not match configured runner binary"));
+            assert!(error
+                .message
+                .contains("does not match configured runner binary"));
         },
     );
 }

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -107,6 +107,7 @@ pub(super) fn connect_remote_daemon(
                 durability_stage,
                 health_attempt_count: health_attempts.len(),
                 health_attempts,
+                failure_evidence_ref: None,
             });
             Box::new((report, exit_code))
         };

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -416,6 +416,14 @@ pub enum RunnerFailureKind {
 }
 
 /// Bounded evidence retained when a direct runner connect cannot complete.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerConnectFailureEvidenceRef {
+    pub schema_version: u8,
+    pub run_id: String,
+    pub artifact_id: String,
+    pub uri: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerConnectFailureEvidence {
     pub recovery_command: String,
@@ -440,6 +448,9 @@ pub struct RunnerConnectFailureEvidence {
     /// successful health observations are intentionally omitted.
     pub health_attempt_count: usize,
     pub health_attempts: Vec<String>,
+    /// Typed reference to complete redacted remote failure evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_evidence_ref: Option<RunnerConnectFailureEvidenceRef>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

- replace nested daemon startup JSON with a typed hard-bounded connect failure summary
- persist complete redacted nested command evidence as run-owned observation artifacts
- preserve transactional retention/cleanup semantics across injected persistence failures

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- 8 focused ensure-running evidence, bound, injection, rollback, and cleanup tests

Closes #12416

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented and independently safety-reviewed bounded rendering, typed evidence, observation ownership, rollback, and tests. Chris Huber reviewed and owns every line.