### PR TITLE
Add compact Cook help and safe plan preview

### DIFF
--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -32,7 +32,57 @@ pub fn scope_lab_cli_arguments(command: Command) -> Command {
             }
         })
     });
-    scope_lab_cli_arguments_at_path(command, &[], &lab_args)
+    scope_cook_help(scope_lab_cli_arguments_at_path(command, &[], &lab_args))
+}
+
+/// Cook has a large control-plane surface, but the routine tracked-task path
+/// only needs a small set of flags. Clap renders `HelpShort` for `--help` and
+/// `HelpLong` for `--help-full`; keep the latter as the complete reference.
+fn scope_cook_help(command: Command) -> Command {
+    const COMMON_COOK_ARGUMENTS: &[&str] = &[
+        "help",
+        "help_full",
+        "preview",
+        "prompt",
+        "goal",
+        "repo",
+        "task_url",
+        "to_worktree",
+        "cwd",
+        "verify",
+        "verify_file",
+        "base",
+        "head",
+        "no_finalize",
+        "draft_pr",
+        "max_attempts",
+    ];
+
+    fn visit(command: Command, path: &[String]) -> Command {
+        let is_cook = path.iter().map(String::as_str).eq(["agent-task", "cook"]);
+        let command = if is_cook {
+            let ids = command
+                .get_arguments()
+                .map(|arg| arg.get_id().to_string())
+                .collect::<Vec<_>>();
+            ids.into_iter().fold(command, |command, id| {
+                if COMMON_COOK_ARGUMENTS.contains(&id.as_str()) {
+                    command
+                } else {
+                    command.mut_arg(id, |arg| arg.hide_short_help(true))
+                }
+            })
+        } else {
+            command
+        };
+        command.mut_subcommands(|subcommand| {
+            let mut child_path = path.to_vec();
+            child_path.push(subcommand.get_name().to_string());
+            visit(subcommand, &child_path)
+        })
+    }
+
+    visit(command, &[])
 }
 
 fn scope_lab_cli_arguments_at_path(

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -41,6 +41,15 @@ fn cook_help_snapshot_is_task_first_and_full_help_retains_advanced_controls() {
     assert!(!compact.contains("--max-provider-rotations"), "{compact}");
     assert!(full.contains("--max-provider-rotations"), "{full}");
     assert!(full.contains("--provider-command"), "{full}");
+    for advanced in [
+        "--placement",
+        "--private-verify",
+        "--gate-env",
+        "--provider-config",
+        "--require-acceptance",
+    ] {
+        assert!(full.contains(advanced), "missing {advanced}:\n{full}");
+    }
 
     // The routine path stays readable while the complete reference remains
     // deliberately available through `--help-full`.

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -17,6 +17,44 @@ use super::{lab_cli_arguments_are_visible_for_path, LAB_VISIBLE_COMMAND_PATHS};
 use crate::cli_surface::{current_command_surface, Cli, CommandSurfaceEntry};
 use clap::{CommandFactory, FromArgMatches};
 
+fn cook_command(command: clap::Command) -> clap::Command {
+    command
+        .find_subcommand("agent-task")
+        .expect("agent-task command")
+        .find_subcommand("cook")
+        .expect("cook command")
+        .clone()
+}
+
+#[test]
+fn cook_help_snapshot_is_task_first_and_full_help_retains_advanced_controls() {
+    let mut compact = cook_command(Cli::command_with_scoped_lab_args());
+    let compact = compact.render_help().to_string();
+    let mut full = cook_command(Cli::command_with_scoped_lab_args());
+    let full = full.render_long_help().to_string();
+
+    assert!(compact.contains("Quick start:"), "{compact}");
+    assert!(compact.contains("--repo <REPO>"), "{compact}");
+    assert!(compact.contains("--task-url <URL>"), "{compact}");
+    assert!(compact.contains("--preview"), "{compact}");
+    assert!(compact.contains("--help-full"), "{compact}");
+    assert!(!compact.contains("--max-provider-rotations"), "{compact}");
+    assert!(full.contains("--max-provider-rotations"), "{full}");
+    assert!(full.contains("--provider-command"), "{full}");
+
+    // The routine path stays readable while the complete reference remains
+    // deliberately available through `--help-full`.
+    assert!(
+        compact.len() <= 6_000,
+        "compact Cook help is {} bytes",
+        compact.len()
+    );
+    assert!(
+        full.len() > compact.len() * 2,
+        "full Cook help is not materially larger"
+    );
+}
+
 #[test]
 fn scoped_command_tree_has_valid_argument_relationships() {
     Cli::command_with_scoped_lab_args().debug_assert();

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -222,7 +222,7 @@ pub(crate) fn run_with_cook_progress_and_provenance(
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
         AgentTaskCommand::Cook(cook_args) => {
             if cook_args.preview {
-                return run::preview_cook(*cook_args);
+                return run::preview_cook(*cook_args, provenance);
             }
             // Reject unsupported Cook source shapes before discovering a provider
             // or preparing the local/Lab execution route.

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -221,6 +221,9 @@ pub(crate) fn run_with_cook_progress_and_provenance(
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
         AgentTaskCommand::Cook(cook_args) => {
+            if cook_args.preview {
+                return run::preview_cook(*cook_args);
+            }
             // Reject unsupported Cook source shapes before discovering a provider
             // or preparing the local/Lab execution route.
             run::validate_cook_request_with_provenance(&cook_args, provenance)?;

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -76,6 +76,9 @@ pub enum AgentTaskCommand {
     /// client that needs the detached contract should pass
     /// `--detach-after-handoff` rather than rely on the default, and read the
     /// terminal outcome from `agent-task status <run-id>` in either case.
+    #[command(
+        after_help = "Quick start:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test'\n\nInspect inferred inputs without side effects:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test' --preview\n\nUse --help-full for the complete advanced option reference."
+    )]
     Cook(Box<AgentTaskCookArgs>),
     /// Continue a detached Cook from its durable Cook ID or provider attempt ID.
     /// The persisted recipe supplies the original prompt, transport, gates,

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -898,7 +898,15 @@ mod tests {
 }
 
 #[derive(Args, Debug, Clone)]
+#[command(disable_help_flag = true)]
 pub struct AgentTaskCookArgs {
+    /// Show the compact task-first Cook help. Use `--help-full` for every
+    /// advanced transport, provider, gate, and recovery option.
+    #[arg(short = 'h', long, action = clap::ArgAction::HelpShort)]
+    pub help: Option<bool>,
+    /// Show the complete Cook option reference.
+    #[arg(long = "help-full", action = clap::ArgAction::HelpLong)]
+    pub help_full: Option<bool>,
     #[command(flatten)]
     pub dispatch: DispatchArgs,
     /// Completion rule for isolated candidates: wait for all results (default)
@@ -909,6 +917,10 @@ pub struct AgentTaskCookArgs {
     pub attempt_run_id: Option<String>,
     #[arg(long, hide = true)]
     pub attempt_plan: Option<String>,
+    /// Resolve the Cook plan and validate static inputs without creating a run
+    /// or provisioning a worktree. Includes a replayable command.
+    #[arg(long)]
+    pub preview: bool,
     /// One-line statement of what a successful cook must achieve. Recorded as
     /// framing metadata for the provider task and used for review. Without
     /// --prompt, it supplies the one provider task.

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -162,10 +162,23 @@ pub(crate) fn run_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
 
 /// Resolve the same pre-provisioning Cook inputs used by execution. This path
 /// intentionally never calls `provision_cook_destination` or a durable service.
-pub(crate) fn preview_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
+pub(crate) fn preview_cook(
+    mut args: AgentTaskCookArgs,
+    provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
+) -> CmdResult<Value> {
     args.gates.snapshot_file_inputs()?;
-    let args = resolve_cook_destination(args)?;
-    validate_cook_request(&args)?;
+    // Source policy is a static validation and must apply to preview exactly as
+    // it applies before an execution route can inspect the destination.
+    validate_cook_request_with_provenance(&args, provenance)?;
+    let (args, provision) = resolve_cook_preview_destination(args)?;
+    if !args.provider_evidence_inputs.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "provider-evidence",
+            "preview cannot project --provider-evidence without a Cook workspace; run the replay command to materialize the evidence",
+            None,
+            None,
+        ));
+    }
     let gate_workspace = args.dispatch.cwd.as_deref().map(Path::new).or_else(|| {
         args.to_worktree
             .as_deref()
@@ -183,9 +196,7 @@ pub(crate) fn preview_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
     )?;
     preflight_cook_provider_credentials(&args)?;
 
-    // `lookup_pending` is the resolver's established representation for a
-    // destination whose path is intentionally unavailable before provisioning.
-    let mut plan = compile_cook_plan(&args, serde_json::json!({ "action": "lookup_pending" }))?;
+    let mut plan = compile_cook_plan(&args, provision)?;
     resolve_cook_execution_budget(&args, &mut plan)?;
     plan.metadata["gate_contract_validation"] = serde_json::to_value(gate_contract_validation)
         .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
@@ -195,7 +206,7 @@ pub(crate) fn preview_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
         .first()
         .map(|task| serde_json::to_value(&task.executor).unwrap_or(Value::Null))
         .unwrap_or(Value::Null);
-    let replay_argv = cook_preview_replay_argv(&args);
+    let replay = cook_preview_replay_argv(&args);
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-cook-preview/v1",
@@ -218,27 +229,37 @@ pub(crate) fn preview_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
                     "ai_tool": args.ai_tool,
                 },
             },
-            "replay_argv": replay_argv,
+            "replay_argv": replay.argv,
+            "replay_omissions": replay.omissions,
         }),
         0,
     ))
 }
 
-fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
+const MAX_PREVIEW_REPLAY_ARGS: usize = 128;
+const MAX_PREVIEW_REPLAY_BYTES: usize = 16 * 1024;
+
+#[derive(Debug)]
+struct PreviewReplayArgv {
+    argv: Vec<String>,
+    omissions: Vec<String>,
+}
+
+fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
     let process_argv = std::env::args().collect::<Vec<_>>();
     if process_argv
         .windows(2)
         .any(|parts| parts == ["agent-task", "cook"])
         && process_argv.iter().any(|part| part == "--preview")
     {
-        return std::iter::once("homeboy".to_string())
-            .chain(
+        return redact_preview_replay_argv(
+            std::iter::once("homeboy".to_string()).chain(
                 process_argv
                     .into_iter()
                     .skip(1)
                     .filter(|part| part != "--preview"),
-            )
-            .collect();
+            ),
+        );
     }
 
     // Unit callers do not have the original process argv. Keep their fallback
@@ -277,7 +298,54 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
     if args.draft_pr {
         argv.push("--draft-pr".to_string());
     }
-    argv
+    redact_preview_replay_argv(argv)
+}
+
+fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
+    const VALUE_FLAGS: &[&str] = &[
+        "--gate-env",
+        "--provider-config",
+        "--client-context",
+        "--lab-env-json",
+        "--provider-argv",
+        "--provider-command",
+        "--runner-env",
+    ];
+    let mut replay = Vec::new();
+    let mut omissions = Vec::new();
+    let mut redact_next = None;
+    let mut bytes = 0;
+    for value in argv {
+        if replay.len() == MAX_PREVIEW_REPLAY_ARGS || bytes + value.len() > MAX_PREVIEW_REPLAY_BYTES
+        {
+            omissions.push("replay argv was truncated at the preview safety budget; re-add omitted non-secret arguments from the original command".to_string());
+            break;
+        }
+        if let Some(flag) = redact_next.take() {
+            replay.push(format!("<redacted:{flag}>"));
+            omissions.push(format!("{flag} was redacted; replace its placeholder with the original value before replaying"));
+        } else if let Some((flag, _)) = value.split_once('=') {
+            if VALUE_FLAGS.contains(&flag) {
+                replay.push(format!("{flag}=<redacted:{flag}>"));
+                omissions.push(format!("{flag} was redacted; replace its placeholder with the original value before replaying"));
+            } else {
+                redact_next = VALUE_FLAGS
+                    .contains(&value.as_str())
+                    .then_some(value.clone());
+                replay.push(value);
+            }
+        } else {
+            redact_next = VALUE_FLAGS
+                .contains(&value.as_str())
+                .then_some(value.clone());
+            replay.push(value);
+        }
+        bytes += replay.last().map_or(0, String::len);
+    }
+    PreviewReplayArgv {
+        argv: replay,
+        omissions,
+    }
 }
 
 #[cfg(test)]
