### PR TITLE
Allow components to opt out of registry publication

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/config.rs
+++ b/crates/contracts/homeboy-component-contract/src/config.rs
@@ -243,6 +243,12 @@ pub struct GithubHostConfig {
 pub struct ComponentReleaseConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_release: Option<ComponentGithubReleaseConfig>,
+    /// Whether extension-provided registry or package publication is permitted.
+    ///
+    /// Absent preserves the extension capability's default behavior. Set this to
+    /// `false` when release assets are the component's deliverable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publish: Option<bool>,
     /// Allow contributors to edit `changelog_target` outside Homeboy releases.
     /// Disabled by default because configured changelogs are release-generated.
     #[serde(default, skip_serializing_if = "is_false")]
@@ -262,6 +268,10 @@ pub struct ComponentReleaseConfig {
 impl ComponentReleaseConfig {
     pub fn is_default(value: &Self) -> bool {
         value == &Self::default()
+    }
+
+    pub fn publish_enabled(&self) -> bool {
+        self.publish.unwrap_or(true)
     }
 
     pub fn validate_package_coverage(&self) -> HomeboyResult<()> {
@@ -520,8 +530,19 @@ mod tests {
     fn manual_changelog_edit_policy_is_absent_when_defaulted() {
         let value = serde_json::to_value(ComponentReleaseConfig::default()).expect("serialize");
 
+        assert!(value.get("publish").is_none());
         assert!(value.get("allow_manual_changelog_edits").is_none());
         assert!(value.get("manual_version_targets").is_none());
         assert!(value.get("manual_release_lockfiles").is_none());
+    }
+
+    #[test]
+    fn release_publish_defaults_to_enabled_and_accepts_an_explicit_opt_out() {
+        let disabled: ComponentReleaseConfig =
+            serde_json::from_value(serde_json::json!({ "publish": false }))
+                .expect("release configuration");
+
+        assert!(ComponentReleaseConfig::default().publish_enabled());
+        assert!(!disabled.publish_enabled());
     }
 }

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -1045,6 +1045,57 @@ mod tests {
     }
 
     #[test]
+    fn disabled_publish_step_is_not_dispatched() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let component_path = tempfile::tempdir().expect("component path");
+            let marker = component_path.path().join("publish-invoked");
+            let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "Registry",
+                "version": "1.0.0",
+                "actions": [{
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": format!("touch {}", marker.display())
+                }]
+            }))
+            .expect("extension manifest");
+            extension.id = "registry".to_string();
+            homeboy_extension::save_manifest(&extension).expect("save extension manifest");
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: component_path.path().to_string_lossy().to_string(),
+                ..Component::default()
+            };
+            let options = ReleaseOptions::default();
+            let extensions = vec![extension];
+            let mut context = ReleaseExecutionContext {
+                component: &component,
+                extensions: &extensions,
+                component_id: "fixture",
+                options: &options,
+                state: ReleaseState::default(),
+                publish_failed: false,
+            };
+            let step = PlanStep::disabled("publish.registry", "publish.registry")
+                .input_value(
+                    "reason",
+                    serde_json::json!("component release.publish=false"),
+                )
+                .build();
+
+            assert!(execute_release_plan_step(&step, &mut context)
+                .expect("disabled publish dispatch")
+                .is_none());
+            assert!(
+                !marker.exists(),
+                "disabled publication must not invoke its action"
+            );
+            assert!(!context.publish_failed);
+        });
+    }
+
+    #[test]
     fn release_package_builds_once_and_validates_the_uploaded_durable_bytes() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let repo = tempfile::tempdir().expect("repo");

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -1,4 +1,4 @@
-use super::builders::{ready_step, string_array_config, string_config, StepConfig};
+use super::builders::{disabled_step, ready_step, string_array_config, string_config, StepConfig};
 use super::changelog::build_changelog_steps;
 use super::hints::{github_release_applies, push_publish_vs_github_release_hints};
 use crate::release::pipeline_capabilities::{
@@ -53,6 +53,7 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
 ) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
     let publish_targets = get_publish_targets(extensions);
+    let registry_publish_enabled = component.release.publish_enabled();
 
     push_publish_vs_github_release_hints(component, options, &publish_targets, hints);
 
@@ -70,7 +71,10 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
         );
     }
 
