### PR TITLE
refactor(agent-task): root Cook finalization stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -45,28 +45,43 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
 ) -> Result<AgentTaskPrFinalizationReport> {
-    finalize_pr_with_backend_mode(options, backend, true)
+    finalize_pr_with_backend_mode(options, backend, true, None)
+}
+
+pub(crate) fn finalize_pr_with_backend_in_store<B: AgentTaskPrFinalizationBackend>(
+    options: AgentTaskPrFinalizationOptions,
+    backend: &mut B,
+    lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+) -> Result<AgentTaskPrFinalizationReport> {
+    finalize_pr_with_backend_mode(options, backend, true, Some(lifecycle_store))
 }
 
 pub fn preflight_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
 ) -> Result<AgentTaskPrFinalizationReport> {
-    finalize_pr_with_backend_mode(options, backend, false)
+    finalize_pr_with_backend_mode(options, backend, false, None)
 }
 
 fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     mut options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
     publish: bool,
+    lifecycle_store: Option<&crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
 ) -> Result<AgentTaskPrFinalizationReport> {
     let mut durable_changed_files = Vec::new();
     let durable_acceptance;
     if options.manual_finalization {
         durable_acceptance = validate_manual_finalization_policy(&options.run_id)?;
     } else {
-        let lifecycle = backend.hydrate_run(&options.run_id)?;
-        let gate_proof = backend.hydrate_gate_proof(&options.run_id)?;
+        let lifecycle = match lifecycle_store {
+            Some(store) => backend.hydrate_run_in_store(store, &options.run_id)?,
+            None => backend.hydrate_run(&options.run_id)?,
+        };
+        let gate_proof = match lifecycle_store {
+            Some(store) => backend.hydrate_gate_proof_in_store(store, &options.run_id)?,
+            None => backend.hydrate_gate_proof(&options.run_id)?,
+        };
         let review_form_only_follow_up =
             is_review_form_only_follow_up(&gate_proof.promotion, &gate_proof.run_id);
         let authenticated_follow_up = review_form_only_follow_up
@@ -85,7 +100,8 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
             ));
         }
         validate_gate_proof_binding(&gate_proof, &options)?;
-        durable_acceptance = validate_durable_acceptance(&options.run_id, &gate_proof.promotion)?;
+        durable_acceptance =
+            validate_durable_acceptance(&options.run_id, &gate_proof.promotion, lifecycle_store)?;
         let eligibility =
             validate_durable_publication_eligibility(&lifecycle, &gate_proof.promotion)?;
         durable_changed_files = normalize_changed_files(&gate_proof.promotion.changed_files);
@@ -415,8 +431,12 @@ fn validate_manual_finalization_policy(
 fn validate_durable_acceptance(
     run_id: &str,
     promotion: &AgentTaskPromotionReport,
+    lifecycle_store: Option<&crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
 ) -> Result<Option<crate::agent_task_lifecycle::AgentTaskAcceptanceRecord>> {
-    let record = match crate::agent_task_lifecycle::persisted_status(run_id) {
+    let record = match lifecycle_store.map_or_else(
+        || crate::agent_task_lifecycle::persisted_status(run_id),
+        |store| store.read_record(run_id),
+    ) {
         Ok(record) => record,
         // Durable proofs created before acceptance existed have no lifecycle
         // record to carry an acceptance requirement. Preserve that established

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -37,6 +37,36 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         })
     }
 
+    fn hydrate_run_in_store(
+        &mut self,
+        lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<RunLifecycleRecord> {
+        Ok(lifecycle_store.read_record(run_id)?.lifecycle)
+    }
+
+    fn hydrate_gate_proof_in_store(
+        &mut self,
+        lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<AgentTaskPrDurableGateProof> {
+        let record = lifecycle_store.read_record(run_id)?;
+        let promotion = record.metadata.get("latest_promotion").cloned().ok_or_else(|| Error::validation_invalid_argument("run_id", "normal finalization requires the run's persisted applied promotion; run agent-task promote first or use --manual-finalization", None, None))?;
+        let promotion: AgentTaskPromotionReport =
+            serde_json::from_value(promotion).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "run_id",
+                    "durable latest promotion record is invalid",
+                    None,
+                    None,
+                )
+            })?;
+        Ok(AgentTaskPrDurableGateProof {
+            run_id: record.run_id,
+            promotion,
+        })
+    }
+
     fn validate_candidate(&mut self, options: &AgentTaskPrFinalizationOptions) -> Result<()> {
         validate_real_candidate_fingerprint(options)?;
         homeboy_core::repository_integrity::verify_tracked_symlink_portability(

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -78,6 +78,24 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
             )
         })
     }
