### PR TITLE
Refresh stale Lab inventory before Cook refusal

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1578,6 +1578,111 @@ fn is_builtin_subcommand(name: &str) -> bool {
     crate::command_contract::registered_command(name).is_some()
 }
 
+#[derive(Debug, serde::Serialize)]
+struct LabInventoryAdmissionDiagnostic {
+    observed_state: String,
+    observed_at_ms: u128,
+    source_freshness: Option<String>,
+    refresh_attempted: bool,
+    refreshed_state: Option<String>,
+    refreshed_at_ms: Option<u128>,
+    terminal_reason: &'static str,
+    refresh_error_code: Option<String>,
+    refresh_error: Option<String>,
+}
+
+/// Resolve the inventory used by a terminal resource-policy placement decision.
+/// A stale projection gets one runner-owned live refresh; a fresh empty result
+/// is already authoritative enough to refuse without opening another probe.
+fn resolve_terminal_lab_inventory<F>(
+    observed: crate::runner::runners::LabRunnerReadiness,
+    observed_at_ms: u128,
+    refresh: F,
+) -> (
+    crate::runner::runners::LabRunnerReadiness,
+    LabInventoryAdmissionDiagnostic,
+)
+where
+    F: FnOnce() -> crate::core::Result<(crate::runner::runners::LabRunnerReadiness, u128)>,
+{
+    use crate::runner::runners::LabRunnerReadinessState;
+
+    let observed_state = observed.state.as_str().to_string();
+    let source_freshness = Some(observed_state.clone());
+    if observed.state != LabRunnerReadinessState::Stale {
+        return (
+            observed,
+            LabInventoryAdmissionDiagnostic {
+                observed_state,
+                observed_at_ms,
+                source_freshness,
+                refresh_attempted: false,
+                refreshed_state: None,
+                refreshed_at_ms: None,
+                terminal_reason: "no_ready_capacity",
+                refresh_error_code: None,
+                refresh_error: None,
+            },
+        );
+    }
+
+    match refresh() {
+        Ok((refreshed, refreshed_at_ms)) => {
+            let terminal_reason = if refreshed.state == LabRunnerReadinessState::ConnectedReady {
+                "ready_after_refresh"
+            } else if refreshed.state == LabRunnerReadinessState::Stale {
+                "inventory_stale"
+            } else {
+                "no_ready_capacity"
+            };
+            let refreshed_state = Some(refreshed.state.as_str().to_string());
+            (
+                refreshed,
+                LabInventoryAdmissionDiagnostic {
+                    observed_state,
+                    observed_at_ms,
+                    source_freshness,
+                    refresh_attempted: true,
+                    refreshed_state,
+                    refreshed_at_ms: Some(refreshed_at_ms),
+                    terminal_reason,
+                    refresh_error_code: None,
+                    refresh_error: None,
+                },
+            )
+        }
+        Err(error) => {
+            let timed_out = error.code == crate::core::ErrorCode::RemoteCommandTimeout;
+            let refresh_error_code = error.code.as_str().to_string();
+            (
+                observed,
+                LabInventoryAdmissionDiagnostic {
+                    observed_state,
+                    observed_at_ms,
+                    source_freshness,
+                    refresh_attempted: true,
+                    refreshed_state: None,
+                    refreshed_at_ms: Some(unix_timestamp_ms()),
+                    terminal_reason: if timed_out {
+                        "refresh_timeout"
+                    } else {
+                        "refresh_failed"
+                    },
+                    refresh_error_code: Some(refresh_error_code),
+                    refresh_error: Some(error.message),
+                },
+            )
+        }
+    }
+}
+
+fn unix_timestamp_ms() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
 fn preflight_hot_command(
     cli: &Cli,
     output_file: Option<&str>,
@@ -1590,10 +1695,13 @@ fn preflight_hot_command(
             } else {
                 None
             };
+            // Timestamp the projection after it has completed; it describes the
+            // exact inventory consumed by the terminal placement decision.
+            let lab_inventory_observed_at_ms = unix_timestamp_ms();
+            let mut lab_inventory_diagnostic = None;
             // A cached/projection-based inventory is enough for normal routing,
-            // but not for refusing portable work on a hot controller. Refresh
-            // the bounded, read-only admission facts once before rejection so
-            // an idle connected runner is not hidden behind stale inventory.
+            // but not for a terminal local-resource refusal. A stale inventory
+            // receives exactly one bounded runner-owned refresh before placement.
             if hot_command.lab_offload_supported
                 && cli.runner.is_none()
                 && !matches!(cli.placement, crate::cli_surface::Placement::Local)
@@ -1603,12 +1711,20 @@ fn preflight_hot_command(
                     lab_readiness.as_ref(),
                 )
                 .is_some()
-                && lab_readiness.as_ref().is_some_and(|readiness| {
-                    readiness.state
-                        != crate::runner::runners::LabRunnerReadinessState::ConnectedReady
-                })
             {
-                lab_readiness = crate::runner::refresh_lab_runner_readiness_for_admission().ok();
+                if let Some(observed) = lab_readiness.take() {
+                    let (resolved, diagnostic) = resolve_terminal_lab_inventory(
+                        observed,
+                        lab_inventory_observed_at_ms,
+                        || {
+                            let refreshed =
+                                crate::runner::refresh_lab_runner_readiness_for_admission()?;
+                            Ok((refreshed, unix_timestamp_ms()))
+                        },
+                    );
+                    lab_readiness = Some(resolved);
+                    lab_inventory_diagnostic = Some(diagnostic);
+                }
             }
             // An explicit runner is a routing decision, not a default-runner
             // fallback. Let Lab offload report any runner-specific readiness or
@@ -1733,7 +1849,7 @@ fn preflight_hot_command(
             }
             resource_policy::capture_context(resource_policy_context);
             if let Some(warning) = warning.as_ref() {
-                if let Some(err) = resource_policy::non_interactive_preflight_error(
+                if let Some(mut err) = resource_policy::non_interactive_preflight_error(
                     warning,
                     cli.placement.is_explicit_local_override() || runner_hosted,
                     is_interactive_shell(),
@@ -1752,6 +1868,10 @@ fn preflight_hot_command(
                     }),
                     runner_admits_offload || auto_local_capacity_fallback,
                 ) {
+                    if let Some(diagnostic) = lab_inventory_diagnostic {
+                        err.details["lab_inventory_admission"] = serde_json::to_value(diagnostic)
+                            .expect("Lab inventory admission diagnostic serializes");
+                    }
                     if review_test_deferred_workload_eligible(cli, warning, runner_admits_offload) {
                         return None;
                     }
@@ -2173,6 +2293,245 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn lab_readiness(
+        state: crate::runner::runners::LabRunnerReadinessState,
+    ) -> crate::runner::runners::LabRunnerReadiness {
+        crate::runner::runners::LabRunnerReadiness {
+            state,
+            selected_runner_id: (state
+                == crate::runner::runners::LabRunnerReadinessState::ConnectedReady)
+                .then(|| "lab-a".to_string()),
+            available_runner_ids: (state
+                == crate::runner::runners::LabRunnerReadinessState::ConnectedReady)
+                .then(|| vec!["lab-a".to_string()])
+                .unwrap_or_default(),
+            reasons: Vec::new(),
+            remediation_commands: Vec::new(),
+        }
+    }
+
+    fn hot_resources() -> crate::commands::resources::DoctorOutput {
+        use crate::commands::resources::{
+            DoctorOutput, LoadSummary, ProcessSummary, ResourceRecommendation, RigLeaseSummary,
+        };
+
+        DoctorOutput {
+            command: "self.resources",
+            recommendation: ResourceRecommendation::Warm,
+            load: LoadSummary {
+                one: Some(4.0),
+                five: Some(4.0),
+                fifteen: Some(4.0),
+                cpu_count: 2,
+                recommendation: ResourceRecommendation::Warm,
+            },
+            memory: None,
+            processes: ProcessSummary {
+                relevant_count: 0,
+                top_cpu: Vec::new(),
+                top_rss: Vec::new(),
+                recommendation: ResourceRecommendation::Ok,
+            },
+            rig_leases: RigLeaseSummary {
+                active_count: 0,
+                concurrency_limit: None,
+                leases: Vec::new(),
+                recommendation: ResourceRecommendation::Ok,
+            },
+            notes: Vec::new(),
+        }
+    }
+
+    fn cook_hot_command() -> resource_policy::HotCommand {
+        resource_policy::HotCommand {
+            label: "agent-task cook/run-plan/retry --run",
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+            allows_warm_runner_coordination: true,
+            offload_only_when_hot: false,
+        }
+    }
+
+    #[test]
+    fn stale_inventory_refreshes_once_and_routes_newly_ready_capacity() {
+        let (resolved, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Ok((
+                    lab_readiness(crate::runner::runners::LabRunnerReadinessState::ConnectedReady),
+                    200,
+                ))
+            },
+        );
+
+        assert_eq!(
+            resolved.state,
+            crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+        );
+        assert_eq!(resolved.selected_runner_id.as_deref(), Some("lab-a"));
+        assert!(diagnostic.refresh_attempted);
+        assert_eq!(diagnostic.observed_at_ms, 100);
+        assert_eq!(diagnostic.source_freshness.as_deref(), Some("stale"));
+        assert_eq!(diagnostic.refreshed_at_ms, Some(200));
+        assert_eq!(diagnostic.terminal_reason, "ready_after_refresh");
+    }
+
+    #[test]
+    fn stale_inventory_refresh_to_empty_reports_confirmed_no_ready_capacity() {
+        let (resolved, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Ok((
+                    lab_readiness(crate::runner::runners::LabRunnerReadinessState::CapacityBlocked),
+                    200,
+                ))
+            },
+        );
+
+        assert_eq!(
+            resolved.state,
+            crate::runner::runners::LabRunnerReadinessState::CapacityBlocked
+        );
+        assert_eq!(
+            diagnostic.refreshed_state.as_deref(),
+            Some("capacity_blocked")
+        );
+        assert_eq!(diagnostic.terminal_reason, "no_ready_capacity");
+    }
+
+    #[test]
+    fn stale_inventory_refresh_timeout_is_reported_without_local_fallback() {
+        let (resolved, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Err(crate::core::Error::new(
+                    crate::core::ErrorCode::RemoteCommandTimeout,
+                    "runner stopped answering",
+                    serde_json::Value::Null,
+                ))
+            },
+        );
+
+        assert_eq!(
+            resolved.state,
+            crate::runner::runners::LabRunnerReadinessState::Stale
+        );
+        assert_eq!(diagnostic.terminal_reason, "refresh_timeout");
+        assert!(diagnostic.refresh_attempted);
+        assert_eq!(
+            diagnostic.refresh_error_code.as_deref(),
+            Some("remote.command_timeout")
+        );
+        assert!(diagnostic.refresh_error.is_some());
+    }
+
+    #[test]
+    fn fresh_empty_inventory_does_not_open_a_refresh_probe() {
+        let (resolved, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::CapacityBlocked),
+            100,
+            || -> crate::core::Result<_> { panic!("fresh inventory must not refresh") },
+        );
+
+        assert_eq!(
+            resolved.state,
+            crate::runner::runners::LabRunnerReadinessState::CapacityBlocked
+        );
+        assert!(!diagnostic.refresh_attempted);
+        assert_eq!(diagnostic.observed_at_ms, 100);
+        assert_eq!(diagnostic.terminal_reason, "no_ready_capacity");
+    }
+
+    #[test]
+    fn preflight_resource_policy_routes_stale_inventory_to_refreshed_lab_capacity() {
+        let resources = hot_resources();
+        let (readiness, diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Ok((
+                    lab_readiness(crate::runner::runners::LabRunnerReadinessState::ConnectedReady),
+                    200,
+                ))
+            },
+        );
+
+        assert_eq!(diagnostic.terminal_reason, "ready_after_refresh");
+        assert!(resource_policy::admits_warm_runner_coordination(
+            cook_hot_command(),
+            &resources,
+            readiness.selected_runner_id.as_deref(),
+            Some(&readiness),
+        ));
+
+        // This is the exact routing capture boundary used by
+        // `preflight_hot_command`: the refreshed selection must survive beyond
+        // admission and become the auto-placement input consumed by dispatch.
+        resource_policy::reset_captured_context_for_test();
+        let warning = resource_policy::evaluate_with_runner_hint(
+            cook_hot_command(),
+            &resources,
+            Some(&readiness),
+        );
+        resource_policy::capture_context(resource_policy::resource_policy_context_from_evaluation(
+            cook_hot_command(),
+            &resources,
+            warning.as_ref(),
+            false,
+            false,
+            Some(&readiness),
+            false,
+        ));
+        let captured = resource_policy::captured_context().expect("preflight routing capture");
+        assert_eq!(
+            captured.runner_selection.runner_id.as_deref(),
+            Some("lab-a")
+        );
+        assert_eq!(captured.runner_selection.reason, "default_lab_runner");
+        resource_policy::reset_captured_context_for_test();
+    }
+
+    #[test]
+    fn preflight_resource_policy_keeps_timeout_and_fresh_empty_local_fallback_closed() {
+        let resources = hot_resources();
+        let (timed_out, timeout_diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Stale),
+            100,
+            || {
+                Err(crate::core::Error::new(
+                    crate::core::ErrorCode::RemoteCommandTimeout,
+                    "runner stopped answering",
+                    serde_json::Value::Null,
+                ))
+            },
+        );
+        let (fresh_empty, fresh_diagnostic) = resolve_terminal_lab_inventory(
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::CapacityBlocked),
+            300,
+            || -> crate::core::Result<_> { panic!("fresh inventory must not refresh") },
+        );
+
+        assert_eq!(timeout_diagnostic.terminal_reason, "refresh_timeout");
+        assert_eq!(fresh_diagnostic.terminal_reason, "no_ready_capacity");
+        for readiness in [&timed_out, &fresh_empty] {
+            assert!(!resource_policy::admits_warm_runner_coordination(
+                cook_hot_command(),
+                &resources,
+                readiness.selected_runner_id.as_deref(),
+                Some(readiness),
+            ));
+            assert!(!resource_policy::admits_auto_local_capacity_fallback(
+                cook_hot_command(),
+                &resources,
+                Some(readiness),
+                crate::cli_surface::Placement::Auto,
+            ));
+        }
+    }
 
     #[test]
     fn command_identity_uses_the_resolved_top_level_and_nested_path() {

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -1169,6 +1169,8 @@ mod tests {
 
     #[test]
     fn automatic_cook_refusal_names_when_no_runner_is_eligible() {
+        let _lock = env_lock();
+        let _ci = EnvVarGuard::remove("GITHUB_ACTIONS");
         let command = lab_supported_hot("agent-task cook/run-plan/retry --run");
         let unavailable = LabRunnerReadiness {
             state: crate::runner::runners::LabRunnerReadinessState::ConnectedIneligible,
@@ -1586,6 +1588,7 @@ mod tests {
     fn hot_lab_or_local_requires_admission_before_local_fallback() {
         let _lock = env_lock();
         let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
+        let _ci = EnvVarGuard::remove("GITHUB_ACTIONS");
         let placement = crate::cli_surface::Placement::LabOrLocal;
         let disconnected = LabRunnerReadiness {
             state: crate::runner::runners::LabRunnerReadinessState::Disconnected,

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -6,13 +6,13 @@ use homeboy_agents::agent_tasks::provider::{
     AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
 };
 use homeboy_core::engine::shell;
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use homeboy_core::server::{
     self, execute_local_command_in_dir, execute_local_command_in_dir_with_timeout, SshClient,
 };
 
-use super::runner_probe_gate::deduplicated_probe;
+use super::runner_probe_gate::{deduplicated_probe, deduplicated_probe_until};
 use super::{remote_runner_homeboy_path, Runner, RunnerKind, RunnerToolRegistry};
 
 /// Stable label for the remote capability probe in the probe-gate ledger.
@@ -286,11 +286,41 @@ pub struct RunnerCapabilityInventory {
 }
 
 pub fn runner_capability_inventory(runner_id: &str) -> Result<RunnerCapabilityInventory> {
+    runner_capability_inventory_with_preflight(runner_id, RunnerCapabilityPreflight::default())
+}
+
+/// Read the runner capability inventory under the caller's shared observation
+/// deadline. `execute_with_timeout` terminates the SSH process group when the
+/// remaining budget expires, so admission cannot leave a probe behind.
+pub fn runner_capability_inventory_until(
+    runner_id: &str,
+    deadline: std::time::Instant,
+) -> Result<RunnerCapabilityInventory> {
+    let timeout = deadline
+        .checked_duration_since(std::time::Instant::now())
+        .filter(|timeout| !timeout.is_zero())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::RemoteCommandTimeout,
+                "Runner capability inventory deadline expired before probing",
+                serde_json::json!({ "runner_id": runner_id }),
+            )
+        })?;
+    runner_capability_inventory_with_preflight(
+        runner_id,
+        RunnerCapabilityPreflight {
+            timeout: Some(timeout),
+            ..RunnerCapabilityPreflight::default()
+        },
+    )
+}
+
+fn runner_capability_inventory_with_preflight(
+    runner_id: &str,
+    preflight: RunnerCapabilityPreflight,
+) -> Result<RunnerCapabilityInventory> {
     let runner = super::load(runner_id)?;
-    let snapshot = RunnerCapabilitySnapshot::from_runner_probe(
-        &runner,
-        &RunnerCapabilityPreflight::default(),
-    )?;
+    let snapshot = RunnerCapabilitySnapshot::from_runner_probe(&runner, &preflight)?;
     let mut capabilities = snapshot
         .tools
         .iter()
@@ -436,25 +466,47 @@ impl RunnerCapabilitySnapshot {
         // script and the environment it runs under are identical, so collapse
         // concurrent askers onto one connection and cap how many can be open to
         // this runner at all.
-        let fingerprint = batch_probe_fingerprint(&script, &client.env);
-        deduplicated_probe(
-            &runner.id,
-            RUNNER_CAPABILITY_PROBE,
-            &fingerprint,
-            move || {
-                let output = preflight
-                    .timeout
-                    .map(|timeout| client.execute_with_timeout(&script, timeout))
-                    .unwrap_or_else(|| client.execute(&script));
-                Ok(parse_batch_probe_output(
-                    &output.stdout,
-                    &tool_commands,
-                    &command_names,
-                    &capability_probes,
-                    &preflight.required_toolchain_probes,
-                ))
-            },
-        )
+        let fingerprint = format!(
+            "{}:timeout_ms={}",
+            batch_probe_fingerprint(&script, &client.env),
+            preflight
+                .timeout
+                .map(|timeout| timeout.as_millis())
+                .unwrap_or(0),
+        );
+        let probe = move || {
+            let output = preflight
+                .timeout
+                .map(|timeout| client.execute_with_timeout(&script, timeout))
+                .unwrap_or_else(|| client.execute(&script));
+            if output.timed_out {
+                return Err(Error::new(
+                    ErrorCode::RemoteCommandTimeout,
+                    "Runner capability inventory probe timed out",
+                    serde_json::json!({
+                        "runner_id": runner.id,
+                        "timeout_ms": preflight.timeout.map(|timeout| timeout.as_millis()),
+                    }),
+                ));
+            }
+            Ok(parse_batch_probe_output(
+                &output.stdout,
+                &tool_commands,
+                &command_names,
+                &capability_probes,
+                &preflight.required_toolchain_probes,
+            ))
+        };
+        match preflight.timeout {
+            Some(timeout) => deduplicated_probe_until(
+                &runner.id,
+                RUNNER_CAPABILITY_PROBE,
+                &fingerprint,
+                std::time::Instant::now() + timeout,
+                probe,
+            ),
+            None => deduplicated_probe(&runner.id, RUNNER_CAPABILITY_PROBE, &fingerprint, probe),
+        }
     }
 
     fn local_batch_probe(
@@ -1106,6 +1158,15 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_secs(1));
         assert!(snapshot.tool_capabilities.is_empty());
+    }
+
+    #[test]
+    fn deadline_aware_inventory_fails_with_a_structured_timeout_before_probing() {
+        let error = runner_capability_inventory_until("lab", std::time::Instant::now())
+            .expect_err("expired admission budget must not start a capability probe");
+
+        assert_eq!(error.code, ErrorCode::RemoteCommandTimeout);
+        assert_eq!(error.details["runner_id"], "lab");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -293,10 +293,10 @@ pub use apply::{
 };
 pub use capabilities::{
     evaluate_lab_runner_capabilities_for_inventory, evaluate_lab_runner_capabilities_for_runner,
-    prepare_lab_runner_capability, runner_capability_inventory, LabRunnerCapabilityContract,
-    LabRunnerGateDecision, LabRunnerGateMode, PreparedLabRunnerCapability,
-    RunnerCapabilityInventory, RunnerCapabilityPreflight, RunnerRequiredTool,
-    RunnerToolCapabilityRequirement, RunnerToolchainReadinessProbe,
+    prepare_lab_runner_capability, runner_capability_inventory, runner_capability_inventory_until,
+    LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
+    PreparedLabRunnerCapability, RunnerCapabilityInventory, RunnerCapabilityPreflight,
+    RunnerRequiredTool, RunnerToolCapabilityRequirement, RunnerToolchainReadinessProbe,
 };
 pub(crate) use command_path::normalize_runner_command_env_for_homeboy_path;
 pub use command_path::preflight_remote_argv_path_translation;
@@ -875,57 +875,81 @@ pub fn refresh_lab_runner_readiness_for_admission() -> Result<LabRunnerReadiness
     let preferred = defaults::load_config().lab.preferred_runner;
     let mut runner_ids = configured_lab_runner_ids()?;
     runner_ids.sort();
-    let candidates = runner_ids
-        .into_iter()
-        .take(DETACHED_QUEUE_REFRESH_LIMIT)
-        .filter_map(|runner_id| {
-            let runner = load(&runner_id).ok()?;
-            runner_probe_gate::invalidate_runner_probes(&runner_id);
-            let status = status(&runner_id).ok();
-            let Some(status) = status else {
-                // A configured runner whose authoritative status is unavailable
-                // is disconnected, not absent. Preserve that distinction for
-                // the recovery command reported by hot-controller admission.
-                return Some(DefaultLabRunnerCandidate {
-                    id: runner_id,
-                    mode: RunnerTunnelMode::DirectSsh,
-                    connected: false,
-                    capacity: runner.settings.concurrency_limit,
-                    stale_daemon: false,
-                    unverified_daemon: false,
-                    admission_fresh: true,
-                    admission_remediation: None,
-                    active_jobs: 0,
-                    active_jobs_available: false,
-                    capabilities_ready: false,
-                });
-            };
-            let capabilities_ready = runner_capability_inventory(&runner_id)
-                .is_ok_and(|inventory| !inventory.runtime_ids.is_empty());
-            let mode = status
-                .session
-                .as_ref()
-                .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
-            Some(DefaultLabRunnerCandidate {
-                id: runner_id,
-                mode,
-                connected: status.connected,
-                capacity: runner.settings.concurrency_limit,
-                stale_daemon: status.admission_blocking_stale_daemon().is_some(),
-                unverified_daemon: status.unverified_daemon().is_some(),
-                admission_fresh: status.daemon_fresh_for_admission(),
-                admission_remediation: status
-                    .admission_action()
-                    .map(|action| action.render_command()),
-                active_jobs: status.active_job_count.max(status.active_jobs.len()),
-                active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
-                capabilities_ready,
-            })
-        })
-        .collect();
-    Ok(lab_runner_readiness_from_candidates(
-        preferred.as_deref(),
-        candidates,
+    let deadline = std::time::Instant::now() + readonly_probe::readonly_probe_timeout();
+    let mut observations = Vec::new();
+    for runner_id in runner_ids.into_iter().take(DETACHED_QUEUE_REFRESH_LIMIT) {
+        observations.push(observe_lab_runner_admission_candidate(&runner_id, deadline));
+    }
+    lab_runner_readiness_from_refresh_observations(preferred.as_deref(), observations)
+}
+
+fn observe_lab_runner_admission_candidate(
+    runner_id: &str,
+    deadline: std::time::Instant,
+) -> Result<DefaultLabRunnerCandidate> {
+    let runner = load(runner_id)?;
+    runner_probe_gate::invalidate_runner_probes(runner_id);
+    let status = runner_admission_snapshot_until(runner_id, deadline)?.status;
+    let capabilities_ready = runner_capability_inventory_until(runner_id, deadline)?
+        .runtime_ids
+        .contains("homeboy");
+    let mode = status
+        .session
+        .as_ref()
+        .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
+    Ok(DefaultLabRunnerCandidate {
+        id: runner_id.to_string(),
+        mode,
+        connected: status.connected,
+        capacity: runner.settings.concurrency_limit,
+        stale_daemon: status.admission_blocking_stale_daemon().is_some(),
+        unverified_daemon: status.unverified_daemon().is_some(),
+        admission_fresh: status.daemon_fresh_for_admission(),
+        admission_remediation: status
+            .admission_action()
+            .map(|action| action.render_command()),
+        active_jobs: status.active_job_count.max(status.active_jobs.len()),
+        active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+        capabilities_ready,
+    })
+}
+
+fn lab_runner_readiness_from_refresh_observations(
+    preferred: Option<&str>,
+    observations: Vec<Result<DefaultLabRunnerCandidate>>,
+) -> Result<LabRunnerReadiness> {
+    let mut candidates = Vec::new();
+    let mut failures = Vec::new();
+    for observation in observations {
+        match observation {
+            Ok(candidate) => candidates.push(candidate),
+            Err(error) => failures.push(serde_json::json!({
+                "code": error.code.as_str(),
+                "message": error.message,
+                "details": error.details,
+            })),
+        }
+    }
+    let readiness = lab_runner_readiness_from_candidates(preferred, candidates);
+    if readiness.state == LabRunnerReadinessState::ConnectedReady || failures.is_empty() {
+        return Ok(readiness);
+    }
+    let timeout = failures.iter().all(|failure| {
+        failure.get("code").and_then(serde_json::Value::as_str)
+            == Some(homeboy_core::error::ErrorCode::RemoteCommandTimeout.as_str())
+    });
+    Err(homeboy_core::error::Error::new(
+        if timeout {
+            homeboy_core::error::ErrorCode::RemoteCommandTimeout
+        } else {
+            homeboy_core::error::ErrorCode::RunnerLabTransportFailure
+        },
+        "No Lab runner completed the bounded admission refresh",
+        serde_json::json!({
+            "runner_failures": failures,
+            "observed_readiness_state": readiness.state.as_str(),
+            "available_runner_ids": readiness.available_runner_ids,
+        }),
     ))
 }
 
@@ -1881,6 +1905,61 @@ mod tests {
         );
         assert_eq!(refreshed.state, LabRunnerReadinessState::ConnectedReady);
         assert_eq!(refreshed.selected_runner_id.as_deref(), Some("lab-a"));
+    }
+
+    #[test]
+    fn admission_refresh_continues_past_a_failed_runner_to_ready_capacity() {
+        let readiness = lab_runner_readiness_from_refresh_observations(
+            None,
+            vec![
+                Err(homeboy_core::error::Error::new(
+                    homeboy_core::error::ErrorCode::RemoteCommandTimeout,
+                    "lab-a timed out",
+                    serde_json::Value::Null,
+                )),
+                Ok(default_lab_candidate(
+                    "lab-b",
+                    RunnerTunnelMode::Reverse,
+                    true,
+                )),
+            ],
+        )
+        .expect("a later ready runner must win admission");
+
+        assert_eq!(readiness.selected_runner_id.as_deref(), Some("lab-b"));
+        assert_eq!(readiness.available_runner_ids, ["lab-b"]);
+    }
+
+    #[test]
+    fn admission_refresh_aggregates_failures_only_when_no_runner_is_ready() {
+        let mut full = default_lab_candidate("lab-b", RunnerTunnelMode::Reverse, true);
+        full.capacity = Some(1);
+        full.active_jobs = 1;
+        let error = lab_runner_readiness_from_refresh_observations(
+            None,
+            vec![
+                Err(homeboy_core::error::Error::new(
+                    homeboy_core::error::ErrorCode::RemoteCommandTimeout,
+                    "lab-a timed out",
+                    serde_json::Value::Null,
+                )),
+                Ok(full),
+            ],
+        )
+        .expect_err("aggregate failures only after every runner is unavailable");
+
+        assert_eq!(
+            error.code,
+            homeboy_core::error::ErrorCode::RemoteCommandTimeout
+        );
+        assert_eq!(
+            error.details["runner_failures"][0]["code"],
+            "remote.command_timeout"
+        );
+        assert_eq!(
+            error.details["observed_readiness_state"],
+            "capacity_blocked"
+        );
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runner_probe_gate.rs
+++ b/crates/homeboy-lab-runner/src/runner_probe_gate.rs
@@ -50,7 +50,7 @@ use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::{Error, ErrorCode, Result};
 
 /// How long a successful probe answer stays reusable without reconnecting.
 pub const DEFAULT_PROBE_CACHE_TTL: Duration = Duration::from_secs(30);
@@ -277,8 +277,14 @@ impl Drop for ProbePermit {
     }
 }
 
-/// Block until this runner has a free connection slot, then take it.
-fn acquire_permit(runner_id: &str, probe: &str, limit: usize) -> ProbePermit {
+/// Block until this runner has a free connection slot, then take it. The caller
+/// owns the deadline so a saturated probe gate cannot outlive admission.
+fn acquire_permit_until(
+    runner_id: &str,
+    probe: &str,
+    limit: usize,
+    deadline: Instant,
+) -> Result<ProbePermit> {
     let budget = budget_for(runner_id);
     let mut throttled = false;
     let peak;
@@ -286,10 +292,18 @@ fn acquire_permit(runner_id: &str, probe: &str, limit: usize) -> ProbePermit {
         let mut inner = lock(&budget.inner);
         while inner.active >= limit {
             throttled = true;
-            inner = budget
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .ok_or_else(|| probe_permit_timeout_error(runner_id, probe, limit))?;
+            let (guard, timeout) = budget
                 .released
-                .wait(inner)
+                .wait_timeout(inner, remaining)
                 .unwrap_or_else(PoisonError::into_inner);
+            inner = guard;
+            if timeout.timed_out() && inner.active >= limit {
+                return Err(probe_permit_timeout_error(runner_id, probe, limit));
+            }
         }
         inner.active += 1;
         inner.peak = inner.peak.max(inner.active);
@@ -308,7 +322,20 @@ fn acquire_permit(runner_id: &str, probe: &str, limit: usize) -> ProbePermit {
             metrics.throttled += 1;
         }
     });
-    ProbePermit { budget }
+    Ok(ProbePermit { budget })
+}
+
+fn probe_permit_timeout_error(runner_id: &str, probe: &str, limit: usize) -> Error {
+    Error::new(
+        ErrorCode::RemoteCommandTimeout,
+        "Runner probe admission deadline expired while waiting for capacity",
+        serde_json::json!({
+            "runner_id": runner_id,
+            "probe": probe,
+            "concurrency_limit": limit,
+            "stage": "probe_permit",
+        }),
+    )
 }
 
 /// Clears the in-flight marker even if the probe panics, so a panicking probe
@@ -356,6 +383,28 @@ where
     T: Clone + Send + Sync + 'static,
     F: FnOnce() -> Result<T>,
 {
+    deduplicated_probe_until(
+        runner_id,
+        probe,
+        fingerprint,
+        Instant::now() + probe_wait(),
+        run,
+    )
+}
+
+/// Deadline-aware form of [`deduplicated_probe`]. The shared deadline covers
+/// cache coalescing, permit acquisition, and the caller's bounded transport.
+pub fn deduplicated_probe_until<T, F>(
+    runner_id: &str,
+    probe: &str,
+    fingerprint: &str,
+    deadline: Instant,
+    run: F,
+) -> Result<T>
+where
+    T: Clone + Send + Sync + 'static,
+    F: FnOnce() -> Result<T>,
+{
     let ttl = probe_cache_ttl();
     let wait = probe_wait();
     let limit = probe_concurrency();
@@ -389,11 +438,18 @@ where
             break;
         }
         waited = true;
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| probe_permit_timeout_error(runner_id, probe, limit))?;
         let (guard, timeout) = slot
             .ready
-            .wait_timeout(inner, wait)
+            .wait_timeout(inner, wait.min(remaining))
             .unwrap_or_else(PoisonError::into_inner);
         inner = guard;
+        if timeout.timed_out() && Instant::now() >= deadline {
+            return Err(probe_permit_timeout_error(runner_id, probe, limit));
+        }
         if timeout.timed_out() {
             // Fail open. The owner is slower than the wait budget; opening one
             // extra connection beats blocking the caller indefinitely.
@@ -411,7 +467,7 @@ where
     let _in_flight = InFlightGuard {
         slot: Arc::clone(&slot),
     };
-    let permit = acquire_permit(runner_id, probe, limit);
+    let permit = acquire_permit_until(runner_id, probe, limit, deadline)?;
     record(runner_id, probe, |metrics| metrics.dispatched += 1);
     let outcome = run();
     drop(permit);
@@ -515,6 +571,38 @@ mod tests {
         let metrics = metrics_for("lab", "cached");
         assert_eq!(metrics.dispatched, 1);
         assert_eq!(metrics.cache_hits, 4);
+    }
+
+    #[test]
+    fn deadline_aware_probe_times_out_while_waiting_for_a_saturated_permit() {
+        let _serialized = serialized();
+        let limit = probe_concurrency();
+        let permits = (0..limit)
+            .map(|_| {
+                acquire_permit_until(
+                    "lab",
+                    "saturated",
+                    limit,
+                    Instant::now() + Duration::from_secs(1),
+                )
+                .expect("saturating permit")
+            })
+            .collect::<Vec<_>>();
+
+        let started = Instant::now();
+        let error = deduplicated_probe_until(
+            "lab",
+            "saturated",
+            "second-question",
+            Instant::now() + Duration::from_millis(25),
+            || Ok("unreachable".to_string()),
+        )
+        .expect_err("saturated permit must respect the admission deadline");
+
+        assert_eq!(error.code, ErrorCode::RemoteCommandTimeout);
+        assert_eq!(error.details["stage"], "probe_permit");
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(permits);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/runners.rs
+++ b/crates/homeboy-lab-runner/src/runners.rs
@@ -83,7 +83,9 @@ pub use crate::{
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
     RunnerWorkspaceUpdateOptions, RunnerWorkspaceUpdateOutput, RuntimeMaterializationStatus,
 };
-pub use crate::{observe_runner_capabilities, runner_capability_inventory};
+pub use crate::{
+    observe_runner_capabilities, runner_capability_inventory, runner_capability_inventory_until,
+};
 
 // Registry CRUD entry points.
 pub use crate::{


### PR DESCRIPTION
## Summary

- refresh stale Lab readiness once through a shared deadline before terminal local-resource refusal
- bound probe-permit waits and SSH capability discovery, continue across failed runners, and select later ready capacity
- preserve structured timeout/failure evidence and prevent implicit local fallback

## Verification

- Lab admission refresh and saturated-probe tests
- CLI resource-policy routing tests
- `cargo check -p homeboy-cli`
- `cargo fmt --check`

Fixes #12520.

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** implementation, control-plane review, and deterministic Rust test execution. Chris Huber reviewed and remains responsible for every line.