### PR TITLE
Stop reporting a cook with no PR as succeeded

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1735,6 +1735,24 @@ fn attach_cook_completion(value: &mut Value, record: &AgentTaskRunRecord) {
     ) {
         value["cook_completion"] = serde_json::to_value(completion).expect("completion serializes");
     }
+    // The completion projection answers whether a PR exists; it does not carry
+    // the PR's identity. Project that beside it so `status` can answer "is there
+    // a PR, and where" without a second command (#12571).
+    if let Some(pr_url) = cook_finalization_pr_url(record) {
+        value["pr_url"] = Value::String(pr_url.to_string());
+    }
+}
+
+/// The published pull request for this Cook attempt, read from the durable
+/// finalization receipt that `has_finalized_pr` accepts as publication proof.
+fn cook_finalization_pr_url(record: &AgentTaskRunRecord) -> Option<&str> {
+    let finalization = record.metadata.get("cook_finalization")?;
+    let url = finalization
+        .get("pr_url")
+        .or_else(|| finalization.get("pull_request_url"))
+        .and_then(Value::as_str)?
+        .trim();
+    (!url.is_empty()).then_some(url)
 }
 
 /// Basis marker for `next_actions`: the diagnosis mapped a typed failure
@@ -3886,6 +3904,19 @@ fn compact_status_summary_with_aggregate(
                     "created_at",
                 ],
             );
