### PR TITLE
Fix strict exact-source Lab admission

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1532,7 +1532,9 @@ pub(crate) fn run_lab_offload_inner(
     }
     let blocking_runner_homeboy_drift = direct_capability_admission
         .as_ref()
-        .map(|admission| require_exact_runner_version || !admission.compatible)
+        .map(|admission| {
+            capability_admission_has_blocking_drift(admission, require_exact_runner_version)
+        })
         .unwrap_or_else(|| {
             lab_runner_homeboy_has_blocking_drift_against_configured_identity(
                 &runner_status,

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -96,6 +96,15 @@ pub(crate) fn direct_runner_capability_admission(
     ))
 }
 
+pub(crate) fn capability_admission_has_blocking_drift(
+    admission: &LabCapabilityAdmission,
+    require_exact_runner_version: bool,
+) -> bool {
+    !admission.compatible
+        || (require_exact_runner_version
+            && admission.provenance.ancestry != LabRuntimeAncestry::ExactSource)
+}
+
 pub(super) fn hash_bound_runner_command_evidence(
     status: &RunnerStatusReport,
     homeboy: &str,

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -659,6 +659,48 @@ fn exact_immutable_daemon_supplies_command_capabilities_when_the_second_probe_is
 }
 
 #[test]
+fn strict_capability_admission_accepts_only_compatible_exact_source() {
+    use homeboy_lab_runner_contract::{
+        LabCapabilityAdmission, LabCapabilityNegotiationProvenance, LabRuntimeAncestry,
+        LabRuntimeIdentity,
+    };
+
+    let identity = LabRuntimeIdentity {
+        build_identity: "homeboy 0.348.7+5ebb24a09bc5".to_string(),
+        source_revision: "5ebb24a09bc5".to_string(),
+        clean: true,
+    };
+    let admission = |compatible, ancestry| LabCapabilityAdmission {
+        compatible,
+        provenance: LabCapabilityNegotiationProvenance {
+            schema: "homeboy/lab-capability-negotiation/v1".to_string(),
+            controller_requirement: identity.clone(),
+            executed_runner_command: identity.clone(),
+            active_daemon: identity.clone(),
+            ancestry,
+            negotiated_capabilities: Vec::new(),
+            compatible,
+            rejection_reason: (!compatible).then(|| "incompatible".to_string()),
+        },
+    };
+
+    let exact = admission(true, LabRuntimeAncestry::ExactSource);
+    assert!(!capability_admission_has_blocking_drift(&exact, true));
+    assert!(!capability_admission_has_blocking_drift(&exact, false));
+
+    let newer = admission(true, LabRuntimeAncestry::VerifiedNewerDescendant);
+    assert!(capability_admission_has_blocking_drift(&newer, true));
+    assert!(!capability_admission_has_blocking_drift(&newer, false));
+
+    let incompatible = admission(false, LabRuntimeAncestry::ExactSource);
+    assert!(capability_admission_has_blocking_drift(&incompatible, true));
+    assert!(capability_admission_has_blocking_drift(
+        &incompatible,
+        false
+    ));
+}
+
+#[test]
 fn daemon_capabilities_do_not_substitute_for_a_conflicting_configured_identity() {
     let hash = "a".repeat(64);
     let identity = "homeboy 0.348.6+b83a29fa4dea";


### PR DESCRIPTION
## Summary

- accept compatible `ExactSource` capability admissions when strict Homeboy matching is enabled
- keep verified newer descendants blocked in strict mode
- keep incompatible capability admissions blocked in every mode

Closes #12481.

## Verification

- `cargo test -p homeboy-lab-runner lab::offload::tests` (103 passed)
- `cargo check -p homeboy-lab-runner`
- `cargo fmt --all`
- `git diff --check`

## AI assistance

GPT-5.6 Sol via OpenCode diagnosed the live Lab preacceptance failure, implemented the focused predicate repair and regression matrix, and ran verification. Chris Huber reviewed and is responsible for every line.