-    if !publish_targets.is_empty() && !has_package_capability(extensions) {
+    if registry_publish_enabled
+        && !publish_targets.is_empty()
+        && !has_package_capability(extensions)
+    {
         warnings.push(
             "Publish targets derived from extensions but no extension provides 'release.package'. \
              Add an extension that provides packaging."
@@ -221,7 +225,7 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
     }
 
     let mut publish_step_ids: Vec<String> = Vec::new();
-    if !publish_targets.is_empty() && !options.pipeline.skip_publish {
+    if !publish_targets.is_empty() && !options.pipeline.skip_publish && registry_publish_enabled {
         for target in &publish_targets {
             let step_id = format!("publish.{}", target);
             publish_step_ids.push(step_id.clone());
@@ -233,6 +237,8 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
                 StepConfig::new(),
             ));
         }
+    } else if !publish_targets.is_empty() && !registry_publish_enabled {
+        add_disabled_publish_steps(&mut steps, &publish_targets);
     } else if options.pipeline.skip_publish && !publish_targets.is_empty() {
         homeboy_core::log_status!(
             "release",
@@ -264,7 +270,10 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
     if !post_release_hooks.is_empty() {
         let post_release_needs = if package_step_needed && !options.pipeline.deploy {
             vec!["cleanup".to_string()]
-        } else if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+        } else if !options.pipeline.skip_publish
+            && registry_publish_enabled
+            && !publish_targets.is_empty()
+        {
             if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
@@ -286,7 +295,10 @@ pub(in crate::release) fn build_release_steps_with_reconciliation(
     if options.pipeline.deploy {
         let deploy_needs = if !post_release_hooks.is_empty() {
             vec!["post_release".to_string()]
-        } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
+        } else if !options.pipeline.skip_publish
+            && registry_publish_enabled
+            && !publish_step_ids.is_empty()
+        {
             publish_step_ids
         } else {
             vec!["git.push".to_string()]
@@ -315,10 +327,12 @@ fn build_head_release_steps(
 ) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
     let mut artifact_need = "preflight.head_identity".to_string();
+    let registry_publish_enabled = component.release.publish_enabled();
     let package_step_needed = options.pipeline.from_artifacts.is_none()
         && head_package_step_needed(component, extensions, publish_targets, options);
 
-    if !publish_targets.is_empty()
+    if registry_publish_enabled
+        && !publish_targets.is_empty()
         && !options.pipeline.skip_publish
         && options.pipeline.from_artifacts.is_none()
         && !has_package_capability(extensions)
@@ -383,7 +397,7 @@ fn build_head_release_steps(
     }
 
     let mut publish_step_ids: Vec<String> = Vec::new();
-    if !publish_targets.is_empty() && !options.pipeline.skip_publish {
+    if !publish_targets.is_empty() && !options.pipeline.skip_publish && registry_publish_enabled {
         for target in publish_targets {
             let step_id = format!("publish.{}", target);
             publish_step_ids.push(step_id.clone());
@@ -395,6 +409,8 @@ fn build_head_release_steps(
                 StepConfig::new(),
             ));
         }
+    } else if !publish_targets.is_empty() && !registry_publish_enabled {
+        add_disabled_publish_steps(&mut steps, publish_targets);
     }
 
     if package_step_needed && !options.pipeline.deploy {
@@ -421,7 +437,10 @@ fn build_head_release_steps(
     if !post_release_hooks.is_empty() {
         let post_release_needs = if package_step_needed && !options.pipeline.deploy {
             vec!["cleanup".to_string()]
-        } else if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+        } else if !options.pipeline.skip_publish
+            && registry_publish_enabled
+            && !publish_targets.is_empty()
+        {
             if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
@@ -445,7 +464,10 @@ fn build_head_release_steps(
     if options.pipeline.deploy {
         let deploy_needs = if !post_release_hooks.is_empty() {
             vec!["post_release".to_string()]
-        } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
+        } else if !options.pipeline.skip_publish
+            && registry_publish_enabled
+            && !publish_step_ids.is_empty()
+        {
             publish_step_ids
         } else if github_release_needed(component, options) {
             vec!["github.release".to_string()]
@@ -507,7 +529,9 @@ fn package_step_needed(
     github_release_needed: bool,
 ) -> bool {
     (has_package_capability(extensions) || has_component_package_contract(component))
-        && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
+        && ((component.release.publish_enabled()
+            && !publish_targets.is_empty()
+            && !options.pipeline.skip_publish)
             || github_release_needed)
 }
 
@@ -518,7 +542,9 @@ fn head_package_step_needed(
     options: &ReleaseOptions,
 ) -> bool {
     (has_package_capability(extensions) || has_component_package_contract(component))
-        && ((!publish_targets.is_empty() && !options.pipeline.skip_publish)
+        && ((component.release.publish_enabled()
+            && !publish_targets.is_empty()
+            && !options.pipeline.skip_publish)
             || github_release_needed(component, options))
 }
 
@@ -528,6 +554,18 @@ fn has_component_package_contract(component: &Component) -> bool {
         .as_deref()
         .is_some_and(|path| !path.trim().is_empty())
         && component.has_script(ExtensionCapability::Build)
+}
+
+fn add_disabled_publish_steps(steps: &mut Vec<PlanStep>, publish_targets: &[String]) {
+    for target in publish_targets {
+        let step_id = format!("publish.{}", target);
+        steps.push(disabled_step(
+            &step_id,
+            &step_id,
+            format!("Publish to {} (disabled)", target),
+            string_config("reason", "component release.publish=false"),
+        ));
+    }
 }
 
 fn add_release_extension_diagnostics(

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -46,6 +46,42 @@ fn test_build_preflight_steps() {
 }
 
 #[test]
+fn release_publish_defaults_to_extension_provided_registry_publication() {
+    let component = github_fixture_component();
+    let extension = release_extension("nodejs", &["release.package", "release.publish"]);
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        dry_run: true,
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    assert_eq!(
+        steps
+            .iter()
+            .find(|step| step.id == "publish.nodejs")
+            .expect("public registry publish step")
+            .status,
+        PlanStepStatus::Ready
+    );
+}
+
+#[test]
 fn release_plan_marks_git_identity_ready_when_requested() {
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),
@@ -649,6 +685,57 @@ fn skip_publish_with_package_provider_still_packages_before_github_release() {
     assert!(!ids.contains(&"publish.artifact-packager"));
     assert_eq!(
         steps[step_index(&ids, "cleanup")].needs,
+        vec!["github.release"]
+    );
+}
+
+#[test]
+fn release_publish_false_disables_registry_publication_but_keeps_github_assets() {
+    let mut component = github_fixture_component();
+    component.release.publish = Some(false);
+    let extension = release_extension("nodejs", &["release.package", "release.publish"]);
+    let mut warnings = Vec::new();
+    let mut hints = Vec::new();
+    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
+    let options = ReleaseOptions {
+        bump_type: "patch".to_string(),
+        dry_run: true,
+        ..Default::default()
+    };
+
+    let steps = build_release_steps(
+        &component,
+        &[extension],
+        "1.0.0",
+        "1.0.1",
+        &fixture_changelog_plan(),
+        &options,
+        &release_scope,
+        &mut warnings,
+        &mut hints,
+    )
+    .expect("steps");
+
+    let publish = steps
+        .iter()
+        .find(|step| step.id == "publish.nodejs")
+        .expect("disabled publish step remains visible");
+    assert_eq!(publish.status, PlanStepStatus::Disabled);
+    assert_eq!(
+        publish
+            .inputs
+            .get("reason")
+            .and_then(|value| value.as_str()),
+        Some("component release.publish=false")
+    );
+    assert!(steps.iter().any(|step| step.id == "package"));
+    assert!(steps.iter().any(|step| step.id == "github.release"));
+    assert_eq!(
+        steps
+            .iter()
+            .find(|step| step.id == "cleanup")
+            .expect("cleanup")
+            .needs,
         vec!["github.release"]
     );
 }

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -74,6 +74,11 @@ Extensions should own ecosystem-specific release semantics:
 Core should own generic sequencing, state, git operations, output contracts, and
 failure handling.
 
+Components that ship only release assets can declare `release.publish: false`.
+The plan retains each extension-derived `publish.<target>` as a disabled step
+with the declaration as its reason; GitHub Release creation and asset upload are
+separate release operations and remain planned.
+
 ## Commands
 
 Preview a release without executing mutating steps:

--- a/docs/reference/schemas/component-schema.md
+++ b/docs/reference/schemas/component-schema.md
@@ -96,6 +96,7 @@ Component configuration defines buildable and deployable units stored in `compon
   - Deploy planning fails closed when a selection includes only part of a declared group. Select all coupled components explicitly or use `--all` for the project.
 - **`release`** (object): Component-scoped release configuration
   - **`enabled`** (boolean): Whether release pipeline is enabled
+  - **`publish`** (boolean): Whether extension-provided registry/package publication is permitted; defaults to enabled when absent. Set `false` for components delivered exclusively through GitHub Release assets. GitHub Release creation and asset upload remain enabled independently.
   - **`steps`** (array): Release step definitions
   - **`settings`** (object): Release pipeline settings
   - **`package_coverage`** (array): Optional ZIP completeness mappings for transformed archive layouts


### PR DESCRIPTION
## Summary

- add generic `release.publish: false` component policy
- retain extension-derived publish steps as visibly disabled with a reason
- keep package creation and GitHub Release assets independent and enabled
- preserve existing registry publication behavior by default

Closes #3647.

## Verification

- `cargo test -p homeboy-component-contract release_publish --lib`
- `cargo test -p homeboy-release release_publish --lib`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

GPT-5.6 Sol and GPT-5.6 Terra via OpenCode were used to reproduce the current release plan, design the generic publication policy, implement planning/execution coverage, and run verification. Chris Huber reviewed and is responsible for every line.