### PR TITLE
Reuse hash-bound Lab capability evidence

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -29,22 +29,10 @@ pub(crate) fn direct_runner_capability_admission(
         source_revision: controller.git_commit.unwrap_or_default(),
         clean: controller.git_dirty == Some(false),
     };
-    let Some((runner_command, runner_command_capabilities)) =
-        crate::configured_runner_homeboy_handshake_evidence(runner, homeboy)?
-    else {
-        return Ok(negotiate_lab_capability_handshake(
-            &LabCapabilityHandshake {
-                controller: controller_identity.clone(),
-                required_capabilities: required_lab_handoff_capabilities(),
-                runner_command: controller_identity.clone(),
-                runner_command_capabilities: Vec::new(),
-                daemon: controller_identity,
-                daemon_capabilities: Vec::new(),
-                ancestry: LabRuntimeAncestry::Unknown,
-            },
-        ));
-    };
+    let command_evidence = crate::configured_runner_homeboy_handshake_evidence(runner, homeboy)?;
     let Some(session) = status.session.as_ref() else {
+        let (runner_command, runner_command_capabilities) =
+            command_evidence.unwrap_or_else(|| (controller_identity.clone(), Vec::new()));
         return Ok(negotiate_lab_capability_handshake(
             &LabCapabilityHandshake {
                 controller: controller_identity.clone(),
@@ -76,6 +64,21 @@ pub(crate) fn direct_runner_capability_admission(
         .as_deref()
         .and_then(|url| crate::daemon_lab_handoff_capabilities(url).ok())
         .unwrap_or_default();
+    let command_evidence = command_evidence
+        .or_else(|| hash_bound_runner_command_evidence(status, homeboy, &daemon_capabilities));
+    let Some((runner_command, runner_command_capabilities)) = command_evidence else {
+        return Ok(negotiate_lab_capability_handshake(
+            &LabCapabilityHandshake {
+                controller: controller_identity.clone(),
+                required_capabilities: required_lab_handoff_capabilities(),
+                runner_command: controller_identity.clone(),
+                runner_command_capabilities: Vec::new(),
+                daemon: controller_identity,
+                daemon_capabilities,
+                ancestry: LabRuntimeAncestry::Unknown,
+            },
+        ));
+    };
     let ancestry = runtime_ancestry(
         &controller_identity.source_revision,
         &runner_command.source_revision,
@@ -90,6 +93,48 @@ pub(crate) fn direct_runner_capability_admission(
             daemon_capabilities,
             ancestry,
         },
+    ))
+}
+
+pub(super) fn hash_bound_runner_command_evidence(
+    status: &RunnerStatusReport,
+    homeboy: &str,
+    daemon_capabilities: &[homeboy_lab_runner_contract::LabCapabilityVersion],
+) -> Option<(
+    LabRuntimeIdentity,
+    Vec<homeboy_lab_runner_contract::LabCapabilityVersion>,
+)> {
+    let configured_identity = status.configured_job_binary_build_identity.as_deref()?;
+    let session = status.session.as_ref()?;
+    let session_identity = session.homeboy_build_identity.as_deref()?;
+    let freshness = status.daemon_freshness.as_ref()?;
+    let binary_hash = freshness.binary_hash.as_deref()?;
+    let slot_hash = Path::new(homeboy)
+        .parent()?
+        .file_name()?
+        .to_str()?
+        .strip_prefix("homeboy-")?;
+    let hash_is_valid = slot_hash.len() == 64
+        && slot_hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && slot_hash == binary_hash;
+    if !freshness.fresh
+        || session.mode != RunnerTunnelMode::DirectSsh
+        || freshness.lease_id != session.remote_daemon_lease_id
+        || freshness.pid != session.remote_daemon_pid
+        || !hash_is_valid
+        || daemon_capabilities.is_empty()
+        || configured_identity != session_identity
+        || freshness.daemon_build_identity.as_deref() != Some(configured_identity)
+    {
+        return None;
+    }
+    Some((
+        LabRuntimeIdentity {
+            build_identity: configured_identity.to_string(),
+            source_revision: build_commit(configured_identity)?.to_string(),
+            clean: !configured_identity.ends_with("-dirty"),
+        },
+        daemon_capabilities.to_vec(),
     ))
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -621,6 +621,87 @@ fn runner_homeboy_version_drift_blocks_offload_with_upgrade_guidance() {
         .is_some_and(|hint| hint.contains("no ancestry-verified refresh target"))));
 }
 
+#[test]
+fn exact_immutable_daemon_supplies_command_capabilities_when_the_second_probe_is_unavailable() {
+    let hash = "a".repeat(64);
+    let identity = "homeboy 0.348.6+b83a29fa4dea";
+    let mut status = hash_bound_direct_status(identity);
+    status.daemon_freshness = Some(homeboy_core::daemon::DaemonFreshnessReport {
+        fresh: true,
+        stale_reason_code: None,
+        restartable: false,
+        lease_id: Some("lease-a".to_string()),
+        pid: Some(42),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: Some(hash.clone()),
+        daemon_version: Some("0.348.6".to_string()),
+        daemon_build_identity: Some(identity.to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    });
+    let capabilities = homeboy_lab_runner_contract::required_lab_handoff_capabilities();
+
+    let evidence = super::super::metadata::hash_bound_runner_command_evidence(
+        &status,
+        &format!("/runner/homeboy-{hash}/homeboy"),
+        &capabilities,
+    )
+    .expect("the exact immutable daemon proves the command evidence");
+
+    assert_eq!(evidence.0.build_identity, identity);
+    assert_eq!(evidence.0.source_revision, "b83a29fa4dea");
+    assert_eq!(evidence.1, capabilities);
+}
+
+#[test]
+fn daemon_capabilities_do_not_substitute_for_a_different_configured_binary_hash() {
+    let hash = "a".repeat(64);
+    let identity = "homeboy 0.348.6+b83a29fa4dea";
+    let mut status = hash_bound_direct_status(identity);
+    status.daemon_freshness = Some(homeboy_core::daemon::DaemonFreshnessReport {
+        fresh: true,
+        stale_reason_code: None,
+        restartable: false,
+        lease_id: Some("lease-a".to_string()),
+        pid: Some(42),
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: Some(hash),
+        daemon_version: Some("0.348.6".to_string()),
+        daemon_build_identity: Some(identity.to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    });
+
+    assert!(super::super::metadata::hash_bound_runner_command_evidence(
+        &status,
+        &format!("/runner/homeboy-{}/homeboy", "b".repeat(64)),
+        &homeboy_lab_runner_contract::required_lab_handoff_capabilities(),
+    )
+    .is_none());
+}
+
+fn hash_bound_direct_status(identity: &str) -> RunnerStatusReport {
+    let mut status = reverse_status("homeboy-lab");
+    let session = status.session.as_mut().expect("session");
+    session.mode = RunnerTunnelMode::DirectSsh;
+    session.local_url = Some("http://127.0.0.1:7421".to_string());
+    session.remote_daemon_address = Some("127.0.0.1:7422".to_string());
+    session.remote_daemon_pid = Some(42);
+    session.remote_daemon_lease_id = Some("lease-a".to_string());
+    session.homeboy_version = "0.348.6".to_string();
+    session.homeboy_build_identity = Some(identity.to_string());
+    status.configured_job_binary_build_identity = Some(identity.to_string());
+    status
+}
+
 /// Build a reverse-connected status whose runner session reports `version`.
 fn status_with_runner_version(runner_id: &str, version: &str) -> RunnerStatusReport {
     let mut status = reverse_status(runner_id);


### PR DESCRIPTION
## Summary

- reuse live daemon capabilities when direct-runner status proves the configured executable and daemon are the exact same immutable binary bytes
- bind the fallback to immutable slot SHA-256, daemon lease/PID, freshness, and build identity
- preserve fail-closed behavior for mismatched hashes, missing capabilities, or ambiguous generations

Closes #12475.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner lab::offload::tests` (102 passed)
- `cargo check -p homeboy-lab-runner`
- `git diff --check`

## Runtime evidence

MDI Cook `agent-task-196eae4b-c49b-4cc1-9efd-1a642496be3f-attempt-3-75fda04a` reproduced the duplicate-probe failure with zero provider executions while `runner status --full` proved matching `b83a29fa4dea` identities and exact daemon binary hash.

## AI assistance

GPT-5.6 Sol via OpenCode traced the duplicate capability probe, implemented the hash-bound evidence reuse, and ran the listed verification. Chris Huber reviewed and remains responsible for every line.