### PR TITLE
Preserve pending runner ownership during PID projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -207,11 +207,12 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
     // its key before cancellation so the original job is cancelled rather than
     // left running on the runner. Preparing intents have no replay request and
     // deliberately do not reach this lookup.
-    if record.state == AgentTaskRunState::Queued
-        && super::lab_handoff_reconciliation::bind_pending_runner_submission_if_accepted(
-            &record.run_id,
-        )?
-    {
+    if matches!(
+        record.state,
+        AgentTaskRunState::Queued | AgentTaskRunState::Running
+    ) && super::lab_handoff_reconciliation::bind_pending_runner_submission_if_accepted(
+        &record.run_id,
+    )? {
         record = store::read_record(&record.run_id)?;
     }
     if record.state == AgentTaskRunState::Cancelled {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -72,8 +72,10 @@ pub(crate) fn has_expired_pending_runner_submission_intent(
     record: &AgentTaskRunRecord,
     now: chrono::DateTime<chrono::Utc>,
 ) -> bool {
-    record.state == AgentTaskRunState::Queued
-        && record.runner_job_id().is_none()
+    matches!(
+        record.state,
+        AgentTaskRunState::Queued | AgentTaskRunState::Running
+    ) && record.runner_job_id().is_none()
         && record.lab_handoff.as_ref().is_some_and(|handoff| {
             handoff.state == AgentTaskLabHandoffState::Pending
                 && handoff.authority == AgentTaskLabHandoffAuthority::Controller
@@ -92,7 +94,15 @@ pub(crate) fn has_expired_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
 }
 
 fn has_complete_pending_runner_submission_intent(record: &AgentTaskRunRecord) -> bool {
-    if record.state != AgentTaskRunState::Queued || record.runner_job_id().is_some() {
+    // The reverse broker can start the runner-side workload before its accepted
+    // job projection reaches this controller record. That transient `Running`
+    // record is still submission-owned until the acceptance deadline, not an
+    // ownerless process that stale reconciliation may cancel.
+    if !matches!(
+        record.state,
+        AgentTaskRunState::Queued | AgentTaskRunState::Running
+    ) || record.runner_job_id().is_some()
+    {
         return false;
     }
     let Some(handoff) = record.lab_handoff.as_ref().filter(|handoff| {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -529,16 +529,18 @@ impl AgentTaskRunRecord {
         &self,
         now: chrono::DateTime<chrono::Utc>,
     ) -> bool {
-        self.state == AgentTaskRunState::Queued
-            && self.lab_handoff.as_ref().is_some_and(|handoff| {
-                handoff.is_valid()
-                    && handoff.state == AgentTaskLabHandoffState::Pending
-                    && handoff
-                        .acceptance_deadline_at
-                        .as_deref()
-                        .and_then(parse_rfc3339)
-                        .is_some_and(|deadline| deadline <= now)
-            })
+        matches!(
+            self.state,
+            AgentTaskRunState::Queued | AgentTaskRunState::Running
+        ) && self.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.is_valid()
+                && handoff.state == AgentTaskLabHandoffState::Pending
+                && handoff
+                    .acceptance_deadline_at
+                    .as_deref()
+                    .and_then(parse_rfc3339)
+                    .is_some_and(|deadline| deadline <= now)
+        })
     }
 
     pub(crate) fn record_runner_metadata(&mut self, reclaimed_stale: bool) {
@@ -558,7 +560,20 @@ impl AgentTaskRunRecord {
     }
 
     pub(crate) fn annotate_stale_running(&mut self) {
-        if self.state != AgentTaskRunState::Running || self.owner_process_is_running() {
+        if self.state != AgentTaskRunState::Running {
+            return;
+        }
+
+        // A reverse-broker job may begin before the daemon's accepted job/PID
+        // projection arrives. Its complete, unexpired submission intent remains
+        // the authoritative owner during that narrow handoff window.
+        // Its PID belongs to the runner host, so this controller cannot use a
+        // local PID probe to disprove that ownership.
+        if super::has_live_pending_runner_submission_intent(self, chrono::Utc::now()) {
+            return;
+        }
+
+        if self.owner_process_is_running() {
             return;
         }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -12,6 +12,7 @@ use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
+use crate::agent_task_service::reconcile_stale_active_runs;
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
@@ -745,6 +746,125 @@ fn detached_cook_intent_reconciliation_converges_both_crash_windows_without_secr
             .expect("broker JSON");
         assert!(!persisted.contains("secret-value"));
         assert!(lookups.lock().expect("lookup log").is_empty());
+    });
+}
+
+#[test]
+fn pending_submission_owns_running_proxy_until_job_projection_arrives() {
+    super::ensure_runner_continuation_provider_reset_hook();
+    with_isolated_home(|_| {
+        let store = JobStore::default();
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let lookups = Arc::new(Mutex::new(Vec::new()));
+        let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
+            store: store.clone(),
+            submitted: Arc::clone(&submitted),
+            lookups: Arc::clone(&lookups),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        let run_id = "delayed-runner-job-projection";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("record controller proxy");
+        let request = replay_request(run_id, &command);
+        record_lab_offload_submission_request(run_id, &request)
+            .expect("persist pending broker request");
+        let accepted_job = store
+            .submit_remote_runner_job(request)
+            .expect("broker accepts before response projection");
+        rewrite_record_for_test(run_id, |record| {
+            set_run_state(record, AgentTaskRunState::Running);
+            record.tasks[0].state = AgentTaskState::Running;
+            // This is a runner-host PID. It cannot be probed by the controller.
+            record.metadata["runner_pid"] = json!(u32::MAX);
+        })
+        .expect("simulate runner start before projection");
+
+        assert_eq!(
+            reconcile_stale_active_runs(false)
+                .expect("remote PID does not make pending submission stale")
+                .considered,
+            0
+        );
+
+        let mut cancelled_job = accepted_job.clone();
+        cancelled_job.status = homeboy_core::api_jobs::JobStatus::Cancelled;
+        let expected_job_id = accepted_job.id.to_string();
+        let _cancel = crate::agent_task_lifecycle::cancellation::test_cancel_hook::install(
+            Box::new(move |runner_id, runner_job_id, durable_run_id| {
+                assert_eq!(runner_id, "homeboy-lab");
+                assert_eq!(runner_job_id, expected_job_id);
+                assert_eq!(durable_run_id, run_id);
+                Ok((cancelled_job.clone(), Vec::new()))
+            }),
+        );
+        let cancelled = cancel_run(run_id, Some("operator cancellation"))
+            .expect("cancellation binds and cancels accepted broker job");
+        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            cancelled.runner_job_id(),
+            Some(accepted_job.id.to_string().as_str())
+        );
+        assert_eq!(
+            cancelled.metadata["live_cancellation"]["cancellation"],
+            "runner_job_cancel"
+        );
+        assert_eq!(lookups.lock().expect("submission lookup").len(), 1);
+        assert!(submitted.lock().expect("replay submissions").is_empty());
+    });
+}
+
+#[test]
+fn expired_running_submission_retains_typed_handoff_rejection() {
+    super::ensure_runner_continuation_provider_reset_hook();
+    with_isolated_home(|_| {
+        let _runner = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
+            store: JobStore::default(),
+            submitted: Arc::new(Mutex::new(Vec::new())),
+            lookups: Arc::new(Mutex::new(Vec::new())),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        let run_id = "expired-running-submission";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("record controller proxy");
+        record_lab_offload_submission_request(run_id, &replay_request(run_id, &command))
+            .expect("persist pending broker request");
+        rewrite_record_for_test(run_id, |record| {
+            set_run_state(record, AgentTaskRunState::Running);
+            record.tasks[0].state = AgentTaskState::Running;
+            record
+                .lab_handoff
+                .as_mut()
+                .expect("pending handoff")
+                .acceptance_deadline_at =
+                Some((chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339());
+        })
+        .expect("simulate rejected runner submission");
+
+        let expired = status(run_id).expect("expired handoff is terminalized");
+        assert_eq!(expired.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            expired.metadata["cancel_reason"],
+            EXPIRED_LAB_HANDOFF_REASON
+        );
+        assert_eq!(expired.metadata["phase"], "handoff_rejected");
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -652,6 +652,16 @@ fn classify_liveness(
         return AgentTaskLiveness::Active;
     }
 
+    if agent_task_lifecycle::has_expired_pending_runner_submission_intent(record, now) {
+        return AgentTaskLiveness::Unreconciled;
+    }
+    // Pending reverse-broker ownership is runner-host authority. A projected
+    // runner PID cannot be probed on this controller; acceptance or expiry is
+    // the durable boundary for resolving its liveness.
+    if agent_task_lifecycle::has_live_pending_runner_submission_intent(record, now) {
+        return AgentTaskLiveness::Active;
+    }
+
     if record.is_stale_running() {
         return AgentTaskLiveness::Stale;
     }


### PR DESCRIPTION
## Summary

Preserve reverse-broker submission ownership when a Lab proxy reaches `Running` before its accepted runner job/PID projection reaches the controller.

Closes #12535.

## What Changed

- Treat complete, unexpired pending submission intent as authoritative in both `Queued` and transitional `Running` states.
- Order discovery and stale annotation so runner-host pending authority is resolved before controller-local PID checks.
- Bind accepted pending submissions by submission key before cancelling either `Queued` or `Running` proxies, preventing orphaned runner work.
- Keep expired `Running` submissions on the existing typed `handoff_rejected` path.
- Add broker-backed coverage for delayed projection, cross-host PID handling, exact accepted-job binding, idempotent lookup, and routed cancellation.

## Root Cause

The reverse broker can start the runner-side workload before accepted job/PID projection reaches the controller record. The lifecycle only recognized pending ownership while `Queued`; once the proxy became `Running`, stale reconciliation interpreted the missing projection as `missing_runner_pid` and cancelled before provider start.

## Verification

- `cargo test -p homeboy-agents agent_task_lifecycle::tests --lib` (231 passed)
- `cargo test -p homeboy-agents status_and_recovery --lib` (53 passed after final rebase)
- `cargo fmt --check`
- `cargo check -p homeboy-agents --all-targets`
- `git diff --check`

## Evidence Boundary

The deterministic tests use the production broker contract fixture and job store to reproduce accepted work with delayed projection and prove cancellation binding. A live Lab replay remains the post-merge verification step before resuming #12290.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode investigated the durable Cook and runner evidence, implemented and reviewed the lifecycle repair, identified and corrected cancellation and cross-host PID issues during review, and ran the verification commands. Chris Huber reviewed and owns every line.