### PR TITLE
refactor(agent-task): root Cook follow-up stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -228,7 +228,16 @@ pub fn checkpoint_candidate_adoption_remediation(
     run_id: &str,
     remediation_run_id: &str,
 ) -> Result<()> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    checkpoint_candidate_adoption_remediation_in_store(&lifecycle_store, run_id, remediation_run_id)
+}
+
+pub(crate) fn checkpoint_candidate_adoption_remediation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    remediation_run_id: &str,
+) -> Result<()> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let Some(attempt) = record.candidate_adoption.as_mut() else {
         return Err(Error::validation_invalid_argument(
             "run_id",
@@ -247,7 +256,7 @@ pub fn checkpoint_candidate_adoption_remediation(
     attempt.remediation_status_command = Some(format!(
         "homeboy agent-task status {remediation_run_id} --full"
     ));
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4536,6 +4536,16 @@ pub(crate) fn update_cook_candidate_after_completion(
     aggregate: &AgentTaskAggregate,
     promotion: Option<Value>,
 ) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    update_cook_candidate_after_completion_in_store(&lifecycle_store, record, aggregate, promotion)
+}
+
+pub(crate) fn update_cook_candidate_after_completion_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+    promotion: Option<Value>,
+) -> Result<()> {
     let Some(cook_id) = record.metadata.get("cook_id").and_then(Value::as_str) else {
         return Ok(());
     };
@@ -4547,7 +4557,7 @@ pub(crate) fn update_cook_candidate_after_completion(
     else {
         return Ok(());
     };
-    store::update_cook_index(cook_id, |index| {
+    lifecycle_store.update_cook_index(cook_id, |index| {
         replace_latest_substantive_candidate(index, candidate)
     })?;
     Ok(())
@@ -4786,8 +4796,17 @@ fn empty_acceptance_candidate() -> crate::agent_task_promotion::AgentTaskCandida
 }
 
 pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_promotion_in_store(&lifecycle_store, run_id, promotion)
+}
+
+pub(crate) fn record_promotion_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    promotion: Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("latest_promotion") == Some(&promotion) {
             return false;
         }
@@ -4865,10 +4884,15 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
     })?;
     let record = match record {
         Some(record) => record,
-        None => store::read_record(&run_id)?,
+        None => lifecycle_store.read_record(&run_id)?,
     };
-    if let Ok(aggregate) = store::read_aggregate(&run_id) {
-        update_cook_candidate_after_completion(&record, &aggregate, Some(promotion))?;
+    if let Ok(aggregate) = lifecycle_store.read_aggregate(&run_id) {
+        update_cook_candidate_after_completion_in_store(
+            lifecycle_store,
+            &record,
+            &aggregate,
+            Some(promotion),
+        )?;
     }
     Ok(record)
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -43,12 +43,13 @@ use super::cook_pre_execution::{
     with_pre_execution_phase,
 };
 use super::cook_promotion::{
-    attempt_needs_execution, cook_report, finalize_or_load_cook_pr,
+    attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
     finalize_or_load_cook_pr_with_store, is_moving_base_finalization_error,
     moving_base_recovery_for_run_with_store, moving_base_recovery_from_promotion,
     moving_base_recovery_report, next_moving_base_recovery, persisted_promotion_for_attempt,
     promote_or_load_attempt, recover_moving_base_cook_candidate, refreshed_moving_base_recovery,
-    retryable_provider_discovery_failure, CookReportInput, MovingBaseCookRecovery,
+    retryable_provider_discovery_failure, retryable_provider_discovery_failure_with_store,
+    CookReportInput, MovingBaseCookRecovery,
 };
 use super::cook_recipe::CookRecipeStore;
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
@@ -3092,6 +3093,34 @@ fn child_execution_budget(
     }
 }
 
+fn validate_cook_follow_up_stores(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    detached_dispatch: bool,
+) -> Result<()> {
+    if recipe_store.data_root() != lifecycle_store.data_root() {
+        return Err(Error::validation_invalid_argument(
+            "stores",
+            "Cook follow-up recipe and lifecycle stores must share one data root",
+            Some(format!(
+                "recipe={}, lifecycle={}",
+                recipe_store.data_root().display(),
+                lifecycle_store.data_root().display()
+            )),
+            None,
+        ));
+    }
+    if !detached_dispatch && !lifecycle_store.matches_current_environment()? {
+        return Err(Error::validation_invalid_argument(
+            "lifecycle_store",
+            "explicit lifecycle storage for local Cook follow-up execution requires the full execution boundary",
+            Some(lifecycle_store.data_root().display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Append and dispatch one remediation attempt from an authenticated promoted
 /// candidate. Both ordinary Cook feedback and external candidate adoption use
 /// this boundary so their budget, provenance, and baseline authority match.
@@ -3100,7 +3129,7 @@ fn child_execution_budget(
     reason = "Cook follow-up retains explicit durable recipe and dispatch identity fields"
 )]
 pub(crate) fn dispatch_cook_follow_up<E>(
-    store: &CookRecipeStore,
+    stores: (&CookRecipeStore, &AgentTaskLifecycleStore),
     options: &AgentTaskCookServiceOptions,
     executor: E,
     cook_id: &str,
@@ -3119,10 +3148,16 @@ pub(crate) fn dispatch_cook_follow_up<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
+    let (recipe_store, lifecycle_store) = stores;
+    validate_cook_follow_up_stores(
+        recipe_store,
+        lifecycle_store,
+        options.attempt_dispatcher.is_some(),
+    )?;
     if let Some(reason) = remediation_tool_policy_error(&follow_up_request) {
         return Ok(CookFollowUpDispatch::PolicyFailure { reason });
     }
-    let recipe = store.load_recipe(cook_id)?;
+    let recipe = recipe_store.load_recipe(cook_id)?;
     let related_attempts = recipe.attempts.iter().filter(|recipe_attempt| {
         recipe_attempt.plan.tasks.len() == 1
             && recipe_attempt.plan.tasks[0].inputs["cook_loop"]["artifact_provenance"]
@@ -3136,7 +3171,10 @@ where
         .filter(|recipe_attempt| recipe_attempt.attempt > attempt)
         .filter(|recipe_attempt| {
             recipe_attempt.plan.tasks[0].inputs["cook_loop"]["review_form_required"] == true
-                && retryable_provider_discovery_failure(&recipe_attempt.run_id)
+                && retryable_provider_discovery_failure_with_store(
+                    lifecycle_store,
+                    &recipe_attempt.run_id,
+                )
         })
         .cloned();
     let persisted_budget_authority = plan
@@ -3180,7 +3218,7 @@ where
                     .as_str()
                     == Some(source_run_id))
     }) {
-        if let Ok(aggregate) = agent_task_lifecycle::read_aggregate(&recipe_attempt.run_id) {
+        if let Ok(aggregate) = lifecycle_store.read_aggregate(&recipe_attempt.run_id) {
             durable_budget_used.add(execution_budget_usage(&aggregate));
         }
     }
@@ -3204,7 +3242,8 @@ where
         || follow_up_request.inputs["cook_loop"]["review_form_required"] == true)
         .then_some(true)
         .or_else(|| {
-            let durable_provider_executions = agent_task_lifecycle::status(source_run_id)
+            let durable_provider_executions = lifecycle_store
+                .read_record(source_run_id)
                 .ok()
                 .and_then(|record| record.metadata.get("provider_executions").cloned())
                 .filter(|executions| {
@@ -3290,11 +3329,11 @@ where
     let review_form_only =
         follow_up_plan.tasks[0].inputs["cook_loop"]["review_form_required"] == true;
     if let Some(replaced_run_id) = replaced_run_id {
-        store.record_recipe_attempt_replacement(cook_id, &replaced_run_id, &next_run_id)?;
+        recipe_store.record_recipe_attempt_replacement(cook_id, &replaced_run_id, &next_run_id)?;
     } else {
-        store.record_recipe_attempt(cook_id, next_attempt, &next_run_id, &follow_up_plan)?;
+        recipe_store.record_recipe_attempt(cook_id, next_attempt, &next_run_id, &follow_up_plan)?;
     }
-    if attempt_needs_execution(&next_run_id) {
+    if attempt_needs_execution_with_store(lifecycle_store, &next_run_id) {
         let baseline = materialize_follow_up_baseline(
             promotion,
             source_run_id,
@@ -3307,13 +3346,11 @@ where
         // Refresh the durable execution attestation before this plan can be
         // persisted or handed to a local or detached provider.
         bind_dispatch_workspace_attestations(&mut follow_up_plan)?;
-        agent_task_lifecycle::submit_plan(&follow_up_plan, Some(&next_run_id))?;
-        agent_task_lifecycle::record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
+        lifecycle_store.submit_plan_with_current_runtime(&follow_up_plan, &next_run_id)?;
+        lifecycle_store.record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
         if budget_scope == CookFollowUpBudgetScope::CandidateAdoptionReview {
-            agent_task_lifecycle::checkpoint_candidate_adoption_remediation(
-                source_run_id,
-                &next_run_id,
-            )?;
+            lifecycle_store
+                .checkpoint_candidate_adoption_remediation(source_run_id, &next_run_id)?;
         }
         if let Some(dispatcher) = &options.attempt_dispatcher {
             // A detached dispatcher may return before any executor-side
@@ -3327,7 +3364,7 @@ where
             // this baseline-bound workspace contract, and so the run record the
             // claim is written onto exists.
             let operation_key = retry_dispatch_operation_key(&next_run_id);
-            match agent_task_lifecycle::claim_cook_operation(
+            match lifecycle_store.claim_cook_operation(
                 &next_run_id,
                 &operation_key,
                 RETRY_DISPATCH_CLAIM_LEASE,
@@ -3338,7 +3375,7 @@ where
                         &next_run_id,
                         Some(baseline.capability()),
                     )?;
-                    agent_task_lifecycle::complete_cook_operation(
+                    lifecycle_store.complete_cook_operation(
                         &next_run_id,
                         &operation_key,
                         serde_json::json!({ "dispatched_run_id": next_run_id }),
@@ -3364,8 +3401,8 @@ where
     // The generated ID is random by design. Link the execution only after its
     // materialized plan is durable, so a resumed controller selects this exact
     // run without replacing its baseline-bound workspace contract.
-    if !attempt_needs_execution(&next_run_id) {
-        agent_task_lifecycle::record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
+    if !attempt_needs_execution_with_store(lifecycle_store, &next_run_id) {
+        lifecycle_store.record_cook_attempt(cook_id, next_attempt, &next_run_id)?;
     }
     if review_form_only {
         // A form-only retry deliberately makes no code changes. Carry the
@@ -3377,7 +3414,7 @@ where
             "kind": "review_form_only",
             "source_run_id": source_run_id,
         });
-        agent_task_lifecycle::record_promotion(
+        lifecycle_store.record_promotion(
             &next_run_id,
             serde_json::to_value(carried_promotion)
                 .map_err(|error| Error::internal_json(error.to_string(), None))?,
@@ -5603,8 +5640,9 @@ where
                 .0;
                 let review_form_only =
                     follow_up_request.inputs["cook_loop"]["review_form_required"] == true;
+                let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
                 match dispatch_cook_follow_up(
-                    store,
+                    (store, &lifecycle_store),
                     &options,
                     executor.clone(),
                     &cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -681,8 +681,10 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             },
             Err(error) => return Err(error),
         };
+        let lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
         let dispatch = dispatch_cook_follow_up(
-            &store,
+            (&store, &lifecycle_store),
             &options,
             executor.clone(),
             cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -697,18 +697,36 @@ fn promotion_checkpoint_matches(promotion: &AgentTaskPromotionReport, checkpoint
 
 pub(crate) fn attempt_needs_execution(run_id: &str) -> bool {
     agent_task_lifecycle::status(run_id)
-        .map(|record| {
-            !matches!(
-                record.state,
-                agent_task_lifecycle::AgentTaskRunState::Succeeded
-                    | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-                    | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-                    | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-                    | agent_task_lifecycle::AgentTaskRunState::Failed
-                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
-            )
-        })
+        .map(|record| run_record_needs_execution(&record))
         .unwrap_or(true)
+}
+
+pub(crate) fn attempt_needs_execution_with_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> bool {
+    if lifecycle_store
+        .matches_current_environment()
+        .unwrap_or(false)
+    {
+        return attempt_needs_execution(run_id);
+    }
+    lifecycle_store
+        .read_record(run_id)
+        .map(|record| run_record_needs_execution(&record))
+        .unwrap_or(true)
+}
+
+fn run_record_needs_execution(record: &agent_task_lifecycle::AgentTaskRunRecord) -> bool {
+    !matches!(
+        record.state,
+        agent_task_lifecycle::AgentTaskRunState::Succeeded
+            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
+            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+            | agent_task_lifecycle::AgentTaskRunState::Failed
+            | agent_task_lifecycle::AgentTaskRunState::Cancelled
+    )
 }
 
 pub(crate) fn retryable_provider_discovery_failure(run_id: &str) -> bool {
@@ -723,6 +741,32 @@ pub(crate) fn retryable_provider_discovery_failure(run_id: &str) -> bool {
                         .any(|diagnostic| diagnostic.class == "agent_task.provider_missing")
                 })
         })
+}
+
+pub(crate) fn retryable_provider_discovery_failure_with_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> bool {
+    if lifecycle_store
+        .matches_current_environment()
+        .unwrap_or(false)
+    {
+        return retryable_provider_discovery_failure(run_id);
+    }
+    lifecycle_store
+        .read_record(run_id)
+        .is_ok_and(|record| record.state == agent_task_lifecycle::AgentTaskRunState::Failed)
+        && lifecycle_store
+            .read_aggregate(run_id)
+            .is_ok_and(|aggregate| {
+                !aggregate.outcomes.is_empty()
+                    && aggregate.outcomes.iter().all(|outcome| {
+                        outcome
+                            .diagnostics
+                            .iter()
+                            .any(|diagnostic| diagnostic.class == "agent_task.provider_missing")
+                    })
+            })
 }
 
 pub(crate) fn is_moving_base_finalization_error(error: &Error) -> bool {

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -46,6 +46,10 @@ impl CookRecipeStore {
         Ok(Self::from_data_root(paths::homeboy_data()?))
     }
 
+    pub(crate) fn data_root(&self) -> PathBuf {
+        self.data_root.clone()
+    }
+
     fn recipe_root(&self) -> PathBuf {
         self.data_root.join("agent-task-cooks")
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10722,37 +10722,66 @@ fn retry_dispatch_operation_key_claim_dispatches_once() {
     // (or a concurrent one) observes the completed claim / held lease and must
     // not send a second handoff. This exercises that exactly-once contract at the
     // claim boundary without the full git-backed cook loop.
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let cook_id = "cook-dispatch-claim";
-        let next_run_id = "run-dispatch-claim-attempt-2";
-        let plan = AgentTaskPlan::new(cook_id, Vec::new());
-        agent_task_lifecycle::submit_plan(&plan, Some(next_run_id)).unwrap();
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let cook_id = "cook-dispatch-claim";
+    let next_run_id = "run-dispatch-claim-attempt-2";
+    let plan = AgentTaskPlan::new(cook_id, Vec::new());
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, next_run_id, |_| Ok(serde_json::json!({})))
+        .unwrap();
 
-        let operation_key = retry_dispatch_operation_key(next_run_id);
-        let lease = std::time::Duration::from_secs(60);
+    let operation_key = retry_dispatch_operation_key(next_run_id);
+    let lease = std::time::Duration::from_secs(60);
 
-        // First pass acquires the claim → performs the (modeled) dispatch → completes.
-        assert_eq!(
-            agent_task_lifecycle::claim_cook_operation(next_run_id, &operation_key, lease).unwrap(),
-            agent_task_lifecycle::ClaimOutcome::Acquired
-        );
-        agent_task_lifecycle::complete_cook_operation(
+    // First pass acquires the claim → performs the (modeled) dispatch → completes.
+    assert_eq!(
+        lifecycle_store
+            .claim_cook_operation(next_run_id, &operation_key, lease)
+            .unwrap(),
+        agent_task_lifecycle::ClaimOutcome::Acquired
+    );
+    lifecycle_store
+        .complete_cook_operation(
             next_run_id,
             &operation_key,
             serde_json::json!({ "dispatched_run_id": next_run_id }),
         )
         .unwrap();
 
-        // A resumed pass observes AlreadyCompleted and must not re-dispatch.
-        match agent_task_lifecycle::claim_cook_operation(next_run_id, &operation_key, lease)
-            .unwrap()
-        {
-            agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
-                assert_eq!(result["dispatched_run_id"], next_run_id);
-            }
-            other => panic!("expected AlreadyCompleted, got {other:?}"),
+    // A resumed pass observes AlreadyCompleted and must not re-dispatch.
+    match lifecycle_store
+        .claim_cook_operation(next_run_id, &operation_key, lease)
+        .unwrap()
+    {
+        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
+            assert_eq!(result["dispatched_run_id"], next_run_id);
         }
-    });
+        other => panic!("expected AlreadyCompleted, got {other:?}"),
+    }
+}
+
+#[test]
+fn cook_follow_up_store_boundary_rejects_split_roots_and_unrooted_local_execution() {
+    let first = homeboy_core::test_support::HermeticTestContext::new();
+    let second = homeboy_core::test_support::HermeticTestContext::new();
+    let recipe_store = CookRecipeStore::new(first.path_roots());
+    let lifecycle_store = AgentTaskLifecycleStore::new(first.path_roots());
+    let other_lifecycle_store = AgentTaskLifecycleStore::new(second.path_roots());
+
+    validate_cook_follow_up_stores(&recipe_store, &lifecycle_store, true).unwrap();
+
+    let split_root_error =
+        validate_cook_follow_up_stores(&recipe_store, &other_lifecycle_store, true).unwrap_err();
+    assert!(split_root_error
+        .to_string()
+        .contains("recipe and lifecycle stores must share one data root"));
+
+    let local_execution_error =
+        validate_cook_follow_up_stores(&recipe_store, &lifecycle_store, false).unwrap_err();
+    assert!(local_execution_error
+        .to_string()
+        .contains("requires the full execution boundary"));
 }
 
 #[test]
@@ -10921,54 +10950,71 @@ fn concurrent_retry_dispatch_claims_admit_exactly_one_dispatcher() {
     // held lease (or a completed claim) and do not send a second handoff. This
     // exercises the claim's atomic converge-on-one-owner contract for the
     // retry-dispatch key across real threads.
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let cook_id = "cook-concurrent-dispatch";
-        let next_run_id = "run-concurrent-dispatch-attempt-2";
-        let plan = AgentTaskPlan::new(cook_id, Vec::new());
-        agent_task_lifecycle::submit_plan(&plan, Some(next_run_id)).unwrap();
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let next_run_id = "same-concurrent-dispatch-attempt-2";
+    for (store, plan_id) in [(&left_store, "left-plan"), (&right_store, "right-plan")] {
+        store
+            .submit_plan_with_runtime_admission(
+                &AgentTaskPlan::new(plan_id, Vec::new()),
+                next_run_id,
+                |_| Ok(serde_json::json!({})),
+            )
+            .unwrap();
+    }
+    let operation_key = retry_dispatch_operation_key(next_run_id);
+    let lease = std::time::Duration::from_secs(300);
+    let left_acquired = Arc::new(AtomicUsize::new(0));
+    let right_acquired = Arc::new(AtomicUsize::new(0));
+    let barrier = Arc::new(Barrier::new(4));
+    let mut handles = Vec::new();
 
-        let operation_key = retry_dispatch_operation_key(next_run_id);
-        let lease = std::time::Duration::from_secs(300);
-        let acquired = Arc::new(AtomicUsize::new(0));
-        let barrier = Arc::new(Barrier::new(4));
-
-        let handles: Vec<_> = (0..4)
-            .map(|_| {
-                let key = operation_key.clone();
-                let run = next_run_id.to_string();
-                let acquired = Arc::clone(&acquired);
-                let barrier = Arc::clone(&barrier);
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    if let agent_task_lifecycle::ClaimOutcome::Acquired =
-                        agent_task_lifecycle::claim_cook_operation(&run, &key, lease).unwrap()
-                    {
-                        acquired.fetch_add(1, Ordering::SeqCst);
-                        // The winning dispatcher records completion after its handoff.
-                        agent_task_lifecycle::complete_cook_operation(
-                            &run,
+    for (store, acquired) in [
+        (left_store.clone(), Arc::clone(&left_acquired)),
+        (right_store.clone(), Arc::clone(&right_acquired)),
+    ] {
+        for _ in 0..2 {
+            let store = store.clone();
+            let key = operation_key.clone();
+            let acquired = Arc::clone(&acquired);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                if let agent_task_lifecycle::ClaimOutcome::Acquired = store
+                    .claim_cook_operation(next_run_id, &key, lease)
+                    .unwrap()
+                {
+                    acquired.fetch_add(1, Ordering::SeqCst);
+                    store
+                        .complete_cook_operation(
+                            next_run_id,
                             &key,
-                            serde_json::json!({ "dispatched_run_id": run }),
+                            serde_json::json!({ "dispatched_run_id": next_run_id }),
                         )
                         .unwrap();
-                    }
-                })
-            })
-            .collect();
-        for handle in handles {
-            handle.join().unwrap();
+                }
+            }));
         }
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
 
-        assert_eq!(
-            acquired.load(Ordering::SeqCst),
-            1,
-            "exactly one concurrent pass may dispatch the retry"
-        );
-        let claim = agent_task_lifecycle::operation_claim(next_run_id, &operation_key)
+    assert_eq!(left_acquired.load(Ordering::SeqCst), 1);
+    assert_eq!(right_acquired.load(Ordering::SeqCst), 1);
+    for store in [&left_store, &right_store] {
+        let claim = store
+            .operation_claim(next_run_id, &operation_key)
             .unwrap()
             .expect("dispatch claim recorded");
         assert_eq!(claim.state, agent_task_lifecycle::ClaimState::Completed);
-    });
+    }
+    assert_ne!(
+        left_store.run_dir(next_run_id),
+        right_store.run_dir(next_run_id)
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -84,6 +84,10 @@ impl AgentTaskLifecycleStore {
         self.roots.data().to_path_buf()
     }
 
+    pub(crate) fn matches_current_environment(&self) -> Result<bool> {
+        Ok(self.roots == paths::PathRoots::from_environment()?)
+    }
+
     pub(crate) fn workspace_claim_store(
         &self,
     ) -> homeboy_core::workspace_claim::WorkspaceClaimStore {
@@ -126,6 +130,26 @@ impl AgentTaskLifecycleStore {
             None,
             Some(admission_status),
             admit_runtime,
+        )
+    }
+
+    pub(crate) fn submit_plan_with_current_runtime(
+        &self,
+        plan: &AgentTaskPlan,
+        run_id: &str,
+    ) -> Result<AgentTaskRunRecord> {
+        self.submit_plan_with_runtime_admission_status(
+            plan,
+            run_id,
+            super::lifecycle_ops::execution_runner_id(),
+            &|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok(),
+            |run_id| {
+                homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+                    run_id,
+                    || Ok(self.read_record(run_id)?.state.is_terminal()),
+                )
+                .map(|admission| admission.runtime)
+            },
         )
     }
 
@@ -184,6 +208,22 @@ impl AgentTaskLifecycleStore {
         operation_key: &str,
     ) -> Result<Option<super::OperationClaim>> {
         super::operation_claims::operation_claim_in_store(self, run_id, operation_key)
+    }
+
+    pub fn checkpoint_candidate_adoption_remediation(
+        &self,
+        run_id: &str,
+        remediation_run_id: &str,
+    ) -> Result<()> {
+        super::lifecycle_candidate_adoption::checkpoint_candidate_adoption_remediation_in_store(
+            self,
+            run_id,
+            remediation_run_id,
+        )
+    }
+
+    pub fn record_promotion(&self, run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_promotion_in_store(self, run_id, promotion)
     }
 
     pub fn read_controller_plan(&self, run_id: &str) -> Result<AgentTaskPlan> {
@@ -246,6 +286,22 @@ impl AgentTaskLifecycleStore {
 
     pub fn read_cook_index(&self, cook_id: &str) -> Result<AgentTaskCookIndex> {
         read_cook_index_in_store(self, cook_id)
+    }
+
+    pub(crate) fn update_cook_index(
+        &self,
+        cook_id: &str,
+        mutate: impl FnOnce(&mut AgentTaskCookIndex) -> bool,
+    ) -> Result<Option<AgentTaskCookIndex>> {
+        let path = self.cook_index_path(cook_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let mut index = read_json(&path)?;
+        if mutate(&mut index) {
+            write_json(&path, &index)?;
+        }
+        Ok(Some(index))
     }
 
     pub fn cook_index_exists(&self, cook_id: &str) -> bool {
@@ -1002,17 +1058,7 @@ pub(super) fn update_cook_index(
     cook_id: &str,
     mutate: impl FnOnce(&mut AgentTaskCookIndex) -> bool,
 ) -> Result<Option<AgentTaskCookIndex>> {
-    let path = cook_index_path(&sanitize_run_id(cook_id))?;
-    if !path.exists() {
-        return Ok(None);
-    }
-    let mut index = read_json(&path)?;
-    if mutate(&mut index) {
-        // `write_json` is atomic; this makes the pointer update one durable
-        // index transaction without nesting the configuration lock it owns.
-        write_json(&path, &index)?;
-    }
-    Ok(Some(index))
+    default_store()?.update_cook_index(cook_id, mutate)
 }
 
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {


### PR DESCRIPTION
## Summary
- pass an explicit `CookRecipeStore` and `AgentTaskLifecycleStore` through Cook follow-up materialization and detached dispatch
- root retry claims, Cook indexing, adoption remediation checkpoints, aggregate reads, and carried promotion writes in the paired lifecycle store
- reject split recipe/lifecycle roots before mutation and fail closed for non-ambient local execution until the full execution boundary is threaded
- preserve ambient reconciled-status behavior while testing identical run IDs across independent hermetic stores

Continues #7505.

## Verification
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents cook_follow_up_store_boundary --lib`
- `cargo test -p homeboy-agents retry_dispatch --lib`
- `cargo test -p homeboy-agents detached_adoption_follow_up --lib`
- `cargo test -p homeboy-agents cook_alias_status_projects_active_adoption_remediation --lib`
- `git diff --check`

The serial Cook module run passed 177 tests and reported 3 failures. Each failing test reproduces unchanged on `main` at `cfc861afc`:
- `cook_failure_context_counts_preflight_cook_alias_as_zero_execution`
- `reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution`
- `run_cook_persists_recipe_in_explicit_store_only`

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode was used to inspect the lifecycle boundaries, implement the store threading, add tests, run verification, and review the final diff. Chris Huber remains responsible for every line.