### PR TITLE
Migrate Cook onto paired stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -39,7 +39,7 @@ use super::cook_budget::{
     validate_effective_cook_budget, ExecutionBudgetUsage,
 };
 use super::cook_pre_execution::{
-    materialize_cook_attempt_with_store, materialize_initial_cook_attempt_with_store,
+    materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores,
     pre_execution_failure_details, pre_execution_failure_phase, pre_execution_failure_report,
     record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
     with_pre_execution_phase,
@@ -4187,7 +4187,7 @@ where
     // Recipe persistence and lifecycle materialization are a recoverable saga.
     // Complete it before any capacity, workspace, or provider-facing work so a
     // controller interruption leaves a status-addressable, resumable attempt.
-    materialize_initial_cook_attempt_with_store(store, &options)?;
+    materialize_initial_cook_attempt_with_stores(store, &lifecycle_store, &options)?;
     // A persisted recipe can replace the just-validated inputs. Re-check its
     // workspace and candidate topology before it reaches transport preparation
     // or a resumed attempt.
@@ -4429,8 +4429,9 @@ where
         ));
     }
     if let Some(latest_attempt) = recipe.attempts.last() {
-        materialize_cook_attempt_with_store(
+        materialize_cook_attempt_with_stores(
             store,
+            &lifecycle_store,
             &recipe.cook_id,
             &latest_attempt.run_id,
             &latest_attempt.plan,
@@ -4989,7 +4990,13 @@ where
                 }
                 let next_run_id = format!("{run_id}-transport-retry");
                 store.record_recipe_attempt_replacement(&cook_id, &run_id, &next_run_id)?;
-                materialize_cook_attempt_with_store(store, &cook_id, &next_run_id, &plan)?;
+                materialize_cook_attempt_with_stores(
+                    store,
+                    &lifecycle_store,
+                    &cook_id,
+                    &next_run_id,
+                    &plan,
+                )?;
                 run_id = next_run_id;
                 next_plan = Some(plan);
                 continue;

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -240,14 +240,6 @@ pub(crate) fn materialize_initial_cook_attempt(
     materialize_initial_cook_attempt_with_stores(&recipe_store, &lifecycle_store, options)
 }
 
-pub(crate) fn materialize_initial_cook_attempt_with_store(
-    store: &CookRecipeStore,
-    options: &AgentTaskCookServiceOptions,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    materialize_initial_cook_attempt_with_stores(store, &lifecycle_store, options)
-}
-
 /// Persist the controller-owned initial attempt through explicit recipe and
 /// lifecycle stores so the run record and Cook index always land beside the
 /// recipe's authority instead of the ambient environment.
@@ -290,16 +282,6 @@ pub(crate) fn materialize_cook_attempt(
     let recipe_store = CookRecipeStore::from_current_data_root()?;
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     materialize_cook_attempt_with_stores(&recipe_store, &lifecycle_store, cook_id, run_id, plan)
-}
-
-pub(crate) fn materialize_cook_attempt_with_store(
-    store: &CookRecipeStore,
-    cook_id: &str,
-    run_id: &str,
-    plan: &AgentTaskPlan,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    materialize_cook_attempt_with_stores(store, &lifecycle_store, cook_id, run_id, plan)
 }
 
 /// Complete recipe, run-record, and index registration through explicit recipe


### PR DESCRIPTION
## Summary

Next bounded slice of the #7505 owning-layer migration, after #12563.

#12563 added the paired entry points but deliberately moved no callers, so the split-root hazard it describes was still live on main. This slice makes it load-bearing and deletes the footgun.

## The fix

Cook called the single-store entry points in three places. Each takes an explicit `CookRecipeStore` and resolves `AgentTaskLifecycleStore` from the process environment internally — recipe to the injected root, lifecycle record and Cook index to the ambient one.

The part that makes this a clean fix: **every one of those three call sites already had the correct `lifecycle_store` bound in scope.**

| site | proof it was already there |
|---|---|
| `cook.rs:4190` | `cook_attempt_needs_execution_with_store(&lifecycle_store, …)` a few lines below |
| `cook.rs:4432` | `lifecycle_store.read_record(&options.initial_run_id)` immediately after |
| `cook.rs:4992` | `lifecycle_store.record_cook_attempt(…)` a few lines below |

They were discarding it, not missing it.

## What changed

- All three call sites now use `materialize_initial_cook_attempt_with_stores` / `materialize_cook_attempt_with_stores`, passing the in-scope `lifecycle_store`.
- `materialize_initial_cook_attempt_with_store` and `materialize_cook_attempt_with_store` have no remaining callers in the crate and are **deleted**. Both were `pub(crate)`; not a public API break.

Deleting rather than deprecating is deliberate. A function that takes one explicit store and silently resolves the other is a footgun whose entire signature invites the bug — leaving it callable means the next caller inherits the split for free.

**Kept unchanged:** the env-resolving `materialize_initial_cook_attempt` / `materialize_cook_attempt` (legitimate compatibility surface), and `recover_recipe_attempt` / `recover_adoption_attempt`, whose callers in `cook_recipe.rs` and `cook_adoption.rs` have no stores in scope yet.

## No test in this slice — and why

Deliberate, and it's the most useful thing this cook produced.

The reachable Cook spine still binds its lifecycle store from the environment at **`cook.rs:4059`**:

```rust
let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
```

No `run_cook` entry point accepts an injected lifecycle store. So the migrated call sites cannot be driven from two distinct `HermeticTestContext` roots without reintroducing ambient state — a test here would have to call `with_isolated_home` to exist, which is precisely what this campaign is retiring.

Rooting that spine is the next slice. The helper-level guarantee is already proven by `paired_stores_isolate_identical_ids_across_split_recipe_and_lifecycle_roots` from #12563.

## Compatibility

Same-behavior migration plus a dead-code deletion. The only intended behavioral difference is the bug fix itself: the lifecycle half of an attempt now lands in the injected root instead of the ambient one. `home_lock` / `HomeGuard` / `with_isolated_home` untouched.

## Testing

- `cargo fmt --check` — pass
- `cargo check -p homeboy-agents --tests -j2` — pass

Full suite deferred to CI per the repo's disk-budget policy.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** `homeboy agent-task cook` with the `opencode` backend
- **Used for:** Investigation, code edits, gate execution, and PR drafting.

Note: the cook reached `lifecycle_state: Succeeded` with the candidate promoted, then finalization rejected the review form on `verification[0].command` — "no successful visible durable gate for this command". The provider reported the commands it actually ran (`cargo fmt -- --check`, `cargo check -p homeboy-agents -j2`) rather than the exact declared gate strings (`cargo fmt --check`, `nice -n 10 cargo check -p homeboy-agents --tests -j2`). `finalize-pr --recover` replays the same stored form and fails identically. Details on #12561.

Refs #7505
