### PR TITLE
test(provider): bind scheduler storage roots

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -719,8 +719,12 @@ pub(crate) fn record_aggregate_in_store(
         record.metadata["automatic_artifact_retention_inaccessible_roots"] =
             serde_json::Value::Array(retained_roots);
     }
-    crate::controller_scratch::register_outcome_resources(&record.run_id, &aggregate.outcomes)?;
-    crate::controller_scratch::finalize_run(&record.run_id)?;
+    crate::controller_scratch::register_outcome_resources_at(
+        &lifecycle_store.data_root(),
+        &record.run_id,
+        &aggregate.outcomes,
+    )?;
+    crate::controller_scratch::finalize_run_at(&lifecycle_store.data_root(), &record.run_id)?;
     lifecycle_store.write_aggregate_and_record(record, aggregate)?;
     record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
     update_cook_candidate_after_completion(record, aggregate, None)?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2786,8 +2786,18 @@ pub fn record_run_aggregate(
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,
 ) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    record_aggregate(&mut record, plan, aggregate)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_run_aggregate_in_store(&lifecycle_store, run_id, plan, aggregate)
+}
+
+pub(crate) fn record_run_aggregate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
+    record_aggregate_in_store(lifecycle_store, &mut record, plan, aggregate)
 }
 
 /// Reproject terminal artifacts from controller-owned durable state. This is a

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -34,7 +34,10 @@ impl ExecutorArtifactRootIdentity {
         Self::capture_with_finalized_root(path, finalized_root)
     }
 
