### PR TITLE
Fix rotated runner session version

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -312,6 +312,7 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
 pub(crate) fn rotate_daemon_generation(
     runner_id: &str,
     candidate_homeboy: &str,
+    candidate_version: &str,
     candidate_identity: &str,
     candidate_generation: &str,
     candidate_binary_sha256: Option<&str>,
@@ -470,7 +471,7 @@ pub(crate) fn rotate_daemon_generation(
         proxy_forward: current.proxy_forward.clone(),
         remote_daemon_pid: daemon.pid,
         remote_daemon_lease_id: daemon.lease_id,
-        homeboy_version: current.homeboy_version.clone(),
+        homeboy_version: candidate_version.to_string(),
         homeboy_build_identity: Some(candidate_identity.to_string()),
         connected_at: Utc::now().to_rfc3339(),
         worker_identity: None,

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -794,13 +794,8 @@ pub fn refresh_homeboy_binary(
             preserve_generations,
             options.force,
         ) {
-            let candidate_identity = identity
-                .get("data")
-                .unwrap_or(&identity)
-                .get("display")
-                .and_then(Value::as_str)
-                .unwrap_or("candidate")
-                .to_string();
+            let (candidate_version, candidate_identity) = rotation_candidate_identity(&identity)?;
+            let candidate_identity = candidate_identity.to_string();
             let candidate_binary_sha256 = materialized_binary_sha256(&exec_output.stdout);
             let candidate_generation =
                 refreshed_generation_key(&candidate_identity, candidate_binary_sha256.clone());
@@ -811,6 +806,7 @@ pub fn refresh_homeboy_binary(
             if let Err(error) = rotate_daemon_generation(
                 &plan.runner_id,
                 &selected_binary_path,
+                candidate_version,
                 &candidate_identity,
                 &candidate_generation,
                 candidate_binary_sha256.as_deref(),
@@ -2534,6 +2530,22 @@ fn refreshed_binary_path(plan: &HomeboyBinaryRefreshPlan, stdout: &str) -> Resul
 
 fn refreshed_generation_key(identity: &str, binary_sha256: Option<String>) -> String {
     binary_sha256.unwrap_or_else(|| identity.to_string())
+}
+
+fn rotation_candidate_identity(identity: &Value) -> Result<(&str, &str)> {
+    let data = identity.get("data").unwrap_or(identity);
+    let version = data
+        .get("version")
+        .and_then(Value::as_str)
+        .filter(|version| !version.trim().is_empty())
+        .ok_or_else(|| {
+            Error::internal_unexpected("materialized candidate identity did not report a version")
+        })?;
+    let display = data
+        .get("display")
+        .and_then(Value::as_str)
+        .unwrap_or("candidate");
+    Ok((version, display))
 }
 
 fn identity_probe_script(binary_path: &str) -> String {

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_a.rs
@@ -1767,6 +1767,17 @@ fn parse_identity_reads_final_pretty_json_after_command_output() {
 }
 
 #[test]
+fn rotation_candidate_identity_preserves_materialized_version_and_display() {
+    let identity = parse_identity(
+        r#"{"success":true,"data":{"version":"0.348.6","display":"homeboy 0.348.6+candidate"}}"#,
+    )
+    .expect("identity parses");
+    let candidate = rotation_candidate_identity(&identity).expect("candidate identity");
+
+    assert_eq!(candidate, ("0.348.6", "homeboy 0.348.6+candidate"));
+}
+
+#[test]
 fn disconnected_ssh_refresh_dispatches_the_existing_script_with_bounded_transport() {
     let plan = HomeboyBinaryRefreshPlan {
         runner_id: "lab".to_string(),


### PR DESCRIPTION
## Summary

- carry the materialized candidate semantic version into daemon generation rotation
- persist candidate version and build identity as one coherent session identity
- reject rotation identity payloads that omit a semantic version

Closes #12467.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests` (100 passed)
- `cargo test -p homeboy-lab-runner connection::tests` (180 passed)
- `cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings` is blocked by nine pre-existing Rust 1.95 lints in unrelated `homeboy-core` files

## AI assistance

GPT-5.6 Sol via OpenCode traced the runtime evidence, implemented the focused session-identity fix, and ran the verification commands. Chris Huber reviewed and remains responsible for every line.