### PR TITLE
Bind direct runner terminal snapshots

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -932,7 +932,18 @@ fn validate_runner_exec_snapshot_binding(
         .get("runner_job_id")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let snapshot_runner_id = snapshot.job.target_runner_id.as_deref().unwrap_or_default();
+    let snapshot_runner_id = snapshot
+        .job
+        .target_runner_id
+        .as_deref()
+        .or_else(|| {
+            snapshot
+                .job
+                .runner_job_projection
+                .as_ref()
+                .map(|projection| projection.runner_id.as_str())
+        })
+        .unwrap_or_default();
     if runner_id.is_empty()
         || runner_job_id.is_empty()
         || runner_id != snapshot_runner_id

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/runner_exec.rs
@@ -3,7 +3,9 @@
 #![cfg(test)]
 
 use super::*;
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStatus, RunnerJobLogSnapshot};
+use homeboy_core::api_jobs::{
+    Job, JobEvent, JobEventKind, JobStatus, RunnerJobLogSnapshot, RunnerJobProjection,
+};
 use homeboy_core::test_support::with_isolated_home;
 
 #[test]
@@ -708,6 +710,50 @@ fn generic_runner_exec_rejects_stale_terminal_snapshot_binding() {
             .expect("read")
             .expect("run");
         assert_eq!(run.status, "running");
+    });
+}
+
+#[test]
+fn generic_runner_exec_accepts_exact_direct_job_projection_binding() {
+    with_isolated_home(|_| {
+        let run_id = "runner-projection-direct";
+        record_runner_exec_job_identity(
+            run_id,
+            "homeboy-lab",
+            "00000000-0000-0000-0000-000000000123",
+            "/runner/workspace",
+            &["composer".to_string(), "install".to_string()],
+        )
+        .expect("bound direct run");
+        let mut snapshot = runner_snapshot("succeeded");
+        snapshot.job.target_runner_id = None;
+        snapshot.job.runner_job_projection = Some(RunnerJobProjection {
+            runner_id: "other-runner".to_string(),
+            command: "composer install".to_string(),
+            cwd: Some("/runner/workspace".to_string()),
+            source: "runner-daemon".to_string(),
+            kind: "runner.exec".to_string(),
+            lifecycle: None,
+        });
+
+        let error = project_terminal_runner_exec_result(run_id, &snapshot)
+            .expect_err("mismatched direct runner projection is rejected");
+        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+
+        snapshot
+            .job
+            .runner_job_projection
+            .as_mut()
+            .expect("projection")
+            .runner_id = "homeboy-lab".to_string();
+        project_terminal_runner_exec_result(run_id, &snapshot)
+            .expect("exact direct runner projection is accepted");
+        let run = homeboy_core::observation::ObservationStore::open_initialized()
+            .expect("store")
+            .get_run(run_id)
+            .expect("read")
+            .expect("run");
+        assert_eq!(run.status, "pass");
     });
 }
 


### PR DESCRIPTION
## Summary

- resolve direct daemon runner identity from the typed runner-job projection when no target runner is present
- retain target-runner precedence for brokered jobs
- prove mismatched direct projections fail closed and exact projections complete the durable run

Closes #12494.

## Verification

- `cargo test -p homeboy-agents agent_task_lifecycle::tests::runner_exec` (17 passed)
- `cargo check -p homeboy-agents`
- `cargo fmt --all`
- `git diff --check`

## Runtime evidence

Lab Cook hydration job `f7fe745e-397c-4769-adf8-a8fdd8c6292f` completed `composer install` successfully with typed projection runner `homeboy-lab`, but had no `target_runner_id`; terminal binding validation rejected it before OpenCode execution.

## AI assistance

GPT-5.6 Sol via OpenCode traced the durable Cook binding and terminal job evidence, implemented the focused identity fallback and fail-closed regression coverage, and ran verification. Chris Huber reviewed and is responsible for every line.