-    fn capture_with_finalized_root(path: &Path, finalized_root: PathBuf) -> Result<Self> {
+    pub(super) fn capture_with_finalized_root(
+        path: &Path,
+        finalized_root: PathBuf,
+    ) -> Result<Self> {
         let metadata = fs::symlink_metadata(path).map_err(|error| {
             Error::internal_io(
                 error.to_string(),

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -19,6 +19,8 @@ static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::
 pub struct ExtensionProviderAgentTaskExecutor {
     providers: Vec<AgentTaskExecutorProvider>,
     diagnostics: Vec<AgentRuntimeDiscoveryDiagnostic>,
+    #[cfg(test)]
+    pub(super) path_roots: Option<homeboy_core::paths::PathRoots>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -229,6 +231,8 @@ impl ExtensionProviderAgentTaskExecutor {
         Self {
             providers: catalog.providers,
             diagnostics: catalog.diagnostics,
+            #[cfg(test)]
+            path_roots: None,
         }
     }
 
@@ -237,7 +241,14 @@ impl ExtensionProviderAgentTaskExecutor {
         Self {
             providers,
             diagnostics: Vec::new(),
+            path_roots: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_path_roots(mut self, path_roots: homeboy_core::paths::PathRoots) -> Self {
+        self.path_roots = Some(path_roots);
+        self
     }
 
     pub fn providers(&self) -> &[AgentTaskExecutorProvider] {

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -7,7 +7,18 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         request: AgentTaskRequest,
         context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
-        let mut request = match materialize_executor_request(request, &context) {
+        #[cfg(test)]
+        let materialized = match self.path_roots.as_ref() {
+            Some(roots) => materialize_executor_request_at_root(
+                request,
+                &context,
+                roots.artifacts().to_path_buf(),
+            ),
+            None => materialize_executor_request(request, &context),
+        };
+        #[cfg(not(test))]
+        let materialized = materialize_executor_request(request, &context);
+        let mut request = match materialized {
             Ok(request) => request,
             Err((request, path, error)) => {
                 return failure_outcome(
@@ -325,6 +336,7 @@ fn materialize_executor_request_at_root(
     context: &AgentTaskExecutionContext,
     root: PathBuf,
 ) -> Result<AgentTaskExecutorRequest, (AgentTaskRequest, PathBuf, std::io::Error)> {
+    let finalized_root = root.join("executor-finalized");
     let path = root
         .join("agent-task")
         .join("executor-artifacts")
@@ -337,11 +349,11 @@ fn materialize_executor_request_at_root(
     if let Err(error) = ensure_writable_directory(&path) {
         return Err((request, path, error));
     }
-    let artifacts_root_identity =
-        crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(
-            &path,
-        )
-        .map_err(|error| {
+    let artifacts_root_identity = crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture_with_finalized_root(
+        &path,
+        finalized_root,
+    )
+    .map_err(|error| {
             (
                 request.clone(),
                 path.clone(),

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -257,55 +257,45 @@ fn scheduler_dispatches_extension_provider_command() {
 
 #[test]
 fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests() {
-    // The point of this test is that artifacts land in the runner-local root
-    // rather than the controller root, which an isolated home preserves: it
-    // just moves the runner root somewhere hermetic. Without it the test wrote
-    // a durable provider reservation into the developer's real Homeboy state
-    // and failed on every subsequent run with "provider execution was already
-    // reserved by an interrupted controller".
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let runner_root = homeboy_core::artifacts::root().expect("runner artifact root");
-        {
-            let controller_root = tempfile::tempdir().expect("controller root");
-            let command = format!(
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let runner_root = roots.artifacts().to_path_buf();
+    let controller_root = tempfile::tempdir().expect("controller root");
+    let command = format!(
             "node {}",
             script("let fs=require('fs'); let path=require('path'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let valid=path.isAbsolute(req.artifacts_path)&&fs.statSync(req.artifacts_path).isDirectory()&&req.artifacts_path_provenance.owner==='homeboy'&&req.artifacts_path_provenance.locality==='runner'&&!req.artifacts_path.startsWith(req.executor.config.controller_root); fs.writeFileSync(path.join(req.artifacts_path, req.task_id+'.txt'),'captured'); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:valid?(req.executor.config.no_op?'no_op':'succeeded'):'failed',summary:req.artifacts_path,artifacts:[]}));")
         );
-            let (mut no_op, provider) = request("task-no-op", command);
-            no_op.executor.config = json!({
-                "controller_root": controller_root.path(),
-                "no_op": true
-            });
-            let mut editing = no_op.clone();
-            editing.task_id = "task-editing".to_string();
-            editing.executor.config["no_op"] = json!(false);
-            let scheduler =
-                AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                    provider,
-                ]))
-                .with_run_id("runner-local-artifact-run");
-
-            // Recording a provider execution is durable, so the run it belongs
-            // to has to exist before the scheduler dispatches it.
-            let plan = AgentTaskPlan::new("runner-local-artifact-plan", vec![no_op, editing]);
-            crate::agent_task_lifecycle::submit_plan(&plan, Some("runner-local-artifact-run"))
-                .expect("durable run record");
-            let aggregate = scheduler.run(plan);
-
-            assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::NoOp);
-            assert_eq!(
-                aggregate.outcomes[1].status,
-                AgentTaskOutcomeStatus::Succeeded
-            );
-            for outcome in &aggregate.outcomes {
-                let path = PathBuf::from(outcome.summary.as_deref().expect("artifacts path"));
-                assert!(path.starts_with(&runner_root));
-                assert!(!path.starts_with(controller_root.path()));
-                assert!(path.join(format!("{}.txt", outcome.task_id)).is_file());
-            }
-            assert_ne!(aggregate.outcomes[0].summary, aggregate.outcomes[1].summary);
-        }
+    let (mut no_op, provider) = request("task-no-op", command);
+    no_op.executor.config = json!({
+        "controller_root": controller_root.path(),
+        "no_op": true
     });
+    let mut editing = no_op.clone();
+    editing.task_id = "task-editing".to_string();
+    editing.executor.config["no_op"] = json!(false);
+    let scheduler = AgentTaskScheduler::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
+            .with_path_roots(roots.clone()),
+    )
+    .with_scratch_root(roots.data().to_path_buf());
+
+    let aggregate = scheduler.run(AgentTaskPlan::new(
+        "runner-local-artifact-plan",
+        vec![no_op, editing],
+    ));
+
+    assert_eq!(aggregate.outcomes[0].status, AgentTaskOutcomeStatus::NoOp);
+    assert_eq!(
+        aggregate.outcomes[1].status,
+        AgentTaskOutcomeStatus::Succeeded
+    );
+    for outcome in &aggregate.outcomes {
+        let path = PathBuf::from(outcome.summary.as_deref().expect("artifacts path"));
+        assert!(path.starts_with(&runner_root));
+        assert!(!path.starts_with(controller_root.path()));
+        assert!(path.join(format!("{}.txt", outcome.task_id)).is_file());
+    }
+    assert_ne!(aggregate.outcomes[0].summary, aggregate.outcomes[1].summary);
 }
 
 #[test]
@@ -600,48 +590,51 @@ fn provider_sigkill_records_probable_oom_context() {
 
 #[test]
 fn provider_empty_stdout_records_failed_run_with_executor_evidence() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let command = format!(
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let lifecycle_store = crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
+    let command = format!(
             "node {}",
             script("process.stderr.write('provider emitted diagnostics but no outcome'); process.exit(42);")
         );
-        let (request, provider) = request("task-empty-stdout-recorded", command);
-        let plan = AgentTaskPlan::new("plan-empty-stdout-recorded", vec![request]);
-        let run_id = "run-empty-provider-output";
-        let scheduler =
-            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                provider,
-            ]))
-            .with_run_id(run_id);
+    let (request, provider) = request("task-empty-stdout-recorded", command);
+    let plan = AgentTaskPlan::new("plan-empty-stdout-recorded", vec![request]);
+    let run_id = "run-empty-provider-output";
+    let scheduler = AgentTaskScheduler::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
+            .with_path_roots(roots.clone()),
+    )
+    .with_scratch_root(roots.data().to_path_buf());
 
-        crate::agent_tasks::lifecycle::submit_plan(&plan, Some(run_id)).expect("submit plan");
-        crate::agent_tasks::lifecycle::mark_running(run_id).expect("mark running");
-        let aggregate = scheduler.run(plan.clone());
-        let record = crate::agent_tasks::lifecycle::record_run_aggregate(run_id, &plan, &aggregate)
-            .expect("record aggregate");
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submit plan");
+    let aggregate = scheduler.run(plan.clone());
+    let record = lifecycle_store
+        .record_run_aggregate(run_id, &plan, &aggregate)
+        .expect("record aggregate");
 
-        assert_eq!(
-            record.state,
-            crate::agent_task_lifecycle::AgentTaskRunState::Failed
-        );
-        assert_eq!(
-            aggregate.outcomes[0].status,
-            AgentTaskOutcomeStatus::ProviderError
-        );
-        assert_eq!(
-            aggregate.outcomes[0].diagnostics[0].class,
-            "agent_task.provider_empty_stdout"
-        );
-        assert!(aggregate.outcomes[0]
-            .evidence_refs
-            .iter()
-            .any(|reference| reference.kind == "executor-result"));
-        assert!(record.latest_executor_evidence.is_some());
-        assert!(record
-            .artifact_refs
-            .iter()
-            .any(|reference| reference.kind == "executor-result"));
-    });
+    assert_eq!(
+        record.state,
+        crate::agent_task_lifecycle::AgentTaskRunState::Failed
+    );
+    assert_eq!(
+        aggregate.outcomes[0].status,
+        AgentTaskOutcomeStatus::ProviderError
+    );
+    assert_eq!(
+        aggregate.outcomes[0].diagnostics[0].class,
+        "agent_task.provider_empty_stdout"
+    );
+    assert!(aggregate.outcomes[0]
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.kind == "executor-result"));
+    assert!(record.latest_executor_evidence.is_some());
+    assert!(record
+        .artifact_refs
+        .iter()
+        .any(|reference| reference.kind == "executor-result"));
 }
 
 #[test]
@@ -926,62 +919,69 @@ fn provider_command_receives_executor_config_env() {
 
 #[test]
 fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let state = unique_state_path("scratch-attempts");
-        let state_path = state.to_string_lossy().replace('\\', "\\\\");
-        let command = format!(
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let state = unique_state_path("scratch-attempts");
+    let state_path = state.to_string_lossy().replace('\\', "\\\\");
+    let command = format!(
             "node {}",
             script(&format!(
                 "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let tmp=req.executor.config.runtime_env.TMPDIR; let entries=[]; try {{ entries=JSON.parse(fs.readFileSync('{state_path}','utf8')); }} catch (_) {{}} entries.push({{tmp,keep:req.executor.config.runtime_env.KEEP}}); fs.writeFileSync('{state_path}',JSON.stringify(entries)); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:entries.length===1?'failed':'succeeded',failure_classification:entries.length===1?'execution_failed':null,summary:tmp}}));"
             ))
         );
-        let (mut request, provider) = request("task-scratch-retry", command);
-        request.executor.config = json!({ "runtime_env": { "KEEP": "preserved" } });
-        let mut plan = AgentTaskPlan::new("plan-scratch-retry", vec![request]);
-        plan.options.retry.max_attempts = 2;
-        plan.options.retry.retryable_failure_classifications =
-            vec![AgentTaskFailureClassification::ExecutionFailed];
+    let (mut request, provider) = request("task-scratch-retry", command);
+    request.executor.config = json!({ "runtime_env": { "KEEP": "preserved" } });
+    let mut plan = AgentTaskPlan::new("plan-scratch-retry", vec![request]);
+    plan.options.retry.max_attempts = 2;
+    plan.options.retry.retryable_failure_classifications =
+        vec![AgentTaskFailureClassification::ExecutionFailed];
 
-        crate::agent_tasks::lifecycle::submit_plan(&plan, Some("run-scratch-retry"))
-            .expect("submit plan");
-        crate::agent_tasks::lifecycle::mark_running("run-scratch-retry").expect("mark running");
-        let aggregate =
-            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                provider,
-            ]))
-            .with_run_id("run-scratch-retry")
-            .run(plan);
+    let aggregate = AgentTaskScheduler::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
+            .with_path_roots(roots.clone()),
+    )
+    .with_scratch_root(roots.data().to_path_buf())
+    .run(plan);
 
-        assert_eq!(aggregate.totals.succeeded, 1);
-        let attempts: Vec<Value> =
-            serde_json::from_str(&fs::read_to_string(&state).expect("attempt records"))
-                .expect("attempt JSON");
-        assert_eq!(attempts.len(), 2);
-        assert_eq!(attempts[0]["keep"], "preserved");
-        assert_eq!(attempts[1]["keep"], "preserved");
-        assert_ne!(attempts[0]["tmp"], attempts[1]["tmp"]);
-        for attempt in attempts {
-            let tmpdir = PathBuf::from(attempt["tmp"].as_str().expect("TMPDIR"));
-            assert!(tmpdir.is_dir());
-        }
-        let index: Value = serde_json::from_str(
-            &fs::read_to_string(
-                homeboy_core::paths::homeboy_data()
-                    .expect("homeboy data")
-                    .join("controller-scratch/test-indexes")
-                    .join("run-scratch-retry")
-                    .join("resources.json"),
-            )
-            .expect("scratch index"),
+    assert_eq!(aggregate.totals.succeeded, 1);
+    let attempts: Vec<Value> =
+        serde_json::from_str(&fs::read_to_string(&state).expect("attempt records"))
+            .expect("attempt JSON");
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0]["keep"], "preserved");
+    assert_eq!(attempts[1]["keep"], "preserved");
+    assert_ne!(attempts[0]["tmp"], attempts[1]["tmp"]);
+    for attempt in &attempts {
+        let tmpdir = PathBuf::from(attempt["tmp"].as_str().expect("TMPDIR"));
+        assert!(tmpdir.is_dir());
+    }
+    let first_tmpdir = PathBuf::from(attempts[0]["tmp"].as_str().expect("TMPDIR"));
+    let scratch_root =
+        fs::canonicalize(roots.data().join("controller-scratch/attempts")).expect("scratch root");
+    let scratch_run_id = first_tmpdir
+        .strip_prefix(scratch_root)
+        .expect("scratch root")
+        .components()
+        .next()
+        .expect("scratch run id")
+        .as_os_str();
+    let index: Value = serde_json::from_str(
+        &fs::read_to_string(
+            roots
+                .data()
+                .join("controller-scratch/test-indexes")
+                .join(scratch_run_id)
+                .join("resources.json"),
         )
-        .expect("scratch index JSON");
-        let resources = index["resources"].as_array().expect("scratch resources");
-        assert_eq!(resources.len(), 2);
-        assert_eq!(resources[0]["lifecycle_state"], "released");
-        assert_eq!(resources[0]["terminal_reason"], "retry");
-        assert_eq!(resources[1]["lifecycle_state"], "released");
-        assert_eq!(resources[1]["terminal_reason"], "succeeded");
-    });
+        .expect("scratch index"),
+    )
+    .expect("scratch index JSON");
+    let resources = index["resources"].as_array().expect("scratch resources");
+    assert_eq!(resources.len(), 2);
+    assert_eq!(resources[0]["lifecycle_state"], "released");
+    assert_eq!(resources[0]["terminal_reason"], "retry");
+    assert_eq!(resources[1]["lifecycle_state"], "released");
+    assert_eq!(resources[1]["terminal_reason"], "succeeded");
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -27,6 +27,8 @@ pub struct AgentTaskScheduler<E> {
     executor: Arc<E>,
     run_id: Option<String>,
     harvest_context: HarvestExecutionContext,
+    #[cfg(test)]
+    scratch_root: Option<std::path::PathBuf>,
 }
 
 impl<E> AgentTaskScheduler<E>
@@ -44,6 +46,8 @@ where
             executor: Arc::new(executor),
             run_id: None,
             harvest_context: HarvestExecutionContext::default(),
+            #[cfg(test)]
+            scratch_root: None,
         }
     }
 
@@ -54,6 +58,12 @@ where
 
     pub fn with_harvest_context(mut self, context: HarvestExecutionContext) -> Self {
         self.harvest_context = context;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_scratch_root(mut self, data_root: std::path::PathBuf) -> Self {
+        self.scratch_root = Some(data_root);
         self
     }
 
@@ -92,6 +102,12 @@ where
         // A scheduler without a durable run record still needs a private
         // controller-scratch namespace. Plan IDs are semantic labels and can
         // legitimately repeat across independent in-process executions.
+        #[cfg(test)]
+        let scratch_run_id = self
+            .run_id
+            .clone()
+            .unwrap_or_else(|| format!("ephemeral-{}", uuid::Uuid::new_v4()));
+        #[cfg(not(test))]
         let scratch_run_id = self
             .run_id
             .clone()
@@ -511,15 +527,29 @@ where
                 let source_workspace_root = request.workspace.root.clone();
                 let source_provenance = harvest_preflight.source_provenance;
                 #[cfg(test)]
-                let scratch_allocation = crate::controller_scratch::allocate_test_attempt;
+                let scratch = match self.scratch_root.as_ref() {
+                    Some(data_root) => crate::controller_scratch::allocate_test_attempt_at(
+                        data_root,
+                        &scratch_run_id,
+                        &plan.plan_id,
+                        &request.task_id,
+                        scheduled.attempt,
+                    ),
+                    None => crate::controller_scratch::allocate_test_attempt(
+                        &scratch_run_id,
+                        &plan.plan_id,
+                        &request.task_id,
+                        scheduled.attempt,
+                    ),
+                };
                 #[cfg(not(test))]
-                let scratch_allocation = crate::controller_scratch::allocate_attempt;
-                let scratch = match scratch_allocation(
+                let scratch = crate::controller_scratch::allocate_attempt(
                     &scratch_run_id,
                     &plan.plan_id,
                     &request.task_id,
                     scheduled.attempt,
-                ) {
+                );
+                let scratch = match scratch {
                     Ok(scratch) => scratch,
                     Err(error) => {
                         let outcome =

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -90,7 +90,14 @@ pub fn allocate_attempt(
     task_id: &str,
     attempt: u32,
 ) -> Result<ControllerScratchAllocation> {
-    allocate_attempt_at_index(run_id, plan_id, task_id, attempt, index_path()?)
+    allocate_attempt_at_roots(
+        run_id,
+        plan_id,
+        task_id,
+        attempt,
+        paths::controller_scratch_store()?.join("attempts"),
+        index_path()?,
+    )
 }
 
 #[cfg(test)]
@@ -100,21 +107,39 @@ pub fn allocate_test_attempt(
     task_id: &str,
     attempt: u32,
 ) -> Result<ControllerScratchAllocation> {
-    let index_path = paths::homeboy_data()?.join(format!(
-        "controller-scratch/test-indexes/{}/resources.json",
-        paths::sanitize_path_segment(run_id)
-    ));
-    allocate_attempt_at_index(run_id, plan_id, task_id, attempt, index_path)
+    allocate_test_attempt_at(&paths::homeboy_data()?, run_id, plan_id, task_id, attempt)
 }
 
-fn allocate_attempt_at_index(
+#[cfg(test)]
+pub fn allocate_test_attempt_at(
+    data_root: &Path,
     run_id: &str,
     plan_id: &str,
     task_id: &str,
     attempt: u32,
+) -> Result<ControllerScratchAllocation> {
+    let index_path = data_root.join(format!(
+        "controller-scratch/test-indexes/{}/resources.json",
+        paths::sanitize_path_segment(run_id)
+    ));
+    allocate_attempt_at_roots(
+        run_id,
+        plan_id,
+        task_id,
+        attempt,
+        data_root.join("controller-scratch/attempts"),
+        index_path,
+    )
+}
+
+fn allocate_attempt_at_roots(
+    run_id: &str,
+    plan_id: &str,
+    task_id: &str,
+    attempt: u32,
+    root: PathBuf,
     index_path: PathBuf,
 ) -> Result<ControllerScratchAllocation> {
-    let root = paths::controller_scratch_store()?.join("attempts");
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -643,14 +668,37 @@ pub fn retained_storage_inventory() -> Result<Vec<ControllerScratchRetainedResou
 /// `metadata.controller_scratch` object or array. Providers own materializing
 /// the path; Homeboy owns its durable lifecycle and cleanup policy.
 pub fn register_outcome_resources(run_id: &str, outcomes: &[AgentTaskOutcome]) -> Result<()> {
-    let index_path = index_path()?;
+    register_outcome_resources_at_index(index_path()?, run_id, outcomes)
+}
+
+pub(crate) fn register_outcome_resources_at(
+    data_root: &Path,
+    run_id: &str,
+    outcomes: &[AgentTaskOutcome],
+) -> Result<()> {
+    register_outcome_resources_at_index(
+        data_root.join("controller-scratch/resources.json"),
+        run_id,
+        outcomes,
+    )
+}
+
+fn register_outcome_resources_at_index(
+    index_path: PathBuf,
+    run_id: &str,
+    outcomes: &[AgentTaskOutcome],
+) -> Result<()> {
     with_index_lock(&index_path, || {
-        register_outcome_resources_unlocked(run_id, outcomes)
+        register_outcome_resources_unlocked(&index_path, run_id, outcomes)
     })
 }
 
-fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcome]) -> Result<()> {
-    let mut index = read_index_unlocked()?;
+fn register_outcome_resources_unlocked(
+    index_path: &Path,
+    run_id: &str,
+    outcomes: &[AgentTaskOutcome],
+) -> Result<()> {
+    let mut index = read_index_at_unlocked(index_path)?;
     let mut changed = false;
     for outcome in outcomes {
         let values = outcome
@@ -741,7 +789,7 @@ fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcom
         }
     }
     if changed {
-        write_index_unlocked(&index)?;
+        write_index_at_unlocked(index_path, &index)?;
     }
     Ok(())
 }
@@ -749,12 +797,19 @@ fn register_outcome_resources_unlocked(run_id: &str, outcomes: &[AgentTaskOutcom
 /// Marks all resources owned by a terminal run as finalized, including failed
 /// and cancelled exits, so retention starts regardless of task outcome.
 pub fn finalize_run(run_id: &str) -> Result<()> {
-    let index_path = index_path()?;
-    with_index_lock(&index_path, || finalize_run_unlocked(run_id))
+    finalize_run_at_index(index_path()?, run_id)
 }
 
-fn finalize_run_unlocked(run_id: &str) -> Result<()> {
-    let mut index = read_index_unlocked()?;
+pub(crate) fn finalize_run_at(data_root: &Path, run_id: &str) -> Result<()> {
+    finalize_run_at_index(data_root.join("controller-scratch/resources.json"), run_id)
+}
+
+fn finalize_run_at_index(index_path: PathBuf, run_id: &str) -> Result<()> {
+    with_index_lock(&index_path, || finalize_run_unlocked(&index_path, run_id))
+}
+
+fn finalize_run_unlocked(index_path: &Path, run_id: &str) -> Result<()> {
+    let mut index = read_index_at_unlocked(index_path)?;
     let now = chrono::Utc::now().to_rfc3339();
     let mut changed = false;
     for resource in &mut index.resources {
@@ -788,7 +843,7 @@ fn finalize_run_unlocked(run_id: &str) -> Result<()> {
         }
     }
     if changed {
-        write_index_unlocked(&index)?;
+        write_index_at_unlocked(index_path, &index)?;
     }
     Ok(())
 }

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -80,7 +80,7 @@ impl AgentTaskLifecycleStore {
         self.roots.data().join("homeboy.sqlite")
     }
 
-    fn data_root(&self) -> PathBuf {
+    pub(crate) fn data_root(&self) -> PathBuf {
         self.roots.data().to_path_buf()
     }
 
@@ -222,6 +222,15 @@ impl AgentTaskLifecycleStore {
 
     pub fn read_record(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_in_store(self, run_id)
+    }
+
+    pub(crate) fn record_run_aggregate(
+        &self,
+        run_id: &str,
+        plan: &AgentTaskPlan,
+        aggregate: &AgentTaskAggregate,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_run_aggregate_in_store(self, run_id, plan, aggregate)
     }
 
     /// Check this store for one exact durable run identity without Cook alias


### PR DESCRIPTION
## Summary
- bind provider executor artifacts and finalization to explicit artifact roots in hermetic tests
- let scheduler scratch attempts use an explicit data root without changing durable run identity
- keep aggregate scratch projection on the owning `AgentTaskLifecycleStore` data root
- remove the final ambient-home wrappers from provider scheduler tests

## Payoff
- ambient lock sites in `scheduler_tests.rs`: 3 -> 0
- ambient lock sites in the complete provider subsystem: 3 -> 0
- public APIs added: none; new seams are crate-scoped or test-only
- production environment roots and controller-scratch corruption behavior remain unchanged
- diff: +297/-163, net +134 lines

This is intentionally a seam-investment slice rather than a deletion slice. It completes explicit ownership across executor artifacts, controller scratch, and lifecycle aggregate projection so these paths can run concurrently without mutating process-wide HOME.

## Verification
- `cargo test -p homeboy-agents --locked executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests --lib`
- `cargo test -p homeboy-agents --locked provider_empty_stdout_records_failed_run_with_executor_evidence --lib`
- `cargo test -p homeboy-agents --locked provider_attempts_receive_distinct_allocated_runtime_tmpdirs --lib`
- `cargo test -p homeboy-agents --locked agent_task_lifecycle::tests::lifecycle_store --lib` (4 passed)
- `cargo test -p homeboy-agents --locked isolated_cook_rejects_source_identity_drift_before_snapshotting --lib`
- `cargo test -p homeboy-agents --locked retention_override_does_not_bypass_running_owner_guard --lib`
- `cargo check -p homeboy-agents --tests --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Contributes to #7505.

## AI assistance
GPT-5.6 Sol via OpenCode was used to trace artifact, scratch, and lifecycle storage ownership; implement explicit-root seams; review compatibility; and run verification. Chris Huber reviewed and remains responsible for the change.