### PR TITLE
Stabilize fanout admission and scalable Lab staging

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -14,6 +14,7 @@ use crate::agent_task_dependency_graph::{
 };
 use crate::agent_task_lifecycle::{self, AgentTaskRunState};
 use crate::agent_task_schedule::AgentTaskPlan;
+use crate::agent_task_service;
 use homeboy_core::{paths, Error, ErrorCode, Result};
 
 mod types;
@@ -322,6 +323,13 @@ fn heartbeat_fanout_run_batch_in_store(
                 )
             })?;
         coordinator.insert("heartbeat_at".to_string(), json!(now_timestamp()));
+        // An admitting coordinator can spend longer than one lease preparing
+        // gates, worktrees, and recipes. A live heartbeat renews that admission
+        // lease; a dead coordinator still expires when heartbeats stop.
+        coordinator.insert(
+            "admission_deadline_at".to_string(),
+            json!((Utc::now() + chrono::Duration::seconds(COORDINATOR_LEASE_SECONDS)).to_rfc3339()),
+        );
         batch.updated_at = Some(now_timestamp());
         Ok(())
     })
@@ -481,7 +489,7 @@ fn expire_stalled_fanout_admission_in_store(
             .as_str()
             .unwrap_or("admitting")
             .to_string();
-        let command = format!("homeboy agent-task fanout resume {batch_id}");
+        let command = stalled_admission_recovery_command(&batch)?;
         if !batch.metadata.is_object() {
             batch.metadata = Value::Object(serde_json::Map::new());
         }
@@ -504,6 +512,43 @@ fn expire_stalled_fanout_admission_in_store(
         store.write_batch(&batch)?;
         Ok(true)
     })
