### PR TITLE
Keep targeted component resolution bounded

### DIFF
--- a/crates/homeboy-core/src/component/inventory/listing.rs
+++ b/crates/homeboy-core/src/component/inventory/listing.rs
@@ -113,6 +113,55 @@ pub fn registered_by_id(id: &str) -> Result<Option<Component>> {
     load_standalone_component(id)
 }
 
+/// Resolve one persisted component whose configured checkout is `path` without
+/// materializing unrelated component configurations.
+pub fn registered_by_local_path(path: &Path) -> Result<Option<Component>> {
+    let Ok(path) = std::fs::canonicalize(path) else {
+        return Ok(None);
+    };
+    let projects = project::list().unwrap_or_default();
+    let standalone_snapshot = project::StandaloneComponentConfigSnapshot::load();
+    for project in &projects {
+        for attachment in &project.components {
+            let attachment_path =
+                PathBuf::from(shellexpand::tilde(&attachment.local_path).into_owned());
+            if std::fs::canonicalize(attachment_path).ok().as_ref() != Some(&path) {
+                continue;
+            }
+            if let Ok(component) = project::resolve_project_component_with_standalone_snapshot(
+                project,
+                &attachment.id,
+                Some(&standalone_snapshot),
+            ) {
+                return Ok(Some(component));
+            }
+        }
+    }
+
+    let dir = crate::paths::components()?;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(None);
+    };
+    for entry in entries.flatten() {
+        let registration = entry.path();
+        if registration.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(id) = registration.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let Some(info) = read_standalone_file(id) else {
+            continue;
+        };
+        let registered_path = PathBuf::from(shellexpand::tilde(&info.local_path).into_owned());
+        if std::fs::canonicalize(registered_path).ok().as_ref() == Some(&path) {
+            return load_standalone_component(id);
+        }
+    }
+
+    Ok(None)
+}
+
 /// Load standalone component registrations from `~/.config/homeboy/components/`.
 ///
 /// Each `<id>.json` file in the components directory is a registered component
@@ -394,11 +443,26 @@ pub fn list_ids() -> Result<Vec<String>> {
 }
 
 pub fn load(id: &str) -> Result<Component> {
-    if let Some(component) = inventory()?
-        .into_iter()
-        .find(|component| component.id == id)
-    {
+    if let Some(component) = registered_by_id(id)? {
         return Ok(component);
+    }
+
+    // Portable discovery is a command-local fallback after persisted ownership,
+    // matching inventory precedence without resolving unrelated registrations.
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(component) = discover_from_portable(&cwd) {
+            if component.id == id {
+                return Ok(component);
+            }
+        } else if let Some(git_root) = crate::component::resolution::detect_git_root(&cwd) {
+            if git_root != cwd {
+                if let Some(component) = discover_from_portable(&git_root) {
+                    if component.id == id {
+                        return Ok(component);
+                    }
+                }
+            }
+        }
     }
 
     // Component not in full inventory. Check if a standalone registration
@@ -414,8 +478,39 @@ pub fn load(id: &str) -> Result<Component> {
         ));
     }
 
-    let suggestions = list_ids().unwrap_or_default();
+    let suggestions = registered_id_candidates();
     Err(Error::component_not_found(id.to_string(), suggestions))
