### PR TITLE
Run audit detectors concurrently and report where the time went

### DIFF
--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -11,8 +11,9 @@ use super::doc_drift::detect_doc_drift;
 use super::reference::DeadCodeReferenceAnalysis;
 use super::{
     comment_hygiene, compiler_warnings, dead_code, fingerprint, shadow_modules, structural,
-    time_audit_detector, AuditExecutionPlan, AuditTiming, DetectorDescriptor, DetectorRuntime,
-    Finding, FingerprintDetectorRunner, GenericDetectorRunner, RootDetectorRunner,
+    time_audit_detector_isolated, AuditExecutionPlan, AuditTiming, AuditTimingSpan,
+    DetectorDescriptor, DetectorRuntime, Finding, FingerprintDetectorRunner, GenericDetectorRunner,
+    RootDetectorRunner,
 };
 use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::codebase_scan::CodebaseSnapshot;
@@ -226,6 +227,112 @@ fn extend_descriptor_findings(
     all_findings.extend(findings);
 }
 
+/// One descriptor's completed work, carried back from whichever worker thread
+/// ran it.
+///
+/// Findings and spans travel together and are replayed in descriptor-table order
+/// by [`merge_descriptor_outcomes`], so completion order never reaches the audit
+/// result or the timing report.
+pub(super) struct DescriptorOutcome {
+    descriptor: &'static DetectorDescriptor,
+    findings: Vec<Finding>,
+    spans: Vec<AuditTimingSpan>,
+}
+
+/// Run a single descriptor's detector, timed into its own span list.
+///
+/// Pure with respect to everything it touches: it reads the shared immutable
+/// [`DetectorRunContext`] and the plan, and returns owned findings. That is what
+/// makes the fan-out below safe without any locking around detector execution.
+fn run_one_descriptor(
+    plan: &AuditExecutionPlan,
+    descriptor: &'static DetectorDescriptor,
+    context: &DetectorRunContext<'_>,
+) -> DescriptorOutcome {
+    let enabled = plan.detector_enabled(descriptor.id);
+    let (findings, spans) = match descriptor.runtime {
+        DetectorRuntime::Generic(runner) => time_audit_detector_isolated(
+            descriptor.timing_id,
+            enabled,
+            || run_generic_descriptor(runner, context),
+            Vec::new,
+        ),
+        DetectorRuntime::Fingerprint(runner) => time_audit_detector_isolated(
+            descriptor.timing_id,
+            enabled,
+            || run_fingerprint_descriptor(runner, context),
+            Vec::new,
+        ),
+        DetectorRuntime::Root(runner) => time_audit_detector_isolated(
+            descriptor.timing_id,
+            enabled,
+            || run_root_descriptor(runner, context),
+            Vec::new,
+        ),
+        // Filtered out before dispatch by `selected_descriptors`.
+        DetectorRuntime::Manual => (Vec::new(), Vec::new()),
+    };
+
+    DescriptorOutcome {
+        descriptor,
+        findings,
+        spans,
+    }
+}
+
+/// The descriptors this dispatch will run, in descriptor-table order.
+///
+/// `ids = None` selects every data-driven detector (the full-discovery path);
+/// `ids = Some(subset)` selects only the listed detectors (the root-only fast
+/// path). `Manual` descriptors — the convention pipeline, the multi-pass
+/// duplication family, and artifact portability — are sequenced by hand in
+/// `engine.rs` and excluded here.
+fn selected_descriptors(ids: Option<&[&str]>) -> Vec<&'static DetectorDescriptor> {
+    AuditExecutionPlan::descriptors()
+        .iter()
+        .filter(|descriptor| !matches!(descriptor.runtime, DetectorRuntime::Manual))
+        .filter(|descriptor| ids.is_none_or(|ids| ids.contains(&descriptor.id)))
+        .collect()
+}
+
+/// Run the selected descriptor detectors CONCURRENTLY and return their outcomes
+/// in descriptor-table order.
+///
+/// The detectors are independent by construction — each reads the shared
+/// immutable [`DetectorRunContext`] and returns owned findings — and the
+/// descriptor table is the only thing that ever ordered them. Determinism is
+/// therefore preserved exactly: `map_parallel` discards completion order and
+/// returns one outcome per descriptor in table order, and each outcome carries its
+/// own spans, so [`merge_descriptor_outcomes`] can replay both without ever
+/// observing thread scheduling.
+///
+/// Split from the merge so a caller running this concurrently with other detector
+/// families can still emit ITS log lines in the original sequence: the findings
+/// logging happens in the merge, on the caller's thread, after the fan-out.
+pub(super) fn descriptor_detector_outcomes(
+    plan: &AuditExecutionPlan,
+    context: &DetectorRunContext<'_>,
+    ids: Option<&[&str]>,
+) -> Vec<DescriptorOutcome> {
+    let descriptors = selected_descriptors(ids);
+    super::parallel::map_parallel(&descriptors, |descriptor| {
+        run_one_descriptor(plan, descriptor, context)
+    })
+}
+
+/// Replay descriptor outcomes into the audit's timing report and findings vector,
+/// in the descriptor-table order they arrived in.
+pub(super) fn merge_descriptor_outcomes(
+    timing: &mut AuditTiming,
+    all_findings: &mut Vec<Finding>,
+    outcomes: Vec<DescriptorOutcome>,
+) {
+    for outcome in outcomes {
+        timing.spans.extend(outcome.spans);
+        extend_descriptor_findings(all_findings, outcome.descriptor, outcome.findings);
+    }
+}
+
 /// Drive the descriptor table. `ids = None` runs every data-driven detector
 /// (the full-discovery path); `ids = Some(subset)` runs only the listed
 /// detectors (the root-only fast path). `Manual` descriptors — the convention
@@ -238,39 +345,8 @@ pub(super) fn run_descriptor_detectors(
     context: &DetectorRunContext<'_>,
     ids: Option<&[&str]>,
 ) {
-    for descriptor in AuditExecutionPlan::descriptors() {
-        if let Some(ids) = ids {
-            if !ids.contains(&descriptor.id) {
-                continue;
-            }
-        }
-
-        let findings = match descriptor.runtime {
-            DetectorRuntime::Generic(runner) => time_audit_detector(
-                timing,
-                descriptor.timing_id,
-                plan.detector_enabled(descriptor.id),
-                || run_generic_descriptor(runner, context),
-                Vec::new,
-            ),
-            DetectorRuntime::Fingerprint(runner) => time_audit_detector(
-                timing,
-                descriptor.timing_id,
-                plan.detector_enabled(descriptor.id),
-                || run_fingerprint_descriptor(runner, context),
-                Vec::new,
-            ),
-            DetectorRuntime::Root(runner) => time_audit_detector(
-                timing,
-                descriptor.timing_id,
-                plan.detector_enabled(descriptor.id),
-                || run_root_descriptor(runner, context),
-                Vec::new,
-            ),
-            DetectorRuntime::Manual => continue,
-        };
-        extend_descriptor_findings(all_findings, descriptor, findings);
-    }
+    let outcomes = descriptor_detector_outcomes(plan, context, ids);
+    merge_descriptor_outcomes(timing, all_findings, outcomes);
 }
 
 #[cfg(test)]
