### PR TITLE
fix(cook): reject stale controller daemons

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -189,16 +189,25 @@ pub(super) fn intercept_local_detached_cook(
     // A daemon-owned job is the authority that outlives this launcher. Prove it
     // is reachable before a provider-capable child exists, so unsupported
     // detachment is rejected before dispatch.
-    let controller_client = match homeboy::core::daemon::LocalControllerJobClient::connect() {
-        Ok(client) => client,
-        Err(error) => {
-            let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent(
-                &cook_id,
-                "durable controller ownership could not be established",
-            );
-            return Err(error);
-        }
-    };
+    let controller_client =
+        match homeboy::core::daemon::LocalControllerJobClient::connect_current_build() {
+            Ok(client) => client,
+            Err(error)
+                if controller_job_daemon_build_mismatch(&error) && !cli.detach_after_handoff =>
+            {
+                // An attached caller can retain foreground ownership. This keeps a
+                // newer client useful without letting an older resident daemon
+                // interpret and terminate lifecycle records it does not understand.
+                return Ok(None);
+            }
+            Err(error) => {
+                let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                    &cook_id,
+                    "durable controller ownership could not be established",
+                );
+                return Err(error);
+            }
+        };
     let route = detached_route(cli);
     let launch_token = create_local_cook_launch_token(&session_root)?;
     let mut child = match spawn_detached_cook(&child_args, &log_path, route.as_ref(), &launch_token)
@@ -324,6 +333,10 @@ pub(super) fn intercept_local_detached_cook(
     // already accepted ownership, so losing this client cannot cancel provider work.
     let status = stream_attached_cook_log(&mut child, &log_path)?;
     Ok(Some(status.code().unwrap_or(1)))
+}
+
+fn controller_job_daemon_build_mismatch(error: &Error) -> bool {
+    error.details["classification"] == "controller_job_daemon_build_mismatch"
 }
 
 /// Serialize once, then write that exact acknowledgement wherever the caller
@@ -985,6 +998,23 @@ mod tests {
         let (token, path) = create_local_cook_launch_token(directory.path()).expect("launch token");
         assert!(consume_local_cook_launch_token_at(token.as_ref(), &path));
         assert!(!consume_local_cook_launch_token_at(token.as_ref(), &path));
+    }
+
+    #[test]
+    fn daemon_build_mismatch_is_an_explicit_foreground_fallback_signal() {
+        let mut mismatch = Error::validation_invalid_argument(
+            "daemon_build_identity",
+            "resident daemon differs",
+            None,
+            None,
+        );
+        mismatch.details = serde_json::json!({
+            "classification": "controller_job_daemon_build_mismatch"
+        });
+        assert!(controller_job_daemon_build_mismatch(&mismatch));
+
+        let unrelated = Error::internal_unexpected("daemon unavailable");
+        assert!(!controller_job_daemon_build_mismatch(&unrelated));
     }
 
     #[test]

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -172,6 +172,42 @@ fn controller_job_response(value: &serde_json::Value) -> Option<&serde_json::Val
 }
 
 impl LocalControllerJobClient {
+    /// Connect only when the resident daemon runs this exact Homeboy build.
+    ///
+    /// Controller-job drivers are in-process code, so a reachable older daemon
+    /// can deserialize a request while applying stale ownership semantics. Fail
+    /// before submission instead of handing new lifecycle records to it.
+    pub fn connect_current_build() -> Result<Self> {
+        let status = read_status()?;
+        if status.reachable && !status.fresh {
+            let daemon_identity = status
+                .state
+                .as_ref()
+                .map(|state| state.build_identity.display.clone());
+            let mut error = Error::validation_invalid_argument(
+                "daemon_build_identity",
+                "controller jobs require the resident daemon to match the invoking Homeboy build",
+                daemon_identity.clone(),
+                Some(vec![
+                    "Preserve active daemon jobs, then restart or upgrade the daemon through its lease-bound recovery plan before retrying detached work."
+                        .to_string(),
+                    "Attached callers may continue with foreground ownership when the command supports it."
+                        .to_string(),
+                ]),
+            );
+            error.details = json!({
+                "classification": "controller_job_daemon_build_mismatch",
+                "daemon_build_identity": daemon_identity,
+                "invoking_build_identity": build_identity::current().display,
+                "stale_reason": status.stale_reason,
+                "stale_reason_code": status.freshness.stale_reason_code,
+                "active_jobs": status.freshness.active_jobs,
+            });
+            return Err(error);
+        }
+        Self::connect()
+    }
+
     pub fn connect() -> Result<Self> {
         let daemon = ensure_running(DEFAULT_ADDR)?;
         let client = reqwest::blocking::Client::builder()

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1451,6 +1451,30 @@ fn write_daemon_state_for_test(state: &DaemonState) {
 }
 
 #[test]
+fn controller_job_client_rejects_a_live_daemon_from_another_build() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.build_identity.version = "0.0.0-stale".to_string();
+    state.build_identity.display = "homeboy 0.0.0-stale+fixture".to_string();
+    write_daemon_state_for_test(&state);
+
+    let error = match LocalControllerJobClient::connect_current_build() {
+        Ok(_) => panic!("typed controller jobs require the invoking daemon build"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error.details["classification"],
+        "controller_job_daemon_build_mismatch"
+    );
+    assert_eq!(
+        error.details["daemon_build_identity"],
+        "homeboy 0.0.0-stale+fixture"
+    );
+    assert_eq!(error.details["active_jobs"], 0);
+}
+
+#[test]
 fn status_reports_active_job_recovery_evidence_without_mutating_the_store() {
     let _home = HomeGuard::new();
     let mut state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");


### PR DESCRIPTION
## Summary

- require typed controller jobs to use a resident daemon from the exact invoking Homeboy build
- let attached/default Cooks retain foreground ownership when a stale daemon is active
- fail detached Cooks before child spawn with daemon/invoker identities and active-job evidence

This preserves active jobs owned by an older daemon without letting it interpret and cancel lifecycle records created by a newer client.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-cli`
- `cargo test -p homeboy-core controller_job_client_rejects_a_live_daemon_from_another_build -- --nocapture`
- `cargo test -p homeboy-cli daemon_build_mismatch_is_an_explicit_foreground_fallback_signal -- --nocapture`
- actual old-daemon foreground proof reached normal DMC worktree resolution
- actual old-daemon detached proof refused before child spawn with `controller_job_daemon_build_mismatch`

Closes #12380

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the post-merge cancellations to a mixed-version daemon boundary, implemented exact-build admission and foreground fallback, and ran the verification above. Chris Huber reviewed and owns every line.