### PR TITLE
Persist detached Cook admission before daemon startup

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -406,7 +406,10 @@ pub fn record_detached_cook_handoff_child(
         let metadata = record.ensure_metadata_object();
         metadata["detached_cook_handoff"] = json!({
             "state": state,
-            "admission_state": if cancelled { "cancelled" } else { "child_attached" },
+        "admission_state": if cancelled { "cancelled" } else { "child_attached" },
+        "child_supervisor_deadline_at": (chrono::Utc::now()
+            + chrono::Duration::seconds(DETACHED_COOK_ADMISSION_LEASE_SECONDS))
+            .to_rfc3339(),
             "cook_id": cook_id,
             "child_pid": pid,
             "child_start_identity": start_identity,
@@ -627,10 +630,13 @@ pub fn detached_cook_admission_is_live(
         return false;
     }
     match record.metadata["detached_cook_handoff"]["admission_state"].as_str() {
-        Some("child_attached" | "supervising") => true,
-        Some("pre_supervisor") | None => {
-            detached_cook_admission_deadline(record).is_some_and(|deadline| deadline > now)
-        }
+        Some("supervising") => true,
+        Some("child_attached") => detached_cook_child_is_live(record).unwrap_or_else(|| {
+            detached_cook_deadline(record, "child_supervisor_deadline_at")
+                .is_some_and(|deadline| deadline > now)
+        }),
+        Some("pre_supervisor") | None => detached_cook_deadline(record, "admission_deadline_at")
+            .is_some_and(|deadline| deadline > now),
         _ => false,
     }
 }
@@ -647,17 +653,37 @@ pub fn expire_detached_cook_admission(cook_id: &str) -> Result<bool> {
     if !has_expired_detached_cook_admission(&record, chrono::Utc::now()) {
         return Ok(false);
     }
-    fail_detached_cook_handoff_parent(
+    let terminal = fail_detached_cook_handoff_parent(
         cook_id,
         "detached Cook admission lease expired before child or supervisor ownership attached",
     )?;
-    Ok(true)
+    Ok(terminal.state == AgentTaskRunState::Failed
+        && terminal.metadata["detached_cook_handoff"]["admission_state"] == "failed")
 }
 
-fn detached_cook_admission_deadline(
+fn detached_cook_child_is_live(record: &AgentTaskRunRecord) -> Option<bool> {
+    let handoff = &record.metadata["detached_cook_handoff"];
+    let pid = handoff["child_pid"]
+        .as_u64()
+        .and_then(|pid| u32::try_from(pid).ok())?;
+    let identity = serde_json::from_value(handoff["child_start_identity"].clone()).ok()?;
+    match homeboy_core::process::process_identity_state_with_start_identity(
+        pid,
+        None,
+        Some(&identity),
+    ) {
+        homeboy_core::process::ProcessIdentityState::Live => Some(true),
+        homeboy_core::process::ProcessIdentityState::Dead
+        | homeboy_core::process::ProcessIdentityState::IdentityMismatch => Some(false),
+        homeboy_core::process::ProcessIdentityState::Unverifiable => None,
+    }
+}
+
+fn detached_cook_deadline(
     record: &AgentTaskRunRecord,
+    field: &str,
 ) -> Option<chrono::DateTime<chrono::Utc>> {
-    record.metadata["detached_cook_handoff"]["admission_deadline_at"]
+    record.metadata["detached_cook_handoff"][field]
         .as_str()
         .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
         .map(|value| value.with_timezone(&chrono::Utc))

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2,6 +2,8 @@ use super::acceptance_verifier::{
     validate_acceptance_requirement, validate_attestation, with_acceptance_verifier,
 };
 use super::*;
+
+const DETACHED_COOK_ADMISSION_LEASE_SECONDS: i64 = 30;
 use chrono::DateTime;
 use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeSet;
@@ -350,6 +352,9 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
     record.metadata["detached_cook_handoff"] = json!({
         "state": "pending",
         "admission_state": "pre_supervisor",
+        "admission_deadline_at": (chrono::Utc::now()
+            + chrono::Duration::seconds(DETACHED_COOK_ADMISSION_LEASE_SECONDS))
+            .to_rfc3339(),
         "cook_id": cook_id,
         "cancellation_fence": { "state": "open" },
     });
@@ -612,6 +617,58 @@ fn complete_detached_cook_handoff_parent_in_store(
 pub fn has_pending_detached_cook_handoff(record: &AgentTaskRunRecord) -> bool {
     record.metadata["detached_cook_handoff"]["cook_id"] == record.run_id
         && record.metadata["detached_cook_handoff"]["state"] == "pending"
+}
+
+pub fn detached_cook_admission_is_live(
+    record: &AgentTaskRunRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if !has_pending_detached_cook_handoff(record) {
+        return false;
+    }
+    match record.metadata["detached_cook_handoff"]["admission_state"].as_str() {
+        Some("child_attached" | "supervising") => true,
+        Some("pre_supervisor") | None => {
+            detached_cook_admission_deadline(record).is_some_and(|deadline| deadline > now)
+        }
+        _ => false,
+    }
+}
+
+pub fn has_expired_detached_cook_admission(
+    record: &AgentTaskRunRecord,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    has_pending_detached_cook_handoff(record) && !detached_cook_admission_is_live(record, now)
+}
+
+pub fn expire_detached_cook_admission(cook_id: &str) -> Result<bool> {
+    let record = store::read_record(cook_id)?;
+    if !has_expired_detached_cook_admission(&record, chrono::Utc::now()) {
+        return Ok(false);
+    }
+    fail_detached_cook_handoff_parent(
+        cook_id,
+        "detached Cook admission lease expired before child or supervisor ownership attached",
+    )?;
+    Ok(true)
+}
+
+fn detached_cook_admission_deadline(
+    record: &AgentTaskRunRecord,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    record.metadata["detached_cook_handoff"]["admission_deadline_at"]
+        .as_str()
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .or_else(|| {
+            chrono::DateTime::parse_from_rfc3339(&record.submitted_at)
+                .ok()
+                .map(|value| {
+                    value.with_timezone(&chrono::Utc)
+                        + chrono::Duration::seconds(DETACHED_COOK_ADMISSION_LEASE_SECONDS)
+                })
+        })
 }
 
 /// Build the canonical decision for a run this controller is about to execute

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -349,6 +349,7 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
     let mut record = submit_plan(&plan, Some(&cook_id))?;
     record.metadata["detached_cook_handoff"] = json!({
         "state": "pending",
+        "admission_state": "pre_supervisor",
         "cook_id": cook_id,
         "cancellation_fence": { "state": "open" },
     });
@@ -393,17 +394,18 @@ pub fn record_detached_cook_handoff_child(
 ) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
     let record = store::mutate_record(&cook_id, |record| {
-        let state = if record.state == AgentTaskRunState::Cancelled {
-            "cancelled"
-        } else {
-            "pending"
-        };
+        let cancelled = record.state == AgentTaskRunState::Cancelled;
+        let state = if cancelled { "cancelled" } else { "pending" };
+        let cancellation_fence =
+            record.metadata["detached_cook_handoff"]["cancellation_fence"].clone();
         let metadata = record.ensure_metadata_object();
         metadata["detached_cook_handoff"] = json!({
             "state": state,
+            "admission_state": if cancelled { "cancelled" } else { "child_attached" },
             "cook_id": cook_id,
             "child_pid": pid,
             "child_start_identity": start_identity,
+            "cancellation_fence": cancellation_fence,
         });
         record.updated_at = Some(now_timestamp());
         true
@@ -420,6 +422,7 @@ pub fn record_detached_cook_supervisor(cook_id: &str, job_id: &str) -> Result<()
             return false;
         }
         record.metadata["detached_cook_handoff"]["supervisor_job_id"] = json!(job_id);
+        record.metadata["detached_cook_handoff"]["admission_state"] = json!("supervising");
         record.metadata["detached_cook_handoff"]["reattach_command"] =
             json!(format!("homeboy agent-task status {cook_id} --full"));
         true
@@ -554,6 +557,8 @@ pub fn fail_detached_cook_handoff_parent(
         } else {
             "exited_before_handoff"
         });
+        metadata["detached_cook_handoff"]["admission_state"] =
+            json!(if cancelled { "cancelled" } else { "failed" });
         metadata["detached_cook_handoff"]["reason"] = json!(reason);
         if !record.state.is_terminal() {
             set_run_state(record, AgentTaskRunState::Failed);
@@ -586,6 +591,7 @@ fn complete_detached_cook_handoff_parent_in_store(
             }
             let metadata = record.ensure_metadata_object();
             metadata["detached_cook_handoff"]["state"] = json!("redirected");
+            metadata["detached_cook_handoff"]["admission_state"] = json!("materialized");
             metadata["detached_cook_handoff"]["attempt_run_id"] = json!(attempt_run_id);
             metadata["detached_cook_handoff"]
                 .as_object_mut()
@@ -596,6 +602,16 @@ fn complete_detached_cook_handoff_parent_in_store(
             true
         })?;
     Ok(())
+}
+
+/// A detached Cook parent is admission state, never an executable queued plan.
+///
+/// The original persisted shape only carries `state: pending`; treating that as
+/// the default preserves mixed-version records while newer writers add a more
+/// specific `admission_state` for operator visibility.
+pub fn has_pending_detached_cook_handoff(record: &AgentTaskRunRecord) -> bool {
+    record.metadata["detached_cook_handoff"]["cook_id"] == record.run_id
+        && record.metadata["detached_cook_handoff"]["state"] == "pending"
 }
 
 /// Build the canonical decision for a run this controller is about to execute

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -626,6 +626,12 @@ fn classify_liveness(
     last_update_age_minutes: Option<i64>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> AgentTaskLiveness {
+    // A detached Cook parent has no executable task or owner until its child
+    // and supervisor are durably attached. It is an active admission record,
+    // not stale queued work for the daemon reconciliation tick to cancel.
+    if agent_task_lifecycle::has_pending_detached_cook_handoff(record) {
+        return AgentTaskLiveness::Active;
+    }
     if record.lab_handoff_validation_error().is_some() {
         return AgentTaskLiveness::Unreconciled;
     }

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -629,7 +629,7 @@ fn classify_liveness(
     // A detached Cook parent has no executable task or owner until its child
     // and supervisor are durably attached. It is an active admission record,
     // not stale queued work for the daemon reconciliation tick to cancel.
-    if agent_task_lifecycle::has_pending_detached_cook_handoff(record) {
+    if agent_task_lifecycle::detached_cook_admission_is_live(record, now) {
         return AgentTaskLiveness::Active;
     }
     if record.lab_handoff_validation_error().is_some() {

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -115,6 +115,9 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
 
         let expired_handoff =
             agent_task_lifecycle::has_expired_unaccepted_lab_handoff(&run.run_id)?;
+        let record = agent_task_lifecycle::exact_record(&run.run_id)?;
+        let expired_detached_admission =
+            agent_task_lifecycle::has_expired_detached_cook_admission(&record, chrono::Utc::now());
         if dry_run {
             runs.push(AgentTaskReconcileRun {
                 run_id: run.run_id,
@@ -133,7 +136,13 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             .stale_reason
             .clone()
             .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
-        let result = if expired_handoff {
+        let result = if expired_detached_admission {
+            agent_task_lifecycle::expire_detached_cook_admission(&run.run_id).map(|_| {
+                agent_task_lifecycle::status(&run.run_id)
+                    .map(|record| record.state)
+                    .unwrap_or(authoritative_state)
+            })
+        } else if expired_handoff {
             // Handoff expiry answers whether it expired, not what state that
             // left behind; re-read the record for the post-mutation state.
             agent_task_lifecycle::expire_unaccepted_lab_handoff(&run.run_id).map(|_| {
@@ -461,6 +470,86 @@ mod tests {
             assert_eq!(
                 parent.metadata["detached_cook_handoff"]["admission_state"],
                 "pre_supervisor"
+            );
+        });
+    }
+
+    #[test]
+    fn expired_unattached_and_legacy_detached_admissions_terminalize() {
+        with_isolated_home(|_| {
+            for (cook_id, legacy) in [
+                ("expired-pre-supervisor", false),
+                ("expired-legacy-pending", true),
+            ] {
+                agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                    .expect("persist detached admission");
+                agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+                    if legacy {
+                        record.metadata["detached_cook_handoff"]
+                            .as_object_mut()
+                            .expect("handoff metadata")
+                            .remove("admission_state");
+                        record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+                        record.metadata["detached_cook_handoff"]
+                            .as_object_mut()
+                            .expect("handoff metadata")
+                            .remove("admission_deadline_at");
+                    } else {
+                        record.metadata["detached_cook_handoff"]["admission_deadline_at"] =
+                            serde_json::json!("2000-01-01T00:00:00+00:00");
+                    }
+                })
+                .expect("expire admission lease");
+            }
+
+            let report = reconcile_stale_active_runs(false).expect("reconcile expired admissions");
+
+            assert_eq!(report.reconciled, 2, "{report:#?}");
+            for cook_id in ["expired-pre-supervisor", "expired-legacy-pending"] {
+                let parent = agent_task_lifecycle::status(cook_id).expect("read terminal parent");
+                assert_eq!(
+                    parent.state,
+                    agent_task_lifecycle::AgentTaskRunState::Failed
+                );
+                assert_eq!(
+                    parent.metadata["detached_cook_handoff"]["admission_state"],
+                    "failed"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn attached_detached_admission_outlives_its_pre_supervisor_deadline() {
+        with_isolated_home(|_| {
+            let cook_id = "attached-detached-admission";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist detached admission");
+            agent_task_lifecycle::record_detached_cook_handoff_child(
+                cook_id,
+                1,
+                homeboy_core::process::ProcessStartIdentity::Macos {
+                    start_seconds: 1,
+                    start_microseconds: 1,
+                },
+            )
+            .expect("attach child identity");
+            agent_task_lifecycle::record_detached_cook_supervisor(cook_id, "supervisor-1")
+                .expect("attach supervisor");
+            agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+                record.metadata["detached_cook_handoff"]["admission_deadline_at"] =
+                    serde_json::json!("2000-01-01T00:00:00+00:00");
+            })
+            .expect("expire old admission lease");
+
+            let report = reconcile_stale_active_runs(false).expect("reconcile attached admission");
+
+            assert!(report.runs.is_empty(), "{report:#?}");
+            assert_eq!(
+                agent_task_lifecycle::status(cook_id)
+                    .expect("read protected parent")
+                    .metadata["detached_cook_handoff"]["admission_state"],
+                "supervising"
             );
         });
     }

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -441,6 +441,31 @@ mod tests {
     }
 
     #[test]
+    fn pre_supervisor_detached_cook_admission_is_not_reconciled_as_stale_work() {
+        with_isolated_home(|_| {
+            let cook_id = "reconcile-pre-supervisor-cook";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist detached admission");
+
+            let report = reconcile_stale_active_runs(false).expect("reconcile admission state");
+
+            assert!(
+                report.runs.is_empty(),
+                "a pre-supervisor admission is not an abandoned executor: {report:#?}"
+            );
+            let parent = agent_task_lifecycle::status(cook_id).expect("read durable admission");
+            assert_eq!(
+                parent.state,
+                agent_task_lifecycle::AgentTaskRunState::Queued
+            );
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["admission_state"],
+                "pre_supervisor"
+            );
+        });
+    }
+
+    #[test]
     fn a_preview_reports_the_observed_state_and_mutates_nothing() {
         with_isolated_home(|_| {
             orphaned_running_run("reconcile-preview-orphan");

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -98,7 +98,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                 Err(error) => {
                     failed += 1;
                     runs.push(AgentTaskReconcileRun {
-                        run_id: run.run_id,
+                        run_id: run.run_id.clone(),
                         liveness,
                         source: run.source,
                         // The refresh is what failed, so the discovery
@@ -131,18 +131,50 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             });
             continue;
         }
+        if expired_detached_admission {
+            match agent_task_lifecycle::expire_detached_cook_admission(&run.run_id) {
+                Ok(true) => {
+                    reconciled += 1;
+                    runs.push(AgentTaskReconcileRun {
+                        run_id: run.run_id.clone(),
+                        liveness,
+                        source: run.source,
+                        authoritative_state: agent_task_lifecycle::status(&run.run_id)?.state,
+                        stale_reason: run.stale_reason,
+                        action: "reconciled",
+                        error: None,
+                    });
+                }
+                Ok(false) => runs.push(AgentTaskReconcileRun {
+                    run_id: run.run_id.clone(),
+                    liveness,
+                    source: run.source,
+                    authoritative_state: agent_task_lifecycle::status(&run.run_id)?.state,
+                    stale_reason: run.stale_reason,
+                    action: "no-op",
+                    error: None,
+                }),
+                Err(error) => {
+                    failed += 1;
+                    runs.push(AgentTaskReconcileRun {
+                        run_id: run.run_id,
+                        liveness,
+                        source: run.source,
+                        authoritative_state,
+                        stale_reason: run.stale_reason,
+                        action: "failed",
+                        error: Some(error.message),
+                    });
+                }
+            }
+            continue;
+        }
 
         let reason = run
             .stale_reason
             .clone()
             .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
-        let result = if expired_detached_admission {
-            agent_task_lifecycle::expire_detached_cook_admission(&run.run_id).map(|_| {
-                agent_task_lifecycle::status(&run.run_id)
-                    .map(|record| record.state)
-                    .unwrap_or(authoritative_state)
-            })
-        } else if expired_handoff {
+        let result = if expired_handoff {
             // Handoff expiry answers whether it expired, not what state that
             // left behind; re-read the record for the post-mutation state.
             agent_task_lifecycle::expire_unaccepted_lab_handoff(&run.run_id).map(|_| {
@@ -251,6 +283,54 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                         error: None,
                     });
                 } else {
+                    let expired_detached_admission =
+                        agent_task_lifecycle::has_expired_detached_cook_admission(
+                            &refreshed,
+                            chrono::Utc::now(),
+                        );
+                    if expired_detached_admission {
+                        match agent_task_lifecycle::expire_detached_cook_admission(resolved_run_id)
+                        {
+                            Ok(true) => {
+                                reconciled += 1;
+                                runs.push(AgentTaskReconcileRun {
+                                    run_id: resolved_run_id.clone(),
+                                    liveness,
+                                    source: run.source,
+                                    authoritative_state: agent_task_lifecycle::status(
+                                        resolved_run_id,
+                                    )?
+                                    .state,
+                                    stale_reason: run.stale_reason,
+                                    action: "reconciled",
+                                    error: None,
+                                });
+                            }
+                            Ok(false) => runs.push(AgentTaskReconcileRun {
+                                run_id: resolved_run_id.clone(),
+                                liveness,
+                                source: run.source,
+                                authoritative_state: agent_task_lifecycle::status(resolved_run_id)?
+                                    .state,
+                                stale_reason: run.stale_reason,
+                                action: "no-op",
+                                error: None,
+                            }),
+                            Err(error) => {
+                                failed += 1;
+                                runs.push(AgentTaskReconcileRun {
+                                    run_id: resolved_run_id.clone(),
+                                    liveness,
+                                    source: run.source,
+                                    authoritative_state: refreshed.state,
+                                    stale_reason: run.stale_reason,
+                                    action: "failed",
+                                    error: Some(error.message),
+                                });
+                            }
+                        }
+                        continue;
+                    }
                     let reason = run
                         .stale_reason
                         .clone()

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1457,6 +1457,22 @@ fn pending_detached_cook_handoff_is_discoverable_before_attempt_materialization(
         // The handoff parent is the durable operator handle while no provider
         // attempt exists yet, so both discovery views must expose it.
         assert!(parent.tasks.is_empty());
+        assert_eq!(
+            parent.metadata["detached_cook_handoff"]["admission_state"],
+            "pre_supervisor"
+        );
+        assert!(agent_task_lifecycle::has_pending_detached_cook_handoff(
+            &parent
+        ));
+        let mut legacy_parent = parent.clone();
+        legacy_parent.metadata["detached_cook_handoff"]
+            .as_object_mut()
+            .expect("handoff metadata")
+            .remove("admission_state");
+        assert!(
+            agent_task_lifecycle::has_pending_detached_cook_handoff(&legacy_parent),
+            "records written before admission_state remain protected from recovery"
+        );
         let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active discovery");
         assert!(active.runs.iter().any(|run| run.run_id == cook_id));
         let all = discover_runs(AgentTaskDiscoveryFilter::All).expect("all discovery");

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1724,9 +1724,10 @@ fn scoped_reconcile_keeps_exact_attempts_separate_and_expands_cook_aliases_to_th
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
         agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
             // Model the durable parent/attempt link while both projections are
-            // stale, before normal handoff completion terminalizes the parent.
+            // stale after normal handoff completion has redirected the parent.
             record.metadata["detached_cook_handoff"]["attempt_run_id"] =
                 serde_json::json!(&attempt_id);
+            record.metadata["detached_cook_handoff"]["state"] = serde_json::json!("redirected");
         })
         .expect("link stale parent projection");
         for run_id in [cook_id, attempt_id.as_str()] {

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -179,14 +179,26 @@ pub(super) fn intercept_local_detached_cook(
     materialize_stdin_prompt(&mut child_args, &session_root)?;
     let log_path = session_root.join("cook.log");
 
-    // A daemon-owned job is the authority that outlives this launcher. Prove it
-    // is reachable before a provider-capable child exists, so unsupported
-    // detachment is rejected before dispatch.
-    let controller_client = homeboy::core::daemon::LocalControllerJobClient::connect()?;
-
     // Make the returned Cook ID resolvable before a child exists. If this fails,
     // nothing has been spawned and no detached work can leak.
     agent_task_lifecycle::record_detached_cook_handoff_parent(&cook_id)?;
+    // Daemon startup can run reconciliation. Announce the durable admission
+    // handle before that potentially slow boundary so a disconnected caller can
+    // inspect or cancel it safely.
+    crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), &cook_id);
+    // A daemon-owned job is the authority that outlives this launcher. Prove it
+    // is reachable before a provider-capable child exists, so unsupported
+    // detachment is rejected before dispatch.
+    let controller_client = match homeboy::core::daemon::LocalControllerJobClient::connect() {
+        Ok(client) => client,
+        Err(error) => {
+            let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                &cook_id,
+                "durable controller ownership could not be established",
+            );
+            return Err(error);
+        }
+    };
     let route = detached_route(cli);
     let launch_token = create_local_cook_launch_token(&session_root)?;
     let mut child = match spawn_detached_cook(&child_args, &log_path, route.as_ref(), &launch_token)
@@ -279,7 +291,6 @@ pub(super) fn intercept_local_detached_cook(
                 None,
             ));
         }
-        crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), &cook_id);
         let envelope = handoff_envelope(
             &cook_id,
             pid,
@@ -1366,6 +1377,44 @@ mod tests {
                     .expect("pending handoff cancel command resolves")
                     .run_id,
                 "cook-pending"
+            );
+        });
+    }
+
+    #[test]
+    fn handoff_admission_transitions_from_parent_to_child_to_supervisor() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-admission-transitions";
+            let parent = agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist pre-supervisor parent");
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["admission_state"],
+                "pre_supervisor"
+            );
+            let child = agent_task_lifecycle::record_detached_cook_handoff_child(
+                cook_id,
+                1,
+                homeboy::core::process::ProcessStartIdentity::Macos {
+                    start_seconds: 1,
+                    start_microseconds: 1,
+                },
+            )
+            .expect("attach child identity");
+            assert_eq!(
+                child.metadata["detached_cook_handoff"]["admission_state"],
+                "child_attached"
+            );
+            agent_task_lifecycle::record_detached_cook_supervisor(cook_id, "supervisor-1")
+                .expect("attach supervisor");
+            let supervised =
+                agent_task_lifecycle::exact_record(cook_id).expect("read supervised handoff");
+            assert_eq!(
+                supervised.metadata["detached_cook_handoff"]["admission_state"],
+                "supervising"
+            );
+            assert_eq!(
+                supervised.metadata["detached_cook_handoff"]["supervisor_job_id"],
+                "supervisor-1"
             );
         });
     }

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -208,10 +208,35 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
             "--verify",
             "true",
         ]);
-    let output = bounded_output(command);
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(!output.status.success(), "{stdout}");
+    let stdout_path = context.root().join("detached-cook.stdout");
+    let stderr_path = context.root().join("detached-cook.stderr");
+    command
+        .stdout(Stdio::from(
+            std::fs::File::create(&stdout_path).expect("create detached Cook stdout"),
+        ))
+        .stderr(Stdio::from(
+            std::fs::File::create(&stderr_path).expect("create detached Cook stderr"),
+        ));
+    let mut child = command.spawn().expect("start detached Cook launcher");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
+        if stderr.contains("durable run id `local-detach-exits-before-attempt`") {
+            assert!(
+                child.try_wait().expect("poll detached Cook launcher").is_none(),
+                "the launcher must still be crossing daemon/child admission after it emits the durable parent identity"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the parent identity was not emitted before detached admission completed: {stderr}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let status = child.wait().expect("wait for detached Cook launcher");
+    let stdout = std::fs::read_to_string(&stdout_path).expect("read detached Cook stdout");
+    assert!(!status.success(), "{stdout}");
     assert!(
         !stdout.contains("cannot detach after handoff with --placement local"),
         "{stdout}"
@@ -231,6 +256,10 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
     let status = bounded_output(status);
     let status_stdout = String::from_utf8_lossy(&status.stdout);
     assert!(status.status.success(), "{status_stdout}");
+    assert!(
+        status_stdout.contains("\"admission_state\": \"failed\""),
+        "an abandoned admission must terminalize truthfully: {status_stdout}"
+    );
     assert!(
         status_stdout.contains("\"state\": \"failed\""),
         "{status_stdout}"


### PR DESCRIPTION
## Summary

- persist a durable detached Cook parent before daemon connection can block
- model bounded pre-supervisor and child-attached admission leases
- reconcile abandoned admissions truthfully without terminalizing live attached ownership
- preserve legacy pending-record compatibility and cancellation fences

Fixes #11376.

## Verification

- `cargo test -p homeboy-agents detached_cook --lib`
- `cargo test -p homeboy --test cook_lab_handoff_test cook_accepts_local_detachment_after_materializing_an_executable_attempt`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode implemented the state-machine repair, generated focused tests, and ran iterative independent code-review agents. Chris Huber reviewed every finding, verified the final branch, and owns the change.