### PR TITLE
refactor(agent-task): root Cook interruption claims

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -91,11 +91,21 @@ pub fn claim_cook_operation(
     operation_key: &str,
     lease: Duration,
 ) -> Result<ClaimOutcome> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    claim_cook_operation_in_store(&lifecycle_store, run_id, operation_key, lease)
+}
+
+pub(crate) fn claim_cook_operation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    operation_key: &str,
+    lease: Duration,
+) -> Result<ClaimOutcome> {
     let run_id = sanitize_run_id(run_id);
     let now = now_timestamp();
     let lease_deadline = timestamp_after(&now, lease);
     let mut outcome = ClaimOutcome::LeaseHeld;
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let metadata = record.ensure_metadata_object();
         let claims = metadata
             .entry(OPERATION_CLAIMS_KEY.to_string())
@@ -167,10 +177,20 @@ pub fn claim_cook_operation(
 /// terminal result without its durable lease is a lifecycle invariant break,
 /// mirroring [`record_provider_execution_terminal`]).
 pub fn complete_cook_operation(run_id: &str, operation_key: &str, result: Value) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    complete_cook_operation_in_store(&lifecycle_store, run_id, operation_key, result)
+}
+
+pub(crate) fn complete_cook_operation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    operation_key: &str,
+    result: Value,
+) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
     let now = now_timestamp();
     let mut found = false;
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let metadata = record.ensure_metadata_object();
         let Some(claims) = metadata
             .get_mut(OPERATION_CLAIMS_KEY)
