### PR TITLE
fix(agent-task): preserve pending runner authority

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -740,7 +740,7 @@ impl AgentTaskRunRecord {
             })
     }
 
-    fn has_planned_runner_execution(&self) -> bool {
+    pub(crate) fn has_planned_runner_execution(&self) -> bool {
         let execution = self.metadata.get("runner_execution_record");
         execution
             .and_then(|value| value.get("status"))

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -646,7 +646,12 @@ fn classify_liveness(
         let has_live_owner = record.owner_process_is_running();
         let has_live_submission_intent =
             agent_task_lifecycle::has_live_pending_runner_submission_intent(record, now);
-        if !has_live_owner && !has_live_submission_intent {
+        // The materializing proxy write is the state transition into a planned
+        // runner execution. It has no local PID by design, but its fresh
+        // heartbeat proves the controller is still advancing toward submission.
+        let has_fresh_planned_runner_execution =
+            record.has_planned_runner_execution() && record.has_fresh_update();
+        if !has_live_owner && !has_live_submission_intent && !has_fresh_planned_runner_execution {
             return AgentTaskLiveness::Stale;
         }
         return AgentTaskLiveness::Active;

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -511,17 +511,6 @@ mod tests {
             let run_id = "reconcile-tick-planned-runner";
             let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
             agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
-            agent_task_lifecycle::mark_running(run_id).expect("running");
-            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
-                record
-                    .metadata
-                    .as_object_mut()
-                    .expect("metadata object")
-                    .remove("runner_pid");
-            })
-            .expect("controller owner removed");
-            let stale = agent_task_lifecycle::status(run_id).expect("pre-planning status");
-            assert_eq!(stale.metadata["stale_running"], true);
             agent_task_lifecycle::record_lab_offload_phase(
                 run_id,
                 "homeboy-lab",
@@ -533,6 +522,9 @@ mod tests {
             )
             .expect("planned runner submission recorded");
 
+            // The production daemon tick runs before the Lab can return the
+            // accepted job identity. It must observe the materializing proxy's
+            // fresh planned-execution transition, not cancel it as ownerless.
             let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
                 .expect("tick pass");
 
@@ -540,9 +532,46 @@ mod tests {
             let refreshed = agent_task_lifecycle::status(run_id).expect("refreshed");
             assert_eq!(
                 refreshed.state,
-                agent_task_lifecycle::AgentTaskRunState::Running
+                agent_task_lifecycle::AgentTaskRunState::Queued
             );
             assert!(refreshed.metadata.get("stale_running").is_none());
+            assert!(refreshed.metadata.get("cancel_reason").is_none());
+
+            let accepted = agent_task_lifecycle::record_detached_lab_run(
+                agent_task_lifecycle::DetachedLabRunRecord {
+                    run_id,
+                    runner_id: "homeboy-lab",
+                    runner_job_id: "delayed-daemon-job",
+                    remote_workspace: "/runner/workspace/homeboy",
+                    remote_command: &[],
+                },
+            )
+            .expect("delayed daemon identity bound");
+            assert_eq!(accepted.runner_job_id(), Some("delayed-daemon-job"));
+
+            let orphan_run_id = "reconcile-tick-ownerless-runner";
+            orphaned_running_run(orphan_run_id);
+            agent_task_lifecycle::rewrite_record_for_test(orphan_run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+            })
+            .expect("owner identity removed");
+            let stale = agent_task_lifecycle::status(orphan_run_id)
+                .expect("PID-less owner is projected stale before daemon reconciliation");
+            assert_eq!(stale.metadata["stale_running_reason"], "missing_runner_pid");
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("ownerless tick pass");
+            assert_eq!(report["reconciled"], 1, "{report}");
+            let terminal = agent_task_lifecycle::status(orphan_run_id).expect("ownerless run");
+            assert_eq!(
+                terminal.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+            assert_eq!(terminal.metadata["cancel_reason"], "missing_runner_pid");
         });
     }
 


### PR DESCRIPTION
## Summary
- keep a fresh planned runner execution authoritative while queued discovery waits for runner identity binding
- prevent daemon reconciliation from cancelling that valid submission as `missing_runner_pid`
- retain cancellation of genuine PID-less orphans and cover both outcomes through the production status/reconciliation path

Fixes #12535.

## Verification
- `cargo test -p homeboy-agents agent_task_lifecycle` (302 passed)
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests` (8 passed)
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to investigate the persisted lifecycle evidence, implement the bounded reconciliation repair, and run the verification gates. Chris Huber reviewed and remains responsible for the change.