### PR TITLE
Resolve explicit projects before global inventory

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resolve.rs
+++ b/crates/homeboy-cli/src/commands/utils/resolve.rs
@@ -4,11 +4,32 @@ use homeboy::core::{component, project, Error, Result};
 
 pub fn resolve_project_components(first: &str, rest: &[String]) -> Result<(String, Vec<String>)> {
     let projects = project::list_ids().unwrap_or_default();
-    let components = component::list_ids().unwrap_or_default();
+    resolve_project_components_with_inventory(first, rest, projects, || {
+        component::list_ids().unwrap_or_default()
+    })
+}
 
-    if projects.contains(&first.to_string()) {
+fn resolve_project_components_with_inventory(
+    first: &str,
+    rest: &[String],
+    projects: Vec<String>,
+    load_components: impl FnOnce() -> Vec<String>,
+) -> Result<(String, Vec<String>)> {
+    if projects.iter().any(|project| project == first) {
         Ok((first.to_string(), rest.to_vec()))
-    } else if components.contains(&first.to_string()) {
+    } else {
+        let components = load_components();
+        resolve_component_first(first, rest, &projects, &components)
+    }
+}
+
+fn resolve_component_first(
+    first: &str,
+    rest: &[String],
+    projects: &[String],
+    components: &[String],
+) -> Result<(String, Vec<String>)> {
+    if components.iter().any(|component| component == first) {
         if let Some(project_idx) = rest.iter().position(|r| projects.contains(r)) {
             let project = rest[project_idx].clone();
             let mut comps = vec![first.to_string()];
@@ -99,4 +120,36 @@ pub fn infer_project_for_components(component_ids: &[String]) -> Option<String> 
             None
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_project_does_not_load_global_component_inventory() {
+        let components = vec!["plugin".to_string()];
+        let resolved = resolve_project_components_with_inventory(
+            "site",
+            &components,
+            vec!["site".to_string()],
+            || panic!("explicit project resolution must not load component inventory"),
+        )
+        .expect("explicit project should resolve");
+
+        assert_eq!(resolved, ("site".to_string(), components));
+    }
+
+    #[test]
+    fn component_first_resolution_loads_component_inventory() {
+        let resolved = resolve_project_components_with_inventory(
+            "plugin",
+            &["site".to_string()],
+            vec!["site".to_string()],
+            || vec!["plugin".to_string()],
+        )
+        .expect("component-first target should resolve");
+
+        assert_eq!(resolved, ("site".to_string(), vec!["plugin".to_string()]));
+    }
 }


### PR DESCRIPTION
## Summary
- short-circuit explicit project-first command resolution before loading global component inventory
- preserve component-first inference and unknown-target behavior behind a lazy inventory loader
- add deterministic coverage proving explicit project resolution never invokes that loader

## Root cause
`resolve_project_components()` eagerly materialized every globally registered component before checking its already-known project argument. An unrelated relative attachment could therefore trigger an unbounded recursive portable-manifest scan from the caller's CWD and hang an explicit project command before Git or SSH.

Closes #12491.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::utils::resolve::tests -- --nocapture`
- `cargo build --bin homeboy`
- candidate binary completed the exact explicit-project deploy dry-run that previously hung

## AI assistance
GPT-5.6-sol via OpenCode was used to capture the process stack, trace the eager inventory resolution, implement the lazy loader, and run verification. Chris Huber reviewed and remains responsible for the change.