### PR TITLE
fix(daemon): recover candidate stores from procfs

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -77,15 +77,17 @@ pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonPr
         .lines()
         .filter_map(|line| parse_daemon_process_candidate(line, jobs_path, current_exe.as_deref()))
         .map(|mut candidate| {
-            if matches!(
-                command_state_dir(&candidate.cmdline),
-                CommandStateDir::Absent
-            ) {
-                if let Some(store) = process_durable_store_path(candidate.pid) {
-                    candidate.durable_store_path = Some(store.display().to_string());
-                    candidate.ownership = classify_candidate_store(&candidate, jobs_path, &store);
-                }
-            }
+            let process_store_fallback = match command_state_dir(&candidate.cmdline) {
+                CommandStateDir::Proven(_) => None,
+                CommandStateDir::Ambiguous => Some(false),
+                CommandStateDir::Absent => Some(true),
+            };
+            recover_candidate_store_from_process_environment(
+                &mut candidate,
+                jobs_path,
+                process_store_fallback,
+                process_durable_store_path,
+            );
             if test_namespace && candidate.durable_store_path.as_deref() != jobs_path.to_str() {
                 candidate.ownership = DaemonProcessOwnership::Unrelated;
             }
@@ -522,11 +524,29 @@ fn classify_candidate_store(
     }
 }
 
+fn recover_candidate_store_from_process_environment(
+    candidate: &mut DaemonProcessCandidate,
+    jobs_path: &Path,
+    allow_home: Option<bool>,
+    resolve: impl FnOnce(u32, bool) -> Option<PathBuf>,
+) {
+    let Some(allow_home) = allow_home else {
+        return;
+    };
+    // Linux procfs preserves argv/environment boundaries that `ps` flattens.
+    // An explicit state-dir environment may therefore resolve ambiguous command
+    // text; HOME remains a fallback only when argv has no competing signal.
+    if let Some(store) = resolve(candidate.pid, allow_home) {
+        candidate.durable_store_path = Some(store.display().to_string());
+        candidate.ownership = classify_candidate_store(candidate, jobs_path, &store);
+    }
+}
+
 /// `Command::env` does not become argv. Linux exposes the authoritative
 /// inherited environment via procfs; other platforms retain an ambiguous,
 /// fail-closed candidate when argv lacks a durable-store identity.
 #[cfg(target_os = "linux")]
-fn process_durable_store_path(pid: u32) -> Option<PathBuf> {
+fn process_durable_store_path(pid: u32, allow_home: bool) -> Option<PathBuf> {
     let environment = std::fs::read(format!("/proc/{pid}/environ")).ok()?;
     let assignment = |key: &str| {
         environment
@@ -534,18 +554,20 @@ fn process_durable_store_path(pid: u32) -> Option<PathBuf> {
             .find_map(|entry| entry.strip_prefix(format!("{key}=").as_bytes()))
             .and_then(|value| std::str::from_utf8(value).ok())
     };
-    assignment(crate::paths::DAEMON_STATE_DIR_ENV)
+    if let Some(state_dir) =
+        assignment(crate::paths::DAEMON_STATE_DIR_ENV).filter(|value| !value.is_empty())
+    {
+        return Some(durable_store_path(Path::new(state_dir)));
+    }
+    allow_home
+        .then(|| assignment("HOME"))
+        .flatten()
         .filter(|value| !value.is_empty())
-        .map(|value| durable_store_path(Path::new(value)))
-        .or_else(|| {
-            assignment("HOME")
-                .filter(|value| !value.is_empty())
-                .map(|value| durable_store_path(&Path::new(value).join(".config/homeboy/daemon")))
-        })
+        .map(|value| durable_store_path(&Path::new(value).join(".config/homeboy/daemon")))
 }
 
 #[cfg(not(target_os = "linux"))]
-fn process_durable_store_path(_pid: u32) -> Option<PathBuf> {
+fn process_durable_store_path(_pid: u32, _allow_home: bool) -> Option<PathBuf> {
     None
 }
 

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -672,11 +672,171 @@ fn candidate_attribution_reads_command_env_store_identity_from_procfs() {
         .spawn()
         .expect("process with daemon state environment");
 
-    let store = super::process_durable_store_path(process.id()).expect("procfs store path");
+    let store = super::process_durable_store_path(process.id(), true).expect("procfs store path");
     process.kill().expect("stop process");
     process.wait().expect("reap process");
 
     assert_eq!(store, state_dir.path().join("jobs.json"));
+}
+
+#[test]
+fn ambiguous_command_state_uses_explicit_process_store_without_home_fallback() {
+    let selected_state = tempfile::tempdir().expect("selected state directory");
+    let candidate_state = tempfile::tempdir().expect("candidate state directory");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} {} daemon serve --state-dir /flattened/ambiguous trailing-ps-text",
+        executable.display(),
+        executable.display()
+    );
+    let selected_jobs = selected_state.path().join("jobs.json");
+    let mut candidate =
+        super::parse_daemon_process_candidate(&line, &selected_jobs, None).expect("candidate");
+    assert_eq!(candidate.durable_store_path, None);
+
+    let mut allow_home_seen = None;
+    super::recover_candidate_store_from_process_environment(
+        &mut candidate,
+        &selected_jobs,
+        Some(false),
+        |pid, allow_home| {
+            assert_eq!(pid, 4243);
+            allow_home_seen = Some(allow_home);
+            Some(candidate_state.path().join("jobs.json"))
+        },
+    );
+
+    assert_eq!(allow_home_seen, Some(false));
+    assert_eq!(
+        candidate.durable_store_path.as_deref(),
+        candidate_state.path().join("jobs.json").to_str()
+    );
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Unrelated
+    );
+}
+
+#[test]
+fn absent_command_state_allows_process_home_fallback_but_keeps_same_store_safe() {
+    let state = tempfile::tempdir().expect("state directory");
+    let executable = std::env::current_exe().expect("current executable");
+    let line = format!(
+        "4243 {} {} daemon serve --addr 127.0.0.1:0",
+        executable.display(),
+        executable.display()
+    );
+    let jobs = state.path().join("jobs.json");
+    let mut candidate =
+        super::parse_daemon_process_candidate(&line, &jobs, None).expect("candidate");
+
+    super::recover_candidate_store_from_process_environment(
+        &mut candidate,
+        &jobs,
+        Some(true),
+        |_, allow_home| {
+            assert!(allow_home);
+            Some(jobs.clone())
+        },
+    );
+
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Ambiguous,
+        "store evidence does not replace executable identity proof"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn ambiguous_ps_state_dir_uses_only_explicit_procfs_state_identity() {
+    let selected_state = tempfile::tempdir().expect("selected state directory");
+    let candidate_state = tempfile::tempdir().expect("candidate state directory");
+    let mut process = Command::new("sh")
+        .args([
+            "-c",
+            "trap 'kill \"$child\" 2>/dev/null' TERM EXIT; sleep 30 & child=$!; wait \"$child\"",
+            "homeboy",
+            "daemon",
+            "serve",
+            "--addr",
+            "127.0.0.1:0",
+            "--startup-token",
+            "candidate-token",
+            "--state-dir",
+            "/flattened/ambiguous",
+            "trailing-ps-text",
+        ])
+        .env(crate::paths::DAEMON_STATE_DIR_ENV, candidate_state.path())
+        .spawn()
+        .expect("candidate process");
+
+    let candidates = super::daemon_process_candidates(&selected_state.path().join("jobs.json"))
+        .expect("candidate scan");
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.pid == process.id())
+        .expect("spawned candidate");
+    assert_eq!(
+        candidate.durable_store_path.as_deref(),
+        candidate_state.path().join("jobs.json").to_str()
+    );
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Unrelated
+    );
+
+    let candidates = super::daemon_process_candidates(&candidate_state.path().join("jobs.json"))
+        .expect("same-store candidate scan");
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.pid == process.id())
+        .expect("same-store candidate");
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Ambiguous,
+        "procfs store proof does not replace executable identity proof"
+    );
+
+    process.kill().expect("stop candidate process");
+    process.wait().expect("reap candidate process");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn ambiguous_ps_state_dir_does_not_fall_back_to_procfs_home() {
+    let home = tempfile::tempdir().expect("candidate home");
+    let mut process = Command::new("sh")
+        .args([
+            "-c",
+            "trap 'kill \"$child\" 2>/dev/null' TERM EXIT; sleep 30 & child=$!; wait \"$child\"",
+            "homeboy",
+            "daemon",
+            "serve",
+            "--state-dir",
+            "/flattened/ambiguous",
+            "trailing-ps-text",
+        ])
+        .env_remove(crate::paths::DAEMON_STATE_DIR_ENV)
+        .env("HOME", home.path())
+        .spawn()
+        .expect("candidate process");
+
+    let candidates =
+        super::daemon_process_candidates(&home.path().join(".config/homeboy/daemon/jobs.json"))
+            .expect("candidate scan");
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.pid == process.id())
+        .expect("spawned candidate");
+    assert_eq!(candidate.durable_store_path, None);
+    assert_eq!(
+        candidate.ownership,
+        super::super::DaemonProcessOwnership::Ambiguous
+    );
+
+    process.kill().expect("stop candidate process");
+    process.wait().expect("reap candidate process");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- recover an ambiguous flattened `ps` state-dir from authoritative Linux procfs environment evidence
- permit HOME fallback only when argv has no competing state-dir signal
- preserve different-store exclusion and same-store executable/token/process/endpoint safety fences

## Verification

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p homeboy-core daemon::control::control_test:: -- --nocapture` (56 passed on macOS)
- platform-neutral fallback authority tests (2 passed)
- Linux-only process fixtures exercise real `/proc/<pid>/environ` attribution in CI

Closes #12456

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the live post-reconciliation attribution failure, traced the suppressed procfs fallback, implemented the bounded authority rule, and added cross-platform plus Linux process coverage. Chris Huber directed the work and remains responsible for every line.