@@ -301,15 +369,20 @@ mod preview_tests {
     fn preview_reports_destination_blockers_without_creating_homeboy_state() {
         crate::test_support::with_isolated_home(|home| {
             let before = std::fs::read_dir(home).expect("read isolated home").count();
-            let error = preview_cook(cook(&[
-                "homeboy",
-                "agent-task",
-                "cook",
-                "--preview",
-                "--prompt",
-                "implement the issue",
-                "--no-finalize",
-            ]))
+            let error = preview_cook(
+                cook(&[
+                    "homeboy",
+                    "agent-task",
+                    "cook",
+                    "--preview",
+                    "--prompt",
+                    "implement the issue",
+                    "--backend",
+                    "fixture",
+                    "--no-finalize",
+                ]),
+                None,
+            )
             .expect_err("missing destination must block preview");
 
             assert_eq!(
@@ -346,8 +419,196 @@ mod preview_tests {
         ]);
         let resolved = resolve_cook_destination(args).expect("resolve issue destination");
         let replay = cook_preview_replay_argv(&resolved);
-        assert!(!replay.iter().any(|part| part == "--preview"), "{replay:?}");
-        Cli::try_parse_from(&replay).expect("replay argv parses as Cook");
+        assert!(
+            !replay.argv.iter().any(|part| part == "--preview"),
+            "{replay:?}"
+        );
+        Cli::try_parse_from(&replay.argv).expect("replay argv parses as Cook");
+    }
+
+    #[test]
+    fn preview_applies_argument_provenance_before_destination_resolution() {
+        let mut provenance = crate::cli_surface::CommandArgumentProvenance::default();
+        provenance.set(
+            "no_finalize",
+            crate::cli_surface::ArgumentSource::Configuration,
+        );
+        let error = preview_cook(
+            cook(&[
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--preview",
+                "--prompt",
+                "implement the issue",
+                "--to-worktree",
+                "missing@worktree",
+                "--no-finalize",
+            ]),
+            Some(&provenance),
+        )
+        .expect_err("preview must enforce no-finalize provenance");
+        assert!(
+            error.message.contains("explicitly authorized"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn preview_replay_redacts_sensitive_values_and_has_a_fixed_budget() {
+        let replay = redact_preview_replay_argv(std::iter::once("homeboy".to_string()).chain([
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--gate-env".to_string(),
+            "TOKEN=secret-value".to_string(),
+            "--provider-config".to_string(),
+            r#"{"token":"secret-value"}"#.to_string(),
+            "--runner-env=TOKEN=secret-value".to_string(),
+        ]));
+        assert!(
+            !replay.argv.join(" ").contains("secret-value"),
+            "{replay:?}"
+        );
+        assert_eq!(replay.argv[4], "<redacted:--gate-env>");
+        assert_eq!(replay.argv[6], "<redacted:--provider-config>");
+        assert_eq!(replay.argv[7], "--runner-env=<redacted:--runner-env>");
+        assert_eq!(replay.omissions.len(), 3);
+
+        let bounded = redact_preview_replay_argv(
+            (0..MAX_PREVIEW_REPLAY_ARGS + 1).map(|index| format!("arg-{index}")),
+        );
+        assert_eq!(bounded.argv.len(), MAX_PREVIEW_REPLAY_ARGS);
+        assert!(bounded
+            .omissions
+            .iter()
+            .any(|item| item.contains("safety budget")));
+    }
+
+    #[test]
+    fn compile_cook_plan_returns_a_typed_evidence_blocker_without_a_workspace() {
+        let args = cook(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "read the evidence",
+            "--to-worktree",
+            "missing@worktree",
+            "--no-finalize",
+            "--provider-evidence",
+            r#"{"id":"issue","source":"/tmp/issue.md"}"#,
+        ]);
+        let error = compile_cook_plan(&args, serde_json::json!({ "action": "lookup_pending" }))
+            .expect_err("evidence without a workspace must not panic");
+        assert_eq!(
+            error.code,
+            homeboy::core::ErrorCode::ValidationInvalidArgument
+        );
+        assert_eq!(error.details["field"], "provider-evidence");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preview_never_executes_a_configured_worktree_provider() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let marker = temp.path().join("provider-ran");
+            let provider = temp.path().join("provider.sh");
+            std::fs::write(
+                &provider,
+                format!("#!/bin/sh\ntouch {}\n", marker.display()),
+            )
+            .expect("write provider");
+            let mut permissions = std::fs::metadata(&provider)
+                .expect("provider metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+            let mut config = homeboy::core::defaults::load_config();
+            config.worktree_providers.insert(
+                "sentinel".to_string(),
+                homeboy::core::defaults::WorktreeProviderConfig {
+                    enabled: true,
+                    kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                    apply_enabled: true,
+                    lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
+                    lookup_output_limit_bytes: 64 * 1024,
+                    commands: homeboy::core::defaults::WorktreeProviderCommands {
+                        list: Some(vec![provider.display().to_string()]),
+                        ..Default::default()
+                    },
+                    list_result_mapping: None,
+                },
+            );
+            homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+            let error = preview_cook(
+                cook(&[
+                    "homeboy",
+                    "agent-task",
+                    "cook",
+                    "--preview",
+                    "--backend",
+                    "fixture",
+                    "--prompt",
+                    "implement the issue",
+                    "--to-worktree",
+                    "sentinel@missing",
+                    "--no-finalize",
+                ]),
+                None,
+            )
+            .expect_err("provider-backed destination must block preview");
+            assert_eq!(
+                error.code,
+                homeboy::core::ErrorCode::ValidationInvalidArgument
+            );
+            assert!(
+                error.message.contains("preview unresolved destination"),
+                "{}",
+                error.message
+            );
+            assert!(!marker.exists(), "preview executed the configured provider");
+        });
+    }
+
+    #[test]
+    fn preview_rejects_an_existing_unsafe_path_without_changing_it() {
+        crate::test_support::with_isolated_home(|_| {
+            let path = tempfile::tempdir().expect("unsafe path");
+            let sentinel = path.path().join("unchanged");
+            std::fs::write(&sentinel, "keep").expect("write sentinel");
+            let error = preview_cook(
+                cook(&[
+                    "homeboy",
+                    "agent-task",
+                    "cook",
+                    "--preview",
+                    "--backend",
+                    "fixture",
+                    "--prompt",
+                    "implement the issue",
+                    "--to-worktree",
+                    path.path().to_str().expect("UTF-8 path"),
+                    "--no-finalize",
+                ]),
+                None,
+            )
+            .expect_err("non-worktree path must fail static safety checks");
+            assert_eq!(
+                error.code,
+                homeboy::core::ErrorCode::ValidationInvalidArgument
+            );
+            assert_eq!(
+                std::fs::read_to_string(&sentinel).expect("read sentinel"),
+                "keep"
+            );
+        });
     }
 }
 
@@ -1273,6 +1534,96 @@ pub(crate) fn resolve_cook_destination(
         args.head = Some(derived_cook_branch(task_url)?);
     }
     Ok(args)
+}
+
+/// Preview never asks a worktree provider whether a handle exists: even a
+/// provider's nominal "list" command is arbitrary configured code. It only
+/// validates an already-local authority and otherwise returns a typed blocker.
+fn resolve_cook_preview_destination(
+    mut args: AgentTaskCookArgs,
+) -> homeboy::core::Result<(AgentTaskCookArgs, Value)> {
+    normalize_cook_repository_identity(&mut args)?;
+    if args.to_worktree.is_none() {
+        if let Some(cwd) = args.dispatch.cwd.as_deref() {
+            let path = std::fs::canonicalize(cwd).map_err(|error| {
+                homeboy::core::Error::internal_io(error.to_string(), Some(cwd.to_string()))
+            })?;
+            args.to_worktree = Some(path.display().to_string());
+        } else {
+            let repo = args.dispatch.repo.as_deref().ok_or_else(|| {
+                homeboy::core::Error::validation_missing_argument(vec![
+                    "--repo <repo> is required when --to-worktree is omitted".to_string(),
+                ])
+            })?;
+            let task_url = args.dispatch.task_url.as_deref().ok_or_else(|| {
+                homeboy::core::Error::validation_missing_argument(vec![
+                    "--task-url <url> is required when --to-worktree is omitted".to_string(),
+                ])
+            })?;
+            let handle = format!(
+                "{repo}@{}",
+                slugify_cook_branch(&derived_cook_branch(task_url)?)
+            );
+            return Err(preview_destination_blocker(
+                &handle,
+                "the issue-derived destination is not an explicit existing local path; preview will not execute configured worktree-provider commands",
+            ));
+        }
+    }
+    let handle = args.to_worktree.clone().expect("preview destination set");
+    let path = if let Some(cwd) = args.dispatch.cwd.as_deref() {
+        let path = std::fs::canonicalize(cwd).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(cwd.to_string()))
+        })?;
+        ensure_active_managed_cook_destination(&handle)?;
+        homeboy::core::worktree_providers::validate_task_worktree_root(&path, &handle)?;
+        validate_cook_destination_identity(&args, &path)?;
+        validate_cook_cwd_destination_identity(&path, &handle)?;
+        path
+    } else if Path::new(&handle).is_dir() {
+        let path = std::fs::canonicalize(&handle).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(handle.clone()))
+        })?;
+        homeboy::core::worktree_providers::validate_task_worktree_root(&path, &handle)?;
+        validate_cook_destination_identity(&args, &path)?;
+        path
+    } else if let Some(record) = homeboy::core::worktree::resolve_workspace_ref_if_present(&handle)?
+    {
+        ensure_active_managed_cook_destination(&handle)?;
+        let path = PathBuf::from(record.path());
+        if !path.is_dir() {
+            return Err(preview_destination_blocker(
+                &handle,
+                "the registered workspace path is missing",
+            ));
+        }
+        homeboy::core::worktree_providers::validate_task_worktree_root(&path, &handle)?;
+        validate_cook_destination_identity(&args, &path)?;
+        path
+    } else {
+        return Err(preview_destination_blocker(
+            &handle,
+            "destination is missing or provider-backed; preview only validates explicit existing local paths",
+        ));
+    };
+    Ok((
+        args,
+        serde_json::json!({
+            "action": "existing",
+            "kind": "preview_local",
+            "handle": handle,
+            "path": path,
+        }),
+    ))
+}
+
+fn preview_destination_blocker(handle: &str, problem: &str) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "to_worktree",
+        format!("preview unresolved destination `{handle}`: {problem}"),
+        Some(handle.to_string()),
+        Some(vec!["Pass an existing local --cwd or --to-worktree path, or run Cook to let its configured provider resolve the destination.".to_string()]),
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -2372,9 +2723,17 @@ pub(crate) fn compile_cook_plan(
         .validate_explicit_models(&plan)?;
     record_cook_goal(&mut plan, args.goal.as_deref());
     if !args.provider_evidence_inputs.is_empty() {
+        let workspace = workspace.as_deref().ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "provider-evidence",
+                "provider evidence cannot be projected until Cook has a resolved workspace path",
+                None,
+                None,
+            )
+        })?;
         let evidence = project_provider_evidence_inputs(
             &args.provider_evidence_inputs,
-            Path::new(workspace.as_deref().expect("bound Cook workspace")),
+            Path::new(workspace),
             None,
         )?;
         for task in &mut plan.tasks {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -160,6 +160,197 @@ pub(crate) fn run_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
     run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
 }
 
