### PR TITLE
Fail a CI run that skipped its required gates

### DIFF
--- a/.github/ci-required-gates-executed.sh
+++ b/.github/ci-required-gates-executed.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# Terminal gate: claim 3, EXECUTION (#12573).
+#
+# ── Why a third claim ──
+#
+# `validate-required-gates.sh` answers two questions, and both are evaluated at
+# the START of a run:
+#
+#   declaration - `ci.yml` emits every context named by the versioned payload.
+#   enforcement - GitHub actually requires those contexts before `main` moves.
+#
+# Neither can answer the question PR #12567 needed answered: did the gates then
+# RUN? Run 31906427396 was cancelled with every gate mid-flight. The run that
+# cancelled it, 31906482704, was the `pull_request.closed` run, so `pr-state`
+# reported inactive, every gate skipped, and the workflow concluded SUCCESS
+# having compiled nothing and tested nothing. `Required Gates Declaration` was
+# green in the first run while declaring seven gates that never finished, and
+# skipped in the second while declaring seven gates that never started.
+#
+# A `skipped` needs-dependency does not fail a run, so "nothing ran" and
+# "everything passed" produced the same green tick. `gh pr checks` renders the
+# superseded run's `cancelled` jobs as `fail`, so the pull request showed a wall
+# of red and a green overall conclusion at the same time. Neither was true.
+#
+# ── What this script claims ──
+#
+# That the required gates executed and passed in THIS run, measured from two
+# independent directions so neither can be satisfied vacuously:
+#
+#   dependency results - every gate job `ci.yml` names as a dependency concluded
+#                        `success`. Tokenless, structural, and here `skipped`
+#                        and `cancelled` are failures rather than silence.
+#   observed execution - every context in `.github/required-gates-ruleset.json`
+#                        appears in this run's job list with conclusion
+#                        `success`. This is the claim the declaration check
+#                        cannot make: a context can be declared by a job that
+#                        never ran (#10997's vacuous-declaration shape) or by a
+#                        job the whole run skipped (#12573's shape).
+#
+# ── What this script deliberately does NOT do ──
+#
+# It does not change capacity admission, and it does not change the closure
+# run's cancellation of an in-flight candidate DAG. Skipping stays possible; it
+# stops being invisible. A closure run is red here on purpose: it is the LAST
+# word on the pull request and it is the run that read green in #12573, so
+# exempting it would leave the reported hole exactly as it was found.
+#
+# ── Outcomes ──
+#
+# Vocabulary mirrors `validate-required-gates.sh`, which already had to learn
+# that "the check passed" and "the check measured something" are different
+# facts:
+#
+#   executed    every declared context ran and passed; every dependency
+#               concluded success. The only outcome that exits 0.
+#   skipped     at least one required gate did not execute at all.
+#   failed      the gates executed and at least one did not pass.
+#   unverified  this run's job list could not be read. Fails closed: an
+#               unmeasured run is not a verified one.
+#
+# ── Fixture hooks ──
+#
+# REQUIRED_GATES_CONFIG overrides the declared-context payload;
+# REQUIRED_GATES_EXECUTED_JOBS substitutes a jobs-API payload file for the live
+# read; CI_GATE_RESULTS carries `toJSON(needs)`. All three make this runnable
+# without a network or a token.
+
+set -euo pipefail
+
+config="${REQUIRED_GATES_CONFIG:-.github/required-gates-ruleset.json}"
+active="${CI_RUN_ACTIVE:-unknown}"
+
+if [ ! -f "${config}" ]; then
+  echo "::error::required-gates execution check must run from the repository root"
+  echo "required-gates execution check must run from the repository root" >&2
+  exit 1
+fi
+
+if [ -z "${CI_GATE_RESULTS:-}" ]; then
+  echo "::error::required-gates execution check requires CI_GATE_RESULTS=toJSON(needs)"
+  echo "required-gates execution check requires CI_GATE_RESULTS=toJSON(needs)" >&2
+  exit 1
+fi
+
+if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "${CI_GATE_RESULTS}"; then
+  echo "::error::CI_GATE_RESULTS is not the JSON object GitHub's needs context produces"
+  echo "CI_GATE_RESULTS is not the JSON object GitHub's needs context produces" >&2
+  exit 1
+fi
+
+# ── Direction 1: dependency results ──────────────────────────────────────────
+#
+# Every dependency, not only the declared required set. `warning-clean` and
+# `ci-capacity-admission` are not required contexts, but they carry the same
+# `pr-state` condition as the gates that are, so their state is evidence about
+# whether this run ran anything at all.
+
+dependency_failures="$(jq -r '
+  to_entries
+  | map(select(.value.result != "success") | "\(.key)=\(.value.result // "unknown")")
+  | join(" ")
+' <<< "${CI_GATE_RESULTS}")"
+dependency_count="$(jq 'length' <<< "${CI_GATE_RESULTS}")"
+dependency_skipped="$(jq '[.[] | select(.result == "skipped")] | length' <<< "${CI_GATE_RESULTS}")"
+
+# ── Direction 2: observed execution ──────────────────────────────────────────
+
+declared_contexts="$(jq -c '
+  [.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context]
+  | sort
+' "${config}")"
+declared_count="$(jq 'length' <<< "${declared_contexts}")"
+
+if [ "${declared_count}" -eq 0 ]; then
+  echo "::error::required-gates policy declares no required checks, so execution cannot be verified"
+  echo "required-gates policy declares no required checks" >&2
+  exit 1
+fi
+
+run_jobs=''
+probe_error=''
+
+read_run_jobs() {
+  local source="${REQUIRED_GATES_EXECUTED_JOBS:-}"
+  local payload=''
+
+  if [ -n "${source}" ]; then
+    if [ ! -f "${source}" ]; then
+      probe_error="run-jobs fixture ${source} does not exist"
+      return 1
+    fi
+    payload="$(cat "${source}")"
+  else
+    if ! command -v gh >/dev/null 2>&1; then
+      probe_error="gh is not installed, so this run's job list could not be read"
+      return 1
+    fi
+    if ! payload="$(gh api --paginate \
+      "repos/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}/jobs?per_page=100" \
+      | jq -s '[.[] | .jobs[]]' 2>&1)"; then
+      probe_error="gh api actions/runs/${GITHUB_RUN_ID:-} /jobs failed: $(printf '%s' "${payload}" | tr '\n' ' ')"
+      return 1
+    fi
+  fi
+
+  if ! jq -e 'type == "array"' >/dev/null 2>&1 <<< "${payload}"; then
+    probe_error="this run's job list was not a JSON array"
+    return 1
+  fi
+
+  run_jobs="${payload}"
+}
+
+execution='unknown'
+not_executed=''
+not_passing=''
+
+if read_run_jobs; then
+  # A skipped matrix job is reported under its UNEXPANDED name (#12573 observed
+  # `${{ matrix.title }}`), so `homeboy / Audit` is simply absent rather than
+  # present-and-skipped. Absent is therefore `not-executed`, which is exactly
+  # the verdict wanted: the context produced no measurement.
+  execution="$(jq -c --argjson required "${declared_contexts}" '
+    . as $jobs
+    | [ $required[]
+        | . as $context
+        | ($jobs | map(select(.name == $context))) as $matches
+        | {
+            context: $context,
+            state: (
+              if ($matches | length) == 0 then "not-executed"
+              elif ($matches | any(.conclusion != "success"))
+                then ($matches | map(.conclusion // "in-progress") | unique | join(","))
+              else "success"
+              end
+            )
+          }
+      ]
+  ' <<< "${run_jobs}")"
+  not_executed="$(jq -r '[.[] | select(.state == "not-executed") | .context] | join(", ")' <<< "${execution}")"
+  not_passing="$(jq -r '
+    [.[] | select(.state != "success" and .state != "not-executed") | "\(.context)=\(.state)"]
+    | join(", ")
+  ' <<< "${execution}")"
+fi
+
+# ── Verdict ──────────────────────────────────────────────────────────────────
+#
+# `skipped` outranks `failed`: a gate that ran and failed is already a red check
+# a human cannot miss, while a gate that never ran is the invisible case this
+# job exists to surface.
+
+executed_count='unknown'
+if [ "${execution}" != 'unknown' ]; then
+  executed_count="$(jq '[.[] | select(.state != "not-executed")] | length' <<< "${execution}")"
+fi
+
+if [ "${execution}" = 'unknown' ]; then
+  outcome='unverified'
+elif [ -n "${not_executed}" ] || [ "${dependency_skipped}" -gt 0 ]; then
+  outcome='skipped'
+elif [ -n "${not_passing}" ] || [ -n "${dependency_failures}" ]; then
+  outcome='failed'
+else
+  outcome='executed'
+fi
+
+# One machine-readable provenance line in every branch, so a log reader can tell
+# a verified execution from an unverified one without inferring it from the exit
+# code — the same reason `validate-required-gates.sh` emits its enforcement basis
+# before its verdict.
+echo "::notice::required-gates-executed basis=needs-results+run-jobs run=${GITHUB_RUN_ID:-unknown} attempt=${GITHUB_RUN_ATTEMPT:-unknown} pr_state_active=${active} declared=${declared_count} executed=${executed_count} dependencies=${dependency_count} dependencies_skipped=${dependency_skipped} outcome=${outcome}"
+
+closure_note=''
+if [ "${active}" = 'false' ]; then
+  closure_note=" This run is a pull_request.closed run: it exists to cancel the in-flight run in the same concurrency group, so it verified nothing. That is not a defect in this job — it is the state #12573 reported as a green tick, and it is now stated instead."
+fi
+
+case "${outcome}" in
+  executed)
+    headline="All ${declared_count} required gates executed and passed in this run."
+    echo "::notice::required-gates-executed: ${headline}"
+    ;;
+  skipped)
+    headline="Required gates did NOT all execute in this run. not-executed=[${not_executed}] skipped-dependencies=${dependency_skipped} dependency-results=[${dependency_failures}]. Nothing was verified for these contexts, so this run must not read as success (#12573).${closure_note}"
+    echo "::error::required-gates-executed: ${headline}"
+    ;;
+  failed)
+    headline="Required gates executed and did not all pass. failing-contexts=[${not_passing}] dependency-results=[${dependency_failures}]."
+    echo "::error::required-gates-executed: ${headline}"
+    ;;
+  unverified)
+    headline="This run's job list could NOT be read (${probe_error}), so gate execution is unproven. Failing closed: an unmeasured run is not a verified one."
+    echo "::error::required-gates-executed: ${headline}"
+    ;;
+esac
+
+echo "required-gates-executed-status=${outcome}"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Required gates executed"
+    echo
+    echo "| claim | result |"
+    echo "| --- | --- |"
+    echo "| execution (every declared context ran and passed in this run) | **${outcome}** |"
+    echo
+    echo "${headline}"
+    echo
+    echo "| context | state |"
+    echo "| --- | --- |"
+    if [ "${execution}" = 'unknown' ]; then
+      jq -r '.[] | "| `\(.)` | `unverified` |"' <<< "${declared_contexts}"
+    else
+      jq -r '.[] | "| `\(.context)` | `\(.state)` |"' <<< "${execution}"
+    fi
+    echo
+    echo "| dependency | result |"
+    echo "| --- | --- |"
+    jq -r 'to_entries[] | "| `\(.key)` | `\(.value.result // "unknown")` |"' <<< "${CI_GATE_RESULTS}"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if [ "${outcome}" = 'executed' ]; then
+  exit 0
+fi
+
+echo "required-gates execution is ${outcome} for run ${GITHUB_RUN_ID:-unknown}" >&2
+exit 1

