### PR TITLE
refactor(agent-task): root Cook mutation validation stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -260,7 +260,10 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     }
 
     if !options.manual_finalization {
-        backend.validate_candidate(&options)?;
+        match lifecycle_store {
+            Some(store) => backend.validate_candidate_in_store(store, &options)?,
+            None => backend.validate_candidate(&options)?,
+        }
     }
     // Validate intent before commit mutation, then bind evidence to immutable HEAD before push.
     let prospective_identity = if commit_required {

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -75,6 +75,18 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         )
     }
 
+    fn validate_candidate_in_store(
+        &mut self,
+        lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        options: &AgentTaskPrFinalizationOptions,
+    ) -> Result<()> {
+        validate_real_candidate_fingerprint_in_store(lifecycle_store, options)?;
+        homeboy_core::repository_integrity::verify_tracked_symlink_portability(
+            std::path::Path::new(&options.path),
+            "HEAD",
+        )
+    }
+
     fn current_branch(&mut self, path: &str) -> Result<String> {
         let output = std::process::Command::new("git")
             .args(["rev-parse", "--abbrev-ref", "HEAD"])
@@ -659,6 +671,21 @@ pub(super) fn validate_real_candidate_fingerprint(
     options: &AgentTaskPrFinalizationOptions,
 ) -> Result<()> {
     let record = crate::agent_task_lifecycle::status(&options.run_id)?;
+    validate_real_candidate_fingerprint_from_record(options, &record)
+}
+
+pub(super) fn validate_real_candidate_fingerprint_in_store(
+    lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+    options: &AgentTaskPrFinalizationOptions,
+) -> Result<()> {
+    let record = lifecycle_store.read_record(&options.run_id)?;
+    validate_real_candidate_fingerprint_from_record(options, &record)
+}
+
+fn validate_real_candidate_fingerprint_from_record(
+    options: &AgentTaskPrFinalizationOptions,
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+) -> Result<()> {
     let promotion: AgentTaskPromotionReport = deserialize_persisted_value(
         record.metadata.get("latest_promotion").cloned(),
         "normal finalization requires persisted latest_promotion",

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -51,6 +51,31 @@ struct MockBackend {
     last_body: String,
     publication_binding: Option<AgentTaskPublicationBinding>,
     publication_binding_calls: u8,
+    candidate_validation_calls: u8,
+    rooted_candidate_validation_calls: u8,
+}
+
+impl MockBackend {
+    fn validate_candidate_value(&self, options: &AgentTaskPrFinalizationOptions) -> Result<()> {
+        let Some(expected) = self.candidate.as_ref() else {
+            return Ok(());
+        };
+        let actual = crate::agent_task_promotion::candidate_fingerprint(&options.path)?;
+        if actual != *expected {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                "candidate changed after promotion; rerun promotion gates before finalization",
+                None,
+                None,
+            ));
+        }
+        let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint: _ } =
+            actual
+        else {
+            unreachable!("test candidate is Git")
+        };
+        Ok(())
+    }
 }
 
 impl AgentTaskPrFinalizationBackend for MockBackend {
@@ -97,24 +122,16 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
         self.hydrate_gate_proof(run_id)
     }
     fn validate_candidate(&mut self, options: &AgentTaskPrFinalizationOptions) -> Result<()> {
-        let Some(expected) = self.candidate.as_ref() else {
-            return Ok(());
-        };
-        let actual = crate::agent_task_promotion::candidate_fingerprint(&options.path)?;
-        if actual != *expected {
-            return Err(Error::validation_invalid_argument(
-                "path",
-                "candidate changed after promotion; rerun promotion gates before finalization",
-                None,
-                None,
-            ));
-        }
-        let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint: _ } =
-            actual
-        else {
-            unreachable!("test candidate is Git")
-        };
-        Ok(())
+        self.candidate_validation_calls += 1;
+        self.validate_candidate_value(options)
+    }
+    fn validate_candidate_in_store(
+        &mut self,
+        _lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        options: &AgentTaskPrFinalizationOptions,
+    ) -> Result<()> {
+        self.rooted_candidate_validation_calls += 1;
+        self.validate_candidate_value(options)
     }
     fn current_branch(&mut self, _path: &str) -> Result<String> {
         Ok(if self.branch.is_empty() {
@@ -1062,6 +1079,39 @@ fn requires_a_real_durable_run_unless_manual_mode_is_selected() {
 }
 
 #[test]
+fn rooted_finalization_dispatches_candidate_validation_through_the_explicit_store() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-3678";
+    lifecycle_store
+        .submit_plan_with_runtime_admission(
+            &AgentTaskPlan::new("rooted-finalization", Vec::new()),
+            run_id,
+            |_| Ok(json!({})),
+        )
+        .unwrap();
+
+    let mut gate_proof = successful_gate_proof();
+    gate_proof.promotion.changed_files = vec!["src/lib.rs".to_string()];
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(successful_lifecycle("openai/gpt-5.6-terra")),
+        gate_proof: Some(gate_proof),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+    finalization_options.changed_files = vec!["src/lib.rs".to_string()];
+
+    finalize_pr_with_backend_in_store(finalization_options, &mut backend, &lifecycle_store)
+        .expect("rooted finalization");
+
+    assert_eq!(backend.rooted_candidate_validation_calls, 1);
+    assert_eq!(backend.candidate_validation_calls, 0);
+}
+
+#[test]
 fn manual_finalization_cannot_bypass_acceptance_for_an_existing_run_id() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "manual-acceptance-bypass";
@@ -1917,7 +1967,7 @@ fn production_validator_normalizes_changed_file_order_and_duplicates() {
         promotion.source.run_id = Some(run_id.to_string());
         promotion.target.path = Some(repo.path().display().to_string());
         promotion.changed_files = vec!["a".to_string(), "b".to_string()];
-        promotion.provenance = json!({ "candidate": candidate });
+        promotion.provenance = json!({ "candidate": candidate.clone() });
         crate::agent_task_lifecycle::record_promotion(
             run_id,
             serde_json::to_value(promotion).unwrap(),
@@ -1932,6 +1982,51 @@ fn production_validator_normalizes_changed_file_order_and_duplicates() {
         options.changed_files = vec!["a".to_string()];
         assert!(validate_real_candidate_fingerprint(&options).is_err());
     });
+}
+
+#[test]
+fn production_validator_uses_explicit_store_for_colliding_run_ids() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(right_context.path_roots());
+    let repo = real_git_repo();
+    std::fs::write(repo.path().join("a"), "a").unwrap();
+    let candidate =
+        crate::agent_task_promotion::candidate_fingerprint(repo.path().to_str().unwrap()).unwrap();
+    let run_id = "same-production-validator-run";
+    let plan = crate::agent_task_scheduler::AgentTaskPlan::new("validator", Vec::new());
+
+    for (store, changed_files) in [
+        (&left_store, vec!["a".to_string()]),
+        (&right_store, vec!["wrong".to_string()]),
+    ] {
+        store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+            .unwrap();
+        let mut promotion = successful_gate_proof().promotion;
+        promotion.source.run_id = Some(run_id.to_string());
+        promotion.target.path = Some(repo.path().display().to_string());
+        promotion.changed_files = changed_files;
+        promotion.provenance = json!({ "candidate": candidate });
+        store
+            .record_promotion(run_id, serde_json::to_value(promotion).unwrap())
+            .unwrap();
+    }
+
+    let mut options = real_git_finalization_options(repo.path(), vec!["a".to_string()]);
+    options.run_id = run_id.to_string();
+    let mut backend = RealAgentTaskPrFinalizationBackend;
+    backend
+        .validate_candidate_in_store(&left_store, &options)
+        .expect("left candidate validation");
+    let error = backend
+        .validate_candidate_in_store(&right_store, &options)
+        .expect_err("right promotion must not alias left");
+
+    assert!(error.message.contains("persisted promotion report"));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -336,6 +336,18 @@ pub trait AgentTaskPrFinalizationBackend {
     fn validate_candidate(&mut self, _options: &AgentTaskPrFinalizationOptions) -> Result<()> {
         Ok(())
     }
+    fn validate_candidate_in_store(
+        &mut self,
+        _lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+        _options: &AgentTaskPrFinalizationOptions,
+    ) -> Result<()> {
+        Err(Error::validation_invalid_argument(
+            "finalization_backend",
+            "backend does not support explicit lifecycle-store candidate validation",
+            None,
+            None,
+        ))
+    }
     fn current_branch(&mut self, path: &str) -> Result<String>;
     fn changed_files(&mut self, path: &str) -> Result<Vec<String>>;
     fn resolve_base(&mut self, _path: &str, base: &str) -> Result<AgentTaskPrResolvedBase> {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -44,8 +44,6 @@ use super::cook_pre_execution::{
     record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
     with_pre_execution_phase,
 };
-#[cfg(test)]
-use super::cook_promotion::promote_or_load_attempt;
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
     finalize_or_load_cook_pr_with_stores, is_moving_base_finalization_error,
@@ -734,6 +732,7 @@ pub(crate) trait CookSideEffectService {
     /// promotion when this attempt was interrupted after promoting.
     fn promote(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport>;
@@ -790,10 +789,11 @@ where
 {
     fn promote(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport> {
-        promote_with_operation_claim(options, run_id)
+        promote_with_operation_claim_in_store(lifecycle_store, options, run_id)
     }
 
     fn recover_moving_base(
@@ -860,10 +860,11 @@ where
 {
     fn promote(
         &mut self,
+        lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport> {
-        promote_or_load_attempt(options, run_id)
+        promote_or_load_attempt_in_store(lifecycle_store, options, run_id)
     }
 
     fn recover_moving_base(
@@ -3648,9 +3649,16 @@ where
     E: AgentTaskExecutorAdapter + Clone,
 {
     let store = CookRecipeStore::from_current_data_root()?;
-    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
-        finalize_or_load_cook_pr(options, run_id, promotion)
-    });
+    let side_effects =
+        DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
+            finalize_or_load_cook_pr_with_stores(
+                &store,
+                lifecycle_store,
+                options,
+                run_id,
+                promotion,
+            )
+        });
     run_cook_with_boundaries_observed_policy_with_store(
         &store,
         options,
@@ -3672,10 +3680,24 @@ pub fn run_cook_with_durable_observer<E>(
 where
     E: AgentTaskExecutorAdapter + Clone,
 {
-    let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
-        finalize_or_load_cook_pr(options, run_id, promotion)
-    });
-    run_cook_with_boundaries_observed(options, executor, side_effects, Some(observer))
+    let store = CookRecipeStore::from_current_data_root()?;
+    let side_effects =
+        DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
+            finalize_or_load_cook_pr_with_stores(
+                &store,
+                lifecycle_store,
+                options,
+                run_id,
+                promotion,
+            )
+        });
+    run_cook_with_boundaries_observed_with_store(
+        &store,
+        options,
+        executor,
+        side_effects,
+        Some(observer),
+    )
 }
 
 pub(crate) fn run_cook_with_finalizer<E, F>(
@@ -5260,7 +5282,7 @@ where
             attempt,
             None,
         )?;
-        let mut promotion = match side_effects.promote(&options, &run_id) {
+        let mut promotion = match side_effects.promote(&lifecycle_store, &options, &run_id) {
             Ok(report) => report,
             Err(error) => {
                 attempts.push(AgentTaskCookAttemptReport {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1015,6 +1015,7 @@ struct CanonicalSelectionSideEffects {
 impl CookSideEffectService for CanonicalSelectionSideEffects {
     fn promote(
         &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
         options: &AgentTaskCookServiceOptions,
         run_id: &str,
     ) -> Result<AgentTaskPromotionReport> {
@@ -9831,6 +9832,13 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
         }
         self.hydrate_gate_proof(run_id)
     }
+    fn validate_candidate_in_store(
+        &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
+        options: &crate::agent_task_finalization::AgentTaskPrFinalizationOptions,
+    ) -> Result<()> {
+        self.validate_candidate(options)
+    }
     fn current_branch(&mut self, _path: &str) -> Result<String> {
         Ok("fix/8058".to_string())
     }
@@ -10822,7 +10830,7 @@ fn promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores() {
     let options = promotion_claim_options(cook_id, run_id);
     let operation_key = promotion_operation_key(run_id);
 
-    for store in [&left_store, &right_store] {
+    for (store, artifact_id) in [(&left_store, "left-patch"), (&right_store, "right-patch")] {
         store
             .submit_plan_with_runtime_admission(
                 &AgentTaskPlan::new(cook_id, Vec::new()),
@@ -10830,12 +10838,18 @@ fn promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores() {
                 |_| Ok(serde_json::json!({})),
             )
             .unwrap();
+        let mut rooted_promotion = promotion(run_id);
+        rooted_promotion.patch_artifact.id = artifact_id.to_string();
         store
-            .record_promotion(run_id, serde_json::to_value(promotion(run_id)).unwrap())
+            .record_promotion(run_id, serde_json::to_value(rooted_promotion).unwrap())
             .unwrap();
 
-        let first = promote_with_operation_claim_in_store(store, &options, run_id).unwrap();
-        let replayed = promote_with_operation_claim_in_store(store, &options, run_id).unwrap();
+        let mut side_effects = DefaultCookSideEffects::new(|_, _, _, _| {
+            unreachable!("promotion isolation does not finalize")
+        });
+        let first = side_effects.promote(store, &options, run_id).unwrap();
+        let replayed = side_effects.promote(store, &options, run_id).unwrap();
+        assert_eq!(first.patch_artifact.id, artifact_id);
         assert_eq!(replayed.patch_artifact.id, first.patch_artifact.id);
         assert_eq!(
             store
@@ -11087,7 +11101,9 @@ fn duplicate_controller_passes_revalidate_one_promoted_candidate() {
                     Ok(serde_json::json!({"status": "review_ready", "run_id": rid}))
                 },
             );
-            let promotion = side_effects.promote(&options, run_id).unwrap();
+            let promotion = side_effects
+                .promote(&lifecycle_store, &options, run_id)
+                .unwrap();
             let finalization = side_effects
                 .finalize(&lifecycle_store, &options, run_id, &promotion)
                 .unwrap();


### PR DESCRIPTION
## Summary
- route normal finalization candidate validation through the explicit lifecycle store and fail closed for unsupported backends
- propagate the loop-owned lifecycle store through default Cook promotion and production finalization closures
- prove same-ID lifecycle roots retain distinct promotion and candidate-validation state

Progresses #7505.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents agent_task_finalization --lib` (64 passed)
- `cargo test -p homeboy-agents promotion_operation_claim --lib`
- `cargo test -p homeboy-agents promotion_claim_and_replay_isolate_identical_ids_across_lifecycle_stores --lib`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to trace store ownership, implement the mutation-boundary changes, add collision and dispatch coverage, and run verification. Chris Huber reviewed and remains responsible for every line.