### PR TITLE
fix(runner): rebind replacement replay identity

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -468,6 +468,7 @@ fn command_environment_value<'a>(
     }) else {
         return CommandTextValue::Absent;
     };
+    let value = quoted_command_environment_value(value).unwrap_or(value);
     if value.trim().is_empty() || value.contains(['\'', '"', '\\']) {
         return CommandTextValue::Ambiguous;
     }
@@ -482,6 +483,17 @@ fn command_environment_value<'a>(
         Some(command) if *command == executable => CommandTextValue::Proven(value),
         Some(_) | None => CommandTextValue::Ambiguous,
     }
+}
+
+/// `ps` preserves shell quotes around a whitespace-free environment value on
+/// some platforms. A complete matching pair still identifies one argv token;
+/// partial quotes and values split by whitespace remain ambiguous.
+fn quoted_command_environment_value(value: &str) -> Option<&str> {
+    let quote = value.as_bytes().first().copied()?;
+    if !matches!(quote, b'\'' | b'"') || value.as_bytes().last().copied()? != quote {
+        return None;
+    }
+    value.get(1..value.len().checked_sub(1)?)
 }
 
 fn durable_store_path(state_dir: &Path) -> PathBuf {

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1690,7 +1690,6 @@ fn normal_start_response_loss_replays_b_without_creating_c() {
         let generation_count = home.path().join("daemon-generations");
         let old_replay = home.path().join("old-replay");
         let selected_argv = home.path().join("selected-argv");
-        let release_selected_replay = home.path().join("release-selected-replay");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
         let address = listener.local_addr().expect("address");
         let health_requests = Arc::new(AtomicUsize::new(0));
@@ -1770,16 +1769,14 @@ case "$1 $2" in
     if [ "$3" = "--help" ]; then
       printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
    else
-       printf '%s\n' "$@" > "{selected_argv}"
-       while [ ! -f "{release_selected_replay}" ]; do sleep 0.01; done
-       printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
+      printf '%s\n' "$@" > "{selected_argv}"
+      printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
     fi
     ;;
 esac
 "#,
                 address = address,
                 selected_argv = selected_argv.display(),
-                release_selected_replay = release_selected_replay.display(),
             ),
         )
         .expect("write selected Homeboy shim");
@@ -1839,32 +1836,9 @@ esac
         )
         .expect("select refreshed remote Homeboy");
 
-        let replay = std::thread::spawn(|| {
+        let (second, second_exit) =
             connect_with_orphan_adoption("local-runner", None, &[], false, None, None, None)
-        });
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while !selected_argv.exists() && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        assert!(
-            selected_argv.exists(),
-            "the promoted executable must receive the replay before it is released"
-        );
-        let rebound: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(journal_dir.join("replacement-operation.json"))
-                .expect("rebound ensure-running journal"),
-        )
-        .expect("rebound ensure-running journal JSON");
-        assert_eq!(rebound["kind"], "ensure-running");
-        assert!(rebound["replay_command"].as_str().is_some_and(|command| {
-            command.starts_with(selected_daemon.to_str().expect("selected daemon path"))
-                && command.contains(&operation_id)
-        }));
-        std::fs::write(&release_selected_replay, "release").expect("release selected replay");
-        let (second, second_exit) = replay
-            .join()
-            .expect("replay thread")
-            .expect("second connect result");
+                .expect("second connect result");
         assert_eq!(
             second_exit, 0,
             "second connect failed: {:?}",

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1663,6 +1663,11 @@ esac
         assert!(second.connected);
         assert_eq!(second.remote_daemon_pid, Some(4242));
         assert_eq!(
+            second.homeboy_build_identity.as_deref(),
+            Some("homeboy 0.284.0+test"),
+            "the replay report names the identity verified from the selected binary"
+        );
+        assert_eq!(
             std::fs::read_to_string(&generation_count).expect("generation count"),
             "1"
         );
@@ -1685,6 +1690,7 @@ fn normal_start_response_loss_replays_b_without_creating_c() {
         let generation_count = home.path().join("daemon-generations");
         let old_replay = home.path().join("old-replay");
         let selected_argv = home.path().join("selected-argv");
+        let release_selected_replay = home.path().join("release-selected-replay");
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
         let address = listener.local_addr().expect("address");
         let health_requests = Arc::new(AtomicUsize::new(0));
@@ -1763,15 +1769,17 @@ case "$1 $2" in
   "daemon ensure-running")
     if [ "$3" = "--help" ]; then
       printf '%s\n' 'OPTIONS:' '    --replacement-operation-id <ID>'
-    else
-      printf '%s\n' "$@" > "{selected_argv}"
-      printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
+   else
+       printf '%s\n' "$@" > "{selected_argv}"
+       while [ ! -f "{release_selected_replay}" ]; do sleep 0.01; done
+       printf '%s\n' '{{"success":true,"data":{{"pid":4242,"address":"{address}","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}'
     fi
     ;;
 esac
 "#,
                 address = address,
                 selected_argv = selected_argv.display(),
+                release_selected_replay = release_selected_replay.display(),
             ),
         )
         .expect("write selected Homeboy shim");
@@ -1831,9 +1839,32 @@ esac
         )
         .expect("select refreshed remote Homeboy");
 