--- a/.github/validate-required-gates.sh
+++ b/.github/validate-required-gates.sh
@@ -7,14 +7,24 @@
 # This script can answer two questions, and they are NOT the same question:
 #
 #   declaration - every context named by the versioned payload is emitted by
-#                 `.github/workflows/ci.yml` on every pull request. This is
-#                 repository content, so a PR can both break it and fix it, and
-#                 it is checked from the checkout with no network.
+#                 `.github/workflows/ci.yml` on every pull request, and every
+#                 skippable gate job is wired into the terminal execution gate.
+#                 This is repository content, so a PR can both break it and fix
+#                 it, and it is checked from the checkout with no network.
 #   enforcement - GitHub actually *requires* those contexts before `main` can be
 #                 updated. This is repository STATE. A pull request cannot
 #                 change it and, until #10795's payload is installed by an
 #                 administrator, it can be false while the declaration is
 #                 perfect.
+#
+# There is a THIRD question neither half can answer, because both are evaluated
+# before the gates finish: did the declared gates actually EXECUTE? PR #12567
+# merged with this check green in a run whose gates were all cancelled, then
+# skipped entirely in the replacement run that concluded `success` (#12573).
+# `.github/ci-required-gates-executed.sh` owns that claim at the END of a run.
+# What a pull request CAN break about it — the wiring that makes the terminal
+# gate cover every skippable gate job — is checked below, fail-closed, because
+# it is repository content like the rest of the declaration.
 #
 # Before #11084 the CI job ran `--local` and reported a plain green tick named
 # "Required Gates Policy". That tick asserted the second claim while only ever