+        }
+    }
+    // Provider success is nested evidence, not a published PR. The compact view
+    // is the default answer, so the Cook-level completion projection and the PR
+    // identity travel with it instead of living only in `diagnose` (#12571).
+    if let Some(cook_completion) = record.get("cook_completion") {
+        if !cook_completion.is_null() {
+            summary["cook_completion"] = cook_completion.clone();
+        }
+    }
+    if let Some(pr_url) = record.get("pr_url") {
+        if !pr_url.is_null() {
+            summary["pr_url"] = pr_url.clone();
         }
     }
     if let Some(delivery) = record.get("notification_delivery") {
@@ -6400,6 +6431,55 @@ mod tests {
         assert!(summary["notification_delivery"]
             .get("raw_destination")
             .is_none());
+    }
+
+    #[test]
+    fn compact_status_carries_cook_completion_and_pull_request_identity() {
+        // #12571: `pr_finalized` and the PR URL were only reachable through
+        // `diagnose`, so the default status view could not answer whether the
+        // Cook published anything.
+        let summary = compact_status_summary(
+            &json!({
+                "run_id": "cook-attempt-1",
+                "state": "succeeded",
+                "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+                "metadata": { "latest_promotion": {
+                    "status": "applied", "patch_artifact": { "id": "patch" }
+                }},
+                "cook_completion": {
+                    "schema": "homeboy/agent-task-cook-completion/v1",
+                    "candidate_produced": true,
+                    "finalization_requested": true,
+                    "pr_finalized": false,
+                    "state": "candidate_awaiting_finalization"
+                },
+                "pr_url": "https://example.test/pull/1"
+            }),
+            "cook-attempt-1",
+        );
+
+        assert_eq!(
+            summary["cook_completion"]["state"],
+            "candidate_awaiting_finalization"
+        );
+        assert_eq!(summary["cook_completion"]["pr_finalized"], false);
+        assert_eq!(summary["pr_url"], "https://example.test/pull/1");
+        assert_eq!(summary["canonical_candidate"]["state"], "promoted");
+
+        let rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+            crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+            &summary,
+        )
+        .expect("status summary");
+
+        assert!(
+            rendered.contains("Status: provider_succeeded_finalization_incomplete"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("Status: succeeded"), "{rendered}");
+        assert!(rendered.contains("Candidate state: promoted"), "{rendered}");
+        assert!(rendered.contains("PR finalized: no"));
+        assert!(rendered.contains("Pull request: https://example.test/pull/1"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -116,12 +116,19 @@ fn render_status_summary(payload: &Value) -> Option<String> {
             metrics.candidate_scan_degraded,
         )
     });
+    let completion = cook_completion_summary(payload);
+    let headline = match completion.as_ref() {
+        Some(completion) if completion.is_unfinalized_success(state) => {
+            PROVIDER_SUCCEEDED_FINALIZATION_INCOMPLETE
+        }
+        _ => state,
+    };
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
     let mut lines = vec![
         "Agent task status".to_string(),
-        format!("Status: {state}"),
+        format!("Status: {headline}"),
         format!("Run: {run_id}"),
         format!("Tasks planned: {tasks_planned}"),
         format!("Tasks attempted: {tasks_attempted}"),
@@ -131,6 +138,9 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         production_lines[1] = format!("Candidate state: {candidate}");
     }
     lines.extend(production_lines);
+    if let Some(completion) = completion.as_ref() {
+        lines.extend(completion.lines(state));
+    }
     if let Some(diagnostic) = first_actionable_diagnostic(payload) {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
@@ -160,6 +170,84 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
     }
     Some(finish(lines))
+}
+
+/// Headline for a Cook whose provider task succeeded while the pull request it
+/// asked for was never finalized. Presentation only, exactly like
+/// `no_patch_produced`: no lifecycle record ever carries this value (#12571).
+const PROVIDER_SUCCEEDED_FINALIZATION_INCOMPLETE: &str =
+    "provider_succeeded_finalization_incomplete";
+
+/// The Cook-level publication facts, projected from the `cook_completion`
+/// record `agent-task diagnose` already reads. The record is attached only to
+/// Cook attempts, so non-Cook agent-task runs render exactly as before (#12571).
+struct CookCompletionSummary<'a> {
+    state: &'a str,
+    finalization_requested: bool,
+    pr_finalized: bool,
+    pr_url: Option<&'a str>,
+}
+
+impl CookCompletionSummary<'_> {
+    /// A succeeded provider task is not a completed Cook. When this Cook asked
+    /// for a pull request and no durable receipt names one, the headline must
+    /// not read as a plain success.
+    fn is_unfinalized_success(&self, state: &str) -> bool {
+        state == "succeeded" && self.finalization_requested && !self.pr_finalized
+    }
+
+    fn lines(&self, state: &str) -> Vec<String> {
+        let completion = if self.is_unfinalized_success(state) {
+            format!(
+                "Cook completion: {} (provider task succeeded, cook finalization did not complete)",
+                self.state
+            )
+        } else {
+            format!("Cook completion: {}", self.state)
+        };
+        let mut lines = vec![
+            completion,
+            format!(
+                "PR finalized: {}",
+                if self.pr_finalized { "yes" } else { "no" }
+            ),
+        ];
+        if let Some(pr_url) = self.pr_url {
+            lines.push(format!("Pull request: {pr_url}"));
+        }
+        lines
+    }
+}
+
+fn cook_completion_summary(payload: &Value) -> Option<CookCompletionSummary<'_>> {
+    let completion = value_at(payload, &["cook_completion"])?;
+    Some(CookCompletionSummary {
+        state: string_value(completion, &["state"]).unwrap_or("unknown"),
+        finalization_requested: value_at(completion, &["finalization_requested"])
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        pr_finalized: value_at(completion, &["pr_finalized"])
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        pr_url: cook_pr_url(payload),
+    })
+}
+
+/// The pull request this Cook published, read from the projected `pr_url` the
+/// status payload carries and, failing that, from the same durable finalization
+/// receipts that make a candidate `finalized`.
+fn cook_pr_url(payload: &Value) -> Option<&str> {
+    let url = string_value(payload, &["pr_url"])
+        .or_else(|| receipt_pr_url(payload, &["cook_finalization"]))
+        .or_else(|| receipt_pr_url(payload, &["metadata", "cook_finalization"]))
+        .or_else(|| receipt_pr_url(payload, &["finalization"]))?
+        .trim();
+    (!url.is_empty()).then_some(url)
+}
+
+fn receipt_pr_url<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
+    let receipt = value_at(payload, path)?;
+    string_value(receipt, &["pr_url"]).or_else(|| string_value(receipt, &["pull_request_url"]))
 }
 
 fn is_transport_proxy(payload: &Value) -> bool {
@@ -1390,7 +1478,124 @@ mod tests {
             if state == "queued" {
                 assert!(summary.contains("Next: homeboy agent-task run homeboy-4345\n"));
             }
+            // A run with no Cook completion record is not a Cook, so the
+            // publication lines never appear for it (#12571).
+            assert!(!summary.contains("Cook completion:"), "{summary}");
+            assert!(!summary.contains("PR finalized:"), "{summary}");
         }
+    }
+
+    #[test]
+    fn status_summary_never_reports_a_cook_without_a_pull_request_as_succeeded() {
+        // #12571: the provider task succeeded and the candidate was promoted,
+        // but the Cook finalized nothing. The headline must not read as a win.
+        let payload = json!({
+            "run_id": "agent-task-04ad6499",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [{ "task_id": "cook", "kind": "patch", "uri": "artifact://cook/patch.diff", "size_bytes": 32318 }],
+            "execution_states": { "candidate": { "state": "promoted" } },
+            "cook_completion": {
+                "schema": "homeboy/agent-task-cook-completion/v1",
+                "candidate_produced": true,
+                "finalization_requested": true,
+                "pr_finalized": false,
+                "state": "candidate_awaiting_finalization"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(
+            summary.starts_with(
+                "Agent task status\nStatus: provider_succeeded_finalization_incomplete\nRun: agent-task-04ad6499"
+            ),
+            "{summary}"
+        );
+        assert!(!summary.contains("Status: succeeded"), "{summary}");
+        assert!(summary.contains("Candidate state: promoted\n"));
+        assert!(summary.contains(
+            "Cook completion: candidate_awaiting_finalization (provider task succeeded, cook finalization did not complete)\n"
+        ));
+        assert!(summary.contains("PR finalized: no\n"));
+        assert!(!summary.contains("Pull request:"), "{summary}");
+    }
+
+    #[test]
+    fn status_summary_surfaces_the_finalized_pull_request() {
+        let payload = json!({
+            "run_id": "agent-task-finalized",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [{ "task_id": "cook", "kind": "patch", "uri": "artifact://cook/patch.diff", "size_bytes": 32318 }],
+            "cook_completion": {
+                "schema": "homeboy/agent-task-cook-completion/v1",
+                "candidate_produced": true,
+                "finalization_requested": true,
+                "pr_finalized": true,
+                "state": "pr_finalized"
+            },
+            "pr_url": "https://example.test/pull/1"
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"), "{summary}");
+        assert!(summary.contains("Cook completion: pr_finalized\n"));
+        assert!(summary.contains("PR finalized: yes\n"));
+        assert!(summary.contains("Pull request: https://example.test/pull/1\n"));
+        assert!(!summary.contains("provider_succeeded_finalization_incomplete"));
+    }
+
+    #[test]
+    fn status_summary_reads_the_pull_request_from_the_durable_finalization_receipt() {
+        let payload = json!({
+            "run_id": "agent-task-receipt",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [],
+            "cook_completion": {
+                "schema": "homeboy/agent-task-cook-completion/v1",
+                "candidate_produced": true,
+                "finalization_requested": true,
+                "pr_finalized": true,
+                "state": "pr_finalized"
+            },
+            "metadata": {
+                "cook_finalization": { "status": "review_ready", "pr_url": "https://example.test/pull/2" }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("PR finalized: yes\n"));
+        assert!(summary.contains("Pull request: https://example.test/pull/2\n"));
+    }
+
+    #[test]
+    fn status_summary_keeps_a_no_finalize_cook_reported_as_succeeded() {
+        // `--no-finalize` never asked for a pull request, so provider success is
+        // the whole outcome and the headline stays untouched (#12571).
+        let payload = json!({
+            "run_id": "agent-task-no-finalize",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cook", "state": "succeeded" }],
+            "artifact_refs": [{ "task_id": "cook", "kind": "patch", "uri": "artifact://cook/patch.diff", "size_bytes": 32318 }],
+            "cook_completion": {
+                "schema": "homeboy/agent-task-cook-completion/v1",
+                "candidate_produced": true,
+                "finalization_requested": false,
+                "pr_finalized": false,
+                "state": "candidate_produced"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Status: succeeded\n"), "{summary}");
+        assert!(summary.contains("Cook completion: candidate_produced\n"));
+        assert!(summary.contains("PR finalized: no\n"));
+        assert!(!summary.contains("provider_succeeded_finalization_incomplete"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes fixes 1 and 2 of #12571.

`agent-task status` reported a run as **succeeded** when the cook failed and opened nothing:

| `status` said | the cook report said |
|---|---|
| `Status: succeeded` | `"status": "durable_failure"` |
| `Candidate state: promoted` | `"pr_finalized": false` |

The **provider task** succeeded. The **cook** failed. `status` surfaced the first and buried the second, and `pr_finalized` was reachable only through `diagnose`. Across five runs I could never tell from `status` alone whether I had a mergeable result.

## What changed

The summary now consumes the **existing** `cook_completion` record (`homeboy/agent-task-cook-completion/v1`) that `attach_cook_completion` already builds for `diagnose`. No new state machine.

```
- Status: succeeded
+ Status: provider_succeeded_finalization_incomplete
  …
+ Cook completion: candidate_awaiting_finalization (provider task succeeded, cook finalization did not complete)
+ PR finalized: no
+ Pull request: <url>        # when one exists
```

The override fires only when `state == "succeeded"` **and** `finalization_requested` **and** `!pr_finalized`. A `--no-finalize` cook still reads `succeeded`; an already-honest state (`gate_failed`, `no_patch_produced`, `failed`) is untouched. `provider_succeeded_finalization_incomplete` is presentation-only, exactly like the existing `no_patch_produced` synthetic.

The PR URL resolves from the projected `pr_url`, then the same durable receipts `candidate.rs::has_finalized_pr` already uses.

## Why `pr_finalized` was unreachable

`cook_completion` existed only on `--full`/`diagnose`. `compact_status_summary_with_aggregate` now carries `cook_completion` and `pr_url` into the default compact view. Both are non-mandatory, so the existing `enforce_compact_status_budget` ceiling still governs them.

## Compatibility

Presentation only — no lifecycle states, transitions, or control flow change. Structured output is strictly additive. Non-cook runs are unaffected and print none of the new lines (pinned by a test).

## Note on the issue text

The label `Subject state:` in #12571 does not exist in the renderer — the subject's lifecycle state prints as `Status:`, with an existing comment in `status.rs` pinning that. Fixes 3 (vocabulary docs) and 4 (`Changed files: unknown`, attempt-counter regression) remain open.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation and code edits. Review by hand; compilation deferred to CI.

Refs #12571