### PR TITLE
Derive Lab command identity from exact daemon bytes

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -104,7 +104,6 @@ pub(super) fn hash_bound_runner_command_evidence(
     LabRuntimeIdentity,
     Vec<homeboy_lab_runner_contract::LabCapabilityVersion>,
 )> {
-    let configured_identity = status.configured_job_binary_build_identity.as_deref()?;
     let session = status.session.as_ref()?;
     let session_identity = session.homeboy_build_identity.as_deref()?;
     let freshness = status.daemon_freshness.as_ref()?;
@@ -123,16 +122,19 @@ pub(super) fn hash_bound_runner_command_evidence(
         || freshness.pid != session.remote_daemon_pid
         || !hash_is_valid
         || daemon_capabilities.is_empty()
-        || configured_identity != session_identity
-        || freshness.daemon_build_identity.as_deref() != Some(configured_identity)
+        || status
+            .configured_job_binary_build_identity
+            .as_deref()
+            .is_some_and(|configured| configured != session_identity)
+        || freshness.daemon_build_identity.as_deref() != Some(session_identity)
     {
         return None;
     }
     Some((
         LabRuntimeIdentity {
-            build_identity: configured_identity.to_string(),
-            source_revision: build_commit(configured_identity)?.to_string(),
-            clean: !configured_identity.ends_with("-dirty"),
+            build_identity: session_identity.to_string(),
+            source_revision: build_commit(session_identity)?.to_string(),
+            clean: !session_identity.ends_with("-dirty"),
         },
         daemon_capabilities.to_vec(),
     ))

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -626,6 +626,7 @@ fn exact_immutable_daemon_supplies_command_capabilities_when_the_second_probe_is
     let hash = "a".repeat(64);
     let identity = "homeboy 0.348.6+b83a29fa4dea";
     let mut status = hash_bound_direct_status(identity);
+    status.configured_job_binary_build_identity = None;
     status.daemon_freshness = Some(homeboy_core::daemon::DaemonFreshnessReport {
         fresh: true,
         stale_reason_code: None,
@@ -658,10 +659,11 @@ fn exact_immutable_daemon_supplies_command_capabilities_when_the_second_probe_is
 }
 
 #[test]
-fn daemon_capabilities_do_not_substitute_for_a_different_configured_binary_hash() {
+fn daemon_capabilities_do_not_substitute_for_a_conflicting_configured_identity() {
     let hash = "a".repeat(64);
     let identity = "homeboy 0.348.6+b83a29fa4dea";
     let mut status = hash_bound_direct_status(identity);
+    status.configured_job_binary_build_identity = Some("homeboy 0.348.6+different".to_string());
     status.daemon_freshness = Some(homeboy_core::daemon::DaemonFreshnessReport {
         fresh: true,
         stale_reason_code: None,
@@ -671,7 +673,7 @@ fn daemon_capabilities_do_not_substitute_for_a_different_configured_binary_hash(
         recovery_evidence: None,
         ownership_evidence: None,
         adoption_command: None,
-        binary_hash: Some(hash),
+        binary_hash: Some(hash.clone()),
         daemon_version: Some("0.348.6".to_string()),
         daemon_build_identity: Some(identity.to_string()),
         runtime_paths: None,
@@ -682,7 +684,7 @@ fn daemon_capabilities_do_not_substitute_for_a_different_configured_binary_hash(
 
     assert!(super::super::metadata::hash_bound_runner_command_evidence(
         &status,
-        &format!("/runner/homeboy-{}/homeboy", "b".repeat(64)),
+        &format!("/runner/homeboy-{hash}/homeboy"),
         &homeboy_lab_runner_contract::required_lab_handoff_capabilities(),
     )
     .is_none());


### PR DESCRIPTION
## Summary

- derive runner-command identity from the daemon when immutable slot SHA-256 proves the configured path is the exact fresh daemon binary
- keep an observed conflicting configured identity fail-closed
- model the runtime failure where the transient configured-identity field is absent

Closes #12479.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner lab::offload::tests` (102 passed)
- `cargo check -p homeboy-lab-runner`
- `git diff --check`

## Runtime evidence

Persisted MDI retry after #12476 still failed before provider execution because the hash-bound fallback requested the absent transient configured-identity field before evaluating its stronger exact-byte proof.

## AI assistance

GPT-5.6 Sol via OpenCode used runtime acceptance evidence to remove the remaining transient-field dependency and ran the listed verification. Chris Huber reviewed and remains responsible for every line.