### PR TITLE
Root the Cook progress recorder

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2089,8 +2089,27 @@ pub fn record_cook_progress_with_activity(
     detail: Option<&str>,
     activity: Option<Value>,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_progress_with_activity_in_store(
+        &lifecycle_store,
+        run_id,
+        phase,
+        attempt,
+        detail,
+        activity,
+    )
+}
+
+pub fn record_cook_progress_with_activity_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+    activity: Option<Value>,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let now = now_timestamp();
         {
             let metadata = record.ensure_metadata_object();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -198,6 +198,28 @@ fn cook_progress_carries_provider_activity_and_survives_a_failed_probe() {
 }
 
 #[test]
+fn cook_progress_recorder_writes_to_the_injected_store_not_an_ambient_root() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-progress-rooted";
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), run_id, |_| Ok(json!({})))
+        .expect("submit run into injected store");
+    record_cook_progress_with_activity_in_store(
+        &lifecycle_store,
+        run_id,
+        "provider_start",
+        1,
+        Some("rooted progress"),
+        None,
+    )
+    .expect("record progress into injected store");
+    let record = lifecycle_store.read_record(run_id).expect("read run");
+    assert_eq!(record.metadata["cook_progress"]["phase"], "provider_start");
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5745,7 +5745,6 @@ where
                 .0;
                 let review_form_only =
                     follow_up_request.inputs["cook_loop"]["review_form_required"] == true;
-                let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
                 match dispatch_cook_follow_up(
                     (store, &lifecycle_store),
                     &options,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -447,6 +447,21 @@ impl AgentTaskLifecycleStore {
         super::lifecycle_ops::record_cook_attempt_in_store(self, cook_id, attempt, run_id)
     }
 
+    /// Persist Cook phase and an optional provider activity sample using this
+    /// store's durable lifecycle roots.
+    pub fn record_cook_progress_with_activity(
+        &self,
+        run_id: &str,
+        phase: &str,
+        attempt: u32,
+        detail: Option<&str>,
+        activity: Option<Value>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_cook_progress_with_activity_in_store(
+            self, run_id, phase, attempt, detail, activity,
+        )
+    }
+
     pub fn read_record_bounded(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_bounded_in_store(self, run_id)
     }


### PR DESCRIPTION
## Summary

Next bounded slice of the #7505 owning-layer migration, after #12565.

This slice exists because of a negative result. An attempt to convert the Cook spine's lifecycle store binding at `cook.rs:4059` into a parameter **stopped and reported two blockers** rather than forcing the refactor. Both were verified against the tree, and removing them is this slice.

## The two blockers

**1 — a shadowing second store.** The `RetryRequested` arm inside the very function being parameterized resolved its own store at `cook.rs:5748`:

```rust
let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
match dispatch_cook_follow_up((store, &lifecycle_store), ...)
```

A parameter at 4059 would have been **silently shadowed on every retry path** — injected root honored on the happy path, abandoned on retry. That is worse than today's uniform ambient behavior, because it is inconsistent.

**2 — the progress path reaches process-global state.**

```
cook.rs:4332  report_cook_progress
   └─ cook.rs:442  report_cook_progress_with_activity
        └─ agent_task_lifecycle::record_cook_progress_with_activity   (free fn)
             └─ store::mutate_record → default_store()   ambient, hard-fails on `?`
```

A split-root test could not run even with both stores injected. This is the real reason #12565 shipped without one.

## What changed

- `record_cook_progress_with_activity_in_store` mutates through the store it is handed. The existing free function becomes a thin env-resolving wrapper — signature and behavior unchanged — and the operation is exposed as `AgentTaskLifecycleStore::record_cook_progress_with_activity`.
- The `RetryRequested` arm now uses the spine's own `lifecycle_store` binding. Behavior-neutral today since both resolve to the same ambient root; it is the precondition that makes the next slice's parameter honest instead of silently ignored.

## What was deliberately left out

Threading the store through the private `report_cook_progress` wrappers. All ten call sites were enumerated and mapped to their enclosing function's bindings:

| call sites | lifecycle store in scope |
|---|---|
| 9 (inside the spine) | ✅ |
| `cook.rs:3931` in `run_cook_with_boundaries_reported` | ❌ |

Giving that one a store requires threading a parameter through the `~3623-3961` boundary chain, which belongs to a later slice. The wrapper signatures are left unchanged rather than forcing an unrelated signature change to make one call site fit.

## Compatibility

Additive plus one private-to-module simplification. No public API signature changes. No observable behavior change — the shadow-store removal is a no-op until the spine takes a parameter.

`home_lock` / `HomeGuard` / `with_isolated_home` untouched.

## Test

`cook_progress_recorder_writes_to_the_injected_store_not_an_ambient_root` builds a lifecycle store from `HermeticTestContext::path_roots()` and asserts the recorder writes to the store it was handed, not to an ambient root. No environment mutation — no `with_isolated_home`, no `HomeGuard`, no `set_var`.

## Testing

- `cargo fmt --check` — pass
- `cargo check -p homeboy-agents --tests -j2` — pass

Full suite deferred to CI per the repo's disk-budget policy.

## Next slice

With both blockers gone, flipping `cook.rs:4059` to a parameter becomes mechanical, and the end-to-end split-root test that #12565 could not write becomes possible.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** `homeboy agent-task cook` with the `opencode` backend
- **Used for:** Investigation, code edits, test authoring, gate execution, and PR drafting.

Note: the cook promoted the candidate and passed review-form validation, then finalization failed on `Invalid argument 'provider_model': Cook lineage attempt has no concrete executed model`. `finalize-pr --recover --ai-tool ... --ai-model ...` fails identically — the flag does not reach the durable lineage record. Fourth consecutive cook wedged after promotion, fifth distinct failure mode. Details on #12561.

Refs #7505
