### PR TITLE
fix(cook): avoid recursive local supervision

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -278,10 +278,7 @@ pub fn route_after_parse_with_provenance(
     // Cooks must resolve provider ownership before the launcher can acknowledge
     // or observe them. Auto without a runner is a local provider placement and
     // needs the same daemon-owned supervision as explicit local execution.
-    if inferred_runner_id.is_some()
-        || cli.placement.allows_local_fallback()
-        || cli.placement == homeboy::cli_surface::Placement::Auto
-    {
+    if needs_provider_resolved_cook_interception(cli, inferred_runner_id.as_deref()) {
         let provider_placement = if inferred_runner_id.is_some() {
             "lab"
         } else {
@@ -581,6 +578,16 @@ pub fn route_after_parse_with_provenance(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+fn needs_provider_resolved_cook_interception(cli: &Cli, inferred_runner_id: Option<&str>) -> bool {
+    // Explicit local placement was already intercepted before provider
+    // resolution. Running it through this pass again consumes the supervised
+    // child's one-use launch token twice and recursively detaches the child.
+    cli.placement != homeboy::cli_surface::Placement::Local
+        && (inferred_runner_id.is_some()
+            || cli.placement.allows_local_fallback()
+            || cli.placement == homeboy::cli_surface::Placement::Auto)
 }
 
 /// Return the Lab choice made by resource admission. `Some(None)` is an

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1386,6 +1386,35 @@ fn managed_runner_context_bypasses_auto_routing_once() {
 }
 
 #[test]
+fn explicit_local_cook_skips_the_second_interception_pass() {
+    let local = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "local",
+        "agent-task",
+        "cook",
+        "--prompt",
+        "run locally",
+    ]);
+    assert!(!needs_provider_resolved_cook_interception(&local, None));
+
+    let automatic = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "auto",
+        "agent-task",
+        "cook",
+        "--prompt",
+        "resolve provider placement",
+    ]);
+    assert!(needs_provider_resolved_cook_interception(&automatic, None));
+    assert!(needs_provider_resolved_cook_interception(
+        &automatic,
+        Some("ready-runner")
+    ));
+}
+
+#[test]
 fn runner_resident_run_plan_does_not_require_a_second_controller_session() {
     let _env = EnvGuard::set_many(&[
         (homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV, None),

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -260,14 +260,19 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
         status_stdout.contains("\"admission_state\": \"failed\""),
         "an abandoned admission must terminalize truthfully: {status_stdout}"
     );
-    assert!(
-        status_stdout.contains("\"state\": \"failed\""),
+    let status: serde_json::Value =
+        serde_json::from_str(&status_stdout).expect("status is structured JSON");
+    assert_eq!(status["subject_state"], "failed", "{status_stdout}");
+    assert_eq!(
+        status["data"]["metadata"]["task_count"], 0,
         "{status_stdout}"
     );
-    assert!(
-        status_stdout.contains("\"tasks\": []")
-            && status_stdout.contains("\"max_attempts\": 0")
-            && status_stdout.contains("\"exited_before_handoff\""),
+    assert_eq!(
+        status["data"]["metadata"]["provider_executions_consumed"], 0,
+        "{status_stdout}"
+    );
+    assert_eq!(
+        status["data"]["metadata"]["detached_cook_handoff"]["state"], "exited_before_handoff",
         "{status_stdout}"
     );
 }
@@ -377,13 +382,16 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
         assert!(status.status.success(), "{status_stdout}");
         let terminal = serde_json::from_str::<serde_json::Value>(&status_stdout)
             .ok()
-            .and_then(|status| {
-                status
-                    .pointer("/data/state")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_owned)
-            })
-            .is_some_and(|state| matches!(state.as_str(), "succeeded" | "failed" | "cancelled"));
+            .is_some_and(|status| {
+                [
+                    "/data/state",
+                    "/data/child_run_state",
+                    "/data/lifecycle/execution/state",
+                ]
+                .iter()
+                .filter_map(|pointer| status.pointer(pointer).and_then(serde_json::Value::as_str))
+                .any(|state| matches!(state, "succeeded" | "failed" | "cancelled"))
+            });
         if terminal {
             break;
         }


### PR DESCRIPTION
## Summary

- keep explicit local Cooks on their single pre-provider supervision pass
- preserve provider-resolved interception for automatic and runner-selected placement
- update handoff integration assertions to the canonical current status schema

The regression came from #12484 adding a provider-resolution interception pass after the explicit-local pass. A supervised explicit-local child consumed its one-use launch token in the first pass, then appeared unsupervised in the second and recursively detached before stable attempt ownership.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo test -p homeboy-cli explicit_local_cook_skips_the_second_interception_pass -- --nocapture`
- `cargo test --test cook_lab_handoff_test cook_rejects_local_detachment_when_the_child_exits_before_attempt_materialization -- --nocapture`
- `cargo test --test cook_lab_handoff_test cook_accepts_local_detachment_after_materializing_an_executable_attempt -- --nocapture`

Closes #12380

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the duplicate routing pass, implemented the minimal exclusion, updated status-schema assertions, and ran the verification above. Chris Huber reviewed and owns every line.