@@ -281,6 +357,84 @@ mod tests {
         AggregateDefinitionFact, AggregateFieldFact, AggregateProjectionFact, DecisionBranchFact,
         FactLocation, PolicyDecisionSink, PolicyFlowConfig, PolicyFlowRule, ProjectionFieldFact,
     };
+
+    /// A directory containing a single file well past the structural line
+    /// threshold, so the `structural` detector emits exactly one `GodFile`.
+    fn god_file_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("{name}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut content = String::new();
+        for i in 0..1600 {
+            content.push_str(&format!("// line {i}\n"));
+        }
+        std::fs::write(dir.join("big.rs"), content).unwrap();
+        dir
+    }
+
+    /// Fingerprints that describe a policy aggregate, a lossy projection of it,
+    /// and the decision that consumes the projection.
+    fn policy_flow_fingerprints() -> Vec<fingerprint::FileFingerprint> {
+        let source = fingerprint::FileFingerprint {
+            relative_path: "src/policy.ext".to_string(),
+            aggregate_definitions: vec![AggregateDefinitionFact {
+                type_id: "domain::Policy".to_string(),
+                fields: vec![AggregateFieldFact {
+                    name: "threshold".to_string(),
+                    type_id: None,
+                }],
+                location: FactLocation { line: 1, column: 1 },
+            }],
+            ..Default::default()
+        };
+        let projection = fingerprint::FileFingerprint {
+            relative_path: "src/project.ext".to_string(),
+            aggregate_projections: vec![AggregateProjectionFact {
+                source_type_id: "domain::Policy".to_string(),
+                target_type_id: "domain::Carrier".to_string(),
+                callable_id: "domain::project".to_string(),
+                field_mappings: vec![ProjectionFieldFact {
+                    source_field: "id".to_string(),
+                    target_field: "id".to_string(),
+                }],
+                location: FactLocation { line: 4, column: 1 },
+            }],
+            ..Default::default()
+        };
+        let decision = fingerprint::FileFingerprint {
+            relative_path: "src/decide.ext".to_string(),
+            decision_branches: vec![DecisionBranchFact {
+                callable_id: "domain::decide".to_string(),
+                domain_type_id: "domain::Severity".to_string(),
+                discriminant_id: "severity".to_string(),
+                location: FactLocation { line: 7, column: 1 },
+            }],
+            ..Default::default()
+        };
+        vec![source, projection, decision]
+    }
+
+    /// The rule that makes [`policy_flow_fingerprints`] a lossy projection.
+    fn policy_flow_config() -> AuditConfig {
+        AuditConfig {
+            policy_flow: PolicyFlowConfig {
+                rules: vec![PolicyFlowRule {
+                    id: "policy".to_string(),
+                    source_type_id: "domain::Policy".to_string(),
+                    policy_fields: vec!["threshold".to_string()],
+                    authoritative_method_id: "domain::Policy::allows".to_string(),
+                    decision_sinks: vec![PolicyDecisionSink {
+                        carrier_type_id: "domain::Carrier".to_string(),
+                        callable_id: "domain::decide".to_string(),
+                        domain_type_id: "domain::Severity".to_string(),
+                    }],
+                    convention: "policy_flow".to_string(),
+                    severity: "warning".to_string(),
+                }],
+            },
+            ..Default::default()
+        }
+    }
 
     /// Only the three hand-sequenced families remain `Manual`; every other
     /// detector is dispatched through the data-driven runtime. This guards
