### PR TITLE
fix(release): coalesce dry-run planning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,38 +45,16 @@ env:
   # re-attaches HEAD to this branch so the action's branch guard can resolve it.
   RELEASE_BRANCH: main
 
-# ── Concurrency: never queue a push release behind another one (#11749) ──
+# ── Workflow concurrency: never cancel an active release ──
 #
-# This used to be `release-${{ inputs.release_tag || github.ref }}`, so every
-# push run on main shared ONE group, on the theory quoted below: "the queued run
-# starts after the first finishes and its check job exits in seconds because
-# HEAD is already tagged — zero wasted work."
-#
-# The queued run never started. GitHub keeps at most ONE pending run per
-# concurrency group and CANCELS the previously pending one when a newer run is
-# queued — `cancel-in-progress: false` only protects runs that are already
-# in progress, not runs that are waiting. At ~65 merges/day the pending slot is
-# displaced long before a ~35-minute release finishes, so runs were displaced,
-# not deferred. Measured on 2026-08-06: 27 of the last 30 Release runs ended
-# `cancelled` with `total_count: 0` jobs — they never dispatched a single job,
-# so not one of their guards, including `verify-published`, could fire.
-#
-# A push run now gets a group of its OWN. Nothing is ever queued behind another
-# release, so nothing can displace it. Serialization was never what made this
-# correct anyway: the `check` job's supersession test (HEAD vs the branch tip)
-# and `homeboy release`'s tag idempotency (`release-already-at-head`) are what
-# stop two runs preparing the same version, and both cost seconds rather than a
-# 35-minute queue slot. Superseded runs now skip the dry run outright, so the
-# merge path is not slowed and the wasted work is genuinely near zero.
+# Each workflow run gets its own group. A workflow-level main lock can cancel a
+# pending run before it starts, losing its successor/waiter lineage (#10645), or
+# cancel an active run if cancellation is enabled. The check and prepare jobs
+# below carry the narrower coalescing and mutation locks instead.
 #
 # A recovery dispatch still serializes per TAG: two runs repairing the same
 # release must never race on its assets.
 #
-# The tradeoff, stated rather than hidden: two pushes landing close enough that
-# both observe themselves as the branch tip can now both reach `prepare` and
-# compute the same next version. That collision resolves at the tag push, where
-# the loser fails loudly. Recovery of an existing tag is explicit through
-# `workflow_dispatch`; push runs always prioritize current main.
 concurrency:
   group: release-${{ inputs.release_tag || github.run_id }}
   cancel-in-progress: false
@@ -87,6 +65,13 @@ jobs:
   check:
     name: Check for releasable commits
     runs-on: ubuntu-latest
+    # Coalesce only the read-only planning phase. A new main push interrupts an
+    # in-flight dry run before gates or mutation begin; the latest push retains
+    # its exact event SHA and becomes the sole planner. Recovery checks remain
+    # serialized by their explicit tag instead of being cancelled.
+    concurrency:
+      group: release-check-${{ inputs.release_tag || github.ref }}
+      cancel-in-progress: ${{ inputs.release_tag == '' }}
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
       bump-type: ${{ steps.check.outputs['release-bump-type'] }}
@@ -550,6 +535,11 @@ jobs:
       - release-quality-policy
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (needs.check.outputs.recovery-release == 'true' || inputs.release_tag != '' || needs.release-quality-policy.result == 'success') }}
     runs-on: ubuntu-latest
+    # Version, tag, and release-state transitions are the only serialized
+    # section. Unlike check, this lock never cancels an active mutation.
+    concurrency:
+      group: release-mutation-${{ inputs.release_tag || github.ref }}
+      cancel-in-progress: false
     outputs:
       release-version: ${{ steps.outputs.outputs['release-version'] }}
       release-tag: ${{ steps.outputs.outputs['release-tag'] }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -327,45 +327,36 @@ fn release_concurrency_scopes_recovery_runs_to_the_requested_tag() {
     ));
 }
 
-/// A push release run must never be QUEUED behind another one (#11749).
-///
-/// `cancel-in-progress: false` protects a run that is already executing. It
-/// does not protect a run that is waiting: GitHub keeps at most one *pending*
-/// run per concurrency group and cancels the previously pending one whenever a
-/// newer run is queued. With every push on main sharing
-/// `release-refs/heads/main`, and merges arriving faster than a ~35-minute
-/// release finishes, the pending slot was displaced continuously — 27 of the
-/// last 30 Release runs on 2026-08-06 ended `cancelled` having dispatched
-/// **zero** jobs, so none of their guards could fire and releases published
-/// with partial platform assets.
-///
-/// The branch-shaped group is therefore the bug, and pinning its absence is the
-/// point of this test. Correctness comes from the `check` job's supersession
-/// test and tag idempotency, not from the concurrency queue.
+/// Three rapid main pushes must collapse their expensive read-only planning to
+/// the latest SHA without allowing a workflow-level cancellation to interrupt
+/// a release that has already entered mutation or publication (#12504, #10645).
 #[test]
