### PR TITLE
refactor(agent-task): root Cook promotion stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -773,7 +773,8 @@ fn record_terminal_artifact_projection_in_store(
             }
         }
     }
-    match project_terminal_artifacts(record, aggregate) {
+    let observation_store = lifecycle_store.open_observation_initialized()?;
+    match project_terminal_artifacts_in_store(&observation_store, record, aggregate) {
         Ok(()) => {
             record.ensure_metadata_object().insert(
                 "artifact_projection".to_string(),
@@ -1094,6 +1095,14 @@ pub(crate) fn project_terminal_artifacts(
     aggregate: &AgentTaskAggregate,
 ) -> Result<()> {
     let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    project_terminal_artifacts_in_store(&store, record, aggregate)
+}
+
+fn project_terminal_artifacts_in_store(
+    store: &homeboy_core::observation::ObservationStore,
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> Result<()> {
     let status = match record.state {
         AgentTaskRunState::Succeeded => "pass",
         AgentTaskRunState::CandidateRecoverable => "fail",
@@ -1197,12 +1206,12 @@ pub(crate) fn project_terminal_artifacts(
             // direct import. The import remains evidence, while the finalized
             // projection keeps its established derived controller identity.
             let finalized_path = remote_runner
-                .map(|_| controller_finalized_artifact_path(artifact))
+                .map(|_| controller_finalized_artifact_path(store, artifact))
                 .transpose()?
                 .flatten();
             if finalized_path.is_some() {
                 stamp_legacy_artifact_provenance(
-                    &store,
+                    store,
                     &record.run_id,
                     &outcome.task_id,
                     artifact,
@@ -1349,6 +1358,7 @@ pub(crate) fn project_terminal_artifacts(
             } else {
                 let path = artifact.path.as_deref().expect("local path checked above");
                 let path = controller_projected_local_artifact_path(
+                    store,
                     &record.run_id,
                     &outcome.task_id,
                     &artifact.id,
@@ -1377,6 +1387,7 @@ pub(crate) fn project_terminal_artifacts(
 /// projection. The aggregate path remains provenance only and may disappear
 /// when the producer workspace is cleaned up.
 fn controller_projected_local_artifact_path(
+    store: &homeboy_core::observation::ObservationStore,
     run_id: &str,
     task_id: &str,
     artifact_id: &str,
@@ -1400,7 +1411,8 @@ fn controller_projected_local_artifact_path(
             None,
         ));
     }
-    let path = homeboy_core::paths::artifact_root()?
+    let path = store
+        .artifact_root()?
         .join("controller-projected-agent-task-artifacts")
         .join(homeboy_core::paths::sanitize_path_segment(run_id))
         .join(homeboy_core::paths::sanitize_path_segment(task_id))
@@ -1484,7 +1496,7 @@ fn reusable_terminal_artifact(
                 None,
             ));
         }
-        if controller_owned_artifact_path(Path::new(&existing.path)) {
+        if controller_owned_artifact_path(store, Path::new(&existing.path)) {
             // Pre-marker controller projections already have durable storage;
             // retain their record and stamp the current lookup metadata.
             store.update_artifact_metadata(artifact_id, metadata.clone())?;
@@ -1496,6 +1508,7 @@ fn reusable_terminal_artifact(
         // Preserve that record and derive a separate controller-local copy
         // before allowing terminal recovery to use its verified bytes.
         let path = controller_projected_local_artifact_path(
+            store,
             run_id,
             task_id,
             &artifact.id,
@@ -1600,8 +1613,11 @@ fn stamp_legacy_artifact_provenance(
 /// Observation artifacts are controller-owned only when their resolved file is
 /// beneath the controller artifact root. A matching digest alone must not turn
 /// an ephemeral producer path into durable lifecycle input.
-fn controller_owned_artifact_path(path: &Path) -> bool {
-    let Ok(root) = homeboy_core::paths::artifact_root().and_then(|root| {
+fn controller_owned_artifact_path(
+    store: &homeboy_core::observation::ObservationStore,
+    path: &Path,
+) -> bool {
+    let Ok(root) = store.artifact_root().and_then(|root| {
         std::fs::canonicalize(root).map_err(|error| {
             Error::internal_io(
                 error.to_string(),
@@ -1609,6 +1625,13 @@ fn controller_owned_artifact_path(path: &Path) -> bool {
             )
         })
     }) else {
+        return false;
+    };
+    controller_owned_artifact_path_at(path, &root)
+}
+
+fn controller_owned_artifact_path_at(path: &Path, root: &Path) -> bool {
+    let Ok(root) = std::fs::canonicalize(root) else {
         return false;
     };
     let Ok(path) = std::fs::canonicalize(path) else {
@@ -1619,14 +1642,17 @@ fn controller_owned_artifact_path(path: &Path) -> bool {
 
 /// Find finalized bytes already copied into the controller artifact root. Lab
 /// aggregate paths describe runner provenance and are never read after recovery.
-fn controller_finalized_artifact_path(artifact: &AgentTaskArtifact) -> Result<Option<PathBuf>> {
+fn controller_finalized_artifact_path(
+    store: &homeboy_core::observation::ObservationStore,
+    artifact: &AgentTaskArtifact,
+) -> Result<Option<PathBuf>> {
     let Some(expected_sha256) = artifact.sha256.as_deref() else {
         return Ok(None);
     };
     let Some(expected_size) = artifact.size_bytes else {
         return Ok(None);
     };
-    let root = homeboy_core::paths::artifact_root()?.join("executor-finalized");
+    let root = store.artifact_root()?.join("executor-finalized");
     if !root.is_dir() {
         return Ok(None);
     }
@@ -1690,6 +1716,17 @@ pub fn verified_controller_artifact_projection_path(
     task_id: &str,
     artifact: &AgentTaskArtifact,
 ) -> Result<Option<PathBuf>> {
+    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    verified_controller_artifact_projection_path_in_store(&store, run_id, task_id, artifact)
+}
+
+pub(crate) fn verified_controller_artifact_projection_path_in_store(
+    store: &homeboy_core::observation::ObservationStore,
+    run_id: &str,
+    task_id: &str,
+    artifact: &AgentTaskArtifact,
+) -> Result<Option<PathBuf>> {
+    let artifact_root = store.artifact_root()?;
     let Some(expected_sha256) = artifact.sha256.as_deref() else {
         return Ok(None);
     };
@@ -1699,7 +1736,6 @@ pub fn verified_controller_artifact_projection_path(
     else {
         return Ok(None);
     };
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
     let mut candidates: Vec<_> = store
         .list_artifacts(run_id)?
         .into_iter()
@@ -1712,7 +1748,10 @@ pub fn verified_controller_artifact_projection_path(
                         .pointer("/agent_task/projection")
                         .and_then(serde_json::Value::as_str),
                     Some("controller_local" | "controller_finalized" | "runner_mirrored")
-                ) || controller_owned_artifact_path(Path::new(&candidate.path)))
+                ) || controller_owned_artifact_path_at(
+                    Path::new(&candidate.path),
+                    &artifact_root,
+                ))
                 && candidate
                     .metadata_json
                     .pointer("/agent_task/task_id")
@@ -1760,7 +1799,7 @@ pub fn verified_controller_artifact_projection_path(
             None,
         ));
     }
-    if !controller_owned_artifact_path(&path) {
+    if !controller_owned_artifact_path_at(&path, &artifact_root) {
         return Err(Error::validation_invalid_argument(
             "artifact_id",
             format!(
@@ -1796,6 +1835,27 @@ pub fn verified_controller_artifact_projection(
     expected_record_id: Option<&str>,
 ) -> Result<Option<(String, Vec<u8>)>> {
     let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    verified_controller_artifact_projection_in_store(
+        &store,
+        run_id,
+        task_id,
+        logical_artifact_id,
+        kind,
+        expected_sha256,
+        expected_record_id,
+    )
+}
+
+pub(crate) fn verified_controller_artifact_projection_in_store(
+    store: &homeboy_core::observation::ObservationStore,
+    run_id: &str,
+    task_id: &str,
+    logical_artifact_id: &str,
+    kind: &str,
+    expected_sha256: &str,
+    expected_record_id: Option<&str>,
+) -> Result<Option<(String, Vec<u8>)>> {
+    let artifact_root = store.artifact_root()?;
     let candidates: Vec<_> = store
         .list_artifacts(run_id)?
         .into_iter()
@@ -1840,6 +1900,14 @@ pub fn verified_controller_artifact_projection(
         ));
     }
     let path = PathBuf::from(&candidate.path);
+    if !controller_owned_artifact_path_at(&path, &artifact_root) {
+        return Err(Error::validation_invalid_argument(
+            "gate_feedback_candidate_baseline",
+            "controller artifact mirror is outside the owning artifact root",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
     let bytes = std::fs::read(&path).map_err(|error| {
         Error::validation_invalid_argument(
             "gate_feedback_candidate_baseline",
@@ -2097,5 +2165,48 @@ mod tests {
                 .message
                 .contains("conflicts with terminal artifact projection"));
         });
+    }
+
+    #[test]
+    fn controller_local_projection_isolates_identical_ids_across_artifact_roots() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left_store = AgentTaskLifecycleStore::new(left_context.path_roots())
+            .open_observation_initialized()
+            .expect("left observation store");
+        let right_store = AgentTaskLifecycleStore::new(right_context.path_roots())
+            .open_observation_initialized()
+            .expect("right observation store");
+        let left_source = left_context.root().join("source.patch");
+        let right_source = right_context.root().join("source.patch");
+        std::fs::write(&left_source, b"left").expect("left source");
+        std::fs::write(&right_source, b"right").expect("right source");
+
+        let left = controller_projected_local_artifact_path(
+            &left_store,
+            "same-run",
+            "same-task",
+            "same-artifact",
+            left_source.to_str().unwrap(),
+            4,
+            &format!("{:x}", sha2::Sha256::digest(b"left")),
+        )
+        .expect("left projection");
+        let right = controller_projected_local_artifact_path(
+            &right_store,
+            "same-run",
+            "same-task",
+            "same-artifact",
+            right_source.to_str().unwrap(),
+            5,
+            &format!("{:x}", sha2::Sha256::digest(b"right")),
+        )
+        .expect("right projection");
+
+        assert!(left.starts_with(left_store.artifact_root().unwrap()));
+        assert!(right.starts_with(right_store.artifact_root().unwrap()));
+        assert_ne!(left, right);
+        assert_eq!(std::fs::read(left).unwrap(), b"left");
+        assert_eq!(std::fs::read(right).unwrap(), b"right");
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4466,7 +4466,15 @@ const COOK_CANDIDATE_SELECTION_WINDOW: usize = 64;
 /// attempt has candidate bytes, retain the legacy latest attempt for old runs.
 pub fn select_cook_candidate(cook_id: &str) -> Result<AgentTaskCookCandidateSelection> {
     let index = cook_index(cook_id)?;
-    select_cook_candidate_from_index(cook_id, index)
+    select_cook_candidate_from_index(cook_id, index, None)
+}
+
+pub(crate) fn select_cook_candidate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<AgentTaskCookCandidateSelection> {
+    let index = lifecycle_store.read_cook_index(&sanitize_run_id(cook_id))?;
+    select_cook_candidate_from_index(cook_id, index, Some(lifecycle_store))
 }
 
 pub fn select_cook_candidate_from_attempts(
@@ -4486,15 +4494,17 @@ pub fn select_cook_candidate_from_attempts(
             latest_substantive_candidate: None,
             attempts,
         },
+        None,
     )
 }
 
 fn select_cook_candidate_from_index(
     cook_id: &str,
     index: AgentTaskCookIndex,
+    lifecycle_store: Option<&AgentTaskLifecycleStore>,
 ) -> Result<AgentTaskCookCandidateSelection> {
     if let Some(candidate) = index.latest_substantive_candidate.as_ref() {
-        if substantive_candidate(&candidate.run_id).as_ref()
+        if substantive_candidate_in_store(&candidate.run_id, lifecycle_store).as_ref()
             == Some(&(candidate.task_id.clone(), candidate.artifact_id.clone()))
         {
             return Ok(AgentTaskCookCandidateSelection {
@@ -4524,7 +4534,9 @@ fn select_cook_candidate_from_index(
     let mut skipped_newer_run_ids = Vec::new();
     let mut skipped_newer_attempts = Vec::new();
     for attempt in attempts.iter().take(COOK_CANDIDATE_SELECTION_WINDOW) {
-        if let Some((task_id, artifact_id)) = substantive_candidate(&attempt.run_id) {
+        if let Some((task_id, artifact_id)) =
+            substantive_candidate_in_store(&attempt.run_id, lifecycle_store)
+        {
             return Ok(AgentTaskCookCandidateSelection {
                 schema: "homeboy/agent-task-cook-candidate-selection/v1".to_string(),
                 cook_id: index.cook_id,
@@ -4683,14 +4695,28 @@ fn substantive_candidate_from_aggregate(
 }
 
 fn substantive_candidate(run_id: &str) -> Option<(String, String)> {
+    substantive_candidate_in_store(run_id, None)
+}
+
+fn substantive_candidate_in_store(
+    run_id: &str,
+    lifecycle_store: Option<&AgentTaskLifecycleStore>,
+) -> Option<(String, String)> {
     // Candidate recovery is a bounded scan. Avoid the aggregate reader's
     // reconciliation path when this controller record never projected one.
-    let record = exact_record(run_id).ok()?;
+    let record = match lifecycle_store {
+        Some(store) => store.read_record(run_id).ok()?,
+        None => exact_record(run_id).ok()?,
+    };
     let aggregate_path = record.aggregate_path?;
     if !std::path::Path::new(&aggregate_path).exists() {
         return None;
     }
-    let Ok(aggregate) = store::read_aggregate(run_id) else {
+    let aggregate = match lifecycle_store {
+        Some(store) => store.read_aggregate(run_id),
+        None => store::read_aggregate(run_id),
+    };
+    let Ok(aggregate) = aggregate else {
         return None;
     };
     substantive_candidate_in_aggregate(run_id, &aggregate)
@@ -5252,8 +5278,17 @@ pub fn record_cook_moving_base_recovery(
     run_id: &str,
     recovery: Value,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_moving_base_recovery_in_store(&lifecycle_store, run_id, recovery)
+}
+
+pub(crate) fn record_cook_moving_base_recovery_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    recovery: Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("cook_moving_base_recovery") == Some(&recovery) {
             return false;
         }
@@ -5265,13 +5300,21 @@ pub fn record_cook_moving_base_recovery(
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }
 
 pub fn clear_cook_moving_base_recovery(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    clear_cook_moving_base_recovery_in_store(&lifecycle_store, run_id)
+}
+
+pub(crate) fn clear_cook_moving_base_recovery_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(metadata) = record.metadata.as_object_mut() else {
             return false;
         };
@@ -5283,6 +5326,6 @@ pub fn clear_cook_moving_base_recovery(run_id: &str) -> Result<AgentTaskRunRecor
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -267,19 +267,20 @@ pub fn recover_completed_cook_operation(
 /// Failed claims retain their exact bounded diagnostic but are intentionally
 /// reclaimable by a later explicit continuation.
 pub fn fail_cook_operation(run_id: &str, operation_key: &str, result: Value) -> Result<()> {
-    transition_cook_operation(run_id, operation_key, "failed", result)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    fail_cook_operation_in_store(&lifecycle_store, run_id, operation_key, result)
 }
 
-fn transition_cook_operation(
+pub(crate) fn fail_cook_operation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,
-    state: &str,
     result: Value,
 ) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
     let now = now_timestamp();
     let mut found = false;
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let Some(claim) = record
             .ensure_metadata_object()
             .get_mut(OPERATION_CLAIMS_KEY)
@@ -296,7 +297,7 @@ fn transition_cook_operation(
         if claim["state"] == json!("completed") {
             return false;
         }
-        claim["state"] = json!(state);
+        claim["state"] = json!("failed");
         claim["completed_at"] = json!(now);
         claim["result"] = result.clone();
         record.updated_at = Some(now.clone());

--- a/crates/homeboy-agents/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/mod.rs
@@ -28,6 +28,10 @@ pub use promote::promote_with_checkpoint;
 pub use promote::resume_promoted_patch;
 pub(crate) use promote::with_gate_supervision;
 pub use promote::{canonical_recoverable_patch_artifacts, CanonicalRecoverablePatchArtifacts};
+pub(crate) use promote::{
+    canonical_recoverable_patch_artifacts_in_observation_store,
+    promote_with_checkpoint_in_observation_store, resume_promoted_patch_in_observation_store,
+};
 pub use run_plan_projection::mirror_agent_task_run_plan_aggregate;
 pub use types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -71,7 +71,39 @@ pub fn promote_with_checkpoint(
     mut checkpoint: impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
     let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
-    let mut report = promote_with_provider_and_checkpoint(options, &mut provider, &mut checkpoint)?;
+    let mut report = promote_with_provider_and_checkpoint_internal(
+        options,
+        &mut provider,
+        &mut checkpoint,
+        None,
+    )?;
+    if let Some(provenance) = provider.provenance() {
+        report.provenance["worktree_provider"] = provenance.clone();
+    }
+    if let Some(runner_id) = crate::agent_task_lifecycle::execution_runner_id() {
+        report.provenance["lab_offload"] = json!({
+            "runner_id": runner_id,
+            "source_aggregate": report.source.path,
+            "source_artifact": report.patch_artifact.path,
+            "target_worktree": report.to_worktree,
+            "target_workspace": report.target.path,
+        });
+    }
+    Ok(report)
+}
+
+pub(crate) fn promote_with_checkpoint_in_observation_store(
+    options: AgentTaskPromotionOptions,
+    observation_store: &homeboy_core::observation::ObservationStore,
+    mut checkpoint: impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+) -> Result<AgentTaskPromotionReport> {
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
+    let mut report = promote_with_provider_and_checkpoint_internal(
+        options,
+        &mut provider,
+        &mut checkpoint,
+        Some(observation_store),
+    )?;
     if let Some(provenance) = provider.provenance() {
         report.provenance["worktree_provider"] = provenance.clone();
     }
@@ -95,6 +127,24 @@ pub fn resume_promoted_patch(
     target_path: &Path,
     previous: &Value,
 ) -> Result<AgentTaskPromotionReport> {
+    resume_promoted_patch_internal(options, target_path, previous, None)
+}
+
+pub(crate) fn resume_promoted_patch_in_observation_store(
+    options: AgentTaskPromotionOptions,
+    target_path: &Path,
+    previous: &Value,
+    observation_store: &homeboy_core::observation::ObservationStore,
+) -> Result<AgentTaskPromotionReport> {
+    resume_promoted_patch_internal(options, target_path, previous, Some(observation_store))
+}
+
+fn resume_promoted_patch_internal(
+    options: AgentTaskPromotionOptions,
+    target_path: &Path,
+    previous: &Value,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
+) -> Result<AgentTaskPromotionReport> {
     validate_resume_provenance(&options, target_path, previous)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
         Error::validation_invalid_json(
@@ -110,6 +160,7 @@ pub fn resume_promoted_patch(
         &outcome.task_id,
         options.source_run_id.as_deref(),
         options.source_path.as_deref(),
+        observation_store,
     )?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
@@ -467,6 +518,30 @@ pub(super) fn promote_with_provider_and_checkpoint(
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
+    promote_with_provider_and_checkpoint_internal(options, provider, checkpoint, None)
+}
+
+#[cfg(test)]
+pub(super) fn promote_with_provider_and_checkpoint_in_observation_store(
+    options: AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+    observation_store: &homeboy_core::observation::ObservationStore,
+) -> Result<AgentTaskPromotionReport> {
+    promote_with_provider_and_checkpoint_internal(
+        options,
+        provider,
+        checkpoint,
+        Some(observation_store),
+    )
+}
+
+fn promote_with_provider_and_checkpoint_internal(
+    options: AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
+) -> Result<AgentTaskPromotionReport> {
     validate_workspace_handle(&options.to_worktree)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
         Error::validation_invalid_json(
@@ -517,6 +592,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             &options,
             provider,
             checkpoint,
+            observation_store,
             &source_kind,
             &outcome,
             None,
@@ -540,6 +616,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
             &options,
             provider,
             checkpoint,
+            observation_store,
             &source_kind,
             &outcome,
             None,
@@ -548,7 +625,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
     }
 
     let artifact = match if outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable {
-        select_recoverable_patch_artifact(&outcome, &options)
+        select_recoverable_patch_artifact(&outcome, &options, observation_store)
     } else {
         select_patch_artifact(&outcome, options.artifact_id.as_deref())
     } {
@@ -559,6 +636,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
                     &options,
                     provider,
                     checkpoint,
+                    observation_store,
                     &source_kind,
                     &outcome,
                     None,
@@ -579,11 +657,10 @@ pub(super) fn promote_with_provider_and_checkpoint(
             None,
         ));
     }
-    let gate_feedback_baseline = bind_gate_feedback_baseline(gate_feedback_baseline_for_artifact(
-        &source_for_provenance,
-        &outcome,
-        &artifact,
-    )?)?;
+    let gate_feedback_baseline = bind_gate_feedback_baseline_internal(
+        gate_feedback_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?,
+        observation_store,
+    )?;
     let promotion_chain_baseline =
         promotion_chain_baseline_for_artifact(&source_for_provenance, &outcome, &artifact)?;
     let destination_baseline = promotion_chain_baseline
@@ -595,6 +672,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
         &outcome.task_id,
         options.source_run_id.as_deref(),
         options.source_path.as_deref(),
+        observation_store,
     )?;
     let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
         Error::internal_io(
@@ -609,6 +687,7 @@ pub(super) fn promote_with_provider_and_checkpoint(
                 &options,
                 provider,
                 checkpoint,
+                observation_store,
                 &source_kind,
                 &outcome,
                 Some(&artifact),
@@ -979,6 +1058,13 @@ fn gate_feedback_baseline_for_artifact(
 /// identity before a follow-up can reuse a dirty destination. Older baselines
 /// without source identity retain their existing strict path/hash contract.
 pub(crate) fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Option<Value>> {
+    bind_gate_feedback_baseline_internal(baseline, None)
+}
+
+fn bind_gate_feedback_baseline_internal(
+    baseline: Option<Value>,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
+) -> Result<Option<Value>> {
     let Some(mut baseline) = baseline else {
         return Ok(None);
     };
@@ -1042,14 +1128,28 @@ pub(crate) fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Opt
                 None,
             )
         })?;
-    let (record_id, _) = crate::agent_task_lifecycle::verified_controller_artifact_projection(
-        &run_id,
-        &task_id,
-        &artifact_id,
-        &kind,
-        &sha256,
-        None,
-    )?
+    let projection = match observation_store {
+        Some(store) => {
+            crate::agent_task_lifecycle::verified_controller_artifact_projection_in_store(
+                store,
+                &run_id,
+                &task_id,
+                &artifact_id,
+                &kind,
+                &sha256,
+                None,
+            )?
+        }
+        None => crate::agent_task_lifecycle::verified_controller_artifact_projection(
+            &run_id,
+            &task_id,
+            &artifact_id,
+            &kind,
+            &sha256,
+            None,
+        )?,
+    };
+    let (record_id, _) = projection
     .ok_or_else(|| Error::validation_invalid_argument(
         "gate_feedback_candidate_baseline",
         format!(
@@ -1245,6 +1345,7 @@ fn promote_committed_changes(
     options: &AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
     source_kind: &str,
     outcome: &AgentTaskOutcome,
     artifact: Option<&AgentTaskArtifact>,
@@ -1271,9 +1372,14 @@ fn promote_committed_changes(
             None,
         ));
     }
-    let retained_patch_path =
-        retain_committed_changes_artifact(options, outcome, &patch, &committed_patch.sha256)?
-            .unwrap_or_else(|| committed_patch.patch_path.clone());
+    let retained_patch_path = retain_committed_changes_artifact(
+        options,
+        outcome,
+        &patch,
+        &committed_patch.sha256,
+        observation_store,
+    )?
+    .unwrap_or_else(|| committed_patch.patch_path.clone());
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
     // Keep committed-change promotion on the same atomic base-validation
     // boundary as artifact promotion: no apply or checkpoint may precede a
@@ -1293,10 +1399,11 @@ fn promote_committed_changes(
             .map(str::trim)
             .is_none_or(str::is_empty);
     let provider_patch = write_normalized_patch(&normalized_patch.content)?;
-    let gate_feedback_baseline = bind_gate_feedback_baseline(
+    let gate_feedback_baseline = bind_gate_feedback_baseline_internal(
         artifact
             .and_then(|artifact| artifact.metadata.get("gate_feedback_baseline"))
             .cloned(),
+        observation_store,
     )?;
     let mut command_evidence = Vec::new();
     let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
@@ -1433,16 +1540,24 @@ fn promote_committed_changes(
 
 /// Retain the controller-generated committed delta before its producer path can
 /// be cleaned up. Only an existing controller run may own this projection.
-fn retain_committed_changes_artifact(
+pub(super) fn retain_committed_changes_artifact(
     options: &AgentTaskPromotionOptions,
     outcome: &AgentTaskOutcome,
     patch: &str,
     sha256: &str,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
 ) -> Result<Option<PathBuf>> {
     let Some(run_id) = options.source_run_id.as_deref() else {
         return Ok(None);
     };
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let ambient_store;
+    let store = match observation_store {
+        Some(store) => store,
+        None => {
+            ambient_store = homeboy_core::observation::ObservationStore::open_initialized()?;
+            &ambient_store
+        }
+    };
     if store.get_run(run_id)?.is_none() {
         return Ok(None);
     }
@@ -2367,8 +2482,10 @@ pub(crate) fn select_patch_artifact(
 fn select_recoverable_patch_artifact(
     outcome: &AgentTaskOutcome,
     options: &AgentTaskPromotionOptions,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
 ) -> Result<AgentTaskArtifact> {
-    let canonical = canonical_recoverable_patch_artifacts(outcome, options)?;
+    let canonical =
+        canonical_recoverable_patch_artifacts_internal(outcome, options, observation_store)?;
     match canonical.artifacts.len() {
         1 => Ok(canonical.artifacts.into_iter().next().expect("one canonical patch")),
         0 => Err(Error::new(
@@ -2409,6 +2526,22 @@ pub fn canonical_recoverable_patch_artifacts(
     outcome: &AgentTaskOutcome,
     options: &AgentTaskPromotionOptions,
 ) -> Result<CanonicalRecoverablePatchArtifacts> {
+    canonical_recoverable_patch_artifacts_internal(outcome, options, None)
+}
+
+pub(crate) fn canonical_recoverable_patch_artifacts_in_observation_store(
+    outcome: &AgentTaskOutcome,
+    options: &AgentTaskPromotionOptions,
+    observation_store: &homeboy_core::observation::ObservationStore,
+) -> Result<CanonicalRecoverablePatchArtifacts> {
+    canonical_recoverable_patch_artifacts_internal(outcome, options, Some(observation_store))
+}
+
+fn canonical_recoverable_patch_artifacts_internal(
+    outcome: &AgentTaskOutcome,
+    options: &AgentTaskPromotionOptions,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
+) -> Result<CanonicalRecoverablePatchArtifacts> {
     let mut candidates = outcome
         .artifacts
         .iter()
@@ -2435,6 +2568,7 @@ pub fn canonical_recoverable_patch_artifacts(
             &outcome.task_id,
             options.source_run_id.as_deref(),
             options.source_path.as_deref(),
+            observation_store,
         ) {
             Ok(path) => path,
             Err(error) => {
@@ -2522,13 +2656,20 @@ fn resolve_artifact_path(
     task_id: &str,
     source_run_id: Option<&str>,
     source_path: Option<&Path>,
+    observation_store: Option<&homeboy_core::observation::ObservationStore>,
 ) -> Result<PathBuf> {
     if let Some(run_id) = source_run_id {
-        if let Some(projected) =
-            crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
+        let projected = match observation_store {
+            Some(store) => {
+                crate::agent_task_lifecycle::verified_controller_artifact_projection_path_in_store(
+                    store, run_id, task_id, artifact,
+                )?
+            }
+            None => crate::agent_task_lifecycle::verified_controller_artifact_projection_path(
                 run_id, task_id, artifact,
-            )?
-        {
+            )?,
+        };
+        if let Some(projected) = projected {
             return Ok(projected);
         }
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -232,6 +232,16 @@ pub(super) fn record_controller_projection(
 ) -> PathBuf {
     let store =
         homeboy_core::observation::ObservationStore::open_initialized().expect("observation store");
+    record_controller_projection_in_store(&store, run_id, task_id, artifact_id, contents)
+}
+
+pub(super) fn record_controller_projection_in_store(
+    store: &homeboy_core::observation::ObservationStore,
+    run_id: &str,
+    task_id: &str,
+    artifact_id: &str,
+    contents: &str,
+) -> PathBuf {
     store
         .upsert_imported_run(&homeboy_core::observation::RunRecord {
             id: run_id.to_string(),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -9,8 +9,9 @@ use super::super::apply::{
 };
 use super::super::promote::{
     normalize_promotion_patch, promote, promote_with_provider,
-    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
-    validate_artifact_content,
+    promote_with_provider_and_checkpoint,
+    promote_with_provider_and_checkpoint_in_observation_store, resume_promoted_patch,
+    retain_committed_changes_artifact, select_patch_artifact, validate_artifact_content,
 };
 use super::super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
@@ -273,6 +274,154 @@ fn promotion_uses_recovered_controller_projection_without_public_artifact_path()
         assert_eq!(result.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(provider.apply_calls.len(), 1);
     });
+}
+
+#[test]
+fn recoverable_promotion_projection_uses_the_explicit_observation_store() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(left_context.path_roots())
+            .open_observation_initialized()
+            .expect("left observation store");
+    let right_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(right_context.path_roots())
+            .open_observation_initialized()
+            .expect("right observation store");
+    let run_id = "same-projected-run";
+    let task_id = "same-projected-task";
+    let artifact_id = "same-projected-patch";
+    let mut source: Value = serde_json::from_str(&recovered_runner_aggregate(
+        task_id,
+        artifact_id,
+        &sha256_hex(VALID_PATCH),
+        VALID_PATCH.len(),
+    ))
+    .expect("aggregate JSON");
+    source["status"] = Value::String("partial_recoverable".to_string());
+    source["outcomes"][0]["status"] = Value::String("candidate_recoverable".to_string());
+    source["outcomes"][0]["artifacts"][0]["metadata"] = serde_json::json!({
+        "executor_artifact_finalized": true,
+        "run_id": run_id,
+        "task_id": task_id,
+        "producer_attempt": 1,
+        "base_ref": "base-sha",
+        "provider_backend": "test",
+        "repository_identity": "repo",
+        "workspace_identity": "workspace",
+        "gate_feedback_baseline": {
+            "source_run_id": run_id,
+            "source_task_id": task_id,
+            "patch_artifact": {
+                "id": artifact_id,
+                "kind": "patch",
+                "sha256": sha256_hex(VALID_PATCH),
+            }
+        }
+    });
+    source["outcomes"][0]["artifacts"][0]
+        .as_object_mut()
+        .expect("patch artifact")
+        .remove("path");
+    record_controller_projection_in_store(
+        &right_store,
+        run_id,
+        task_id,
+        artifact_id,
+        "wrong patch bytes",
+    );
+    let projected = record_controller_projection_in_store(
+        &left_store,
+        run_id,
+        task_id,
+        artifact_id,
+        VALID_PATCH,
+    );
+    let temp = tempfile::tempdir().expect("promotion tempdir");
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(temp.path().join("target")),
+        ..Default::default()
+    };
+
+    let result = promote_with_provider_and_checkpoint_in_observation_store(
+        AgentTaskPromotionOptions {
+            source: source.to_string(),
+            source_run_id: Some(run_id.to_string()),
+            source_path: None,
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "homeboy@rooted-projection".to_string(),
+            task_id: Some(task_id.to_string()),
+            artifact_id: Some(artifact_id.to_string()),
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+        &mut |_| Ok(()),
+        &left_store,
+    )
+    .expect("explicit projection is promoted");
+
+    assert_eq!(result.patch_artifact.path, projected.display().to_string());
+    assert_eq!(provider.apply_calls.len(), 1);
+}
+
+#[test]
+fn committed_changes_retention_uses_the_explicit_observation_store() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(left_context.path_roots())
+            .open_observation_initialized()
+            .expect("left observation store");
+    let right_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(right_context.path_roots())
+            .open_observation_initialized()
+            .expect("right observation store");
+    let run_id = "same-committed-retention-run";
+    left_store
+        .upsert_imported_run(&homeboy_core::observation::RunRecord {
+            id: run_id.to_string(),
+            kind: "agent-task".to_string(),
+            component_id: None,
+            started_at: "2026-08-15T00:00:00Z".to_string(),
+            finished_at: Some("2026-08-15T00:00:01Z".to_string()),
+            status: "pass".to_string(),
+            command: Some("homeboy agent-task".to_string()),
+            cwd: None,
+            homeboy_version: Some("test".to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::json!({}),
+        })
+        .expect("record explicit run");
+    let aggregate: AgentTaskAggregate = serde_json::from_str(&recovered_runner_aggregate(
+        "committed-task",
+        "patch",
+        &sha256_hex(VALID_PATCH),
+        VALID_PATCH.len(),
+    ))
+    .expect("aggregate");
+    let mut options = promotion_options("homeboy@committed-retention");
+    options.source_run_id = Some(run_id.to_string());
+
+    let retained = retain_committed_changes_artifact(
+        &options,
+        &aggregate.outcomes[0],
+        VALID_PATCH,
+        &sha256_hex(VALID_PATCH),
+        Some(&left_store),
+    )
+    .expect("retain committed changes")
+    .expect("retained path");
+
+    assert!(retained.starts_with(left_context.root()));
+    assert_eq!(left_store.list_artifacts(run_id).unwrap().len(), 1);
+    assert!(right_store.list_artifacts(run_id).unwrap().is_empty());
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -44,14 +44,16 @@ use super::cook_pre_execution::{
     record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
     with_pre_execution_phase,
 };
+#[cfg(test)]
+use super::cook_promotion::promote_or_load_attempt;
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
     finalize_or_load_cook_pr_with_store, is_moving_base_finalization_error,
-    moving_base_recovery_for_run_with_store, moving_base_recovery_from_promotion,
+    moving_base_recovery_for_run_with_stores, moving_base_recovery_from_promotion,
     moving_base_recovery_report, next_moving_base_recovery, persisted_promotion_for_attempt,
-    promote_or_load_attempt, recover_moving_base_cook_candidate, refreshed_moving_base_recovery,
-    retryable_provider_discovery_failure, retryable_provider_discovery_failure_with_store,
-    CookReportInput, MovingBaseCookRecovery,
+    promote_or_load_attempt_in_store, recover_moving_base_cook_candidate_in_store,
+    refreshed_moving_base_recovery, retryable_provider_discovery_failure,
+    retryable_provider_discovery_failure_with_store, CookReportInput, MovingBaseCookRecovery,
 };
 use super::cook_recipe::CookRecipeStore;
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
@@ -560,20 +562,28 @@ fn promote_with_operation_claim(
     options: &AgentTaskCookServiceOptions,
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    promote_with_operation_claim_in_store(&lifecycle_store, options, run_id)
+}
+
+fn promote_with_operation_claim_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> Result<AgentTaskPromotionReport> {
     let operation_key = promotion_operation_key(run_id);
-    match agent_task_lifecycle::claim_cook_operation(run_id, &operation_key, PROMOTION_CLAIM_LEASE)?
-    {
+    match lifecycle_store.claim_cook_operation(run_id, &operation_key, PROMOTION_CLAIM_LEASE)? {
         // A prior pass already promoted and recorded the result. Load the durable
         // promotion rather than repeating the external effect.
         agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(_) => {
-            promote_or_load_attempt(options, run_id)
+            promote_or_load_attempt_in_store(lifecycle_store, options, run_id)
         }
         // Another pass holds a still-fresh lease. The persisted-promotion read in
         // `promote_or_load_attempt` still resolves an already-produced promotion;
         // if none exists yet, promotion proceeds (content-addressed and idempotent
         // on disk). Do not mark the claim completed from here — its owner does.
         agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
-            let claim = agent_task_lifecycle::operation_claim(run_id, &operation_key)?;
+            let claim = lifecycle_store.operation_claim(run_id, &operation_key)?;
             let mut error = Error::validation_invalid_argument(
                 "promotion_operation",
                 "operation_in_progress",
@@ -586,10 +596,11 @@ fn promote_with_operation_claim(
         // This pass owns the operation. Promote, then record the result as the
         // claim's immutable completion.
         agent_task_lifecycle::ClaimOutcome::Acquired => {
-            let promotion = match promote_or_load_attempt(options, run_id) {
+            let promotion = match promote_or_load_attempt_in_store(lifecycle_store, options, run_id)
+            {
                 Ok(promotion) => promotion,
                 Err(error) => {
-                    agent_task_lifecycle::fail_cook_operation(
+                    lifecycle_store.fail_cook_operation(
                         run_id,
                         &operation_key,
                         bounded_error_diagnostic(&error),
@@ -597,7 +608,7 @@ fn promote_with_operation_claim(
                     return Err(error);
                 }
             };
-            agent_task_lifecycle::complete_cook_operation(
+            lifecycle_store.complete_cook_operation(
                 run_id,
                 &operation_key,
                 serde_json::to_value(&promotion)
@@ -719,6 +730,7 @@ pub(crate) trait CookSideEffectService {
     /// Rebase and re-verify a candidate whose base moved under it.
     fn recover_moving_base(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         recovery: &MovingBaseCookRecovery,
     ) -> Result<AgentTaskPromotionReport>;
@@ -764,10 +776,11 @@ where
 
     fn recover_moving_base(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         recovery: &MovingBaseCookRecovery,
     ) -> Result<AgentTaskPromotionReport> {
-        recover_moving_base_cook_candidate(options, recovery)
+        recover_moving_base_cook_candidate_in_store(lifecycle_store, options, recovery)
     }
 
     fn finalize(
@@ -824,6 +837,7 @@ where
 
     fn recover_moving_base(
         &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         recovery: &MovingBaseCookRecovery,
     ) -> Result<AgentTaskPromotionReport> {
@@ -3981,6 +3995,7 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     // The local detached launcher persists this fence before spawn. Recheck it
     // at each durable/external boundary so a dead launcher cannot revive work.
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
@@ -4000,11 +4015,13 @@ where
     // caller-owned overrides and retain their existing behavior. A typed
     // moving-base continuation has already completed provider work and must
     // not require a provider merely to rebase and reverify its candidate.
-    let moving_base_continuation = agent_task_lifecycle::status(&options.initial_run_id)
+    let moving_base_continuation = lifecycle_store
+        .read_record(&options.initial_run_id)
         .ok()
         .and_then(|record| record.metadata.get("cook_moving_base_recovery").cloned())
         .is_some();
-    let verification_pending_continuation = agent_task_lifecycle::status(&options.initial_run_id)
+    let verification_pending_continuation = lifecycle_store
+        .read_record(&options.initial_run_id)
         .ok()
         .is_some_and(|record| {
             record
@@ -4038,11 +4055,14 @@ where
     }
     // The durable reconstruction boundary must exist before an external provider
     // can accept the first attempt.
-    let adopted_model = agent_task_lifecycle::status(&options.initial_run_id)
-        .ok()
-        .map(|record| adopted_attempt_is_ready_for_cook_continuation(&record))
-        .transpose()?
-        .flatten();
+    let adopted_model = if moving_base_continuation || verification_pending_continuation {
+        lifecycle_store.read_record(&options.initial_run_id).ok()
+    } else {
+        agent_task_lifecycle::status(&options.initial_run_id).ok()
+    }
+    .map(|record| adopted_attempt_is_ready_for_cook_continuation(&record))
+    .transpose()?
+    .flatten();
     let existing_recipe = store.recipe_exists(&options.cook_id);
     // A form-only continuation has already appended and persisted its exact
     // attempt. Re-persisting it as a fresh initial recipe would falsely look
@@ -4083,12 +4103,12 @@ where
         {
             reconstructed.initial_run_id = attempt.run_id.clone();
             reconstructed.initial_plan = attempt.plan.clone();
-            if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
+            if lifecycle_store.record_exists(&attempt.run_id)? {
                 // The recipe freezes the task-worktree handle, while the
                 // durable run plan freezes the baseline-bound continuation.
                 // Resolve the former back to its active path: the baseline is
                 // execution evidence, not a task-worktree identity.
-                let continuation_plan = agent_task_lifecycle::load_plan(&attempt.run_id)?;
+                let continuation_plan = lifecycle_store.read_controller_plan(&attempt.run_id)?;
                 rebind_baseline_continuation_workspace(&mut reconstructed, &continuation_plan)?;
                 reconstructed.initial_plan = continuation_plan;
             }
@@ -4113,7 +4133,7 @@ where
     // A detached transport may own workspace materialization on the runner.
     // Its initial handoff has no controller-local source path to validate yet;
     // requiring one here turns an accepted detached retry into a local failure.
-    if cook_attempt_needs_execution(&options.initial_run_id)
+    if cook_attempt_needs_execution_with_store(&lifecycle_store, &options.initial_run_id)
         && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
     {
@@ -4358,7 +4378,7 @@ where
     // The recipe alone is resumable input, not a status-addressable run. Publish
     // the run identity only after initial materialization and a lifecycle read
     // prove status/log recovery resolves for this exact attempt.
-    let materialized_run = agent_task_lifecycle::status(&options.initial_run_id)?;
+    let materialized_run = lifecycle_store.read_record(&options.initial_run_id)?;
     if materialized_run.run_id != options.initial_run_id {
         return Err(Error::internal_unexpected(
             "materialized Cook lifecycle record does not match its initial run id",
@@ -4403,7 +4423,8 @@ where
         .find(|attempt| attempt.run_id == options.initial_run_id)
         .map(|attempt| attempt.attempt)
         .unwrap_or(1);
-    let resumed_run_id = resumable_cook_run_id(
+    let resumed_run_id = resumable_cook_run_id_in_store(
+        &lifecycle_store,
         &recipe,
         &options.cook_id,
         &options.initial_run_id,
@@ -4466,9 +4487,9 @@ where
         }
         let plan = match next_plan.take() {
             Some(plan) => plan,
-            None => agent_task_lifecycle::load_plan(&run_id)?,
+            None => lifecycle_store.read_controller_plan(&run_id)?,
         };
-        let needs_execution = cook_attempt_needs_execution(&run_id);
+        let needs_execution = cook_attempt_needs_execution_with_store(&lifecycle_store, &run_id);
         if needs_execution {
             // The local detached launcher persists this fence before spawn.
             // Recheck immediately before this attempt can publish provider work.
@@ -4476,8 +4497,8 @@ where
             // `provider_start` is a durable lifecycle transition. Create the
             // record before reporting it so a new Cook run is observable before
             // any preflight or provider work can block.
-            if !agent_task_lifecycle::run_record_exists(&run_id)? {
-                agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
+            if !lifecycle_store.record_exists(&run_id)? {
+                lifecycle_store.submit_plan_with_current_runtime(&plan, &run_id)?;
             }
             report_cook_progress(
                 durable_observer,
@@ -4913,8 +4934,14 @@ where
                 continue;
             }
         }
-        agent_task_lifecycle::record_cook_attempt(&cook_id, attempt, &run_id)?;
-        let mut record = agent_task_lifecycle::status(&run_id)?;
+        lifecycle_store.record_cook_attempt(&cook_id, attempt, &run_id)?;
+        let rooted_promotion_continuation =
+            moving_base_continuation || verification_pending_continuation;
+        let mut record = if rooted_promotion_continuation {
+            lifecycle_store.read_record(&run_id)?
+        } else {
+            agent_task_lifecycle::status(&run_id)?
+        };
         // A local controller can disappear after the provider ledger records a
         // terminal result but before the run projection is terminalized. Repair
         // only this Cook attempt, never the active fleet, before deciding whether
@@ -4924,7 +4951,11 @@ where
             && record.aggregate_path.is_none()
         {
             super::reconcile_run(&run_id, false)?;
-            record = agent_task_lifecycle::status(&run_id)?;
+            record = if rooted_promotion_continuation {
+                lifecycle_store.read_record(&run_id)?
+            } else {
+                agent_task_lifecycle::status(&run_id)?
+            };
         }
         let controller_owned_staging = record
             .metadata
@@ -4959,9 +4990,9 @@ where
                 invocation_latest_run_id: Some(&run_id),
             }));
         }
-        let plan = agent_task_lifecycle::load_plan_for_execution(&run_id)?;
+        let plan = lifecycle_store.read_controller_plan_for_execution(&run_id)?;
         budget_limit.get_or_insert_with(|| plan.options.execution_budget.clone());
-        let aggregate = match agent_task_lifecycle::read_aggregate(&run_id) {
+        let aggregate = match lifecycle_store.read_aggregate(&run_id) {
             Ok(aggregate) => aggregate,
             // An aggregate path is authoritative evidence that an aggregate was
             // committed. Its read failure must surface for repair rather than be
@@ -5260,7 +5291,7 @@ where
                 options.gates.gate_timeout(),
                 |_compared, _total| Ok(()),
             )?;
-            agent_task_lifecycle::record_promotion(
+            lifecycle_store.record_promotion(
                 &run_id,
                 serde_json::to_value(&promotion)
                     .map_err(|error| Error::internal_json(error.to_string(), None))?,
@@ -5367,17 +5398,25 @@ where
                     }));
                 }
                 let mut active_moving_base_recovery = None;
-                let promotion = match moving_base_recovery_for_run_with_store(store, &run_id)? {
-                    Some(recovery) => match side_effects.recover_moving_base(&options, &recovery) {
+                let promotion = match moving_base_recovery_for_run_with_stores(
+                    store,
+                    &lifecycle_store,
+                    &run_id,
+                )? {
+                    Some(recovery) => match side_effects.recover_moving_base(
+                        &lifecycle_store,
+                        &options,
+                        &recovery,
+                    ) {
                         Ok(promotion) => {
-                            agent_task_lifecycle::record_promotion(
+                            lifecycle_store.record_promotion(
                                 &run_id,
                                 serde_json::to_value(&promotion).map_err(|error| {
                                     Error::internal_json(error.to_string(), None)
                                 })?,
                             )?;
                             let recovery = refreshed_moving_base_recovery(recovery, &promotion);
-                            agent_task_lifecycle::record_cook_moving_base_recovery(
+                            lifecycle_store.record_cook_moving_base_recovery(
                                 &run_id,
                                 serde_json::to_value(&recovery).map_err(|error| {
                                     Error::internal_json(error.to_string(), None)
@@ -5389,7 +5428,7 @@ where
                                     "rebased candidate did not pass the declared deterministic gates ({:?}); finalization was not attempted",
                                     promotion.status
                                 );
-                                agent_task_lifecycle::record_cook_moving_base_recovery(
+                                lifecycle_store.record_cook_moving_base_recovery(
                                     &run_id,
                                     serde_json::to_value(&recovery).map_err(|error| {
                                         Error::internal_json(error.to_string(), None)
@@ -5408,7 +5447,7 @@ where
                         }
                         Err(error) => {
                             let recovery = next_moving_base_recovery(recovery, error.to_string());
-                            agent_task_lifecycle::record_cook_moving_base_recovery(
+                            lifecycle_store.record_cook_moving_base_recovery(
                                 &run_id,
                                 serde_json::to_value(&recovery).map_err(|error| {
                                     Error::internal_json(error.to_string(), None)
@@ -5440,7 +5479,7 @@ where
                 let finalization = match side_effects.finalize(&options, &run_id, &promotion) {
                     Ok(finalization) => {
                         if active_moving_base_recovery.is_some() {
-                            agent_task_lifecycle::clear_cook_moving_base_recovery(&run_id)?;
+                            lifecycle_store.clear_cook_moving_base_recovery(&run_id)?;
                         }
                         finalization
                     }
@@ -5451,7 +5490,7 @@ where
                             }),
                             error.to_string(),
                         );
-                        agent_task_lifecycle::record_cook_moving_base_recovery(
+                        lifecycle_store.record_cook_moving_base_recovery(
                             &run_id,
                             serde_json::to_value(&recovery)
                                 .map_err(|error| Error::internal_json(error.to_string(), None))?,
@@ -5725,8 +5764,27 @@ fn resumable_cook_run_id(
     requested_attempt: u32,
     verification_pending_continuation: bool,
 ) -> Option<String> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment().ok()?;
+    resumable_cook_run_id_in_store(
+        &lifecycle_store,
+        recipe,
+        cook_id,
+        initial_run_id,
+        requested_attempt,
+        verification_pending_continuation,
+    )
+}
+
+fn resumable_cook_run_id_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    recipe: &super::AgentTaskCookRecipe,
+    cook_id: &str,
+    initial_run_id: &str,
+    requested_attempt: u32,
+    verification_pending_continuation: bool,
+) -> Option<String> {
     (!verification_pending_continuation)
-        .then(|| agent_task_lifecycle::select_cook_candidate(cook_id).ok())
+        .then(|| lifecycle_store.select_cook_candidate(cook_id).ok())
         .flatten()
         .map(|selection| selection.run_id)
         .filter(|run_id| run_id != initial_run_id)
@@ -5799,21 +5857,39 @@ fn bind_dispatch_workspace_attestations(plan: &mut AgentTaskPlan) -> Result<()> 
 
 fn cook_attempt_needs_execution(run_id: &str) -> bool {
     agent_task_lifecycle::status(run_id)
-        .map(|record| {
-            (!matches!(
-                record.state,
-                agent_task_lifecycle::AgentTaskRunState::Succeeded
-                    | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-                    | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
-                    | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-                    | agent_task_lifecycle::AgentTaskRunState::Failed
-                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
-            ) || retryable_pre_execution_failure(&record))
-                && !record.lab_handoff.as_ref().is_some_and(|handoff| {
-                    handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
-                })
-        })
+        .map(|record| cook_run_record_needs_execution(&record))
         .unwrap_or(true)
+}
+
+fn cook_attempt_needs_execution_with_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> bool {
+    if lifecycle_store
+        .matches_current_environment()
+        .unwrap_or(false)
+    {
+        return cook_attempt_needs_execution(run_id);
+    }
+    lifecycle_store
+        .read_record(run_id)
+        .map(|record| cook_run_record_needs_execution(&record))
+        .unwrap_or(true)
+}
+
+fn cook_run_record_needs_execution(record: &agent_task_lifecycle::AgentTaskRunRecord) -> bool {
+    (!matches!(
+        record.state,
+        agent_task_lifecycle::AgentTaskRunState::Succeeded
+            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
+            | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+            | agent_task_lifecycle::AgentTaskRunState::Failed
+            | agent_task_lifecycle::AgentTaskRunState::Cancelled
+    ) || retryable_pre_execution_failure(record))
+        && !record.lab_handoff.as_ref().is_some_and(|handoff| {
+            handoff.state == agent_task_lifecycle::AgentTaskLabHandoffState::Accepted
+        })
 }
 
 /// Validate the Cook target before a provider can run. An explicit source path

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -25,9 +25,10 @@ use crate::agent_task_finalization::{
 };
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
-    candidate_fingerprint, canonical_recoverable_patch_artifacts, promote_with_checkpoint,
-    resume_promoted_patch, AgentTaskPromotionOptions, AgentTaskPromotionReport,
-    AgentTaskPromotionStatus,
+    candidate_fingerprint, canonical_recoverable_patch_artifacts,
+    canonical_recoverable_patch_artifacts_in_observation_store,
+    promote_with_checkpoint_in_observation_store, resume_promoted_patch_in_observation_store,
+    AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
@@ -79,17 +80,37 @@ pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     ))
 }
 
+fn promotion_source_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<(String, Option<PathBuf>)> {
+    lifecycle_store
+        .aggregate_source_exact(run_id)
+        .map(|(raw, path)| (raw, Some(path)))
+}
+
 pub(crate) fn promote_attempt(
     options: &AgentTaskCookServiceOptions,
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
-    let (source, source_path) = promotion_source(run_id)?;
-    let selected_task_id = selected_candidate_task_id(run_id)?;
-    let artifact_id = match continuation_artifact_id(run_id)? {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    promote_attempt_in_store(&lifecycle_store, options, run_id)
+}
+
+pub(crate) fn promote_attempt_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> Result<AgentTaskPromotionReport> {
+    let (source, source_path) = promotion_source_in_store(lifecycle_store, run_id)?;
+    let selected_task_id = selected_candidate_task_id_in_store(lifecycle_store, run_id)?;
+    let artifact_id = match continuation_artifact_id_in_store(lifecycle_store, run_id)? {
         Some(artifact_id) => Some(artifact_id),
-        None => canonical_cook_patch_artifact_id(options, run_id)?,
+        None => canonical_cook_patch_artifact_id_in_store(lifecycle_store, options, run_id)?,
     };
-    promote_with_checkpoint(
+    let observation_store = lifecycle_store.open_observation_initialized()?;
+    promote_with_checkpoint_in_observation_store(
         AgentTaskPromotionOptions {
             source,
             source_run_id: Some(run_id.to_string()),
@@ -106,8 +127,9 @@ pub(crate) fn promote_attempt(
             provider_command: options.provider_command.clone(),
             provider_invocation: options.provider_invocation.clone(),
         },
+        &observation_store,
         |checkpoint| {
-            agent_task_lifecycle::record_promotion(
+            lifecycle_store.record_promotion(
                 run_id,
                 serde_json::to_value(checkpoint).map_err(|error| {
                     Error::internal_json(
@@ -128,9 +150,19 @@ pub(crate) fn canonical_cook_patch_artifact_id(
     options: &AgentTaskCookServiceOptions,
     run_id: &str,
 ) -> Result<Option<String>> {
-    let (source, source_path) = promotion_source(run_id)?;
-    let task_id = selected_candidate_task_id(run_id)?;
-    let aggregate = agent_task_lifecycle::read_attempt_aggregate(run_id)?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    canonical_cook_patch_artifact_id_in_store(&lifecycle_store, options, run_id)
+}
+
+fn canonical_cook_patch_artifact_id_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> Result<Option<String>> {
+    let (source, source_path) = promotion_source_in_store(lifecycle_store, run_id)?;
+    let task_id = selected_candidate_task_id_in_store(lifecycle_store, run_id)?;
+    let aggregate = lifecycle_store.read_aggregate(run_id)?;
     let Some(outcome) = aggregate
         .outcomes
         .iter()
@@ -154,7 +186,12 @@ pub(crate) fn canonical_cook_patch_artifact_id(
         provider_command: options.provider_command.clone(),
         provider_invocation: options.provider_invocation.clone(),
     };
-    let canonical = canonical_recoverable_patch_artifacts(outcome, &promotion_options)?;
+    let observation_store = lifecycle_store.open_observation_initialized()?;
+    let canonical = canonical_recoverable_patch_artifacts_in_observation_store(
+        outcome,
+        &promotion_options,
+        &observation_store,
+    )?;
     match canonical.artifacts.as_slice() {
         [] => Ok(None),
         [artifact] => Ok(Some(artifact.id.clone())),
@@ -327,7 +364,16 @@ pub(crate) fn cook_promotion_argv(
 /// Cook only promotes the candidate selected by the scheduler. A single-task
 /// aggregate has no selection projection and retains the historical behavior.
 pub(crate) fn selected_candidate_task_id(run_id: &str) -> Result<Option<String>> {
-    let aggregate = agent_task_lifecycle::read_attempt_aggregate(run_id)?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    selected_candidate_task_id_in_store(&lifecycle_store, run_id)
+}
+
+fn selected_candidate_task_id_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<String>> {
+    let aggregate = lifecycle_store.read_aggregate(run_id)?;
     Ok(aggregate
         .selected_outcome()
         .or_else(|| {
@@ -345,7 +391,17 @@ pub(crate) fn promote_or_load_attempt(
     options: &AgentTaskCookServiceOptions,
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
-    if let Some(promotion) = persisted_promotion_for_attempt(run_id)? {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    promote_or_load_attempt_in_store(&lifecycle_store, options, run_id)
+}
+
+pub(crate) fn promote_or_load_attempt_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> Result<AgentTaskPromotionReport> {
+    if let Some(promotion) = persisted_promotion_for_attempt_in_store(lifecycle_store, run_id)? {
         if promotion.status == AgentTaskPromotionStatus::VerificationPending {
             let target_path = promotion.target.path.as_deref().or_else(|| {
                 promotion.provenance.get("worktree_path").and_then(Value::as_str)
@@ -362,8 +418,9 @@ pub(crate) fn promote_or_load_attempt(
                     None,
                 )
             })?;
-            let (source, source_path) = promotion_source(run_id)?;
-            let resumed = resume_promoted_patch(
+            let (source, source_path) = promotion_source_in_store(lifecycle_store, run_id)?;
+            let observation_store = lifecycle_store.open_observation_initialized()?;
+            let resumed = resume_promoted_patch_in_observation_store(
                 AgentTaskPromotionOptions {
                     source,
                     source_run_id: Some(run_id.to_string()),
@@ -375,7 +432,7 @@ pub(crate) fn promote_or_load_attempt(
                     to_worktree: options.to_worktree.clone(),
                     // A resumed verification must retain the scheduler-selected
                     // candidate rather than falling back to aggregate outcome order.
-                    task_id: selected_candidate_task_id(run_id)?,
+                    task_id: selected_candidate_task_id_in_store(lifecycle_store, run_id)?,
                     // The checkpoint already authenticated this exact artifact;
                     // retain its identity rather than selecting an equivalent alias.
                     artifact_id: Some(promotion.patch_artifact.id.clone()),
@@ -387,8 +444,9 @@ pub(crate) fn promote_or_load_attempt(
                 &target_path,
                 &serde_json::to_value(&promotion)
                     .map_err(|error| Error::internal_json(error.to_string(), None))?,
+                &observation_store,
             )?;
-            agent_task_lifecycle::record_promotion(
+            lifecycle_store.record_promotion(
                 run_id,
                 serde_json::to_value(&resumed)
                     .map_err(|error| Error::internal_json(error.to_string(), None))?,
@@ -397,8 +455,8 @@ pub(crate) fn promote_or_load_attempt(
         }
         return Ok(promotion);
     }
-    let promotion = promote_attempt(options, run_id)?;
-    crate::agent_task_lifecycle::record_promotion(
+    let promotion = promote_attempt_in_store(lifecycle_store, options, run_id)?;
+    lifecycle_store.record_promotion(
         run_id,
         serde_json::to_value(&promotion).map_err(|error| {
             Error::internal_json(
@@ -413,7 +471,16 @@ pub(crate) fn promote_or_load_attempt(
 /// A selector is accepted only from the route authority written by
 /// `cook-continue`; normal Cook promotion retains automatic selection.
 fn continuation_artifact_id(run_id: &str) -> Result<Option<String>> {
-    let record = agent_task_lifecycle::exact_record(run_id)?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    continuation_artifact_id_in_store(&lifecycle_store, run_id)
+}
+
+fn continuation_artifact_id_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<String>> {
+    let record = lifecycle_store.read_record(run_id)?;
     let Some(route) = record.metadata.get("cook_continue_route") else {
         return Ok(None);
     };
@@ -429,6 +496,13 @@ pub(crate) fn persisted_promotion_for_attempt(
     run_id: &str,
 ) -> Result<Option<AgentTaskPromotionReport>> {
     let record = agent_task_lifecycle::status(run_id)?;
+    persisted_promotion_from_record(run_id, record)
+}
+
+fn persisted_promotion_from_record(
+    requested_run_id: &str,
+    record: agent_task_lifecycle::AgentTaskRunRecord,
+) -> Result<Option<AgentTaskPromotionReport>> {
     let Some(value) = record.metadata.get("latest_promotion") else {
         return Ok(None);
     };
@@ -437,7 +511,7 @@ pub(crate) fn persisted_promotion_for_attempt(
             Error::validation_invalid_argument(
                 "latest_promotion",
                 format!("persisted cook promotion is invalid: {error}"),
-                Some(run_id.to_string()),
+                Some(requested_run_id.to_string()),
                 None,
             )
         })?;
@@ -448,10 +522,10 @@ pub(crate) fn persisted_promotion_for_attempt(
         let mut error = Error::validation_invalid_argument(
             "latest_promotion.source.run_id",
             "persisted cook promotion does not belong to this attempt",
-            Some(run_id.to_string()),
+            Some(requested_run_id.to_string()),
             None,
         );
-        error.details["requested_run_id"] = serde_json::json!(run_id);
+        error.details["requested_run_id"] = serde_json::json!(requested_run_id);
         error.details["resolved_run_id"] = serde_json::json!(record.run_id);
         error.details["promotion_run_id"] = serde_json::json!(promotion.source.run_id);
         return Err(error);
@@ -459,6 +533,14 @@ pub(crate) fn persisted_promotion_for_attempt(
     restore_gate_feedback_baseline(&record, &mut promotion)?;
     promotion.normalize_gate_outcome();
     Ok(Some(promotion))
+}
+
+pub(crate) fn persisted_promotion_for_attempt_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<AgentTaskPromotionReport>> {
+    let record = lifecycle_store.read_record(run_id)?;
+    persisted_promotion_from_record(run_id, record)
 }
 
 /// Records green verification produced after an infrastructure-invalid gate
@@ -793,15 +875,27 @@ pub struct MovingBaseCookRecovery {
 }
 
 pub(crate) fn moving_base_recovery_for_run(run_id: &str) -> Result<Option<MovingBaseCookRecovery>> {
-    let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
-    moving_base_recovery_for_run_with_store(&store, run_id)
+    let recipe_store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    moving_base_recovery_for_run_with_stores(&recipe_store, &lifecycle_store, run_id)
 }
 
 pub(crate) fn moving_base_recovery_for_run_with_store(
     store: &super::cook_recipe::CookRecipeStore,
     run_id: &str,
 ) -> Result<Option<MovingBaseCookRecovery>> {
-    let record = agent_task_lifecycle::exact_record(run_id)?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    moving_base_recovery_for_run_with_stores(store, &lifecycle_store, run_id)
+}
+
+pub(crate) fn moving_base_recovery_for_run_with_stores(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<MovingBaseCookRecovery>> {
+    let record = lifecycle_store.read_record(run_id)?;
     record
         .metadata
         .get("cook_moving_base_recovery")
@@ -945,6 +1039,16 @@ pub(crate) fn recover_moving_base_cook_candidate(
     options: &AgentTaskCookServiceOptions,
     recovery: &MovingBaseCookRecovery,
 ) -> Result<AgentTaskPromotionReport> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    recover_moving_base_cook_candidate_in_store(&lifecycle_store, options, recovery)
+}
+
+pub(crate) fn recover_moving_base_cook_candidate_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    recovery: &MovingBaseCookRecovery,
+) -> Result<AgentTaskPromotionReport> {
     if recovery.base_movements >= 3 {
         return Err(Error::validation_invalid_argument("base", "moving-base recovery budget is exhausted; inspect the retained recovery evidence before retrying", None, None));
     }
@@ -1015,8 +1119,9 @@ pub(crate) fn recover_moving_base_cook_candidate(
         "resolved_base": fresh_base,
         "previous": recovery.promotion.provenance.get("resume_contract"),
     });
-    let (source, source_path) = promotion_source(&recovery.run_id)?;
-    let refreshed = resume_promoted_patch(
+    let (source, source_path) = promotion_source_in_store(lifecycle_store, &recovery.run_id)?;
+    let observation_store = lifecycle_store.open_observation_initialized()?;
+    let refreshed = resume_promoted_patch_in_observation_store(
         AgentTaskPromotionOptions {
             source,
             source_run_id: Some(recovery.run_id.clone()),
@@ -1026,7 +1131,7 @@ pub(crate) fn recover_moving_base_cook_candidate(
             task_base_sha: options.task_base_sha.clone(),
             candidate_ref: None,
             to_worktree: options.to_worktree.clone(),
-            task_id: selected_candidate_task_id(&recovery.run_id)?,
+            task_id: selected_candidate_task_id_in_store(lifecycle_store, &recovery.run_id)?,
             // Moving-base recovery re-verifies the original promoted candidate.
             artifact_id: Some(recovery.promotion.patch_artifact.id.clone()),
             dry_run: false,
@@ -1036,6 +1141,7 @@ pub(crate) fn recover_moving_base_cook_candidate(
         },
         std::path::Path::new(path),
         &checkpoint,
+        &observation_store,
     )?;
     Ok(refreshed)
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12,12 +12,13 @@ use super::super::cook_promotion::{
     canonical_cook_patch_artifact_id, canonical_cook_recovery_run_id, cook_finalization_options,
     cook_promotion_argv, cook_report, finalize_cook_pr_with_backend,
     finalize_or_load_cook_pr_with_backend, moving_base_recovery_for_run,
-    moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
-    persist_manual_finalization_intent, persist_manual_finalization_receipt,
-    persisted_promotion_for_attempt, prepare_manual_finalization_identity,
-    record_replacement_gate_proof, recover_cook_pr_with_backend,
-    recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
-    CookReportInput, MovingBaseCookRecovery,
+    moving_base_recovery_for_run_with_stores, moving_base_recovery_from_promotion,
+    moving_base_recovery_report, next_moving_base_recovery, persist_manual_finalization_intent,
+    persist_manual_finalization_receipt, persisted_promotion_for_attempt,
+    prepare_manual_finalization_identity, record_replacement_gate_proof,
+    recover_cook_pr_with_backend, recover_moving_base_cook_candidate,
+    refreshed_moving_base_recovery, selected_candidate_task_id, CookReportInput,
+    MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::persist_initial_recipe;
 use super::*;
@@ -1024,6 +1025,7 @@ impl CookSideEffectService for CanonicalSelectionSideEffects {
 
     fn recover_moving_base(
         &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
         _options: &AgentTaskCookServiceOptions,
         _recovery: &MovingBaseCookRecovery,
     ) -> Result<AgentTaskPromotionReport> {
@@ -1821,6 +1823,62 @@ fn moving_base_recovery_refreshes_authenticated_candidate_before_retrying_finali
         "rebased"
     );
     assert_eq!(refreshed.base_movements, 0);
+}
+
+#[test]
+fn moving_base_recovery_isolates_identical_attempts_across_explicit_stores() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_recipe_store = CookRecipeStore::new(left_context.path_roots());
+    let right_recipe_store = CookRecipeStore::new(right_context.path_roots());
+    let left_lifecycle_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_lifecycle_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-moving-base-cook";
+    let run_id = "same-moving-base-run";
+    let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.initial_run_id = run_id.to_string();
+
+    for (recipe_store, lifecycle_store, blocker) in [
+        (&left_recipe_store, &left_lifecycle_store, "left blocker"),
+        (&right_recipe_store, &right_lifecycle_store, "right blocker"),
+    ] {
+        recipe_store.persist_initial_recipe(&options).unwrap();
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
+                Ok(serde_json::json!({}))
+            })
+            .unwrap();
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                record.metadata["cook_id"] = serde_json::json!(cook_id);
+                true
+            })
+            .unwrap();
+        let mut recovery = moving_base_recovery_from_promotion(cook_id, run_id, promotion(run_id));
+        recovery.blocker = blocker.to_string();
+        lifecycle_store
+            .record_cook_moving_base_recovery(run_id, serde_json::to_value(recovery).unwrap())
+            .unwrap();
+    }
+
+    let left =
+        moving_base_recovery_for_run_with_stores(&left_recipe_store, &left_lifecycle_store, run_id)
+            .unwrap()
+            .expect("left recovery");
+    let right = moving_base_recovery_for_run_with_stores(
+        &right_recipe_store,
+        &right_lifecycle_store,
+        run_id,
+    )
+    .unwrap()
+    .expect("right recovery");
+
+    assert_eq!(left.blocker, "left blocker");
+    assert_eq!(right.blocker, "right blocker");
+    assert_ne!(
+        left_lifecycle_store.run_dir(run_id),
+        right_lifecycle_store.run_dir(run_id)
+    );
 }
 
 #[test]
@@ -10713,6 +10771,45 @@ fn promotion_operation_claim_completes_once_and_replays_persisted_result() {
         assert_eq!(replayed.source.run_id, first.source.run_id);
         assert_eq!(replayed.patch_artifact.id, first.patch_artifact.id);
     });
+}
+
+#[test]
+fn promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-cook-promote-claim";
+    let run_id = "same-run-promote-claim";
+    let options = promotion_claim_options(cook_id, run_id);
+    let operation_key = promotion_operation_key(run_id);
+
+    for store in [&left_store, &right_store] {
+        store
+            .submit_plan_with_runtime_admission(
+                &AgentTaskPlan::new(cook_id, Vec::new()),
+                run_id,
+                |_| Ok(serde_json::json!({})),
+            )
+            .unwrap();
+        store
+            .record_promotion(run_id, serde_json::to_value(promotion(run_id)).unwrap())
+            .unwrap();
+
+        let first = promote_with_operation_claim_in_store(store, &options, run_id).unwrap();
+        let replayed = promote_with_operation_claim_in_store(store, &options, run_id).unwrap();
+        assert_eq!(replayed.patch_artifact.id, first.patch_artifact.id);
+        assert_eq!(
+            store
+                .operation_claim(run_id, &operation_key)
+                .unwrap()
+                .expect("rooted promotion claim")
+                .state,
+            agent_task_lifecycle::ClaimState::Completed
+        );
+    }
+
+    assert_ne!(left_store.run_dir(run_id), right_store.run_dir(run_id));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -158,7 +158,10 @@ impl AgentTaskLifecycleStore {
     }
 
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
-        ObservationStore::open_initialized_for_lifecycle_at(self.observation_db_path())
+        ObservationStore::open_initialized_for_lifecycle_at_roots(
+            self.observation_db_path(),
+            self.artifact_root(),
+        )
     }
 
     pub fn open_observation_readonly(&self) -> Result<ObservationStore> {
@@ -243,6 +246,38 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub fn fail_cook_operation(
+        &self,
+        run_id: &str,
+        operation_key: &str,
+        result: Value,
+    ) -> Result<()> {
+        super::operation_claims::fail_cook_operation_in_store(self, run_id, operation_key, result)
+    }
+
+    pub(crate) fn aggregate_source_exact(&self, run_id: &str) -> Result<(String, PathBuf)> {
+        let record = self.read_record(run_id)?;
+        record.aggregate_path.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                format!(
+                    "agent-task run '{}' has no aggregate artifact yet",
+                    record.run_id
+                ),
+                Some(record.run_id.clone()),
+                None,
+            )
+        })?;
+        let aggregate = self.read_aggregate(&record.run_id)?;
+        let raw = serde_json::to_string_pretty(&aggregate).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("serialize agent-task aggregate {}", record.run_id)),
+            )
+        })?;
+        Ok((raw, self.aggregate_path(&record.run_id)))
+    }
+
     pub fn operation_claim(
         &self,
         run_id: &str,
@@ -265,6 +300,21 @@ impl AgentTaskLifecycleStore {
 
     pub fn record_promotion(&self, run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {
         super::lifecycle_ops::record_promotion_in_store(self, run_id, promotion)
+    }
+
+    pub(crate) fn record_cook_moving_base_recovery(
+        &self,
+        run_id: &str,
+        recovery: Value,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_cook_moving_base_recovery_in_store(self, run_id, recovery)
+    }
+
+    pub(crate) fn clear_cook_moving_base_recovery(
+        &self,
+        run_id: &str,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::clear_cook_moving_base_recovery_in_store(self, run_id)
     }
 
     pub fn read_controller_plan(&self, run_id: &str) -> Result<AgentTaskPlan> {
@@ -327,6 +377,13 @@ impl AgentTaskLifecycleStore {
 
     pub fn read_cook_index(&self, cook_id: &str) -> Result<AgentTaskCookIndex> {
         read_cook_index_in_store(self, cook_id)
+    }
+
+    pub(crate) fn select_cook_candidate(
+        &self,
+        cook_id: &str,
+    ) -> Result<super::AgentTaskCookCandidateSelection> {
+        super::lifecycle_ops::select_cook_candidate_in_store(self, cook_id)
     }
 
     pub(crate) fn update_cook_index(

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -235,8 +235,13 @@ impl ObservationStore {
                 // A concurrent publisher may be preparing the same logical
                 // artifact before either SQLite transaction commits. Its final
                 // bytes must therefore be owned by this publication token.
-                let stored_path =
-                    publication_artifact_path(&run.id, &publication.id, source, &publication_id)?;
+                let stored_path = publication_artifact_path(
+                    &self.artifact_root()?,
+                    &run.id,
+                    &publication.id,
+                    source,
+                    &publication_id,
+                )?;
                 let size_bytes = (publication.artifact_type == ArtifactPublicationType::File)
                     .then(|| i64::try_from(metadata.len()).ok())
                     .flatten();
@@ -871,7 +876,7 @@ impl ObservationStore {
             .filter(|id| !id.trim().is_empty())
             .map(str::to_string)
             .unwrap_or_else(|| Uuid::new_v4().to_string());
-        let stored_path = persisted_artifact_path(run_id, &id, path)?;
+        let stored_path = persisted_artifact_path_at(&self.artifact_root()?, run_id, &id, path)?;
         preflight_artifact_capacity(&stored_path)?;
         let staged_path = staged_artifact_path(&stored_path, Uuid::new_v4());
         copy_artifact_file(path, &staged_path)?;
@@ -1118,7 +1123,7 @@ impl ObservationStore {
             ));
         }
         let created_at = chrono::Utc::now().to_rfc3339();
-        let stored_path = persisted_artifact_path(run_id, &id, path)?;
+        let stored_path = persisted_artifact_path_at(&self.artifact_root()?, run_id, &id, path)?;
         preflight_artifact_capacity(&stored_path)?;
         copy_artifact_directory(path, &stored_path)?;
         let path_string = stored_path.to_string_lossy().to_string();
@@ -1968,12 +1973,13 @@ impl ObservationStore {
 }
 
 fn publication_artifact_path(
+    artifact_root: &Path,
     run_id: &str,
     artifact_id: &str,
     source: &Path,
     publication_id: &str,
 ) -> Result<PathBuf> {
-    let canonical = persisted_artifact_path(run_id, artifact_id, source)?;
+    let canonical = persisted_artifact_path_at(artifact_root, run_id, artifact_id, source)?;
     let file_name = canonical
         .file_name()
         .and_then(|name| name.to_str())
@@ -2634,6 +2640,7 @@ mod tests {
                 connection,
                 path: database.clone(),
                 readonly: false,
+                artifact_root: None,
             };
             let staging = home.path().join("retry.staging");
             let final_path = home.path().join("retry.final");

--- a/crates/homeboy-core/src/observation/store/helpers.rs
+++ b/crates/homeboy-core/src/observation/store/helpers.rs
@@ -243,7 +243,17 @@ pub(crate) fn collect_rows<T>(
     Ok(records)
 }
 
+#[cfg(test)]
 pub(crate) fn persisted_artifact_path(
+    run_id: &str,
+    artifact_id: &str,
+    source: &Path,
+) -> Result<PathBuf> {
+    persisted_artifact_path_at(&crate::paths::artifact_root()?, run_id, artifact_id, source)
+}
+
+pub(crate) fn persisted_artifact_path_at(
+    artifact_root: &Path,
     run_id: &str,
     artifact_id: &str,
     source: &Path,
@@ -256,7 +266,7 @@ pub(crate) fn persisted_artifact_path(
         .filter(|name| !name.is_empty())
         .map(|name| format!("{artifact_id}-{name}"))
         .unwrap_or_else(|| artifact_id.to_string());
-    Ok(paths::artifact_root()?.join(run_id).join(file_name))
+    Ok(artifact_root.join(run_id).join(file_name))
 }
 
 fn validate_artifact_path_component(field: &str, value: &str) -> Result<()> {

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -21,7 +21,7 @@ use super::records::{
     NewTriageItemRecord, RunCursor, RunListFilter, RunPage, RunRecord, RunStatus, TraceRunRecord,
     TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
-use crate::{paths, Error, Result};
+use crate::{Error, Result};
 pub use artifacts::directory_tree_sha256;
 pub use artifacts::{
     ArtifactListFilter, ArtifactListPage, ArtifactPublication, ArtifactPublicationType,
@@ -62,6 +62,7 @@ pub struct ObservationStore {
     connection: Connection,
     path: PathBuf,
     readonly: bool,
+    artifact_root: Option<PathBuf>,
 }
 
 pub fn database_path() -> Result<PathBuf> {

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -70,6 +70,15 @@ impl ObservationStore {
         Self::open_initialized_at_with_maintenance(path.into(), false)
     }
 
+    pub fn open_initialized_for_lifecycle_at_roots(
+        path: impl Into<PathBuf>,
+        artifact_root: impl Into<PathBuf>,
+    ) -> Result<Self> {
+        let mut store = Self::open_initialized_at_with_maintenance(path.into(), false)?;
+        store.artifact_root = Some(artifact_root.into());
+        Ok(store)
+    }
+
     fn open_initialized_at_with_maintenance(
         path: PathBuf,
         maintain_artifacts: bool,
@@ -89,6 +98,7 @@ impl ObservationStore {
             connection,
             path,
             readonly: false,
+            artifact_root: None,
         };
         if maintain_artifacts {
             // Evidence projections expose opaque handles and failure ranks, so
@@ -116,6 +126,7 @@ impl ObservationStore {
             connection,
             path,
             readonly: false,
+            artifact_root: None,
         })
     }
 
@@ -142,6 +153,7 @@ impl ObservationStore {
                 connection,
                 path,
                 readonly: true,
+                artifact_root: None,
             });
         }
         let connection = schema::open_readonly_connection(&path)?;
@@ -149,7 +161,15 @@ impl ObservationStore {
             connection,
             path,
             readonly: true,
+            artifact_root: None,
         })
+    }
+
+    pub fn artifact_root(&self) -> Result<PathBuf> {
+        self.artifact_root
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(crate::paths::artifact_root)
     }
 
     pub fn status(&self) -> Result<ObservationDbStatus> {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -219,6 +219,7 @@ mod store_init_tests {
                 connection: rusqlite::Connection::open(&path).expect("open test store"),
                 path: path.clone(),
                 readonly: false,
+                artifact_root: None,
             };
             let run = store
                 .start_run(sample_run("test", "homeboy"))


### PR DESCRIPTION
## Summary
- root exact-attempt Cook promotion reads, operation claims, checkpoints, replay, and moving-base recovery in one `AgentTaskLifecycleStore`
- bind controller artifact projection, retention, finalized lookup, and ownership checks to the lifecycle store's explicit `ObservationStore` artifact root
- preserve ambient compatibility entry points while threading explicit stores through internal promotion and continuation paths
- prove same-ID promotion claims, moving-base recovery, controller projections, recoverable promotion, and committed-change retention remain isolated across two roots

Continues #7505 and builds on #12541.

## Verification
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents moving_base_recovery --lib`
- `cargo test -p homeboy-agents promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores --lib`
- `cargo test -p homeboy-agents controller_local_projection_isolates_identical_ids_across_artifact_roots --lib`
- `cargo test -p homeboy-agents recoverable_promotion_projection_uses_the_explicit_observation_store --lib`
- `cargo test -p homeboy-agents committed_changes_retention_uses_the_explicit_observation_store --lib`
- `cargo test -p homeboy-agents adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empty_attempt --lib`
- `cargo test -p homeboy-agents cook_alias_continuation_starts_from_failed_gate_feedback_attempt --lib`
- `git diff --check`

The broad `cargo test -p homeboy-core observation --lib --no-fail-fast` run passed 307/308 tests; `observed_workflow_runner_finishes_error_after_resource_summary` failed under parallel shared-state execution and passed immediately when rerun alone.

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode was used to trace the lifecycle and observation-store boundaries, implement explicit store propagation, add isolation coverage, run verification, and review the final diff. Chris Huber remains responsible for every line.