@@ -142,6 +152,76 @@ if ! jq -e '
   echo "required-gates policy must require checks on the current PR head" >&2
   exit 1
 fi
+
+# ── Claim 1b: the declaration must reach a TERMINAL execution gate (#12573) ───
+#
+# Emitting a context is not running it. Every gate in `ci.yml` is conditional on
+# `pr-state`, and a `skipped` needs-dependency does not fail a run, so a run that
+# skipped all seven declared gates concluded `success` with this check green in
+# the run before it and skipped in the run itself. The end-of-run assertion lives
+# in `.github/ci-required-gates-executed.sh`; the part a pull request can break
+# is its WIRING, so that is verified here from the checkout with no network.
+#
+# The terminal job must exist, must run under `always()` (a gate that skips
+# alongside the gates it guards is not a gate), must invoke the execution
+# assertion, and must depend on EVERY skippable gate job — otherwise a newly
+# added gate could be skipped with nothing left to notice.
+
+terminal_job='required-gates-executed'
+terminal_section="$(awk -v key="  ${terminal_job}:" '
+  $0 == key { inside = 1; next }
+  inside && /^  [A-Za-z0-9_-]+:$/ { inside = 0 }
+  inside { print }
+' "${ci_workflow}")"
+
+if [ -z "${terminal_section}" ]; then
+  echo "${ci_workflow} declares no '${terminal_job}' job, so a run that skips every required gate can still conclude success" >&2
+  exit 1
+fi
+
+for marker in \
+  'name: homeboy / Required Gates Executed' \
+  'if: ${{ always() }}' \
+  'bash .github/ci-required-gates-executed.sh'; do
+  if ! printf '%s\n' "${terminal_section}" | grep -Fq "${marker}"; then
+    echo "the '${terminal_job}' job must contain '${marker}' to be a terminal gate" >&2
+    exit 1
+  fi
+done
+
+terminal_needs="$(printf '%s\n' "${terminal_section}" \
+  | sed -n 's/^    needs: *//p' \
+  | tr -d '[]' \
+  | tr ',' ' ' \
+  | tr -s ' ')"
+
+if [ -z "${terminal_needs//[[:space:]]/}" ]; then
+  echo "the '${terminal_job}' job must declare its dependencies as one inline 'needs: [...]' list" >&2
+  exit 1
+fi
+
+# A job is skippable exactly when it carries the PR-state condition. Deriving the
+# set from the workflow rather than hardcoding it is what makes this survive a
+# gate being added: the new gate is covered the moment it is written.
+gate_condition="if: \${{ needs.pr-state.outputs.active == 'true' }}"
+gate_jobs="$(awk -v cond="${gate_condition}" '
+  /^  [A-Za-z0-9_-]+:$/ { job = substr($0, 3, length($0) - 3); next }
+  job != "" && index($0, cond) { print job; job = "" }
+' "${ci_workflow}")"
+
+if [ -z "${gate_jobs}" ]; then
+  echo "${ci_workflow} declares no PR-state-conditional gate jobs, which contradicts the required-gates policy" >&2
+  exit 1
+fi
+
+for gate_job in ${gate_jobs}; do
+  case " ${terminal_needs} " in
+    *" ${gate_job} "*) continue ;;
+  esac
+
+  echo "gate job '${gate_job}' is skippable but is not a dependency of '${terminal_job}', so skipping it would still conclude success" >&2
+  exit 1
+done
 
 if [ "${mode}" = "--local" ]; then
   exit 0
