### PR TITLE
fix(agent-task): supervise automatic local Cook

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -275,10 +275,13 @@ pub fn route_after_parse_with_provenance(
         return Err(error);
     }
 
-    // Non-local detached Cooks must pass runner selection before the launcher
-    // can acknowledge them. Lab-or-local may fall back here explicitly; auto
-    // without a runner remains subject to Cook's existing rejection below.
-    if inferred_runner_id.is_some() || cli.placement.allows_local_fallback() {
+    // Cooks must resolve provider ownership before the launcher can acknowledge
+    // or observe them. Auto without a runner is a local provider placement and
+    // needs the same daemon-owned supervision as explicit local execution.
+    if inferred_runner_id.is_some()
+        || cli.placement.allows_local_fallback()
+        || cli.placement == homeboy::cli_surface::Placement::Auto
+    {
         let provider_placement = if inferred_runner_id.is_some() {
             "lab"
         } else {

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -445,11 +445,11 @@ fn foreground_local_cook_survives_client_termination_with_artifacts() {
     let provider_started = context.root().join("fixture-provider-started");
     let mut client = context.controller_runtime_command(TestBinary::HomeboyFixture);
     client
+        // This test exercises automatic placement, not live host pressure.
+        .env("GITHUB_ACTIONS", "true")
         .env("HOMEBOY_FIXTURE_PROVIDER_DELAY_MS", "20000")
         .env("HOMEBOY_FIXTURE_PROVIDER_STARTED_FILE", &provider_started)
         .args([
-            "--placement",
-            "local",
             "agent-task",
             "cook",
             "--run-id",


### PR DESCRIPTION
## Summary

- classify default `auto` placement with no selected runner as local before Cook execution starts
- route that resolved local Cook through the existing daemon-owned supervisor
- move the client-termination integration test from explicit local placement to the real default auto-to-local path

## Root cause

Explicit `--placement local` was intercepted and re-executed under the durable local Cook supervisor. Default `auto` placement with no selected runner skipped that interception, reached `LabRouteOutcome::RunLocal`, and executed provider work in the observing client process. When the observer disappeared, daemon reconciliation cancelled the accepted run as `missing_runner_pid` / `owner_process_not_running`.

The fix reuses the existing supervisor. It does not change explicit cancellation, stale-run reconciliation, Lab ownership, or process containment.

Closes #12248.

## Verification

- Converted integration test reproduced the bug by hanging after observer termination before the production fix.
- `cargo test -p homeboy --test cook_lab_handoff_test foreground_local_cook_survives_client_termination_with_artifacts -- --nocapture`
- `cargo test -p homeboy-cli --lib commands::infra::route::local_detach::tests` (38 passed)
- `cargo test -p homeboy --test cook_lab_handoff_test non_tty_local_wait_stays_foreground -- --nocapture`
- `cargo check -p homeboy-cli -p homeboy-agents`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode traced the default placement and ownership paths, converted the integration test to reproduce the observed failure, implemented the bounded routing fix, and ran verification. Chris Huber is responsible for every line.