### PR TITLE
Fix Lab admission identity handoff

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1183,6 +1183,38 @@ where
     probe()
 }
 
+fn carry_forward_prepared_configured_identity(
+    prepared: &RunnerStatusReport,
+    current: &mut RunnerStatusReport,
+) {
+    if current.configured_job_binary_build_identity.is_some()
+        || prepared.admission_blocking_stale_daemon().is_some()
+        || current.admission_blocking_stale_daemon().is_some()
+        || prepared.runner_id != current.runner_id
+    {
+        return;
+    }
+    let (Some(prepared_session), Some(current_session)) =
+        (prepared.session.as_ref(), current.session.as_ref())
+    else {
+        return;
+    };
+    let same_direct_daemon = prepared_session.mode == RunnerTunnelMode::DirectSsh
+        && current_session.mode == RunnerTunnelMode::DirectSsh
+        && prepared_session.remote_daemon_lease_id.is_some()
+        && prepared_session.remote_daemon_lease_id == current_session.remote_daemon_lease_id
+        && prepared_session.remote_daemon_address.is_some()
+        && prepared_session.remote_daemon_address == current_session.remote_daemon_address
+        && prepared_session.remote_daemon_pid.is_some()
+        && prepared_session.remote_daemon_pid == current_session.remote_daemon_pid
+        && prepared_session.homeboy_build_identity.is_some()
+        && prepared_session.homeboy_build_identity == current_session.homeboy_build_identity;
+    if same_direct_daemon {
+        current.configured_job_binary_build_identity =
+            prepared.configured_job_binary_build_identity.clone();
+    }
+}
+
 fn apply_direct_ssh_configured_identity_freshness(
     status: &mut RunnerStatusReport,
     runner_id: &str,
@@ -1226,11 +1258,12 @@ pub(crate) fn run_lab_offload_inner(
     mut plan: HomeboyPlan,
     mut messages: Vec<String>,
     mut overhead: LabOffloadOverhead,
-    _runner_status: RunnerStatusReport,
+    prepared_runner_status: RunnerStatusReport,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let mut runner = load(runner_id)?;
     let mut runner_status = status_for_admission(runner_id)?;
+    carry_forward_prepared_configured_identity(&prepared_runner_status, &mut runner_status);
     if runner.kind != super::super::super::RunnerKind::Ssh {
         return Err(Error::validation_invalid_argument(
             "runner",
@@ -2974,6 +3007,43 @@ mod tests {
     }
 
     #[test]
+    fn direct_ssh_admission_carries_prepared_identity_across_the_same_daemon_generation() {
+        let identity = "homeboy 0.339.0+83a9bd058619";
+        let prepared = direct_identity_status(Some(identity), "lease-a");
+        let mut current = direct_identity_status(None, "lease-a");
+
+        carry_forward_prepared_configured_identity(&prepared, &mut current);
+
+        assert_eq!(
+            current.configured_job_binary_build_identity.as_deref(),
+            Some(identity)
+        );
+    }
+
+    #[test]
+    fn direct_ssh_admission_does_not_carry_identity_across_daemon_generations() {
+        let prepared = direct_identity_status(Some("homeboy 0.339.0+prepared"), "lease-a");
+        let mut current = direct_identity_status(None, "lease-b");
+
+        carry_forward_prepared_configured_identity(&prepared, &mut current);
+
+        assert!(current.configured_job_binary_build_identity.is_none());
+    }
+
+    #[test]
+    fn direct_ssh_admission_does_not_replace_an_observed_mismatch() {
+        let prepared = direct_identity_status(Some("homeboy 0.339.0+prepared"), "lease-a");
+        let mut current = direct_identity_status(Some("homeboy 0.339.0+current"), "lease-a");
+
+        carry_forward_prepared_configured_identity(&prepared, &mut current);
+
+        assert_eq!(
+            current.configured_job_binary_build_identity.as_deref(),
+            Some("homeboy 0.339.0+current")
+        );
+    }
+
+    #[test]
     fn direct_ssh_admission_without_configured_identity_fails_closed() {
         let mut status = runner_status(true);
         status.session = Some(admission_session(
@@ -3325,6 +3395,24 @@ mod tests {
             last_seen_at: None,
             leaseless_recovery_evidence: None,
         }
+    }
+
+    fn direct_identity_status(
+        configured_identity: Option<&str>,
+        lease_id: &str,
+    ) -> RunnerStatusReport {
+        let mut status = runner_status(true);
+        let mut session = admission_session(
+            RunnerTunnelMode::DirectSsh,
+            Some("http://127.0.0.1:7421"),
+            Some(lease_id),
+        );
+        session.remote_daemon_address = Some("127.0.0.1:7422".to_string());
+        session.remote_daemon_pid = Some(42);
+        session.homeboy_build_identity = Some("homeboy 0.339.0+83a9bd058619".to_string());
+        status.session = Some(session);
+        status.configured_job_binary_build_identity = configured_identity.map(str::to_string);
+        status
     }
 
     fn runner_status(connected: bool) -> RunnerStatusReport {


### PR DESCRIPTION
## Summary

- preserve the configured-binary identity proven by Lab preparation when final admission transiently loses only that field
- reuse the evidence only for the same direct-SSH runner, lease, endpoint, daemon PID, and daemon build identity
- retain observed current identities and fail closed across daemon-generation changes

Closes #12460.

## Verification

- `cargo fmt --all`
- `cargo test -p homeboy-lab-runner direct_ssh_admission -- --nocapture` (6 passed)
- `git diff --check`
- `cargo test -p homeboy-lab-runner` was attempted; the broad suite exceeded 20 minutes and reached existing baseline failures, including stale-daemon recovery-command and provider fixture tests unrelated to this one-file change.

## Reproduction

Before this change, Cook `agent-task-8b1dc374-4e34-4669-9119-fc00fe1b6fa3` failed both attempts before provider execution. `runner status --full` and direct `self identity` execution both reported `homeboy 0.348.5+cb419e34dab1` for the configured binary and active daemon, while final admission rendered the configured identity as unavailable.

## AI Assistance

OpenCode with `openai/gpt-5.6-sol` was used to reproduce the failure, inspect the admission snapshots, implement the bounded evidence handoff, and run verification. Chris Huber is responsible for every line.
