### PR TITLE
fix(agent-task): clear stale planned handoffs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -608,6 +608,8 @@ fn record_lab_offload_proxy(
         metadata.insert("remote_command".to_string(), json!(remote_command));
     }
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+    metadata.remove(METADATA_KEY_STALE_RUNNING);
+    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
     metadata.insert(
         "runner_execution_record".to_string(),
         serde_json::to_value(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -2066,6 +2066,17 @@ fn status_keeps_fresh_planned_runner_submission_live() {
         let run_id = "run-planned-runner-submission";
         submit_plan(&plan, Some(run_id)).expect("submitted");
         mark_running(run_id).expect("running");
+        rewrite_record_for_test(run_id, |record| {
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata object")
+                .remove("runner_pid");
+        })
+        .expect("controller owner removed");
+        let stale = status(run_id).expect("pre-planning status loaded");
+        assert_eq!(stale.metadata["stale_running"], true);
+
         record_lab_offload_phase(
             run_id,
             "homeboy-lab",
@@ -2076,14 +2087,6 @@ fn status_keeps_fresh_planned_runner_submission_live() {
             Some(&plan),
         )
         .expect("planned runner submission recorded");
-        rewrite_record_for_test(run_id, |record| {
-            record
-                .metadata
-                .as_object_mut()
-                .expect("metadata object")
-                .remove("runner_pid");
-        })
-        .expect("controller owner removed");
 
         let loaded = status(run_id).expect("status loaded");
 

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -512,6 +512,16 @@ mod tests {
             let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
             agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
             agent_task_lifecycle::mark_running(run_id).expect("running");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+            })
+            .expect("controller owner removed");
+            let stale = agent_task_lifecycle::status(run_id).expect("pre-planning status");
+            assert_eq!(stale.metadata["stale_running"], true);
             agent_task_lifecycle::record_lab_offload_phase(
                 run_id,
                 "homeboy-lab",
@@ -522,14 +532,6 @@ mod tests {
                 Some(&plan),
             )
             .expect("planned runner submission recorded");
-            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
-                record
-                    .metadata
-                    .as_object_mut()
-                    .expect("metadata object")
-                    .remove("runner_pid");
-            })
-            .expect("controller owner removed");
 
             let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
                 .expect("tick pass");


### PR DESCRIPTION
## Summary

Clear an already-persisted stale-running projection when direct Lab planning records a fresh, run-bound runner execution.

Closes #12531.

## Root Cause

`provider_start` can project an ownerless controller proxy stale before direct-SSH materialization writes `runner_execution_record.status = planned`. #12540 prevents new stale annotation after that planned record exists, but the planning transition retained the earlier stale flag. The daemon tick then cancelled the fresh planned handoff with `missing_runner_pid`.

#12539 covers reverse-broker submissions with a complete pending submission intent. Direct-SSH Cook records do not carry that intent, so this is the complementary direct path.

## What Changed

- clear stale-running metadata atomically when the planned runner execution is persisted
- start status and daemon-tick regressions from a pre-annotated stale proxy
- retain the existing assertion that an unaccepted planned handoff becomes stale after the normal heartbeat threshold

## Verification

- `cargo fmt --all --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::handoff_and_proxy` (47 passed)
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests` (8 passed)
- `git diff --check`

## Live Evidence

Aligned `0.350.0+bf057e4e3917` controller and Lab Cook `agent-task-e9fbd013-7230-4abf-a0ad-fa1536b90105` reproduced the ordering twice with zero provider executions. Both records reached `phase: materializing` and persisted a run-bound planned runner execution, then were cancelled by the daemon with `missing_runner_pid` before job acceptance.

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode ran the post-#12540 direct-Lab reproduction, compared the durable transition timestamps with #12539, implemented the stale-projection reset and regression setup, and ran verification. Chris Huber reviewed and owns the change.