### PR TITLE
fix(test): project inventory environment

### DIFF
--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -370,7 +370,12 @@ fn ci_job_passthrough_args(job: Option<&CiResolvedJob>) -> Vec<String> {
 fn test_runner_ci_env(job: Option<&CiResolvedJob>) -> Vec<(String, String)> {
     let mut env = ci_profile::ci_job_env(job);
 
-    for key in ["GITHUB_ACTIONS", "RELEASE_BLOCKING_COMMANDS"] {
+    for key in [
+        "GITHUB_ACTIONS",
+        "RELEASE_BLOCKING_COMMANDS",
+        "HOMEBOY_TEST_INVENTORY_ONLY",
+        "HOMEBOY_TEST_INVENTORY_FILE",
+    ] {
         if let Ok(value) = std::env::var(key) {
             env.push((key.to_string(), value));
         }
@@ -1212,6 +1217,27 @@ mod tests {
             .expect("test should parse --ci-job");
 
         assert_eq!(cli.test.ci_job.as_deref(), Some("unit"));
+    }
+
+    #[test]
+    fn test_runner_ci_env_projects_inventory_contract() {
+        let _lock = homeboy::core::test_support::env_lock();
+        let _inventory_only =
+            EnvVarGuard::set("HOMEBOY_TEST_INVENTORY_ONLY", std::path::Path::new("1"));
+        let _inventory_file = EnvVarGuard::set(
+            "HOMEBOY_TEST_INVENTORY_FILE",
+            std::path::Path::new("/workspace/homeboy-test-inventory.json"),
+        );
+
+        let env = test_runner_ci_env(None);
+
+        assert!(env
+            .iter()
+            .any(|(key, value)| { key == "HOMEBOY_TEST_INVENTORY_ONLY" && value == "1" }));
+        assert!(env.iter().any(|(key, value)| {
+            key == "HOMEBOY_TEST_INVENTORY_FILE"
+                && value == "/workspace/homeboy-test-inventory.json"
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- explicitly project the Action inventory-mode flag into the Homeboy test workflow
- project the requested inventory path so the extension can securely rebind it to its private descriptor-held file
- cover the CLI-to-workflow environment boundary with a focused regression test

## Root cause

Data Machine run [31830411552](https://github.com/Extra-Chill/data-machine/actions/runs/31830411552) used Homeboy `0.348.6+0d020793fb66`. The Action exported `HOMEBOY_TEST_INVENTORY_ONLY=1` and `HOMEBOY_TEST_INVENTORY_FILE`, and WordPress emitted a valid 469-test inventory, but `test_runner_ci_env()` projected neither variable into the workflow. The extension therefore ran with `inventory_mode=false`, producing neither validated inventory nor a rejection diagnostic.

This preserves the existing trust boundary: the public requested path remains untrusted and is rebound by the extension to its descriptor-held private path.

Closes #12452.

## Verification

- `cargo test -p homeboy-cli --lib test_runner_ci_env_projects_inventory_contract -- --nocapture`
- `SCOPE_MODE=changed HOMEBOY_CHANGED_SINCE=outer-base HOMEBOY_CHANGED_TEST_FILES=outer.php cargo test -p homeboy-extension --lib inventory_` (35 passed)
- `cargo check -p homeboy-extension -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode traced the downstream artifact boundary, implemented the explicit environment projection and regression test, and ran the listed verification. Chris Huber is responsible for every line.