@@ -305,18 +459,7 @@ mod tests {
     /// recorded — none of which touches a per-detector block.
     #[test]
     fn migrated_detector_runs_via_data_driven_dispatch() {
-        let dir = std::env::temp_dir().join(format!(
-            "homeboy_descriptor_dispatch_{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        // A god file well past the structural line threshold.
-        let mut content = String::new();
-        for i in 0..1600 {
-            content.push_str(&format!("// line {i}\n"));
-        }
-        std::fs::write(dir.join("big.rs"), content).unwrap();
+        let dir = god_file_dir("homeboy_descriptor_dispatch");
 
         // Confirm the descriptor is genuinely data-driven, not Manual.
         let structural = AuditExecutionPlan::descriptors()
@@ -376,61 +519,9 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
 
-        let source = fingerprint::FileFingerprint {
-            relative_path: "src/policy.ext".to_string(),
-            aggregate_definitions: vec![AggregateDefinitionFact {
-                type_id: "domain::Policy".to_string(),
-                fields: vec![AggregateFieldFact {
-                    name: "threshold".to_string(),
-                    type_id: None,
-                }],
-                location: FactLocation { line: 1, column: 1 },
-            }],
-            ..Default::default()
-        };
-        let projection = fingerprint::FileFingerprint {
-            relative_path: "src/project.ext".to_string(),
-            aggregate_projections: vec![AggregateProjectionFact {
-                source_type_id: "domain::Policy".to_string(),
-                target_type_id: "domain::Carrier".to_string(),
-                callable_id: "domain::project".to_string(),
-                field_mappings: vec![ProjectionFieldFact {
-                    source_field: "id".to_string(),
-                    target_field: "id".to_string(),
-                }],
-                location: FactLocation { line: 4, column: 1 },
-            }],
-            ..Default::default()
-        };
-        let decision = fingerprint::FileFingerprint {
-            relative_path: "src/decide.ext".to_string(),
-            decision_branches: vec![DecisionBranchFact {
-                callable_id: "domain::decide".to_string(),
-                domain_type_id: "domain::Severity".to_string(),
-                discriminant_id: "severity".to_string(),
-                location: FactLocation { line: 7, column: 1 },
-            }],
-            ..Default::default()
-        };
-        let fingerprints = [&source, &projection, &decision];
-        let audit_config = AuditConfig {
-            policy_flow: PolicyFlowConfig {
-                rules: vec![PolicyFlowRule {
-                    id: "policy".to_string(),
-                    source_type_id: "domain::Policy".to_string(),
-                    policy_fields: vec!["threshold".to_string()],
-                    authoritative_method_id: "domain::Policy::allows".to_string(),
-                    decision_sinks: vec![PolicyDecisionSink {
-                        carrier_type_id: "domain::Carrier".to_string(),
-                        callable_id: "domain::decide".to_string(),
-                        domain_type_id: "domain::Severity".to_string(),
-                    }],
-                    convention: "policy_flow".to_string(),
-                    severity: "warning".to_string(),
-                }],
-            },
-            ..Default::default()
-        };
+        let owned = policy_flow_fingerprints();
+        let fingerprints: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+        let audit_config = policy_flow_config();
         let context = DetectorRunContext {
             root: &dir,
             component_id: "fixture-component",
@@ -459,6 +550,69 @@ mod tests {
             .spans
             .iter()
             .any(|span| span.id == "detector.policy_flow" && span.status == "ok"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The detector fan-out must not leak thread scheduling into the audit's
+    /// output. Two detectors that both produce findings are dispatched together,
+    /// and BOTH the findings vector and the timing span list have to come back in
+    /// descriptor-table order — `structural` (table row 2) ahead of `policy_flow`
+    /// (table row 31) — on every run rather than on the lucky ones.
+    ///
+    /// The requested ids are deliberately passed in the OPPOSITE order to prove
+    /// the caller's argument order is not what produces the result order: the
+    /// descriptor table is, exactly as it was when the dispatch was a serial loop.
+    #[test]
+    fn parallel_dispatch_preserves_descriptor_table_order() {
+        let dir = god_file_dir("homeboy_descriptor_order");
+        let owned = policy_flow_fingerprints();
+        let fingerprints: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+        let audit_config = policy_flow_config();
+        let context = DetectorRunContext {
+            root: &dir,
+            component_id: "fixture-component",
+            audit_config: &audit_config,
+            all_fingerprints: &fingerprints,
+            per_file_fingerprints: &fingerprints,
+            policy_fingerprints: &fingerprints,
+            source_snapshot: None,
+            dead_code_references: None,
+        };
+        let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
+
+        // One pass can agree with the table by luck. Repeating it cannot.
+        for attempt in 0..25 {
+            let mut timing = AuditTiming::default();
+            let mut findings = Vec::new();
+            run_descriptor_detectors(
+                &plan,
+                &mut timing,
+                &mut findings,
+                &context,
+                Some(&["policy_flow", "structural"]),
+            );
+
+            let span_ids: Vec<&str> = timing.spans.iter().map(|span| span.id.as_str()).collect();
+            assert_eq!(
+                span_ids,
+                vec!["detector.structural", "detector.policy_flow"],
+                "attempt {attempt}: spans must follow descriptor-table order, not completion order"
+            );
+
+            let kinds: Vec<crate::AuditFinding> = findings
+                .iter()
+                .map(|finding| finding.kind.clone())
+                .collect();
+            assert_eq!(
+                kinds,
+                vec![
+                    crate::AuditFinding::GodFile,
+                    crate::AuditFinding::LossyPolicyProjection
+                ],
+                "attempt {attempt}: findings must be merged in descriptor-table order"
+            );
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -10,21 +10,34 @@
 //! they have a non-uniform shape — the convention pipeline, the multi-pass
 //! `duplication` family (five timing spans plus the `duplicate_groups` side
 //! output), and `artifact_portability` (logs scan statistics even when empty).
+//!
+//! The detector phase runs CONCURRENTLY (see `parallel`). Detectors are pure
+//! functions of an immutable corpus, so the only thing the serial loop ever
+//! provided was ordering — and ordering is now reimposed on the way out: every
+//! unit returns its findings and its timing spans, and the merge below replays
+//! them in the exact sequence the serial pipeline used. Reading the merge order in
+//! `audit_internal` is therefore still enough to know the output order.
 
 use std::collections::HashSet;
 use std::path::Path;
 
-use super::descriptor_runtime::{run_descriptor_detectors, DetectorRunContext};
+use super::descriptor_runtime::{
+    descriptor_detector_outcomes, merge_descriptor_outcomes, run_descriptor_detectors,
+    DetectorRunContext,
+};
 use super::detectors::{artifact_portability, source_policy};
 use super::entry::audit_config_for;
 use super::execution_plan::AuditExecutionPlan;
 use super::findings;
+use super::parallel::spawn_or_run;
 use super::reference::{build_convention_method_set, DeadCodeReferenceAnalysis};
 use super::types::{
-    time_audit_detector, AuditAnalysisContext, AuditSummary, AuditTiming, AuditWithAnalysis,
-    CodeAuditResult, ConventionReport, ScopedAuditExecution,
+    time_audit_detector, time_audit_detector_isolated, AuditAnalysisContext, AuditSummary,
+    AuditTiming, AuditTimingSpan, AuditWithAnalysis, CodeAuditResult, ConventionReport,
+    ScopedAuditExecution,
 };
 use super::{checks, conventions, discovery, duplication, fingerprint, impact, structural, walker};
+use homeboy_audit_contract::AuditConfig;
 use homeboy_engine_primitives::measurement::Measurement;
 use homeboy_error::Result;
 
@@ -100,6 +113,7 @@ pub(super) fn audit_internal(
             &mut timing,
         );
         timing.push_ok("detectors", detector_started.elapsed());
+        timing.log_detector_summary();
         return Ok(AuditWithAnalysis {
             result,
             analysis: AuditAnalysisContext::default(),
@@ -370,20 +384,41 @@ pub(super) fn audit_internal(
 
     // The duplication family stays hand-sequenced: it runs five timing spans and
     // also produces `duplicate_groups`, a side output threaded into the report.
-    let duplication_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.exact",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_duplicates(&all_fingerprints, &convention_methods),
-        Vec::new,
-    );
-    let duplicate_groups = time_audit_detector(
-        &mut timing,
-        "detector.duplication.groups",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_duplicate_groups(&all_fingerprints),
-        Vec::new,
-    );
+    //
+    // "Hand-sequenced" describes the REPORTING, which is still the fixed sequence
+    // of blocks below: each pass owns a distinct log line, and one pass produces
+    // `duplicate_groups`. The passes themselves are independent pure functions of
+    // the same immutable corpus, so `run_duplication_family` runs them
+    // concurrently and hands back one named output per pass.
+    //
+    // Those three families — duplication, the descriptor table, and artifact
+    // portability — are independent of each other too, so all three run
+    // concurrently and every output is merged afterwards in the original order.
+    // Nothing below can observe which unit finished first.
+    let (duplication_unit, descriptor_outcomes, artifact_portability_unit) =
+        std::thread::scope(|scope| {
+            let duplication = spawn_or_run(scope, || {
+                run_duplication_family(plan, &all_fingerprints, &convention_methods, &audit_config)
+            });
+            let artifact = spawn_or_run(scope, || {
+                run_artifact_portability(plan, component_id, &audit_config)
+            });
+
+            // Every other detector — structural, dead code, comment hygiene, the
+            // policy packs, the fingerprint/root families, etc. — is dispatched by
+            // the descriptor table in one pass. Adding a detector is a descriptor
+            // row plus a `run_generic_descriptor` arm, never a new block here.
+            let descriptor_outcomes = descriptor_detector_outcomes(plan, &detector_context, None);
+
+            (duplication.join(), descriptor_outcomes, artifact.join())
+        });
+
+    // Merge order below is the pre-parallel execution order, span for span and
+    // finding for finding: the duplication passes in their fixed sequence, then the
+    // descriptor table in descriptor order, then artifact portability.
+    timing.spans.extend(duplication_unit.spans);
+    let duplicate_groups = duplication_unit.groups;
+    let duplication_findings = duplication_unit.exact;
     if !duplication_findings.is_empty() {
         log_status!(
             "audit",
@@ -395,13 +430,7 @@ pub(super) fn audit_internal(
     }
 
     // Phase 4c2: Intra-method duplication (duplicated blocks within a single method)
-    let intra_dup_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.intra_method",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_intra_method_duplicates(&all_fingerprints),
-        Vec::new,
-    );
+    let intra_dup_findings = duplication_unit.intra_method;
     if !intra_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -412,13 +441,7 @@ pub(super) fn audit_internal(
     }
 
     // Phase 4d: Near-duplicate detection (structural similarity)
-    let near_dup_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.near_duplicate",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_near_duplicates(&all_fingerprints),
-        Vec::new,
-    );
+    let near_dup_findings = duplication_unit.near_duplicate;
     if !near_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -432,13 +455,7 @@ pub(super) fn audit_internal(
     // The exact/near-duplicate detectors key on the method name, so a shared
     // primitive reimplemented under a local name is invisible to them. This pass
     // groups bodies by hash regardless of name.
-    let cross_name_dup_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.cross_name_duplicate",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_cross_name_duplicates(&all_fingerprints),
-        Vec::new,
-    );
+    let cross_name_dup_findings = duplication_unit.cross_name;
     if !cross_name_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -452,13 +469,7 @@ pub(super) fn audit_internal(
     // error/return tail). The near-duplicate pass still encodes each expression's
     // shape, so a primitive reimplemented with a different local error type hashes
     // apart. This coarser pass keys on the call/keyword skeleton and catches those.
-    let skeleton_dup_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.skeleton_duplicate",
-        plan.detector_enabled("duplication"),
-        || duplication::detect_skeleton_duplicates(&all_fingerprints),
-        Vec::new,
-    );
+    let skeleton_dup_findings = duplication_unit.skeleton;
     if !skeleton_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -469,19 +480,7 @@ pub(super) fn audit_internal(
     }
 
     // Phase 4d2: Parallel implementation detection (similar call patterns across files)
-    let parallel_findings = time_audit_detector(
-        &mut timing,
-        "detector.duplication.parallel_implementation",
-        plan.detector_enabled("duplication"),
-        || {
-            duplication::detect_parallel_implementations(
-                &all_fingerprints,
-                &convention_methods,
-                &audit_config.duplication_detector,
-            )
-        },
-        Vec::new,
-    );
+    let parallel_findings = duplication_unit.parallel_implementation;
     if !parallel_findings.is_empty() {
         log_status!(
             "audit",
@@ -491,36 +490,12 @@ pub(super) fn audit_internal(
         all_findings.extend(parallel_findings);
     }
 
-    // Every other detector — structural, dead code, comment hygiene, the policy
-    // packs, the fingerprint/root families, etc. — is dispatched by the
-    // descriptor table in one pass. Adding a detector is a descriptor row plus a
-    // `run_generic_descriptor` arm, never a new block here.
-    run_descriptor_detectors(
-        plan,
-        &mut timing,
-        &mut all_findings,
-        &detector_context,
-        None,
-    );
+    merge_descriptor_outcomes(&mut timing, &mut all_findings, descriptor_outcomes);
 
     // `artifact_portability` stays hand-sequenced: it logs scan statistics (runs,
     // artifacts, metadata fields) even when it produces no findings.
-    let artifact_portability_report = time_audit_detector(
-        &mut timing,
-        "detector.artifact_portability",
-        plan.detector_enabled("artifact_portability"),
-        || {
-            if audit_config.artifact_portability.is_empty() {
-                artifact_portability::run_report(component_id)
-            } else {
-                artifact_portability::run_report_with_config(
-                    component_id,
-                    &audit_config.artifact_portability,
-                )
-            }
-        },
-        Default::default,
-    );
+    timing.spans.extend(artifact_portability_unit.spans);
+    let artifact_portability_report = artifact_portability_unit.report;
     if plan.detector_enabled("artifact_portability") {
         log_status!(
             "audit",
@@ -541,6 +516,7 @@ pub(super) fn audit_internal(
         all_findings.extend(artifact_portability_findings);
     }
     timing.push_ok("detectors", detectors_started.elapsed());
+    timing.log_detector_summary();
 
     // Phase 4p: Impact-scoped filtering — when auditing changed files only,
     // filter findings down to the touched scope (changed files + impact call
@@ -683,6 +659,177 @@ pub(super) fn audit_internal(
         analysis,
         timing,
     })
+}
+
+/// The duplication family's completed work: one named output per pass, plus the
+/// passes' timing spans in pass order.
+///
+/// Naming each output rather than returning a flat `Vec<Finding>` is what lets
+/// the passes run concurrently while the reporting in `audit_internal` stays in
+/// its original fixed order — each pass has its own log line, and
+/// `detect_duplicate_groups` produces `duplicate_groups`, a side output the report
+/// carries separately from the findings.
+struct DuplicationUnit {
+    spans: Vec<AuditTimingSpan>,
+    exact: Vec<findings::Finding>,
+    groups: Vec<duplication::DuplicateGroup>,
+    intra_method: Vec<findings::Finding>,
+    near_duplicate: Vec<findings::Finding>,
+    cross_name: Vec<findings::Finding>,
+    skeleton: Vec<findings::Finding>,
+    parallel_implementation: Vec<findings::Finding>,
+}
+
+/// Run the duplication family's seven passes concurrently.
+///
+/// Every pass is a pure function of the same two immutable inputs — the
+/// convention fingerprint corpus and the convention method set — and returns an
+/// owned vector. There is no data dependency between them, not even between
+/// `detect_duplicates` and `detect_duplicate_groups`, which each rebuild their own
+/// grouping. So the family's "hand-sequenced" shape was never a sequencing
+/// requirement, only a reporting one.
+///
+/// Units are started in pass order and joined in pass order, and the spans are
+/// concatenated in that same order, so the timing report is identical to the
+/// serial one span for span. Under
+/// `HOMEBOY_AUDIT_DETECTOR_THREADS=1`, `spawn_or_run` runs each pass inline at its
+/// start point, which reproduces the original serial execution exactly.
+fn run_duplication_family(
+    plan: &AuditExecutionPlan,
+    all_fingerprints: &[&fingerprint::FileFingerprint],
+    convention_methods: &HashSet<String>,
+    audit_config: &AuditConfig,
+) -> DuplicationUnit {
+    let enabled = plan.detector_enabled("duplication");
+
+    std::thread::scope(|scope| {
+        let exact = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.exact",
+                enabled,
+                || duplication::detect_duplicates(all_fingerprints, convention_methods),
+                Vec::new,
+            )
+        });
+        let groups = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.groups",
+                enabled,
+                || duplication::detect_duplicate_groups(all_fingerprints),
+                Vec::new,
+            )
+        });
+        let intra_method = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.intra_method",
+                enabled,
+                || duplication::detect_intra_method_duplicates(all_fingerprints),
+                Vec::new,
+            )
+        });
+        let near_duplicate = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.near_duplicate",
+                enabled,
+                || duplication::detect_near_duplicates(all_fingerprints),
+                Vec::new,
+            )
+        });
+        let cross_name = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.cross_name_duplicate",
+                enabled,
+                || duplication::detect_cross_name_duplicates(all_fingerprints),
+                Vec::new,
+            )
+        });
+        let skeleton = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.skeleton_duplicate",
+                enabled,
+                || duplication::detect_skeleton_duplicates(all_fingerprints),
+                Vec::new,
+            )
+        });
+        let parallel_implementation = spawn_or_run(scope, || {
+            time_audit_detector_isolated(
+                "detector.duplication.parallel_implementation",
+                enabled,
+                || {
+                    duplication::detect_parallel_implementations(
+                        all_fingerprints,
+                        convention_methods,
+                        &audit_config.duplication_detector,
+                    )
+                },
+                Vec::new,
+            )
+        });
+
+        let (exact, exact_spans) = exact.join();
+        let (groups, groups_spans) = groups.join();
+        let (intra_method, intra_method_spans) = intra_method.join();
+        let (near_duplicate, near_duplicate_spans) = near_duplicate.join();
+        let (cross_name, cross_name_spans) = cross_name.join();
+        let (skeleton, skeleton_spans) = skeleton.join();
+        let (parallel_implementation, parallel_implementation_spans) =
+            parallel_implementation.join();
+
+        let mut spans = Vec::new();
+        spans.extend(exact_spans);
+        spans.extend(groups_spans);
+        spans.extend(intra_method_spans);
+        spans.extend(near_duplicate_spans);
+        spans.extend(cross_name_spans);
+        spans.extend(skeleton_spans);
+        spans.extend(parallel_implementation_spans);
+
+        DuplicationUnit {
+            spans,
+            exact,
+            groups,
+            intra_method,
+            near_duplicate,
+            cross_name,
+            skeleton,
+            parallel_implementation,
+        }
+    })
+}
+
+/// `artifact_portability`'s completed work: the scan report it logs statistics
+/// from, plus its timing span.
+struct ArtifactPortabilityUnit {
+    spans: Vec<AuditTimingSpan>,
+    report: artifact_portability::ArtifactPortabilityReport,
+}
+
+/// Run `artifact_portability` into its own timing span so it can execute
+/// concurrently with the other detector families. The scan-statistics logging
+/// stays with the caller, which is what keeps the log lines in their original
+/// order.
+fn run_artifact_portability(
+    plan: &AuditExecutionPlan,
+    component_id: &str,
+    audit_config: &AuditConfig,
+) -> ArtifactPortabilityUnit {
+    let (report, spans) = time_audit_detector_isolated(
+        "detector.artifact_portability",
+        plan.detector_enabled("artifact_portability"),
+        || {
+            if audit_config.artifact_portability.is_empty() {
+                artifact_portability::run_report(component_id)
+            } else {
+                artifact_portability::run_report_with_config(
+                    component_id,
+                    &audit_config.artifact_portability,
+                )
+            }
+        },
+        Default::default,
+    );
+
+    ArtifactPortabilityUnit { spans, report }
 }
 
 /// Build the shared audit source snapshot consumed by whole-tree detectors.

