### PR TITLE
fix(runner): honor explicit candidate reconciliation

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -811,9 +811,14 @@ fn connect_with_orphan_adoption_and_live_lease(
     // boundary but did not durably receive B's coordinates. Replay it before
     // inspecting A or selecting any ordinary replacement path.
     if recovery_daemon.is_none() {
-        if let Some((kind, command)) =
-            super::generation_store::replacement_operation_replay(runner_id)?
-        {
+        let replay = super::generation_store::replacement_operation_replay(runner_id)?;
+        // Explicit candidate reconciliation is the authority selected to
+        // resolve an unleased process conflict. Replaying a prior
+        // ensure-running command first can only reproduce that conflict; the
+        // reconciliation block below durably records the typed supersession.
+        let replay =
+            replay.filter(|(kind, _)| !(reconcile_unleased_candidates && kind == "ensure-running"));
+        if let Some((kind, command)) = replay {
             let command = if kind == "ensure-running" {
                 if let Err(error) = negotiate_ensure_running_operation_id(
                     &client,
@@ -1207,10 +1212,8 @@ fn connect_with_orphan_adoption_and_live_lease(
             shell::quote_arg(recovery_addr),
             shell::quote_arg(&replacement_operation_id),
         );
-        super::generation_store::record_immutable_replacement_operation_replay(
-            runner_id,
-            "unleased-candidates",
-            &command,
+        super::generation_store::record_unleased_candidate_reconciliation_replay(
+            runner_id, &command,
         )?;
         let output = fenced_remote_mutation(
             runner_id,

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1879,6 +1879,93 @@ esac
     });
 }
 
+/// #12449: an explicit candidate reconciliation is the operator-selected
+/// authority for an unleased conflict. A pending ensure-running replay must be
+/// durably superseded rather than reproducing that conflict first.
+#[cfg(unix)]
+#[test]
+fn explicit_candidate_reconciliation_supersedes_pending_ensure_running_replay() {
+    test_support::with_isolated_home(|home| {
+        let daemon = home.path().join("remote-homeboy");
+        let ensure_running = home.path().join("ensure-running");
+        let reconciliation_argv = home.path().join("reconciliation-argv");
+        std::fs::write(
+            &daemon,
+            format!(
+                r#"#!/bin/sh
+case "$1 $2" in
+  "self identity")
+    printf '%s\n' '{{"success":true,"data":{{"version":"0.348.2","display":"homeboy 0.348.2+test","daemon_recovery_capabilities":[{{"id":"daemon-recovery-unleased-candidates","version":1}}]}}}}'
+    ;;
+  "daemon ensure-running")
+    printf '%s' 'executed' > "{ensure_running}"
+    exit 98
+    ;;
+  "daemon reconcile-unleased-candidates")
+    printf '%s\n' "$@" > "{reconciliation_argv}"
+    printf '%s\n' '{{"success":true,"data":{{"applied":true,"active_jobs":0,"candidates":[],"retired_pids":[],"blocked_pids":[],"evidence":["reconciled"],"replacement":{{"pid":4242,"address":"127.0.0.1:9","state_path":"/tmp/state-b.json","lease_id":"lease-b"}}}}}}'
+    ;;
+esac
+"#,
+                ensure_running = ensure_running.display(),
+                reconciliation_argv = reconciliation_argv.display(),
+            ),
+        )
+        .expect("write remote Homeboy shim");
+        let mut permissions = std::fs::metadata(&daemon).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&daemon, permissions).expect("make shim executable");
+        server::create(
+            &serde_json::json!({ "id": "local-runner", "host": "localhost", "user": "test" })
+                .to_string(),
+            false,
+        )
+        .expect("create local server");
+        crate::create(
+            &serde_json::json!({
+                "id": "local-runner",
+                "kind": "ssh",
+                "homeboy_path": daemon,
+            })
+            .to_string(),
+            false,
+        )
+        .expect("enable local runner");
+
+        let operation_id = crate::generation_store::replacement_operation("local-runner")
+            .expect("replacement operation");
+        crate::generation_store::record_replacement_operation_replay(
+            "local-runner",
+            "ensure-running",
+            "obsolete-homeboy daemon ensure-running --replacement-operation-id old",
+        )
+        .expect("pending ensure-running replay");
+
+        let (result, exit_code) = connect_with_unleased_candidate_reconciliation("local-runner")
+            .expect("candidate reconciliation result");
+        assert_eq!(
+            exit_code, 20,
+            "the unreachable test endpoint fails later health"
+        );
+        assert!(result.failure_kind.is_some());
+        assert!(
+            !ensure_running.exists(),
+            "explicit reconciliation must not execute pending ensure-running"
+        );
+        let reconciliation_argv =
+            std::fs::read_to_string(reconciliation_argv).expect("reconciliation argv");
+        assert!(reconciliation_argv.contains("reconcile-unleased-candidates"));
+        assert!(reconciliation_argv.contains("--apply"));
+        assert!(reconciliation_argv.contains(&operation_id));
+        assert_eq!(
+            crate::generation_store::replacement_operation_replay("local-runner")
+                .expect("replacement replay")
+                .map(|(kind, _)| kind),
+            Some("unleased-candidates".to_string())
+        );
+    });
+}
+
 #[test]
 fn state_loss_recovery_delegation_uses_the_canonical_exact_contract() {
     let command = remote_state_loss_recovery_command(

--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -74,6 +74,13 @@ fn rejected_replacement_path(runner_id: &str) -> Result<PathBuf> {
         .join(format!("{}.json", uuid::Uuid::new_v4())))
 }
 
+fn superseded_replacement_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(paths::runner_sessions_dir()?
+        .join(runner_id)
+        .join("superseded-replacements")
+        .join(format!("{}.json", uuid::Uuid::new_v4())))
+}
+
 fn admission_reservation_path(runner_id: &str) -> Result<PathBuf> {
     Ok(paths::runner_sessions_dir()?
         .join(runner_id)
@@ -113,6 +120,18 @@ struct RejectedReplacementEvidence<'a> {
     timed_out: bool,
     stdout: &'a str,
     stderr: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct SupersededReplacementEvidence<'a> {
+    schema: &'static str,
+    runner_id: &'a str,
+    operation_id: &'a str,
+    previous_kind: &'a str,
+    previous_replay_command: &'a str,
+    replacement_kind: &'a str,
+    replacement_replay_command: &'a str,
+    superseded_at: String,
 }
 
 pub(crate) fn write_durable_json<T: serde::Serialize>(
@@ -794,6 +813,55 @@ pub(crate) fn record_immutable_replacement_operation_replay(
             return Ok(());
         }
         operation.kind = Some(kind.to_string());
+        operation.replay_command = Some(command.to_string());
+        write_durable_json(&path, &operation)
+    })
+}
+
+/// Bind candidate reconciliation to the current replacement identity. An
+/// explicit operator recovery may supersede only `ensure-running`: that command
+/// can create one of the candidates reconciliation is responsible for, and
+/// replaying it first would reproduce the conflict the operator selected this
+/// recovery to resolve.
+pub(crate) fn record_unleased_candidate_reconciliation_replay(
+    runner_id: &str,
+    command: &str,
+) -> Result<()> {
+    with_registry_lock(runner_id, || {
+        let path = replacement_operation_path(runner_id)?;
+        let mut operation: ReplacementOperation =
+            serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
+            })?)
+            .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))?;
+        match (
+            operation.kind.as_deref(),
+            operation.replay_command.as_deref(),
+        ) {
+            (Some("unleased-candidates"), Some(existing)) if existing == command => return Ok(()),
+            (Some("ensure-running"), Some(previous_command)) => {
+                write_durable_json(
+                    &superseded_replacement_path(runner_id)?,
+                    &SupersededReplacementEvidence {
+                        schema: "homeboy/runner-replacement-operation-supersession/v1",
+                        runner_id,
+                        operation_id: &operation.operation_id,
+                        previous_kind: "ensure-running",
+                        previous_replay_command: previous_command,
+                        replacement_kind: "unleased-candidates",
+                        replacement_replay_command: command,
+                        superseded_at: Utc::now().to_rfc3339(),
+                    },
+                )?;
+            }
+            (None, None) => {}
+            _ => {
+                return Err(Error::internal_unexpected(
+                    "replacement operation cannot transition to unleased candidate reconciliation",
+                ));
+            }
+        }
+        operation.kind = Some("unleased-candidates".to_string());
         operation.replay_command = Some(command.to_string());
         write_durable_json(&path, &operation)
     })
