### PR TITLE
test(provider): isolate backend policy selection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -252,6 +252,17 @@ impl ExtensionProviderAgentTaskExecutor {
         default_backend_from_policy(None)
     }
 
+    #[cfg(test)]
+    pub(super) fn default_backend_with_policy(
+        &self,
+        extensions: Vec<extension::ExtensionManifest>,
+        config: &defaults::HomeboyConfig,
+    ) -> homeboy_core::Result<Option<String>> {
+        default_backend_from_policy_sources(None, extensions, || {
+            config.agent_task.default_backend.clone()
+        })
+    }
+
     pub fn required_extension_ids_for_plan(&self, plan: &AgentTaskPlan) -> Vec<String> {
         required_extension_ids_for_plan_with_providers(plan, &self.providers)
     }
@@ -618,16 +629,29 @@ pub fn provider_secret_sources_for_backend(
 }
 
 fn default_backend_from_policy(component_id: Option<&str>) -> homeboy_core::Result<Option<String>> {
-    if let Some(component_id) = component_id {
-        if let Ok(component) = component::load(component_id) {
-            if let Some(default_backend) = component_default_backend(&component) {
-                return Ok(Some(default_backend));
-            }
+    let component = component_id.and_then(|id| component::load(id).ok());
+    default_backend_from_policy_sources(
+        component.as_ref(),
+        extension::load_all_extensions().unwrap_or_default(),
+        || defaults::load_config().agent_task.default_backend,
+    )
+}
+
+pub(super) fn default_backend_from_policy_sources<F>(
+    component: Option<&component::Component>,
+    extensions: Vec<extension::ExtensionManifest>,
+    config_default: F,
+) -> homeboy_core::Result<Option<String>>
+where
+    F: FnOnce() -> Option<String>,
+{
+    if let Some(component) = component {
+        if let Some(default_backend) = component_default_backend(component) {
+            return Ok(Some(default_backend));
         }
     }
 
-    let extension_defaults: Vec<String> = extension::load_all_extensions()
-        .unwrap_or_default()
+    let extension_defaults: Vec<String> = extensions
         .into_iter()
         .filter_map(|manifest| {
             manifest
@@ -651,10 +675,7 @@ fn default_backend_from_policy(component_id: Option<&str>) -> homeboy_core::Resu
         return Ok(Some(default_backend));
     }
 
-    Ok(defaults::load_config()
-        .agent_task
-        .default_backend
-        .filter(|backend| !backend.trim().is_empty()))
+    Ok(config_default().filter(|backend| !backend.trim().is_empty()))
 }
 
 pub(super) fn component_default_backend(component: &component::Component) -> Option<String> {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
@@ -526,8 +526,17 @@ fn provider_manifest_parses_runner_and_dependency_contracts() {
     );
 }
 
+fn extension_policy(id: &str, backend: &str) -> extension::ExtensionManifest {
+    serde_json::from_value(json!({
+        "name": id,
+        "version": "1.0.0",
+        "agent_task": { "default_backend": backend }
+    }))
+    .expect("extension manifest")
+}
+
 #[test]
-fn default_backend_ignores_provider_declaration() {
+fn provider_declarations_do_not_select_default_backend() {
     let (_request, mut provider_a) = request("task-a", "node provider-a.js".to_string());
     provider_a.backend = "first".to_string();
     let (_request, mut provider_b) = request("task-b", "node provider-b.js".to_string());
@@ -536,81 +545,61 @@ fn default_backend_ignores_provider_declaration() {
 
     let executor = ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
-    homeboy_core::test_support::with_isolated_home(|_| {
-        assert_eq!(executor.default_backend().unwrap(), None);
-    });
+    assert_eq!(
+        executor
+            .default_backend_with_policy(Vec::new(), &defaults::HomeboyConfig::default())
+            .unwrap(),
+        None
+    );
 }
 
 #[test]
 fn default_backend_uses_global_config_policy() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        defaults::save_config(&defaults::HomeboyConfig {
-            agent_task: defaults::AgentTaskConfig {
-                default_backend: Some("configured".to_string()),
-                ..defaults::AgentTaskConfig::default()
-            },
-            ..defaults::HomeboyConfig::default()
-        })
-        .expect("config saved");
+    let config = defaults::HomeboyConfig {
+        agent_task: defaults::AgentTaskConfig {
+            default_backend: Some("configured".to_string()),
+            ..defaults::AgentTaskConfig::default()
+        },
+        ..defaults::HomeboyConfig::default()
+    };
 
-        assert_eq!(default_backend().unwrap().as_deref(), Some("configured"));
-    });
+    assert_eq!(
+        default_backend_from_policy_sources(None, Vec::new(), || {
+            config.agent_task.default_backend.clone()
+        })
+        .unwrap()
+        .as_deref(),
+        Some("configured")
+    );
 }
 
 #[test]
 fn default_backend_uses_extension_policy() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        defaults::save_config(&defaults::HomeboyConfig {
-            agent_task: defaults::AgentTaskConfig {
-                default_backend: Some("global-policy".to_string()),
-                ..defaults::AgentTaskConfig::default()
-            },
-            ..defaults::HomeboyConfig::default()
-        })
-        .expect("config saved");
-        let extension_dir = home
-            .path()
-            .join(".config/homeboy/extensions/runtime-extension");
-        std::fs::create_dir_all(&extension_dir).expect("extension dir");
-        std::fs::write(
-            extension_dir.join("runtime-extension.json"),
-            json!({
-                "name": "Runtime Extension",
-                "version": "1.0.0",
-                "agent_task": { "default_backend": "extension-policy" }
-            })
-            .to_string(),
+    assert_eq!(
+        default_backend_from_policy_sources(
+            None,
+            vec![extension_policy("Runtime Extension", "extension-policy")],
+            || panic!("global config should remain lazy"),
         )
-        .expect("extension manifest");
-
-        assert_eq!(
-            default_backend().unwrap().as_deref(),
-            Some("extension-policy")
-        );
-    });
+        .unwrap()
+        .as_deref(),
+        Some("extension-policy")
+    );
 }
 
 #[test]
 fn default_backend_rejects_ambiguous_extension_policy() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        for (id, backend) in [("runtime-a", "backend-a"), ("runtime-b", "backend-b")] {
-            let extension_dir = home.path().join(format!(".config/homeboy/extensions/{id}"));
-            std::fs::create_dir_all(&extension_dir).expect("extension dir");
-            std::fs::write(
-                extension_dir.join(format!("{id}.json")),
-                json!({
-                    "name": id,
-                    "version": "1.0.0",
-                    "agent_task": { "default_backend": backend }
-                })
-                .to_string(),
-            )
-            .expect("extension manifest");
-        }
+    let error = default_backend_from_policy_sources(
+        None,
+        vec![
+            extension_policy("runtime-a", "backend-a"),
+            extension_policy("runtime-b", "backend-b"),
+        ],
+        || None,
+    )
+    .expect_err("ambiguous policy should fail");
 
