### PR TITLE
Parse nested Lab daemon capabilities

### DIFF
--- a/crates/homeboy-lab-runner/src/connection/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/mod.rs
@@ -14,8 +14,9 @@ use std::os::unix::fs::PermissionsExt;
 
 use super::super::session::RunnerStaleRuntimePath;
 use super::connection_daemon::{
-    daemon_identity_from_body, daemon_runtime_loaded_paths_from_body,
-    daemon_runtime_stale_paths_from_body, daemon_version_from_body, versions_match,
+    daemon_identity_from_body, daemon_lab_handoff_capabilities_from_body,
+    daemon_runtime_loaded_paths_from_body, daemon_runtime_stale_paths_from_body,
+    daemon_version_from_body, versions_match,
 };
 use homeboy_core::daemon::{DaemonFreshnessReport, DaemonRecoveryEvidence};
 use homeboy_core::test_support;

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -523,6 +523,45 @@ fn extracts_current_daemon_version_shape() {
 }
 
 #[test]
+fn extracts_daemon_lab_capabilities_from_supported_response_shapes() {
+    let capabilities = serde_json::json!([
+        {"id": "daemon-protocol", "version": 1},
+        {"id": "artifact-transport", "version": 1}
+    ]);
+
+    for body in [
+        serde_json::json!({"lab_handoff_capabilities": capabilities.clone()}),
+        serde_json::json!({
+            "success": true,
+            "data": {"lab_handoff_capabilities": capabilities}
+        }),
+    ] {
+        let parsed = daemon_lab_handoff_capabilities_from_body(&body)
+            .expect("supported daemon capability response");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].id, "daemon-protocol");
+        assert_eq!(parsed[1].id, "artifact-transport");
+    }
+}
+
+#[test]
+fn rejects_missing_or_malformed_daemon_lab_capabilities() {
+    let missing = daemon_lab_handoff_capabilities_from_body(&serde_json::json!({
+        "success": true,
+        "data": {}
+    }))
+    .expect_err("missing capabilities must fail closed");
+    assert!(missing.contains("did not include"));
+
+    let malformed = daemon_lab_handoff_capabilities_from_body(&serde_json::json!({
+        "success": true,
+        "data": {"lab_handoff_capabilities": "daemon-protocol"}
+    }))
+    .expect_err("malformed capabilities must fail closed");
+    assert!(malformed.contains("malformed"));
+}
+
+#[test]
 fn parses_self_identity_json_envelope() {
     let identity = parse_self_identity_output(
         r#"{"success":true,"data":{"version":"0.228.13","display":"homeboy 0.228.13+19a41cd5102d"}}"#,

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -473,8 +473,20 @@ pub(crate) fn daemon_http_lab_handoff_capabilities(
     local_url: &str,
 ) -> std::result::Result<Vec<LabCapabilityVersion>, String> {
     let response = daemon_http_body(local_url)?;
-    serde_json::from_value(response.body["lab_handoff_capabilities"].clone()).map_err(|_| {
-        "remote daemon version response did not include Lab handoff capabilities".to_string()
+    daemon_lab_handoff_capabilities_from_body(&response.body)
+}
+
+pub(super) fn daemon_lab_handoff_capabilities_from_body(
+    body: &Value,
+) -> std::result::Result<Vec<LabCapabilityVersion>, String> {
+    let capabilities = body
+        .get("lab_handoff_capabilities")
+        .or_else(|| body.pointer("/data/lab_handoff_capabilities"))
+        .ok_or_else(|| {
+            "remote daemon version response did not include Lab handoff capabilities".to_string()
+        })?;
+    serde_json::from_value(capabilities.clone()).map_err(|_| {
+        "remote daemon version response included malformed Lab handoff capabilities".to_string()
     })
 }
 


### PR DESCRIPTION
## Summary

- parse Lab handoff capabilities from the standard nested daemon response envelope
- retain support for legacy top-level capability responses
- distinguish missing and malformed capability payloads while remaining fail-closed

Closes #12486.

## Verification

- `cargo test -p homeboy-lab-runner connection::tests::session` (91 passed)
- `cargo test -p homeboy-lab-runner lab::offload::tests` (103 passed)
- `cargo check -p homeboy-lab-runner`
- `cargo fmt --all`
- `git diff --check`

## Runtime evidence

The active daemon `/version` response advertises all required capabilities at `data.lab_handoff_capabilities`; the prior parser inspected only the top-level field and converted that parse failure into an empty negotiated set.

## AI assistance

GPT-5.6 Sol via OpenCode captured the live command and daemon capability evidence, identified the envelope mismatch, implemented the parser repair and regression coverage, and ran verification. Chris Huber reviewed and is responsible for every line.