### PR TITLE
fix(runner): scope Lab doctor provider readiness

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/checks.rs
@@ -241,6 +241,51 @@ pub fn overall_status(checks: &[RunnerCheck]) -> RunnerDoctorStatus {
     }
 }
 
+pub fn lab_offload_status(
+    checks: &[RunnerCheck],
+    eligible_provider_ids: &[String],
+) -> (RunnerDoctorStatus, types::RunnerDoctorProviderReadiness) {
+    let mut ready_for = eligible_provider_ids.to_vec();
+    let mut blocked_for = Vec::new();
+    let mut has_runner_error = false;
+    let mut has_warning = false;
+
+    for check in checks {
+        if check.status == RunnerDoctorStatus::Warning {
+            has_warning = true;
+        }
+        if check.status != RunnerDoctorStatus::Error {
+            continue;
+        }
+        let Some(provider_id) = check.details.get("provider_id") else {
+            has_runner_error = true;
+            continue;
+        };
+        if eligible_provider_ids.iter().any(|id| id == provider_id) {
+            ready_for.retain(|id| id != provider_id);
+            if !blocked_for.contains(provider_id) {
+                blocked_for.push(provider_id.clone());
+            }
+        }
+    }
+
+    let status = if has_runner_error || (!eligible_provider_ids.is_empty() && ready_for.is_empty())
+    {
+        RunnerDoctorStatus::Error
+    } else if has_warning {
+        RunnerDoctorStatus::Warning
+    } else {
+        RunnerDoctorStatus::Ok
+    };
+    (
+        status,
+        types::RunnerDoctorProviderReadiness {
+            ready_for,
+            blocked_for,
+        },
+    )
+}
+
 pub(super) fn ok_with_details(
     id: impl Into<String>,
     message: String,

--- a/crates/homeboy-cli/src/commands/runner/doctor/local.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/local.rs
@@ -204,6 +204,7 @@ pub fn report(
         diagnostics: None,
         daemon_recovery: None,
         admission_summary: None,
+        provider_readiness: None,
         repairs: Vec::new(),
     }
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -78,7 +78,20 @@ pub fn run_with_options(
     // process-local capability answer, so the next execution preflight probes
     // the exact command environment rather than replaying stale remediation.
     runner::observe_runner_capabilities(runner_id);
-    report.status = checks::overall_status(&report.checks);
+    if options.scope == RunnerDoctorScope::LabOffload {
+        let catalog = homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog::discover();
+        let eligible_provider_ids = probes::eligible_provider_ids(
+            catalog.providers(),
+            options.agent_backend.as_deref(),
+            options.agent_selector.as_deref(),
+        );
+        let (status, provider_readiness) =
+            checks::lab_offload_status(&report.checks, &eligible_provider_ids);
+        report.status = status;
+        report.provider_readiness = Some(provider_readiness);
+    } else {
+        report.status = checks::overall_status(&report.checks);
+    }
     let exit_code = report.status.operational_exit_code();
     Ok((report, exit_code))
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -393,8 +393,31 @@ pub fn provider_readiness_checks(
 ) -> Vec<RunnerCheck> {
     contracts
         .iter()
-        .filter_map(|contract| provider_readiness_check(client, contract))
+        .filter_map(|contract| {
+            provider_readiness_check(client, contract).map(|mut check| {
+                check
+                    .details
+                    .entry("provider_id".to_string())
+                    .or_insert_with(|| contract.provider_id.clone());
+                check
+            })
+        })
         .collect()
+}
+
+pub fn eligible_provider_ids(
+    providers: &[AgentTaskExecutorProvider],
+    selected_backend: Option<&str>,
+    selected_provider_id: Option<&str>,
+) -> Vec<String> {
+    selected_provider_executor_resolution_providers(
+        providers,
+        selected_backend,
+        selected_provider_id,
+    )
+    .into_iter()
+    .map(|provider| provider.id.clone())
+    .collect()
 }
 
 pub fn local_provider_executor_resolution_checks(

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -384,6 +384,7 @@ pub fn report(
         diagnostics,
         daemon_recovery: persisted_status.and_then(|status| status.daemon_freshness.clone()),
         admission_summary: admission_snapshot.map(|snapshot| snapshot.summary),
+        provider_readiness: None,
         repairs: Vec::new(),
     }
 }
@@ -412,7 +413,7 @@ pub(super) fn unreachable_report(
         runner: runner_summary("ssh", Some(runner), Some(server)), status: RunnerDoctorStatus::Error,
         capabilities: RunnerCapabilities::default(), resources: RunnerResources::default(),
         checks: vec![checks::error("ssh.execution", format!("SSH runner {} is not reachable", runner_id), Some("Run `homeboy server status <server-id>` and verify host, user, port, identity_file, and network access".to_string()), common::detail_map(&[("stderr", output.stderr.trim()), ("stdout", output.stdout.trim())]))],
-        secret_env_migration: None, diagnostics: Some(types::RunnerDoctorDiagnostics { status: "partial", completed_checks: 1, timed_out_probes: Vec::new() }), daemon_recovery: None, admission_summary: None, repairs: Vec::new(),
+        secret_env_migration: None, diagnostics: Some(types::RunnerDoctorDiagnostics { status: "partial", completed_checks: 1, timed_out_probes: Vec::new() }), daemon_recovery: None, admission_summary: None, provider_readiness: None, repairs: Vec::new(),
     }
 }
 
@@ -477,6 +478,7 @@ pub(super) fn disconnected_report(
         diagnostics: None,
         daemon_recovery,
         admission_summary,
+        provider_readiness: None,
         repairs: Vec::new(),
     }
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -66,6 +66,49 @@ fn overall_status_promotes_errors_over_warnings() {
 }
 
 #[test]
+fn lab_offload_readiness_keeps_a_healthy_eligible_provider_ready() {
+    let checks = vec![
+        provider_check("selected.provider", RunnerDoctorStatus::Ok),
+        provider_check("optional.provider", RunnerDoctorStatus::Error),
+    ];
+    let eligible = vec![
+        "selected.provider".to_string(),
+        "optional.provider".to_string(),
+    ];
+
+    let (status, readiness) = checks::lab_offload_status(&checks, &eligible);
+
+    assert_eq!(status, RunnerDoctorStatus::Ok);
+    assert_eq!(readiness.ready_for, vec!["selected.provider"]);
+    assert_eq!(readiness.blocked_for, vec!["optional.provider"]);
+}
+
+#[test]
+fn lab_offload_readiness_blocks_a_failed_selected_provider() {
+    let checks = vec![
+        provider_check("selected.provider", RunnerDoctorStatus::Error),
+        provider_check("optional.provider", RunnerDoctorStatus::Ok),
+    ];
+    let eligible = vec!["selected.provider".to_string()];
+
+    let (status, readiness) = checks::lab_offload_status(&checks, &eligible);
+
+    assert_eq!(status, RunnerDoctorStatus::Error);
+    assert!(readiness.ready_for.is_empty());
+    assert_eq!(readiness.blocked_for, vec!["selected.provider"]);
+}
+
+fn provider_check(provider_id: &str, status: RunnerDoctorStatus) -> types::RunnerCheck {
+    types::RunnerCheck {
+        id: format!("provider.{provider_id}"),
+        status,
+        message: "provider readiness".to_string(),
+        remediation: None,
+        details: BTreeMap::from([("provider_id".to_string(), provider_id.to_string())]),
+    }
+}
+
+#[test]
 fn operational_exit_code_matches_the_doctor_readiness_verdict() {
     for (scenario, status, expected_exit_code) in [
         ("healthy", RunnerDoctorStatus::Ok, 0),

--- a/crates/homeboy-cli/src/commands/runner/doctor/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/types.rs
@@ -41,6 +41,9 @@ pub struct RunnerDoctorOutput {
     /// The same retained-job ownership projection used by status and reconcile.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub admission_summary: Option<homeboy::runner::runners::RunnerAdmissionSummary>,
+    /// Provider-specific Lab readiness, separate from runner substrate checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_readiness: Option<RunnerDoctorProviderReadiness>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub repairs: Vec<RunnerRepair>,
 }
@@ -51,6 +54,12 @@ pub struct RunnerDoctorDiagnostics {
     pub completed_checks: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub timed_out_probes: Vec<RunnerDoctorTimedOutProbe>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerDoctorProviderReadiness {
+    pub ready_for: Vec<String>,
+    pub blocked_for: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

- separate provider-specific readiness from core runner substrate failures in Lab doctor output
- expose `ready_for` and `blocked_for` provider sets
- keep selected-provider failures blocking while optional broken providers remain bounded diagnostics

Closes #12507.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::runner::doctor::tests --lib` (62 passed)
- `cargo check -p homeboy-cli`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode compared scoped doctor output with actual provider admission, implemented provider-aware readiness through a general coding subagent, and independently reviewed and verified the resulting diff. Chris Huber reviewed and is responsible for every line.