### PR TITLE
fix(agent-task): preserve planned runner handoffs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -562,7 +562,9 @@ impl AgentTaskRunRecord {
             return;
         }
 
-        if self.runner_job_id().is_some() && self.has_fresh_update() {
+        if self.has_fresh_update()
+            && (self.runner_job_id().is_some() || self.has_planned_runner_execution())
+        {
             return;
         }
 
@@ -721,6 +723,22 @@ impl AgentTaskRunRecord {
                     .num_minutes()
                     < homeboy_core::observation::RUNNING_HEARTBEAT_STALE_MINUTES
             })
+    }
+
+    fn has_planned_runner_execution(&self) -> bool {
+        let execution = self.metadata.get("runner_execution_record");
+        execution
+            .and_then(|value| value.get("status"))
+            .and_then(Value::as_str)
+            == Some("planned")
+            && execution
+                .and_then(|value| value.get("agent_task_run_id"))
+                .and_then(Value::as_str)
+                == Some(self.run_id.as_str())
+            && execution
+                .and_then(|value| value.get("runner_id"))
+                .and_then(Value::as_str)
+                .is_some_and(|runner_id| self.runner_id() == Some(runner_id))
     }
 
     /// A run is runner-backed when its durable record carries a runner id or

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -2060,6 +2060,57 @@ fn status_marks_running_run_without_owner_as_stale() {
 }
 
 #[test]
+fn status_keeps_fresh_planned_runner_submission_live() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let run_id = "run-planned-runner-submission";
+        submit_plan(&plan, Some(run_id)).expect("submitted");
+        mark_running(run_id).expect("running");
+        record_lab_offload_phase(
+            run_id,
+            "homeboy-lab",
+            "materializing",
+            None,
+            None,
+            None,
+            Some(&plan),
+        )
+        .expect("planned runner submission recorded");
+        rewrite_record_for_test(run_id, |record| {
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata object")
+                .remove("runner_pid");
+        })
+        .expect("controller owner removed");
+
+        let loaded = status(run_id).expect("status loaded");
+
+        assert_eq!(loaded.state, AgentTaskRunState::Running);
+        assert_eq!(
+            loaded.metadata["runner_execution_record"]["status"],
+            "planned"
+        );
+        assert!(loaded.metadata.get("stale_running").is_none());
+
+        rewrite_record_for_test(run_id, |record| {
+            record.updated_at = Some(
+                (chrono::Utc::now()
+                    - chrono::Duration::minutes(
+                        homeboy_core::observation::RUNNING_HEARTBEAT_STALE_MINUTES,
+                    ))
+                .to_rfc3339(),
+            );
+        })
+        .expect("planned submission aged past heartbeat threshold");
+        let stale = status(run_id).expect("stale status loaded");
+        assert_eq!(stale.metadata["stale_running"], true);
+        assert_eq!(stale.metadata["stale_running_reason"], "missing_runner_pid");
+    });
+}
+
+#[test]
 fn cancel_run_marks_queued_record_cancelled() {
     with_isolated_home(|_| {
         let plan = test_plan();

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -505,6 +505,46 @@ mod tests {
     }
 
     #[test]
+    fn the_daemon_tick_preserves_a_fresh_planned_runner_submission() {
+        with_isolated_home(|_| {
+            register_orchestration_driver();
+            let run_id = "reconcile-tick-planned-runner";
+            let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+            agent_task_lifecycle::mark_running(run_id).expect("running");
+            agent_task_lifecycle::record_lab_offload_phase(
+                run_id,
+                "homeboy-lab",
+                "materializing",
+                None,
+                None,
+                None,
+                Some(&plan),
+            )
+            .expect("planned runner submission recorded");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+            })
+            .expect("controller owner removed");
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("tick pass");
+
+            assert_eq!(report["reconciled"], 0, "{report}");
+            let refreshed = agent_task_lifecycle::status(run_id).expect("refreshed");
+            assert_eq!(
+                refreshed.state,
+                agent_task_lifecycle::AgentTaskRunState::Running
+            );
+            assert!(refreshed.metadata.get("stale_running").is_none());
+        });
+    }
+
+    #[test]
     fn a_reconciled_run_reports_the_state_it_was_left_in() {
         // The `reconciled` branch used to hardcode `Running` — reporting the
         // state of a run it had just cancelled, which made the whole report


### PR DESCRIPTION
## Summary

- keep a fresh, run-bound planned runner execution live while daemon job/PID publication is pending
- preserve existing stale reconciliation after the normal heartbeat threshold expires
- cover both status projection and the automatic daemon reconciliation tick

Closes #12531.
Refs #12535.

## Verification

- `cargo fmt --all --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::handoff_and_proxy` (47 passed)
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests` (8 passed)
- `cargo test -p homeboy-agents cancel_run_reclaims_stale_running_record` (1 passed)
- `cargo test -p homeboy-agents discovery_active_classifies_liveness_and_source` (1 passed)
- `git diff --check`

The full `cargo test -p homeboy-agents --lib` run completed with 1,809 passed, 6 ignored, and 16 failures under shared process/temp-directory contention. The one liveness-adjacent failure passed independently; the remaining failures were unrelated promotion, scheduler, provider, and scratch fixtures.

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode correlated the MDI and SSI durable-run evidence, traced the cancellation race, implemented the bounded liveness predicate and regression tests, and ran the verification commands. Chris Huber reviewed and owns the change.