@@ -2246,6 +2314,53 @@ mod tests {
                 replacement_operation("runner-a").expect("new operation"),
                 next_operation
             );
+        });
+    }
+
+    #[test]
+    fn explicit_candidate_reconciliation_supersedes_ensure_running_with_evidence() {
+        test_support::with_isolated_home(|_| {
+            let operation_id = replacement_operation("runner-a").expect("operation");
+            record_replacement_operation_replay(
+                "runner-a",
+                "ensure-running",
+                "homeboy daemon ensure-running --replacement-operation-id operation-a",
+            )
+            .expect("ensure-running replay");
+
+            let reconciliation = "homeboy daemon reconcile-unleased-candidates --apply --replacement-operation-id operation-a";
+            record_unleased_candidate_reconciliation_replay("runner-a", reconciliation)
+                .expect("explicit reconciliation supersedes ensure-running");
+            record_unleased_candidate_reconciliation_replay("runner-a", reconciliation)
+                .expect("same reconciliation replay is idempotent");
+
+            assert_eq!(
+                replacement_operation("runner-a").expect("preserved operation"),
+                operation_id
+            );
+            assert_eq!(
+                replacement_operation_replay("runner-a").expect("replacement replay"),
+                Some((
+                    "unleased-candidates".to_string(),
+                    reconciliation.to_string()
+                ))
+            );
+            let evidence_dir = paths::runner_sessions_dir()
+                .expect("runner sessions")
+                .join("runner-a")
+                .join("superseded-replacements");
+            let evidence = std::fs::read_dir(evidence_dir)
+                .expect("supersession evidence")
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .expect("evidence entries");
+            assert_eq!(evidence.len(), 1, "idempotent replay writes one transition");
+            let evidence: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(evidence[0].path()).expect("read supersession evidence"),
+            )
+            .expect("supersession evidence JSON");
+            assert_eq!(evidence["operation_id"], operation_id);
+            assert_eq!(evidence["previous_kind"], "ensure-running");
+            assert_eq!(evidence["replacement_kind"], "unleased-candidates");
         });
     }
 


### PR DESCRIPTION
## Summary

- let explicit unleased-candidate reconciliation supersede a pending `ensure-running` replay instead of reproducing the known conflict first
- preserve the replacement operation identity and write durable evidence describing the authority transition
- keep ordinary connect replay behavior unchanged and prove both paths through the connection recovery suite

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p homeboy-lab-runner connection::tests::recovery:: -- --nocapture` (73 passed)
- focused supersession state tests (2 passed)
- the broad `homeboy-lab-runner` suite exposed three unrelated preparation/provider failures and exceeded 40 minutes; focused changed-path and workspace gates pass

Closes #12449

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the live Lab recovery failure, traced the replay ordering, implemented the evidence-preserving authority transition, and added regression coverage. Chris Huber directed the work and remains responsible for every line.