@@ -314,7 +394,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo
     echo "| claim | result |"
     echo "| --- | --- |"
-    echo "| declaration (\`ci.yml\` emits every declared context) | **verified** |"
+    echo "| declaration (\`ci.yml\` emits every declared context and wires every gate into \`required-gates-executed\`) | **verified** |"
     echo "| enforcement (GitHub requires them on \`${branch}\`) | **${outcome}** |"
     echo
     echo "${headline}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,3 +287,39 @@ jobs:
           name: homeboy-ci-capacity-evidence-${{ github.run_attempt }}
           path: ci-capacity-evidence.json
           if-no-files-found: warn
+
+  # Terminal gate. A run's conclusion has to mean something (#12573).
+  #
+  # PR #12567 merged with ZERO gates executed. Its first run was cancelled with
+  # every gate mid-flight; the `pull_request.closed` run that cancelled it
+  # reported `pr-state` inactive, skipped every gate, and concluded SUCCESS. A
+  # `skipped` needs-dependency does not fail a run, so "nothing ran" and
+  # "everything passed" were the same green tick — and `gh pr checks`, which
+  # renders `cancelled` as `fail`, showed the superseded run's red at the same
+  # time. Neither reading was true.
+  #
+  # This job depends on every gate above, runs under `always()` so skipping
+  # cannot skip it too, and fails unless each dependency concluded `success` AND
+  # every context in `.github/required-gates-ruleset.json` appears in this run's
+  # job list having actually executed and passed. Two directions, because a
+  # declared context can be emitted by a job that never ran.
+  #
+  # Capacity admission and closure cancellation are untouched: skipping stays
+  # possible, it just stops being invisible. `homeboy / Required Gates
+  # Declaration` remains the required context for the DECLARATION claim; this is
+  # the EXECUTION claim, named for what it checks.
+  required-gates-executed:
+    name: homeboy / Required Gates Executed
+    needs: [pr-state, ci-capacity-admission, required-gates-declaration, workspace-tests-compile, warning-clean, windows-compile, rustfmt, homeboy-fast, homeboy]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Assert every required gate executed and passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CI_GATE_RESULTS: ${{ toJSON(needs) }}
+          CI_RUN_ACTIVE: ${{ needs.pr-state.outputs.active }}
+        run: bash .github/ci-required-gates-executed.sh

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -1,7 +1,7 @@
 # Required CI Gates
 
