### PR TITLE
Name the cause when a local Cook runs in-tree

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -127,6 +127,27 @@ pub(crate) fn cook_rotation_disclosure(plan: &AgentTaskPlan) -> String {
     }
 }
 
+/// Operator-facing statement that an attached local Cook shares its client's
+/// lifetime.
+///
+/// `--detach-after-handoff` already documents the safe shape — with local
+/// placement the Cook is re-executed in its own session, so it survives a client
+/// that is interrupted or times out — but nothing said the default was the other
+/// one. An attached local Cook runs its whole provider stack inside the calling
+/// client's process tree, so a client that goes away takes the provider with it
+/// and leaves the durable run reporting `queued` with zero attempts and nothing
+/// executing it (#12570). This is diagnostics only: the default is unchanged and
+/// is still frequently the right one, so state the consequence rather than
+/// choosing differently.
+pub(crate) fn cook_attached_local_placement_disclosure(
+    provider_placement: Option<&str>,
+    detach_after_handoff: bool,
+) -> Option<String> {
+    (provider_placement == Some("local") && !detach_after_handoff).then(|| {
+        "cook: attached local placement — the provider runs in this client's process tree and will not survive it; pass --detach-after-handoff to re-execute the Cook in its own session".to_string()
+    })
+}
+
 fn cook_resolved_policy_disclosure(max_attempts: u32, plan: &AgentTaskPlan) -> String {
     let budget = &plan.options.execution_budget;
     format!(
@@ -3879,7 +3900,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        cook_continuation_status, cook_provider_timeout_disclosure, cook_report_with_continuation,
+        cook_attached_local_placement_disclosure, cook_continuation_status,
+        cook_provider_timeout_disclosure, cook_report_with_continuation,
         cook_resolved_policy_disclosure, durable_cook_identity_lines, preflight_continue_cook,
     };
     use crate::commands::agent_task::args::CookContinueArgs;
@@ -3941,6 +3963,31 @@ mod tests {
             cook_provider_timeout_disclosure(&plan),
             "cook: provider timeout: 2700s per provider execution (override with --timeout-ms)"
         );
+    }
+
+    /// The unsafe shape is the default one, so the submission preamble is the
+    /// only place an operator learns that this Cook dies with its client.
+    #[test]
+    fn attached_local_placement_is_disclosed_at_submission() {
+        assert_eq!(
+            cook_attached_local_placement_disclosure(Some("local"), false).as_deref(),
+            Some("cook: attached local placement — the provider runs in this client's process tree and will not survive it; pass --detach-after-handoff to re-execute the Cook in its own session")
+        );
+    }
+
+    /// A detached local Cook already survives its client, and a Lab-placed
+    /// provider never ran inside it. Warning there would be noise.
+    #[test]
+    fn a_detached_or_lab_placed_cook_is_not_warned_about_its_client() {
+        assert_eq!(
+            cook_attached_local_placement_disclosure(Some("local"), true),
+            None
+        );
+        assert_eq!(
+            cook_attached_local_placement_disclosure(Some("lab"), false),
+            None
+        );
+        assert_eq!(cook_attached_local_placement_disclosure(None, false), None);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -100,6 +100,46 @@ fn consume_local_cook_launch_token_at(token: &std::ffi::OsStr, path: &Path) -> b
     valid
 }
 
+/// Say so when this Cook's provider is about to run inside the caller's own
+/// process tree.
+///
+/// Diagnostics only, and emitted here because this is the one point where the
+/// resolved provider placement and the caller's detachment request are both
+/// known. It is stated before the paths below can fall back to foreground
+/// execution, so an operator hears it whether or not supervision is available. A
+/// runner-owned execution is excluded: the runner, not this client, owns that
+/// attempt.
+fn announce_attached_local_cook_placement(
+    cli: &Cli,
+    runner_side: bool,
+    provider_placement: Option<&str>,
+) {
+    if runner_side || attached_local_cook_progress_is_suppressed(cli) {
+        return;
+    }
+    let disclosure = crate::commands::agent_task::run::cook_attached_local_placement_disclosure(
+        provider_placement,
+        cli.detach_after_handoff,
+    );
+    if let Some(warning) = disclosure {
+        eprintln!("{warning}");
+    }
+}
+
+/// Whether this Cook asked for a quiet submission.
+///
+/// `--no-progress` suppresses Cook's submission preamble lines, and the attached
+/// local placement warning is one of them.
+fn attached_local_cook_progress_is_suppressed(cli: &Cli) -> bool {
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+    }) = &cli.command
+    else {
+        return false;
+    };
+    cook.no_progress
+}
+
 /// Durable local supervision needs both a separate child session and an exact
 /// process identity for safe cancellation. Platforms without both retain the
 /// normal foreground Cook path rather than making an ownership promise they