+    fn hydrate_run_in_store(
+        &mut self,
+        lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<RunLifecycleRecord> {
+        if self.hydrate_run_id.is_some() {
+            return RealAgentTaskPrFinalizationBackend
+                .hydrate_run_in_store(lifecycle_store, run_id);
+        }
+        self.hydrate_run(run_id)
+    }
+    fn hydrate_gate_proof_in_store(
+        &mut self,
+        _lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<AgentTaskPrDurableGateProof> {
+        self.hydrate_gate_proof(run_id)
+    }
     fn validate_candidate(&mut self, options: &AgentTaskPrFinalizationOptions) -> Result<()> {
         let Some(expected) = self.candidate.as_ref() else {
             return Ok(());

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -307,6 +307,30 @@ pub struct AgentTaskPrDurableGateProof {
 pub trait AgentTaskPrFinalizationBackend {
     fn hydrate_run(&mut self, run_id: &str) -> Result<RunLifecycleRecord>;
     fn hydrate_gate_proof(&mut self, run_id: &str) -> Result<AgentTaskPrDurableGateProof>;
+    fn hydrate_run_in_store(
+        &mut self,
+        _lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        _run_id: &str,
+    ) -> Result<RunLifecycleRecord> {
+        Err(Error::validation_invalid_argument(
+            "finalization_backend",
+            "backend does not support explicit lifecycle-store hydration",
+            None,
+            None,
+        ))
+    }
+    fn hydrate_gate_proof_in_store(
+        &mut self,
+        _lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        _run_id: &str,
+    ) -> Result<AgentTaskPrDurableGateProof> {
+        Err(Error::validation_invalid_argument(
+            "finalization_backend",
+            "backend does not support explicit lifecycle-store gate-proof hydration",
+            None,
+            None,
+        ))
+    }
     /// Real finalization binds the exact promoted bytes immediately before the
     /// first mutation. Test backends can focus on publication behavior.
     fn validate_candidate(&mut self, _options: &AgentTaskPrFinalizationOptions) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5168,8 +5168,17 @@ pub fn record_acceptance_verdict_with_feedback(
 /// Persist the controller publication result separately from promotion so a
 /// resumed cook can prove finalization already completed before it publishes.
 pub fn record_cook_finalization(run_id: &str, finalization: Value) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_finalization_in_store(&lifecycle_store, run_id, finalization)
+}
+
+pub(crate) fn record_cook_finalization_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    finalization: Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("cook_finalization") == Some(&finalization) {
             return false;
         }
@@ -5181,7 +5190,7 @@ pub fn record_cook_finalization(run_id: &str, finalization: Value) -> Result<Age
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -48,7 +48,7 @@ use super::cook_pre_execution::{
 use super::cook_promotion::promote_or_load_attempt;
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
-    finalize_or_load_cook_pr_with_store, is_moving_base_finalization_error,
+    finalize_or_load_cook_pr_with_stores, is_moving_base_finalization_error,
     moving_base_recovery_for_run_with_stores, moving_base_recovery_from_promotion,
     moving_base_recovery_report, next_moving_base_recovery, persisted_promotion_for_attempt,
     promote_or_load_attempt_in_store, recover_moving_base_cook_candidate_in_store,
@@ -510,12 +510,23 @@ fn finalize_with_operation_claim(
         &AgentTaskPromotionReport,
     ) -> Result<Value>,
 ) -> Result<Value> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    finalize_with_operation_claim_in_store(&lifecycle_store, options, run_id, promotion, finalize)
+}
+
+fn finalize_with_operation_claim_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    finalize: &mut dyn FnMut(
+        &AgentTaskCookServiceOptions,
+        &str,
+        &AgentTaskPromotionReport,
+    ) -> Result<Value>,
+) -> Result<Value> {
     let operation_key = finalization_operation_key(run_id, promotion);
-    match agent_task_lifecycle::claim_cook_operation(
-        run_id,
-        &operation_key,
-        FINALIZATION_CLAIM_LEASE,
-    )? {
+    match lifecycle_store.claim_cook_operation(run_id, &operation_key, FINALIZATION_CLAIM_LEASE)? {
         // A completed claim only proves an earlier publication. Re-run the
         // idempotent finalizer so a later force-push or PR-head mutation cannot
         // be returned as a still-valid publication.
@@ -532,7 +543,7 @@ fn finalize_with_operation_claim(
             let finalization = match finalize(options, run_id, promotion) {
                 Ok(finalization) => finalization,
                 Err(error) => {
-                    agent_task_lifecycle::fail_cook_operation(
+                    lifecycle_store.fail_cook_operation(
                         run_id,
                         &operation_key,
                         bounded_error_diagnostic(&error),
@@ -540,7 +551,7 @@ fn finalize_with_operation_claim(
                     return Err(error);
                 }
             };
-            agent_task_lifecycle::complete_cook_operation(
+            lifecycle_store.complete_cook_operation(
                 run_id,
                 &operation_key,
                 finalization.clone(),
@@ -740,6 +751,7 @@ pub(crate) trait CookSideEffectService {
     /// finalizing.
     fn finalize(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
         promotion: &AgentTaskPromotionReport,
@@ -755,7 +767,12 @@ pub(crate) struct DefaultCookSideEffects<F> {
 
 impl<F> DefaultCookSideEffects<F>
 where
-    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+    F: FnMut(
+        &AgentTaskLifecycleStore,
+        &AgentTaskCookServiceOptions,
+        &str,
+        &AgentTaskPromotionReport,
+    ) -> Result<Value>,
 {
     pub(crate) fn new(finalize: F) -> Self {
         Self { finalize }
@@ -764,7 +781,12 @@ where
 
 impl<F> CookSideEffectService for DefaultCookSideEffects<F>
 where
-    F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
+    F: FnMut(
+        &AgentTaskLifecycleStore,
+        &AgentTaskCookServiceOptions,
+        &str,
+        &AgentTaskPromotionReport,
+    ) -> Result<Value>,
 {
     fn promote(
         &mut self,
@@ -785,11 +807,20 @@ where
 
     fn finalize(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
         promotion: &AgentTaskPromotionReport,
     ) -> Result<Value> {
-        finalize_with_operation_claim(options, run_id, promotion, &mut self.finalize)
+        finalize_with_operation_claim_in_store(
+            lifecycle_store,
+            options,
+            run_id,
+            promotion,
+            &mut |options, run_id, promotion| {
+                (self.finalize)(lifecycle_store, options, run_id, promotion)
+            },
+        )
     }
 }
 
@@ -846,6 +877,7 @@ where
 
     fn finalize(
         &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
         promotion: &AgentTaskPromotionReport,
@@ -3601,9 +3633,10 @@ pub fn run_cook_with_store<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    let side_effects = DefaultCookSideEffects::new(|options, run_id, promotion| {
-        finalize_or_load_cook_pr_with_store(store, options, run_id, promotion)
-    });
+    let side_effects =
+        DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
+            finalize_or_load_cook_pr_with_stores(store, lifecycle_store, options, run_id, promotion)
+        });
     run_cook_with_boundaries_with_store(store, options, executor, side_effects)
 }
 
@@ -3615,7 +3648,9 @@ where
     E: AgentTaskExecutorAdapter + Clone,
 {
     let store = CookRecipeStore::from_current_data_root()?;
-    let side_effects = DefaultCookSideEffects::new(finalize_or_load_cook_pr);
+    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
+        finalize_or_load_cook_pr(options, run_id, promotion)
+    });
     run_cook_with_boundaries_observed_policy_with_store(
         &store,
         options,
@@ -3637,7 +3672,9 @@ pub fn run_cook_with_durable_observer<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    let side_effects = DefaultCookSideEffects::new(finalize_or_load_cook_pr);
+    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
+        finalize_or_load_cook_pr(options, run_id, promotion)
+    });
     run_cook_with_boundaries_observed(options, executor, side_effects, Some(observer))
 }
 
@@ -3658,13 +3695,15 @@ pub(crate) fn run_cook_with_finalizer_with_store<E, F>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
     executor: E,
-    finalize: F,
+    mut finalize: F,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
     E: AgentTaskExecutorAdapter + Clone,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
-    let side_effects = DefaultCookSideEffects::new(finalize);
+    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
+        finalize(options, run_id, promotion)
+    });
     run_cook_with_boundaries_with_store(store, options, executor, side_effects)
 }
 
@@ -5476,39 +5515,43 @@ where
                     attempt,
                     None,
                 )?;
-                let finalization = match side_effects.finalize(&options, &run_id, &promotion) {
-                    Ok(finalization) => {
-                        if active_moving_base_recovery.is_some() {
-                            lifecycle_store.clear_cook_moving_base_recovery(&run_id)?;
+                let finalization =
+                    match side_effects.finalize(&lifecycle_store, &options, &run_id, &promotion) {
+                        Ok(finalization) => {
+                            if active_moving_base_recovery.is_some() {
+                                lifecycle_store.clear_cook_moving_base_recovery(&run_id)?;
+                            }
+                            finalization
                         }
-                        finalization
-                    }
-                    Err(error) if is_moving_base_finalization_error(&error) => {
-                        let recovery = next_moving_base_recovery(
-                            active_moving_base_recovery.unwrap_or_else(|| {
-                                moving_base_recovery_from_promotion(&cook_id, &run_id, promotion)
-                            }),
-                            error.to_string(),
-                        );
-                        lifecycle_store.record_cook_moving_base_recovery(
-                            &run_id,
-                            serde_json::to_value(&recovery)
-                                .map_err(|error| Error::internal_json(error.to_string(), None))?,
-                        )?;
-                        if recovery.base_movements < 3 {
-                            store.enqueue_terminal_continuation(&cook_id, &run_id)?;
+                        Err(error) if is_moving_base_finalization_error(&error) => {
+                            let recovery = next_moving_base_recovery(
+                                active_moving_base_recovery.unwrap_or_else(|| {
+                                    moving_base_recovery_from_promotion(
+                                        &cook_id, &run_id, promotion,
+                                    )
+                                }),
+                                error.to_string(),
+                            );
+                            lifecycle_store.record_cook_moving_base_recovery(
+                                &run_id,
+                                serde_json::to_value(&recovery).map_err(|error| {
+                                    Error::internal_json(error.to_string(), None)
+                                })?,
+                            )?;
+                            if recovery.base_movements < 3 {
+                                store.enqueue_terminal_continuation(&cook_id, &run_id)?;
+                            }
+                            let continuation_queued = recovery.base_movements < 3;
+                            return Ok(moving_base_recovery_report(
+                                cook_id,
+                                attempts,
+                                recovery,
+                                continuation_queued,
+                                Some(&run_id),
+                            ));
                         }
-                        let continuation_queued = recovery.base_movements < 3;
-                        return Ok(moving_base_recovery_report(
-                            cook_id,
-                            attempts,
-                            recovery,
-                            continuation_queued,
-                            Some(&run_id),
-                        ));
-                    }
-                    Err(error) if error.message.contains("awaiting_acceptance") => {
-                        return Ok(cook_report(CookReportInput {
+                        Err(error) if error.message.contains("awaiting_acceptance") => {
+                            return Ok(cook_report(CookReportInput {
                             cook_id,
                             status: "awaiting_acceptance",
                             disposition: CookDisposition::Terminal,
@@ -5529,9 +5572,9 @@ where
                             exit_code: 1,
                             invocation_latest_run_id: Some(&run_id),
                         }));
-                    }
-                    Err(error) => return Err(error),
-                };
+                        }
+                        Err(error) => return Err(error),
+                    };
                 let final_status = finalization["status"]
                     .as_str()
                     .unwrap_or("unknown")
@@ -5567,7 +5610,8 @@ where
                         attempt,
                         Some("accepted inherited baseline-red gate"),
                     )?;
-                    let finalization = side_effects.finalize(&options, &run_id, &promotion)?;
+                    let finalization =
+                        side_effects.finalize(&lifecycle_store, &options, &run_id, &promotion)?;
                     let final_status = finalization["status"]
                         .as_str()
                         .unwrap_or("unknown")

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -18,10 +18,10 @@ use homeboy_engine_primitives::content_hash;
 use homeboy_engine_primitives::shell::quote_args;
 
 use crate::agent_task_finalization::{
-    finalize_pr_with_backend, preflight_pr_with_backend, validate_publication_intent,
-    AgentTaskPrEvidence, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
-    AgentTaskPrFinalizationReport, AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship,
-    AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
+    finalize_pr_with_backend, finalize_pr_with_backend_in_store, preflight_pr_with_backend,
+    validate_publication_intent, AgentTaskPrEvidence, AgentTaskPrFinalizationBackend,
+    AgentTaskPrFinalizationOptions, AgentTaskPrFinalizationReport, AgentTaskPrRuntimeGuardrails,
+    AgentTaskPrSourceRelationship, AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
@@ -1643,8 +1643,27 @@ pub(crate) fn finalize_or_load_cook_pr_with_store(
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
 ) -> Result<Value> {
-    finalize_or_load_cook_pr_with_backend_with_store(
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    finalize_or_load_cook_pr_with_stores(
         store,
+        &lifecycle_store,
+        options,
+        successful_run_id,
+        promotion,
+    )
+}
+
+pub(crate) fn finalize_or_load_cook_pr_with_stores(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+) -> Result<Value> {
+    finalize_or_load_cook_pr_with_backend_with_stores(
+        store,
+        lifecycle_store,
         options,
         successful_run_id,
         promotion,
@@ -1677,14 +1696,37 @@ pub(crate) fn finalize_or_load_cook_pr_with_backend_with_store<
     promotion: &AgentTaskPromotionReport,
     backend: &mut B,
 ) -> Result<Value> {
-    let finalization = finalize_cook_pr_with_backend_with_store(
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    finalize_or_load_cook_pr_with_backend_with_stores(
         store,
+        &lifecycle_store,
+        options,
+        successful_run_id,
+        promotion,
+        backend,
+    )
+}
+
+pub(crate) fn finalize_or_load_cook_pr_with_backend_with_stores<
+    B: AgentTaskPrFinalizationBackend,
+>(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    backend: &mut B,
+) -> Result<Value> {
+    let finalization = finalize_cook_pr_with_backend_with_stores(
+        store,
+        lifecycle_store,
         options,
         successful_run_id,
         promotion,
         backend,
     )?;
-    agent_task_lifecycle::record_cook_finalization(successful_run_id, finalization.clone())?;
+    lifecycle_store.record_cook_finalization(successful_run_id, finalization.clone())?;
     Ok(finalization)
 }
 
@@ -1705,6 +1747,26 @@ pub(crate) fn finalize_cook_pr_with_backend_with_store<B: AgentTaskPrFinalizatio
     promotion: &AgentTaskPromotionReport,
     backend: &mut B,
 ) -> Result<Value> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    finalize_cook_pr_with_backend_with_stores(
+        store,
+        &lifecycle_store,
+        options,
+        successful_run_id,
+        promotion,
+        backend,
+    )
+}
+
+pub(crate) fn finalize_cook_pr_with_backend_with_stores<B: AgentTaskPrFinalizationBackend>(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    backend: &mut B,
+) -> Result<Value> {
     let mut promotion = promotion.clone();
     promotion.normalize_gate_outcome();
     if !promotion.finalization_eligible(options.gates.accept_inherited_failures) {
@@ -1715,18 +1777,19 @@ pub(crate) fn finalize_cook_pr_with_backend_with_store<B: AgentTaskPrFinalizatio
             None,
         ));
     }
-    let finalization = cook_finalization_options_with_store(
+    let finalization = cook_finalization_options_with_stores(
         store,
+        lifecycle_store,
         options,
         successful_run_id,
         &promotion,
         Vec::new(),
     )?;
-    crate::agent_task_lifecycle::record_promotion(
+    lifecycle_store.record_promotion(
         successful_run_id,
         serde_json::to_value(&promotion).unwrap_or(Value::Null),
     )?;
-    finalize_pr_with_backend(finalization, backend)
+    finalize_pr_with_backend_in_store(finalization, backend, lifecycle_store)
         .map(|report| serde_json::to_value(report).unwrap_or(Value::Null))
 }
 
@@ -1742,6 +1805,26 @@ pub(crate) fn cook_finalization_options(
 
 pub(crate) fn cook_finalization_options_with_store(
     store: &super::cook_recipe::CookRecipeStore,
+    options: &AgentTaskCookServiceOptions,
+    successful_run_id: &str,
+    promotion: &AgentTaskPromotionReport,
+    overrides: Vec<AgentTaskReviewOverride>,
+) -> Result<AgentTaskPrFinalizationOptions> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    cook_finalization_options_with_stores(
+        store,
+        &lifecycle_store,
+        options,
+        successful_run_id,
+        promotion,
+        overrides,
+    )
+}
+
+pub(crate) fn cook_finalization_options_with_stores(
+    store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
     successful_run_id: &str,
     promotion: &AgentTaskPromotionReport,
@@ -1781,8 +1864,13 @@ pub(crate) fn cook_finalization_options_with_store(
                 None,
             )
         })?;
-    let mut review_dossier =
-        cook_review_dossier_with_store(store, options, promotion, successful_run_id)?;
+    let mut review_dossier = cook_review_dossier_with_stores(
+        store,
+        lifecycle_store,
+        options,
+        promotion,
+        successful_run_id,
+    )?;
     review_dossier.overrides = overrides;
     // A non-empty option is an explicit operator disclosure. Otherwise retain
     // the validated review form's process statement as durable PR provenance.
@@ -1843,7 +1931,8 @@ pub(crate) fn cook_finalization_options_with_store(
             runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
             changed_public_contracts: Vec::new(),
             public_contract_evidence: None,
-            lifecycle: crate::agent_task_lifecycle::status(successful_run_id)
+            lifecycle: lifecycle_store
+                .read_record(successful_run_id)
                 .ok()
                 .map(|record| record.lifecycle),
         },
@@ -2594,8 +2683,9 @@ fn validate_manual_preflight_report(
     })
 }
 
-fn cook_review_dossier_with_store(
+fn cook_review_dossier_with_stores(
     store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
     promotion: &AgentTaskPromotionReport,
     successful_run_id: &str,
@@ -2609,7 +2699,7 @@ fn cook_review_dossier_with_store(
         .and_then(Value::as_str);
     let implementation_promotion = source_run_id
         .map(|run_id| {
-            persisted_promotion_for_attempt(run_id)?.ok_or_else(|| {
+            persisted_promotion_for_attempt_in_store(lifecycle_store, run_id)?.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "promotion.provenance.cook_follow_up.source_run_id",
                     "form-only finalization requires its source attempt's persisted promotion",
@@ -2669,10 +2759,11 @@ fn cook_review_dossier_with_store(
     // A form-only follow-up owns reviewer metadata, not the candidate it carries
     // forward. Resolve the persisted Cook lineage so that follow-up prose cannot
     // erase the implementation attempt that produced the delivered patch.
-    let terminal_form = review_form_for_finalization(successful_run_id)?;
+    let terminal_form = review_form_for_finalization_in_store(lifecycle_store, successful_run_id)?;
     let verified_commands = terminal_form.verify_against_promotion(verification_promotion)?;
-    let lineage = cook_ai_lineage_with_store(
+    let lineage = cook_ai_lineage_with_stores(
         store,
+        lifecycle_store,
         options,
         terminal_promotion,
         successful_run_id,
@@ -2706,7 +2797,8 @@ fn cook_review_dossier_with_store(
     ];
     // Form-only continuations may substitute the implementation promotion for
     // candidate metadata; the persisted terminal record remains recovery proof.
-    if let Some(replacement) = agent_task_lifecycle::status(successful_run_id)
+    if let Some(replacement) = lifecycle_store
+        .read_record(successful_run_id)
         .ok()
         .and_then(|record| {
             record
@@ -2790,8 +2882,11 @@ struct CookAttemptExecution {
     review_form_only: bool,
 }
 
-fn selected_outcome_for_attempt(run_id: &str) -> Result<crate::agent_task::AgentTaskOutcome> {
-    let aggregate = agent_task_lifecycle::read_aggregate(run_id)?;
+fn selected_outcome_for_attempt_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<crate::agent_task::AgentTaskOutcome> {
+    let aggregate = lifecycle_store.read_aggregate(run_id)?;
     aggregate
         .selected_outcome()
         .cloned()
@@ -2815,9 +2910,12 @@ fn selected_outcome_for_attempt(run_id: &str) -> Result<crate::agent_task::Agent
 /// recipe or finalization flags. A pre-provider adopted source has task context
 /// but no executed model; any attempt used as an execution is validated by its
 /// caller before disclosure.
-fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
-    let plan = agent_task_lifecycle::load_plan(run_id)?;
-    let record = agent_task_lifecycle::exact_record(run_id)?;
+fn cook_attempt_execution_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<CookAttemptExecution> {
+    let plan = lifecycle_store.read_controller_plan(run_id)?;
+    let record = lifecycle_store.read_record(run_id)?;
     if let Some(task) = plan.tasks.iter().find(|task| {
         agent_task_lifecycle::candidate_adoption_recovery_outcome(&record, task).is_some()
     }) {
@@ -2843,7 +2941,7 @@ fn cook_attempt_execution(run_id: &str) -> Result<CookAttemptExecution> {
             review_form_only: false,
         });
     }
-    let outcome = selected_outcome_for_attempt(run_id)?;
+    let outcome = selected_outcome_for_attempt_in_store(lifecycle_store, run_id)?;
     let task = plan
         .tasks
         .iter()
@@ -2917,8 +3015,9 @@ fn required_execution_model(execution: &CookAttemptExecution, run_id: &str) -> R
     })
 }
 
-fn cook_ai_lineage_with_store(
+fn cook_ai_lineage_with_stores(
     store: &super::cook_recipe::CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
     promotion: &AgentTaskPromotionReport,
     successful_run_id: &str,
@@ -2942,7 +3041,7 @@ fn cook_ai_lineage_with_store(
     // Preserve the byte-for-byte single-attempt output. Multi-attempt form-only
     // recovery instead makes each authenticated role visible to reviewers.
     if terminal_index == 0 {
-        let execution = cook_attempt_execution(successful_run_id)?;
+        let execution = cook_attempt_execution_in_store(lifecycle_store, successful_run_id)?;
         let model = required_execution_model(&execution, successful_run_id)?;
         return Ok(CookAiLineage {
             summary: terminal_form.summary.clone(),
@@ -2953,7 +3052,7 @@ fn cook_ai_lineage_with_store(
             used_for: terminal_form.used_for.clone(),
         });
     }
-    let terminal = cook_attempt_execution(successful_run_id)?;
+    let terminal = cook_attempt_execution_in_store(lifecycle_store, successful_run_id)?;
     let terminal_model = required_execution_model(&terminal, successful_run_id)?;
     if !terminal.review_form_only {
         return Err(Error::validation_invalid_argument(
@@ -2995,7 +3094,7 @@ fn cook_ai_lineage_with_store(
             None,
         ));
     }
-    let implementation = cook_attempt_execution(&implementation.run_id)?;
+    let implementation = cook_attempt_execution_in_store(lifecycle_store, &implementation.run_id)?;
     let changed = promotion
         .changed_files
         .iter()
@@ -3058,10 +3157,11 @@ fn cook_ai_lineage_with_store(
 /// of the reviewer-facing prose. Its absence/invalidity here is an invariant
 /// violation (the gate would have looped), surfaced as a hard error rather than
 /// silently falling back to machine-templated prose.
-fn review_form_for_finalization(
+fn review_form_for_finalization_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<crate::agent_task_review_dossier::AiFilledReviewForm> {
-    let outcome = selected_outcome_for_attempt(run_id)?;
+    let outcome = selected_outcome_for_attempt_in_store(lifecycle_store, run_id)?;
     let form = crate::agent_task_review_dossier::AiFilledReviewForm::from_outcome_outputs(
         &outcome.outputs,
     )?

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10,15 +10,16 @@ use super::super::cook_adoption::{
 use super::super::cook_baseline::git_output;
 use super::super::cook_promotion::{
     canonical_cook_patch_artifact_id, canonical_cook_recovery_run_id, cook_finalization_options,
-    cook_promotion_argv, cook_report, finalize_cook_pr_with_backend,
-    finalize_or_load_cook_pr_with_backend, moving_base_recovery_for_run,
+    cook_finalization_options_with_stores, cook_promotion_argv, cook_report,
+    finalize_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend,
+    finalize_or_load_cook_pr_with_backend_with_stores, moving_base_recovery_for_run,
     moving_base_recovery_for_run_with_stores, moving_base_recovery_from_promotion,
     moving_base_recovery_report, next_moving_base_recovery, persist_manual_finalization_intent,
     persist_manual_finalization_receipt, persisted_promotion_for_attempt,
-    prepare_manual_finalization_identity, record_replacement_gate_proof,
-    recover_cook_pr_with_backend, recover_moving_base_cook_candidate,
-    refreshed_moving_base_recovery, selected_candidate_task_id, CookReportInput,
-    MovingBaseCookRecovery,
+    persisted_promotion_for_attempt_in_store, prepare_manual_finalization_identity,
+    record_replacement_gate_proof, recover_cook_pr_with_backend,
+    recover_moving_base_cook_candidate, refreshed_moving_base_recovery, selected_candidate_task_id,
+    CookReportInput, MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::persist_initial_recipe;
 use super::*;
@@ -595,46 +596,46 @@ fn durable_cook_inspection_reports_an_unsupported_run_schema() {
 }
 
 fn seed_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
+    let aggregate = review_form_aggregate(plan);
+    agent_task_lifecycle::record_run_aggregate(run_id, plan, &aggregate).unwrap();
+}
+
+fn review_form_aggregate(plan: &AgentTaskPlan) -> crate::agent_task_scheduler::AgentTaskAggregate {
     use crate::agent_task::{AgentTaskOutcome, AgentTaskOutcomeStatus};
     use crate::agent_task_scheduler::{
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     };
     let form = test_review_form();
     let task = plan.tasks.first().expect("review form plan has one task");
-    agent_task_lifecycle::record_run_aggregate(
-        run_id,
-        plan,
-        &AgentTaskAggregate {
-            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
-            plan_id: plan.plan_id.clone(),
-            status: AgentTaskAggregateStatus::Succeeded,
-            totals: AgentTaskAggregateTotals {
-                succeeded: 1,
-                ..Default::default()
-            },
-            outcomes: vec![AgentTaskOutcome {
-                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                task_id: task.task_id.clone(),
-                status: AgentTaskOutcomeStatus::Succeeded,
-                summary: Some("provider dispatched once".to_string()),
-                failure_classification: None,
-                artifacts: Vec::new(),
-                typed_artifacts: Vec::new(),
-                evidence_refs: Vec::new(),
-                diagnostics: Vec::new(),
-                outputs: serde_json::json!({ "review_form": form }),
-                workflow: None,
-                follow_up: None,
-                metadata: serde_json::json!({ "model": task.executor.model() }),
-            }],
-            events: Vec::new(),
-            artifact_lineage: Vec::new(),
-            child_runs: Vec::new(),
-            artifact_bindings: Vec::new(),
-            queue: Default::default(),
+    AgentTaskAggregate {
+        schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: plan.plan_id.clone(),
+        status: AgentTaskAggregateStatus::Succeeded,
+        totals: AgentTaskAggregateTotals {
+            succeeded: 1,
+            ..Default::default()
         },
-    )
-    .unwrap();
+        outcomes: vec![AgentTaskOutcome {
+            schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: task.task_id.clone(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("provider dispatched once".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: serde_json::json!({ "review_form": form }),
+            workflow: None,
+            follow_up: None,
+            metadata: serde_json::json!({ "model": task.executor.model() }),
+        }],
+        events: Vec::new(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: Default::default(),
+    }
 }
 
 fn seed_timeout_review_form_aggregate(run_id: &str, plan: &AgentTaskPlan) {
@@ -1034,6 +1035,7 @@ impl CookSideEffectService for CanonicalSelectionSideEffects {
 
     fn finalize(
         &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
         _options: &AgentTaskCookServiceOptions,
         _run_id: &str,
         _promotion: &AgentTaskPromotionReport,
@@ -5944,7 +5946,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
         let result = run_cook_with_boundaries_observed_inner(
             options.clone(),
             UnusedExecutor,
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             false,
         )
@@ -5952,7 +5954,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
         let repeated = run_cook_with_boundaries_observed_inner(
             options,
             UnusedExecutor,
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             false,
         )
@@ -9793,6 +9795,42 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
             promotion: promotion(run_id),
         })
     }
+    fn hydrate_run_in_store(
+        &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<RunLifecycleRecord> {
+        if self.hydrate_run_id.is_some() {
+            return RealAgentTaskPrFinalizationBackend
+                .hydrate_run_in_store(lifecycle_store, run_id);
+        }
+        self.hydrate_run(run_id)
+    }
+    fn hydrate_gate_proof_in_store(
+        &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<AgentTaskPrDurableGateProof> {
+        if self.hydrate_run_id.is_some() || self.hydrate_gate_proof_run_id.is_some() {
+            return RealAgentTaskPrFinalizationBackend
+                .hydrate_gate_proof_in_store(lifecycle_store, run_id);
+        }
+        if let Some(mut promotion) = self.synthetic_gate_proof.clone() {
+            promotion.source.run_id = Some(run_id.to_string());
+            if let Ok(Some(persisted)) =
+                persisted_promotion_for_attempt_in_store(lifecycle_store, run_id)
+            {
+                if let Some(follow_up) = persisted.provenance.get("cook_follow_up") {
+                    promotion.provenance["cook_follow_up"] = follow_up.clone();
+                }
+            }
+            return Ok(AgentTaskPrDurableGateProof {
+                run_id: run_id.to_string(),
+                promotion,
+            });
+        }
+        self.hydrate_gate_proof(run_id)
+    }
     fn current_branch(&mut self, _path: &str) -> Result<String> {
         Ok("fix/8058".to_string())
     }
@@ -10352,7 +10390,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
@@ -10382,7 +10420,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
@@ -10418,7 +10456,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         let result = run_cook_with_boundaries_observed_policy(
             historical.clone(),
             executor.clone(),
-            DefaultCookSideEffects::new(|_, _, _| Ok(serde_json::json!({}))),
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             true,
         )
@@ -10605,7 +10643,7 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
         let result = run_cook_with_boundaries_observed(
             options,
             UnusedExecutor,
-            DefaultCookSideEffects::new(move |_, received_run, promotion| {
+            DefaultCookSideEffects::new(move |_, _, received_run, promotion| {
                 finalization_count.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(received_run, expected_run_id);
                 assert_eq!(promotion.verified_base.as_ref().unwrap().sha, expected_base);
@@ -10925,6 +10963,55 @@ fn finalization_operation_claim_revalidates_completed_publication() {
 }
 
 #[test]
+fn finalization_claims_isolate_identical_run_ids_across_lifecycle_stores() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-cook-finalize-claim";
+    let run_id = "same-run-finalize-claim";
+    let plan = AgentTaskPlan::new(cook_id, Vec::new());
+    let options = promotion_claim_options(cook_id, run_id);
+    let promotion = promotion(run_id);
+
+    for (store, root) in [(&left_store, "left"), (&right_store, "right")] {
+        store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(serde_json::json!({})))
+            .unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&calls);
+        let mut finalize =
+            move |_: &AgentTaskCookServiceOptions, _: &str, _: &AgentTaskPromotionReport| {
+                counted.fetch_add(1, Ordering::SeqCst);
+                Ok(serde_json::json!({ "root": root }))
+            };
+
+        for _ in 0..2 {
+            let result = finalize_with_operation_claim_in_store(
+                store,
+                &options,
+                run_id,
+                &promotion,
+                &mut finalize,
+            )
+            .unwrap();
+            assert_eq!(result["root"], root);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            store
+                .operation_claim(run_id, &finalization_operation_key(run_id, &promotion))
+                .unwrap()
+                .expect("rooted finalization claim")
+                .state,
+            agent_task_lifecycle::ClaimState::Completed
+        );
+    }
+
+    assert_ne!(left_store.run_dir(run_id), right_store.run_dir(run_id));
+}
+
+#[test]
 fn review_form_follow_up_finalization_replays_its_durable_claim_after_restart() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-review-form-restart";
@@ -10988,16 +11075,22 @@ fn duplicate_controller_passes_revalidate_one_promoted_candidate() {
         // side-effect boundary, exactly as three restarted/concurrent controllers
         // would. The injected finalize effect increments a shared counter.
         let mut finalizations = Vec::new();
+        let lifecycle_store = AgentTaskLifecycleStore::from_current_environment().unwrap();
         for _ in 0..3 {
             let calls = Arc::clone(&finalize_calls);
             let mut side_effects = DefaultCookSideEffects::new(
-                move |_: &AgentTaskCookServiceOptions, rid: &str, _: &AgentTaskPromotionReport| {
+                move |_: &AgentTaskLifecycleStore,
+                      _: &AgentTaskCookServiceOptions,
+                      rid: &str,
+                      _: &AgentTaskPromotionReport| {
                     calls.fetch_add(1, Ordering::SeqCst);
                     Ok(serde_json::json!({"status": "review_ready", "run_id": rid}))
                 },
             );
             let promotion = side_effects.promote(&options, run_id).unwrap();
-            let finalization = side_effects.finalize(&options, run_id, &promotion).unwrap();
+            let finalization = side_effects
+                .finalize(&lifecycle_store, &options, run_id, &promotion)
+                .unwrap();
             finalizations.push(finalization);
         }
 
@@ -11299,6 +11392,122 @@ fn cook_finalization_adopts_validated_review_form_used_for_when_option_is_empty(
             "Operator-authored disclosure."
         );
     });
+}
+
+#[test]
+fn finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_recipe_store = CookRecipeStore::new(left_context.path_roots());
+    let right_recipe_store = CookRecipeStore::new(right_context.path_roots());
+    let left_lifecycle_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_lifecycle_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-cook-finalization-dossier";
+    let run_id = "same-run-finalization-dossier";
+    let target = tempfile::tempdir().expect("fixture target");
+
+    let mut left_options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    left_options.initial_run_id = run_id.to_string();
+    left_options.initial_plan.tasks[0].executor.model = Some("left-model".to_string());
+    let mut right_options = left_options.clone();
+    right_options.initial_plan.tasks[0].executor.model = Some("right-model".to_string());
+
+    for (recipe_store, lifecycle_store, options, artifact_id) in [
+        (
+            &left_recipe_store,
+            &left_lifecycle_store,
+            &left_options,
+            "left-patch",
+        ),
+        (
+            &right_recipe_store,
+            &right_lifecycle_store,
+            &right_options,
+            "right-patch",
+        ),
+    ] {
+        recipe_store.persist_initial_recipe(options).unwrap();
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
+                Ok(serde_json::json!({}))
+            })
+            .unwrap();
+        lifecycle_store
+            .record_cook_attempt(cook_id, 1, run_id)
+            .unwrap();
+        lifecycle_store
+            .record_run_aggregate(
+                run_id,
+                &options.initial_plan,
+                &review_form_aggregate(&options.initial_plan),
+            )
+            .unwrap();
+        let mut rooted_promotion = promotion_with_existing_path(run_id, target.path());
+        rooted_promotion.patch_artifact.id = artifact_id.to_string();
+        lifecycle_store
+            .record_promotion(run_id, serde_json::to_value(rooted_promotion).unwrap())
+            .unwrap();
+    }
+
+    let promotion = promotion_with_existing_path(run_id, target.path());
+    let left = cook_finalization_options_with_stores(
+        &left_recipe_store,
+        &left_lifecycle_store,
+        &left_options,
+        run_id,
+        &promotion,
+        Vec::new(),
+    )
+    .unwrap();
+    let right = cook_finalization_options_with_stores(
+        &right_recipe_store,
+        &right_lifecycle_store,
+        &right_options,
+        run_id,
+        &promotion,
+        Vec::new(),
+    )
+    .unwrap();
+    assert_eq!(left.review_dossier.ai_assistance.model, "left-model");
+    assert_eq!(right.review_dossier.ai_assistance.model, "right-model");
+
+    let mut backend = RealAgentTaskPrFinalizationBackend;
+    let left_proof = backend
+        .hydrate_gate_proof_in_store(&left_lifecycle_store, run_id)
+        .unwrap();
+    let right_proof = backend
+        .hydrate_gate_proof_in_store(&right_lifecycle_store, run_id)
+        .unwrap();
+    assert_eq!(left_proof.promotion.patch_artifact.id, "left-patch");
+    assert_eq!(right_proof.promotion.patch_artifact.id, "right-patch");
+
+    for (recipe_store, lifecycle_store, options) in [
+        (&left_recipe_store, &left_lifecycle_store, &left_options),
+        (&right_recipe_store, &right_lifecycle_store, &right_options),
+    ] {
+        let mut backend = CaptureBackend {
+            synthetic_gate_proof: Some(promotion.clone()),
+            ..Default::default()
+        };
+        let finalization = finalize_or_load_cook_pr_with_backend_with_stores(
+            recipe_store,
+            lifecycle_store,
+            options,
+            run_id,
+            &promotion,
+            &mut backend,
+        )
+        .unwrap();
+
+        assert_eq!(finalization["status"], "review_ready");
+        assert!(backend.created);
+        assert!(lifecycle_store
+            .read_record(run_id)
+            .unwrap()
+            .metadata
+            .get("cook_finalization")
+            .is_some());
+    }
 }
 
 #[test]

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -302,6 +302,14 @@ impl AgentTaskLifecycleStore {
         super::lifecycle_ops::record_promotion_in_store(self, run_id, promotion)
     }
 
+    pub(crate) fn record_cook_finalization(
+        &self,
+        run_id: &str,
+        finalization: Value,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_cook_finalization_in_store(self, run_id, finalization)
+    }
+
     pub(crate) fn record_cook_moving_base_recovery(
         &self,
         run_id: &str,


### PR DESCRIPTION
## Summary
- carry one explicit `AgentTaskLifecycleStore` through Cook finalization claims, dossier construction, acceptance checks, backend hydration, and finalization persistence
- add store-aware finalization backend hydration that fails closed instead of silently falling back to ambient state
- root review-form outcomes, provider/model lineage, source promotion lookup, and replacement gate proof in the exact finalizing attempt
- prove colliding run IDs finalize independently across two lifecycle roots, including full fake publication and durable finalization receipts

Continues #7505 and builds on #12545.

## Why this stabilizes Cook
Finalization is the last mutation boundary: commit, push, and PR publication. Before this change, Cook could claim one attempt while dossier or backend hydration read another ambient record with the same ID. The full publication decision now derives from one store before any Git or GitHub mutation.

## Verification
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents finalization_claims_isolate_identical_run_ids_across_lifecycle_stores --lib`
- `cargo test -p homeboy-agents finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store --lib`
- `cargo test -p homeboy-agents finalization_operation_claim --lib`
- `cargo test -p homeboy-agents cook_finalization --lib`
- `cargo test -p homeboy-agents agent_task_finalization --lib` (62 passed)
- `git diff --check`

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode was used to map finalization boundaries, implement explicit store propagation, add collision coverage, run verification, and review the final diff. Chris Huber remains responsible for every line.