### PR TITLE
Report progress for component release builds

### DIFF
--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -180,7 +180,7 @@ fn run_local_command(
         }
     };
     let mut cleanup_guard = Some(ProcessGroupCleanupGuard::new(child.id()));
-    let mut supervision = ChildSupervision::start(env, command, child.id());
+    let mut supervision = ChildSupervision::start(env, command, current_dir, child.id());
     let _invocation_child_guard = invocation_child_guard(
         env,
         child.id(),
@@ -772,6 +772,11 @@ fn wait_for_child_or_delegated_failure(
 const CHILD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 const CHILD_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
 pub const CHILD_SECRET_ENV_NAMES_ENV: &str = "HOMEBOY_CHILD_SECRET_ENV_NAMES";
+/// Opt in to concise lifecycle messages for a supervised local child.
+///
+/// The value is a generic operation label. Callers that own machine-readable
+/// stdout can use it to make long-running child work visible on stderr.
+pub const CHILD_PROGRESS_LABEL_ENV: &str = "HOMEBOY_CHILD_PROGRESS_LABEL";
 static CHILD_SUPERVISION_TEMP_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
@@ -788,6 +793,8 @@ struct ChildSupervisionRecord {
     timeout_ms: Option<u128>,
     cancellation_reason: Option<String>,
     exit_code: Option<i32>,
+    duration_ms: Option<u128>,
+    termination: Option<String>,
     stdout_tail: String,
     stderr_tail: String,
 }
@@ -797,15 +804,35 @@ struct ChildSupervision {
     record: ChildSupervisionRecord,
     redaction_values: Vec<String>,
     last_heartbeat: Instant,
+    started: Instant,
+    progress_label: Option<String>,
 }
 
 impl ChildSupervision {
-    fn start(env: Option<&[(&str, &str)]>, command: &str, child_pid: u32) -> Option<Self> {
+    fn start(
+        env: Option<&[(&str, &str)]>,
+        command: &str,
+        current_dir: Option<&str>,
+        child_pid: u32,
+    ) -> Option<Self> {
         let run_dir = env?.iter().find_map(|(key, value)| {
             (*key == crate::engine::run_dir::run_dir_env()).then_some(*value)
         })?;
         let now = Utc::now().to_rfc3339();
         let redaction_values = child_secret_values(env);
+        let progress_label = env.and_then(|pairs| {
+            pairs.iter().find_map(|(key, value)| {
+                (*key == CHILD_PROGRESS_LABEL_ENV && !value.trim().is_empty())
+                    .then_some((*value).to_string())
+            })
+        });
+        if let Some(label) = &progress_label {
+            eprintln!(
+                "[{label}] started command={} cwd={}",
+                redact_child_secret_values(command, &redaction_values),
+                current_dir.unwrap_or(".")
+            );
+        }
         let supervision = Self {
             path: PathBuf::from(run_dir).join(crate::engine::run_dir::files::CHILD_SUPERVISION),
             record: ChildSupervisionRecord {
@@ -820,11 +847,15 @@ impl ChildSupervision {
                 timeout_ms: None,
                 cancellation_reason: None,
                 exit_code: None,
+                duration_ms: None,
+                termination: None,
                 stdout_tail: String::new(),
                 stderr_tail: String::new(),
             },
             redaction_values,
             last_heartbeat: Instant::now(),
+            started: Instant::now(),
+            progress_label,
         };
         supervision.persist();
         Some(supervision)
@@ -836,6 +867,12 @@ impl ChildSupervision {
         }
         self.record.heartbeat_at = Utc::now().to_rfc3339();
         self.last_heartbeat = Instant::now();
+        if let Some(label) = &self.progress_label {
+            eprintln!(
+                "[{label}] still running elapsed={}s",
+                self.started.elapsed().as_secs()
+            );
+        }
         self.persist();
     }
 
@@ -861,6 +898,14 @@ impl ChildSupervision {
             signal.map(|signal| format!("signal:{signal}"))
         };
         self.record.exit_code = Some(output.exit_code);
+        self.record.duration_ms = Some(self.started.elapsed().as_millis());
+        self.record.termination = Some(if timed_out {
+            "timeout".to_string()
+        } else if signal.is_some() {
+            "cancelled".to_string()
+        } else {
+            "completed".to_string()
+        });
         self.record.stdout_tail = bounded_redacted_tail(&output.stdout, &self.redaction_values);
         self.record.stderr_tail = bounded_redacted_tail(&output.stderr, &self.redaction_values);
         self.persist();

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -770,6 +770,7 @@ fn wait_for_child_or_delegated_failure(
 }
 
 const CHILD_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+const CHILD_PROGRESS_REPORT_INTERVAL: Duration = Duration::from_secs(30);
 const CHILD_OUTPUT_TAIL_BYTES: usize = 16 * 1024;
 pub const CHILD_SECRET_ENV_NAMES_ENV: &str = "HOMEBOY_CHILD_SECRET_ENV_NAMES";
 /// Opt in to concise lifecycle messages for a supervised local child.
@@ -804,6 +805,7 @@ struct ChildSupervision {
     record: ChildSupervisionRecord,
     redaction_values: Vec<String>,
     last_heartbeat: Instant,
+    last_progress_report: Instant,
     started: Instant,
     progress_label: Option<String>,
 }
@@ -830,7 +832,7 @@ impl ChildSupervision {
             eprintln!(
                 "[{label}] started command={} cwd={}",
                 redact_child_secret_values(command, &redaction_values),
-                current_dir.unwrap_or(".")
+                redact_child_secret_values(current_dir.unwrap_or("."), &redaction_values)
             );
         }
         let supervision = Self {
@@ -854,6 +856,7 @@ impl ChildSupervision {
             },
             redaction_values,
             last_heartbeat: Instant::now(),
+            last_progress_report: Instant::now(),
             started: Instant::now(),
             progress_label,
         };
@@ -867,11 +870,14 @@ impl ChildSupervision {
         }
         self.record.heartbeat_at = Utc::now().to_rfc3339();
         self.last_heartbeat = Instant::now();
-        if let Some(label) = &self.progress_label {
-            eprintln!(
-                "[{label}] still running elapsed={}s",
-                self.started.elapsed().as_secs()
-            );
+        if progress_report_due(self.last_progress_report, Instant::now()) {
+            if let Some(label) = &self.progress_label {
+                eprintln!(
+                    "[{label}] still running elapsed={}s",
+                    self.started.elapsed().as_secs()
+                );
+                self.last_progress_report = Instant::now();
+            }
         }
         self.persist();
     }
@@ -939,6 +945,10 @@ impl ChildSupervision {
             let _ = std::fs::remove_file(temporary);
         }
     }
+}
+
+fn progress_report_due(last_report: Instant, now: Instant) -> bool {
+    now.duration_since(last_report) >= CHILD_PROGRESS_REPORT_INTERVAL
 }
 
 fn child_secret_values(env: Option<&[(&str, &str)]>) -> Vec<String> {
@@ -1028,6 +1038,31 @@ mod tests {
                 Some(libc::ESRCH)
             );
         }
+    }
+
+    #[test]
+    fn progress_reports_are_rate_limited_separately_from_supervision() {
+        let started = Instant::now();
+
+        assert!(!progress_report_due(
+            started,
+            started + CHILD_PROGRESS_REPORT_INTERVAL - Duration::from_secs(1)
+        ));
+        assert!(progress_report_due(
+            started,
+            started + CHILD_PROGRESS_REPORT_INTERVAL
+        ));
+    }
+
+    #[test]
+    fn progress_cwd_redacts_declared_child_secrets() {
+        let secret = "secret-value";
+        let cwd = format!("/work/{secret}/component");
+
+        assert_eq!(
+            redact_child_secret_values(&cwd, &[secret.to_string()]),
+            "/work/[REDACTED]/component"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/server/client/mod.rs
+++ b/crates/homeboy-core/src/server/client/mod.rs
@@ -19,7 +19,7 @@ pub use host::{
 };
 pub use local_exec::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
-    execute_local_command_interactive, execute_local_command_passthrough,
+    execute_local_command_interactive, execute_local_command_passthrough, CHILD_PROGRESS_LABEL_ENV,
     CHILD_SECRET_ENV_NAMES_ENV,
 };
 pub use local_exec::{

--- a/crates/homeboy-core/src/server/mod.rs
+++ b/crates/homeboy-core/src/server/mod.rs
@@ -16,7 +16,7 @@ pub use client::{
     execute_local_command, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout,
     execute_local_command_interactive, execute_local_command_passthrough, is_transient_ssh_error,
     server_host_resolves_only_to_loopback, server_uses_loopback_transport, CommandOutput,
-    SshClient, CHILD_SECRET_ENV_NAMES_ENV, TRANSIENT_SSH_STDERR_PATTERNS,
+    SshClient, CHILD_PROGRESS_LABEL_ENV, CHILD_SECRET_ENV_NAMES_ENV, TRANSIENT_SSH_STDERR_PATTERNS,
 };
 pub use client::{
     execute_local_command_passthrough_with_timeout, execute_local_command_stderr_passthrough,

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -326,11 +326,19 @@ fn bounded_output_tail(output: &str) -> String {
     if tail.len() <= BUILD_ERROR_TAIL_BYTES {
         return tail;
     }
-    let start = tail.len() - BUILD_ERROR_TAIL_BYTES;
+    let start = unicode_safe_tail_start(&tail, BUILD_ERROR_TAIL_BYTES);
     format!(
         "[output truncated to last {BUILD_ERROR_TAIL_BYTES} bytes]\n{}",
         &tail[start..]
     )
+}
+
+fn unicode_safe_tail_start(value: &str, max_bytes: usize) -> usize {
+    let start = value.len().saturating_sub(max_bytes);
+    value
+        .char_indices()
+        .find_map(|(index, _)| (index >= start).then_some(index))
+        .unwrap_or_default()
 }
 
 // === Internal implementation ===
@@ -928,6 +936,16 @@ mod tests {
         assert!(tail.starts_with("[output truncated"));
         assert!(tail.ends_with("final diagnostic"));
         assert!(tail.len() <= BUILD_ERROR_TAIL_BYTES + 64);
+    }
+
+    #[test]
+    fn build_error_tail_is_safe_for_multibyte_output() {
+        let output = format!("{}\nfinal diagnostic", "x€".repeat(BUILD_ERROR_TAIL_BYTES));
+
+        let tail = bounded_output_tail(&output);
+
+        assert!(tail.ends_with("final diagnostic"));
+        assert!(tail.is_char_boundary(0));
     }
 
     #[test]

--- a/crates/homeboy-extension/src/build/mod.rs
+++ b/crates/homeboy-extension/src/build/mod.rs
@@ -2,6 +2,7 @@ use crate as extension;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::time::Instant;
 
 use crate::{exec_context, ExtensionCapability, ExtensionExecutionContext, ExtensionPhaseTiming};
 use homeboy_core::artifact_inputs::{self, ResolvedArtifactInput};
@@ -175,6 +176,9 @@ pub struct BuildOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cargo_target: Option<homeboy_core::CargoTargetEvidence>,
     pub success: bool,
+    pub duration_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub termination: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -240,7 +244,7 @@ pub fn run_changed_since(input: &str, changed_since: Option<&str>) -> Result<(Bu
 /// Thin wrapper around `execute_build_component` that adapts the return type
 /// for the deploy pipeline's error handling convention.
 pub fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
-    let result = execute_build_component(component, None);
+    let result = build_component_with_output(component);
 
     match result {
         Ok((output, exit_code)) => {
@@ -264,6 +268,12 @@ pub fn build_component(component: &component::Component) -> (Option<i32>, Option
     }
 }
 
+/// Execute a component-owned build and retain the structured execution evidence
+/// required by callers that publish build results, such as release packaging.
+pub fn build_component_with_output(component: &component::Component) -> Result<(BuildOutput, i32)> {
+    execute_build_component(component, None)
+}
+
 /// Format a build error message with context from stderr/stdout.
 /// Only includes universal POSIX exit code hints - Homeboy is technology-agnostic.
 fn format_build_error(
@@ -281,9 +291,7 @@ fn format_build_error(
         stderr
     };
 
-    // Get last 15 lines for context
-    let tail: Vec<&str> = output_text.lines().rev().take(15).collect();
-    let output_tail: String = tail.into_iter().rev().collect::<Vec<_>>().join("\n");
+    let output_tail = bounded_output_tail(output_text);
 
     // Translate universal POSIX exit codes only (no tool-specific hints)
     let hint = match exit_code {
@@ -308,6 +316,21 @@ fn format_build_error(
     }
 
     msg
+}
+
+const BUILD_ERROR_TAIL_BYTES: usize = 16 * 1024;
+
+fn bounded_output_tail(output: &str) -> String {
+    let tail: Vec<&str> = output.lines().rev().take(15).collect();
+    let tail = tail.into_iter().rev().collect::<Vec<_>>().join("\n");
+    if tail.len() <= BUILD_ERROR_TAIL_BYTES {
+        return tail;
+    }
+    let start = tail.len() - BUILD_ERROR_TAIL_BYTES;
+    format!(
+        "[output truncated to last {BUILD_ERROR_TAIL_BYTES} bytes]\n{}",
+        &tail[start..]
+    )
 }
 
 // === Internal implementation ===
@@ -424,6 +447,7 @@ fn execute_build_component(
     comp: &Component,
     changed_since: Option<&str>,
 ) -> Result<(BuildOutput, i32)> {
+    let started = Instant::now();
     comp.validate_supported_build_config()?;
 
     // Validate required extensions are installed before resolving build commands.
@@ -470,6 +494,8 @@ fn execute_build_component(
                 changed_scope: changed_scope.map(|decision| decision.report),
                 cargo_target: None,
                 success: true,
+                duration_ms: started.elapsed().as_millis(),
+                termination: Some("completed".to_string()),
             },
             0,
         ));
@@ -504,6 +530,8 @@ fn execute_build_component(
                     changed_scope: changed_scope.clone().map(|decision| decision.report),
                     cargo_target: None,
                     success: false,
+                    duration_ms: started.elapsed().as_millis(),
+                    termination: Some("failed".to_string()),
                 },
                 exit_code,
             ));
@@ -530,7 +558,7 @@ fn execute_build_component(
                 capability: extension::ExtensionCapability::Build,
                 source_path: &validated_path,
                 run_dir: &run_dir,
-                passthrough: true,
+                passthrough: false,
                 extra_env: &build_env(changed_since, changed_scope.as_ref()),
                 script_args: &[],
                 timeout: Some(build_timeout),
@@ -544,6 +572,8 @@ fn execute_build_component(
             .command_override(build_cmd.clone())
             .with_run_dir(&run_dir)
             .timeout(Some(build_timeout))
+            .passthrough(false)
+            .stderr_passthrough(true)
             // Legacy env var for backward compat with existing build scripts
             .env("HOMEBOY_PLUGIN_PATH", &comp.local_path);
         for (key, value) in build_env(changed_since, changed_scope.as_ref()) {
@@ -559,6 +589,8 @@ fn execute_build_component(
             .command_override(build_cmd.clone())
             .with_run_dir(&run_dir)
             .timeout(Some(build_timeout))
+            .passthrough(false)
+            .stderr_passthrough(true)
             .env("HOMEBOY_PLUGIN_PATH", &comp.local_path);
         for (key, value) in build_env(changed_since, changed_scope.as_ref()) {
             runner = runner.env(&key, &value);
@@ -586,6 +618,14 @@ fn execute_build_component(
             changed_scope: changed_scope.map(|decision| decision.report),
             cargo_target,
             success,
+            duration_ms: started.elapsed().as_millis(),
+            termination: Some(if runner_output.timed_out {
+                "timeout".to_string()
+            } else if success {
+                "completed".to_string()
+            } else {
+                "failed".to_string()
+            }),
         },
         runner_output.exit_code,
     );
@@ -735,6 +775,10 @@ fn build_env(
     changed_scope: Option<&BuildChangedScopeDecision>,
 ) -> Vec<(String, String)> {
     let mut env = Vec::new();
+    env.push((
+        homeboy_core::server::CHILD_PROGRESS_LABEL_ENV.to_string(),
+        "build".to_string(),
+    ));
     if let Some(changed_since) = changed_since {
         env.push((
             "HOMEBOY_CHANGED_SINCE".to_string(),
@@ -870,6 +914,20 @@ mod tests {
             build_timeout_from(Some("invalid")),
             Duration::from_secs(30 * 60)
         );
+    }
+
+    #[test]
+    fn build_error_tail_is_bounded_and_keeps_the_last_output() {
+        let output = format!(
+            "{}\nfinal diagnostic",
+            "x".repeat(BUILD_ERROR_TAIL_BYTES + 100)
+        );
+
+        let tail = bounded_output_tail(&output);
+
+        assert!(tail.starts_with("[output truncated"));
+        assert!(tail.ends_with("final diagnostic"));
+        assert!(tail.len() <= BUILD_ERROR_TAIL_BYTES + 64);
     }
 
     #[test]
@@ -1019,6 +1077,10 @@ mod tests {
             "HOMEBOY_BUILD_SCOPE_OUTCOME".to_string(),
             "full".to_string()
         )));
+        assert!(env.contains(&(
+            homeboy_core::server::CHILD_PROGRESS_LABEL_ENV.to_string(),
+            "build".to_string()
+        )));
     }
 
     #[test]
@@ -1034,12 +1096,16 @@ mod tests {
             changed_scope: None,
             cargo_target: None,
             success: true,
+            duration_ms: 0,
+            termination: Some("completed".to_string()),
         }));
 
         let value = serde_json::to_value(result).expect("build result serializes");
 
         assert_eq!(value["command"], "build.run");
         assert_eq!(value["component_id"], "example");
+        assert_eq!(value["duration_ms"], 0);
+        assert_eq!(value["termination"], "completed");
         assert!(value.get("Single").is_none());
     }
 }

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -468,7 +468,11 @@ fn output_tail(output: &str, max_bytes: usize) -> String {
     if output.len() <= max_bytes {
         return output.trim().to_string();
     }
-    format!("[truncated]\n{}", output[output.len() - max_bytes..].trim())
+    let start = output
+        .char_indices()
+        .find_map(|(index, _)| (index >= output.len().saturating_sub(max_bytes)).then_some(index))
+        .unwrap_or_default();
+    format!("[truncated]\n{}", output[start..].trim())
 }
 
 #[cfg(test)]
@@ -500,6 +504,16 @@ mod build_failure_tests {
         assert!(error.contains("Working directory: /work/example"));
         assert!(error.ends_with("tail"));
         assert!(error.len() < 17_000);
+    }
+
+    #[test]
+    fn output_tail_is_safe_for_multibyte_output() {
+        let output = format!("{}final diagnostic", "x€".repeat(10_000));
+
+        let tail = output_tail(&output, 16 * 1024);
+
+        assert!(tail.starts_with("[truncated]"));
+        assert!(tail.ends_with("final diagnostic"));
     }
 }
 

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -56,8 +56,9 @@ pub(crate) fn run_package(
             .filter(|m| m.actions.iter().any(|a| a.id == "release.package"))
             .collect();
 
-        let declared_artifact_built =
+        let component_build =
             build_declared_component_artifact(component, declared_build_artifact)?;
+        let declared_artifact_built = component_build.is_some();
         if declared_artifact_built {
             collect_declared_build_artifact(
                 state,
@@ -76,6 +77,7 @@ pub(crate) fn run_package(
                     Some(serde_json::json!({
                         "action": "scripts.build",
                         "artifact": declared_build_artifact,
+                        "component_build": component_build,
                         "package_owned_paths": state.package_owned_paths,
                     })),
                     Vec::new(),
@@ -137,6 +139,7 @@ pub(crate) fn run_package(
                 "extension": response["extension"],
                 "action": "release.package",
                 "response": response["response"],
+                "component_build": component_build,
                 "package_owned_paths": state.package_owned_paths,
             })
         } else {
@@ -144,6 +147,7 @@ pub(crate) fn run_package(
                 "action": "release.package",
                 "extensions": responses.iter().map(|response| response["extension"].clone()).collect::<Vec<_>>(),
                 "responses": responses,
+                "component_build": component_build,
                 "package_owned_paths": state.package_owned_paths,
             })
         };
@@ -399,27 +403,104 @@ fn record_existing_cleanup_path(component_path: &Path, path: &str, paths: &mut B
 fn build_declared_component_artifact(
     component: &Component,
     declared_build_artifact: Option<&str>,
-) -> Result<bool> {
+) -> Result<Option<homeboy_extension::build::BuildOutput>> {
     if declared_build_artifact.is_none_or(|path| path.trim().is_empty())
         || !component.has_script(ExtensionCapability::Build)
     {
-        return Ok(false);
+        return Ok(None);
     }
 
-    let (exit_code, build_error) = homeboy_extension::build::build_component(component);
-    if let Some(error) = build_error {
-        return Err(Error::validation_invalid_argument(
-            "scripts.build",
+    let (build, exit_code) = homeboy_extension::build::build_component_with_output(component)
+        .map_err(|error| {
+            Error::validation_invalid_argument(
+                "scripts.build",
+                error.message,
+                Some(component.id.clone()),
+                None,
+            )
+        })?;
+    if !build.success {
+        let error = format_build_failure(&build, &component.local_path, exit_code);
+        return Err(Error::new(
+            homeboy_core::error::ErrorCode::ValidationInvalidArgument,
             format!(
-                "Failed to build declared build_artifact for component '{}' (exit {:?}): {}",
+                "Failed to build declared build_artifact for component '{}' (exit {}): {}",
                 component.id, exit_code, error
             ),
-            Some(component.id.clone()),
-            None,
+            serde_json::json!({
+                "field": "scripts.build",
+                "component_id": component.id,
+                "component_build": build,
+            }),
         ));
     }
 
-    Ok(true)
+    Ok(Some(build))
+}
+
+fn format_build_failure(
+    build: &homeboy_extension::build::BuildOutput,
+    working_dir: &str,
+    exit_code: i32,
+) -> String {
+    let output = if build.output.stderr.trim().is_empty() {
+        &build.output.stdout
+    } else {
+        &build.output.stderr
+    };
+    let tail = output_tail(output, 16 * 1024);
+    format!(
+        "Component build {} after {}ms (exit {}).\n  Command: {}\n  Working directory: {}{}",
+        build.termination.as_deref().unwrap_or("failed"),
+        build.duration_ms,
+        exit_code,
+        build.build_command,
+        working_dir,
+        if tail.is_empty() {
+            String::new()
+        } else {
+            format!("\n\n--- Build output tail ---\n{tail}")
+        },
+    )
+}
+
+fn output_tail(output: &str, max_bytes: usize) -> String {
+    if output.len() <= max_bytes {
+        return output.trim().to_string();
+    }
+    format!("[truncated]\n{}", output[output.len() - max_bytes..].trim())
+}
+
+#[cfg(test)]
+mod build_failure_tests {
+    use super::*;
+    use homeboy_engine_primitives::command::CapturedOutput;
+
+    #[test]
+    fn timed_out_build_error_is_reproducible_and_bounded() {
+        let build = homeboy_extension::build::BuildOutput {
+            command: "build.run".to_string(),
+            component_id: "example".to_string(),
+            build_command: "make release".to_string(),
+            active_env_keys: Vec::new(),
+            output: CapturedOutput::new(String::new(), format!("{}tail", "x".repeat(20_000))),
+            artifact_inputs: Vec::new(),
+            extension_phase_timings: Vec::new(),
+            changed_scope: None,
+            cargo_target: None,
+            success: false,
+            duration_ms: 30_000,
+            termination: Some("timeout".to_string()),
+        };
+
+        let error = format_build_failure(&build, "/work/example", 124);
+
+        assert!(error.contains("timeout after 30000ms"));
+        assert!(error.contains("Command: make release"));
+        assert!(error.contains("Working directory: /work/example"));
+        assert!(error.ends_with("tail"));
+        assert!(error.len() < 17_000);
+    }
 }
 
 /// Add a component-owned deploy artifact even when its packaging provider also


### PR DESCRIPTION
## Summary

- make long component-owned release builds identify their command and redacted working directory
- emit rate-limited 30-second elapsed heartbeats while retaining 1-second supervision persistence
- record build duration and termination in release evidence
- make timeout diagnostics reproducible, bounded, secret-redacted, and UTF-8 safe

Closes #12485.

## Verification

- `cargo test -p homeboy-extension build::tests --lib`
- `cargo test -p homeboy-release build_failure_tests --lib`
- `cargo check -p homeboy-core -p homeboy-extension -p homeboy-release`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

GPT-5.6 Sol and GPT-5.6 Terra via OpenCode were used to trace subprocess supervision, implement generic release-build progress and evidence, identify UTF-8/log-volume risks during review, and run verification. Chris Huber reviewed and is responsible for every line.