-        let (second, second_exit) =
+        let replay = std::thread::spawn(|| {
             connect_with_orphan_adoption("local-runner", None, &[], false, None, None, None)
-                .expect("second connect result");
+        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !selected_argv.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            selected_argv.exists(),
+            "the promoted executable must receive the replay before it is released"
+        );
+        let rebound: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(journal_dir.join("replacement-operation.json"))
+                .expect("rebound ensure-running journal"),
+        )
+        .expect("rebound ensure-running journal JSON");
+        assert_eq!(rebound["kind"], "ensure-running");
+        assert!(rebound["replay_command"].as_str().is_some_and(|command| {
+            command.starts_with(selected_daemon.to_str().expect("selected daemon path"))
+                && command.contains(&operation_id)
+        }));
+        std::fs::write(&release_selected_replay, "release").expect("release selected replay");
+        let (second, second_exit) = replay
+            .join()
+            .expect("replay thread")
+            .expect("second connect result");
         assert_eq!(
             second_exit, 0,
             "second connect failed: {:?}",
@@ -1841,6 +1872,20 @@ esac
         );
         assert!(second.connected);
         assert_eq!(second.remote_daemon_pid, Some(4242));
+        assert_eq!(
+            second.homeboy_build_identity.as_deref(),
+            Some("homeboy 0.284.0+test"),
+            "the report must name the identity verified from the promoted executable"
+        );
+        assert_eq!(
+            crate::load("local-runner")
+                .expect("load promoted runner")
+                .settings
+                .homeboy_path
+                .as_deref(),
+            selected_daemon.to_str(),
+            "the promoted runner must retain the selected executable path"
+        );
         assert_eq!(
             std::fs::read_to_string(&generation_count).expect("B only start count"),
             "1",

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -2274,6 +2274,42 @@ mod tests {
         });
     }
 
+    #[test]
+    fn legacy_replacement_journal_remains_replayable_after_rebinding() {
+        test_support::with_isolated_home(|_| {
+            let path = replacement_operation_path("runner-a").expect("journal path");
+            write_durable_json(
+                &path,
+                &serde_json::json!({
+                    "runner_id": "runner-a",
+                    "operation_id": "legacy-operation",
+                }),
+            )
+            .expect("write legacy journal");
+
+            assert_eq!(
+                replacement_operation("runner-a").expect("read operation"),
+                "legacy-operation"
+            );
+            assert!(replacement_operation_replay("runner-a")
+                .expect("read legacy replay")
+                .is_none());
+            record_replacement_operation_replay(
+                "runner-a",
+                "ensure-running",
+                "/selected/homeboy daemon ensure-running --replacement-operation-id legacy-operation --addr 127.0.0.1:0",
+            )
+            .expect("rebind legacy journal");
+            assert_eq!(
+                replacement_operation_replay("runner-a").expect("read rebound replay"),
+                Some((
+                    "ensure-running".to_string(),
+                    "/selected/homeboy daemon ensure-running --replacement-operation-id legacy-operation --addr 127.0.0.1:0".to_string(),
+                ))
+            );
+        });
+    }
+
     #[derive(Default)]
     struct FakeEndpointOperations {
         active_jobs: RefCell<std::collections::BTreeMap<String, usize>>,

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -392,6 +392,56 @@ fn daemon_process_attribution_matches_explicit_state_directory_store() {
 }
 
 #[test]
+fn daemon_process_attribution_classifies_multiple_quoted_generation_state_directory_stores() {
+    let home = tempfile::tempdir().expect("home");
+    let generation_root = tempfile::tempdir().expect("generation root");
+    let jobs = home.path().join(".config/homeboy/daemon/jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+
+    for (generation, quote) in [("generation-a", '\''), ("generation-b", '"')] {
+        let state_dir = generation_root.path().join(generation);
+        let line = format!(
+            "4243 {} HOME={} HOMEBOY_DAEMON_STATE_DIR={quote}{}{quote} {} daemon serve --addr 127.0.0.1:7421",
+            executable.display(),
+            home.path().display(),
+            state_dir.display(),
+            executable.display(),
+        );
+        let candidate = super::parse_daemon_process_candidate(&line, &jobs, Some(&executable))
+            .expect("candidate");
+        assert_eq!(
+            candidate.ownership,
+            super::super::DaemonProcessOwnership::Unrelated,
+            "{line}"
+        );
+        assert_eq!(
+            candidate.durable_store_path.as_deref(),
+            state_dir.join("jobs.json").to_str()
+        );
+    }
+}
+
+#[test]
+fn daemon_process_attribution_keeps_quoted_same_store_ambiguous_without_binary_proof() {
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let jobs = state_dir.path().join("jobs.json");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} HOMEBOY_DAEMON_STATE_DIR=\"{}\" {} daemon serve --addr 127.0.0.1:7421",
+        executable.display(),
+        state_dir.path().display(),
+        executable.display(),
+    );
+
+    let candidate = super::parse_daemon_process_candidate(&line, &jobs, None).expect("candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Ambiguous
+    );
+    assert_eq!(candidate.durable_store_path.as_deref(), jobs.to_str());
+}
+
+#[test]
 fn daemon_process_attribution_keeps_whitespace_environment_assignments_ambiguous() {
     let root = tempfile::tempdir().expect("state root");
     let state_dir = root.path().join("state directory");


### PR DESCRIPTION
## Summary

- parse quoted explicit generation state directories from daemon candidate environments
- keep different-store generations from blocking conventional replacement while failing closed for same-store ambiguity
- prove pending replacement replay durably rebinds to the promoted identity-verified executable

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-lab-runner`
- focused combined promotion/replay/generation, legacy journal, and attribution tests

Closes #12419

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented and independently reviewed candidate parsing, replay rebinding, legacy compatibility, and combined regression coverage. Chris Huber reviewed and owns every line.