-Two different things can be true or false here, and conflating them is what
-caused #11084:
+Three different things can be true or false here, and conflating them is what
+caused #11084 and #12573:
 
 - **Declaration** — every context named by
   [`../../.github/required-gates-ruleset.json`](../../.github/required-gates-ruleset.json)
@@ -11,12 +11,21 @@ caused #11084:
 - **Enforcement** — GitHub actually requires those contexts before `main` can be
   updated. This is repository *state*. A pull request cannot change it, and it
   can be false while the declaration is perfect.
+- **Execution** — the declared gates actually ran and passed in a given run.
+  This is *run* state. It can be false while the declaration is perfect and the
+  enforcement is installed, because a skipped or cancelled gate reports nothing
+  at all.
 
 `homeboy / Required Gates Declaration` runs
 `bash .github/validate-required-gates.sh --report`. It **fails closed on the
 declaration** — a renamed, removed, duplicate, or path-filtered required job
 turns the check red — and it **reports, but never enforces, the live
 enforcement outcome**. Nothing in this check can newly block a pull request.
+
+`homeboy / Required Gates Executed` runs
+`bash .github/ci-required-gates-executed.sh` after every gate, under
+`if: always()`. It **fails closed on execution**, and it is the only check whose
+green tick means work was actually done.
 
 ## What The Check Reports
 