-fn release_push_runs_are_never_queued_behind_another_release() {
+fn release_coalesces_only_dry_run_planning_and_serializes_mutation() {
     let workflow = release_workflow();
+    let check = job_section(workflow, "check");
+    let prepare = job_section(workflow, "prepare");
 
     assert!(
         workflow.contains("group: release-${{ inputs.release_tag || github.run_id }}"),
-        "a push release must get a concurrency group of its own so nothing can displace it"
+        "workflow-level concurrency must stay per-run so a coalesced waiter retains its workflow"
     );
     assert!(
-        !workflow.contains("group: release-${{ inputs.release_tag || github.ref }}"),
-        "a branch-shaped concurrency group makes every push run queue behind the last one, \
-         where a newer push cancels it before it dispatches a single job (#11749)"
+        check.contains("group: release-check-${{ inputs.release_tag || github.ref }}")
+            && check.contains("cancel-in-progress: ${{ inputs.release_tag == '' }}"),
+        "rapid main pushes must cancel only the stale check job, leaving the latest exact SHA to plan"
     );
-
-    // Recovery keeps serializing per TAG: two runs repairing the same release
-    // must not race on its assets.
     assert!(
-        workflow.contains("inputs.release_tag ||"),
-        "a recovery dispatch must still be scoped to the tag it repairs"
+        prepare.contains("group: release-mutation-${{ inputs.release_tag || github.ref }}")
+            && prepare.contains("cancel-in-progress: false"),
+        "version/tag mutation must serialize without cancelling an active release"
     );
 
-    // Per-run concurrency is only affordable if a superseded run is cheap, so
-    // the expensive dry run must be skipped once supersession is proven.
-    let check = job_section(workflow, "check");
+    assert!(
+        check.contains("inputs.release_tag || github.ref")
+            && prepare.contains("inputs.release_tag || github.ref"),
+        "recovery runs must use their tag, not the main-push lock"
+    );
+
     let dry_run = release_step_block(check, "name: Dry-run release check");
     assert!(
         dry_run.contains("steps.attach.outputs.superseded != 'true'"),
@@ -382,6 +373,8 @@ fn release_is_a_direct_non_cancellable_rolling_main_pipeline() {
     assert!(workflow.contains(
         "concurrency:\n  group: release-${{ inputs.release_tag || github.run_id }}\n  cancel-in-progress: false"
     ));
+    assert!(job_section(workflow, "check")
+        .contains("group: release-check-${{ inputs.release_tag || github.ref }}"));
     assert!(!workflow.contains("workflow_run:"));
     assert!(!workflow.contains("release-qualification:"));
     assert!(!workflow.contains("Main Guard"));
@@ -1763,6 +1756,7 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
     git(&["init", "-q", "-b", "main", "."], &upstream);
     git(&["commit", "-q", "--allow-empty", "-m", "c1"], &upstream);
     git(&["commit", "-q", "--allow-empty", "-m", "c2"], &upstream);
+    git(&["commit", "-q", "--allow-empty", "-m", "c3"], &upstream);
     git(&["clone", "-q", upstream.to_str().unwrap(), "work"], &dir);
     let work = dir.join("work");
 
@@ -1808,8 +1802,9 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
         recorded()
     );
 
-    // An older commit is NOT the branch tip. Attaching it would let a release
-    // be cut from an arbitrary SHA — the exact thing the guard exists to stop.
+    // Two rapid pushes have each become stale behind c3. Attaching either
+    // source identity would let a release be cut from an arbitrary SHA — the
+    // exact thing the guard exists to stop.
     git(&["checkout", "-q", "--detach", "HEAD~1"], &work);
     let out = attach(&work);
     assert!(
@@ -1839,6 +1834,23 @@ fn release_head_attach_refuses_any_commit_that_is_not_the_branch_tip() {
     assert!(
         recorded_refusal.contains(&format!("branch-tip={tip}")),
         "a superseded commit must name the tip that beat it: {recorded_refusal}"
+    );
+
+    git(&["checkout", "-q", "--detach", "HEAD~2"], &work);
+    let out = attach(&work);
+    assert!(
+        out.status.success(),
+        "the oldest rapid push must also resolve as superseded"
+    );
+    assert_eq!(
+        branch_of(&work),
+        "HEAD",
+        "every stale source identity must remain detached"
+    );
+    assert!(
+        recorded().contains(&format!("branch-tip={tip}")),
+        "every superseded source must retain the same latest successor: {}",
+        recorded()
     );
 
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- coalesce only the expensive read-only release check for rapid main pushes
- serialize version and tag mutation separately without cancelling active publication
- preserve per-run workflow identity and recovery-tag isolation

Closes #12504.

## Verification

- `cargo fmt --check`
- `cargo test --test release_workflow_test` (65 passed)
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode analyzed the release workflow timings, implemented the concurrency change through a general coding subagent, and independently reviewed and verified the resulting diff. Chris Huber reviewed and is responsible for every line.