### PR TITLE
Let the Cook spine take its lifecycle store

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3919,9 +3919,42 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
-    let failure_options = options.clone();
-    let result = match run_cook_with_boundaries_observed_inner_with_store(
+    // The spine used to resolve this store itself. Resolve it here instead and
+    // keep the failure routed exactly where the spine's own resolution error
+    // used to land, so an unresolvable environment still returns the durable
+    // report for an already-created Cook rather than a bare error.
+    let lifecycle_store = match AgentTaskLifecycleStore::from_current_environment() {
+        Ok(lifecycle_store) => lifecycle_store,
+        Err(error) => return durable_cook_error_report_with_store(store, &options, error),
+    };
+    run_cook_with_boundaries_reported_with_stores(
         store,
+        &lifecycle_store,
+        options,
+        executor,
+        side_effects,
+        durable_observer,
+        allow_historical_terminal,
+    )
+}
+
+fn run_cook_with_boundaries_reported_with_stores<E, S>(
+    store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: AgentTaskCookServiceOptions,
+    executor: E,
+    side_effects: S,
+    durable_observer: Option<&CookProgressObserver<'_>>,
+    allow_historical_terminal: bool,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+    S: CookSideEffectService,
+{
+    let failure_options = options.clone();
+    let result = match run_cook_with_boundaries_observed_inner_with_stores(
+        store,
+        lifecycle_store,
         options,
         executor,
         side_effects,
@@ -4049,9 +4082,13 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
+    // Env-resolving entry point. Both stores are resolved here, once, so the
+    // spine below only ever sees explicit roots.
     let store = CookRecipeStore::from_current_data_root()?;
-    run_cook_with_boundaries_observed_inner_with_store(
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    run_cook_with_boundaries_observed_inner_with_stores(
         &store,
+        &lifecycle_store,
         options,
         executor,
         side_effects,
@@ -4062,6 +4099,35 @@ where
 
 fn run_cook_with_boundaries_observed_inner_with_store<E, S>(
     store: &CookRecipeStore,
+    options: AgentTaskCookServiceOptions,
+    executor: E,
+    side_effects: S,
+    durable_observer: Option<&CookProgressObserver<'_>>,
+    allow_historical_terminal: bool,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
+where
+    E: AgentTaskExecutorAdapter + Clone,
+    S: CookSideEffectService,
+{
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    run_cook_with_boundaries_observed_inner_with_stores(
+        store,
+        &lifecycle_store,
+        options,
+        executor,
+        side_effects,
+        durable_observer,
+        allow_historical_terminal,
+    )
+}
+
+/// The Cook spine, bound to explicit recipe and lifecycle roots. Every durable
+/// write on this path resolves through the two passed stores, so a caller can
+/// place a Cook's recipe and its lifecycle records wherever it owns them
+/// instead of wherever the process environment happens to point (#7505).
+fn run_cook_with_boundaries_observed_inner_with_stores<E, S>(
+    store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
     mut options: AgentTaskCookServiceOptions,
     executor: E,
     mut side_effects: S,
@@ -4072,7 +4138,6 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     // The local detached launcher persists this fence before spawn. Recheck it
     // at each durable/external boundary so a dead launcher cannot revive work.
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
@@ -4203,14 +4268,14 @@ where
     // Recipe persistence and lifecycle materialization are a recoverable saga.
     // Complete it before any capacity, workspace, or provider-facing work so a
     // controller interruption leaves a status-addressable, resumable attempt.
-    materialize_initial_cook_attempt_with_stores(store, &lifecycle_store, &options)?;
+    materialize_initial_cook_attempt_with_stores(store, lifecycle_store, &options)?;
     // A persisted recipe can replace the just-validated inputs. Re-check its
     // workspace and candidate topology before it reaches transport preparation
     // or a resumed attempt.
     // A detached transport may own workspace materialization on the runner.
     // Its initial handoff has no controller-local source path to validate yet;
     // requiring one here turns an accepted detached retry into a local failure.
-    if cook_attempt_needs_execution_with_store(&lifecycle_store, &options.initial_run_id)
+    if cook_attempt_needs_execution_with_store(lifecycle_store, &options.initial_run_id)
         && !cook_workspace_lookup_pending(&options.initial_plan)
         && options.attempt_dispatcher.is_none()
     {
@@ -4246,7 +4311,7 @@ where
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     if cook_workspace_lookup_pending(&options.initial_plan) {
         report_cook_progress(
-            &lifecycle_store,
+            lifecycle_store,
             durable_observer,
             &options.cook_id,
             &options.initial_run_id,
@@ -4351,7 +4416,7 @@ where
     // to be the first identity-bearing observer event, which put the operator
     // handle behind work that can outlive a client timeout (#10419, #9163).
     report_cook_progress(
-        &lifecycle_store,
+        lifecycle_store,
         durable_observer,
         &options.cook_id,
         &options.initial_run_id,
@@ -4453,7 +4518,7 @@ where
     if let Some(latest_attempt) = recipe.attempts.last() {
         materialize_cook_attempt_with_stores(
             store,
-            &lifecycle_store,
+            lifecycle_store,
             &recipe.cook_id,
             &latest_attempt.run_id,
             &latest_attempt.plan,
@@ -4469,7 +4534,7 @@ where
         ));
     }
     report_cook_progress(
-        &lifecycle_store,
+        lifecycle_store,
         durable_observer,
         &options.cook_id,
         &options.initial_run_id,
@@ -4509,7 +4574,7 @@ where
         .map(|attempt| attempt.attempt)
         .unwrap_or(1);
     let resumed_run_id = resumable_cook_run_id_in_store(
-        &lifecycle_store,
+        lifecycle_store,
         &recipe,
         &options.cook_id,
         &options.initial_run_id,
@@ -4574,7 +4639,7 @@ where
             Some(plan) => plan,
             None => lifecycle_store.read_controller_plan(&run_id)?,
         };
-        let needs_execution = cook_attempt_needs_execution_with_store(&lifecycle_store, &run_id);
+        let needs_execution = cook_attempt_needs_execution_with_store(lifecycle_store, &run_id);
         if needs_execution {
             // The local detached launcher persists this fence before spawn.
             // Recheck immediately before this attempt can publish provider work.
@@ -4586,7 +4651,7 @@ where
                 lifecycle_store.submit_plan_with_current_runtime(&plan, &run_id)?;
             }
             report_cook_progress(
-                &lifecycle_store,
+                lifecycle_store,
                 durable_observer,
                 &cook_id,
                 &run_id,
@@ -5021,7 +5086,7 @@ where
                 store.record_recipe_attempt_replacement(&cook_id, &run_id, &next_run_id)?;
                 materialize_cook_attempt_with_stores(
                     store,
-                    &lifecycle_store,
+                    lifecycle_store,
                     &cook_id,
                     &next_run_id,
                     &plan,
@@ -5311,7 +5376,7 @@ where
             ));
         }
         report_cook_progress(
-            &lifecycle_store,
+            lifecycle_store,
             durable_observer,
             &cook_id,
             &run_id,
@@ -5319,7 +5384,7 @@ where
             attempt,
             None,
         )?;
-        let mut promotion = match side_effects.promote(&lifecycle_store, &options, &run_id) {
+        let mut promotion = match side_effects.promote(lifecycle_store, &options, &run_id) {
             Ok(report) => report,
             Err(error) => {
                 attempts.push(AgentTaskCookAttemptReport {
@@ -5498,76 +5563,76 @@ where
                 let mut active_moving_base_recovery = None;
                 let promotion = match moving_base_recovery_for_run_with_stores(
                     store,
-                    &lifecycle_store,
+                    lifecycle_store,
                     &run_id,
                 )? {
-                    Some(recovery) => match side_effects.recover_moving_base(
-                        &lifecycle_store,
-                        &options,
-                        &recovery,
-                    ) {
-                        Ok(promotion) => {
-                            lifecycle_store.record_promotion(
-                                &run_id,
-                                serde_json::to_value(&promotion).map_err(|error| {
-                                    Error::internal_json(error.to_string(), None)
-                                })?,
-                            )?;
-                            let recovery = refreshed_moving_base_recovery(recovery, &promotion);
-                            lifecycle_store.record_cook_moving_base_recovery(
-                                &run_id,
-                                serde_json::to_value(&recovery).map_err(|error| {
-                                    Error::internal_json(error.to_string(), None)
-                                })?,
-                            )?;
-                            if promotion.status != AgentTaskPromotionStatus::Applied {
-                                let mut recovery = recovery;
-                                recovery.blocker = format!(
-                                    "rebased candidate did not pass the declared deterministic gates ({:?}); finalization was not attempted",
-                                    promotion.status
-                                );
+                    Some(recovery) => {
+                        match side_effects.recover_moving_base(lifecycle_store, &options, &recovery)
+                        {
+                            Ok(promotion) => {
+                                lifecycle_store.record_promotion(
+                                    &run_id,
+                                    serde_json::to_value(&promotion).map_err(|error| {
+                                        Error::internal_json(error.to_string(), None)
+                                    })?,
+                                )?;
+                                let recovery = refreshed_moving_base_recovery(recovery, &promotion);
                                 lifecycle_store.record_cook_moving_base_recovery(
                                     &run_id,
                                     serde_json::to_value(&recovery).map_err(|error| {
                                         Error::internal_json(error.to_string(), None)
                                     })?,
                                 )?;
+                                if promotion.status != AgentTaskPromotionStatus::Applied {
+                                    let mut recovery = recovery;
+                                    recovery.blocker = format!(
+                                    "rebased candidate did not pass the declared deterministic gates ({:?}); finalization was not attempted",
+                                    promotion.status
+                                );
+                                    lifecycle_store.record_cook_moving_base_recovery(
+                                        &run_id,
+                                        serde_json::to_value(&recovery).map_err(|error| {
+                                            Error::internal_json(error.to_string(), None)
+                                        })?,
+                                    )?;
+                                    return Ok(moving_base_recovery_report(
+                                        cook_id,
+                                        attempts,
+                                        recovery,
+                                        false,
+                                        Some(&run_id),
+                                    ));
+                                }
+                                active_moving_base_recovery = Some(recovery);
+                                promotion
+                            }
+                            Err(error) => {
+                                let recovery =
+                                    next_moving_base_recovery(recovery, error.to_string());
+                                lifecycle_store.record_cook_moving_base_recovery(
+                                    &run_id,
+                                    serde_json::to_value(&recovery).map_err(|error| {
+                                        Error::internal_json(error.to_string(), None)
+                                    })?,
+                                )?;
+                                if recovery.base_movements < 3 {
+                                    store.enqueue_terminal_continuation(&cook_id, &run_id)?;
+                                }
+                                let continuation_queued = recovery.base_movements < 3;
                                 return Ok(moving_base_recovery_report(
                                     cook_id,
                                     attempts,
                                     recovery,
-                                    false,
+                                    continuation_queued,
                                     Some(&run_id),
                                 ));
                             }
-                            active_moving_base_recovery = Some(recovery);
-                            promotion
                         }
-                        Err(error) => {
-                            let recovery = next_moving_base_recovery(recovery, error.to_string());
-                            lifecycle_store.record_cook_moving_base_recovery(
-                                &run_id,
-                                serde_json::to_value(&recovery).map_err(|error| {
-                                    Error::internal_json(error.to_string(), None)
-                                })?,
-                            )?;
-                            if recovery.base_movements < 3 {
-                                store.enqueue_terminal_continuation(&cook_id, &run_id)?;
-                            }
-                            let continuation_queued = recovery.base_movements < 3;
-                            return Ok(moving_base_recovery_report(
-                                cook_id,
-                                attempts,
-                                recovery,
-                                continuation_queued,
-                                Some(&run_id),
-                            ));
-                        }
-                    },
+                    }
                     None => promotion,
                 };
                 report_cook_progress(
-                    &lifecycle_store,
+                    lifecycle_store,
                     durable_observer,
                     &cook_id,
                     &run_id,
@@ -5576,7 +5641,7 @@ where
                     None,
                 )?;
                 let finalization =
-                    match side_effects.finalize(&lifecycle_store, &options, &run_id, &promotion) {
+                    match side_effects.finalize(lifecycle_store, &options, &run_id, &promotion) {
                         Ok(finalization) => {
                             if active_moving_base_recovery.is_some() {
                                 lifecycle_store.clear_cook_moving_base_recovery(&run_id)?;
@@ -5663,7 +5728,7 @@ where
                 if options.gates.accept_inherited_failures && promotion.finalization_eligible(true)
                 {
                     report_cook_progress(
-                        &lifecycle_store,
+                        lifecycle_store,
                         durable_observer,
                         &cook_id,
                         &run_id,
@@ -5672,7 +5737,7 @@ where
                         Some("accepted inherited baseline-red gate"),
                     )?;
                     let finalization =
-                        side_effects.finalize(&lifecycle_store, &options, &run_id, &promotion)?;
+                        side_effects.finalize(lifecycle_store, &options, &run_id, &promotion)?;
                     let final_status = finalization["status"]
                         .as_str()
                         .unwrap_or("unknown")
@@ -5778,7 +5843,7 @@ where
                 let review_form_only =
                     follow_up_request.inputs["cook_loop"]["review_form_required"] == true;
                 match dispatch_cook_follow_up(
-                    (store, &lifecycle_store),
+                    (store, lifecycle_store),
                     &options,
                     executor.clone(),
                     &cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1554,6 +1554,93 @@ fn pre_artifact_interruption_claim_isolated_store_pairs_recover_identical_ids() 
 }
 
 #[test]
+fn cook_spine_materializes_into_the_injected_stores_across_split_recipe_and_lifecycle_roots() {
+    let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(recipe_context.data_dir(), lifecycle_context.data_dir());
+
+    let recipe_store = CookRecipeStore::new(recipe_context.path_roots());
+    let lifecycle_store = AgentTaskLifecycleStore::new(lifecycle_context.path_roots());
+
+    let cook_id = "split-root-spine-cook";
+    let run_id = "split-root-spine-run";
+    let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.initial_run_id = run_id.to_string();
+    // The candidate-group preflight is the first purely local boundary the spine
+    // reaches after materialization, so an ambiguous candidate group stops this
+    // Cook exactly there. Everything past it — the runtime generation pin, the
+    // dispatch loop's controller-plan and attempt writes — still reaches
+    // process-global lifecycle state and is not part of this seam yet (#7505).
+    let mut sibling = options.initial_plan.tasks[0].clone();
+    sibling.task_id = "sibling".to_string();
+    options.initial_plan.tasks.push(sibling);
+
+    // Seed only the run record, in the lifecycle root, so materialization never
+    // needs the ambient controller-runtime admission lock. The recipe and the
+    // Cook index below are the spine's own writes.
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
+            Ok(serde_json::json!({}))
+        })
+        .expect("seed the run record in the lifecycle root");
+
+    let error = run_cook_with_boundaries_observed_inner_with_stores(
+        &recipe_store,
+        &lifecycle_store,
+        options,
+        UnusedExecutor,
+        DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+        None,
+        false,
+    )
+    .expect_err("the spine stops at its candidate-group preflight");
+    assert_eq!(error.details["field"], "group_key");
+
+    // The recipe landed under the recipe root.
+    assert!(recipe_store.recipe_exists(cook_id));
+    assert_eq!(
+        recipe_store
+            .load_recipe(cook_id)
+            .expect("read recipe in the recipe root")
+            .attempts[0]
+            .run_id,
+        run_id
+    );
+
+    // The run record and the Cook index landed under the lifecycle root.
+    assert_eq!(
+        lifecycle_store
+            .read_cook_index(cook_id)
+            .expect("read cook index in the lifecycle root")
+            .latest_run_id,
+        run_id
+    );
+    assert_eq!(
+        lifecycle_store
+            .read_record(run_id)
+            .expect("read run record in the lifecycle root")
+            .run_id,
+        run_id
+    );
+    assert!(lifecycle_store
+        .run_dir(run_id)
+        .starts_with(lifecycle_context.data_dir()));
+    assert!(lifecycle_store
+        .cook_index_path(cook_id)
+        .starts_with(lifecycle_context.data_dir()));
+
+    // The negatives: neither root holds the other's durable state, so the
+    // injected pair — not an ambient root — decided where every write went.
+    let recipe_root_lifecycle_store = AgentTaskLifecycleStore::new(recipe_context.path_roots());
+    assert!(!recipe_root_lifecycle_store
+        .record_exists(run_id)
+        .expect("no run record in the recipe root"));
+    assert!(!recipe_root_lifecycle_store.cook_index_exists(cook_id));
+    let lifecycle_root_recipe_store = CookRecipeStore::new(lifecycle_context.path_roots());
+    assert!(!lifecycle_root_recipe_store.recipe_exists(cook_id));
+}
+
+#[test]
 fn cook_service_retry_uses_the_same_passed_context_after_ambient_mutation() {
     let _env_lock = homeboy_core::test_support::env_lock();
     let prior = std::env::var_os(homeboy_core::observation::SOURCE_SNAPSHOT_METADATA_ENV);


### PR DESCRIPTION
## Summary

**The payoff slice of #7505.** Five PRs built to this point:

```
#12563  paired store entry points exist
#12565  Cook migrated onto them              ← shipped without a test
#12567  progress recorder rooted, RetryRequested shadow store removed
#12574  Cook's progress wrappers wired to it
#12582  the spine takes its store  +  THE TEST
```

#12565 could not carry a test because the spine manufactured its own lifecycle store. That is now a parameter, and the test exists.

## What changed

- `run_cook_with_boundaries_observed_inner_with_stores` takes both stores explicitly and owns the body
- `run_cook_with_boundaries_reported_with_stores` does the same for the caller that already held an explicit recipe store
- Both single-store forms remain as thin env-resolving wrappers
- `run_cook_with_boundaries_observed_inner` stays the env-resolving entry point, now resolving both stores in **one place** before delegating

## Verification that the parameter is actually honored

The whole spine body (lines 4128–5928) was scanned for `AgentTaskLifecycleStore::from_current_environment`, `CookRecipeStore::from_current_data_root`, and any store constructor of either type. **Zero matches.** #12567's removal of the `RetryRequested` shadow held, so the injected pair is honored on every path including retry.

The reported caller resolves through a `match` rather than `?`, so an unresolvable environment still lands in `durable_cook_error_report_with_store` exactly where the old line-4075 binding's failure landed — no observable behavior change.

## The test

`cook_spine_materializes_into_the_injected_stores_across_split_recipe_and_lifecycle_roots`

Two distinct `HermeticTestContext` roots, `path_roots()` only. **No `with_isolated_home`, no `HomeGuard`, no `set_var`.**

| assertion | root |
|---|---|
| recipe with `attempts[0].run_id` | recipe ✅ |
| Cook index `latest_run_id`, run record, `run_dir`, `cook_index_path` | lifecycle ✅ |
| lifecycle store on the **recipe** root: `record_exists`, `cook_index_exists` | **false** |
| recipe store on the **lifecycle** root: `recipe_exists` | **false** |

`UnusedExecutor` panics if reached, so it also proves no provider execution. All doubles reused (`batch_cook_options`, `AcceptedDetachedAttemptDispatcher`, `UnusedExecutor`, `DefaultCookSideEffects`) — none written.

The Cook index is the assertion that actually fails if the parameter is ignored.

## Two scoping limits, commented in the test

1. **The run record is seeded** through the lifecycle store, because materialization's submission branch reaches `controller_runtime::admit_current_for_with_cancellation_check`, which takes a process-global admission lock and writes `runtime_root()`. Same approach as `paired_stores_isolate_identical_ids_across_split_recipe_and_lifecycle_roots`.
2. **The Cook stops at `validate_cook_candidate_group`**, the first purely local boundary after materialization. Past it the spine reaches `agent_task_notify::cook_started`, `runtime_promotion::pin_cook_generation`, and the dispatch loop's `persist_controller_plan` / `record_cook_attempt` free functions.

## Named for the next slices

The spine still reaches process-global lifecycle state through **free functions** rather than store constructors — out of scope here, but now enumerated: `require_detached_cook_handoff_fence_open`, `agent_task_lifecycle::status`/`exact_record`, `record_pre_execution_failure`, `persist_controller_plan`, the free `record_cook_attempt`, `record_cook_supervision*`, `runtime_promotion::pin_cook_generation`, `paths::controller_scratch_store`, `agent_task_notify::*`. All sit after the materialization boundary except the fence/status probes, which swallow their errors and never write when the id is absent.

## Compatibility

No public API change — the spine and its callers are private to the module. No observable behavior change; the only difference is that a caller can supply the lifecycle store instead of having it manufactured.

Two mechanical notes for review: `lifecycle_store` went from an owned value to a reference, so 19 argument-position borrows were dropped to satisfy default-on `clippy::needless_borrow`; and the scoped-thread bindings are unchanged, since `&&T` coerces at the concrete call sites and is `Send` whenever `T: Sync`. The recipe-store parameter is still named `store`, matching every other `*_with_store` in this file, rather than renaming ~40 sites in an 1800-line body nothing can compile-check before CI.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and test authoring. Review by hand; compilation deferred to CI.

Refs #7505