+}
+
+fn stalled_admission_recovery_command(batch: &AgentTaskBatchRecord) -> Result<String> {
+    stalled_admission_recovery_command_with(batch, |child| {
+        agent_task_service::recipe_exists(&child.task_id)
+    })
+}
+
+fn stalled_admission_recovery_command_with(
+    batch: &AgentTaskBatchRecord,
+    mut recipe_exists: impl FnMut(&AgentTaskBatchChildRun) -> Result<bool>,
+) -> Result<String> {
+    let recipes_exist = batch
+        .child_runs
+        .iter()
+        .map(&mut recipe_exists)
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .all(|exists| exists);
+    if recipes_exist {
+        return Ok(format!(
+            "homeboy agent-task fanout resume {}",
+            batch.batch_id
+        ));
+    }
+    batch.metadata["replan_command"]
+        .as_str()
+        .filter(|command| !command.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "replan_command",
+                "stalled fanout admission has no persisted child recipes or replan command",
+                Some(batch.batch_id.clone()),
+                None,
+            )
+        })
 }
 
 fn status_in_store<S, P>(
@@ -1196,8 +1241,8 @@ impl AgentTaskBatchStore {
     fn status(&self, batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
         self.status_with(
             batch_id,
-            agent_task_lifecycle::status,
-            agent_task_lifecycle::terminal_artifact_projection_readiness,
+            agent_task_lifecycle::persisted_status,
+            agent_task_lifecycle::terminal_artifact_projection_readiness_bounded,
         )
     }
 
@@ -2459,6 +2504,8 @@ mod tests {
                 batch.metadata["coordinator"]["admission_deadline_at"] =
                     json!("2000-01-01T00:00:00Z");
                 batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+                batch.metadata["replan_command"] =
+                    json!("homeboy agent-task fanout run-plan --input @plan.json");
                 Ok(())
             })
             .expect("expire admission");
@@ -2476,7 +2523,83 @@ mod tests {
         );
         assert_eq!(
             status.batch.metadata["terminal_failure"]["failure"]["next_action"],
-            "homeboy agent-task fanout resume stuck-wave"
+            "homeboy agent-task fanout run-plan --input @plan.json"
+        );
+    }
+
+    #[test]
+    fn stalled_admission_recovery_resumes_only_when_every_recipe_exists() {
+        let batch = AgentTaskBatchRecord {
+            schema: AGENT_TASK_BATCH_SCHEMA.to_string(),
+            batch_id: "recipe-wave".to_string(),
+            plan_id: "recipe-wave".to_string(),
+            state: AgentTaskBatchState::Admitting,
+            submitted_at: now_timestamp(),
+            updated_at: None,
+            task_count: 2,
+            child_runs: vec![
+                AgentTaskBatchChildRun {
+                    task_id: "a".to_string(),
+                    run_id: "a-run".to_string(),
+                    state: AgentTaskRunState::Queued,
+                },
+                AgentTaskBatchChildRun {
+                    task_id: "b".to_string(),
+                    run_id: "b-run".to_string(),
+                    state: AgentTaskRunState::Queued,
+                },
+            ],
+            metadata: json!({
+                "replan_command": "homeboy agent-task fanout run-plan --input @plan.json"
+            }),
+        };
+
+        assert_eq!(
+            stalled_admission_recovery_command_with(&batch, |_| Ok(false))
+                .expect("pre-recipe recovery command"),
+            "homeboy agent-task fanout run-plan --input @plan.json"
+        );
+        assert_eq!(
+            stalled_admission_recovery_command_with(&batch, |_| Ok(true))
+                .expect("recipe-backed recovery command"),
+            "homeboy agent-task fanout resume recipe-wave"
+        );
+    }
+
+    #[test]
+    fn a_heartbeat_renews_slow_preflight_admission_without_false_expiry() {
+        let (_temp, store) = batch_store();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "slow-preflight".to_string(),
+            run_id: "slow-preflight-run".to_string(),
+        }];
+        store
+            .persist_fanout_run_batch("slow-preflight", "slow-preflight", &children, json!({}))
+            .expect("persist");
+        let claim_id = store
+            .claim_fanout_run_batch("slow-preflight")
+            .expect("claim")
+            .expect("claim id");
+        store
+            .mutate_batch("slow-preflight", |batch| {
+                batch.metadata["coordinator"]["admission_deadline_at"] =
+                    json!("2000-01-01T00:00:00Z");
+                batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+                Ok(())
+            })
+            .expect("age initial admission lease");
+
+        store
+            .heartbeat_fanout_run_batch("slow-preflight", &claim_id)
+            .expect("healthy preflight heartbeat");
+
+        assert!(!store
+            .expire_stalled_fanout_admission("slow-preflight")
+            .expect("live preflight is retained"));
+        assert_ne!(
+            store.read_batch("slow-preflight").expect("batch").metadata["coordinator"]
+                ["admission_deadline_at"],
+            json!("2000-01-01T00:00:00Z")
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -452,7 +452,24 @@ fn expire_stalled_fanout_admission_in_store(
     store.with_batch_lock(batch_id, || {
         let mut batch = store.read_batch(batch_id)?;
         let coordinator = &batch.metadata["coordinator"];
+        let heartbeat_stale = coordinator["heartbeat_at"]
+            .as_str()
+            .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+            .is_some_and(|heartbeat| {
+                Utc::now() - heartbeat.with_timezone(&Utc)
+                    > chrono::Duration::seconds(COORDINATOR_LEASE_SECONDS)
+            });
+        let child_started = batch.child_runs.iter().any(|child| {
+            child.state != AgentTaskRunState::Queued
+                || batch.metadata["child_finalizations"]
+                    .get(&child.run_id)
+                    .is_some()
+                || agent_task_lifecycle::run_record_exists(&child.run_id).unwrap_or(true)
+        });
         let expired = batch.state == AgentTaskBatchState::Admitting
+            && coordinator["stage"].as_str() == Some("admitting")
+            && heartbeat_stale
+            && !child_started
             && coordinator["admission_deadline_at"]
                 .as_str()
                 .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
@@ -503,6 +520,14 @@ where
     if batch.metadata["terminal_failure"].is_object() {
         batch.state = AgentTaskBatchState::Failed;
         let commands = commands(&batch.batch_id);
+        let admission_blocker = batch.metadata["terminal_failure"].clone();
+        let mut next_actions = vec![commands.status.clone(), commands.artifacts.clone()];
+        if let Some(command) = admission_blocker
+            .pointer("/failure/next_action")
+            .and_then(Value::as_str)
+        {
+            next_actions.insert(0, command.to_string());
+        }
         return Ok(AgentTaskBatchStatusReport {
             schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
             status: "failed".to_string(),
@@ -510,11 +535,12 @@ where
             totals: totals_for_children(&batch.child_runs),
             batch,
             unavailable_child_runs: Vec::new(),
+            admission_blocker: Some(admission_blocker),
             projection_pending_child_runs: Vec::new(),
             resumable_child_runs: Vec::new(),
             resumable: false,
             dependency_graph: None,
-            next_actions: vec![commands.status.clone(), commands.artifacts.clone()],
+            next_actions,
             commands,
         });
     }
@@ -615,6 +641,7 @@ where
         batch,
         totals,
         unavailable_child_runs,
+        admission_blocker: None,
         projection_pending_child_runs,
         resumable_child_runs,
         resumable,
@@ -2431,6 +2458,7 @@ mod tests {
             .mutate_batch("stuck-wave", |batch| {
                 batch.metadata["coordinator"]["admission_deadline_at"] =
                     json!("2000-01-01T00:00:00Z");
+                batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
                 Ok(())
             })
             .expect("expire admission");
@@ -2449,6 +2477,89 @@ mod tests {
         assert_eq!(
             status.batch.metadata["terminal_failure"]["failure"]["next_action"],
             "homeboy agent-task fanout resume stuck-wave"
+        );
+    }
+
+    #[test]
+    fn expired_admission_with_a_fresh_heartbeat_or_started_child_is_not_terminated() {
+        let (_temp, store) = batch_store();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "live".to_string(),
+            run_id: "live-run".to_string(),
+        }];
+        for (batch_id, started) in [("live-wave", false), ("started-wave", true)] {
+            store
+                .persist_fanout_run_batch(batch_id, batch_id, &children, json!({}))
+                .expect("persist");
+            store
+                .claim_fanout_run_batch(batch_id)
+                .expect("claim")
+                .expect("claim id");
+            store
+                .mutate_batch(batch_id, |batch| {
+                    batch.metadata["coordinator"]["admission_deadline_at"] =
+                        json!("2000-01-01T00:00:00Z");
+                    if started {
+                        batch.metadata["coordinator"]["heartbeat_at"] =
+                            json!("2000-01-01T00:00:00Z");
+                        batch.child_runs[0].state = AgentTaskRunState::Running;
+                    }
+                    Ok(())
+                })
+                .expect("set durable progress");
+
+            assert!(
+                !store
+                    .expire_stalled_fanout_admission(batch_id)
+                    .expect("observe active admission"),
+                "{batch_id} must retain its active coordinator"
+            );
+            assert_eq!(
+                store.read_batch(batch_id).expect("batch").state,
+                AgentTaskBatchState::Admitting
+            );
+        }
+    }
+
+    #[test]
+    fn status_projects_the_exact_returned_admission_blocker() {
+        let (_temp, store) = batch_store();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "source".to_string(),
+            run_id: "source-run".to_string(),
+        }];
+        store
+            .persist_fanout_run_batch("source-wave", "source-wave", &children, json!({}))
+            .expect("persist");
+        let claim_id = store
+            .claim_fanout_run_batch("source-wave")
+            .expect("claim")
+            .expect("claim id");
+        store
+            .record_fanout_run_batch_failure(
+                "source-wave",
+                &claim_id,
+                "source_staging",
+                json!({
+                    "code": "source_package_too_large",
+                    "message": "source package exceeds configured entry or total size bounds",
+                    "next_action": "homeboy agent-task fanout resume source-wave",
+                }),
+            )
+            .expect("record source blocker");
+
+        let status = store.status("source-wave").expect("project blocker");
+        assert_eq!(
+            status.admission_blocker.as_ref().unwrap()["stage"],
+            "source_staging"
+        );
+        assert_eq!(
+            status.admission_blocker.as_ref().unwrap()["failure"]["code"],
+            "source_package_too_large"
+        );
+        assert_eq!(
+            status.next_actions[0],
+            "homeboy agent-task fanout resume source-wave"
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -283,9 +283,11 @@ fn claim_fanout_run_batch_in_store(
         let metadata = batch.metadata.as_object_mut().expect("metadata object");
         metadata.remove("terminal_failure");
         let claim_id = Uuid::new_v4().to_string();
+        let admission_deadline_at = (Utc::now() + chrono::Duration::seconds(COORDINATOR_LEASE_SECONDS))
+            .to_rfc3339();
         metadata.insert(
             "coordinator".to_string(),
-            json!({ "claim_id": claim_id, "stage": "admitting", "heartbeat_at": now_timestamp(), "lease_seconds": COORDINATOR_LEASE_SECONDS }),
+            json!({ "claim_id": claim_id, "stage": "admitting", "heartbeat_at": now_timestamp(), "admission_deadline_at": admission_deadline_at, "lease_seconds": COORDINATOR_LEASE_SECONDS }),
         );
         batch.state = AgentTaskBatchState::Admitting;
         batch.updated_at = Some(now_timestamp());
@@ -427,7 +429,64 @@ fn record_fanout_run_batch_failed_admissions_in_store<'a>(
 }
 
 pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
-    AgentTaskBatchStore::from_current_data_root()?.status(batch_id)
+    let store = AgentTaskBatchStore::from_current_data_root()?;
+    let _ = store.expire_stalled_fanout_admission(batch_id)?;
+    store.status(batch_id)
+}
+
+/// Expire a live coordinator only when its durable record proves it never
+/// advanced beyond pre-child admission. Detached supervision uses this to stop
+/// the stranded process as soon as the durable terminal blocker is written.
+pub fn expire_stalled_fanout_admission(batch_id: &str) -> Result<bool> {
+    AgentTaskBatchStore::from_current_data_root()?.expire_stalled_fanout_admission(batch_id)
+}
+
+/// Turn an accepted coordinator that never leaves admission into durable,
+/// actionable state. The admission deadline is independent of the heartbeat:
+/// a live process that is stuck before it can create a child must not renew its
+/// way into an indefinite `admitting` state.
+fn expire_stalled_fanout_admission_in_store(
+    store: &AgentTaskBatchStore,
+    batch_id: &str,
+) -> Result<bool> {
+    store.with_batch_lock(batch_id, || {
+        let mut batch = store.read_batch(batch_id)?;
+        let coordinator = &batch.metadata["coordinator"];
+        let expired = batch.state == AgentTaskBatchState::Admitting
+            && coordinator["admission_deadline_at"]
+                .as_str()
+                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                .is_some_and(|deadline| Utc::now() >= deadline.with_timezone(&Utc));
+        if !expired {
+            return Ok(false);
+        }
+        let stage = coordinator["stage"]
+            .as_str()
+            .unwrap_or("admitting")
+            .to_string();
+        let command = format!("homeboy agent-task fanout resume {batch_id}");
+        if !batch.metadata.is_object() {
+            batch.metadata = Value::Object(serde_json::Map::new());
+        }
+        batch.metadata.as_object_mut().expect("metadata object").insert(
+            "terminal_failure".to_string(),
+            json!({
+                "stage": stage,
+                "failure": {
+                    "code": "coordinator_admission_timeout",
+                    "message": format!("fanout coordinator did not advance beyond '{stage}' before its admission deadline"),
+                    "next_action": command,
+                }
+            }),
+        );
+        for child in &mut batch.child_runs {
+            child.state = AgentTaskRunState::Failed;
+        }
+        batch.state = AgentTaskBatchState::Failed;
+        batch.updated_at = Some(now_timestamp());
+        store.write_batch(&batch)?;
+        Ok(true)
+    })
 }
 
 fn status_in_store<S, P>(
@@ -1113,6 +1172,10 @@ impl AgentTaskBatchStore {
             agent_task_lifecycle::status,
             agent_task_lifecycle::terminal_artifact_projection_readiness,
         )
+    }
+
+    fn expire_stalled_fanout_admission(&self, batch_id: &str) -> Result<bool> {
+        expire_stalled_fanout_admission_in_store(self, batch_id)
     }
 
     fn status_with<S, P>(
@@ -2347,6 +2410,45 @@ mod tests {
                 .expect("reclaimed batch")
                 .state,
             AgentTaskBatchState::Admitting
+        );
+    }
+
+    #[test]
+    fn expired_admission_is_a_durable_terminal_blocker_with_a_recovery_command() {
+        let (_temp, store) = batch_store();
+        let children = vec![FanoutRunBatchChild {
+            task_id: "stuck".to_string(),
+            run_id: "stuck-run".to_string(),
+        }];
+        store
+            .persist_fanout_run_batch("stuck-wave", "stuck-wave", &children, json!({}))
+            .expect("persist");
+        store
+            .claim_fanout_run_batch("stuck-wave")
+            .expect("claim")
+            .expect("claim id");
+        store
+            .mutate_batch("stuck-wave", |batch| {
+                batch.metadata["coordinator"]["admission_deadline_at"] =
+                    json!("2000-01-01T00:00:00Z");
+                Ok(())
+            })
+            .expect("expire admission");
+
+        assert!(store
+            .expire_stalled_fanout_admission("stuck-wave")
+            .expect("terminalize stalled admission"));
+        let status = store.status("stuck-wave").expect("read failed batch");
+
+        assert_eq!(status.batch.state, AgentTaskBatchState::Failed);
+        assert_eq!(status.batch.child_runs[0].state, AgentTaskRunState::Failed);
+        assert_eq!(
+            status.batch.metadata["terminal_failure"]["failure"]["code"],
+            "coordinator_admission_timeout"
+        );
+        assert_eq!(
+            status.batch.metadata["terminal_failure"]["failure"]["next_action"],
+            "homeboy agent-task fanout resume stuck-wave"
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -14,7 +14,7 @@ use crate::agent_task_dependency_graph::{
 };
 use crate::agent_task_lifecycle::{self, AgentTaskRunState};
 use crate::agent_task_schedule::AgentTaskPlan;
-use homeboy_core::{paths, Error, Result};
+use homeboy_core::{paths, Error, ErrorCode, Result};
 
 mod types;
 
@@ -447,6 +447,7 @@ where
         return Ok(AgentTaskBatchStatusReport {
             schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
             status: "failed".to_string(),
+            observation_fresh: true,
             totals: totals_for_children(&batch.child_runs),
             batch,
             unavailable_child_runs: Vec::new(),
@@ -544,6 +545,7 @@ where
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
         status: state.outcome_status().to_string(),
+        observation_fresh: unavailable_child_runs.is_empty(),
         dependency_graph,
         next_actions,
         commands,
@@ -566,7 +568,7 @@ pub fn fanout_dependency_graph_with_finalization_statuses(
     refresh_dependency_graph_with_finalization_statuses(
         &mut batch,
         Some(statuses),
-        &mut agent_task_lifecycle::status,
+        &mut agent_task_lifecycle::persisted_status,
     )
 }
 
@@ -628,19 +630,25 @@ where
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
     let mut states = BTreeMap::new();
     for child in &batch.child_runs {
-        let finalization_status = finalization_statuses
-            .and_then(|statuses| statuses.get(&child.task_id).cloned())
-            .or_else(|| {
-                child_status(&child.run_id)
-                    .ok()
-                    .and_then(|record| record.metadata.get("cook_finalization").cloned())
-                    .and_then(|value| {
-                        value
-                            .get("status")
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                    })
-            });
+        let finalization_status = if let Some(status) =
+            finalization_statuses.and_then(|statuses| statuses.get(&child.task_id).cloned())
+        {
+            Some(status)
+        } else {
+            match child_status(&child.run_id) {
+                Ok(record) => record
+                    .metadata
+                    .get("cook_finalization")
+                    .and_then(|value| value.get("status"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                // A status projection has already retained the batch's last
+                // durable child state; a transient read lock must not turn a
+                // graph refresh into a user-visible status failure.
+                Err(error) if error.code == ErrorCode::ObservationStoreBusy => None,
+                Err(error) => return Err(error),
+            }
+        };
         let has_finalization = finalization_status.is_some();
         let mut state = match child.state {
             AgentTaskRunState::Failed => AgentTaskDependencyState::Failed,
@@ -1367,6 +1375,7 @@ mod tests {
         AgentTaskExecutionContext, AgentTaskExecutorAdapter,
     };
     use std::collections::HashMap;
+    use std::sync::{Arc, Barrier};
 
     fn batch_store() -> (tempfile::TempDir, AgentTaskBatchStore) {
         let temp = tempfile::tempdir().expect("temporary batch data root");
@@ -1949,6 +1958,68 @@ mod tests {
                 .updated_at,
             before.updated_at
         );
+    }
+
+    #[test]
+    fn fanout_status_retains_durable_state_while_observation_writers_contend() {
+        let (_temp, batch_store, lifecycle_store) = batch_and_lifecycle_stores();
+        let plan = AgentTaskPlan::new(
+            "fanout/contended-status",
+            vec![request("a"), request("b"), request("c")],
+        );
+        let batch = submit_batch(
+            &batch_store,
+            &lifecycle_store,
+            &plan,
+            "batch/contended-status",
+        );
+        let database = lifecycle_store.observation_db_path();
+        let barrier = Arc::new(Barrier::new(batch.child_runs.len() + 1));
+        let writers = batch
+            .child_runs
+            .iter()
+            .enumerate()
+            .map(|(writer, child)| {
+                let barrier = Arc::clone(&barrier);
+                let database = database.clone();
+                let run_id = child.run_id.clone();
+                std::thread::spawn(move || {
+                    let store =
+                        homeboy_core::observation::ObservationStore::open_initialized_at(database)
+                            .expect("open contending writer");
+                    let metadata = store
+                        .get_run(&run_id)
+                        .expect("read writer record")
+                        .expect("writer record exists")
+                        .metadata_json;
+                    barrier.wait();
+                    for sequence in 0..50 {
+                        let mut metadata = metadata.clone();
+                        metadata["contention"] = json!({ "writer": writer, "sequence": sequence });
+                        store
+                            .update_run_metadata(&run_id, metadata)
+                            .expect("bounded observation writer completes");
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for _ in 0..100 {
+            let report = batch_store
+                .status_with(
+                    "batch/contended-status",
+                    |run_id| lifecycle_store.read_record_bounded(run_id),
+                    |_| Ok(None),
+                )
+                .expect("fanout status remains available during writes");
+            assert_eq!(report.batch.state, AgentTaskBatchState::Queued);
+            assert_eq!(report.totals.queued, 3);
+            assert!(report.observation_fresh);
+        }
+        for writer in writers {
+            writer.join().expect("contending writer joined");
+        }
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -463,6 +463,7 @@ where
     let mut projection_pending_child_runs = Vec::new();
     let mut resumable_child_runs = Vec::new();
     let mut timed_out_child_runs = HashSet::new();
+    let mut observation_fresh = true;
     for child in &mut batch.child_runs {
         if terminal_preflight_or_admission_failure(&batch.metadata, &child.run_id) {
             continue;
@@ -493,6 +494,9 @@ where
                 }
             }
             Err(error) => {
+                if error.code == ErrorCode::ObservationStoreBusy {
+                    observation_fresh = false;
+                }
                 if !child.state.is_terminal() {
                     unavailable_child_runs.push(child_issue(
                         child,
@@ -545,7 +549,7 @@ where
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
         status: state.outcome_status().to_string(),
-        observation_fresh: unavailable_child_runs.is_empty(),
+        observation_fresh,
         dependency_graph,
         next_actions,
         commands,
@@ -1611,6 +1615,42 @@ mod tests {
             .next_actions
             .iter()
             .any(|action| action.contains("partial results only")));
+    }
+
+    #[test]
+    fn terminal_child_busy_observation_keeps_terminal_state_but_marks_staleness() {
+        let (_temp, batch_store, lifecycle_store) = batch_and_lifecycle_stores();
+        let plan = AgentTaskPlan::new("fanout/terminal-busy", vec![request("a")]);
+        submit_batch(&batch_store, &lifecycle_store, &plan, "batch/terminal-busy");
+        rewrite_record(&lifecycle_store, "batch_terminal-busy-a", |record| {
+            record.state = AgentTaskRunState::Succeeded;
+        });
+        let mut batch = batch_store
+            .read_batch("batch/terminal-busy")
+            .expect("durable batch");
+        batch.child_runs[0].state = AgentTaskRunState::Succeeded;
+        batch_store
+            .write_batch(&batch)
+            .expect("persist terminal batch state");
+
+        let report = batch_store
+            .status_with(
+                "batch/terminal-busy",
+                |_| {
+                    Err(Error::observation_store_busy(
+                        "test.sqlite",
+                        "read terminal child",
+                        750,
+                    ))
+                },
+                |_| Ok(None),
+            )
+            .expect("fanout status falls back to terminal durable state");
+
+        assert_eq!(report.batch.state, AgentTaskBatchState::Succeeded);
+        assert_eq!(report.totals.succeeded, 1);
+        assert!(!report.observation_fresh);
+        assert!(report.unavailable_child_runs.is_empty());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -73,6 +73,9 @@ pub struct AgentTaskBatchStatusReport {
     pub schema: &'static str,
     /// Additive top-level projection of `batch.state` for command envelopes.
     pub status: String,
+    /// Whether every child lifecycle observation was available for this status
+    /// projection. `batch` remains the durable orchestration state when false.
+    pub observation_fresh: bool,
     pub batch: AgentTaskBatchRecord,
     pub totals: AgentTaskBatchTotals,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -78,6 +78,11 @@ pub struct AgentTaskBatchStatusReport {
     pub observation_fresh: bool,
     pub batch: AgentTaskBatchRecord,
     pub totals: AgentTaskBatchTotals,
+    /// The controller-side blocker that prevented any child admission. This
+    /// projects the typed failure persisted before a child lifecycle record
+    /// exists, rather than making callers inspect batch metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_blocker: Option<Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unavailable_child_runs: Vec<AgentTaskBatchChildIssue>,
     /// Terminal children whose runner patch remains unavailable to the

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1047,7 +1047,27 @@ pub(crate) fn terminal_artifact_projection_is_verified(
 /// recovery behavior.
 pub fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<String>> {
     let record = store::read_record(&super::sanitize_run_id(run_id))?;
-    let Ok(aggregate) = store::read_aggregate(&record.run_id) else {
+    terminal_artifact_projection_readiness_for_record(
+        &record,
+        store::read_aggregate(&record.run_id),
+    )
+}
+
+/// Bounded read-only counterpart used by fanout status while coordinators are
+/// writing observations. It intentionally leaves reconciliation to `resume`.
+pub fn terminal_artifact_projection_readiness_bounded(run_id: &str) -> Result<Option<String>> {
+    let record = store::read_record_bounded(&super::sanitize_run_id(run_id))?;
+    terminal_artifact_projection_readiness_for_record(
+        &record,
+        store::read_aggregate_bounded(&record.run_id),
+    )
+}
+
+fn terminal_artifact_projection_readiness_for_record(
+    record: &AgentTaskRunRecord,
+    aggregate: Result<AgentTaskAggregate>,
+) -> Result<Option<String>> {
+    let Ok(aggregate) = aggregate else {
         return Ok(None);
     };
     if terminal_artifact_projection_is_verified(&record, &aggregate)? {

--- a/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
@@ -549,6 +549,16 @@ impl CookBatchJobDriver {
                 handle.progress(job.progress_projection())?;
             }
 
+            // A pre-child admission timeout is the one safe point to stop the
+            // coordinator directly: the batch store just proved every child is
+            // still unstarted and terminalized the wave with its recovery
+            // command. Later phases retain the ordinary child-safe cancellation
+            // path above.
+            if agent_task_batch::expire_stalled_fanout_admission(&job.request.batch_id)? {
+                let _ = homeboy_core::process::terminate_process_tree(job.request.child_pid);
+                return job.observe_terminal();
+            }
+
             if !coordinator_is_live(&job.request) {
                 return job.observe_terminal();
             }

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -307,7 +307,7 @@ pub mod lifecycle {
         exact_record, fail_cook_operation, fail_detached_cook_handoff_parent,
         has_accepted_runner_handoff, invalidate_cook_finalization_for_dependency, list_records,
         load_controller_plan, load_plan, logs, mark_resuming, mark_running,
-        materialize_recovered_patch_artifact, pin_current_controller_runtime,
+        materialize_recovered_patch_artifact, persisted_status, pin_current_controller_runtime,
         pinned_runtime_for_mutation, prune_controller_runtime_pins, quarantine_queued_run_exact,
         rearm_quarantined_run, reconcile_record_health, reconcile_terminal_artifact_projection,
         record_acceptance_verdict_with_feedback, record_completed_run, record_cook_attempt,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -258,8 +258,17 @@ fn reconcile_fanout_pr_states(batch_id: &str, mutate: bool) -> Result<BTreeMap<S
     let mut resolutions = Vec::new();
     let mut statuses = BTreeMap::new();
     for child in batch.child_runs {
-        let Ok(record) = agent_task_lifecycle::status(&child.run_id) else {
-            continue;
+        let record = if mutate {
+            agent_task_lifecycle::status(&child.run_id)?
+        } else {
+            match agent_task_lifecycle::persisted_status(&child.run_id) {
+                Ok(record) => record,
+                // The batch report retains the last durable child state and
+                // marks observation freshness separately below. A transient
+                // projection lock must not make status itself unavailable.
+                Err(error) if error.code == ErrorCode::ObservationStoreBusy => continue,
+                Err(error) => return Err(error),
+            }
         };
         let Some(mut finalization) = record.metadata.get("cook_finalization").cloned() else {
             continue;

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -88,7 +88,10 @@ struct CoordinatorHeartbeat {
 }
 
 impl CoordinatorHeartbeat {
-    fn start(batch_id: String, claim_id: String) -> Self {
+    fn start(batch_id: String, claim_id: String) -> Result<Self> {
+        // Claim admission before preflight, then renew it synchronously before
+        // any potentially slow gate, workspace, recipe, or provider work.
+        batch::heartbeat_fanout_run_batch(&batch_id, &claim_id)?;
         let (stop, receiver) = std::sync::mpsc::channel();
         let stale_error = std::sync::Arc::new(std::sync::Mutex::new(None));
         let worker_error = std::sync::Arc::clone(&stale_error);
@@ -115,11 +118,11 @@ impl CoordinatorHeartbeat {
                 }
             }
         });
-        Self {
+        Ok(Self {
             stop,
             worker: Some(worker),
             stale_error,
-        }
+        })
     }
 
     fn finish(mut self) -> Result<()> {
@@ -583,7 +586,7 @@ fn reconcile_portfolio(
     let observations = batch_record
         .child_runs
         .iter()
-        .map(|child| portfolio_observation(&child.task_id, &child.run_id))
+        .map(|child| portfolio_observation(&child.task_id, &child.run_id, false))
         .collect::<Result<Vec<_>>>()?;
     let dependencies = durable_graph_dependencies(batch_record)?;
     let status = portfolio.reconcile(observations, &dependencies);
@@ -696,7 +699,7 @@ impl supervisor::FanoutPortfolioAdapter for CookFanoutPortfolioAdapter {
         &mut self,
         child: &supervisor::AgentTaskFanoutPortfolioChild,
     ) -> Result<supervisor::AgentTaskFanoutPortfolioObservation> {
-        portfolio_observation(&child.child_id, &child.run_id)
+        portfolio_observation(&child.child_id, &child.run_id, true)
     }
 
     fn continue_provider(
@@ -878,9 +881,15 @@ fn resume_fanout_child(
 fn portfolio_observation(
     child_id: &str,
     run_id: &str,
+    reconcile: bool,
 ) -> Result<homeboy::agents::agent_tasks::fanout_supervisor::AgentTaskFanoutPortfolioObservation> {
     use homeboy::agents::agent_tasks::fanout_supervisor as supervisor;
-    let record = agent_task_lifecycle::status(run_id).ok();
+    let record = if reconcile {
+        agent_task_lifecycle::status(run_id)
+    } else {
+        agent_task_lifecycle::persisted_status(run_id)
+    }
+    .ok();
     let provider = match record.as_ref().map(|record| record.state) {
         Some(agent_task_lifecycle::AgentTaskRunState::Running) => {
             supervisor::AgentTaskFanoutProviderState::Running
@@ -1210,6 +1219,7 @@ fn persist_fanout_run_batch_record(plan: &BatchCookFanoutPlan) -> Result<()> {
         serde_json::json!({
             "source": "fanout-run-plan",
             "durable_child_runs": true,
+            "replan_command": secure_batch_plan_execution(&plan.fanout_id),
             "dependency_graph": plan.dependency_graph_metadata()?,
         }),
     )?;
@@ -1273,6 +1283,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
         None => claim_fanout_run_batch_coordinator(&plan)?,
     };
     let outcome = (|| {
+        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone())?;
         persist_batch_cook_recipes(&plan, |options| {
             record_gate_contract_validation(options, &gate_contract_validation);
             options.attempt_dispatcher = Some(attempt_dispatcher(options));
@@ -1286,7 +1297,6 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
         // Resolved once, here, and bound for the whole batch: every worker thread
         // re-binds this same absolute instant, so the budget covers the batch
         // rather than restarting per child.
-        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone());
         let result = with_current_cook_deadline(plan.cook_deadline(), || {
             batch::heartbeat_fanout_run_batch(&plan.fanout_id, &claim_id)?;
             agent_task_service::run_cook_batch_with_control(
@@ -1345,6 +1355,7 @@ where
         None => claim_fanout_run_batch_coordinator(&plan)?,
     };
     let outcome = (|| {
+        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone())?;
         persist_batch_cook_recipes(&plan, |options| {
             record_gate_contract_validation(options, &gate_contract_validation);
         })?;
@@ -1355,7 +1366,6 @@ where
         let concurrency = batch_concurrency(&plan, &cooks);
         // See the sibling runner: the budget is resolved once and bound for the
         // whole batch so it does not restart per child.
-        let heartbeat = CoordinatorHeartbeat::start(plan.fanout_id.clone(), claim_id.clone());
         let result = with_current_cook_deadline(plan.cook_deadline(), || {
             batch::heartbeat_fanout_run_batch(&plan.fanout_id, &claim_id)?;
             agent_task_service::run_cook_batch_with_control(
@@ -7063,6 +7073,81 @@ fi
                 "{state:?}"
             );
         }
+    }
+
+    #[test]
+    fn public_fanout_status_returns_stale_durable_state_during_observation_contention() {
+        with_isolated_home(|_| {
+            let batch_id = "contended-public-status";
+            let run_id = "contended-public-status-child";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(run_id)
+                .expect("persist child lifecycle record");
+            batch::persist_fanout_run_batch(
+                batch_id,
+                batch_id,
+                &[batch::FanoutRunBatchChild {
+                    task_id: run_id.to_string(),
+                    run_id: run_id.to_string(),
+                }],
+                json!({ "replan_command": "homeboy agent-task fanout run-plan --input @plan.json" }),
+            )
+            .expect("persist fanout batch");
+
+            let database =
+                homeboy::core::observation::store::database_path().expect("observation path");
+            let connection =
+                rusqlite::Connection::open(database).expect("open contention connection");
+            connection
+                // WAL permits concurrent readers. Use rollback-journal locking so
+                // the public command must exercise the bounded busy fallback.
+                .execute_batch("PRAGMA journal_mode=DELETE; BEGIN EXCLUSIVE")
+                .expect("hold observation write lock");
+
+            let (value, exit_code) = batch_status(AgentTaskFanoutBatchStatusArgs {
+                batch_id: batch_id.to_string(),
+            })
+            .expect("public status keeps the durable batch readable");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["batch"]["observation_fresh"], false);
+            assert_eq!(value["batch"]["batch"]["state"], "queued");
+        });
+    }
+
+    #[test]
+    fn coordinator_heartbeat_starts_before_slow_preflight() {
+        with_isolated_home(|_| {
+            let batch_id = "heartbeat-before-preflight";
+            batch::persist_fanout_run_batch(
+                batch_id,
+                batch_id,
+                &[batch::FanoutRunBatchChild {
+                    task_id: "child".to_string(),
+                    run_id: "child-run".to_string(),
+                }],
+                json!({ "replan_command": "homeboy agent-task fanout run-plan --input @plan.json" }),
+            )
+            .expect("persist batch");
+            let claim_id = batch::claim_fanout_run_batch(batch_id)
+                .expect("claim")
+                .expect("claim id");
+            let before = batch::read_batch_record(batch_id).expect("batch").metadata["coordinator"]
+                ["admission_deadline_at"]
+                .clone();
+
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            CoordinatorHeartbeat::start(batch_id.to_string(), claim_id)
+                .expect("start heartbeat before preflight")
+                .finish()
+                .expect("finish heartbeat");
+
+            assert_ne!(
+                batch::read_batch_record(batch_id)
+                    .expect("renewed batch")
+                    .metadata["coordinator"]["admission_deadline_at"],
+                before
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -100,6 +100,18 @@ impl CoordinatorHeartbeat {
                         *worker_error.lock().expect("heartbeat error lock") = Some(error.message);
                         break;
                     }
+                    if let Ok(record) = batch::read_batch_record(&batch_id) {
+                        eprintln!(
+                            "{{\"event\":\"coordinator_heartbeat\",\"phase\":{},\"children_total\":{},\"next_action\":{}}}",
+                            serde_json::to_string(&record.metadata["coordinator"]["stage"])
+                                .expect("coordinator stage serializes"),
+                            record.child_runs.len(),
+                            serde_json::to_string(&format!(
+                                "homeboy agent-task fanout status {batch_id}"
+                            ))
+                            .expect("status command serializes"),
+                        );
+                    }
                 }
             }
         });
@@ -1207,6 +1219,10 @@ fn persist_fanout_run_batch_record(plan: &BatchCookFanoutPlan) -> Result<()> {
 fn claim_fanout_run_batch_coordinator(plan: &BatchCookFanoutPlan) -> Result<String> {
     persist_fanout_run_batch_record(plan)?;
     if let Some(claim_id) = batch::claim_fanout_run_batch(&plan.fanout_id)? {
+        eprintln!(
+            "{{\"event\":\"coordinator_admission_claimed\",\"phase\":\"admitting\",\"children_total\":{},\"next_action\":\"homeboy agent-task fanout status {}\"}}",
+            plan.cooks.len(), plan.fanout_id,
+        );
         return Ok(claim_id);
     }
     Err(Error::validation_invalid_argument(
@@ -1218,12 +1234,24 @@ fn claim_fanout_run_batch_coordinator(plan: &BatchCookFanoutPlan) -> Result<Stri
 }
 
 fn record_batch_failure(plan: &BatchCookFanoutPlan, claim_id: &str, stage: &str, error: &Error) {
-    let _ = batch::record_fanout_run_batch_failure(
+    let recorded = batch::record_fanout_run_batch_failure(
         &plan.fanout_id,
         claim_id,
         stage,
         serde_json::json!({ "message": error.message, "details": error.details }),
     );
+    if recorded.is_ok() {
+        eprintln!(
+            "{{\"event\":\"coordinator_failed\",\"phase\":{},\"children_total\":{},\"next_action\":{}}}",
+            serde_json::to_string(stage).expect("stage serializes"),
+            plan.cooks.len(),
+            serde_json::to_string(&format!(
+                "homeboy agent-task fanout resume {}",
+                plan.fanout_id
+            ))
+            .expect("resume command serializes"),
+        );
+    }
 }
 
 fn run_batch_cook_fanout_plan_with_attempt_dispatcher(

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
@@ -33,7 +33,7 @@
 //! rather than silently ignored: a flag that refuses is better than a flag that
 //! lies, which is the whole defect being fixed.
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -459,7 +459,15 @@ fn spawn_detached_fanout(
             Some("resolve current executable for a detached local fanout".to_string()),
         )
     })?;
-    let log = std::fs::File::create(log_path).map_err(|error| {
+    let mut log = std::fs::File::create(log_path).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
+    })?;
+    writeln!(
+        log,
+        "{{\"event\":\"coordinator_started\",\"phase\":\"launching\",\"fanout_id\":{fanout_id:?},\"next_action\":\"homeboy agent-task fanout status {fanout_id}\"}}"
+    )
+    .map_err(|error| Error::internal_io(error.to_string(), Some(log_path.display().to_string())))?;
+    log.flush().map_err(|error| {
         Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
     })?;
     let log_err = log.try_clone().map_err(|error| {
@@ -1054,5 +1062,21 @@ mod tests {
             envelope["commands"]["resume"],
             "homeboy agent-task fanout resume wave-7"
         );
+    }
+
+    #[test]
+    fn detached_coordinator_log_starts_with_a_statusable_lifecycle_event() {
+        let directory = tempfile::tempdir().expect("temporary log directory");
+        let log_path = directory.path().join("fanout.log");
+        let args = vec!["self".to_string()];
+
+        let mut child = spawn_detached_fanout(&args, "wave-log", &log_path, None)
+            .expect("spawn detached coordinator");
+        terminate_and_reap_detached_child(&mut child);
+        let log = std::fs::read_to_string(log_path).expect("read coordinator log");
+
+        assert!(log.contains("\"event\":\"coordinator_started\""), "{log}");
+        assert!(log.contains("\"phase\":\"launching\""), "{log}");
+        assert!(log.contains("fanout status wave-log"), "{log}");
     }
 }

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -183,6 +183,8 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
             progress_sink,
             require_child_identity_acknowledgement,
             child_started,
+            #[cfg(unix)]
+            None,
         )?;
         let (stdout, stderr) = super::execution::redaction::redact_runner_exec_streams(
             output.stdout,

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -12,8 +12,10 @@ use homeboy_core::{Error, Result};
 
 use crate::lab_staging_controller::LabStagingRecipe;
 
+pub const DIRECT_LAB_HANDOFF_SCHEMA_V1: &str = "homeboy/direct-lab-handoff/v1";
 pub const DIRECT_LAB_HANDOFF_SCHEMA: &str = "homeboy/direct-lab-handoff/v2";
 pub const DIRECT_LAB_HANDOFF_RECEIPT_SCHEMA: &str = "homeboy/direct-lab-handoff-receipt/v1";
+pub const DIRECT_LAB_HANDOFF_CAPABILITY_V1: &str = "direct-lab-handoff/v1";
 pub const DIRECT_LAB_HANDOFF_CAPABILITY: &str = "direct-lab-handoff/v2";
 
 /// Complete runner admission input. It has no controller-local attachment or
@@ -48,8 +50,10 @@ impl DirectLabHandoffEnvelope {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.schema != DIRECT_LAB_HANDOFF_SCHEMA
-            || self.run_id.trim().is_empty()
+        if !matches!(
+            self.schema.as_str(),
+            DIRECT_LAB_HANDOFF_SCHEMA_V1 | DIRECT_LAB_HANDOFF_SCHEMA
+        ) || self.run_id.trim().is_empty()
             || self.runner_id.trim().is_empty()
             || self.idempotency_key != self.run_id
             || self.controller_identity.trim().is_empty()
@@ -146,11 +150,16 @@ pub fn submit_direct_lab_handoff(
     envelope: &DirectLabHandoffEnvelope,
 ) -> Result<DirectLabHandoffReceipt> {
     envelope.validate()?;
-    if !receiver.supports_capability(DIRECT_LAB_HANDOFF_CAPABILITY) {
+    let capability = if envelope.schema == DIRECT_LAB_HANDOFF_SCHEMA_V1 {
+        DIRECT_LAB_HANDOFF_CAPABILITY_V1
+    } else {
+        DIRECT_LAB_HANDOFF_CAPABILITY
+    };
+    if !receiver.supports_capability(capability) {
         return Err(Error::validation_invalid_argument(
             "runner_capabilities",
             format!(
-                "runner `{}` does not support {DIRECT_LAB_HANDOFF_CAPABILITY}",
+                "runner `{}` does not support {capability}",
                 envelope.runner_id
             ),
             Some(envelope.runner_id.clone()),

--- a/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
+++ b/crates/homeboy-lab-runner/src/direct_lab_handoff.rs
@@ -12,9 +12,9 @@ use homeboy_core::{Error, Result};
 
 use crate::lab_staging_controller::LabStagingRecipe;
 
-pub const DIRECT_LAB_HANDOFF_SCHEMA: &str = "homeboy/direct-lab-handoff/v1";
+pub const DIRECT_LAB_HANDOFF_SCHEMA: &str = "homeboy/direct-lab-handoff/v2";
 pub const DIRECT_LAB_HANDOFF_RECEIPT_SCHEMA: &str = "homeboy/direct-lab-handoff-receipt/v1";
-pub const DIRECT_LAB_HANDOFF_CAPABILITY: &str = "direct-lab-handoff/v1";
+pub const DIRECT_LAB_HANDOFF_CAPABILITY: &str = "direct-lab-handoff/v2";
 
 /// Complete runner admission input. It has no controller-local attachment or
 /// filesystem references, so the runner can persist it before acknowledging.
@@ -59,7 +59,7 @@ impl DirectLabHandoffEnvelope {
         {
             return Err(Error::validation_invalid_argument(
                 "direct_lab_handoff",
-                "direct Lab handoff requires its v1 schema, bound identities, run-scoped idempotency key, controller identity, recipe, and durable plan",
+                "direct Lab handoff requires its v2 schema, bound identities, run-scoped idempotency key, controller identity, recipe, and durable plan",
                 Some(self.run_id.clone()),
                 None,
             ));

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -613,13 +613,37 @@ mod tests {
             std::fs::rename(&original_for_hook, &moved).expect("move original");
             std::fs::rename(&replacement_for_hook, &original_for_hook).expect("replace path");
         }));
-        let mut command = std::process::Command::new("sh");
-        command.args(["-c", "cat marker"]).current_dir(&original);
-        bind_verified_cwd(&mut command, directory.as_raw_fd());
-        test_spawn_hook::invoke();
-        let output = command.output().expect("spawn from verified fd");
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"verified");
+        let plan = PreparedRunnerProcess {
+            runner: Runner {
+                id: "race".to_string(),
+                kind: RunnerKind::Local,
+                server_id: None,
+                workspace_root: Some(original.display().to_string()),
+                settings: server::RunnerSettings::default(),
+                env: HashMap::new(),
+                secret_env: HashMap::new(),
+                resources: HashMap::new(),
+                policy: server::RunnerPolicy::default(),
+            },
+            cwd: original.display().to_string(),
+            command: vec!["sh".to_string(), "-c".to_string(), "cat marker".to_string()],
+            env: HashMap::new(),
+            resource_guard_env: HashMap::new(),
+            secret_env_names: Vec::new(),
+            source_snapshot: SourceSnapshot::default(),
+            require_paths: Vec::new(),
+        };
+        let output = execute_runner_process_until_cancelled_with_progress(
+            &plan,
+            || false,
+            None,
+            false,
+            None,
+            Some(directory.as_raw_fd()),
+        )
+        .expect("execute from verified fd");
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "verified");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -511,10 +511,24 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     progress_sink: Option<RunnerCommandProgressSink>,
     require_child_identity_acknowledgement: bool,
     child_started: Option<Arc<dyn Fn(u32) -> Result<()> + Send + Sync + 'static>>,
+    #[cfg(unix)] verified_cwd_fd: Option<std::os::fd::RawFd>,
 ) -> Result<ProcessOutput> {
     let temp_owner = runner_temp_owner(&plan.env)?;
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
+    #[cfg(unix)]
+    if let Some(fd) = verified_cwd_fd {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(move || {
+                if libc::fchdir(fd) == 0 {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::last_os_error())
+                }
+            });
+        }
+    }
     apply_runner_process_env(&mut command, plan, &temp_owner)?;
 
     command_output_until_cancelled_with_progress(

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -518,19 +518,12 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
     #[cfg(unix)]
     if let Some(fd) = verified_cwd_fd {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            command.pre_exec(move || {
-                if libc::fchdir(fd) == 0 {
-                    Ok(())
-                } else {
-                    Err(std::io::Error::last_os_error())
-                }
-            });
-        }
+        bind_verified_cwd(&mut command, fd);
     }
     apply_runner_process_env(&mut command, plan, &temp_owner)?;
 
+    #[cfg(test)]
+    test_spawn_hook::invoke();
     command_output_until_cancelled_with_progress(
         &mut command,
         is_cancelled,
@@ -544,6 +537,42 @@ pub(crate) fn execute_runner_process_until_cancelled_with_progress(
     )
 }
 
+#[cfg(unix)]
+fn bind_verified_cwd(command: &mut std::process::Command, fd: std::os::fd::RawFd) {
+    use std::os::unix::process::CommandExt;
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(fd) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+pub(super) mod test_spawn_hook {
+    use std::sync::{Mutex, OnceLock};
+    type Hook = Box<dyn FnOnce() + Send>;
+    static HOOK: OnceLock<Mutex<Option<Hook>>> = OnceLock::new();
+    pub(super) struct Guard;
+    pub(super) fn install(hook: Hook) -> Guard {
+        *HOOK.get_or_init(|| Mutex::new(None)).lock().expect("hook") = Some(hook);
+        Guard
+    }
+    pub(super) fn invoke() {
+        if let Some(hook) = HOOK
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .expect("hook")
+            .take()
+        {
+            hook();
+        }
+    }
+}
+
 #[cfg(test)]
 #[expect(
     clippy::items_after_test_module,
@@ -553,12 +582,45 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    #[cfg(unix)]
+    use std::os::{fd::AsRawFd, unix::fs::OpenOptionsExt};
     use std::sync::{Arc, Barrier};
 
     const GUTENBERG_LAB_OFFLOAD_BYTES: usize = 142_952;
     const GUTENBERG_SOURCE_SNAPSHOT_BYTES: usize = 44_680;
     const GUTENBERG_EXECUTION_BUNDLE_BYTES: usize = 8_552;
     const SAFE_CHILD_PROVENANCE_ENV_BYTES: usize = 16 * 1024;
+
+    #[cfg(unix)]
+    #[test]
+    fn verified_directory_fd_survives_a_spawn_boundary_path_replacement() {
+        let root = tempfile::tempdir().expect("root");
+        let original = root.path().join("workspace");
+        let replacement = root.path().join("replacement");
+        std::fs::create_dir(&original).expect("original");
+        std::fs::create_dir(&replacement).expect("replacement");
+        std::fs::write(original.join("marker"), "verified").expect("original marker");
+        std::fs::write(replacement.join("marker"), "replacement").expect("replacement marker");
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY);
+        let directory = options.open(&original).expect("open verified directory");
+        let moved = root.path().join("moved-original");
+        let original_for_hook = original.clone();
+        let replacement_for_hook = replacement.clone();
+        let _hook = test_spawn_hook::install(Box::new(move || {
+            std::fs::rename(&original_for_hook, &moved).expect("move original");
+            std::fs::rename(&replacement_for_hook, &original_for_hook).expect("replace path");
+        }));
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", "cat marker"]).current_dir(&original);
+        bind_verified_cwd(&mut command, directory.as_raw_fd());
+        test_spawn_hook::invoke();
+        let output = command.output().expect("spawn from verified fd");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"verified");
+    }
 
     #[test]
     fn controller_proxy_projection_is_explicit_and_replaces_only_the_requested_name() {

--- a/crates/homeboy-lab-runner/src/execution/worker.rs
+++ b/crates/homeboy-lab-runner/src/execution/worker.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::fd::RawFd;
 
 use homeboy_core::error::Result;
 
@@ -20,6 +22,7 @@ pub(crate) fn exec_worker_local_until_cancelled_with_progress(
     runner_id: &str,
     options: RunnerExecOptions,
     before_provider: impl FnOnce() -> Result<()>,
+    #[cfg(unix)] verified_cwd_fd: Option<RawFd>,
     is_cancelled: impl FnMut() -> bool,
     progress_sink: Option<super::super::RunnerCommandProgressSink>,
 ) -> Result<(RunnerExecOutput, i32)> {
@@ -31,6 +34,8 @@ pub(crate) fn exec_worker_local_until_cancelled_with_progress(
             progress_sink,
             true,
             None,
+            #[cfg(unix)]
+            verified_cwd_fd,
         )
     })
 }

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1126,52 +1126,67 @@ fn submit_deferred_runner_staging(
         )
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
-    let (source_artifact, workspace) =
-        match SourceArtifactTransfer::from_directory(format!("source-{run_id}"), &source_path) {
-            Ok(artifact) => (Some(artifact), None),
-            Err(artifact_error) => {
-                // Large clean Git worktrees are staged through the existing
-                // controller-routed bundle authority. Non-Git sources retain the
-                // bounded sealed-artifact contract and surface their original
-                // containment/filtering failure.
-                let git_status = std::process::Command::new("git")
-                    .args(["status", "--porcelain=v1"])
-                    .current_dir(&source_path)
-                    .output()
-                    .ok()
-                    .filter(|output| output.status.success());
-                let Some(git_status) = git_status else {
-                    return Err(artifact_error);
-                };
-                if !git_status.stdout.is_empty() {
-                    return Err(artifact_error);
-                }
-                let stage =
-                    crate::lab::offload::workspace_stage::prepare_lab_offload_workspace_stage(
-                        request,
-                        crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(
-                            &recipe.command,
-                        ),
-                        crate::lab_plan::base_lab_plan(None),
-                        runner_id,
-                        &source_path,
-                        &["homeboy".to_string()],
-                        request.job_overrides.workspace_root.as_deref(),
-                        Some(run_id.to_string()),
-                        &recipe.normalized_args,
-                        Some(run_id),
-                    )?;
-                (
+    let (source_artifact, workspace) = match SourceArtifactTransfer::from_directory(
+        format!("source-{run_id}"),
+        &source_path,
+    ) {
+        Ok(artifact) => (Some(artifact), None),
+        Err(artifact_error) => {
+            if !source_artifact_exceeds_transfer_bounds(&artifact_error) {
+                return Err(artifact_error);
+            }
+            // Large clean Git worktrees are staged through the existing
+            // controller-routed bundle authority. Non-Git sources retain the
+            // bounded sealed-artifact contract and surface their original
+            // containment/filtering failure.
+            let git_status = std::process::Command::new("git")
+                .args(["status", "--porcelain=v1"])
+                .current_dir(&source_path)
+                .output()
+                .ok()
+                .filter(|output| output.status.success());
+            let Some(git_status) = git_status else {
+                return Err(artifact_error);
+            };
+            if !git_status.stdout.is_empty() {
+                return Err(artifact_error);
+            }
+            let stage = crate::lab::offload::workspace_stage::prepare_lab_offload_workspace_stage(
+                request,
+                crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(
+                    &recipe.command,
+                ),
+                crate::lab_plan::base_lab_plan(None),
+                runner_id,
+                &source_path,
+                &["homeboy".to_string()],
+                request.job_overrides.workspace_root.as_deref(),
+                Some(run_id.to_string()),
+                &recipe.normalized_args,
+                Some(run_id),
+            )?;
+            (
                     None,
                     Some(ControllerWorkspaceMaterialization::new(
                         stage.remote_cwd.clone(),
                         stage.remote_cwd,
                         stage.synced.snapshot_identity,
+                        stage.synced.prepared_workspace_lease.ok_or_else(|| {
+                            Error::internal_unexpected(
+                                "controller-materialized Git workspace did not report its runner lease",
+                            )
+                        })?,
+                        stage.synced.current_workspace.source_commit.ok_or_else(|| {
+                            Error::internal_unexpected(
+                                "controller-materialized Git workspace did not report its source commit",
+                            )
+                        })?,
+                        run_id,
                         canonical_digest(plan)?,
                     )),
                 )
-            }
-        };
+        }
+    };
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,
@@ -1221,6 +1236,35 @@ fn submit_deferred_runner_staging(
         },
     )?;
     Ok(deferred_receipt)
+}
+
+fn source_artifact_exceeds_transfer_bounds(error: &Error) -> bool {
+    let Some(source_package) = error.details.get("source_package") else {
+        return false;
+    };
+    if source_package.get("schema").and_then(Value::as_str)
+        != Some("homeboy/source-package-limit-diagnostic/v1")
+    {
+        return false;
+    }
+    let measured_entries = source_package
+        .pointer("/measured/file_count")
+        .and_then(Value::as_u64);
+    let measured_bytes = source_package
+        .pointer("/measured/bytes")
+        .and_then(Value::as_u64);
+    let entry_limit = source_package
+        .pointer("/limits/entry_limit")
+        .and_then(Value::as_u64);
+    let byte_limit = source_package
+        .pointer("/limits/byte_limit")
+        .and_then(Value::as_u64);
+    let file_byte_limit = source_package
+        .pointer("/limits/file_byte_limit")
+        .and_then(Value::as_u64);
+    matches!((measured_entries, entry_limit), (Some(measured), Some(limit)) if measured > limit)
+        || matches!((measured_bytes, byte_limit), (Some(measured), Some(limit)) if measured > limit)
+        || matches!((measured_bytes, file_byte_limit), (Some(measured), Some(limit)) if measured > limit)
 }
 
 /// A response can be lost after the daemon accepted the request. Create uses
@@ -4482,17 +4526,16 @@ mod tests {
             request.durable_agent_task_plan = Some(&plan);
             request.job_overrides.workspace_root =
                 Some(home.path().join("runner-workspaces").display().to_string());
-            let pre_provider = || {
-                Err(Error::internal_unexpected(
-                    "fixture typed pre-provider daemon admission failure",
-                ))
-            };
             let receipt = submit_detached_staging_with_daemon_ensure(
                 run_id,
                 "lab",
                 crate::RunnerTunnelMode::Reverse,
                 &request,
-                pre_provider,
+                || {
+                    Err(Error::internal_unexpected(
+                        "fixture typed pre-provider daemon admission failure",
+                    ))
+                },
             )
             .expect("admit durable fallback staging");
             let DetachedStagingSubmission::Deferred(receipt) = receipt else {
@@ -4586,7 +4629,87 @@ mod tests {
                     .expect("replay projection"),
                 0
             );
+
+            // A second accepted workspace is replaced after staging but before
+            // its reverse worker consumes the execution receipt. The worker
+            // must reject the changed Git baseline rather than execute it.
+            let tampered_run_id = "authenticated-reverse-staging-tampered-run";
+            submit_recipe_run(tampered_run_id);
+            let tampered_receipt = submit_detached_staging_with_daemon_ensure(
+                tampered_run_id,
+                "lab",
+                crate::RunnerTunnelMode::Reverse,
+                &request,
+                || {
+                    Err(Error::internal_unexpected(
+                        "fixture typed pre-provider daemon admission failure",
+                    ))
+                },
+            )
+            .expect("admit tamper fixture");
+            let DetachedStagingSubmission::Deferred(_) = tampered_receipt else {
+                panic!("typed pre-provider failure must select deferred staging");
+            };
+            let staging_store = homeboy_core::paths::runner_session_file("lab")
+                .expect("session path")
+                .with_file_name("lab-staging/store.json");
+            let staged: Value = serde_json::from_slice(
+                &std::fs::read(staging_store).expect("read runner staging store"),
+            )
+            .expect("parse runner staging store");
+            let remote_cwd = staged
+                .pointer(&format!(
+                    "/stages/{tampered_run_id}/envelope/materialization/workspace/remote_cwd"
+                ))
+                .and_then(Value::as_str)
+                .expect("tampered workspace path");
+            std::fs::write(
+                std::path::Path::new(remote_cwd).join("input.txt"),
+                "replacement",
+            )
+            .expect("replace staged workspace content");
+            let error = crate::run_reverse_worker(crate::ReverseRunnerWorkerOptions {
+                runner_id: "lab".to_string(),
+                broker_url: broker.url().to_string(),
+                broker_token: Some(broker.token().to_string()),
+                project_id: None,
+                lease_ms: 30_000,
+                concurrency_limit: Some(1),
+                loop_mode: false,
+                idle_backoff_ms: 1,
+                max_idle_backoff_ms: 10,
+                broker_failure_backoff_ms: 1,
+                broker_retry_limit: 1,
+            })
+            .expect_err("tampered workspace must be rejected before execution");
+            assert_eq!(
+                error.code,
+                homeboy_core::ErrorCode::ValidationInvalidArgument
+            );
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unsafe_tracked_symlink_is_not_eligible_for_scalable_source_fallback() {
+        let source = tempfile::tempdir().expect("source");
+        assert!(std::process::Command::new("git")
+            .arg("init")
+            .current_dir(source.path())
+            .status()
+            .expect("init")
+            .success());
+        std::os::unix::fs::symlink("/etc/passwd", source.path().join("escape"))
+            .expect("create escape link");
+        assert!(std::process::Command::new("git")
+            .args(["add", "escape"])
+            .current_dir(source.path())
+            .status()
+            .expect("track link")
+            .success());
+        let error = SourceArtifactTransfer::from_directory("unsafe-link", source.path())
+            .expect_err("unsafe link remains terminal");
+        assert!(!source_artifact_exceeds_transfer_bounds(&error));
     }
 
     fn envelope() -> LabStagingDispatchEnvelope {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -4472,7 +4472,7 @@ mod tests {
             // never ask the reverse worker to reach the private origin.
             std::fs::write(
                 source.join("input.txt"),
-                [b"staged-source\n".as_slice(), &vec![b'x'; 4 * 1024 * 1024]].concat(),
+                [b"staged-source\n".as_slice(), &vec![b'x'; 3 * 1024 * 1024]].concat(),
             )
             .expect("write source");
             for args in [

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1187,11 +1187,14 @@ fn submit_deferred_runner_staging(
                 )
         }
     };
-    let handoff = DirectLabHandoffEnvelope::new(
+    let mut handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,
         plan.clone(),
     );
+    if source_artifact.is_some() {
+        handoff.schema = crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA_V1.to_string();
+    }
     let envelope = RemoteRunnerStagingEnvelope::from_direct_handoff(
         &handoff,
         RunnerMaterializationAuthority {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -26,8 +26,8 @@ use homeboy_core::{Error, Result};
 
 use crate::direct_lab_handoff::DirectLabHandoffEnvelope;
 use crate::runner_staging_operation::{
-    RemoteRunnerStagingEnvelope, RunnerMaterializationAuthority, SealedSourceAuthority,
-    SourceArtifactTransfer,
+    ControllerWorkspaceMaterialization, RemoteRunnerStagingEnvelope,
+    RunnerMaterializationAuthority, SealedSourceAuthority, SourceArtifactTransfer,
 };
 use crate::{LabOffloadCommand, LabOffloadRequest};
 
@@ -1126,8 +1126,52 @@ fn submit_deferred_runner_staging(
         )
     })?;
     let digest = format!("sha256:{}", content_hash::sha256_hex(&sealed_payload));
-    let source_artifact =
-        SourceArtifactTransfer::from_directory(format!("source-{run_id}"), &source_path)?;
+    let (source_artifact, workspace) =
+        match SourceArtifactTransfer::from_directory(format!("source-{run_id}"), &source_path) {
+            Ok(artifact) => (Some(artifact), None),
+            Err(artifact_error) => {
+                // Large clean Git worktrees are staged through the existing
+                // controller-routed bundle authority. Non-Git sources retain the
+                // bounded sealed-artifact contract and surface their original
+                // containment/filtering failure.
+                let git_status = std::process::Command::new("git")
+                    .args(["status", "--porcelain=v1"])
+                    .current_dir(&source_path)
+                    .output()
+                    .ok()
+                    .filter(|output| output.status.success());
+                let Some(git_status) = git_status else {
+                    return Err(artifact_error);
+                };
+                if !git_status.stdout.is_empty() {
+                    return Err(artifact_error);
+                }
+                let stage =
+                    crate::lab::offload::workspace_stage::prepare_lab_offload_workspace_stage(
+                        request,
+                        crate::lab::offload::workspace_stage::LabWorkspaceStageCommand::from(
+                            &recipe.command,
+                        ),
+                        crate::lab_plan::base_lab_plan(None),
+                        runner_id,
+                        &source_path,
+                        &["homeboy".to_string()],
+                        request.job_overrides.workspace_root.as_deref(),
+                        Some(run_id.to_string()),
+                        &recipe.normalized_args,
+                        Some(run_id),
+                    )?;
+                (
+                    None,
+                    Some(ControllerWorkspaceMaterialization::new(
+                        stage.remote_cwd.clone(),
+                        stage.remote_cwd,
+                        stage.synced.snapshot_identity,
+                        canonical_digest(plan)?,
+                    )),
+                )
+            }
+        };
     let handoff = DirectLabHandoffEnvelope::new(
         homeboy_product_identity::build_identity().display,
         recipe,
@@ -1146,7 +1190,8 @@ fn submit_deferred_runner_staging(
                     ))
                 })?,
             ),
-            source_artifact: Some(source_artifact),
+            source_artifact,
+            workspace,
         },
     )?;
     let mut transport =
@@ -4375,12 +4420,50 @@ mod tests {
 
             let source = home.path().join("source");
             std::fs::create_dir_all(&source).expect("create source");
-            std::fs::write(source.join("input.txt"), "staged-source\n").expect("write source");
+            // Exceed the sealed artifact bound with a clean Git worktree. The
+            // deferred controller must stage this through its Git authority,
+            // never ask the reverse worker to reach the private origin.
+            std::fs::write(
+                source.join("input.txt"),
+                [b"staged-source\n".as_slice(), &vec![b'x'; 4 * 1024 * 1024]].concat(),
+            )
+            .expect("write source");
+            for args in [
+                vec!["init"],
+                vec!["config", "user.email", "fixture@example.test"],
+                vec!["config", "user.name", "Fixture"],
+                vec!["add", "input.txt"],
+                vec!["commit", "-m", "fixture"],
+            ] {
+                assert!(std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(&source)
+                    .status()
+                    .expect("run git")
+                    .success());
+            }
+            let origin = home.path().join("origin.git");
+            assert!(std::process::Command::new("git")
+                .args(["init", "--bare", origin.to_str().expect("origin path")])
+                .status()
+                .expect("create origin")
+                .success());
+            assert!(std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    origin.to_str().expect("origin path")
+                ])
+                .current_dir(&source)
+                .status()
+                .expect("set origin")
+                .success());
             let output = home.path().join("worker-output.txt");
             let args = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("cat input.txt | tee {}", output.display()),
+                format!("grep -o staged-source input.txt | tee {}", output.display()),
             ];
             let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
                 "authenticated-reverse-staging",
@@ -4397,6 +4480,8 @@ mod tests {
                 );
             request.source_path = Some(&source);
             request.durable_agent_task_plan = Some(&plan);
+            request.job_overrides.workspace_root =
+                Some(home.path().join("runner-workspaces").display().to_string());
             let pre_provider = || {
                 Err(Error::internal_unexpected(
                     "fixture typed pre-provider daemon admission failure",
@@ -4452,6 +4537,27 @@ mod tests {
                 .get(uuid::Uuid::parse_str(&job_id).expect("job id"))
                 .expect("broker job");
             assert_eq!(job.status, JobStatus::Succeeded);
+            let staging_store = homeboy_core::paths::runner_session_file("lab")
+                .expect("session path")
+                .with_file_name("lab-staging/store.json");
+            let staged: Value = serde_json::from_slice(
+                &std::fs::read(staging_store).expect("read runner staging store"),
+            )
+            .expect("parse runner staging store");
+            let workspace = staged
+                .pointer(&format!(
+                    "/stages/{run_id}/envelope/materialization/workspace"
+                ))
+                .expect("controller-routed workspace materialization");
+            assert!(workspace.get("source_snapshot_id").is_some());
+            assert!(
+                staged
+                    .pointer(&format!(
+                        "/stages/{run_id}/envelope/materialization/source_artifact"
+                    ))
+                    .is_none(),
+                "over-bound Git source must not cross the bounded artifact channel"
+            );
             let results = broker.store.events(job.id).expect("terminal evidence");
             assert_eq!(
                 results

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -22,8 +22,10 @@ use homeboy_engine_primitives::content_hash;
 
 use crate::direct_lab_handoff::{DirectLabHandoffEnvelope, DirectLabHandoffReceipt};
 
+pub const REMOTE_RUNNER_STAGING_SCHEMA_V1: &str = "homeboy/remote-runner-staging/v1";
 pub const REMOTE_RUNNER_STAGING_SCHEMA: &str = "homeboy/remote-runner-staging/v2";
 pub const REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA: &str = "homeboy/remote-runner-staging-receipt/v1";
+pub const REMOTE_RUNNER_STAGING_CAPABILITY_V1: &str = "remote-runner-staging/v1";
 pub const REMOTE_RUNNER_STAGING_CAPABILITY: &str = "remote-runner-staging/v2";
 pub const REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY: &str =
     "remote-runner-source-materialization/v2";
@@ -1717,7 +1719,11 @@ impl RemoteRunnerStagingEnvelope {
         let mut handoff = handoff.clone();
         handoff.recipe.source_path = None;
         let envelope = Self {
-            schema: REMOTE_RUNNER_STAGING_SCHEMA.to_string(),
+            schema: if handoff.schema == crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA_V1 {
+                REMOTE_RUNNER_STAGING_SCHEMA_V1.to_string()
+            } else {
+                REMOTE_RUNNER_STAGING_SCHEMA.to_string()
+            },
             handoff,
             materialization,
         };
@@ -1726,9 +1732,15 @@ impl RemoteRunnerStagingEnvelope {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.schema != REMOTE_RUNNER_STAGING_SCHEMA
-            || self.handoff.recipe.source_path.is_some()
-            || self.handoff.schema != crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA
+        if !matches!(
+            self.schema.as_str(),
+            REMOTE_RUNNER_STAGING_SCHEMA_V1 | REMOTE_RUNNER_STAGING_SCHEMA
+        ) || self.handoff.recipe.source_path.is_some()
+            || !matches!(
+                self.handoff.schema.as_str(),
+                crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA_V1
+                    | crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA
+            )
             || self.handoff.run_id.trim().is_empty()
             || self.handoff.runner_id.trim().is_empty()
             || self.handoff.idempotency_key != self.handoff.run_id
@@ -1746,6 +1758,18 @@ impl RemoteRunnerStagingEnvelope {
         }
         self.handoff.recipe.validate_for_runner_staging()?;
         self.materialization.validate()?;
+        if self.schema == REMOTE_RUNNER_STAGING_SCHEMA_V1
+            && (self.handoff.schema != crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA_V1
+                || self.materialization.source_artifact.is_none()
+                || self.materialization.workspace.is_some())
+        {
+            return Err(Error::validation_invalid_argument(
+                "remote_runner_staging",
+                "v1 staging accepts bounded source artifacts only",
+                Some(self.handoff.run_id.clone()),
+                None,
+            ));
+        }
         if let Some(workspace) = &self.materialization.workspace {
             let plan = canonical_json_bytes(&self.handoff.durable_plan).map_err(|error| {
                 Error::internal_json(
@@ -1851,15 +1875,22 @@ pub fn submit_remote_runner_staging(
             None,
         ));
     }
-    if !transport.supports_capability(REMOTE_RUNNER_STAGING_CAPABILITY) {
+    let staging_capability = if envelope.schema == REMOTE_RUNNER_STAGING_SCHEMA_V1 {
+        REMOTE_RUNNER_STAGING_CAPABILITY_V1
+    } else {
+        REMOTE_RUNNER_STAGING_CAPABILITY
+    };
+    if !transport.supports_capability(staging_capability) {
         return Err(Error::runner_capability_missing(
             &envelope.handoff.runner_id,
             "sealed runner staging",
-            vec![REMOTE_RUNNER_STAGING_CAPABILITY.to_string()],
+            vec![staging_capability.to_string()],
             Vec::new(),
         ));
     }
-    if !transport.supports_capability(REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY) {
+    if envelope.materialization.workspace.is_some()
+        && !transport.supports_capability(REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY)
+    {
         return Err(Error::runner_capability_missing(
             &envelope.handoff.runner_id,
             "versioned runner source materialization",
@@ -1920,7 +1951,11 @@ pub(crate) mod tests_support {
             self.connected
         }
         fn supports_capability(&self, capability: &str) -> bool {
-            (self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY)
+            (self.compatible
+                && matches!(
+                    capability,
+                    REMOTE_RUNNER_STAGING_CAPABILITY | REMOTE_RUNNER_STAGING_CAPABILITY_V1
+                ))
                 || (self.compatible
                     && capability == REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY)
                 || (self.source_artifact_compatible
@@ -2114,6 +2149,17 @@ pub(crate) mod tests_support {
                 .remote_cwd,
             "/runner/workspaces/run-1"
         );
+    }
+
+    #[test]
+    fn bounded_artifact_v1_interoperates_with_a_new_runner() {
+        let mut envelope = envelope();
+        envelope.handoff.schema =
+            crate::direct_lab_handoff::DIRECT_LAB_HANDOFF_SCHEMA_V1.to_string();
+        envelope.schema = REMOTE_RUNNER_STAGING_SCHEMA_V1.to_string();
+        let receipt = submit_remote_runner_staging(&mut transport(), &envelope)
+            .expect("new runner accepts old bounded staging");
+        assert!(receipt.artifacts.source_artifact.is_some());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -33,7 +33,10 @@ pub const MAX_SOURCE_ARTIFACT_BYTES: u64 = 4 * 1024 * 1024;
 pub const MAX_SOURCE_PACKAGE_ENTRIES: usize = 1024;
 pub const MAX_SOURCE_PACKAGE_FILE_BYTES: u64 = 1024 * 1024;
 pub const MAX_SOURCE_PACKAGE_EXCLUSIONS: usize = 1024;
+/// Legacy result schema accepted for persisted source-package checks.
 pub const SOURCE_PACKAGE_CHECK_SCHEMA: &str = "homeboy/source-package-check/v1";
+pub const SOURCE_PACKAGE_CHECK_SCHEMA_V2: &str = "homeboy/source-package-check/v2";
+const SOURCE_PACKAGE_LIMIT_DIAGNOSTIC_SCHEMA: &str = "homeboy/source-package-limit-diagnostic/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -59,7 +62,9 @@ pub struct SourcePackageFailure {
 pub struct SourcePackageCheckVerdict {
     pub schema: String,
     pub valid: bool,
-    pub limits: SourcePackageLimits,
+    /// Present for v2 results. V1 records did not declare aggregate limits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limits: Option<SourcePackageLimits>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted: Option<SourcePackageAccepted>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -134,9 +139,9 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
                 .sum();
             return SourcePackageScan {
                 verdict: SourcePackageCheckVerdict {
-                    schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
+                    schema: SOURCE_PACKAGE_CHECK_SCHEMA_V2.to_string(),
                     valid: true,
-                    limits: source_package_limits(),
+                    limits: Some(source_package_limits()),
                     accepted: Some(SourcePackageAccepted {
                         package_format: transfer.package.format,
                         file_count,
@@ -153,9 +158,9 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
         Err(error) => {
             return SourcePackageScan {
                 verdict: SourcePackageCheckVerdict {
-                    schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
+                    schema: SOURCE_PACKAGE_CHECK_SCHEMA_V2.to_string(),
                     valid: false,
-                    limits: source_package_limits(),
+                    limits: Some(source_package_limits()),
                     accepted: None,
                     partial: source_package_partial_from_error(&error).or(Some(
                         SourcePackagePartial {
@@ -431,9 +436,9 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
         });
         SourcePackageScan {
             verdict: SourcePackageCheckVerdict {
-                schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
+                schema: SOURCE_PACKAGE_CHECK_SCHEMA_V2.to_string(),
                 valid: failures.is_empty(),
-                limits: source_package_limits(),
+                limits: Some(source_package_limits()),
                 accepted,
                 partial: (!failures.is_empty()).then_some(SourcePackagePartial {
                     file_count,
@@ -575,7 +580,7 @@ fn source_package_limit_error(
         ]),
     );
     error.details["source_package"] = json!({
-        "schema": SOURCE_PACKAGE_CHECK_SCHEMA,
+        "schema": SOURCE_PACKAGE_LIMIT_DIAGNOSTIC_SCHEMA,
         "measured": measured,
         "limits": limits,
         "excluded_path_policy": {
@@ -2380,7 +2385,10 @@ pub(crate) mod tests_support {
                 .contains("homeboy source package check --path")
         );
         let verdict = scan_source_package(source.path()).verdict;
-        assert_eq!(verdict.limits.entry_limit, MAX_SOURCE_PACKAGE_ENTRIES);
+        assert_eq!(
+            verdict.limits.expect("v2 limits").entry_limit,
+            MAX_SOURCE_PACKAGE_ENTRIES
+        );
         assert_eq!(
             verdict.partial.expect("partial measurement").file_count,
             MAX_SOURCE_PACKAGE_ENTRIES + 1
@@ -2414,6 +2422,45 @@ pub(crate) mod tests_support {
                 .as_array()
                 .expect("contributors")[0]["path"],
             "0000"
+        );
+    }
+
+    #[test]
+    fn source_package_check_v1_round_trips_without_v2_limits() {
+        let legacy = json!({
+            "schema": SOURCE_PACKAGE_CHECK_SCHEMA,
+            "valid": false,
+            "partial": {"file_count": 3, "bytes": 12},
+            "excluded": [],
+            "blocked": []
+        });
+
+        let verdict: SourcePackageCheckVerdict =
+            serde_json::from_value(legacy).expect("deserialize v1 check");
+        assert_eq!(verdict.schema, SOURCE_PACKAGE_CHECK_SCHEMA);
+        assert!(verdict.limits.is_none());
+        let serialized = serde_json::to_value(&verdict).expect("serialize v1 check");
+        assert!(serialized.get("limits").is_none());
+        assert_eq!(
+            serialized["partial"]["largest_entries"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn source_package_check_v2_round_trips_with_limits() {
+        let verdict = scan_source_package(tempfile::tempdir().expect("source").path()).verdict;
+        assert_eq!(verdict.schema, SOURCE_PACKAGE_CHECK_SCHEMA_V2);
+        assert_eq!(
+            verdict.limits.as_ref().expect("v2 limits").byte_limit,
+            MAX_SOURCE_ARTIFACT_BYTES
+        );
+        assert_eq!(
+            serde_json::from_value::<SourcePackageCheckVerdict>(
+                serde_json::to_value(&verdict).expect("serialize v2 check")
+            )
+            .expect("deserialize v2 check"),
+            verdict
         );
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -729,7 +729,10 @@ mod source_directory {
 
     use homeboy_core::{Error, Result};
 
-    use super::MAX_SOURCE_PACKAGE_FILE_BYTES;
+    use super::{
+        MAX_SOURCE_ARTIFACT_BYTES, MAX_SOURCE_PACKAGE_ENTRIES, MAX_SOURCE_PACKAGE_FILE_BYTES,
+        SOURCE_PACKAGE_LIMIT_DIAGNOSTIC_SCHEMA,
+    };
 
     #[cfg(any(
         target_os = "macos",
@@ -911,13 +914,32 @@ mod source_directory {
         let metadata = file.metadata().map_err(|error| {
             Error::internal_io(error.to_string(), Some(name.to_string_lossy().into_owned()))
         })?;
-        if !metadata.is_file() || metadata.len() > MAX_SOURCE_PACKAGE_FILE_BYTES {
+        if !metadata.is_file() {
             return Err(Error::validation_invalid_argument(
                 "source_path",
-                "source package file must remain a bounded regular file when opened",
+                "source package file must remain a regular file when opened",
                 Some(name.to_string_lossy().into_owned()),
                 None,
             ));
+        }
+        if metadata.len() > MAX_SOURCE_PACKAGE_FILE_BYTES {
+            let mut error = Error::validation_invalid_argument(
+                "source_path",
+                "source package file exceeds the configured size bound",
+                Some(name.to_string_lossy().into_owned()),
+                None,
+            );
+            error.details["source_package"] = serde_json::json!({
+                "schema": SOURCE_PACKAGE_LIMIT_DIAGNOSTIC_SCHEMA,
+                "measured": { "file_count": 1, "bytes": metadata.len(), "largest_entries": [] },
+                "limits": {
+                    "entry_limit": MAX_SOURCE_PACKAGE_ENTRIES,
+                    "byte_limit": MAX_SOURCE_ARTIFACT_BYTES,
+                    "file_byte_limit": MAX_SOURCE_PACKAGE_FILE_BYTES,
+                    "exclusion_limit": super::MAX_SOURCE_PACKAGE_EXCLUSIONS,
+                },
+            });
+            return Err(error);
         }
         let mut bytes = Vec::with_capacity(metadata.len() as usize);
         file.take(MAX_SOURCE_PACKAGE_FILE_BYTES + 1)
@@ -1592,6 +1614,9 @@ pub struct ControllerWorkspaceMaterialization {
     pub workspace_id: String,
     pub remote_cwd: String,
     pub source_snapshot_id: String,
+    pub workspace_lease: String,
+    pub source_commit: String,
+    pub run_id: String,
     pub durable_plan_digest: String,
 }
 
@@ -1603,6 +1628,9 @@ impl ControllerWorkspaceMaterialization {
         workspace_id: impl Into<String>,
         remote_cwd: impl Into<String>,
         source_snapshot_id: impl Into<String>,
+        workspace_lease: impl Into<String>,
+        source_commit: impl Into<String>,
+        run_id: impl Into<String>,
         durable_plan_digest: impl Into<String>,
     ) -> Self {
         Self {
@@ -1610,6 +1638,9 @@ impl ControllerWorkspaceMaterialization {
             workspace_id: workspace_id.into(),
             remote_cwd: remote_cwd.into(),
             source_snapshot_id: source_snapshot_id.into(),
+            workspace_lease: workspace_lease.into(),
+            source_commit: source_commit.into(),
+            run_id: run_id.into(),
             durable_plan_digest: durable_plan_digest.into(),
         }
     }
@@ -1619,6 +1650,13 @@ impl ControllerWorkspaceMaterialization {
             || self.workspace_id.trim().is_empty()
             || self.remote_cwd.trim().is_empty()
             || self.source_snapshot_id.trim().is_empty()
+            || self.workspace_lease.trim().is_empty()
+            || self.source_commit.len() != 40
+            || !self
+                .source_commit
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            || self.run_id.trim().is_empty()
             || !self.durable_plan_digest.starts_with("sha256:")
         {
             return Err(Error::validation_invalid_argument(
@@ -2059,6 +2097,9 @@ pub(crate) mod tests_support {
             "runner-workspace-1",
             "/runner/workspaces/run-1",
             "git:abc123",
+            "workspace:lease-1",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "run-1",
             durable_plan_digest,
         ));
         let receipt = submit_remote_runner_staging(&mut transport(), &envelope)

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -1301,6 +1301,23 @@ impl SourceArtifactTransfer {
                     entries,
                 },
             };
+            // The HTTP envelope carries Base64, not raw package bytes. Keep the
+            // inline transport bound truthful and route its overflow through
+            // the same typed scalable-materialization decision.
+            if transfer.content_base64.len() as u64 > MAX_SOURCE_ARTIFACT_BYTES {
+                let mut error = Error::validation_invalid_argument(
+                    "source_path",
+                    "source package exceeds the encoded inline transfer bound",
+                    Some(root.display().to_string()),
+                    None,
+                );
+                error.details["source_package"] = json!({
+                    "schema": SOURCE_PACKAGE_LIMIT_DIAGNOSTIC_SCHEMA,
+                    "measured": { "file_count": transfer.package.entries.len(), "bytes": transfer.content_base64.len(), "largest_entries": [] },
+                    "limits": { "entry_limit": MAX_SOURCE_PACKAGE_ENTRIES, "byte_limit": MAX_SOURCE_ARTIFACT_BYTES, "file_byte_limit": MAX_SOURCE_PACKAGE_FILE_BYTES, "exclusion_limit": MAX_SOURCE_PACKAGE_EXCLUSIONS }
+                });
+                return Err(error);
+            }
             transfer.decode_verified()?;
             Ok((transfer, exclusions))
         }

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -16,13 +16,17 @@ use std::path::{Component, Path};
 #[cfg(unix)]
 use std::process::Command;
 
+use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use homeboy_core::{Error, Result};
+use homeboy_engine_primitives::content_hash;
 
 use crate::direct_lab_handoff::{DirectLabHandoffEnvelope, DirectLabHandoffReceipt};
 
-pub const REMOTE_RUNNER_STAGING_SCHEMA: &str = "homeboy/remote-runner-staging/v1";
+pub const REMOTE_RUNNER_STAGING_SCHEMA: &str = "homeboy/remote-runner-staging/v2";
 pub const REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA: &str = "homeboy/remote-runner-staging-receipt/v1";
-pub const REMOTE_RUNNER_STAGING_CAPABILITY: &str = "remote-runner-staging/v1";
+pub const REMOTE_RUNNER_STAGING_CAPABILITY: &str = "remote-runner-staging/v2";
+pub const REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY: &str =
+    "remote-runner-source-materialization/v2";
 pub const REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY: &str = "remote-runner-source-artifact/v1";
 pub const REMOTE_RUNNER_SOURCE_ARTIFACT_SYMLINK_CAPABILITY: &str =
     "remote-runner-source-artifact/v2";
@@ -1574,6 +1578,58 @@ pub struct RunnerMaterializationAuthority {
     pub source: SealedSourceAuthority,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_artifact: Option<SourceArtifactTransfer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<ControllerWorkspaceMaterialization>,
+}
+
+/// A controller-routed workspace has already crossed the controller-to-runner
+/// boundary. It identifies the runner-owned execution target without exporting
+/// controller paths or reopening the runner's private Git-origin access.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerWorkspaceMaterialization {
+    pub schema: String,
+    pub workspace_id: String,
+    pub remote_cwd: String,
+    pub source_snapshot_id: String,
+    pub durable_plan_digest: String,
+}
+
+pub const CONTROLLER_WORKSPACE_MATERIALIZATION_SCHEMA: &str =
+    "homeboy/controller-workspace-materialization/v1";
+
+impl ControllerWorkspaceMaterialization {
+    pub fn new(
+        workspace_id: impl Into<String>,
+        remote_cwd: impl Into<String>,
+        source_snapshot_id: impl Into<String>,
+        durable_plan_digest: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema: CONTROLLER_WORKSPACE_MATERIALIZATION_SCHEMA.to_string(),
+            workspace_id: workspace_id.into(),
+            remote_cwd: remote_cwd.into(),
+            source_snapshot_id: source_snapshot_id.into(),
+            durable_plan_digest: durable_plan_digest.into(),
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != CONTROLLER_WORKSPACE_MATERIALIZATION_SCHEMA
+            || self.workspace_id.trim().is_empty()
+            || self.remote_cwd.trim().is_empty()
+            || self.source_snapshot_id.trim().is_empty()
+            || !self.durable_plan_digest.starts_with("sha256:")
+        {
+            return Err(Error::validation_invalid_argument(
+                "controller_workspace_materialization",
+                "remote staging requires a v1 runner workspace target, source identity, and durable-plan digest",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl RunnerMaterializationAuthority {
@@ -1591,18 +1647,16 @@ impl RunnerMaterializationAuthority {
             ));
         }
         self.source.validate()?;
-        self.source_artifact
-            .as_ref()
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "source_artifact",
-                    "remote staging requires a transferable source artifact before admission",
-                    Some(self.authority_id.clone()),
-                    None,
-                )
-            })?
-            .decode_verified()
-            .map(|_| ())
+        match (&self.source_artifact, &self.workspace) {
+            (Some(artifact), None) => artifact.decode_verified().map(|_| ()),
+            (None, Some(workspace)) => workspace.validate(),
+            _ => Err(Error::validation_invalid_argument(
+                "source_materialization",
+                "remote staging requires exactly one bounded source artifact or controller-materialized workspace",
+                Some(self.authority_id.clone()),
+                None,
+            )),
+        }
     }
 }
 
@@ -1647,13 +1701,32 @@ impl RemoteRunnerStagingEnvelope {
         {
             return Err(Error::validation_invalid_argument(
                 "remote_runner_staging",
-                "remote staging requires its v1 schema, bound handoff identities, and no controller-local source path",
+                "remote staging requires its v2 schema, bound handoff identities, and no controller-local source path",
                 Some(self.handoff.run_id.clone()),
                 None,
             ));
         }
         self.handoff.recipe.validate_for_runner_staging()?;
-        self.materialization.validate()
+        self.materialization.validate()?;
+        if let Some(workspace) = &self.materialization.workspace {
+            let plan = canonical_json_bytes(&self.handoff.durable_plan).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("canonicalize staged durable plan".to_string()),
+                )
+            })?;
+            if workspace.durable_plan_digest
+                != format!("sha256:{}", content_hash::sha256_hex(&plan))
+            {
+                return Err(Error::validation_invalid_argument(
+                    "controller_workspace_materialization.durable_plan_digest",
+                    "controller-materialized workspace is not bound to this durable plan",
+                    Some(self.handoff.run_id.clone()),
+                    None,
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1692,18 +1765,21 @@ impl RemoteRunnerStagingReceipt {
                 None,
             ));
         }
-        self.artifacts
-            .source_artifact
-            .as_ref()
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "remote_runner_staging_receipt.source_artifact",
-                    "remote staging receipt is missing its immutable source artifact",
+        match (
+            &self.artifacts.source_artifact,
+            &envelope.materialization.workspace,
+        ) {
+            (Some(artifact), None) => artifact.validate()?,
+            (None, Some(_)) => {}
+            _ => {
+                return Err(Error::validation_invalid_argument(
+                    "remote_runner_staging_receipt.source_materialization",
+                    "remote staging receipt does not match its accepted source materialization",
                     Some(envelope.handoff.run_id.clone()),
                     None,
-                )
-            })?
-            .validate()?;
+                ));
+            }
+        }
         self.handoff.validate_for(&envelope.handoff)
     }
 }
@@ -1745,7 +1821,17 @@ pub fn submit_remote_runner_staging(
             Vec::new(),
         ));
     }
-    if !transport.supports_capability(REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY) {
+    if !transport.supports_capability(REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY) {
+        return Err(Error::runner_capability_missing(
+            &envelope.handoff.runner_id,
+            "versioned runner source materialization",
+            vec![REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string()],
+            Vec::new(),
+        ));
+    }
+    if envelope.materialization.source_artifact.is_some()
+        && !transport.supports_capability(REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY)
+    {
         return Err(Error::runner_capability_missing(
             &envelope.handoff.runner_id,
             "sealed runner source artifact transfer",
@@ -1797,6 +1883,8 @@ pub(crate) mod tests_support {
         }
         fn supports_capability(&self, capability: &str) -> bool {
             (self.compatible && capability == REMOTE_RUNNER_STAGING_CAPABILITY)
+                || (self.compatible
+                    && capability == REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY)
                 || (self.source_artifact_compatible
                     && capability == REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY)
                 || (self.symlink_artifact_compatible
@@ -1903,6 +1991,7 @@ pub(crate) mod tests_support {
                     "source-package-1",
                     b"source package",
                 )),
+                workspace: None,
             },
         )
         .expect("sealed envelope")
@@ -1954,6 +2043,36 @@ pub(crate) mod tests_support {
         assert!(submit_remote_runner_staging(&mut disconnected, &envelope).is_err());
         assert_eq!(disconnected.calls, 0);
         assert_eq!(disconnected.provider_budget, 0);
+    }
+
+    #[test]
+    fn controller_materialized_workspace_is_accepted_without_source_bytes() {
+        let mut envelope = envelope();
+        let durable_plan_digest = format!(
+            "sha256:{}",
+            content_hash::sha256_hex(
+                &canonical_json_bytes(&envelope.handoff.durable_plan).expect("canonical plan"),
+            )
+        );
+        envelope.materialization.source_artifact = None;
+        envelope.materialization.workspace = Some(ControllerWorkspaceMaterialization::new(
+            "runner-workspace-1",
+            "/runner/workspaces/run-1",
+            "git:abc123",
+            durable_plan_digest,
+        ));
+        let receipt = submit_remote_runner_staging(&mut transport(), &envelope)
+            .expect("accept controller-materialized source");
+        assert!(receipt.artifacts.source_artifact.is_none());
+        assert_eq!(
+            envelope
+                .materialization
+                .workspace
+                .as_ref()
+                .expect("workspace")
+                .remote_cwd,
+            "/runner/workspaces/run-1"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runner_staging_operation.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_operation.rs
@@ -7,6 +7,7 @@
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 #[cfg(unix)]
@@ -58,6 +59,7 @@ pub struct SourcePackageFailure {
 pub struct SourcePackageCheckVerdict {
     pub schema: String,
     pub valid: bool,
+    pub limits: SourcePackageLimits,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted: Option<SourcePackageAccepted>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,6 +81,26 @@ pub struct SourcePackageAccepted {
 #[serde(deny_unknown_fields)]
 pub struct SourcePackagePartial {
     pub file_count: usize,
+    pub bytes: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub largest_entries: Vec<SourcePackageContributor>,
+}
+
+/// The fixed safety bounds applied by sealed source-artifact staging.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourcePackageLimits {
+    pub entry_limit: usize,
+    pub byte_limit: u64,
+    pub file_byte_limit: u64,
+    pub exclusion_limit: usize,
+}
+
+/// A bounded, deterministic sample of entries consuming the package budget.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourcePackageContributor {
+    pub path: String,
     pub bytes: u64,
 }
 
@@ -114,6 +136,7 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
                 verdict: SourcePackageCheckVerdict {
                     schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
                     valid: true,
+                    limits: source_package_limits(),
                     accepted: Some(SourcePackageAccepted {
                         package_format: transfer.package.format,
                         file_count,
@@ -132,11 +155,15 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
                 verdict: SourcePackageCheckVerdict {
                     schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
                     valid: false,
+                    limits: source_package_limits(),
                     accepted: None,
-                    partial: Some(SourcePackagePartial {
-                        file_count: 0,
-                        bytes: 0,
-                    }),
+                    partial: source_package_partial_from_error(&error).or(Some(
+                        SourcePackagePartial {
+                            file_count: 0,
+                            bytes: 0,
+                            largest_entries: Vec::new(),
+                        },
+                    )),
                     excluded: Vec::new(),
                     blocked: vec![SourcePackageFailure {
                         kind: "source_package".to_string(),
@@ -406,9 +433,13 @@ pub fn scan_source_package(root: &Path) -> SourcePackageScan {
             verdict: SourcePackageCheckVerdict {
                 schema: SOURCE_PACKAGE_CHECK_SCHEMA.to_string(),
                 valid: failures.is_empty(),
+                limits: source_package_limits(),
                 accepted,
-                partial: (!failures.is_empty())
-                    .then_some(SourcePackagePartial { file_count, bytes }),
+                partial: (!failures.is_empty()).then_some(SourcePackagePartial {
+                    file_count,
+                    bytes,
+                    largest_entries: source_package_contributors(&payloads),
+                }),
                 excluded: exclusions,
                 blocked: failures,
             },
@@ -464,6 +495,100 @@ impl SourcePackagePayload {
             Self::Symlink { target } => target.len() as u64,
         }
     }
+}
+
+fn source_package_limits() -> SourcePackageLimits {
+    SourcePackageLimits {
+        entry_limit: MAX_SOURCE_PACKAGE_ENTRIES,
+        byte_limit: MAX_SOURCE_ARTIFACT_BYTES,
+        file_byte_limit: MAX_SOURCE_PACKAGE_FILE_BYTES,
+        exclusion_limit: MAX_SOURCE_PACKAGE_EXCLUSIONS,
+    }
+}
+
+fn source_package_contributors(
+    payloads: &BTreeMap<String, SourcePackagePayload>,
+) -> Vec<SourcePackageContributor> {
+    let mut entries = payloads
+        .iter()
+        .map(|(path, payload)| SourcePackageContributor {
+            path: path.clone(),
+            bytes: payload.size_bytes(),
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        right
+            .bytes
+            .cmp(&left.bytes)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    entries.truncate(5);
+    entries
+}
+
+fn source_package_partial(
+    payloads: &BTreeMap<String, SourcePackagePayload>,
+) -> SourcePackagePartial {
+    SourcePackagePartial {
+        file_count: payloads.len(),
+        bytes: payloads
+            .values()
+            .map(SourcePackagePayload::size_bytes)
+            .sum(),
+        largest_entries: source_package_contributors(payloads),
+    }
+}
+
+fn source_package_partial_from_error(error: &Error) -> Option<SourcePackagePartial> {
+    serde_json::from_value(
+        error
+            .details
+            .get("source_package")?
+            .get("measured")?
+            .clone(),
+    )
+    .ok()
+}
+
+fn source_package_limit_error(
+    root: &Path,
+    payloads: &BTreeMap<String, SourcePackagePayload>,
+) -> Error {
+    let measured = source_package_partial(payloads);
+    let limits = source_package_limits();
+    let check_command = format!(
+        "homeboy source package check --path {}",
+        homeboy_core::engine::shell::quote_arg(&root.display().to_string())
+    );
+    let retry = "Retry the original Lab command after reducing the source package or selecting a Git-capable Lab route.";
+    let mut error = Error::validation_invalid_argument(
+        "source_path",
+        format!(
+            "source package exceeds configured bounds: measured {} entries / {} bytes; limits {} entries / {} bytes",
+            measured.file_count, measured.bytes, limits.entry_limit, limits.byte_limit,
+        ),
+        Some(root.display().to_string()),
+        Some(vec![
+            format!("Inspect the exact package budget and excluded paths: {check_command}"),
+            "Remove generated or vendored files from the source worktree before retrying; `.git` and untracked symlinks are excluded automatically.".to_string(),
+            retry.to_string(),
+        ]),
+    );
+    error.details["source_package"] = json!({
+        "schema": SOURCE_PACKAGE_CHECK_SCHEMA,
+        "measured": measured,
+        "limits": limits,
+        "excluded_path_policy": {
+            "excluded": [".git", "untracked_symlink"],
+            "tracked_symlinks": "included only when their relative target remains inside the source root"
+        },
+        "continuation": {
+            "preflight_command": check_command,
+            "retry": retry,
+            "scalable_transport": "Git workspace materialization is selected automatically for eligible clean repository worktrees."
+        }
+    });
+    error
 }
 
 fn source_package_format(payloads: &BTreeMap<String, SourcePackagePayload>) -> &'static str {
@@ -909,6 +1034,7 @@ impl SourceArtifactTransfer {
             }
             #[cfg(unix)]
             fn collect(
+                root: &Path,
                 directory: &std::fs::File,
                 relative_directory: &str,
                 tracked_links: &BTreeSet<String>,
@@ -974,11 +1100,20 @@ impl SourceArtifactTransfer {
                                     target: verdict.target,
                                 },
                             );
+                            if entries.len() > MAX_SOURCE_PACKAGE_ENTRIES
+                                || entries
+                                    .values()
+                                    .map(SourcePackagePayload::size_bytes)
+                                    .sum::<u64>()
+                                    > MAX_SOURCE_ARTIFACT_BYTES
+                            {
+                                return Err(source_package_limit_error(root, entries));
+                            }
                             continue;
                         }
                         libc::S_IFDIR => {
                             let child = source_directory::open_directory_at(directory, &name)?;
-                            collect(&child, &relative, tracked_links, entries, exclusions)?;
+                            collect(root, &child, &relative, tracked_links, entries, exclusions)?;
                         }
                         libc::S_IFREG => {
                             let bytes = source_directory::read_regular_file_at(directory, &name)?;
@@ -1013,12 +1148,7 @@ impl SourceArtifactTransfer {
                             .sum::<u64>()
                             > MAX_SOURCE_ARTIFACT_BYTES
                     {
-                        return Err(Error::validation_invalid_argument(
-                            "source_path",
-                            "source package exceeds configured entry or total size bounds",
-                            None,
-                            None,
-                        ));
+                        return Err(source_package_limit_error(root, entries));
                     }
                 }
                 Ok(())
@@ -1045,6 +1175,7 @@ impl SourceArtifactTransfer {
             let mut exclusions = Vec::new();
             #[cfg(unix)]
             collect(
+                root,
                 &root_directory,
                 "",
                 &tracked_links,
@@ -2196,9 +2327,93 @@ pub(crate) mod tests_support {
         assert_eq!(
             verdict.partial,
             Some(SourcePackagePartial {
-                file_count: 0,
+                file_count: MAX_SOURCE_PACKAGE_ENTRIES + 1,
                 bytes: 0,
+                largest_entries: vec![
+                    SourcePackageContributor {
+                        path: "a/0000".to_string(),
+                        bytes: 0,
+                    },
+                    SourcePackageContributor {
+                        path: "a/0001".to_string(),
+                        bytes: 0,
+                    },
+                    SourcePackageContributor {
+                        path: "a/0002".to_string(),
+                        bytes: 0,
+                    },
+                    SourcePackageContributor {
+                        path: "a/0003".to_string(),
+                        bytes: 0,
+                    },
+                    SourcePackageContributor {
+                        path: "a/0004".to_string(),
+                        bytes: 0,
+                    },
+                ],
             })
+        );
+    }
+
+    #[test]
+    fn source_package_entry_limit_reports_measured_values_limits_and_continuation() {
+        let source = tempfile::tempdir().expect("source");
+        for index in 0..=MAX_SOURCE_PACKAGE_ENTRIES {
+            std::fs::write(source.path().join(format!("{index:04}")), b"x").expect("file");
+        }
+
+        let error = SourceArtifactTransfer::from_directory("source-1", source.path())
+            .expect_err("entry limit");
+        assert!(error.message.contains("1025 entries / 1025 bytes"));
+        assert_eq!(
+            error.details["source_package"]["measured"]["file_count"],
+            MAX_SOURCE_PACKAGE_ENTRIES + 1
+        );
+        assert_eq!(
+            error.details["source_package"]["limits"]["entry_limit"],
+            MAX_SOURCE_PACKAGE_ENTRIES
+        );
+        assert!(
+            error.details["source_package"]["continuation"]["preflight_command"]
+                .as_str()
+                .expect("preflight command")
+                .contains("homeboy source package check --path")
+        );
+        let verdict = scan_source_package(source.path()).verdict;
+        assert_eq!(verdict.limits.entry_limit, MAX_SOURCE_PACKAGE_ENTRIES);
+        assert_eq!(
+            verdict.partial.expect("partial measurement").file_count,
+            MAX_SOURCE_PACKAGE_ENTRIES + 1
+        );
+    }
+
+    #[test]
+    fn source_package_byte_limit_reports_measured_values_limits_and_contributors() {
+        let source = tempfile::tempdir().expect("source");
+        for index in 0..4 {
+            std::fs::write(
+                source.path().join(format!("{index:04}")),
+                vec![b'x'; MAX_SOURCE_PACKAGE_FILE_BYTES as usize],
+            )
+            .expect("file");
+        }
+        std::fs::write(source.path().join("0004"), b"x").expect("overflow file");
+
+        let error = SourceArtifactTransfer::from_directory("source-1", source.path())
+            .expect_err("byte limit");
+        assert_eq!(
+            error.details["source_package"]["measured"]["bytes"],
+            MAX_SOURCE_ARTIFACT_BYTES + 1
+        );
+        assert_eq!(
+            error.details["source_package"]["limits"]["byte_limit"],
+            MAX_SOURCE_ARTIFACT_BYTES
+        );
+        assert_eq!(
+            error.details["source_package"]["measured"]["largest_entries"]
+                .as_array()
+                .expect("contributors")[0]["path"],
+            "0000"
         );
     }
 }

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -23,7 +23,8 @@ use crate::runner_staging_operation::{
     RemoteRunnerStagingEnvelope, RemoteRunnerStagingReceipt, RemoteRunnerStagingTransport,
     RunnerSourceArtifact, RunnerStagingArtifacts, SourcePackageEntryKind,
     REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY, REMOTE_RUNNER_SOURCE_ARTIFACT_SYMLINK_CAPABILITY,
-    REMOTE_RUNNER_STAGING_CAPABILITY, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
+    REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY, REMOTE_RUNNER_STAGING_CAPABILITY,
+    REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
 };
 use crate::{broker_submit_token_for_runner, RunnerSession, RunnerTunnelMode};
 
@@ -269,7 +270,8 @@ struct StoredStage {
 #[serde(deny_unknown_fields)]
 struct StagingIntent {
     envelope: RemoteRunnerStagingEnvelope,
-    source_artifact: RunnerSourceArtifact,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_artifact: Option<RunnerSourceArtifact>,
     state: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     runner_job_id: Option<String>,
@@ -367,13 +369,16 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                 None,
             ));
         }
-        let transfer = envelope
+        let source_artifact = envelope
             .materialization
             .source_artifact
             .as_ref()
-            .expect("envelope validation requires source artifact");
-        let bytes = transfer.decode_verified()?;
-        let source_artifact = transfer.descriptor();
+            .map(|transfer| {
+                transfer
+                    .decode_verified()
+                    .map(|bytes| (transfer.descriptor(), bytes))
+            })
+            .transpose()?;
         let _lock = self.admission_lock()?;
         let mut state = self.load()?;
         let key = &envelope.handoff.idempotency_key;
@@ -386,7 +391,9 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
                     None,
                 ));
             }
-            self.verify_source_artifact(&source_artifact)?;
+            if let Some((artifact, _)) = &source_artifact {
+                self.verify_source_artifact(artifact)?;
+            }
             return Ok(existing.receipt.clone());
         }
 
@@ -395,7 +402,9 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
             .entry(key.clone())
             .or_insert_with(|| StagingIntent {
                 envelope: envelope.clone(),
-                source_artifact: source_artifact.clone(),
+                source_artifact: source_artifact
+                    .as_ref()
+                    .map(|(artifact, _)| artifact.clone()),
                 state: "intent_created".to_string(),
                 runner_job_id: None,
             });
@@ -403,7 +412,9 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
 
         // The lock covers materialization and receipt publication. Concurrent
         // requests therefore observe one durable admission, not two writes.
-        self.persist_source_artifact(&source_artifact, &bytes)?;
+        if let Some((artifact, bytes)) = &source_artifact {
+            self.persist_source_artifact(artifact, bytes)?;
+        }
         // Source bytes are now durable before any queue entry can become claimable.
         state.intents.get_mut(key).expect("intent").state = "source_ready".to_string();
         self.persist(&state)?;
@@ -427,7 +438,7 @@ impl<M: RunnerStagingMaterializer> RunnerStagingStore<M> {
             schema: REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA.to_string(),
             handoff: DirectLabHandoffReceipt::accepted(&envelope.handoff, runner_job_id),
             artifacts: RunnerStagingArtifacts {
-                source_artifact: Some(source_artifact),
+                source_artifact: source_artifact.map(|(artifact, _)| artifact),
                 ..artifacts
             },
         };
@@ -676,7 +687,9 @@ impl<M: RunnerStagingMaterializer> RemoteRunnerStagingTransport for RunnerStagin
         self.compatible
             && (matches!(
                 capability,
-                REMOTE_RUNNER_STAGING_CAPABILITY | REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY
+                REMOTE_RUNNER_STAGING_CAPABILITY
+                    | REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY
+                    | REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY
             ) || (cfg!(unix) && capability == REMOTE_RUNNER_SOURCE_ARTIFACT_SYMLINK_CAPABILITY))
     }
     fn stage_durable(
@@ -908,6 +921,7 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
     fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
         let mut capabilities = vec![
             REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+            REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
             REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
         ];
         if cfg!(unix) {
@@ -957,8 +971,8 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
             .materialization
             .source_artifact
             .as_ref()
-            .expect("validated source artifact")
-            .descriptor();
+            .map(crate::runner_staging_operation::SourceArtifactTransfer::descriptor);
+        let workspace = request.envelope.materialization.workspace.clone();
         let receipt = transport
             .store
             .stage_durable_with_submit(&request.envelope, |envelope| {
@@ -968,7 +982,9 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
                         project_id: None,
                         operation: "runner_staged_execution".to_string(),
                         command: envelope.handoff.recipe.normalized_args.clone(),
-                        cwd: None,
+                        cwd: workspace
+                            .as_ref()
+                            .map(|workspace| workspace.remote_cwd.clone()),
                         env: std::collections::HashMap::new(),
                         secret_env_names: Vec::new(),
                         secret_env_plan: Default::default(),
@@ -985,6 +1001,7 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
                         metadata: Some(serde_json::json!({
                             "submission_key": envelope.handoff.idempotency_key,
                             "staged_source_artifact": source_artifact,
+                            "staged_workspace_materialization": workspace,
                         })),
                     },
                 )?;
@@ -1316,6 +1333,7 @@ mod tests {
             session: direct_session,
             capabilities: vec![
                 REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
                 REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
             ],
         };
@@ -1330,6 +1348,7 @@ mod tests {
             session: reverse_session,
             capabilities: vec![
                 REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
+                REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
                 REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),
             ],
         };

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -24,7 +24,7 @@ use crate::runner_staging_operation::{
     RunnerSourceArtifact, RunnerStagingArtifacts, SourcePackageEntryKind,
     REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY, REMOTE_RUNNER_SOURCE_ARTIFACT_SYMLINK_CAPABILITY,
     REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY, REMOTE_RUNNER_STAGING_CAPABILITY,
-    REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
+    REMOTE_RUNNER_STAGING_CAPABILITY_V1, REMOTE_RUNNER_STAGING_RECEIPT_SCHEMA,
 };
 use crate::{broker_submit_token_for_runner, RunnerSession, RunnerTunnelMode};
 
@@ -730,6 +730,7 @@ impl<M: RunnerStagingMaterializer> RemoteRunnerStagingTransport for RunnerStagin
             && (matches!(
                 capability,
                 REMOTE_RUNNER_STAGING_CAPABILITY
+                    | REMOTE_RUNNER_STAGING_CAPABILITY_V1
                     | REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY
                     | REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY
             ) || (cfg!(unix) && capability == REMOTE_RUNNER_SOURCE_ARTIFACT_SYMLINK_CAPABILITY))
@@ -962,6 +963,7 @@ struct ProductionStagingProvider;
 impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionStagingProvider {
     fn capabilities(&self, _runner_id: &str) -> Result<Vec<String>> {
         let mut capabilities = vec![
+            REMOTE_RUNNER_STAGING_CAPABILITY_V1.to_string(),
             REMOTE_RUNNER_STAGING_CAPABILITY.to_string(),
             REMOTE_RUNNER_SOURCE_MATERIALIZATION_CAPABILITY.to_string(),
             REMOTE_RUNNER_SOURCE_ARTIFACT_CAPABILITY.to_string(),

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -225,6 +225,48 @@ pub fn extract_staged_source_artifact(
     Ok(root)
 }
 
+/// Re-resolve the workspace authority from runner-owned staging state before a
+/// claimed job executes. Queue metadata is a projection, not the authority.
+pub fn verify_staged_workspace_materialization(
+    store_path: impl AsRef<Path>,
+    workspace: &crate::runner_staging_operation::ControllerWorkspaceMaterialization,
+) -> Result<()> {
+    workspace.validate()?;
+    let state: StagingStoreState =
+        serde_json::from_slice(&fs::read(store_path.as_ref()).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(store_path.as_ref().display().to_string()),
+            )
+        })?)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse {}", store_path.as_ref().display())),
+            )
+        })?;
+    let stage = state.stages.get(&workspace.run_id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            "runner staging store has no durable workspace authority for this run",
+            Some(workspace.run_id.clone()),
+            None,
+        )
+    })?;
+    stage.envelope.validate()?;
+    if stage.envelope.handoff.run_id != workspace.run_id
+        || stage.envelope.materialization.workspace.as_ref() != Some(workspace)
+    {
+        return Err(Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            "queued workspace materialization does not match runner-owned staging authority",
+            Some(workspace.run_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 fn extraction_conflict(path: &Path) -> Error {
     Error::validation_invalid_argument(
         "source_package",

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -1006,7 +1006,39 @@ fn materialize_staged_source_artifact(
     job_id: &str,
     envelope: &mut RunnerExecutionEnvelope,
 ) -> Result<()> {
-    let Some(source) = envelope.metadata.get("staged_source_artifact") else {
+    if let Some(workspace) = envelope
+        .metadata
+        .get("staged_workspace_materialization")
+        .filter(|workspace| !workspace.is_null())
+    {
+        let workspace: crate::runner_staging_operation::ControllerWorkspaceMaterialization =
+            serde_json::from_value(workspace.clone()).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "staged_workspace_materialization",
+                    format!("invalid staged workspace materialization: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+        workspace.validate()?;
+        let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
+            Error::internal_unexpected("staged runner job has no execution dispatch")
+        })?;
+        if dispatch.cwd.as_deref() != Some(workspace.remote_cwd.as_str()) {
+            return Err(Error::validation_invalid_argument(
+                "staged_workspace_materialization",
+                "staged runner workspace does not match the claimed execution target",
+                Some(workspace.workspace_id),
+                None,
+            ));
+        }
+        return Ok(());
+    }
+    let Some(source) = envelope
+        .metadata
+        .get("staged_source_artifact")
+        .filter(|source| !source.is_null())
+    else {
         return Ok(());
     };
     let source = serde_json::from_value(source.clone()).map_err(|error| {

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -5,6 +5,14 @@ use std::sync::{
 };
 use std::thread;
 use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::{
+    fs::File,
+    io::Read,
+    os::fd::{AsRawFd, FromRawFd},
+    os::unix::{fs::OpenOptionsExt, process::CommandExt},
+    process::Command,
+};
 
 use reqwest::blocking::Client;
 use serde_json::json;
@@ -363,7 +371,7 @@ fn run_once_output(
     let _command_assets =
         materialize_command_assets(&claim.job.id.to_string(), &mut execution_envelope)?;
     let _private_at_files = verify_private_at_files(&mut execution_envelope)?;
-    materialize_staged_source_artifact(
+    let _staged_workspace = materialize_staged_source_artifact(
         &options.runner_id,
         &claim.job.id.to_string(),
         &mut execution_envelope,
@@ -419,6 +427,7 @@ fn run_once_output(
             claim.job.id.to_string(),
         )?,
         || {
+            verify_staged_workspace_before_execution(&options.runner_id, &execution_envelope)?;
             let recovered =
                 resolve_runner_execution_context(&options.runner_id, execution_context.id())?;
             consume_execution(
@@ -1005,7 +1014,7 @@ fn materialize_staged_source_artifact(
     runner_id: &str,
     job_id: &str,
     envelope: &mut RunnerExecutionEnvelope,
-) -> Result<()> {
+) -> Result<Option<StagedWorkspaceDirectory>> {
     if let Some(workspace) = envelope
         .metadata
         .get("staged_workspace_materialization")
@@ -1020,8 +1029,7 @@ fn materialize_staged_source_artifact(
                     None,
                 )
             })?;
-        workspace.validate()?;
-        let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
+        let dispatch = envelope.dispatch.as_mut().ok_or_else(|| {
             Error::internal_unexpected("staged runner job has no execution dispatch")
         })?;
         if dispatch.cwd.as_deref() != Some(workspace.remote_cwd.as_str()) {
@@ -1032,14 +1040,15 @@ fn materialize_staged_source_artifact(
                 None,
             ));
         }
-        return Ok(());
+        let directory = verify_controller_workspace(runner_id, &workspace)?;
+        return Ok(Some(directory));
     }
     let Some(source) = envelope
         .metadata
         .get("staged_source_artifact")
         .filter(|source| !source.is_null())
     else {
-        return Ok(());
+        return Ok(None);
     };
     let source = serde_json::from_value(source.clone()).map_err(|error| {
         Error::validation_invalid_argument(
@@ -1064,7 +1073,211 @@ fn materialize_staged_source_artifact(
         .as_mut()
         .ok_or_else(|| Error::internal_unexpected("staged runner job has no execution dispatch"))?;
     dispatch.cwd = Some(workspace.display().to_string());
+    Ok(None)
+}
+
+struct StagedWorkspaceDirectory {
+    #[cfg(unix)]
+    directory: File,
+}
+
+fn verify_staged_workspace_before_execution(
+    runner_id: &str,
+    envelope: &RunnerExecutionEnvelope,
+) -> Result<()> {
+    let Some(raw) = envelope
+        .metadata
+        .get("staged_workspace_materialization")
+        .filter(|workspace| !workspace.is_null())
+    else {
+        return Ok(());
+    };
+    let workspace = serde_json::from_value(raw.clone()).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            format!("invalid staged workspace materialization: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let _directory = verify_controller_workspace(runner_id, &workspace)?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn verify_controller_workspace(
+    runner_id: &str,
+    workspace: &crate::runner_staging_operation::ControllerWorkspaceMaterialization,
+) -> Result<StagedWorkspaceDirectory> {
+    use std::fs::OpenOptions;
+
+    workspace.validate()?;
+    let session_path = homeboy_core::paths::runner_session_file(runner_id)?;
+    let store_path = session_path.with_file_name(format!("{runner_id}-staging/store.json"));
+    crate::runner_staging_store::verify_staged_workspace_materialization(store_path, workspace)?;
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY);
+    let directory = options.open(&workspace.remote_cwd).map_err(|error| {
+        Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            format!("open runner-owned workspace without following links: {error}"),
+            Some(workspace.remote_cwd.clone()),
+            None,
+        )
+    })?;
+    let descriptor_flags = unsafe { libc::fcntl(directory.as_raw_fd(), libc::F_GETFD) };
+    if descriptor_flags < 0
+        || unsafe {
+            libc::fcntl(
+                directory.as_raw_fd(),
+                libc::F_SETFD,
+                descriptor_flags & !libc::FD_CLOEXEC,
+            )
+        } < 0
+    {
+        return Err(Error::internal_io(
+            std::io::Error::last_os_error().to_string(),
+            Some("retain staged workspace descriptor for execution".to_string()),
+        ));
+    }
+    let metadata = read_workspace_metadata_nofollow(&directory)?;
+    let actual_path = metadata
+        .get("remote_path")
+        .and_then(serde_json::Value::as_str);
+    let snapshot = metadata
+        .get("snapshot_identity")
+        .and_then(serde_json::Value::as_str);
+    let lease = metadata
+        .get("workspace_lease")
+        .and_then(serde_json::Value::as_str);
+    let commit = metadata
+        .get("source_commit")
+        .and_then(serde_json::Value::as_str);
+    let run_id = metadata.get("run_id").and_then(serde_json::Value::as_str);
+    if actual_path != Some(workspace.remote_cwd.as_str())
+        || snapshot != Some(workspace.source_snapshot_id.as_str())
+        || lease != Some(workspace.workspace_lease.as_str())
+        || commit != Some(workspace.source_commit.as_str())
+        || run_id != Some(workspace.run_id.as_str())
+    {
+        return Err(Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            "runner workspace metadata no longer matches the staged source identity, lease, and run ownership",
+            Some(workspace.run_id.clone()),
+            None,
+        ));
+    }
+    let fd = directory.as_raw_fd();
+    let mut command = Command::new("git");
+    command.args(["status", "--porcelain=v1"]);
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(fd) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    let output = command.output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("verify staged Git workspace".to_string()),
+        )
+    })?;
+    if !output.status.success() || !output.stdout.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            "runner workspace Git baseline is missing or dirty after staging",
+            Some(workspace.run_id.clone()),
+            None,
+        ));
+    }
+    let fd = directory.as_raw_fd();
+    let mut command = Command::new("git");
+    command.args(["rev-parse", "HEAD"]);
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(fd) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    let output = command.output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read staged Git baseline".to_string()),
+        )
+    })?;
+    if !output.status.success()
+        || String::from_utf8_lossy(&output.stdout).trim() != workspace.source_commit
+    {
+        return Err(Error::validation_invalid_argument(
+            "staged_workspace_materialization",
+            "runner workspace Git baseline does not match the staged source commit",
+            Some(workspace.run_id.clone()),
+            None,
+        ));
+    }
+    Ok(StagedWorkspaceDirectory { directory })
+}
+
+#[cfg(not(unix))]
+fn verify_controller_workspace(
+    _runner_id: &str,
+    _workspace: &crate::runner_staging_operation::ControllerWorkspaceMaterialization,
+) -> Result<StagedWorkspaceDirectory> {
+    Err(Error::validation_invalid_argument(
+        "staged_workspace_materialization",
+        "controller-materialized workspaces require Unix no-follow verification",
+        None,
+        None,
+    ))
+}
+
+#[cfg(unix)]
+fn read_workspace_metadata_nofollow(directory: &File) -> Result<serde_json::Value> {
+    use std::ffi::CString;
+
+    fn open_at(directory: &File, name: &str, flags: i32) -> Result<File> {
+        let name = CString::new(name).expect("literal has no NUL");
+        let fd = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                flags | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(Error::validation_invalid_argument(
+                "staged_workspace_materialization",
+                std::io::Error::last_os_error().to_string(),
+                None,
+                None,
+            ));
+        }
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    let homeboy = open_at(directory, ".homeboy", libc::O_RDONLY | libc::O_DIRECTORY)?;
+    let mut metadata = open_at(&homeboy, "runner-workspace.json", libc::O_RDONLY)?;
+    let mut bytes = Vec::new();
+    metadata.read_to_end(&mut bytes).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("read runner workspace metadata".to_string()),
+        )
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse runner workspace metadata".to_string()),
+        )
+    })
 }
 
 /// Materialize broker-owned command files in the worker's durable data root and

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -427,7 +427,11 @@ fn run_once_output(
             claim.job.id.to_string(),
         )?,
         || {
-            verify_staged_workspace_before_execution(&options.runner_id, &execution_envelope)?;
+            verify_staged_workspace_before_execution(
+                &options.runner_id,
+                &execution_envelope,
+                _staged_workspace.as_ref(),
+            )?;
             let recovered =
                 resolve_runner_execution_context(&options.runner_id, execution_context.id())?;
             consume_execution(
@@ -448,6 +452,8 @@ fn run_once_output(
             // must not be used to recompute the pre-consumption receipt.
             Ok(())
         },
+        #[cfg(unix)]
+        _staged_workspace.as_ref().map(StagedWorkspaceDirectory::fd),
         || {
             if cancel_seen || last_cancel_poll.elapsed() < BROKER_CANCEL_POLL_INTERVAL {
                 return cancel_seen;
@@ -1040,7 +1046,7 @@ fn materialize_staged_source_artifact(
                 None,
             ));
         }
-        let directory = verify_controller_workspace(runner_id, &workspace)?;
+        let directory = verify_controller_workspace(runner_id, &workspace, None)?;
         return Ok(Some(directory));
     }
     let Some(source) = envelope
@@ -1081,9 +1087,17 @@ struct StagedWorkspaceDirectory {
     directory: File,
 }
 
+impl StagedWorkspaceDirectory {
+    #[cfg(unix)]
+    fn fd(&self) -> std::os::fd::RawFd {
+        self.directory.as_raw_fd()
+    }
+}
+
 fn verify_staged_workspace_before_execution(
     runner_id: &str,
     envelope: &RunnerExecutionEnvelope,
+    authority: Option<&StagedWorkspaceDirectory>,
 ) -> Result<()> {
     let Some(raw) = envelope
         .metadata
@@ -1100,7 +1114,10 @@ fn verify_staged_workspace_before_execution(
             None,
         )
     })?;
-    let _directory = verify_controller_workspace(runner_id, &workspace)?;
+    let authority = authority.ok_or_else(|| {
+        Error::internal_unexpected("staged workspace authority was not retained until execution")
+    })?;
+    verify_controller_workspace(runner_id, &workspace, Some(authority))?;
     Ok(())
 }
 
@@ -1108,6 +1125,7 @@ fn verify_staged_workspace_before_execution(
 fn verify_controller_workspace(
     runner_id: &str,
     workspace: &crate::runner_staging_operation::ControllerWorkspaceMaterialization,
+    retained: Option<&StagedWorkspaceDirectory>,
 ) -> Result<StagedWorkspaceDirectory> {
     use std::fs::OpenOptions;
 
@@ -1119,7 +1137,7 @@ fn verify_controller_workspace(
     options
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY);
-    let directory = options.open(&workspace.remote_cwd).map_err(|error| {
+    let opened = options.open(&workspace.remote_cwd).map_err(|error| {
         Error::validation_invalid_argument(
             "staged_workspace_materialization",
             format!("open runner-owned workspace without following links: {error}"),
@@ -1127,21 +1145,9 @@ fn verify_controller_workspace(
             None,
         )
     })?;
-    let descriptor_flags = unsafe { libc::fcntl(directory.as_raw_fd(), libc::F_GETFD) };
-    if descriptor_flags < 0
-        || unsafe {
-            libc::fcntl(
-                directory.as_raw_fd(),
-                libc::F_SETFD,
-                descriptor_flags & !libc::FD_CLOEXEC,
-            )
-        } < 0
-    {
-        return Err(Error::internal_io(
-            std::io::Error::last_os_error().to_string(),
-            Some("retain staged workspace descriptor for execution".to_string()),
-        ));
-    }
+    let directory = retained
+        .map(|authority| &authority.directory)
+        .unwrap_or(&opened);
     let metadata = read_workspace_metadata_nofollow(&directory)?;
     let actual_path = metadata
         .get("remote_path")
@@ -1223,13 +1229,14 @@ fn verify_controller_workspace(
             None,
         ));
     }
-    Ok(StagedWorkspaceDirectory { directory })
+    Ok(StagedWorkspaceDirectory { directory: opened })
 }
 
 #[cfg(not(unix))]
 fn verify_controller_workspace(
     _runner_id: &str,
     _workspace: &crate::runner_staging_operation::ControllerWorkspaceMaterialization,
+    _retained: Option<&StagedWorkspaceDirectory>,
 ) -> Result<StagedWorkspaceDirectory> {
     Err(Error::validation_invalid_argument(
         "staged_workspace_materialization",

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -1004,52 +1004,6 @@ fn reverse_worker_executes_a_verified_staged_source_package() {
 }
 
 #[test]
-fn reverse_worker_executes_the_controller_materialized_workspace_target() {
-    test_support::with_isolated_home(|_| {
-        create_shell_runner();
-        let workspace = tempfile::tempdir().expect("workspace");
-        std::fs::write(
-            workspace.path().join("authoritative.txt"),
-            "controller-routed",
-        )
-        .expect("write source");
-        let path = tempfile::tempdir().expect("jobs").path().join("jobs.json");
-        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
-        let mut request = run_id_echo_request();
-        request.command = vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "cat authoritative.txt".to_string(),
-        ];
-        request.cwd = Some(workspace.path().display().to_string());
-        request.metadata = Some(serde_json::json!({
-            "submission_key": "controller-workspace-job-1",
-            "staged_workspace_materialization": crate::runner_staging_operation::ControllerWorkspaceMaterialization::new(
-                "runner-workspace-1",
-                workspace.path().display().to_string(),
-                "git:abc123",
-                "sha256:durable-plan",
-            ),
-        }));
-        let job = store
-            .submit_remote_runner_job(request)
-            .expect("submit staged job");
-        drop(store);
-        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
-        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
-        let (output, exit_code) =
-            run_reverse_worker(worker_options(broker_url)).expect("run worker");
-        assert_eq!(exit_code, 0);
-        assert_eq!(output.job.expect("job").id, job.id);
-        handle.join().expect("mock broker joins");
-        assert_eq!(
-            result_event_data(&store, job.id)["stdout"],
-            serde_json::json!("controller-routed")
-        );
-    });
-}
-
-#[test]
 fn reverse_worker_loop_backs_off_when_no_job_is_available() {
     test_support::with_isolated_home(|_| {
         crate::create(

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -1004,6 +1004,52 @@ fn reverse_worker_executes_a_verified_staged_source_package() {
 }
 
 #[test]
+fn reverse_worker_executes_the_controller_materialized_workspace_target() {
+    test_support::with_isolated_home(|_| {
+        create_shell_runner();
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(
+            workspace.path().join("authoritative.txt"),
+            "controller-routed",
+        )
+        .expect("write source");
+        let path = tempfile::tempdir().expect("jobs").path().join("jobs.json");
+        let store = JobStore::open_without_reconciliation(&path).expect("open durable store");
+        let mut request = run_id_echo_request();
+        request.command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat authoritative.txt".to_string(),
+        ];
+        request.cwd = Some(workspace.path().display().to_string());
+        request.metadata = Some(serde_json::json!({
+            "submission_key": "controller-workspace-job-1",
+            "staged_workspace_materialization": crate::runner_staging_operation::ControllerWorkspaceMaterialization::new(
+                "runner-workspace-1",
+                workspace.path().display().to_string(),
+                "git:abc123",
+                "sha256:durable-plan",
+            ),
+        }));
+        let job = store
+            .submit_remote_runner_job(request)
+            .expect("submit staged job");
+        drop(store);
+        let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
+        let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
+        let (output, exit_code) =
+            run_reverse_worker(worker_options(broker_url)).expect("run worker");
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.job.expect("job").id, job.id);
+        handle.join().expect("mock broker joins");
+        assert_eq!(
+            result_event_data(&store, job.id)["stdout"],
+            serde_json::json!("controller-routed")
+        );
+    });
+}
+
+#[test]
 fn reverse_worker_loop_backs_off_when_no_job_is_available() {
     test_support::with_isolated_home(|_| {
         crate::create(

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -41,6 +41,67 @@ fn is_reserved_runner_workspace_path(relative: &str) -> bool {
     RESERVED_RUNNER_WORKSPACE_PATHS.contains(&relative)
 }
 
+/// The runner owns this container and may remove it with its metadata while a
+/// snapshot traversal still holds a directory entry for it. Its disappearance
+/// is therefore a cache miss, unlike a source path disappearing mid-read.
+fn is_runner_metadata_directory(logical: &Path) -> bool {
+    logical == Path::new(".homeboy")
+}
+
+#[cfg(test)]
+mod test_snapshot_directory_discovery_hook {
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
+
+    type Hook = (PathBuf, Box<dyn FnOnce() + Send>);
+
+    static HOOK: OnceLock<Mutex<Option<Hook>>> = OnceLock::new();
+
+    pub(crate) struct Guard;
+
+    pub(crate) fn install(path: PathBuf, action: impl FnOnce() + Send + 'static) -> Guard {
+        let mut hook = HOOK
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .expect("snapshot discovery hook lock");
+        assert!(
+            hook.is_none(),
+            "snapshot discovery hook is already installed"
+        );
+        *hook = Some((path, Box::new(action)));
+        Guard
+    }
+
+    pub(crate) fn run(path: &Path) {
+        let action = HOOK
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .expect("snapshot discovery hook lock")
+            .take_if(|(expected, _)| expected == path)
+            .map(|(_, action)| action);
+        if let Some(action) = action {
+            action();
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            *HOOK
+                .get_or_init(|| Mutex::new(None))
+                .lock()
+                .expect("snapshot discovery hook lock") = None;
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn register_after_snapshot_directory_discovery_hook(
+    path: std::path::PathBuf,
+    action: impl FnOnce() + Send + 'static,
+) -> test_snapshot_directory_discovery_hook::Guard {
+    test_snapshot_directory_discovery_hook::install(path, action)
+}
+
 // The workspace-content *identity spec* (permission-policy names, the default
 // policy, the policy -> algorithm-marker mapping, and the content manifest
 // types) lives in the leaf `homeboy-source-snapshot-contract` crate so the
@@ -269,17 +330,28 @@ impl ContentHashTraversal<'_> {
         logical: &Path,
         ancestors: &mut Vec<std::path::PathBuf>,
     ) -> Result<()> {
-        let mut children = fs::read_dir(path)
-            .map_err(|err| {
-                Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|err| {
-                Error::internal_io(
+        let mut children = match fs::read_dir(path) {
+            Ok(children) => children,
+            Err(err)
+                if is_runner_metadata_directory(logical)
+                    && err.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Ok(());
+            }
+            Err(err) => {
+                return Err(Error::internal_io(
                     err.to_string(),
-                    Some("read sync directory entry".to_string()),
-                )
-            })?;
+                    Some("read sync directory".to_string()),
+                ));
+            }
+        }
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("read sync directory entry".to_string()),
+            )
+        })?;
         children.sort_by_key(|entry| entry.path());
         for entry in children {
             let entry_path = entry.path();
@@ -297,9 +369,23 @@ impl ContentHashTraversal<'_> {
             {
                 continue;
             }
-            let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
-                Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-            })?;
+            #[cfg(test)]
+            test_snapshot_directory_discovery_hook::run(&entry_path);
+            let link_metadata = match fs::symlink_metadata(&entry_path) {
+                Ok(metadata) => metadata,
+                Err(err)
+                    if is_runner_metadata_directory
+                        && err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    continue;
+                }
+                Err(err) => {
+                    return Err(Error::internal_io(
+                        err.to_string(),
+                        Some("read sync file metadata".to_string()),
+                    ));
+                }
+            };
             // A symlink whose target resolves is dereferenced so its target content
             // stays provenance-bound (target drift changes the hash). A symlink whose
             // target is intentionally unavailable on the controller (e.g. a tracked
@@ -337,13 +423,32 @@ impl ContentHashTraversal<'_> {
             } else {
                 entry_path.clone()
             };
-            let metadata = fs::metadata(&resolved).map_err(|err| {
-                Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-            })?;
+            let metadata = match fs::metadata(&resolved) {
+                Ok(metadata) => metadata,
+                Err(err)
+                    if is_runner_metadata_directory
+                        && err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    continue;
+                }
+                Err(err) => {
+                    return Err(Error::internal_io(
+                        err.to_string(),
+                        Some("read sync file metadata".to_string()),
+                    ));
+                }
+            };
             if metadata.is_dir() {
-                let canonical = resolved
-                    .canonicalize()
-                    .map_err(|err| Error::internal_io(err.to_string(), None))?;
+                let canonical = match resolved.canonicalize() {
+                    Ok(canonical) => canonical,
+                    Err(err)
+                        if is_runner_metadata_directory
+                            && err.kind() == std::io::ErrorKind::NotFound =>
+                    {
+                        continue;
+                    }
+                    Err(err) => return Err(Error::internal_io(err.to_string(), None)),
+                };
                 if ancestors.contains(&canonical) {
                     return Err(Error::validation_invalid_argument(
                         "workspace",
@@ -491,17 +596,28 @@ fn collect_content_hash_entries_v1(
     ancestors: &mut Vec<std::path::PathBuf>,
     entries: &mut Vec<(String, &'static str, u32, Vec<u8>)>,
 ) -> Result<()> {
-    let mut children = fs::read_dir(path)
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync directory".to_string()))
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|err| {
-            Error::internal_io(
+    let mut children = match fs::read_dir(path) {
+        Ok(children) => children,
+        Err(err)
+            if is_runner_metadata_directory(logical)
+                && err.kind() == std::io::ErrorKind::NotFound =>
+        {
+            return Ok(());
+        }
+        Err(err) => {
+            return Err(Error::internal_io(
                 err.to_string(),
-                Some("read sync directory entry".to_string()),
-            )
-        })?;
+                Some("read sync directory".to_string()),
+            ));
+        }
+    }
+    .collect::<std::result::Result<Vec<_>, _>>()
+    .map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("read sync directory entry".to_string()),
+        )
+    })?;
     children.sort_by_key(|entry| entry.path());
     for entry in children {
         let entry_path = entry.path();
@@ -514,9 +630,22 @@ fn collect_content_hash_entries_v1(
         {
             continue;
         }
-        let link_metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-        })?;
+        #[cfg(test)]
+        test_snapshot_directory_discovery_hook::run(&entry_path);
+        let link_metadata = match fs::symlink_metadata(&entry_path) {
+            Ok(metadata) => metadata,
+            Err(err)
+                if is_runner_metadata_directory && err.kind() == std::io::ErrorKind::NotFound =>
+            {
+                continue;
+            }
+            Err(err) => {
+                return Err(Error::internal_io(
+                    err.to_string(),
+                    Some("read sync file metadata".to_string()),
+                ));
+            }
+        };
         // Resolvable symlinks are dereferenced (target content stays bound); a
         // tracked symlink with an unavailable target binds its target text
         // instead of failing the hash. See the v2 collector for rationale. (#8374)
@@ -538,13 +667,31 @@ fn collect_content_hash_entries_v1(
         } else {
             entry_path.clone()
         };
-        let metadata = fs::metadata(&resolved).map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
-        })?;
+        let metadata = match fs::metadata(&resolved) {
+            Ok(metadata) => metadata,
+            Err(err)
+                if is_runner_metadata_directory && err.kind() == std::io::ErrorKind::NotFound =>
+            {
+                continue;
+            }
+            Err(err) => {
+                return Err(Error::internal_io(
+                    err.to_string(),
+                    Some("read sync file metadata".to_string()),
+                ));
+            }
+        };
         if metadata.is_dir() {
-            let canonical = resolved
-                .canonicalize()
-                .map_err(|err| Error::internal_io(err.to_string(), None))?;
+            let canonical = match resolved.canonicalize() {
+                Ok(canonical) => canonical,
+                Err(err)
+                    if is_runner_metadata_directory
+                        && err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(Error::internal_io(err.to_string(), None)),
+            };
             if ancestors.contains(&canonical) {
                 return Err(Error::validation_invalid_argument(
                     "workspace",

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -468,6 +468,7 @@ pub fn sync_workspace(
                     ResourceCleanupPolicy::DeleteOnSuccess,
                 )
             });
+            let prepared_workspace_lease = metadata.workspace_lease.clone();
             let validation_dependencies = match write_metadata_and_sync_validation_dependencies(
                 &runner,
                 metadata,
@@ -502,7 +503,7 @@ pub fn sync_workspace(
                     resource_lifecycle,
                     sync_mode: RunnerWorkspaceSyncMode::Git,
                     snapshot_identity: git.head,
-                    prepared_workspace_lease: None,
+                    prepared_workspace_lease,
                     counts: ByteFileCounts::default(),
                     excludes,
                     includes,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -6,11 +6,12 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::workspace::snapshot::{
     copy_snapshot_to_directory, ensure_no_runner_workspace_metadata_collision,
-    scratch_scoped_command, snapshot_archive_command, snapshot_install_command,
-    snapshot_materialization_command, snapshot_overlay_install_command, synthetic_checkout_value,
-    workspace_content_hash, workspace_content_hash_algorithm, workspace_content_hash_for_policy,
-    workspace_content_hash_v1, workspace_content_manifest_for_policy,
-    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    register_after_snapshot_directory_discovery_hook, scratch_scoped_command,
+    snapshot_archive_command, snapshot_install_command, snapshot_materialization_command,
+    snapshot_overlay_install_command, synthetic_checkout_value, workspace_content_hash,
+    workspace_content_hash_algorithm, workspace_content_hash_for_policy, workspace_content_hash_v1,
+    workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
@@ -731,6 +732,54 @@ fn generic_snapshot_copy_allows_source_owned_runner_workspace_path() {
             .expect("copied metadata"),
         "source-owned generic snapshot content\n"
     );
+}
+
+#[test]
+fn workspace_content_hash_skips_runner_metadata_removed_after_discovery() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::write(workspace.path().join("source.txt"), "source\n").expect("source file");
+    let metadata = workspace.path().join(".homeboy");
+    fs::create_dir_all(&metadata).expect("runner metadata directory");
+    fs::write(metadata.join("runner-workspace.json"), "{}\n").expect("runner metadata");
+    let expected = workspace_content_hash(workspace.path(), &[]).expect("baseline hash");
+
+    let metadata_to_remove = metadata.clone();
+    {
+        let _hook = register_after_snapshot_directory_discovery_hook(
+            metadata.canonicalize().expect("canonical metadata path"),
+            move || {
+                fs::remove_dir_all(&metadata_to_remove)
+                    .expect("remove runner metadata during traversal");
+            },
+        );
+        assert_eq!(
+            workspace_content_hash(workspace.path(), &[])
+                .expect("metadata cache miss is reconciled"),
+            expected,
+            "runner-owned metadata must not make an active snapshot claimant fail"
+        );
+    }
+
+    fs::create_dir_all(&metadata).expect("restore runner metadata directory");
+    fs::write(metadata.join("runner-workspace.json"), "{}\n").expect("restore runner metadata");
+    let expected_v1 =
+        workspace_content_hash_v1(workspace.path(), &[]).expect("legacy baseline hash");
+    let metadata_to_remove = metadata.clone();
+    {
+        let _hook = register_after_snapshot_directory_discovery_hook(
+            metadata.canonicalize().expect("canonical metadata path"),
+            move || {
+                fs::remove_dir_all(&metadata_to_remove)
+                    .expect("remove runner metadata during legacy traversal");
+            },
+        );
+        assert_eq!(
+            workspace_content_hash_v1(workspace.path(), &[])
+                .expect("legacy metadata cache miss is reconciled"),
+            expected_v1,
+            "legacy verification must tolerate the same runner metadata race"
+        );
+    }
 }
 
 #[test]

--- a/docs/commands/source.md
+++ b/docs/commands/source.md
@@ -11,14 +11,23 @@ The command is read-only. It does not create a run, runner job, workspace,
 artifact, connection, or source transfer.
 
 It returns the standard JSON envelope. `data.source_package` has schema
-`homeboy/source-package-check/v1` and reports the scanner's `accepted`,
-`excluded`, and `blocked` result sets. An accepted result includes the exact
-package format, file count, bytes, and deterministic digest that staging uses. A
-blocked result instead includes `partial` diagnostic counts without a package
-identity. It exits with status 1, which makes it suitable for shell and
-orchestration preflight.
+`homeboy/source-package-check/v1` and reports the scanner's configured `limits`
+plus its `accepted`, `excluded`, and `blocked` result sets. An accepted result
+includes the exact package format, file count, bytes, and deterministic digest
+that staging uses. A blocked result instead includes `partial` measured counts,
+bytes, and the five largest contributing entries without a package identity. It
+exits with status 1, which makes it suitable for shell and orchestration
+preflight.
 
 Package format and link handling are scanner-owned. The command reports the exact
 v1 or v2 accepted, excluded, and blocked outcome supplied by the shared staging
 scanner, without traversing excluded entries. Special files, unreadable paths,
 per-file size limits, aggregate byte limits, and entry limits are blocking.
+
+When aggregate limits block Lab staging, the structured error repeats the
+measured values and limits under `details.source_package`, identifies the largest
+contributors and automatic exclusions (`.git` and untracked symlinks), and
+provides an executable `preflight_command` continuation. Eligible clean Git
+worktrees continue through Git workspace materialization automatically;
+otherwise reduce generated or vendored source content before retrying the
+original Lab command.

--- a/docs/commands/source.md
+++ b/docs/commands/source.md
@@ -11,13 +11,13 @@ The command is read-only. It does not create a run, runner job, workspace,
 artifact, connection, or source transfer.
 
 It returns the standard JSON envelope. `data.source_package` has schema
-`homeboy/source-package-check/v1` and reports the scanner's configured `limits`
+`homeboy/source-package-check/v2` and reports the scanner's configured `limits`
 plus its `accepted`, `excluded`, and `blocked` result sets. An accepted result
 includes the exact package format, file count, bytes, and deterministic digest
 that staging uses. A blocked result instead includes `partial` measured counts,
 bytes, and the five largest contributing entries without a package identity. It
 exits with status 1, which makes it suitable for shell and orchestration
-preflight.
+preflight. Homeboy continues to read persisted v1 checks, which omit `limits`.
 
 Package format and link handling are scanner-owned. The command reports the exact
 v1 or v2 accepted, excluded, and blocked outcome supplied by the shared staging


### PR DESCRIPTION
## Summary

- keep detached fanout status usable under observation-store contention
- make admission expiry heartbeat-aware and expose durable blockers and valid recovery commands
- tolerate transient snapshot metadata disappearance without masking real I/O failures
- diagnose source-package limits and add scalable, versioned staging for oversized Git sources
- bind controller-materialized execution to verified workspace authority and a retained directory descriptor
- retain v1 bounded-artifact compatibility while requiring v2 for scalable materialization

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- `cargo build -p homeboy-lab-runner`
- runner staging, compatibility, source-authority, and spawn-race suites passed
- `homeboy-agents` batch suite: 34 tests passed

Closes #12472.
Closes #12473.
Closes #12474.
Addresses #9373.

## AI assistance

- **Model:** OpenAI GPT-5.6-sol
- **Tool:** OpenCode
- **Use:** Parallel implementation, security and compatibility review, rebase conflict analysis, and deterministic regression testing. Chris Huber reviewed and remains responsible for every line.