+/// Resolve the same pre-provisioning Cook inputs used by execution. This path
+/// intentionally never calls `provision_cook_destination` or a durable service.
+pub(crate) fn preview_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
+    args.gates.snapshot_file_inputs()?;
+    let args = resolve_cook_destination(args)?;
+    validate_cook_request(&args)?;
+    let gate_workspace = args.dispatch.cwd.as_deref().map(Path::new).or_else(|| {
+        args.to_worktree
+            .as_deref()
+            .map(Path::new)
+            .filter(|path| path.is_dir())
+    });
+    let gate_contract_validation = validate_gate_contracts(
+        args.gates
+            .verify
+            .iter()
+            .chain(&args.gates.private_verify)
+            .cloned(),
+        gate_workspace,
+        &crate::cli_runtime::current_augmented_command_contract(),
+    )?;
+    preflight_cook_provider_credentials(&args)?;
+
+    // `lookup_pending` is the resolver's established representation for a
+    // destination whose path is intentionally unavailable before provisioning.
+    let mut plan = compile_cook_plan(&args, serde_json::json!({ "action": "lookup_pending" }))?;
+    resolve_cook_execution_budget(&args, &mut plan)?;
+    plan.metadata["gate_contract_validation"] = serde_json::to_value(gate_contract_validation)
+        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+
+    let executor = plan
+        .tasks
+        .first()
+        .map(|task| serde_json::to_value(&task.executor).unwrap_or(Value::Null))
+        .unwrap_or(Value::Null);
+    let replay_argv = cook_preview_replay_argv(&args);
+    Ok((
+        serde_json::json!({
+            "schema": "homeboy/agent-task-cook-preview/v1",
+            "mutates": false,
+            "resolved": {
+                "repository": args.dispatch.repo,
+                "worktree": args.to_worktree,
+                "base": args.base,
+                "head": args.head,
+                "placement": "none (preview)",
+                "provider": executor,
+                "gates": {
+                    "public": args.gates.verify.len(),
+                    "private": args.gates.private_verify.len(),
+                },
+                "retry_budget": plan.metadata["cook_retry_policy"],
+                "publication": {
+                    "finalize": !args.no_finalize,
+                    "draft": args.draft_pr,
+                    "ai_tool": args.ai_tool,
+                },
+            },
+            "replay_argv": replay_argv,
+        }),
+        0,
+    ))
+}
+
+fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
+    let process_argv = std::env::args().collect::<Vec<_>>();
+    if process_argv
+        .windows(2)
+        .any(|parts| parts == ["agent-task", "cook"])
+        && process_argv.iter().any(|part| part == "--preview")
+    {
+        return std::iter::once("homeboy".to_string())
+            .chain(
+                process_argv
+                    .into_iter()
+                    .skip(1)
+                    .filter(|part| part != "--preview"),
+            )
+            .collect();
+    }
+
+    // Unit callers do not have the original process argv. Keep their fallback
+    // useful for embedding while the CLI path above preserves every supplied
+    // advanced flag exactly.
+    let mut argv = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    if let Some(prompt) = &args.dispatch.prompt {
+        argv.extend(["--prompt".to_string(), prompt.clone()]);
+    }
+    if let Some(goal) = &args.goal {
+        argv.extend(["--goal".to_string(), goal.clone()]);
+    }
+    if let Some(repo) = &args.dispatch.repo {
+        argv.extend(["--repo".to_string(), repo.clone()]);
+    }
+    if let Some(task_url) = &args.dispatch.task_url {
+        argv.extend(["--task-url".to_string(), task_url.clone()]);
+    }
+    if let Some(worktree) = &args.to_worktree {
+        argv.extend(["--to-worktree".to_string(), worktree.clone()]);
+    }
+    for gate in &args.gates.verify {
+        argv.extend(["--verify".to_string(), gate.clone()]);
+    }
+    argv.extend(["--base".to_string(), args.base.clone()]);
+    if let Some(head) = &args.head {
+        argv.extend(["--head".to_string(), head.clone()]);
+    }
+    if args.no_finalize {
+        argv.push("--no-finalize".to_string());
+    }
+    if args.draft_pr {
+        argv.push("--draft-pr".to_string());
+    }
+    argv
+}
+
+#[cfg(test)]
+mod preview_tests {
+    use super::*;
+    use crate::cli_surface::{Cli, Commands};
+    use clap::Parser;
+
+    fn cook(argv: &[&str]) -> AgentTaskCookArgs {
+        let cli = Cli::try_parse_from(argv).expect("parse Cook preview");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("Cook command");
+        };
+        *cook
+    }
+
+    #[test]
+    fn preview_reports_destination_blockers_without_creating_homeboy_state() {
+        crate::test_support::with_isolated_home(|home| {
+            let before = std::fs::read_dir(home).expect("read isolated home").count();
+            let error = preview_cook(cook(&[
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--preview",
+                "--prompt",
+                "implement the issue",
+                "--no-finalize",
+            ]))
+            .expect_err("missing destination must block preview");
+
+            assert_eq!(
+                error.code,
+                homeboy::core::ErrorCode::ValidationMissingArgument
+            );
+            assert_eq!(
+                error.details["args"],
+                serde_json::json!(["--repo <repo> is required when --to-worktree is omitted"])
+            );
+            assert_eq!(
+                std::fs::read_dir(home).expect("read isolated home").count(),
+                before,
+                "preview must not create Homeboy state"
+            );
+        });
+    }
+
+    #[test]
+    fn preview_replay_argv_is_executable_cook_argv_without_preview() {
+        let args = cook(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--preview",
+            "--prompt",
+            "implement the issue",
+            "--repo",
+            "homeboy",
+            "--task-url",
+            "https://github.com/Extra-Chill/homeboy/issues/12478",
+            "--verify",
+            "cargo test -p homeboy-cli",
+        ]);
+        let resolved = resolve_cook_destination(args).expect("resolve issue destination");
+        let replay = cook_preview_replay_argv(&resolved);
+        assert!(!replay.iter().any(|part| part == "--preview"), "{replay:?}");
+        Cli::try_parse_from(&replay).expect("replay argv parses as Cook");
+    }
+}
+
 /// Resume a Cook from its immutable recipe rather than asking the operator to
 /// replay prompt, provider, gate, workspace, or disclosure arguments.
 pub(crate) fn continue_cook(args: CookContinueArgs) -> CmdResult<Value> {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -330,9 +330,8 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
 }
 
 fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