+}
+
+fn registered_id_candidates() -> Vec<String> {
+    // Suggestions describe configured candidates without resolving their
+    // repositories. Resolution failures remain the selected command's concern.
+    let mut ids = HashSet::new();
+    for project in project::list().unwrap_or_default() {
+        ids.extend(
+            project
+                .components
+                .into_iter()
+                .map(|attachment| attachment.id),
+        );
+    }
+    if let Ok(entries) = crate::paths::components().and_then(|dir| {
+        std::fs::read_dir(&dir).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", dir.display())))
+        })
+    }) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+                if let Some(id) = path.file_stem().and_then(|stem| stem.to_str()) {
+                    ids.insert(id.to_string());
+                }
+            }
+        }
+    }
+    let mut ids = ids.into_iter().collect::<Vec<_>>();
+    ids.sort();
+    ids
 }
 
 pub fn exists(id: &str) -> bool {

--- a/crates/homeboy-core/src/component/inventory/tests.rs
+++ b/crates/homeboy-core/src/component/inventory/tests.rs
@@ -488,6 +488,92 @@ fn targeted_lookup_rejects_traversal_component_id() {
 }
 
 #[test]
+fn load_resolves_the_selected_registration_without_requiring_global_inventory() {
+    let dir = temp_home_dir();
+    let target_repo = dir.path().join("target-repo");
+    let unrelated_repo = dir.path().join("unrelated-repo");
+    fs::create_dir_all(&target_repo).unwrap();
+    fs::create_dir_all(&unrelated_repo).unwrap();
+    fs::write(
+        target_repo.join("homeboy.json"),
+        serde_json::json!({
+            "id": "target",
+            "remote_url": "https://github.com/example/target.git"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    // Resolving this unrelated attachment would invoke Git remote enrichment.
+    write_portable_id(&unrelated_repo, "different-id");
+    let _home = with_home_override(dir.path());
+    crate::project::save(&Project {
+        id: "site".to_string(),
+        components: vec![
+            ProjectComponentAttachment {
+                id: "target".to_string(),
+                local_path: target_repo.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            ProjectComponentAttachment {
+                id: "unrelated".to_string(),
+                local_path: unrelated_repo.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    })
+    .unwrap();
+    crate::component::portable::take_discovery_paths_for_test();
+
+    let component = load("target").expect("selected component");
+    let missing = load("missing").expect_err("missing component");
+    let discovery_paths = crate::component::portable::take_discovery_paths_for_test();
+
+    assert_eq!(component.id, "target");
+    assert_eq!(component.local_path, target_repo.to_string_lossy());
+    assert_eq!(missing.code, crate::error::ErrorCode::ComponentNotFound);
+    assert!(
+        !discovery_paths.iter().any(|path| path == &unrelated_repo),
+        "targeted load inspected the unrelated component: {discovery_paths:?}"
+    );
+}
+
+#[test]
+fn targeted_path_lookup_does_not_substitute_a_same_id_project_checkout() {
+    let dir = temp_home_dir();
+    let standalone_repo = dir.path().join("standalone-repo");
+    let project_repo = dir.path().join("project-repo");
+    fs::create_dir_all(&standalone_repo).unwrap();
+    fs::create_dir_all(&project_repo).unwrap();
+    write_portable_id(&standalone_repo, "shared");
+    write_portable_id(&project_repo, "shared");
+    let _home = with_home_override(dir.path());
+    let components = crate::paths::components().unwrap();
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        components.join("shared.json"),
+        serde_json::json!({ "local_path": standalone_repo }).to_string(),
+    )
+    .unwrap();
+    crate::project::save(&Project {
+        id: "site".to_string(),
+        components: vec![ProjectComponentAttachment {
+            id: "shared".to_string(),
+            local_path: project_repo.to_string_lossy().to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    })
+    .unwrap();
+
+    let component = registered_by_local_path(&standalone_repo)
+        .unwrap()
+        .expect("standalone path match");
+
+    assert_eq!(component.local_path, standalone_repo.to_string_lossy());
+}
+
+#[test]
 fn load_standalone_skips_missing_local_path() {
     let dir = temp_home_dir();
 

--- a/crates/homeboy-core/src/component/mod.rs
+++ b/crates/homeboy-core/src/component/mod.rs
@@ -47,7 +47,7 @@ pub use config::{
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
-    reconcile_standalone_registration, registered, registered_by_id,
+    reconcile_standalone_registration, registered, registered_by_id, registered_by_local_path,
     write_standalone_component_config, write_standalone_registration, ComponentReconcileReport,
 };
 pub use model::{Component, ComponentLifecycle, ComponentManagedExecution};

--- a/crates/homeboy-core/src/component/portable.rs
+++ b/crates/homeboy-core/src/component/portable.rs
@@ -3,6 +3,16 @@ use crate::error::{Error, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+thread_local! {
+    static DISCOVERY_PATHS: std::cell::RefCell<Vec<PathBuf>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+pub(crate) fn take_discovery_paths_for_test() -> Vec<PathBuf> {
+    DISCOVERY_PATHS.with(|paths| std::mem::take(&mut *paths.borrow_mut()))
+}
+
 /// Read a `homeboy.json` portable config from a repo directory.
 pub(crate) fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
     let config_path = repo_path.join("homeboy.json");
@@ -267,6 +277,8 @@ pub fn discover_from_portable(dir: &Path) -> Option<Component> {
 }
 
 pub fn try_discover_from_portable(dir: &Path) -> Result<Option<Component>> {
+    #[cfg(test)]
+    DISCOVERY_PATHS.with(|paths| paths.borrow_mut().push(dir.to_path_buf()));
     let Some(portable) = read_portable_config(dir)? else {
         return Ok(None);
     };

--- a/crates/homeboy-core/src/source_snapshot.rs
+++ b/crates/homeboy-core/src/source_snapshot.rs
@@ -148,22 +148,18 @@ fn component_extension_sync_excludes(path: &Path) -> Vec<String> {
     let Ok(path) = fs::canonicalize(path) else {
         return Vec::new();
     };
-    let Ok(components) = crate::component::inventory() else {
+    // Resolve only the selected checkout. Project attachment configuration wins
+    // for an exact registered path; portable configuration owns other checkouts.
+    let component = crate::component::registered_by_local_path(&path)
+        .ok()
+        .flatten()
+        .or_else(|| crate::component::discover_from_portable(&path));
+    let Some(component) = component else {
         return Vec::new();
     };
 
     let mut excludes = Vec::new();
-    for component in components {
-        let component_path = PathBuf::from(shellexpand::tilde(&component.local_path).into_owned());
-        let Ok(component_path) = fs::canonicalize(component_path) else {
-            continue;
-        };
-        if component_path != path {
-            continue;
-        }
-        let Some(extensions) = component.extensions.as_ref() else {
-            continue;
-        };
+    if let Some(extensions) = component.extensions.as_ref() {
         let mut extension_ids = extensions.keys().collect::<Vec<_>>();
         extension_ids.sort();
         for extension_id in extension_ids {
@@ -345,6 +341,141 @@ mod tests {
             gitignore_sync_excludes(tempdir.path()),
             vec!["./dist".to_string(), "dist".to_string()]
         );
+    }
+
+    #[test]
+    fn extension_excludes_resolve_from_the_selected_checkout() {
+        crate::test_support::with_isolated_home(|_| {
+            let checkout = tempfile::tempdir().expect("creates checkout");
+            fs::write(
+                checkout.path().join("homeboy.json"),
+                serde_json::json!({
+                    "id": "selected",
+                    "extensions": { "snapshot-fixture": {} }
+                })
+                .to_string(),
+            )
+            .expect("writes portable component");
+            let extension_dir =
+                crate::paths::extension("snapshot-fixture").expect("resolves extension directory");
+            fs::create_dir_all(&extension_dir).expect("creates extension directory");
+            fs::write(
+                extension_dir.join("snapshot-fixture.json"),
+                serde_json::json!({
+                    "name": "Snapshot fixture",
+                    "version": "1.0.0",
+                    "source_snapshot": {
+                        "sync_excludes": ["selected-cache/"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("writes extension manifest");
+
+            let component = crate::component::discover_from_portable(checkout.path())
+                .expect("discovers selected checkout");
+            assert!(component
+                .extensions
+                .as_ref()
+                .is_some_and(|extensions| extensions.contains_key("snapshot-fixture")));
+            let extension = crate::extension_store::load_extension("snapshot-fixture")
+                .expect("loads extension manifest");
+            assert_eq!(
+                extension
+                    .source_snapshot
+                    .as_ref()
+                    .map(|source| source.sync_excludes.as_slice()),
+                Some(["selected-cache/".to_string()].as_slice())
+            );
+
+            assert_eq!(
+                component_extension_sync_excludes(checkout.path()),
+                vec!["selected-cache/".to_string()]
+            );
+        });
+    }
+
+    #[test]
+    fn extension_excludes_preserve_exact_project_attachment_configuration() {
+        crate::test_support::with_isolated_home(|_| {
+            let checkout = tempfile::tempdir().expect("creates checkout");
+            fs::write(
+                checkout.path().join("homeboy.json"),
+                serde_json::json!({
+                    "id": "selected",
+                    "remote_url": "https://github.com/example/selected.git"
+                })
+                .to_string(),
+            )
+            .expect("writes portable component");
+            let extension_dir =
+                crate::paths::extension("snapshot-fixture").expect("resolves extension directory");
+            fs::create_dir_all(&extension_dir).expect("creates extension directory");
+            fs::write(
+                extension_dir.join("snapshot-fixture.json"),
+                serde_json::json!({
+                    "name": "Snapshot fixture",
+                    "version": "1.0.0",
+                    "source_snapshot": {
+                        "sync_excludes": ["project-cache/"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("writes extension manifest");
+            crate::project::save(&crate::project::Project {
+                id: "site".to_string(),
+                components: vec![crate::project::ProjectComponentAttachment {
+                    id: "selected".to_string(),
+                    local_path: checkout.path().to_string_lossy().to_string(),
+                    ..Default::default()
+                }],
+                extensions: Some(std::collections::HashMap::from([(
+                    "snapshot-fixture".to_string(),
+                    crate::component::ScopedExtensionConfig::default(),
+                )])),
+                ..Default::default()
+            })
+            .expect("saves project attachment");
+
+            assert_eq!(
+                component_extension_sync_excludes(checkout.path()),
+                vec!["project-cache/".to_string()]
+            );
+        });
+    }
+
+    #[test]
+    fn unregistered_path_does_not_resolve_unrelated_components() {
+        crate::test_support::with_isolated_home(|home| {
+            let source = home.path().join("source-without-manifest");
+            let unrelated = home.path().join("unrelated");
+            fs::create_dir_all(&source).expect("creates source");
+            fs::create_dir_all(&unrelated).expect("creates unrelated checkout");
+            fs::write(
+                unrelated.join("homeboy.json"),
+                serde_json::json!({ "id": "unrelated" }).to_string(),
+            )
+            .expect("writes unrelated component");
+            crate::project::save(&crate::project::Project {
+                id: "site".to_string(),
+                components: vec![crate::project::ProjectComponentAttachment {
+                    id: "unrelated".to_string(),
+                    local_path: unrelated.to_string_lossy().to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+            .expect("saves unrelated attachment");
+            crate::component::portable::take_discovery_paths_for_test();
+
+            assert!(component_extension_sync_excludes(&source).is_empty());
+            let discovery_paths = crate::component::portable::take_discovery_paths_for_test();
+            assert!(
+                !discovery_paths.iter().any(|path| path == &unrelated),
+                "source lookup inspected the unrelated component: {discovery_paths:?}"
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
Closes #12543

## Summary

- resolve explicit component IDs through targeted project/standalone lookup instead of materializing global inventory
- keep missing-component suggestions bounded to configured IDs while preserving project, standalone, and portable precedence
- resolve source-snapshot extension exclusions from the exact selected checkout, including project-owned configuration, without traversing unrelated repositories
- cover successful, missing, no-manifest, same-ID/different-path, and project-extension cases with thread-local discovery evidence

## Verification

- `cargo test -p homeboy-core component::inventory::tests::` (25 passed)
- `cargo test -p homeboy-core source_snapshot::tests::` (9 passed)
- `cargo test -p homeboy-core --no-run`
- `cargo check -p homeboy-core`
- `cargo fmt --check`
- `git diff --check`

A full `cargo test -p homeboy-core` attempt was not used as green proof: the shared local runner reported unrelated ambient macOS temp-path, daemon-process, and worktree fixture failures. The affected suites and complete core test compilation pass after the final test-isolation change.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode sampled the blocked Cook process, traced the global inventory path, implemented the targeted resolution repair, and developed/reviewed the regression coverage. Chris Huber reviewed and remains responsible for every line.