### PR TITLE
fix(runner): converge disconnected refresh reconnect

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -558,10 +558,12 @@ pub fn refresh_homeboy_binary(
     let promotion_lease =
         acquire_runner_binary_promotion(&options.runner_id, &promotion_candidate)?;
     // Materialization may have waited behind a newer refresh. Re-read every
-    // authority while holding the promotion lease so an old candidate cannot
-    // overwrite a newer controller selection or reconnect over its daemon.
+    // authority while holding the promotion lease. In particular, a daemon can
+    // connect while materialization runs, so reconnect decisions cannot use the
+    // pre-materialization status snapshot.
     promotion_lease.assert_generation()?;
-    let promotion_authorities = refresh_promotion_authorities(&plan.runner_id)?;
+    let post_lease_status = super::status(&plan.runner_id)?;
+    let promotion_authorities = refresh_promotion_authorities(&plan.runner_id, &post_lease_status)?;
     // Selection belongs to the controller-owned runner registry. It must be
     // persisted after the candidate has been verified, whether or not this
     // invocation also replaces the active daemon.
@@ -745,13 +747,10 @@ pub fn refresh_homeboy_binary(
     let updated_fields = bootstrap.updated_fields.clone();
     let rollback = bootstrap.rollback.clone();
 
-    // Re-read the session after selection as well. The pre-materialization
-    // record is not safe to use for a reconnect after a queued promotion.
-    let refresh_session = options
-        .reconnect
-        .then(|| super::connection::recorded_session(&plan.runner_id))
-        .transpose()?
-        .flatten();
+    // The status captured under the promotion lease is the reconnect authority:
+    // an old daemon that appeared while materializing must be retired, while a
+    // stale session for a disconnected runner must not block direct connect.
+    let refresh_session = reconnect_session_after_promotion(options.reconnect, &post_lease_status);
     let refresh_owned_lease = refresh_session.clone().and_then(refresh_owned_lease);
 
     let mut daemon_refreshed = false;
@@ -1029,7 +1028,19 @@ pub fn refresh_homeboy_binary(
                 probe_reconnected_admission_readiness(&plan.runner_id, identity_commit)
             {
                 daemon_refreshed = false;
-                phase_summary.push(refresh_phase("reconnect_transport", true, 0));
+                // The readiness probe can discover that the newly connected
+                // transport vanished. Never certify a transient connect as a
+                // successful reconnect when its postcondition is disconnected.
+                let transport_exit_code = reconnect_transport_exit_code(
+                    super::status(&plan.runner_id)
+                        .map(|status| status.is_connected())
+                        .unwrap_or(false),
+                );
+                phase_summary.push(refresh_phase(
+                    "reconnect_transport",
+                    true,
+                    transport_exit_code,
+                ));
                 phase_summary.push(refresh_phase("daemon_identity_verification", true, 0));
                 phase_summary.push(refresh_phase("admission_readiness", true, 1));
                 return Ok((
@@ -1229,6 +1240,32 @@ fn refresh_bootstrap_provenance(
 /// failure can require reconciliation without requiring another reconnect.
 fn reconnect_required_after_refresh(daemon_refreshed: bool) -> bool {
     !daemon_refreshed
+}
+
+/// A stale daemon is still a live transport that must be retired before its
+/// replacement starts. A disconnected status may retain an obsolete session
+/// record, but it has no transport to rotate.
+fn reconnect_rotates_existing_transport(status: &super::RunnerStatusReport) -> bool {
+    status.is_connected()
+}
+
+fn reconnect_session_after_promotion(
+    reconnect: bool,
+    status: &super::RunnerStatusReport,
+) -> Option<super::RunnerSession> {
+    (reconnect && reconnect_rotates_existing_transport(status))
+        .then(|| status.session.clone())
+        .flatten()
+}
+
+/// A successful reconnect phase is only valid while an authoritative status
+/// still observes an active transport.
+fn reconnect_transport_exit_code(connected: bool) -> i32 {
+    if connected {
+        0
+    } else {
+        1
+    }
 }
 
 /// A refresh rotates a live daemon but starts a disconnected runner directly.
@@ -1737,9 +1774,11 @@ struct RefreshPromotionAuthorities {
     configured_selected: Option<String>,
 }
 
-fn refresh_promotion_authorities(runner_id: &str) -> Result<RefreshPromotionAuthorities> {
+fn refresh_promotion_authorities(
+    runner_id: &str,
+    status: &super::RunnerStatusReport,
+) -> Result<RefreshPromotionAuthorities> {
     let runner = load(runner_id)?;
-    let status = super::status(runner_id)?;
     let configured_selected = runner
         .settings
         .homeboy_path
@@ -2823,14 +2862,39 @@ fn refresh_reconnect_failure(
     report: &super::RunnerConnectReport,
     daemon_identity_verification: Option<&str>,
 ) -> HomeboyBinaryRefreshFailure {
-    let mut failure = refresh_failure(plan, execution.clone(), 1);
-    failure.verification = Some(format!(
-        "reconnect failed after selection and the configured binary was restored: {}",
+    refresh_reconnect_failure_with_message(
+        plan,
+        execution,
         report
             .failure_message
             .as_deref()
             .or(daemon_identity_verification)
-            .unwrap_or("runner connect returned a non-zero exit code")
+            .unwrap_or("runner connect returned a non-zero exit code"),
+    )
+}
+
+/// Selection has already committed when reconnect fails. Keep that promotion
+/// evidence intact and offer the exact next lifecycle operation, rather than a
+/// retry that can rematerialize or select a different executable.
+fn refresh_reconnect_failure_with_message(
+    plan: &HomeboyBinaryRefreshPlan,
+    execution: &RunnerExecOutput,
+    reconnect_error: &str,
+) -> HomeboyBinaryRefreshFailure {
+    let mut failure = refresh_failure(plan, execution.clone(), 1);
+    failure.recovery_actions = vec![
+        homeboy_core::runner_execution_envelope::RunnerExecutionNextAction {
+            label: "reconnect_after_promotion".to_string(),
+            command: vec![
+                "homeboy".to_string(),
+                "runner".to_string(),
+                "connect".to_string(),
+                plan.runner_id.clone(),
+            ],
+        },
+    ];
+    failure.verification = Some(format!(
+        "reconnect failed after selection; the promoted configured binary remains selected: {reconnect_error}"
     ));
     failure
 }

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -265,6 +265,51 @@ fn disconnected_refresh_connects_without_rotating_a_missing_daemon() {
     assert_eq!(operations.into_inner(), ["connect promoted binary"]);
 }
 
+/// #12418: reconnect behavior is selected from the authoritative post-lease
+/// transport state. A stale but connected daemon is still rotated; a retained
+/// record for a disconnected runner must not block connecting the promotion.
+#[test]
+fn reconnect_transport_state_matrix_preserves_disconnected_and_rotation_paths() {
+    let disconnected = refreshed_daemon_status(false, None);
+    let mut stale_connected = refreshed_daemon_status(true, Some("homeboy 0.294.0+oldcommit"));
+    stale_connected.stale_daemon = Some(RunnerStaleDaemonWarning::new(
+        "lab",
+        "0.294.0".to_string(),
+        "0.294.0".to_string(),
+        Some("homeboy 0.294.0+oldcommit".to_string()),
+        Some("homeboy 0.294.0+newcommit".to_string()),
+    ));
+    let healthy_connected = refreshed_daemon_status(true, Some("homeboy 0.294.0+newcommit"));
+
+    assert!(
+        !reconnect_rotates_existing_transport(&disconnected),
+        "a disconnected runner starts the promoted binary directly"
+    );
+    assert_eq!(
+        reconnect_transport_exit_code(disconnected.is_connected()),
+        1,
+        "a disconnected runner cannot report reconnect transport success"
+    );
+    assert!(
+        reconnect_rotates_existing_transport(&stale_connected),
+        "a stale connected daemon is rotated before reconnect"
+    );
+    assert_eq!(
+        reconnect_transport_exit_code(stale_connected.is_connected()),
+        0,
+        "a stale but connected transport remains a completed reconnect phase"
+    );
+    assert!(
+        reconnect_rotates_existing_transport(&healthy_connected),
+        "a healthy connected daemon retains the established rotation behavior"
+    );
+    assert_eq!(
+        reconnect_transport_exit_code(healthy_connected.is_connected()),
+        0,
+        "a healthy connected transport remains a completed reconnect phase"
+    );
+}
+
 #[test]
 fn connected_refresh_rotates_before_connecting_the_promoted_binary() {
     let session = RunnerSession {
@@ -302,6 +347,63 @@ fn connected_refresh_rotates_before_connecting_the_promoted_binary() {
     assert_eq!(
         operations.into_inner(),
         ["disconnect existing daemon", "connect promoted binary"]
+    );
+}
+
+/// #12418: materialization begins from a disconnected observation, but another
+/// controller can connect the old daemon before this refresh obtains promotion
+/// ownership. The post-lease session must drive retirement, and active work
+/// remains owned by the draining generation rather than being interrupted.
+#[test]
+fn materialization_race_rotates_the_newly_connected_daemon_and_preserves_active_work() {
+    let materialization_snapshot = refreshed_daemon_status(false, None);
+    let mut post_lease_status = refreshed_daemon_status(true, Some("homeboy 0.294.0+oldcommit"));
+    let old_session = post_lease_status
+        .session
+        .as_mut()
+        .expect("post-materialization connection persists a session");
+    old_session.remote_daemon_lease_id = Some("lease-old".to_string());
+    old_session.remote_daemon_pid = Some(42);
+
+    assert!(
+        !reconnect_rotates_existing_transport(&materialization_snapshot),
+        "materialization began while the runner was disconnected"
+    );
+    let post_lease_session = reconnect_session_after_promotion(true, &post_lease_status)
+        .expect("the post-lease connected daemon is the one to retire");
+    assert_eq!(
+        post_lease_session.remote_daemon_lease_id.as_deref(),
+        Some("lease-old")
+    );
+
+    let operations = RefCell::new(Vec::new());
+    disconnect_before_reconnect(Some(&post_lease_session), |_| {
+        operations.borrow_mut().push("retire lease-old");
+        Ok(())
+    })
+    .expect("the daemon observed after materialization is retired before connect");
+    operations.borrow_mut().push("connect promoted binary");
+    assert_eq!(
+        operations.into_inner(),
+        ["retire lease-old", "connect promoted binary"]
+    );
+
+    let active_job = active_admission("active-job");
+    assert!(
+        should_rotate_daemon_generation(true, false, false),
+        "active work selects generation rotation instead of daemon replacement"
+    );
+    let mut generations = crate::RollingGenerations::new("lease-old", "old daemon");
+    generations.admit_job(&active_job.job_id);
+    assert_eq!(
+        generations.begin("lease-new", "promoted daemon"),
+        crate::RollingStart::Start
+    );
+    assert!(generations.activate("lease-new"));
+    assert_eq!(
+        generations.job_owner(&active_job.job_id),
+        Some("lease-old"),
+        "the old generation retains active work while the promoted generation admits new work"
     );
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -654,7 +654,8 @@ fn equivalent_refresh_waiter_reloads_the_owner_selection_after_promotion_handoff
             let _lease = acquire_runner_binary_promotion_with("lab", "0123456789ab", |event| {
                 queued_tx.send(event).expect("report queued owner")
             })?;
-            refresh_promotion_authorities("lab")?;
+            let status = crate::status("lab")?;
+            refresh_promotion_authorities("lab", &status)?;
             crate::load("lab")
         });
         let event = queued_rx
@@ -920,7 +921,7 @@ fn blocked_connect_preserves_successful_promotion_with_one_continuation() {
                 ("identity_verification", "succeeded"),
                 ("bootstrap_promotion", "succeeded"),
                 ("configuration_promotion", "succeeded"),
-                ("reconnect_transport", "succeeded"),
+                ("reconnect_transport", "failed"),
                 ("daemon_identity_verification", "succeeded"),
                 ("admission_readiness", "failed"),
             ]
@@ -935,6 +936,16 @@ fn blocked_connect_preserves_successful_promotion_with_one_continuation() {
             output.followup_commands,
             ["homeboy runner connect lab-local"]
         );
+        let failure = output.failure.expect("typed reconnect partial failure");
+        assert_eq!(
+            failure.recovery_actions[0].command,
+            ["homeboy", "runner", "connect", "lab-local"]
+        );
+        assert!(failure
+            .verification
+            .as_deref()
+            .expect("reconnect verification")
+            .contains("promoted configured binary remains selected"));
         assert!(output.bootstrap_provenance.is_some());
         assert_eq!(
             crate::load("lab-local")
@@ -948,7 +959,7 @@ fn blocked_connect_preserves_successful_promotion_with_one_continuation() {
 }
 
 #[test]
-fn connected_refresh_blocker_preserves_the_newly_selected_binary() {
+fn stale_session_refresh_blocker_starts_the_newly_selected_binary() {
     test_support::with_isolated_home(|_| {
         let fixture = tempfile::tempdir().expect("fixture");
         let second_binary = fixture.path().join("second-homeboy");
@@ -1056,8 +1067,7 @@ fn connected_refresh_blocker_preserves_the_newly_selected_binary() {
                 ("identity_verification", "succeeded"),
                 ("bootstrap_promotion", "succeeded"),
                 ("configuration_promotion", "succeeded"),
-                ("disconnect", "succeeded"),
-                ("reconnect_transport", "succeeded"),
+                ("reconnect_transport", "failed"),
                 ("daemon_identity_verification", "succeeded"),
                 ("admission_readiness", "failed"),
             ]


### PR DESCRIPTION
## Summary

- connect initially disconnected runners after successful refresh promotion
- re-read authoritative status after promotion lease acquisition to close connection races
- make reconnect transport phase truthfully represent a live transport and preserve typed partial outcomes

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-lab-runner`
- 97 focused refresh lifecycle and race tests passed

Closes #12418

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced and independently reviewed refresh convergence, promotion races, phase truthfulness, and regression coverage. Chris Huber reviewed and owns every line.