-    let units = clap_replay_units(argv.into_iter().collect());
+    let (units, mut requires) = clap_replay_units(argv.into_iter().collect());
     let mut replay = Vec::new();
-    let mut requires = Vec::new();
     let mut bytes = 0;
     for unit in units {
         let unit_bytes = unit.iter().map(String::len).sum::<usize>();
@@ -355,34 +354,10 @@ fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> Preview
     }
 }
 
-fn clap_replay_units(argv: Vec<String>) -> Vec<Vec<String>> {
-    const VALUE_FLAGS: &[&str] = &[
-        "--prompt",
-        "--goal",
-        "--repo",
-        "--task-url",
-        "--to-worktree",
-        "--cwd",
-        "--workspace",
-        "--verify",
-        "--verify-file",
-        "--private-verify",
-        "--private-verify-file",
-        "--gate-env",
-        "--provider-config",
-        "--client-context",
-        "--lab-env-json",
-        "--provider-argv",
-        "--provider-command",
-        "--runner-env",
-        "--secret-env",
-        "--backend",
-        "--selector",
-        "--model",
-        "--base",
-        "--head",
-    ];
+fn clap_replay_units(argv: Vec<String>) -> (Vec<Vec<String>>, Vec<String>) {
+    let value_flags = cook_value_flags();
     let mut units = Vec::new();
+    let mut requires = Vec::new();
     let mut index = 0;
     while index < argv.len() {
         let value = &argv[index];
@@ -391,15 +366,41 @@ fn clap_replay_units(argv: Vec<String>) -> Vec<Vec<String>> {
         } else if let Some((_flag, _)) = value.split_once('=') {
             units.push(vec![value.clone()]);
             index += 1;
-        } else if VALUE_FLAGS.contains(&value.as_str()) && index + 1 < argv.len() {
-            units.push(vec![value.clone(), argv[index + 1].clone()]);
-            index += 2;
+        } else if value_flags.contains(value) {
+            if let Some(next) = argv.get(index + 1).filter(|next| !next.starts_with("--")) {
+                units.push(vec![value.clone(), next.clone()]);
+                index += 2;
+            } else {
+                requires.push(format!("{value} was omitted because its value is absent; provide the original value before replaying"));
+                index += 1;
+            }
         } else {
             units.push(vec![value.clone()]);
             index += 1;
         }
     }
-    units
+    (units, requires)
+}
+
+fn cook_value_flags() -> std::collections::BTreeSet<String> {
+    let command = crate::cli_surface::Cli::command_with_scoped_lab_args();
+    let cook = command
+        .find_subcommand("agent-task")
+        .and_then(|agent_task| agent_task.find_subcommand("cook"))
+        .expect("Cook command exists in generated Clap metadata");
+    let mut flags = std::collections::BTreeSet::new();
+    for arg in cook
+        .get_arguments()
+        .filter(|arg| arg.get_action().takes_values())
+    {
+        if let Some(flag) = arg.get_long() {
+            flags.insert(format!("--{flag}"));
+        }
+        if let Some(aliases) = arg.get_all_aliases() {
+            flags.extend(aliases.into_iter().map(|alias| format!("--{alias}")));
+        }
+    }
+    flags
 }
 
 fn redact_replay_unit(unit: Vec<String>) -> (Vec<String>, Option<String>) {
@@ -410,10 +411,6 @@ fn redact_replay_unit(unit: Vec<String>) -> (Vec<String>, Option<String>) {
         .split('=')
         .next()
         .unwrap_or_default();
-    let value = unit
-        .get(1)
-        .map(String::as_str)
-        .or_else(|| unit[0].split_once('=').map(|(_, value)| value));
     let sensitive = flag == "--private-verify"
         || flag == "--private-verify-file"
         || flag == "--gate-env"
@@ -421,9 +418,12 @@ fn redact_replay_unit(unit: Vec<String>) -> (Vec<String>, Option<String>) {
         || flag == "--lab-env-json"
         || matches!(
             flag,
-            "--provider-config" | "--client-context" | "--provider-command"
-        ) && value.is_some_and(sensitive_payload)
-        || flag == "--provider-argv" && value.is_some_and(sensitive_payload);
+            "--provider-config"
+                | "--provider-command"
+                | "--provider-argv"
+                | "--client-context"
+                | "--secret-env"
+        );
     if !sensitive {
         return (unit, None);
     }
@@ -438,21 +438,6 @@ fn redact_replay_unit(unit: Vec<String>) -> (Vec<String>, Option<String>) {
         vec![format!("{flag}={placeholder}")]
     };
     (replay, Some(format!("{flag} was redacted; replace its parseable placeholder with the original value before replaying")))
-}
-
-fn sensitive_payload(value: &str) -> bool {
-    let value = value.to_ascii_lowercase();
-    [
-        "token",
-        "secret",
-        "password",
-        "api_key",
-        "apikey",
-        "bearer",
-        "authorization",
-    ]
-    .iter()
-    .any(|needle| value.contains(needle))
 }
 
 fn preview_placement_policy() -> Value {
@@ -596,7 +581,7 @@ mod preview_tests {
     }
 
     #[test]
-    fn preview_replay_redacts_sensitive_values_and_preserves_ordinary_provider_argv() {
+    fn preview_replay_redacts_opaque_provider_values_and_arbitrary_credential_names() {
         let replay = redact_preview_replay_argv(std::iter::once("homeboy".to_string()).chain([
             "agent-task".to_string(),
             "cook".to_string(),
@@ -607,7 +592,7 @@ mod preview_tests {
             "--private-verify".to_string(),
             "printf secret-value".to_string(),
             "--provider-argv".to_string(),
-            "ordinary-provider-argument".to_string(),
+            "credential-without-a-secret-name".to_string(),
             "--runner-env=TOKEN=secret-value".to_string(),
         ]));
         assert!(
@@ -618,9 +603,9 @@ mod preview_tests {
         assert_eq!(replay.argv[6], "<redacted:--provider-config>");
         assert_eq!(replay.argv[7], "--private-verify");
         assert_eq!(replay.argv[8], "<redacted:--private-verify>");
-        assert_eq!(replay.argv[10], "ordinary-provider-argument");
+        assert_eq!(replay.argv[10], "<redacted:--provider-argv>");
         assert_eq!(replay.argv[11], "--runner-env=<redacted:--runner-env>");
-        assert_eq!(replay.requires.len(), 4);
+        assert_eq!(replay.requires.len(), 5);
         Cli::try_parse_from(&replay.argv).expect("redacted replay remains parseable");
     }
 
@@ -642,6 +627,42 @@ mod preview_tests {
         for boundary in (3..=replay.argv.len()).step_by(2) {
             Cli::try_parse_from(&replay.argv[..boundary])
                 .unwrap_or_else(|error| panic!("boundary {boundary} is not parseable: {error}"));
+        }
+    }
+
+    #[test]
+    fn every_generated_cook_value_option_is_atomic_and_never_dangles() {
+        for flag in cook_value_flags() {
+            let (_, missing_requires) = clap_replay_units(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                flag.clone(),
+            ]);
+            assert!(
+                missing_requires
+                    .iter()
+                    .any(|requirement| requirement.starts_with(&flag)),
+                "missing value-taking flag {flag} was not withheld atomically"
+            );
+
+            let (units, requires) = clap_replay_units(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                flag.clone(),
+                "placeholder".to_string(),
+            ]);
+            assert!(
+                requires.is_empty(),
+                "complete {flag} unexpectedly needs input"
+            );
+            assert!(
+                units
+                    .iter()
+                    .any(|unit| unit == &[flag.clone(), "placeholder".to_string()]),
+                "value-taking flag {flag} was not retained as one unit"
+            );
         }
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -384,20 +384,24 @@ fn clap_replay_units(argv: Vec<String>) -> (Vec<Vec<String>>, Vec<String>) {
 
 fn cook_value_flags() -> std::collections::BTreeSet<String> {
     let command = crate::cli_surface::Cli::command_with_scoped_lab_args();
-    let cook = command
-        .find_subcommand("agent-task")
-        .and_then(|agent_task| agent_task.find_subcommand("cook"))
-        .expect("Cook command exists in generated Clap metadata");
     let mut flags = std::collections::BTreeSet::new();
-    for arg in cook
-        .get_arguments()
-        .filter(|arg| arg.get_action().takes_values())
-    {
-        if let Some(flag) = arg.get_long() {
-            flags.insert(format!("--{flag}"));
-        }
-        if let Some(aliases) = arg.get_all_aliases() {
-            flags.extend(aliases.into_iter().map(|alias| format!("--{alias}")));
+    let agent_task = command
+        .find_subcommand("agent-task")
+        .expect("agent-task command exists in generated Clap metadata");
+    let cook = agent_task
+        .find_subcommand("cook")
+        .expect("Cook command exists in generated Clap metadata");
+    for command in [&command, agent_task, cook] {
+        for arg in command
+            .get_arguments()
+            .filter(|arg| arg.get_action().takes_values())
+        {
+            if let Some(flag) = arg.get_long() {
+                flags.insert(format!("--{flag}"));
+            }
+            if let Some(aliases) = arg.get_all_aliases() {
+                flags.extend(aliases.into_iter().map(|alias| format!("--{alias}")));
+            }
         }
     }
     flags
@@ -663,6 +667,118 @@ mod preview_tests {
                     .any(|unit| unit == &[flag.clone(), "placeholder".to_string()]),
                 "value-taking flag {flag} was not retained as one unit"
             );
+        }
+    }
+
+    #[test]
+    fn root_value_options_and_aliases_are_atomic_in_separated_and_equals_forms() {
+        let root_values = [
+            ("--output", "preview.json"),
+            ("--notification-transport", "webhook"),
+            ("--notification-route", "https://example.test/hook"),
+            ("--placement", "auto"),
+            ("--artifact-root", "artifacts"),
+            ("--runner", "runner-1"),
+            ("--runner-env", "TOKEN=value"),
+            ("--runner-secret-env", "TOKEN"),
+            ("--lab-env-json", "{}"),
+            ("--runner-workspace-root", "workspace"),
+        ];
+        let value_flags = cook_value_flags();
+        for (flag, value) in root_values {
+            assert!(value_flags.contains(flag), "missing root value flag {flag}");
+            let (separated, requires) = clap_replay_units(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                flag.to_string(),
+                value.to_string(),
+            ]);
+            assert!(requires.is_empty(), "{flag} separated form needs input");
+            assert!(
+                separated
+                    .iter()
+                    .any(|unit| unit == &[flag.to_string(), value.to_string()]),
+                "{flag} separated form was not atomic"
+            );
+
+            let (equals, requires) = clap_replay_units(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                format!("{flag}={value}"),
+            ]);
+            assert!(requires.is_empty(), "{flag} equals form needs input");
+            assert!(
+                equals
+                    .iter()
+                    .any(|unit| unit == &[format!("{flag}={value}")]),
+                "{flag} equals form was not atomic"
+            );
+        }
+    }
+
+    #[test]
+    fn root_value_units_are_never_split_at_any_replay_budget_boundary() {
+        for flag in [
+            "--output",
+            "--notification-route",
+            "--runner-env",
+            "--lab-env-json",
+        ] {
+            let argv = std::iter::once("homeboy".to_string())
+                .chain(["agent-task".to_string(), "cook".to_string()])
+                .chain(
+                    (0..MAX_PREVIEW_REPLAY_ARGS)
+                        .flat_map(|index| [flag.to_string(), format!("value-{index}")]),
+                )
+                .collect::<Vec<_>>();
+            let replay = redact_preview_replay_argv(argv);
+            assert_eq!(replay.argv.len() % 2, 1, "{flag} was split at the budget");
+            assert!(replay
+                .requires
+                .iter()
+                .any(|item| item.contains("safety budget")));
+        }
+    }
+
+    #[test]
+    fn valid_root_value_forms_parse_before_and_after_cook() {
+        for (flag, value) in [
+            ("--output", "preview.json"),
+            ("--placement", "local"),
+            ("--artifact-root", "artifacts"),
+            ("--runner-env", "TOKEN=value"),
+            ("--runner-secret-env", "TOKEN"),
+            ("--lab-env-json", "{}"),
+            ("--runner-workspace-root", "workspace"),
+        ] {
+            Cli::try_parse_from(["homeboy", flag, value, "agent-task", "cook"])
+                .unwrap_or_else(|error| panic!("separated {flag} must parse: {error}"));
+            let equals = format!("{flag}={value}");
+            Cli::try_parse_from(["homeboy", "agent-task", "cook", &equals])
+                .unwrap_or_else(|error| panic!("equals {flag} must parse: {error}"));
+        }
+        for args in [
+            vec![
+                "homeboy",
+                "--notification-transport",
+                "webhook",
+                "--notification-route",
+                "https://example.test/hook",
+                "agent-task",
+                "cook",
+            ],
+            vec![
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--notification-transport=webhook",
+                "--notification-route=https://example.test/hook",
+            ],
+        ] {
+            Cli::try_parse_from(args)
+                .unwrap_or_else(|error| panic!("notification pair must parse: {error}"));
         }
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -171,14 +171,6 @@ pub(crate) fn preview_cook(
     // it applies before an execution route can inspect the destination.
     validate_cook_request_with_provenance(&args, provenance)?;
     let (args, provision) = resolve_cook_preview_destination(args)?;
-    if !args.provider_evidence_inputs.is_empty() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "provider-evidence",
-            "preview cannot project --provider-evidence without a Cook workspace; run the replay command to materialize the evidence",
-            None,
-            None,
-        ));
-    }
     let gate_workspace = args.dispatch.cwd.as_deref().map(Path::new).or_else(|| {
         args.to_worktree
             .as_deref()
@@ -196,7 +188,43 @@ pub(crate) fn preview_cook(
     )?;
     preflight_cook_provider_credentials(&args)?;
 
-    let mut plan = compile_cook_plan(&args, provision)?;
+    // Preview binds evidence to the same resolved workspace, but only projects
+    // its read-only paths. Cook alone performs the later secure copy.
+    let mut compile_args = args.clone();
+    compile_args.provider_evidence_inputs.clear();
+    let workspace = provision["path"]
+        .as_str()
+        .expect("preview local workspace")
+        .to_string();
+    let evidence = if !args.provider_evidence_inputs.is_empty() {
+        let mut dispatch = dispatch_args_for_cook(&args);
+        resolve_dispatch_prompt(&mut dispatch)?;
+        validate_provider_evidence_inputs(
+            &args.provider_evidence_inputs,
+            dispatch.prompt.as_deref(),
+        )?;
+        compile_args.dispatch.prompt = dispatch.prompt;
+        let evidence =
+            projected_provider_evidence(&args.provider_evidence_inputs, Some(&workspace))?;
+        rewrite_provider_evidence_prompt(
+            &mut compile_args.dispatch.prompt,
+            &args.provider_evidence_inputs,
+            Some(&workspace),
+        );
+        Some(evidence)
+    } else {
+        None
+    };
+    let mut plan = compile_cook_plan(&compile_args, provision)?;
+    if let Some(evidence) = evidence {
+        for task in &mut plan.tasks {
+            if !task.executor.config.is_object() {
+                task.executor.config = serde_json::json!({});
+            }
+            task.executor.config["evidence_inputs"] = serde_json::to_value(&evidence)
+                .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+        }
+    }
     resolve_cook_execution_budget(&args, &mut plan)?;
     plan.metadata["gate_contract_validation"] = serde_json::to_value(gate_contract_validation)
         .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
@@ -216,7 +244,7 @@ pub(crate) fn preview_cook(
                 "worktree": args.to_worktree,
                 "base": args.base,
                 "head": args.head,
-                "placement": "none (preview)",
+                "placement": preview_placement_policy(),
                 "provider": executor,
                 "gates": {
                     "public": args.gates.verify.len(),
@@ -230,7 +258,7 @@ pub(crate) fn preview_cook(
                 },
             },
             "replay_argv": replay.argv,
-            "replay_omissions": replay.omissions,
+            "replay_requires": replay.requires,
         }),
         0,
     ))
@@ -242,7 +270,7 @@ const MAX_PREVIEW_REPLAY_BYTES: usize = 16 * 1024;
 #[derive(Debug)]
 struct PreviewReplayArgv {
     argv: Vec<String>,
-    omissions: Vec<String>,
+    requires: Vec<String>,
 }
 
 fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
@@ -302,7 +330,44 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
 }
 
 fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
+    let units = clap_replay_units(argv.into_iter().collect());
+    let mut replay = Vec::new();
+    let mut requires = Vec::new();
+    let mut bytes = 0;
+    for unit in units {
+        let unit_bytes = unit.iter().map(String::len).sum::<usize>();
+        if replay.len() + unit.len() > MAX_PREVIEW_REPLAY_ARGS
+            || bytes + unit_bytes > MAX_PREVIEW_REPLAY_BYTES
+        {
+            requires.push("replay was truncated at the safety budget; re-add omitted complete flag/value units from the original command".to_string());
+            break;
+        }
+        let (unit, requirement) = redact_replay_unit(unit);
+        replay.extend(unit);
+        bytes += unit_bytes;
+        if let Some(requirement) = requirement {
+            requires.push(requirement);
+        }
+    }
+    PreviewReplayArgv {
+        argv: replay,
+        requires,
+    }
+}
+
+fn clap_replay_units(argv: Vec<String>) -> Vec<Vec<String>> {
     const VALUE_FLAGS: &[&str] = &[
+        "--prompt",
+        "--goal",
+        "--repo",
+        "--task-url",
+        "--to-worktree",
+        "--cwd",
+        "--workspace",
+        "--verify",
+        "--verify-file",
+        "--private-verify",
+        "--private-verify-file",
         "--gate-env",
         "--provider-config",
         "--client-context",
@@ -310,42 +375,117 @@ fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> Preview
         "--provider-argv",
         "--provider-command",
         "--runner-env",
+        "--secret-env",
+        "--backend",
+        "--selector",
+        "--model",
+        "--base",
+        "--head",
     ];
-    let mut replay = Vec::new();
-    let mut omissions = Vec::new();
-    let mut redact_next = None;
-    let mut bytes = 0;
-    for value in argv {
-        if replay.len() == MAX_PREVIEW_REPLAY_ARGS || bytes + value.len() > MAX_PREVIEW_REPLAY_BYTES
-        {
-            omissions.push("replay argv was truncated at the preview safety budget; re-add omitted non-secret arguments from the original command".to_string());
-            break;
-        }
-        if let Some(flag) = redact_next.take() {
-            replay.push(format!("<redacted:{flag}>"));
-            omissions.push(format!("{flag} was redacted; replace its placeholder with the original value before replaying"));
-        } else if let Some((flag, _)) = value.split_once('=') {
-            if VALUE_FLAGS.contains(&flag) {
-                replay.push(format!("{flag}=<redacted:{flag}>"));
-                omissions.push(format!("{flag} was redacted; replace its placeholder with the original value before replaying"));
-            } else {
-                redact_next = VALUE_FLAGS
-                    .contains(&value.as_str())
-                    .then_some(value.clone());
-                replay.push(value);
-            }
+    let mut units = Vec::new();
+    let mut index = 0;
+    while index < argv.len() {
+        let value = &argv[index];
+        if value == "--preview" {
+            index += 1;
+        } else if let Some((_flag, _)) = value.split_once('=') {
+            units.push(vec![value.clone()]);
+            index += 1;
+        } else if VALUE_FLAGS.contains(&value.as_str()) && index + 1 < argv.len() {
+            units.push(vec![value.clone(), argv[index + 1].clone()]);
+            index += 2;
         } else {
-            redact_next = VALUE_FLAGS
-                .contains(&value.as_str())
-                .then_some(value.clone());
-            replay.push(value);
+            units.push(vec![value.clone()]);
+            index += 1;
         }
-        bytes += replay.last().map_or(0, String::len);
     }
-    PreviewReplayArgv {
-        argv: replay,
-        omissions,
+    units
+}
+
+fn redact_replay_unit(unit: Vec<String>) -> (Vec<String>, Option<String>) {
+    let flag = unit
+        .first()
+        .map(String::as_str)
+        .unwrap_or_default()
+        .split('=')
+        .next()
+        .unwrap_or_default();
+    let value = unit
+        .get(1)
+        .map(String::as_str)
+        .or_else(|| unit[0].split_once('=').map(|(_, value)| value));
+    let sensitive = flag == "--private-verify"
+        || flag == "--private-verify-file"
+        || flag == "--gate-env"
+        || flag == "--runner-env"
+        || flag == "--lab-env-json"
+        || matches!(
+            flag,
+            "--provider-config" | "--client-context" | "--provider-command"
+        ) && value.is_some_and(sensitive_payload)
+        || flag == "--provider-argv" && value.is_some_and(sensitive_payload);
+    if !sensitive {
+        return (unit, None);
     }
+    let placeholder = if flag == "--gate-env" {
+        "REDACTED=<redacted:--gate-env>".to_string()
+    } else {
+        format!("<redacted:{flag}>")
+    };
+    let replay = if unit.len() == 2 {
+        vec![flag.to_string(), placeholder]
+    } else {
+        vec![format!("{flag}={placeholder}")]
+    };
+    (replay, Some(format!("{flag} was redacted; replace its parseable placeholder with the original value before replaying")))
+}
+
+fn sensitive_payload(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    [
+        "token",
+        "secret",
+        "password",
+        "api_key",
+        "apikey",
+        "bearer",
+        "authorization",
+    ]
+    .iter()
+    .any(|needle| value.contains(needle))
+}
+
+fn preview_placement_policy() -> Value {
+    let argv = std::env::args().collect::<Vec<_>>();
+    preview_placement_policy_from_argv(&argv)
+}
+
+fn preview_placement_policy_from_argv(argv: &[String]) -> Value {
+    let placement = argv
+        .iter()
+        .enumerate()
+        .find_map(|(index, value)| {
+            value
+                .strip_prefix("--placement=")
+                .map(str::to_string)
+                .or_else(|| {
+                    (value == "--placement")
+                        .then(|| argv.get(index + 1).cloned())
+                        .flatten()
+                })
+        })
+        .unwrap_or_else(|| "auto".to_string());
+    let runner = argv.iter().enumerate().find_map(|(index, value)| {
+        value
+            .strip_prefix("--runner=")
+            .map(str::to_string)
+            .or_else(|| {
+                (value == "--runner")
+                    .then(|| argv.get(index + 1).cloned())
+                    .flatten()
+            })
+    });
+    serde_json::json!({ "requested": placement, "runner": runner, "route_executed": false })
 }
 
 #[cfg(test)]
@@ -456,7 +596,7 @@ mod preview_tests {
     }
 
     #[test]
-    fn preview_replay_redacts_sensitive_values_and_has_a_fixed_budget() {
+    fn preview_replay_redacts_sensitive_values_and_preserves_ordinary_provider_argv() {
         let replay = redact_preview_replay_argv(std::iter::once("homeboy".to_string()).chain([
             "agent-task".to_string(),
             "cook".to_string(),
@@ -464,23 +604,84 @@ mod preview_tests {
             "TOKEN=secret-value".to_string(),
             "--provider-config".to_string(),
             r#"{"token":"secret-value"}"#.to_string(),
+            "--private-verify".to_string(),
+            "printf secret-value".to_string(),
+            "--provider-argv".to_string(),
+            "ordinary-provider-argument".to_string(),
             "--runner-env=TOKEN=secret-value".to_string(),
         ]));
         assert!(
             !replay.argv.join(" ").contains("secret-value"),
             "{replay:?}"
         );
-        assert_eq!(replay.argv[4], "<redacted:--gate-env>");
+        assert_eq!(replay.argv[4], "REDACTED=<redacted:--gate-env>");
         assert_eq!(replay.argv[6], "<redacted:--provider-config>");
-        assert_eq!(replay.argv[7], "--runner-env=<redacted:--runner-env>");
-        assert_eq!(replay.omissions.len(), 3);
+        assert_eq!(replay.argv[7], "--private-verify");
+        assert_eq!(replay.argv[8], "<redacted:--private-verify>");
+        assert_eq!(replay.argv[10], "ordinary-provider-argument");
+        assert_eq!(replay.argv[11], "--runner-env=<redacted:--runner-env>");
+        assert_eq!(replay.requires.len(), 4);
+        Cli::try_parse_from(&replay.argv).expect("redacted replay remains parseable");
+    }
+
+    #[test]
+    fn preview_replay_truncates_only_at_parseable_clap_unit_boundaries() {
+        let argv = std::iter::once("homeboy".to_string())
+            .chain(["agent-task".to_string(), "cook".to_string()])
+            .chain(
+                (0..MAX_PREVIEW_REPLAY_ARGS)
+                    .flat_map(|index| ["--verify".to_string(), format!("true-{index}")]),
+            )
+            .collect::<Vec<_>>();
+        let replay = redact_preview_replay_argv(argv);
+        assert!(replay.argv.len() < MAX_PREVIEW_REPLAY_ARGS);
+        assert!(replay
+            .requires
+            .iter()
+            .any(|item| item.contains("safety budget")));
+        for boundary in (3..=replay.argv.len()).step_by(2) {
+            Cli::try_parse_from(&replay.argv[..boundary])
+                .unwrap_or_else(|error| panic!("boundary {boundary} is not parseable: {error}"));
+        }
+    }
+
+    #[test]
+    fn preview_reports_requested_placement_without_executing_a_route() {
+        let policy = preview_placement_policy_from_argv(&[
+            "homeboy".to_string(),
+            "--placement=lab-or-local".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ]);
+        assert_eq!(policy["requested"], "lab-or-local");
+        assert_eq!(policy["route_executed"], false);
+    }
+
+    #[test]
+    fn read_only_evidence_projection_uses_the_resolved_workspace_path() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let source = tempfile::NamedTempFile::new().expect("evidence");
+        std::fs::write(source.path(), "evidence").expect("write evidence");
+        let evidence = vec![AgentTaskProviderEvidenceInput {
+            id: "issue".to_string(),
+            source: source.path().display().to_string(),
+        }];
+        validate_provider_evidence_inputs(&evidence, Some("Read the evidence."))
+            .expect("validate evidence");
+        let projected = projected_provider_evidence(&evidence, workspace.path().to_str())
+            .expect("project read-only evidence path");
+        assert!(projected[0]["path"]
+            .as_str()
+            .expect("projection path")
+            .starts_with(workspace.path().to_str().expect("workspace path")));
+        assert!(projected[0]["read_only"].as_bool().expect("read-only flag"));
 
         let bounded = redact_preview_replay_argv(
             (0..MAX_PREVIEW_REPLAY_ARGS + 1).map(|index| format!("arg-{index}")),
         );
         assert_eq!(bounded.argv.len(), MAX_PREVIEW_REPLAY_ARGS);
         assert!(bounded
-            .omissions
+            .requires
             .iter()
             .any(|item| item.contains("safety budget")));
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -574,6 +574,8 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
         homeboy::core::defaults::save_config(&config).expect("save worktree provider config");
         let (value, exit_code) = run_cook_with_executor(
             AgentTaskCookArgs {
+                help: None,
+                help_full: None,
                 provider_evidence_inputs: Vec::new(),
                 dispatch: DispatchArgs {
                     prompt: None,
@@ -613,6 +615,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 candidate_completion: homeboy::agents::agent_task_scheduler::AgentTaskCandidateCompletionPolicy::WaitAll,
                 attempt_run_id: Some("cook-missing-provider-attempt-1-controller".to_string()),
                 attempt_plan: None,
+                preview: false,
                 goal: Some("cook fixture".to_string()),
                 to_worktree: Some(target.display().to_string()),
                 provider_command: None,
@@ -980,6 +983,8 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
         let prepared = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (value, exit_code) = run_cook_with_executor_and_dispatcher(
             AgentTaskCookArgs {
+                help: None,
+                help_full: None,
                 provider_evidence_inputs: Vec::new(),
                 dispatch: DispatchArgs {
                     prompt: Some("commit a change".to_string()),
@@ -1015,6 +1020,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 candidate_completion: homeboy::agents::agent_task_scheduler::AgentTaskCandidateCompletionPolicy::WaitAll,
                 attempt_run_id: None,
                 attempt_plan: None,
+                preview: false,
                 goal: None,
                 to_worktree: Some(target.display().to_string()),
                 provider_command: None,


### PR DESCRIPTION
## Summary

- make default Cook help task-first while retaining full advanced help
- add a read-only preview using Cook validation and resolution primitives
- refuse provider-backed mutation paths during preview
- emit bounded, parseable replay guidance with conservative secret redaction

Fixes #12478.

## Verification

- `cargo test -p homeboy-cli commands::agent_task::run::preview_tests --lib` (14 passed)
- `cargo test -p homeboy-cli cook_help --lib`
- `cargo test -p homeboy-cli command_contract::lab --lib`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode implemented the preview/help surface and adversarial no-mutation/redaction tests, then ran iterative independent security reviews. Chris Huber reviewed every finding, verified the final branch, and owns the change.