@@ -292,8 +312,17 @@ fn transition_cook_operation(
 
 /// Read a single operation claim for reconciliation, if present.
 pub fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<OperationClaim>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    operation_claim_in_store(&lifecycle_store, run_id, operation_key)
+}
+
+pub(crate) fn operation_claim_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    operation_key: &str,
+) -> Result<Option<OperationClaim>> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::read_record(&run_id)?;
+    let record = lifecycle_store.read_record(&run_id)?;
     Ok(record
         .metadata
         .get(OPERATION_CLAIMS_KEY)

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -14,7 +14,7 @@ use crate::agent_task_cook_loop::{
 use crate::agent_task_dispatch_plan::{build_dispatch_plan, validate_single_cook_prompt_source};
 use crate::agent_task_dispatch_service::{self, AgentTaskDispatchCommand};
 use crate::agent_task_gate::VerifyGateOptions;
-use crate::agent_task_lifecycle;
+use crate::agent_task_lifecycle::{self, AgentTaskLifecycleStore};
 use crate::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use crate::agent_task_scheduler::{
     AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
@@ -255,18 +255,46 @@ fn claim_pre_artifact_interruption_retry(
     run_id: &str,
     plan: &AgentTaskPlan,
 ) -> Result<Option<(u32, String)>> {
-    let store = CookRecipeStore::from_current_data_root()?;
-    claim_pre_artifact_interruption_retry_with_store(&store, cook_id, attempt, run_id, plan, false)
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    claim_pre_artifact_interruption_retry_with_stores(
+        (&recipe_store, &lifecycle_store),
+        cook_id,
+        attempt,
+        run_id,
+        plan,
+        false,
+    )
 }
 
 fn claim_pre_artifact_interruption_retry_with_store(
-    store: &CookRecipeStore,
+    recipe_store: &CookRecipeStore,
     cook_id: &str,
     attempt: u32,
     run_id: &str,
     plan: &AgentTaskPlan,
     replace_semantic_attempt: bool,
 ) -> Result<Option<(u32, String)>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    claim_pre_artifact_interruption_retry_with_stores(
+        (recipe_store, &lifecycle_store),
+        cook_id,
+        attempt,
+        run_id,
+        plan,
+        replace_semantic_attempt,
+    )
+}
+
+fn claim_pre_artifact_interruption_retry_with_stores(
+    stores: (&CookRecipeStore, &AgentTaskLifecycleStore),
+    cook_id: &str,
+    attempt: u32,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    replace_semantic_attempt: bool,
+) -> Result<Option<(u32, String)>> {
+    let (recipe_store, lifecycle_store) = stores;
     let next_attempt = if replace_semantic_attempt {
         attempt
     } else {
@@ -281,7 +309,7 @@ fn claim_pre_artifact_interruption_retry_with_store(
     };
     let operation_key = pre_artifact_interruption_operation_key(run_id);
     let recipe_next_attempt = || {
-        store.load_recipe(cook_id).map(|recipe| {
+        recipe_store.load_recipe(cook_id).map(|recipe| {
             recipe
                 .attempts
                 .iter()
@@ -290,7 +318,7 @@ fn claim_pre_artifact_interruption_retry_with_store(
         })
     };
 
-    match agent_task_lifecycle::claim_cook_operation(
+    match lifecycle_store.claim_cook_operation(
         run_id,
         &operation_key,
         PRE_ARTIFACT_INTERRUPTION_CLAIM_LEASE,
@@ -302,11 +330,11 @@ fn claim_pre_artifact_interruption_retry_with_store(
                 agent_task_lifecycle::cook_attempt_run_id(cook_id, next_attempt)
             };
             if replace_semantic_attempt {
-                store.record_recipe_attempt_replacement(cook_id, run_id, &next_run_id)?;
+                recipe_store.record_recipe_attempt_replacement(cook_id, run_id, &next_run_id)?;
             } else {
-                store.record_recipe_attempt(cook_id, next_attempt, &next_run_id, plan)?;
+                recipe_store.record_recipe_attempt(cook_id, next_attempt, &next_run_id, plan)?;
             }
-            agent_task_lifecycle::complete_cook_operation(
+            lifecycle_store.complete_cook_operation(
                 run_id,
                 &operation_key,
                 serde_json::json!({
@@ -336,7 +364,7 @@ fn claim_pre_artifact_interruption_retry_with_store(
             // A crash after recipe append but before claim completion is safe to
             // finish: the immutable next attempt is already fully identified.
             if let Some(next_run_id) = recipe_next_attempt()? {
-                agent_task_lifecycle::complete_cook_operation(
+                lifecycle_store.complete_cook_operation(
                     run_id,
                     &operation_key,
                     serde_json::json!({

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1405,6 +1405,150 @@ fn pre_artifact_interruption_claim_is_restart_and_concurrent_controller_idempote
 }
 
 #[test]
+fn pre_artifact_interruption_claim_isolated_store_pairs_recover_identical_ids() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_recipe_store = CookRecipeStore::new(left_context.path_roots());
+    let right_recipe_store = CookRecipeStore::new(right_context.path_roots());
+    let left_lifecycle_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_lifecycle_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-pre-artifact-cook";
+    let run_id = "same-pre-artifact-run";
+    let mut left_options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    left_options.initial_run_id = run_id.to_string();
+    left_options.initial_plan.plan_id = "left-pre-artifact-plan".to_string();
+    let mut right_options =
+        batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    right_options.initial_run_id = run_id.to_string();
+    right_options.initial_plan.plan_id = "right-pre-artifact-plan".to_string();
+    left_recipe_store
+        .persist_initial_recipe(&left_options)
+        .expect("persist left recipe");
+    let left_plan = left_recipe_store
+        .load_recipe(cook_id)
+        .expect("load left recipe")
+        .attempts[0]
+        .plan
+        .clone();
+    right_recipe_store
+        .persist_initial_recipe(&right_options)
+        .expect("persist right recipe");
+    let right_plan = right_recipe_store
+        .load_recipe(cook_id)
+        .expect("load right recipe")
+        .attempts[0]
+        .plan
+        .clone();
+    left_lifecycle_store
+        .submit_plan_with_runtime_admission(&left_plan, run_id, |_| {
+            Ok(serde_json::json!({ "store": "left" }))
+        })
+        .expect("seed left lifecycle");
+    right_lifecycle_store
+        .submit_plan_with_runtime_admission(&right_plan, run_id, |_| {
+            Ok(serde_json::json!({ "store": "right" }))
+        })
+        .expect("seed right lifecycle");
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (left_result, right_result) = std::thread::scope(|scope| {
+        let left_barrier = Arc::clone(&barrier);
+        let recipe_store = left_recipe_store.clone();
+        let lifecycle_store = left_lifecycle_store.clone();
+        let plan = left_plan.clone();
+        let left = scope.spawn(move || {
+            left_barrier.wait();
+            claim_pre_artifact_interruption_retry_with_stores(
+                (&recipe_store, &lifecycle_store),
+                cook_id,
+                1,
+                run_id,
+                &plan,
+                false,
+            )
+            .expect("claim left retry")
+            .expect("left retry acquired")
+        });
+        let right_barrier = Arc::clone(&barrier);
+        let recipe_store = right_recipe_store.clone();
+        let lifecycle_store = right_lifecycle_store.clone();
+        let plan = right_plan.clone();
+        let right = scope.spawn(move || {
+            right_barrier.wait();
+            claim_pre_artifact_interruption_retry_with_stores(
+                (&recipe_store, &lifecycle_store),
+                cook_id,
+                1,
+                run_id,
+                &plan,
+                false,
+            )
+            .expect("claim right retry")
+            .expect("right retry acquired")
+        });
+        (left.join().unwrap(), right.join().unwrap())
+    });
+
+    assert_eq!(left_result.0, 2);
+    assert_eq!(right_result.0, 2);
+    assert_ne!(left_result.1, right_result.1);
+    for (recipe_store, lifecycle_store, plan, expected_plan_id, expected_result) in [
+        (
+            &left_recipe_store,
+            &left_lifecycle_store,
+            &left_plan,
+            "left-pre-artifact-plan",
+            &left_result,
+        ),
+        (
+            &right_recipe_store,
+            &right_lifecycle_store,
+            &right_plan,
+            "right-pre-artifact-plan",
+            &right_result,
+        ),
+    ] {
+        let persisted = recipe_store.load_recipe(cook_id).expect("load recipe");
+        assert_eq!(persisted.attempts[1].plan, *plan);
+        let persisted_claim = lifecycle_store
+            .operation_claim(run_id, &pre_artifact_interruption_operation_key(run_id))
+            .expect("read completed operation claim")
+            .expect("completed operation claim exists");
+        assert_eq!(
+            persisted_claim.result.as_ref().unwrap()["next_run_id"],
+            expected_result.1
+        );
+        let resumed = claim_pre_artifact_interruption_retry_with_stores(
+            (recipe_store, lifecycle_store),
+            cook_id,
+            1,
+            run_id,
+            plan,
+            false,
+        )
+        .expect("resume completed claim")
+        .expect("completed retry retained");
+        assert_eq!(&resumed, expected_result);
+        let recipe = recipe_store.load_recipe(cook_id).expect("load recipe");
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].plan.plan_id, expected_plan_id);
+        let claim = lifecycle_store
+            .operation_claim(run_id, &pre_artifact_interruption_operation_key(run_id))
+            .expect("read operation claim")
+            .expect("operation claim exists");
+        assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
+        assert_eq!(
+            claim.result.as_ref().unwrap()["next_run_id"],
+            expected_result.1
+        );
+    }
+    assert_ne!(
+        left_lifecycle_store.run_dir(run_id),
+        right_lifecycle_store.run_dir(run_id)
+    );
+}
+
+#[test]
 fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
     let _env_lock = homeboy_core::test_support::env_lock();
     let prior = std::env::var_os(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV);

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -155,6 +155,37 @@ impl AgentTaskLifecycleStore {
         super::record_pre_execution_failure_in_store(self, run_id, plan, phase, error)
     }
 
+    pub fn claim_cook_operation(
+        &self,
+        run_id: &str,
+        operation_key: &str,
+        lease: Duration,
+    ) -> Result<super::ClaimOutcome> {
+        super::operation_claims::claim_cook_operation_in_store(self, run_id, operation_key, lease)
+    }
+
+    pub fn complete_cook_operation(
+        &self,
+        run_id: &str,
+        operation_key: &str,
+        result: Value,
+    ) -> Result<()> {
+        super::operation_claims::complete_cook_operation_in_store(
+            self,
+            run_id,
+            operation_key,
+            result,
+        )
+    }
+
+    pub fn operation_claim(
+        &self,
+        run_id: &str,
+        operation_key: &str,
+    ) -> Result<Option<super::OperationClaim>> {
+        super::operation_claims::operation_claim_in_store(self, run_id, operation_key)
+    }
+
     pub fn read_controller_plan(&self, run_id: &str) -> Result<AgentTaskPlan> {
         read_controller_plan_in_store(self, run_id)
     }


### PR DESCRIPTION
## Summary
- route pre-artifact interruption retry claims through one explicit `CookRecipeStore` and `AgentTaskLifecycleStore` pair
- expose rooted lifecycle claim, completion, and reconciliation methods while preserving ambient compatibility wrappers
- prove concurrent same-ID retries and restarts remain isolated and idempotent across independent store roots

Progresses #7505.

## Verification
- `cargo test -p homeboy-agents pre_artifact_interruption_claim --lib`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::operation_claims --lib`
- `cargo check -p homeboy-agents --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Strict Clippy remains blocked by inherited Rust 1.95 warnings outside this change; no changed claim/store code produced a new warning.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace the Cook interruption claim path, implement the paired-store lifecycle seam, diagnose persisted plan canonicalization in the isolation fixture, review compatibility, and run verification. Chris Huber reviewed and remains responsible for every line.