@@ -135,6 +175,9 @@ pub(super) fn intercept_local_detached_cook(
     {
         return Ok(None);
     }
+    // Diagnostics only: an attached local Cook shares this client's lifetime and
+    // nothing said so (#12570). Placement itself is unchanged.
+    announce_attached_local_cook_placement(cli, runner_side, provider_placement);
     if !local_cook_supervision_supported() {
         return if cli.detach_after_handoff {
             Err(Error::validation_invalid_argument(
@@ -971,6 +1014,31 @@ mod tests {
             let (cli, _) = cook_cli(&["--placement", placement, "--detach-after-handoff"]);
             assert!(is_unsupervised_local_cook(&cli), "{placement}");
         }
+    }
+
+    /// The attached local placement warning is a submission preamble line, so it
+    /// obeys the same `--no-progress` suppression as the rest of them.
+    #[test]
+    fn no_progress_suppresses_the_attached_local_placement_warning() {
+        let (loud, _) = cook_cli(&["--placement", "local"]);
+        assert!(!attached_local_cook_progress_is_suppressed(&loud));
+
+        let quiet = Cli::try_parse_from([
+            "homeboy",
+            "--placement",
+            "local",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "true",
+            "--no-progress",
+        ])
+        .expect("parse quiet cook invocation");
+        assert!(attached_local_cook_progress_is_suppressed(&quiet));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the diagnostic half of #12570. The first pass of this PR was based on a **wrong model** and has been reworked; the finding that corrected it is filed as #12581.

## What the first pass got wrong

It warned on every attached local placement, on the theory that attached local cooks run in the client's process tree. **They do not.** `intercept_local_detached_cook`'s guard admits them:

```rust
if !is_unsupervised_local_cook(cli)
    || (!cli.detach_after_handoff && provider_placement != Some("local"))
{
    return Ok(None);
}
```

An attached local cook satisfies the second clause, so it takes the **same** path as a detached one — re-exec in its own session, launch token, daemon-owned controller job, start-identity pinning, supervisor projection. The only divergence is at line 355: detached awaits handoff, attached streams until terminal.

So `--detach-after-handoff` is a wait-policy flag, not an ownership flag. Warning that attached cooks live in the client's tree was a false positive on the normal, safe path.

## What actually causes in-tree execution

Three degradations returning `Ok(None)`. Each **errors for a detached caller and silently falls back for an attached one** — that asymmetry, not the placement, is what left a run wedged at `queued` with no clue.

| site | line | attached | disclosure |
|---|---|---|---|
| platform lacks session detachment | 199–213 | warns | `cook: running in this client's process tree — local Cook session detachment is unsupported on this platform; the Cook will not survive this client` |
| `runner_side` | 214–224 | **silent, deliberately** | — |
| resident daemon build mismatch | 261–271 | warns | `cook: running in this client's process tree — the resident controller daemon is a different build than this client (<invoking build identity>); the Cook will not survive this client` |

The daemon-mismatch message reads `details["invoking_build_identity"]` from the error already in scope — no new plumbing — and degrades gracefully when absent.

## Why runner-side stays silent

That process **is** the runner's owned execution of one attempt. It has no controller lifecycle to hand off, and the runner — not a client — owns and can recover it. In-tree is the correct shape there, so a client-lifetime warning would be noise on every Lab offload subprocess. Encoded as a comment at the `Ok(None)` plus a test.

## Notably, the disclosures no longer advertise `--detach-after-handoff`

Because it is not what decides this. A test pins that they never mention it. Renaming the flag to describe wait policy is #12581.

## Compatibility

Diagnostics only. No placement, detachment, or `Ok(None)`/`Err(...)` decision changed. Detached branches untouched. The flag name and clap help are untouched, so the generated CLI reference is unaffected.

## Environment that produced the original orphan

```
installed CLI              homeboy 0.345.0+d478a72959b2
main                       v0.350.3
newest controller runtime  homeboy_0_345_0_d478a72959b2-e38ea999…
resident controller daemon none running
```

Five releases of drift with no resident daemon of the current build — consistent with the daemon-mismatch fallback, which this PR now makes visible.

## Not included

Orphan detection and changing the default remain open on #12570; flag renaming and surfacing the degradation on the durable run record are #12581.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation and code edits. Review by hand; compilation deferred to CI.

Refs #12570, #12581