### PR TITLE
refactor(agent-task): root local Cook execution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1779,6 +1779,14 @@ pub fn prune_controller_runtime_pins(
 }
 
 fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    migrate_record_controller_runtime_in_store(&lifecycle_store, record)
+}
+
+fn migrate_record_controller_runtime_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<()> {
     let Some(runtime) = record
         .metadata
         .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
@@ -1790,7 +1798,7 @@ fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<
         homeboy_core::controller_runtime::migrate_legacy_pin_and_persist(&original, |migrated| {
             record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
                 migrated.clone();
-            store::write_record(record)
+            lifecycle_store.write_record(record)
         })?;
     record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = migrated;
     Ok(())
@@ -1829,15 +1837,23 @@ pub fn recover_controller_runtime(
 }
 
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    mark_running_in_store(&lifecycle_store, run_id)
+}
+
+pub(crate) fn mark_running_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let mut record = store::read_record(&run_id)?;
-    migrate_record_controller_runtime(&mut record)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
+    migrate_record_controller_runtime_in_store(lifecycle_store, &mut record)?;
     homeboy_core::controller_runtime::validate_for_mutation(
         &record.metadata,
         &homeboy_core::build_identity::current().display,
     )?;
     let mut error = None;
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("queue_quarantine").is_some() {
             error = Some(Error::validation_invalid_argument(
                 "run_id",
@@ -1901,11 +1917,24 @@ pub fn reserve_provider_execution(
     task: &AgentTaskRequest,
     attempt: u32,
 ) -> Result<ProviderExecutionReservation> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    reserve_provider_execution_in_store(&lifecycle_store, run_id, task, attempt)
+}
+
+pub(crate) fn reserve_provider_execution_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task: &AgentTaskRequest,
+    attempt: u32,
+) -> Result<ProviderExecutionReservation> {
     let run_id = sanitize_run_id(run_id);
-    require_record_workspace_owner(&store::read_record(&run_id)?)?;
+    require_record_workspace_owner_in_store(
+        &lifecycle_store.workspace_claim_store(),
+        &lifecycle_store.read_record(&run_id)?,
+    )?;
     let execution_key = format!("{}:{attempt}", task.task_id);
     let mut reservation = ProviderExecutionReservation::AlreadyReserved;
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let started_at = now_timestamp();
         let consumed = {
             let metadata = record.ensure_metadata_object();
@@ -2284,10 +2313,21 @@ pub fn record_provider_execution_terminal(
     attempt: u32,
     state: &str,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_provider_execution_terminal_in_store(&lifecycle_store, run_id, task_id, attempt, state)
+}
+
+pub(crate) fn record_provider_execution_terminal_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    state: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let execution_key = format!("{task_id}:{attempt}");
     let mut found = false;
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let cancelled = record.state == AgentTaskRunState::Cancelled;
         let Some(execution) = record
             .ensure_metadata_object()
@@ -2353,10 +2393,27 @@ pub fn record_provider_execution_cleanup_elapsed(
     attempt: u32,
     elapsed_ms: u64,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_provider_execution_cleanup_elapsed_in_store(
+        &lifecycle_store,
+        run_id,
+        task_id,
+        attempt,
+        elapsed_ms,
+    )
+}
+
+pub(crate) fn record_provider_execution_cleanup_elapsed_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    elapsed_ms: u64,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let execution_key = format!("{task_id}:{attempt}");
     let mut found = false;
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(execution) = record
             .ensure_metadata_object()
             .get_mut("provider_executions")

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1,6 +1,6 @@
 use homeboy_engine_primitives::content_hash;
 use std::collections::{HashMap, VecDeque};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Instant;
@@ -27,6 +27,7 @@ pub struct AgentTaskScheduler<E> {
     executor: Arc<E>,
     run_id: Option<String>,
     harvest_context: HarvestExecutionContext,
+    lifecycle_store: Option<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
     #[cfg(test)]
     scratch_root: Option<std::path::PathBuf>,
 }
@@ -46,6 +47,7 @@ where
             executor: Arc::new(executor),
             run_id: None,
             harvest_context: HarvestExecutionContext::default(),
+            lifecycle_store: None,
             #[cfg(test)]
             scratch_root: None,
         }
@@ -58,6 +60,14 @@ where
 
     pub fn with_harvest_context(mut self, context: HarvestExecutionContext) -> Self {
         self.harvest_context = context;
+        self
+    }
+
+    pub(crate) fn with_lifecycle_store(
+        mut self,
+        lifecycle_store: crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+    ) -> Self {
+        self.lifecycle_store = Some(lifecycle_store);
         self
     }
 
@@ -526,29 +536,43 @@ where
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
                 let source_provenance = harvest_preflight.source_provenance;
-                #[cfg(test)]
-                let scratch = match self.scratch_root.as_ref() {
-                    Some(data_root) => crate::controller_scratch::allocate_test_attempt_at(
-                        data_root,
+                let scratch = if let Some(lifecycle_store) = self.lifecycle_store.as_ref() {
+                    crate::controller_scratch::allocate_attempt_at(
+                        &lifecycle_store.data_root(),
                         &scratch_run_id,
                         &plan.plan_id,
                         &request.task_id,
                         scheduled.attempt,
-                    ),
-                    None => crate::controller_scratch::allocate_test_attempt(
-                        &scratch_run_id,
-                        &plan.plan_id,
-                        &request.task_id,
-                        scheduled.attempt,
-                    ),
+                    )
+                } else {
+                    #[cfg(test)]
+                    {
+                        match self.scratch_root.as_ref() {
+                            Some(data_root) => crate::controller_scratch::allocate_test_attempt_at(
+                                data_root,
+                                &scratch_run_id,
+                                &plan.plan_id,
+                                &request.task_id,
+                                scheduled.attempt,
+                            ),
+                            None => crate::controller_scratch::allocate_test_attempt(
+                                &scratch_run_id,
+                                &plan.plan_id,
+                                &request.task_id,
+                                scheduled.attempt,
+                            ),
+                        }
+                    }
+                    #[cfg(not(test))]
+                    {
+                        crate::controller_scratch::allocate_attempt(
+                            &scratch_run_id,
+                            &plan.plan_id,
+                            &request.task_id,
+                            scheduled.attempt,
+                        )
+                    }
                 };
-                #[cfg(not(test))]
-                let scratch = crate::controller_scratch::allocate_attempt(
-                    &scratch_run_id,
-                    &plan.plan_id,
-                    &request.task_id,
-                    scheduled.attempt,
-                );
                 let scratch = match scratch {
                     Ok(scratch) => scratch,
                     Err(error) => {
@@ -644,9 +668,13 @@ where
                 };
 
                 if let Some(run_id) = self.run_id.as_deref() {
-                    match crate::agent_task_lifecycle::reserve_provider_execution(
-                        run_id, &request, attempt,
-                    ) {
+                    let reservation = match self.lifecycle_store.as_ref() {
+                        Some(store) => store.reserve_provider_execution(run_id, &request, attempt),
+                        None => crate::agent_task_lifecycle::reserve_provider_execution(
+                            run_id, &request, attempt,
+                        ),
+                    };
+                    match reservation {
                         Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::Acquired) => {}
                         Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::AlreadyReserved) => {
                             let outcome = scratch_allocation_failure(
@@ -719,6 +747,10 @@ where
                     source_workspace_root,
                     _attempt_workspace: attempt_workspace.clone(),
                     run_id: self.run_id.clone(),
+                    artifact_root: self
+                        .lifecycle_store
+                        .as_ref()
+                        .map(|store| store.artifact_root()),
                     artifact_nonce: uuid::Uuid::new_v4().to_string(),
                     task_base_sha,
                     source_provenance,
@@ -759,6 +791,7 @@ where
                 &mut outcomes,
                 &mut events,
                 self.executor.as_ref(),
+                self.lifecycle_store.as_ref(),
             );
 
             if running.is_empty() {
@@ -815,14 +848,23 @@ where
                             AgentTaskOutcomeStatus::CandidateRecoverable => "candidate_recoverable",
                             _ => "failed",
                         };
-                        if let Err(error) =
-                            crate::agent_task_lifecycle::record_provider_execution_terminal(
+                        let terminal = match self.lifecycle_store.as_ref() {
+                            Some(store) => store.record_provider_execution_terminal(
                                 run_id,
                                 &outcome.task_id,
                                 result.attempt,
                                 terminal_state,
-                            )
-                        {
+                            ),
+                            None => {
+                                crate::agent_task_lifecycle::record_provider_execution_terminal(
+                                    run_id,
+                                    &outcome.task_id,
+                                    result.attempt,
+                                    terminal_state,
+                                )
+                            }
+                        };
+                        if let Err(error) = terminal {
                             outcome.status = AgentTaskOutcomeStatus::Failed;
                             outcome.failure_classification =
                                 Some(AgentTaskFailureClassification::ExecutionFailed);
@@ -1149,13 +1191,20 @@ where
                         &outcome,
                     );
                     if let Some(run_id) = running_task.run_id.as_deref() {
-                        let _ =
-                            crate::agent_task_lifecycle::record_provider_execution_cleanup_elapsed(
+                        let _ = match self.lifecycle_store.as_ref() {
+                            Some(store) => store.record_provider_execution_cleanup_elapsed(
                                 run_id,
                                 &outcome.task_id,
                                 result.attempt,
                                 provider_completed_at.elapsed().as_millis() as u64,
-                            );
+                            ),
+                            None => crate::agent_task_lifecycle::record_provider_execution_cleanup_elapsed(
+                                run_id,
+                                &outcome.task_id,
+                                result.attempt,
+                                provider_completed_at.elapsed().as_millis() as u64,
+                            ),
+                        };
                     }
                     record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                     if candidate_completion == AgentTaskCandidateCompletionPolicy::FirstGreen
@@ -1198,6 +1247,7 @@ where
                             &mut outcomes,
                             &mut events,
                             self.executor.as_ref(),
+                            self.lifecycle_store.as_ref(),
                         );
                         break;
                     }
@@ -1371,6 +1421,7 @@ pub(super) struct RunningTask {
     /// thread holds a clone so timeout finalization cannot race provider I/O.
     pub(super) _attempt_workspace: Option<Arc<AttemptWorkspace>>,
     pub(super) run_id: Option<String>,
+    pub(super) artifact_root: Option<std::path::PathBuf>,
     pub(super) artifact_nonce: String,
     /// Workspace HEAD captured immediately before the executor runs. It bounds
     /// any committed patch candidate to this dispatch attempt.
@@ -1406,11 +1457,7 @@ pub(super) fn deferred_cleanup_action_artifact(
     running: &RunningTask,
 ) -> Result<AgentTaskArtifact, HarvestError> {
     let run_id = running.run_id.as_deref().unwrap_or("unrecorded-run");
-    let directory = homeboy_core::artifacts::root()
-        .map_err(|error| HarvestError::ArtifactDirectory {
-            path: Path::new("<artifact-root>").to_path_buf(),
-            message: error.message,
-        })?
+    let directory = artifact_root_for_running(running)?
         .join("agent-task")
         .join("deferred-cleanup")
         .join(homeboy_core::paths::sanitize_path_segment(run_id));
@@ -1452,6 +1499,23 @@ pub(super) fn deferred_cleanup_action_artifact(
         sha256: Some(content_hash::sha256_hex(&content)),
         metadata: serde_json::json!({ "run_id": running.run_id, "task_id": running.task_id, "attempt": running.attempt }),
     })
+}
+
+pub(super) fn artifact_root_for_running(running: &RunningTask) -> Result<PathBuf, HarvestError> {
+    if let Some(root) = running.artifact_root.as_ref() {
+        return Ok(root.clone());
+    }
+    #[cfg(test)]
+    {
+        Ok(running.scratch.path.clone())
+    }
+    #[cfg(not(test))]
+    {
+        homeboy_core::artifacts::root().map_err(|error| HarvestError::ArtifactDirectory {
+            path: Path::new("<artifact-root>").to_path_buf(),
+            message: error.message,
+        })
+    }
 }
 
 pub(super) fn complete_deferred_cleanup_recovery(

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -384,14 +384,7 @@ fn patch_sha256(contents: impl AsRef<[u8]>) -> String {
 
 fn attempt_patch_path(running: &RunningTask, kind: &str) -> Result<PathBuf, HarvestError> {
     let run_id = running.run_id.as_deref().unwrap_or("unrecorded-run");
-    #[cfg(test)]
-    let root = running.scratch.path.clone();
-    #[cfg(not(test))]
-    let root =
-        homeboy_core::artifacts::root().map_err(|error| HarvestError::ArtifactDirectory {
-            path: PathBuf::from("<artifact-root>"),
-            message: error.message,
-        })?;
+    let root = super::artifact_root_for_running(running)?;
     let dir = root
         .join("agent-task")
         .join("attempt-patches")
@@ -926,6 +919,7 @@ mod committed_harvest_tests {
             source_workspace_root: None,
             _attempt_workspace: None,
             run_id: Some("committed-harvest-test".to_string()),
+            artifact_root: None,
             artifact_nonce: "test-artifact".to_string(),
             task_base_sha: Some(base),
             source_provenance: None,
@@ -1055,6 +1049,7 @@ mod committed_harvest_tests {
             source_workspace_root: None,
             _attempt_workspace: None,
             run_id: Some("metadata-exclude-test".to_string()),
+            artifact_root: None,
             artifact_nonce: "test-artifact".to_string(),
             task_base_sha: Some(base),
             source_provenance: None,
@@ -1283,6 +1278,7 @@ mod committed_harvest_tests {
             source_workspace_root: Some(source.display().to_string()),
             _attempt_workspace: None,
             run_id: Some("reaped-harvest-test".to_string()),
+            artifact_root: None,
             artifact_nonce: "test-artifact".to_string(),
             task_base_sha: Some(base),
             source_provenance: None,

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -653,6 +653,7 @@ impl AgentTaskScheduleSupport {
         outcomes: &mut Vec<AgentTaskOutcome>,
         events: &mut Vec<AgentTaskProgressEvent>,
         executor: &E,
+        lifecycle_store: Option<&crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
     ) where
         E: AgentTaskExecutorAdapter,
     {
@@ -689,12 +690,20 @@ impl AgentTaskScheduleSupport {
 
             let mut task = running.remove(index);
             if let Some(run_id) = task.run_id.as_deref() {
-                let _ = crate::agent_task_lifecycle::record_provider_execution_terminal(
-                    run_id,
-                    &task.task_id,
-                    task.attempt,
-                    "timed_out",
-                );
+                let _ = match lifecycle_store {
+                    Some(store) => store.record_provider_execution_terminal(
+                        run_id,
+                        &task.task_id,
+                        task.attempt,
+                        "timed_out",
+                    ),
+                    None => crate::agent_task_lifecycle::record_provider_execution_terminal(
+                        run_id,
+                        &task.task_id,
+                        task.attempt,
+                        "timed_out",
+                    ),
+                };
             }
             let mut outcome =
                 deferred_timeout_outcome(&task.task_id, timeout_ms, "scheduler_timeout");

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -27,9 +27,11 @@ use homeboy_core::{Error, Result};
 use homeboy_engine_primitives::shell::quote_arg;
 
 use super::cook_activity::{CookActivityProbe, CookProviderActivity};
+#[cfg(test)]
+use super::cook_baseline::materialize_follow_up_baseline;
 use super::cook_baseline::{
     compare_gate_failures_to_verified_base, cook_attempt_harvest_context,
-    materialize_follow_up_baseline, materialize_initial_candidate_baseline,
+    materialize_follow_up_baseline_in_root, materialize_initial_candidate_baseline,
     re_materialize_follow_up_baseline, CookFollowUpBaseline, DerivedCookBaselineCapability,
 };
 use super::cook_budget::{
@@ -53,7 +55,9 @@ use super::cook_promotion::{
 };
 use super::cook_recipe::CookRecipeStore;
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
-use super::execution::run_loaded_plan_with_derived_cook_baseline;
+use super::execution::{
+    run_loaded_plan_with_derived_cook_baseline, run_loaded_plan_with_derived_cook_baseline_in_store,
+};
 use super::AgentTaskRunResult;
 
 /// Lease window for a cook promotion operation claim. Long enough that a healthy
@@ -3096,7 +3100,6 @@ fn child_execution_budget(
 fn validate_cook_follow_up_stores(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
-    detached_dispatch: bool,
 ) -> Result<()> {
     if recipe_store.data_root() != lifecycle_store.data_root() {
         return Err(Error::validation_invalid_argument(
@@ -3107,14 +3110,6 @@ fn validate_cook_follow_up_stores(
                 recipe_store.data_root().display(),
                 lifecycle_store.data_root().display()
             )),
-            None,
-        ));
-    }
-    if !detached_dispatch && !lifecycle_store.matches_current_environment()? {
-        return Err(Error::validation_invalid_argument(
-            "lifecycle_store",
-            "explicit lifecycle storage for local Cook follow-up execution requires the full execution boundary",
-            Some(lifecycle_store.data_root().display().to_string()),
             None,
         ));
     }
@@ -3149,11 +3144,7 @@ where
     E: AgentTaskExecutorAdapter + Clone,
 {
     let (recipe_store, lifecycle_store) = stores;
-    validate_cook_follow_up_stores(
-        recipe_store,
-        lifecycle_store,
-        options.attempt_dispatcher.is_some(),
-    )?;
+    validate_cook_follow_up_stores(recipe_store, lifecycle_store)?;
     if let Some(reason) = remediation_tool_policy_error(&follow_up_request) {
         return Ok(CookFollowUpDispatch::PolicyFailure { reason });
     }
@@ -3334,8 +3325,9 @@ where
         recipe_store.record_recipe_attempt(cook_id, next_attempt, &next_run_id, &follow_up_plan)?;
     }
     if attempt_needs_execution_with_store(lifecycle_store, &next_run_id) {
-        let baseline = materialize_follow_up_baseline(
+        let baseline = materialize_follow_up_baseline_in_root(
             promotion,
+            &lifecycle_store.artifact_root(),
             source_run_id,
             &follow_up_plan.tasks[0].task_id,
         )?;
@@ -3389,7 +3381,8 @@ where
                 | agent_task_lifecycle::ClaimOutcome::LeaseHeld => {}
             }
         } else {
-            run_loaded_plan_with_derived_cook_baseline(
+            run_loaded_plan_with_derived_cook_baseline_in_store(
+                lifecycle_store,
                 follow_up_plan,
                 Some(&next_run_id),
                 executor,

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -277,7 +277,22 @@ pub(crate) fn materialize_follow_up_baseline(
     source_run_id: &str,
     bound_task_id: &str,
 ) -> Result<CookFollowUpBaseline> {
-    materialize_follow_up_baseline_at(promotion, None, source_run_id, bound_task_id)
+    materialize_follow_up_baseline_at(promotion, None, None, source_run_id, bound_task_id)
+}
+
+pub(crate) fn materialize_follow_up_baseline_in_root(
+    promotion: &AgentTaskPromotionReport,
+    artifact_root: &std::path::Path,
+    source_run_id: &str,
+    bound_task_id: &str,
+) -> Result<CookFollowUpBaseline> {
+    materialize_follow_up_baseline_at(
+        promotion,
+        Some(artifact_root),
+        None,
+        source_run_id,
+        bound_task_id,
+    )
 }
 
 /// Replay unresolved failed gates against the immutable verified base. This is
@@ -519,7 +534,13 @@ pub(crate) fn re_materialize_follow_up_baseline(
     source_run_id: &str,
     bound_task_id: &str,
 ) -> Result<CookFollowUpBaseline> {
-    materialize_follow_up_baseline_at(promotion, Some(target_path), source_run_id, bound_task_id)
+    materialize_follow_up_baseline_at(
+        promotion,
+        None,
+        Some(target_path),
+        source_run_id,
+        bound_task_id,
+    )
 }
 
 /// Shared worktree/patch materialization logic. When `target_path` is `None` a
@@ -528,6 +549,7 @@ pub(crate) fn re_materialize_follow_up_baseline(
 /// recovery to re-materialize a reaped baseline at its original location).
 fn materialize_follow_up_baseline_at(
     promotion: &AgentTaskPromotionReport,
+    artifact_root: Option<&std::path::Path>,
     target_path: Option<&std::path::Path>,
     source_run_id: &str,
     bound_task_id: &str,
@@ -625,7 +647,11 @@ fn materialize_follow_up_baseline_at(
             // Same reasoning as the initial-candidate baseline above: a whole
             // working-tree checkout belongs under the artifact root, not in
             // the process temp dir where nothing can see or reap it (#11128).
-            let parent = homeboy_core::artifacts::root()?.join("cook-baseline");
+            let root = match artifact_root {
+                Some(root) => root.to_path_buf(),
+                None => homeboy_core::artifacts::root()?,
+            };
+            let parent = root.join("cook-baseline");
             std::fs::create_dir_all(&parent).map_err(|error| {
                 Error::internal_io(
                     error.to_string(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10762,26 +10762,20 @@ fn retry_dispatch_operation_key_claim_dispatches_once() {
 }
 
 #[test]
-fn cook_follow_up_store_boundary_rejects_split_roots_and_unrooted_local_execution() {
+fn cook_follow_up_store_boundary_accepts_local_execution_and_rejects_split_roots() {
     let first = homeboy_core::test_support::HermeticTestContext::new();
     let second = homeboy_core::test_support::HermeticTestContext::new();
     let recipe_store = CookRecipeStore::new(first.path_roots());
     let lifecycle_store = AgentTaskLifecycleStore::new(first.path_roots());
     let other_lifecycle_store = AgentTaskLifecycleStore::new(second.path_roots());
 
-    validate_cook_follow_up_stores(&recipe_store, &lifecycle_store, true).unwrap();
+    validate_cook_follow_up_stores(&recipe_store, &lifecycle_store).unwrap();
 
     let split_root_error =
-        validate_cook_follow_up_stores(&recipe_store, &other_lifecycle_store, true).unwrap_err();
+        validate_cook_follow_up_stores(&recipe_store, &other_lifecycle_store).unwrap_err();
     assert!(split_root_error
         .to_string()
         .contains("recipe and lifecycle stores must share one data root"));
-
-    let local_execution_error =
-        validate_cook_follow_up_stores(&recipe_store, &lifecycle_store, false).unwrap_err();
-    assert!(local_execution_error
-        .to_string()
-        .contains("requires the full execution boundary"));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -81,6 +81,48 @@ where
 }
 
 pub(crate) fn run_loaded_plan_with_derived_cook_baseline<E>(
+    plan: AgentTaskPlan,
+    record_run_id: Option<&str>,
+    executor: E,
+    derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    supplied_harvest_context: Option<crate::agent_task_scheduler::HarvestExecutionContext>,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    run_loaded_plan_with_derived_cook_baseline_in_optional_store(
+        None,
+        plan,
+        record_run_id,
+        executor,
+        derived_cook_baseline,
+        supplied_harvest_context,
+    )
+}
+
+pub(crate) fn run_loaded_plan_with_derived_cook_baseline_in_store<E>(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    plan: AgentTaskPlan,
+    record_run_id: Option<&str>,
+    executor: E,
+    derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    supplied_harvest_context: Option<crate::agent_task_scheduler::HarvestExecutionContext>,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    run_loaded_plan_with_derived_cook_baseline_in_optional_store(
+        Some(lifecycle_store),
+        plan,
+        record_run_id,
+        executor,
+        derived_cook_baseline,
+        supplied_harvest_context,
+    )
+}
+
+fn run_loaded_plan_with_derived_cook_baseline_in_optional_store<E>(
+    lifecycle_store: Option<&agent_task_lifecycle::AgentTaskLifecycleStore>,
     mut plan: AgentTaskPlan,
     record_run_id: Option<&str>,
     executor: E,
@@ -95,42 +137,85 @@ where
         // the same materialized workspace contract. In particular, Cook's
         // derived baseline capability must bind the persisted task workspace.
         if let Err(error) = prepare_plan_for_execution(&mut plan, Some(run_id)) {
-            agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
-            agent_task_lifecycle::record_pre_execution_failure(
-                run_id,
-                &plan,
-                "prepare_plan_for_execution",
-                &error,
-            )?;
+            match lifecycle_store {
+                Some(store) => {
+                    store.submit_plan_with_current_runtime(&plan, run_id)?;
+                    store.record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "prepare_plan_for_execution",
+                        &error,
+                    )?;
+                }
+                None => {
+                    agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+                    agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "prepare_plan_for_execution",
+                        &error,
+                    )?;
+                }
+            }
             return Err(error);
         }
-        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+        match lifecycle_store {
+            Some(store) => {
+                store.submit_plan_with_current_runtime(&plan, run_id)?;
+            }
+            None => {
+                agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+            }
+        }
         let harvest_context = match supplied_harvest_context.clone().map(Ok).unwrap_or_else(
             crate::agent_task_scheduler::HarvestExecutionContext::from_current_process,
         ) {
             Ok(context) => context,
             Err(error) => {
-                agent_task_lifecycle::record_pre_execution_failure(
-                    run_id,
-                    &plan,
-                    "validate_harvest_transport",
-                    &error,
-                )?;
+                match lifecycle_store {
+                    Some(store) => store.record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "validate_harvest_transport",
+                        &error,
+                    )?,
+                    None => agent_task_lifecycle::record_pre_execution_failure(
+                        run_id,
+                        &plan,
+                        "validate_harvest_transport",
+                        &error,
+                    )?,
+                };
                 return Err(error);
             }
         };
         if harvest_context.snapshot_signaled() {
             bind_runner_snapshot_workspace_attestations(&mut plan)?;
         }
-        agent_task_lifecycle::mark_running(run_id)?;
+        match lifecycle_store {
+            Some(store) => {
+                store.mark_running(run_id)?;
+            }
+            None => {
+                agent_task_lifecycle::mark_running(run_id)?;
+            }
+        }
         let aggregate = run_plan_with_scheduler(
+            lifecycle_store,
             plan.clone(),
             record_run_id,
             executor,
             derived_cook_baseline,
             harvest_context,
         )?;
-        agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
+        match lifecycle_store {
+            Some(store) => {
+                store.record_run_aggregate(run_id, &plan, &aggregate)?;
+            }
+            None => {
+                agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)?;
+            }
+        }
         return Ok(AgentTaskRunResult {
             exit_code: aggregate_exit_code(&aggregate),
             value: crate::agent_task_artifacts::reviewer_facing_aggregate(&aggregate),
@@ -145,6 +230,7 @@ where
         bind_runner_snapshot_workspace_attestations(&mut plan)?;
     }
     let aggregate = run_plan_with_scheduler(
+        lifecycle_store,
         plan.clone(),
         record_run_id,
         executor,
@@ -1151,8 +1237,14 @@ fn run_prepared_claimed<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let aggregate =
-        run_plan_with_scheduler(plan.clone(), Some(&run_id), executor, None, harvest_context)?;
+    let aggregate = run_plan_with_scheduler(
+        None,
+        plan.clone(),
+        Some(&run_id),
+        executor,
+        None,
+        harvest_context,
+    )?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
@@ -1231,6 +1323,7 @@ fn preflight_queued_plan_provider_eligibility(plan: &AgentTaskPlan) -> Result<()
 }
 
 fn run_plan_with_scheduler<E>(
+    lifecycle_store: Option<&agent_task_lifecycle::AgentTaskLifecycleStore>,
     plan: AgentTaskPlan,
     run_id: Option<&str>,
     executor: E,
@@ -1242,6 +1335,10 @@ where
 {
     let scheduler =
         AgentTaskScheduler::new_controller(executor).with_harvest_context(harvest_context);
+    let scheduler = match lifecycle_store {
+        Some(store) => scheduler.with_lifecycle_store(store.clone()),
+        None => scheduler,
+    };
     match run_id {
         Some(run_id) => Ok(scheduler
             .with_run_id(run_id.to_string())
@@ -1411,11 +1508,111 @@ fn materialization_string(materialization: &Value, key: &str) -> Option<String> 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::Path;
+    use std::process::Command;
 
     use super::*;
-    use crate::agent_task_scheduler::{
-        AgentTaskManagedService, AgentTaskManagedServiceLifecycle, AgentTaskPlan,
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AgentTaskWorkspaceMode,
+        AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
+    use crate::agent_task_scheduler::{
+        AgentTaskExecutionContext, AgentTaskManagedService, AgentTaskManagedServiceLifecycle,
+        AgentTaskPlan, HarvestExecutionContext,
+    };
+
+    #[derive(Clone)]
+    struct SuccessfulExecutor;
+
+    impl AgentTaskExecutorAdapter for SuccessfulExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            if let Some(root) = request.workspace.root.as_deref() {
+                std::fs::write(
+                    Path::new(root).join("rooted-change.txt"),
+                    format!("change from {}\n", request.task_id),
+                )
+                .expect("write provider change");
+            }
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("succeeded".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: serde_json::json!({}),
+            }
+        }
+    }
+
+    fn one_task_plan(plan_id: &str, workspace: &Path) -> AgentTaskPlan {
+        AgentTaskPlan::new(
+            plan_id,
+            vec![AgentTaskRequest {
+                schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                task_id: "same-task".to_string(),
+                group_key: None,
+                parent_plan_id: Some(plan_id.to_string()),
+                executor: AgentTaskExecutor {
+                    backend: "test".to_string(),
+                    selector: None,
+                    runtime_selection: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    model: None,
+                    config: Value::Null,
+                },
+                instructions: "execute the rooted task".to_string(),
+                inputs: Value::Null,
+                source_refs: Vec::new(),
+                workspace: AgentTaskWorkspace {
+                    mode: AgentTaskWorkspaceMode::Existing,
+                    root: Some(workspace.display().to_string()),
+                    ..Default::default()
+                },
+                component_contracts: Vec::new(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits::default(),
+                expected_artifacts: Vec::new(),
+                artifact_declarations: Vec::new(),
+                output_declarations: Vec::new(),
+                runtime_tools: Vec::new(),
+                metadata: Value::Null,
+            }],
+        )
+    }
+
+    fn initialize_workspace(path: &Path) {
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("run git fixture command");
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.email", "agent@example.test"]);
+        git(&["config", "user.name", "Agent"]);
+        std::fs::write(path.join("base.txt"), "base\n").expect("write base fixture");
+        git(&["add", "base.txt"]);
+        git(&["commit", "-m", "base"]);
+    }
 
     fn invalid_service() -> AgentTaskManagedService {
         AgentTaskManagedService {
@@ -1459,5 +1656,69 @@ mod tests {
             homeboy_core::ErrorCode::ValidationInvalidArgument
         );
         assert!(error.message.contains("cleanup_deadline_ms"));
+    }
+
+    #[test]
+    fn local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores() {
+        let first = homeboy_core::test_support::HermeticTestContext::new();
+        let second = homeboy_core::test_support::HermeticTestContext::new();
+        let first_store = agent_task_lifecycle::AgentTaskLifecycleStore::new(first.path_roots());
+        let second_store = agent_task_lifecycle::AgentTaskLifecycleStore::new(second.path_roots());
+        let first_workspace = tempfile::tempdir().expect("first workspace");
+        let second_workspace = tempfile::tempdir().expect("second workspace");
+        initialize_workspace(first_workspace.path());
+        initialize_workspace(second_workspace.path());
+        let run_id = "same-local-follow-up-run";
+
+        for (store, plan_id, workspace) in [
+            (
+                &first_store,
+                "first-local-follow-up",
+                first_workspace.path(),
+            ),
+            (
+                &second_store,
+                "second-local-follow-up",
+                second_workspace.path(),
+            ),
+        ] {
+            let result = run_loaded_plan_with_derived_cook_baseline_in_store(
+                store,
+                one_task_plan(plan_id, workspace),
+                Some(run_id),
+                SuccessfulExecutor,
+                None,
+                Some(HarvestExecutionContext::default()),
+            )
+            .expect("execute through the explicit lifecycle store");
+            assert_eq!(result.exit_code, 0);
+
+            let record = store.read_record(run_id).expect("rooted terminal record");
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Succeeded
+            );
+            assert_eq!(
+                record.metadata["provider_executions"][0]["state"],
+                "succeeded"
+            );
+            assert!(
+                record.metadata["provider_executions"][0]["post_provider_cleanup_finished_at"]
+                    .is_string()
+            );
+            let aggregate = store.read_aggregate(run_id).expect("rooted aggregate");
+            let patch_path = aggregate.outcomes[0].artifacts[0]
+                .path
+                .as_deref()
+                .map(Path::new)
+                .expect("harvested patch path");
+            assert!(patch_path.starts_with(store.artifact_root()));
+            assert!(patch_path.exists());
+            let scratch_index = store.data_root().join("controller-scratch/resources.json");
+            let scratch = std::fs::read_to_string(scratch_index).expect("rooted scratch index");
+            assert!(scratch.contains(run_id));
+        }
+
+        assert_ne!(first_store.run_dir(run_id), second_store.run_dir(run_id));
     }
 }

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -100,6 +100,24 @@ pub fn allocate_attempt(
     )
 }
 
+pub(crate) fn allocate_attempt_at(
+    data_root: &Path,
+    run_id: &str,
+    plan_id: &str,
+    task_id: &str,
+    attempt: u32,
+) -> Result<ControllerScratchAllocation> {
+    let store = data_root.join("controller-scratch");
+    allocate_attempt_at_roots(
+        run_id,
+        plan_id,
+        task_id,
+        attempt,
+        store.join("attempts"),
+        store.join("resources.json"),
+    )
+}
+
 #[cfg(test)]
 pub fn allocate_test_attempt(
     run_id: &str,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -84,6 +84,10 @@ impl AgentTaskLifecycleStore {
         self.roots.data().to_path_buf()
     }
 
+    pub(crate) fn artifact_root(&self) -> PathBuf {
+        self.roots.artifacts().to_path_buf()
+    }
+
     pub(crate) fn matches_current_environment(&self) -> Result<bool> {
         Ok(self.roots == paths::PathRoots::from_environment()?)
     }
@@ -177,6 +181,43 @@ impl AgentTaskLifecycleStore {
         error: &Error,
     ) -> Result<AgentTaskRunRecord> {
         super::record_pre_execution_failure_in_store(self, run_id, plan, phase, error)
+    }
+
+    pub(crate) fn mark_running(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::mark_running_in_store(self, run_id)
+    }
+
+    pub(crate) fn reserve_provider_execution(
+        &self,
+        run_id: &str,
+        task: &crate::agent_task::AgentTaskRequest,
+        attempt: u32,
+    ) -> Result<super::ProviderExecutionReservation> {
+        super::lifecycle_ops::reserve_provider_execution_in_store(self, run_id, task, attempt)
+    }
+
+    pub(crate) fn record_provider_execution_terminal(
+        &self,
+        run_id: &str,
+        task_id: &str,
+        attempt: u32,
+        state: &str,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_provider_execution_terminal_in_store(
+            self, run_id, task_id, attempt, state,
+        )
+    }
+
+    pub(crate) fn record_provider_execution_cleanup_elapsed(
+        &self,
+        run_id: &str,
+        task_id: &str,
+        attempt: u32,
+        elapsed_ms: u64,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_provider_execution_cleanup_elapsed_in_store(
+            self, run_id, task_id, attempt, elapsed_ms,
+        )
     }
 
     pub fn claim_cook_operation(


### PR DESCRIPTION
## Summary
- thread an explicit `AgentTaskLifecycleStore` through local Cook follow-up execution and scheduler lifecycle transitions
- root provider reservations, terminal/cleanup ledger writes, controller scratch, follow-up baselines, harvested patches, and deferred cleanup actions in the supplied path roots
- retain ambient compatibility wrappers for existing execution and scheduler callers
- allow matching non-ambient Cook store pairs to execute locally while continuing to reject split recipe/lifecycle roots
- prove identical local run IDs execute independently across two hermetic roots with real Git patch harvesting

Continues #7505 and builds on #12538.

## Verification
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores --lib`
- `cargo test -p homeboy-agents cook_follow_up_store_boundary --lib`
- `cargo test -p homeboy-agents detached_adoption_follow_up --lib`
- `cargo test -p homeboy-agents materialize_follow_up_baseline --lib`
- `cargo test -p homeboy-agents normalizes_slow_task_to_timeout --lib`
- `cargo test -p homeboy-agents timeout_after_writing_patch_reconciles_required_artifacts_and_authenticates_candidate --lib`
- `git diff --check`

The `provider_execution` filter passed 12 relevant tests and also selected `reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution`, a known failure that reproduces unchanged on `main` at `cfc861afc` and was documented in #12538.

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode was used to map the local execution boundary, implement explicit store propagation, add isolation coverage, run verification, and review the final diff. Chris Huber remains responsible for every line.