-        let error = default_backend().expect_err("ambiguous policy should fail");
-        assert!(error.message.contains("ambiguous"));
-    });
+    assert!(error.message.contains("ambiguous"));
 }
 
 #[test]
@@ -636,51 +625,6 @@ fn default_backend_reads_component_scoped_extension_policy() {
         component_default_backend(&component).as_deref(),
         Some("component-policy")
     );
-}
-
-#[test]
-fn default_backend_ignores_provider_manifest_default_backend() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let runtime_dir = home
-            .path()
-            .join(".config/homeboy/agent-runtimes/standalone-runtime");
-        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
-        std::fs::write(
-            runtime_dir.join("standalone-runtime.json"),
-            json!({
-                "schema": agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
-                "id": "standalone-runtime",
-                "agent_task_executors": [{
-                    "schema": "homeboy/agent-task-executor-provider/v1",
-                    "id": "runtime.provider",
-                    "backend": "runtime-default",
-                    "default_backend": true,
-                    "invocation": { "argv": ["runtime-provider"] },
-                    "request_schema": AGENT_TASK_REQUEST_SCHEMA,
-                    "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA
-                }]
-            })
-            .to_string(),
-        )
-        .expect("runtime manifest");
-
-        assert_eq!(default_backend().unwrap(), None);
-    });
-}
-
-#[test]
-fn default_backend_is_absent_without_provider_declaration() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let (_request, mut provider_a) = request("task-a", "node provider-a.js".to_string());
-        provider_a.backend = "first".to_string();
-        let (_request, mut provider_b) = request("task-b", "node provider-b.js".to_string());
-        provider_b.backend = "second".to_string();
-
-        let executor =
-            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
-
-        assert_eq!(executor.default_backend().unwrap(), None);
-    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- separate backend-policy evaluation from ambient component, extension, and config loading
- feed typed extension manifests and config defaults directly into selection tests
- consolidate duplicate provider-default cases and remove every HOME wrapper from the complete selection module

## Payoff
- ambient lock sites in `selection_tests.rs`: 6 -> 0
- remaining provider lock sites: 9 -> 3
- public APIs added: none; the evaluator and test seam are module-scoped
- config fallback remains lazy when component or extension policy wins
- diff: +82/-117, net -35 lines
- targeted 24-test module executes in ~0.60s after compilation, so this PR makes no timing claim

## Verification
- `cargo test -p homeboy-agents --locked agent_task_provider::tests::selection_tests --lib` (24 passed)
- `cargo check -p homeboy-agents --tests --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Contributes to #7505.

## AI assistance
GPT-5.6 Sol via OpenCode was used to inspect backend policy precedence, separate ambient loading from typed policy evaluation, consolidate duplicate tests, and run verification. Chris Huber reviewed and remains responsible for the change.