@@ -52,6 +61,46 @@ no required-status-check rule at all.
 This is a reporting fix on purpose. The repository merges fast by design and a
 post-merge guard was removed by design; the defect was the false assurance, not
 the absence of a block.
+
+## Execution: What A Green Run Has To Mean
+
+Every gate in `ci.yml` is conditional on `homeboy / PR State`, and a `skipped`
+needs-dependency does not fail a GitHub Actions run. On 2026-08-15 PR #12567
+merged on exactly that: run `31906427396` was cancelled with all seven gates
+mid-flight, and the `pull_request.closed` run that cancelled it — `31906482704` —
+skipped every gate and concluded **success**. Net verification for the merge was
+`PR State` and `CI Capacity Evidence`. Nothing compiled, nothing was tested, and
+`gh pr checks` simultaneously showed the superseded run's `cancelled` jobs as
+`fail`, so the pull request read red and green at once (#12573).
+
+`homeboy / Required Gates Executed` is the terminal gate for that. It measures
+two independent things and fails unless both hold:
+
+| direction | claim |
+| --- | --- |
+| dependency results | every gate job `ci.yml` names in its `needs` concluded `success`; `skipped` and `cancelled` are failures here, not silence |
+| observed execution | every declared context appears in this run's job list with conclusion `success`, read back from `actions/runs/<id>/jobs` |
+
+| outcome | meaning |
+| --- | --- |
+| `executed` | every declared context ran and passed — the only outcome that exits 0 |
+| `skipped` | at least one required gate did not execute at all |
+| `failed` | the gates executed and at least one did not pass |
+| `unverified` | this run's job list could not be read; an unmeasured run is not a verified one |
+
+Capacity admission and the closure run's cancellation are deliberately
+unchanged. Skipping stays possible; it stops being invisible. **A
+`pull_request.closed` run is red here on purpose**: it is the last run on the
+pull request and it is the run that read green in #12573, so exempting it would
+leave the reported hole exactly where it was found. Read the job summary, not the
+colour, to tell "this run cancelled an in-flight run and verified nothing" from
+"a gate failed".
+
+The wiring half of this is declaration, not execution, so
+`validate-required-gates.sh` fails closed when `required-gates-executed` is
+missing, is not `if: ${{ always() }}`, does not invoke the assertion, or omits
+any PR-state-conditional gate job from its `needs`. Adding a gate to `ci.yml`
+without wiring it into the terminal job turns `Required Gates Declaration` red.
 
 ## Apply And Verify
 


### PR DESCRIPTION
## Summary

Fixes fixes 1 and 2 of #12573.

PR #12567 merged having run **zero** real gates. One run was cancelled with every gate mid-flight; its replacement skipped all of them and concluded `success` on `PR State` + `CI Capacity Evidence` alone. **A skipped `needs` dependency does not fail a run** — that is the hole.

## What changed

### Fix 1 — a terminal `Required Gates Executed` job

`.github/workflows/ci.yml` gains one job at the end, plus `.github/ci-required-gates-executed.sh`. It asserts **two independent directions**, both of which must hold:

| direction | source | catches |
|---|---|---|
| dependency results | `toJSON(needs)` | `skipped` / `cancelled` gates |
| observed execution | `actions/runs/<id>/jobs` vs `required-gates-ruleset.json` | a declared context whose job never ran |

The second catches what `needs` cannot. A skipped matrix job reports under its unexpanded name `homeboy / ${{ matrix.title }}`, so `homeboy / Audit` is simply absent → `not-executed`.

Outcomes follow the sibling scripts' vocabulary: `executed` (only exit 0), `skipped`, `failed`, `unverified` (fails closed). `skipped` outranks `failed` because a gate that ran and failed is already a visible red check.

I deliberately did **not** extend the existing `ci-capacity-evidence` aggregate: this repo treats a check's name as half its claim (#11084), "evidence published" ≠ "gates passed", and a failing assertion there would abort before its artifact upload.

### Fix 2 — declaration cannot assert execution, so the wiring is gated instead

`Required Gates Declaration` runs at the *start* of the run, in parallel with the gates it declares, so it structurally cannot assert they executed. The assertion lives in the terminal job where the facts exist; the part a PR can break is enforced in `validate-required-gates.sh` (fail-closed, no network, all modes): the terminal job must exist, use `always()`, invoke the assertion, and list **every** `pr-state`-conditional gate in `needs` — derived by scanning ci.yml, so a newly added gate is covered the moment it is written.

## Read this before merging

**All 22 of the last 22 `success` CI runs are closure runs with 8 skipped / 2 success.** Not one green CI conclusion in recent history had a gate execute.

Closure runs fail **deliberately** here — `pull_request.closed` sets `active=false` and skips everything, which is exactly run `31906482704` from the issue. Exempting it would leave the reported hole open. The error message says so explicitly, so red on a merged PR reads as *"this run verified nothing"*, not *"something broke"*.

**Consequence:** after this lands, every merged PR ends with a red `Required Gates Executed` until fix 4 (re-queue rather than letting the replacement skip) is done. That fix is what makes green possible again and was out of scope here. If that is too noisy to accept first, fix 4 should land before or with this.

## Required-job classification

Required = the seven contexts in `required-gates-ruleset.json`, which a Rust test pins to exactly those seven — so I did not add one. `warning-clean` and `ci-capacity-admission` are checked too: not declared-required, but they carry the same `pr-state` condition so their state is evidence about whether the run ran anything. `ci-capacity-evidence` is excluded (`always()`, not a gate). No path filters or partially-applicable matrix entries exist in this workflow.

The new `Required Gates Executed` context is **not** in the ruleset, since that test pins it to seven and changing it needs an admin re-apply. It is visible in the run conclusion and `gh pr checks`, but not yet in branch protection — a one-line follow-up plus a test update if you want it enforced.

## Verification

No cargo. `bash -n` on both scripts, `yaml.safe_load` on ci.yml, `validate-required-gates.sh --local` passing with four injected regressions each failing closed, all existing `--report`/`--github` outcomes reproduced from fixtures, the terminal script driven through green / the exact #12573 closure shape / a real failure / unreadable jobs, and the string assertions of `pr_ci_lifecycle_test.rs` and `required_gates_policy_test.rs` replicated in Python. Job names confirmed against the live API on an active run.

## Not included

Fix 3 (PR-comment surfacing — owned by `homeboy-action`) and fix 4 (re-queue on supersede) remain open on #12573.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, workflow and script edits, and fixture-driven verification. Review by hand.

Refs #12573