--- a/crates/homeboy-code-audit/src/lib.rs
+++ b/crates/homeboy-code-audit/src/lib.rs
@@ -43,6 +43,7 @@ mod idiomatic;
 pub(crate) mod impact;
 pub(crate) mod import_matching;
 pub mod naming;
+pub(crate) mod parallel;
 pub mod recorded_artifacts;
 pub mod report;
 mod requirements;
@@ -97,7 +98,7 @@ pub use entry::{
 pub(crate) use entry::{
     audit_path_scoped_with_plan_and_analysis, audit_path_with_id_with_plan_and_analysis,
 };
-pub(crate) use types::{time_audit_detector, AuditAnalysisContext, AuditWithAnalysis};
+pub(crate) use types::{time_audit_detector_isolated, AuditAnalysisContext, AuditWithAnalysis};
 pub use types::{
     AuditSummary, AuditTiming, AuditTimingSpan, CodeAuditResult, ConventionReport,
     DirectoryConvention, DirectoryOutlier,

--- a/crates/homeboy-code-audit/src/parallel.rs
+++ b/crates/homeboy-code-audit/src/parallel.rs
@@ -1,0 +1,262 @@
+//! Deterministic scoped-thread fan-out for the audit's independent detectors.
+//!
+//! Audit detectors are independent by construction: each one is a pure function
+//! of an immutable corpus (`&[&FileFingerprint]`, a `CodebaseSnapshot`, the
+//! resolved `AuditConfig`) and returns an owned `Vec<Finding>`. Nothing in the
+//! detector phase mutates shared state, so the phase was serial only because it
+//! was written as a loop.
+//!
+//! `std::thread::scope` is used rather than a work-stealing crate deliberately:
+//! it needs no new dependency (so no `Cargo.lock` churn on a `--locked` CI
+//! build), it lets the detectors keep borrowing the corpora that live on the
+//! caller's stack, and the fan-out shape here is one flat batch of independent
+//! jobs — the case scoped threads handle without ceremony.
+//!
+//! The contract that matters for the audit is DETERMINISM: [`map_parallel`]
+//! returns its outputs in job order, never completion order, so no caller can
+//! observe thread scheduling in a findings vector or a timing report.
+//!
+//! One thing the fan-out does change is progress LOGGING. `time_audit_detector`'s
+//! `Running …` / `Completed … in Nms` lines are emitted from the worker threads as
+//! work happens, so they interleave: each `eprintln!` is atomic, but a `Running`
+//! line no longer sits next to its own `Completed` line.
+//! `AuditTiming::log_detector_summary` is the ordered, ranked view that replaces
+//! reading those lines top to bottom.
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::thread::ScopedJoinHandle;
+
+/// Operator override for the detector worker count. `1` forces the original
+/// serial execution, which is the first thing to try when a detector is
+/// suspected of being order- or concurrency-sensitive.
+const WORKER_COUNT_ENV: &str = "HOMEBOY_AUDIT_DETECTOR_THREADS";
+
+/// Run `run` over every job concurrently and return the outputs **in job
+/// order**, regardless of completion order.
+///
+/// Jobs are handed out through a shared cursor rather than pre-partitioned
+/// because detector costs are wildly uneven — one duplication pass can outweigh
+/// thirty per-file scanners — and a static split would leave workers idle behind
+/// the slowest chunk.
+///
+/// The caller participates as one of the workers, so an `n`-job batch on `n`-way
+/// parallelism spawns `n - 1` threads rather than `n`.
+///
+/// Bounds worth stating explicitly, because scoped threads only compile when
+/// they hold: `J: Sync` is what makes `&jobs` sendable to a worker, `F: Sync` is
+/// what makes `&run` sendable, and `R: Send` is what lets a completed output
+/// move back to the caller through the collector.
+pub(crate) fn map_parallel<J, R, F>(jobs: &[J], run: F) -> Vec<R>
+where
+    J: Sync,
+    R: Send,
+    F: Fn(&J) -> R + Sync,
+{
+    let workers = worker_count(jobs.len());
+    if workers <= 1 {
+        return jobs.iter().map(run).collect();
+    }
+
+    let cursor = AtomicUsize::new(0);
+    let collected: Mutex<Vec<(usize, R)>> = Mutex::new(Vec::with_capacity(jobs.len()));
+
+    std::thread::scope(|scope| {
+        let helpers: Vec<_> = (1..workers)
+            .map(|_| scope.spawn(|| drain_jobs(jobs, &run, &cursor, &collected)))
+            .collect();
+        // The caller is a worker too, so a batch never costs an idle thread.
+        drain_jobs(jobs, &run, &cursor, &collected);
+        for helper in helpers {
+            join_scoped(helper);
+        }
+    });
+
+    let mut collected = collected
+        .into_inner()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // The single point where completion order is discarded. Job indices are
+    // unique, so this total order is exact — not a tie-broken approximation.
+    collected.sort_by_key(|(index, _)| *index);
+    collected.into_iter().map(|(_, output)| output).collect()
+}
+
+/// Take jobs from the shared cursor until the batch is exhausted, tagging each
+/// output with the index it came from.
+///
+/// `run` is called OUTSIDE the collector lock: the lock is held only for the
+/// push, so two detectors never serialize against each other.
+fn drain_jobs<J, R, F>(
+    jobs: &[J],
+    run: &F,
+    cursor: &AtomicUsize,
+    collected: &Mutex<Vec<(usize, R)>>,
+) where
+    J: Sync,
+    R: Send,
+    F: Fn(&J) -> R + Sync,
+{
+    loop {
+        let index = cursor.fetch_add(1, Ordering::Relaxed);
+        let Some(job) = jobs.get(index) else {
+            break;
+        };
+        let output = run(job);
+        lock(collected).push((index, output));
+    }
+}
+
+/// A unit of work that either already ran on the caller's thread or is running on
+/// a scoped worker.
+///
+/// This exists so a fan-out site keeps ONE code path across the concurrent mode
+/// and the `HOMEBOY_AUDIT_DETECTOR_THREADS=1` serial mode: the site always writes
+/// `spawn_or_run(...)` and later `join()`, and only the scheduling differs. A
+/// hand-written second serial branch would be a place for the two modes to drift
+/// apart — and the whole value of the escape hatch is that the serial mode is a
+/// faithful reference for the concurrent one.
+pub(crate) enum ScopedUnit<'scope, T> {
+    /// Already computed inline, because concurrency is disabled.
+    Ready(T),
+    /// Running on a scoped worker thread.
+    Running(ScopedJoinHandle<'scope, T>),
+}
+
+impl<T> ScopedUnit<'_, T> {
+    /// Take the unit's output, waiting for its worker when there is one.
+    pub(crate) fn join(self) -> T {
+        match self {
+            Self::Ready(value) => value,
+            Self::Running(handle) => join_scoped(handle),
+        }
+    }
+}
+
+/// Start `run` on `scope`, or run it inline when detector concurrency is
+/// disabled.
+///
+/// In the inline case the work happens at the call site, so a site that starts
+/// its units in a fixed order and joins them in that same order executes exactly
+/// the sequence it did before this fan-out existed.
+pub(crate) fn spawn_or_run<'scope, 'env, T, F>(
+    scope: &'scope std::thread::Scope<'scope, 'env>,
+    run: F,
+) -> ScopedUnit<'scope, T>
+where
+    F: FnOnce() -> T + Send + 'scope,
+    T: Send + 'scope,
+{
+    if concurrency_enabled() {
+        ScopedUnit::Running(scope.spawn(run))
+    } else {
+        ScopedUnit::Ready(run())
+    }
+}
+
+/// Whether the detector phase may fan out at all.
+///
+/// Honors the same `HOMEBOY_AUDIT_DETECTOR_THREADS` override as
+/// [`map_parallel`], so setting it to `1` restores fully serial execution across
+/// every fan-out site rather than just this module's job pool.
+pub(crate) fn concurrency_enabled() -> bool {
+    worker_count(2) > 1
+}
+
+/// Join a scoped worker, re-raising its panic in the caller.
+///
+/// A detector panic used to abort the audit immediately; propagating the payload
+/// keeps that observable behavior (same panic, same message, non-zero exit)
+/// instead of silently swallowing it into a `Result`.
+pub(crate) fn join_scoped<T>(handle: ScopedJoinHandle<'_, T>) -> T {
+    match handle.join() {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+/// Lock the collector, tolerating poisoning.
+///
+/// A poisoned collector means another worker panicked while pushing. That panic
+/// is already on its way to the caller via [`join_scoped`], so refusing the lock
+/// here would only replace a real diagnosis with a secondary one.
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Worker count for a batch of `job_count` jobs: never more workers than jobs,
+/// never more than the machine's available parallelism, and always at least one
+/// for a non-empty batch.
+fn worker_count(job_count: usize) -> usize {
+    if job_count <= 1 {
+        return job_count;
+    }
+
+    let requested = std::env::var(WORKER_COUNT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(NonZeroUsize::get)
+                .unwrap_or(1)
+        });
+
+    requested.clamp(1, job_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one property every caller depends on: outputs come back in job order
+    /// even though the jobs finish in a different order. The reversed sleep makes
+    /// late jobs finish first, so a collection-order implementation fails this
+    /// rather than passing by luck.
+    #[test]
+    fn outputs_are_returned_in_job_order_not_completion_order() {
+        let jobs: Vec<u64> = (0..16).collect();
+        let outputs = map_parallel(&jobs, |job| {
+            std::thread::sleep(std::time::Duration::from_millis(16 - *job));
+            *job * 10
+        });
+
+        assert_eq!(
+            outputs,
+            (0..16).map(|job| job * 10).collect::<Vec<u64>>(),
+            "map_parallel must discard completion order"
+        );
+    }
+
+    /// Repeating the fan-out must produce identical output. A single run can pass
+    /// by scheduling luck; a hundred cannot.
+    #[test]
+    fn repeated_runs_are_identical() {
+        let jobs: Vec<u32> = (0..32).collect();
+        let expected: Vec<u32> = jobs.iter().map(|job| job * job).collect();
+
+        for _ in 0..100 {
+            assert_eq!(map_parallel(&jobs, |job| job * job), expected);
+        }
+    }
+
+    #[test]
+    fn empty_and_single_job_batches_run_inline() {
+        let empty: Vec<usize> = Vec::new();
+        assert!(map_parallel(&empty, |job: &usize| *job).is_empty());
+        assert_eq!(worker_count(0), 0);
+        assert_eq!(worker_count(1), 1);
+
+        assert_eq!(map_parallel(&[7usize], |job| *job + 1), vec![8]);
+    }
+
+    #[test]
+    fn worker_count_never_exceeds_job_count() {
+        for job_count in 2..8 {
+            assert!(worker_count(job_count) <= job_count);
+            assert!(worker_count(job_count) >= 1);
+        }
+    }
+}

--- a/crates/homeboy-code-audit/src/types.rs
+++ b/crates/homeboy-code-audit/src/types.rs
@@ -96,6 +96,126 @@ impl AuditTiming {
                 .map(AuditTimingSpan::from),
         );
     }
+
+    /// Emit the recorded detector spans to stderr, slowest first.
+    ///
+    /// These spans were already collected and already serialized — the audit
+    /// result carries them as `timing.spans[]` (see
+    /// [`AuditCommandOutput`](crate::report::AuditCommandOutput)) and the CLI
+    /// copies them into observation metadata as `timing.spans`. Both are
+    /// post-mortem artifacts: when the detector phase overruns its CI budget the
+    /// run is cancelled and neither is ever written, which is how a 507-second
+    /// audit managed to report nothing at all about where the 507 seconds went
+    /// (#12583). This prints as soon as the phase ends, on the stream an operator
+    /// is already watching.
+    ///
+    /// Deliberately `eprintln!` rather than `log_status!`: that macro is gated on
+    /// stderr being a terminal (see `audit_log.rs`), and CI — the one place this
+    /// measurement is needed — is never a terminal. The `[audit] ` prefix and
+    /// phrasing match `log_status!("audit", ...)` so the lines read identically
+    /// alongside the rest of the audit's progress output, and it matches how
+    /// [`time_audit_detector`] already emits its per-detector lines.
+    ///
+    /// Only `detector.*` spans are ranked. The coarse phases
+    /// (`discovery_fingerprinting`, `detectors`, `report`) are aggregates that
+    /// contain the detector spans, so mixing them into one ranking would
+    /// double-count. The `detectors` aggregate is reported separately as the
+    /// phase's wall time, which is what the CI budget is spent against.
+    pub(crate) fn log_detector_summary(&self) {
+        let mut ranked: Vec<(&str, f64)> = self
+            .spans
+            .iter()
+            .filter(|span| span.id.starts_with(DETECTOR_SPAN_PREFIX))
+            .filter_map(|span| span.duration_ms.map(|ms| (span.id.as_str(), ms)))
+            .collect();
+        if ranked.is_empty() {
+            return;
+        }
+
+        let skipped = self
+            .spans
+            .iter()
+            .filter(|span| span.id.starts_with(DETECTOR_SPAN_PREFIX) && span.status == "skipped")
+            .count();
+        // Duration descending, then id ascending. The id tiebreak is what keeps
+        // the ranking stable when several detectors report the same duration —
+        // without it, equal-cost spans would order by whichever thread happened
+        // to record first.
+        ranked.sort_by(|left, right| right.1.total_cmp(&left.1).then_with(|| left.0.cmp(right.0)));
+
+        let summed: f64 = ranked.iter().map(|(_, ms)| *ms).sum();
+        let wall = self
+            .spans
+            .iter()
+            .rev()
+            .find(|span| span.id == DETECTOR_PHASE_SPAN_ID)
+            .and_then(|span| span.duration_ms);
+
+        match wall {
+            // `summed` exceeding `wall` is the expected shape once detectors run
+            // concurrently, and the gap between the two IS the parallel speedup.
+            Some(wall) => eprintln!(
+                "[audit] Detector timing: {} wall, {} summed across {} span(s) ({} skipped)",
+                format_millis(wall),
+                format_millis(summed),
+                ranked.len(),
+                skipped
+            ),
+            None => eprintln!(
+                "[audit] Detector timing: {} summed across {} span(s) ({} skipped)",
+                format_millis(summed),
+                ranked.len(),
+                skipped
+            ),
+        }
+
+        for (rank, (id, ms)) in ranked.iter().take(DETECTOR_SUMMARY_TOP_N).enumerate() {
+            eprintln!(
+                "[audit] Detector timing:   {}. {} {}",
+                rank + 1,
+                id,
+                format_millis(*ms)
+            );
+        }
+
+        let remaining = ranked.len().saturating_sub(DETECTOR_SUMMARY_TOP_N);
+        if remaining > 0 {
+            let tail: f64 = ranked
+                .iter()
+                .skip(DETECTOR_SUMMARY_TOP_N)
+                .map(|(_, ms)| *ms)
+                .sum();
+            eprintln!(
+                "[audit] Detector timing:   + {remaining} more span(s), {} total",
+                format_millis(tail)
+            );
+        }
+    }
+}
+
+/// Timing-id prefix every per-detector span shares.
+const DETECTOR_SPAN_PREFIX: &str = "detector.";
+
+/// Timing id of the aggregate span covering the whole detector phase.
+const DETECTOR_PHASE_SPAN_ID: &str = "detectors";
+
+/// How many detector spans [`AuditTiming::log_detector_summary`] names
+/// individually. The full audit records 40+ detector spans; one line each would
+/// bury the hotspot the summary exists to expose, so the slowest few are named
+/// and the rest are totalled on one line. Every span is still in the result JSON.
+const DETECTOR_SUMMARY_TOP_N: usize = 8;
+
+/// Render a fractional-millisecond duration at a scale an operator can read:
+/// seconds once a span is expensive enough to matter to a phase budget, and a
+/// decimal below 10ms so a sub-millisecond detector does not read as `0ms`.
+fn format_millis(millis: f64) -> String {
+    if millis >= 1000.0 {
+        format!("{:.1}s", millis / 1000.0)
+    } else if millis >= 10.0 {
+        format!("{millis:.0}ms")
+    } else {
+        format!("{millis:.1}ms")
+    }
 }
 
 #[derive(Debug)]
@@ -155,6 +275,26 @@ pub(crate) fn time_audit_detector<T>(
         timing.push_skipped(id);
         skipped()
     }
+}
+
+/// [`time_audit_detector`] against a private timing report, returning the
+/// detector's value together with the spans recorded for it.
+///
+/// This is what lets a detector run on a worker thread. `&mut AuditTiming` is a
+/// single mutable borrow and cannot be shared across threads; a `Mutex` around it
+/// would compile but would make span ORDER depend on completion order, which is
+/// exactly the nondeterminism the parallel detector phase must not introduce.
+/// Handing each detector its own report and concatenating the spans afterwards in
+/// a fixed order keeps the timing report byte-identical to the serial one.
+pub(crate) fn time_audit_detector_isolated<T>(
+    id: &'static str,
+    enabled: bool,
+    run: impl FnOnce() -> T,
+    skipped: impl FnOnce() -> T,
+) -> (T, Vec<AuditTimingSpan>) {
+    let mut timing = AuditTiming::default();
+    let value = time_audit_detector(&mut timing, id, enabled, run, skipped);
+    (value, timing.spans)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

First half of #12583. Audit takes **507s**, blows its 300s phase budget, and emits nothing but heartbeats for eight minutes. The crate had **zero** parallelism while its detectors are independent by construction.

Two coupled changes — parallelizing changes how timing must be collected, so they belong together.

## The measurement was already there, just unreachable

`AuditTiming` already flows to `timing.spans` on the audit envelope and into observation metadata. Both are **post-mortem artifacts** — when the phase overruns and the run is cancelled, neither is ever written. That is exactly why 507 seconds produced no information.

`AuditTiming::log_detector_summary` now ranks `detector.*` spans by duration after the detector phase:

```
[audit] Detector timing: 228.9s wall, 396.3s summed across 11 span(s) (1 skipped)
[audit] Detector timing:   1. detector.duplication.near_duplicate 214.3s
[audit] Detector timing:   2. detector.dead_code 91.4s
...
[audit] Detector timing:   + 3 more span(s), 137ms total
```

Only `detector.*` is ranked — the coarse `detectors` / `discovery_fingerprinting` / `report` spans are aggregates *containing* them and would double-count.

<h3>The finding worth its own attention</h3>

**`log_status!` is gated on `IsTerminal::is_terminal(&stderr())`.** In CI stderr is a pipe, so **every existing `log_status!("audit", …)` line emits nothing.** That gate is itself a large part of the eight minutes of silence.

So this summary uses `eprintln!` with the same `[audit] ` prefix and phrasing, matching how `time_audit_detector` already emits unconditionally. Routing a measurement through that gate would have shipped something invisible in the only place it is needed. Reasoning is in the doc comment.

## Parallelism: `std::thread::scope`, not rayon

`rayon` is not in `[workspace.dependencies]` (no such section exists), not in any sibling crate, and **not in `Cargo.lock`**. CI builds `--locked`, so adding it would fail. New `parallel.rs` uses `std::thread::scope` with shared-cursor work handout where the caller participates as a worker, and one code path across concurrent and serial mode. **`Cargo.toml` and `Cargo.lock` untouched.**

`HOMEBOY_AUDIT_DETECTOR_THREADS=1` restores fully serial execution.

| concurrent | sequential |
|---|---|
| all ~34 descriptor-table detectors | discovery / fingerprinting |
| the 7 duplication passes | convention discovery + method set |
| artifact portability | `DeadCodeReferenceAnalysis::build` |
| …and those three families with each other | Phase 4b2 scope computation |

The seven duplication passes are independent pure functions of the same immutable inputs — `detect_duplicates` and `detect_duplicate_groups` each rebuild their own grouping, so there is no data dependency. **`duplication.rs` is untouched**; existing entry points are called unchanged.

## Determinism is preserved by construction, not luck

No unit shares `&mut AuditTiming`. Each returns its spans, merged in fixed order after the join. A `Mutex<AuditTiming>` would compile and make span order depend on **completion** order — deliberately avoided.

- **Span order** — descriptor spans replayed in descriptor-table order, duplication spans in fixed pass order, then artifact portability. Byte-identical to serial.
- **Finding order** — conventions → duplication in the original 6-block sequence → descriptor table order → artifact portability.
- **Log order** — the descriptor merge was split out specifically so `log_status!` lines still fire on the caller's thread *after* the fan-out. Only `time_audit_detector`'s pre-existing `Running…`/`Completed…` lines interleave; documented.

Tests: 4 in `parallel.rs` including a reversed-sleep test that fails any collection-order implementation and a 100-iteration identity test, plus `parallel_dispatch_preserves_descriptor_table_order` which dispatches two detectors with ids **reversed** and asserts spans and finding kinds come back in table order, 25×.

## `Sync` reasoning

`&T: Send` only when `T: Sync`, so `DetectorRunContext` must be `Sync`. Verified field by field — all plain owned data, no `Rc`/`RefCell`/raw pointers anywhere in the contract crates. Two non-obvious ones chased down:

1. No mutable global state in the crate; every `static` is a `LazyLock`/`OnceLock<Regex>`.
2. **`provider_registry!` holds its `Mutex` for the whole callback**, so provider-mediated work auto-serializes per registry. Checked for ABBA deadlock: no audit code nests two registries, and none of the four registered impls reaches back into another audit registry inside its callback.

## Verification without cargo

Per this VPS's disk budget, no cargo ran. Instead: `parallel.rs` has zero external deps, so it was compiled and run standalone with `rustc --test` (4/4 pass); then a stub-typed replica of the restructured engine was compiled with plain `rustc` **and `clippy-driver`**. That caught two real defects — an `explicit_auto_deref`, and that leaving `time_audit_detector` in a now-unused `pub(crate) use` would trip `unused_imports` and fail the `-Dwarnings` **Warning Clean** gate. Both fixed. `rustfmt --check` clean.

## Compatibility

No detector logic or findings change. Purely *when* work happens and *what is reported about timing*.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and standalone verification. Review by hand; workspace compilation deferred to CI.

Refs #12583