### PR TITLE
Seed the duplication family from the changed scope

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -11,6 +11,28 @@
 //! - `detect_duplicate_groups()` → structured `Vec<DuplicateGroup>` for the fixer
 //! - `detect_near_duplicates()` → flat `Vec<Finding>` for structural near-duplicates
 //! - `detect_intra_method_duplicates()` → duplicated blocks within a single method
+//!
+//! # Scope-seeded entry points
+//!
+//! The exact-duplicate family also exposes two-phase, scope-seeded variants —
+//! [`detect_duplicates_scoped`] and [`detect_duplicate_groups_scoped`] — for
+//! changed-scope (`--changed-since`) audits. Duplication is a *cross-file*
+//! detector: a duplicate is only a duplicate because a counterpart body exists
+//! somewhere else, and that counterpart may sit outside the changed scope. So
+//! the full corpus cannot simply be replaced by the scoped subset.
+//!
+//! It can, however, be split in two:
+//!
+//! 1. **Seed** the candidate `(method_name, body_hash)` keys from the scoped
+//!    subset only.
+//! 2. **Expand** those candidates to their counterparts by matching them
+//!    against the full corpus.
+//!
+//! Every *reportable* finding is keyed to an in-scope file (out-of-scope
+//! findings are discarded by the engine's scope filter), so a group with no
+//! in-scope member can never produce a surviving finding — dropping it early is
+//! behavior-preserving. Cost then scales with the size of the change rather
+//! than the size of the repository. See Extra-Chill/homeboy#12583.
 
 use std::collections::{HashMap, HashSet};
 
@@ -35,15 +57,79 @@ use intra_method::{has_logic_signal, is_scaffolding_line};
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
 
+/// `(method_name, body_hash)` → the files that contain that exact body.
+///
+/// The shared grouping behind `detect_duplicates` and `detect_duplicate_groups`.
+type BodyHashGroups = HashMap<(String, String), Vec<String>>;
+
+/// Candidate seed index: `method_name` → the body hashes seen for that name in
+/// the seed corpus. Nested (rather than a `HashSet<(String, String)>`) so the
+/// expansion phase can probe it with borrowed `&String` keys and never has to
+/// allocate a tuple per method just to ask "is this a candidate?".
+type SeededBodyHashes = HashMap<String, HashSet<String>>;
+
 /// Build grouped duplication data from fingerprints.
 ///
 /// For each group of identical functions, picks a canonical file (shortest
 /// path, then alphabetical) and lists the rest as removal targets.
-fn build_groups(fingerprints: &[&FileFingerprint]) -> HashMap<(String, String), Vec<String>> {
-    let mut hash_groups: HashMap<(String, String), Vec<String>> = HashMap::new();
+fn build_groups(fingerprints: &[&FileFingerprint]) -> BodyHashGroups {
+    let mut hash_groups: BodyHashGroups = HashMap::new();
 
     for fp in fingerprints {
         for (method_name, body_hash) in &fp.method_hashes {
+            hash_groups
+                .entry((method_name.clone(), body_hash.clone()))
+                .or_default()
+                .push(fp.relative_path.clone());
+        }
+    }
+
+    hash_groups
+}
+
+/// Phase 1 of scope-seeded duplication: collect the candidate
+/// `(method_name, body_hash)` keys contributed by the scoped subset.
+fn seed_body_hashes(scoped: &[&FileFingerprint]) -> SeededBodyHashes {
+    let mut seeds: SeededBodyHashes = HashMap::new();
+
+    for fp in scoped {
+        for (method_name, body_hash) in &fp.method_hashes {
+            seeds
+                .entry(method_name.clone())
+                .or_default()
+                .insert(body_hash.clone());
+        }
+    }
+
+    seeds
+}
+
+/// Two-phase equivalent of [`build_groups`]: seed candidate keys from `scoped`,
+/// then expand each candidate to *all* of its locations across `all`.
+///
+/// `scoped` must be a subset of `all` — it is the changed-scope filter of the
+/// same corpus. Under that precondition the returned groups are byte-identical
+/// to `build_groups(all)` restricted to the keys present in `scoped`, including
+/// location order (both phases walk `all` in the same order).
+///
+/// Groups whose key appears nowhere in `scoped` are omitted: they have no
+/// in-scope member, so no finding derived from them could survive the engine's
+/// scope filter.
+fn build_groups_seeded(scoped: &[&FileFingerprint], all: &[&FileFingerprint]) -> BodyHashGroups {
+    let seeds = seed_body_hashes(scoped);
+    let mut hash_groups: BodyHashGroups = HashMap::new();
+    if seeds.is_empty() {
+        return hash_groups;
+    }
+
+    for fp in all {
+        for (method_name, body_hash) in &fp.method_hashes {
+            let is_candidate = seeds
+                .get(method_name)
+                .is_some_and(|hashes| hashes.contains(body_hash));
+            if !is_candidate {
+                continue;
+            }
             hash_groups
                 .entry((method_name.clone(), body_hash.clone()))
                 .or_default()
@@ -80,10 +166,30 @@ fn pick_canonical(locations: &[String]) -> String {
 ///
 /// Returns structured data the fixer uses to remove duplicates.
 pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
-    let hash_groups = build_groups(fingerprints);
+    detect_duplicate_groups_scoped(fingerprints, fingerprints)
+}
+
+/// Scope-seeded [`detect_duplicate_groups`].
+///
+/// Seeds candidate `(method_name, body_hash)` keys from `scoped`, then expands
+/// each candidate to its full member list across `all`, so canonical selection
+/// and `remove_from` see every counterpart — including out-of-scope ones.
+///
+/// `scoped` must be a subset of `all`. Output equals `detect_duplicate_groups(all)`
+/// restricted to the groups that have at least one member in `scoped` (a group
+/// with no in-scope member is not actionable for a changed-scope run).
+pub(crate) fn detect_duplicate_groups_scoped(
+    scoped: &[&FileFingerprint],
+    all: &[&FileFingerprint],
+) -> Vec<DuplicateGroup> {
+    duplicate_groups_from_body_hash_groups(&build_groups_seeded(scoped, all))
+}
+
+/// Shared group-construction phase for both the scoped and unscoped paths.
+fn duplicate_groups_from_body_hash_groups(hash_groups: &BodyHashGroups) -> Vec<DuplicateGroup> {
     let mut groups = Vec::new();
 
-    for ((method_name, _hash), locations) in &hash_groups {
+    for ((method_name, _hash), locations) in hash_groups {
         if locations.len() < MIN_DUPLICATE_LOCATIONS {
             continue;
         }
@@ -107,16 +213,6 @@ pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<
     groups
 }
 
-/// Detect duplicated functions across all fingerprinted files.
-///
-/// Groups functions by their body hash. When two or more files contain a
-/// function with the same name and the same normalized body hash, a finding
-/// is emitted for each location.
-/// Detect exact function body duplicates across files.
-///
-/// `convention_methods` are excluded — identical implementations across convention-
-/// following files are expected behavior (e.g. `__construct`, `checkPermission`,
-/// interface methods with identical bodies).
 /// Set of `(method_name, file)` pairs whose definition sits inside an inline
 /// `#[cfg(test)]` region of a production file. These are test fixtures
 /// (`make_fp`, `git_repo`, `local_client`, …) that `is_test_path` — which only
@@ -148,6 +244,55 @@ fn inline_test_context_methods(fingerprints: &[&FileFingerprint]) -> HashSet<(St
     out
 }
 
+/// [`inline_test_context_methods`] restricted to the `(file → method_names)`
+/// pairs a caller will actually query.
+///
+/// `inline_test_context_methods` scans the content of *every* fingerprint and
+/// probes it once per method — an O(corpus) content pass. The exact-duplicate
+/// detector only ever asks about `(method_name, file)` pairs that are members of
+/// a surviving duplicate group, which is a tiny slice of the corpus. Restricting
+/// the scan to those pairs returns the same answer for every query the caller
+/// makes: the unrestricted set is exactly this one unioned over all pairs, and
+/// membership is decided per pair independently.
+///
+/// The `method_hashes` guard mirrors the unrestricted version, which only
+/// considers method names present in that file's `method_hashes`.
+fn inline_test_context_methods_for(
+    fingerprints: &[&FileFingerprint],
+    wanted: &HashMap<&str, HashSet<&str>>,
+) -> HashSet<(String, String)> {
+    let mut out = HashSet::new();
+    if wanted.is_empty() {
+        return out;
+    }
+
+    for fp in fingerprints {
+        let Some(method_names) = wanted.get(fp.relative_path.as_str()) else {
+            continue;
+        };
+        let regions = inline_test_regions(&fp.content, fp.language.inline_test_region_markers());
+        if regions.is_empty() {
+            continue;
+        }
+        for method_name in method_names {
+            if !fp.method_hashes.contains_key(*method_name) {
+                continue;
+            }
+            let needle = format!("fn {}", method_name);
+            if let Some(pos) = fp.content.find(&needle) {
+                if regions
+                    .iter()
+                    .any(|(start, end)| pos >= *start && pos <= *end)
+                {
+                    out.insert(((*method_name).to_string(), fp.relative_path.clone()));
+                }
+            }
+        }
+    }
+
+    out
+}
+
 /// Whether a duplicate location is test code — either a whole test file
 /// (`is_test_path`) or a method defined inside an inline `#[cfg(test)]` block.
 fn is_test_location(
@@ -158,21 +303,86 @@ fn is_test_location(
     is_test_path(file) || inline_test_methods.contains(&(method_name.to_string(), file.to_string()))
 }
 
+/// Detect exact function body duplicates across files.
+///
+/// Groups functions by `(method_name, body_hash)`. When two or more files
+/// contain a function with the same name and the same normalized body hash, a
+/// finding is emitted for each location.
+///
+/// `convention_methods` are excluded — identical implementations across
+/// convention-following files are expected behavior (e.g. `__construct`,
+/// `checkPermission`, interface methods with identical bodies).
 pub(crate) fn detect_duplicates(
     fingerprints: &[&FileFingerprint],
     convention_methods: &std::collections::HashSet<String>,
 ) -> Vec<Finding> {
-    let hash_groups = build_groups(fingerprints);
-    let inline_test_methods = inline_test_context_methods(fingerprints);
-    let mut findings = Vec::new();
+    detect_duplicates_scoped(fingerprints, fingerprints, convention_methods)
+}
 
-    for ((method_name, _hash), locations) in &hash_groups {
-        if locations.len() < MIN_DUPLICATE_LOCATIONS {
+/// Scope-seeded [`detect_duplicates`].
+///
+/// Phase 1 seeds candidate `(method_name, body_hash)` keys from `scoped`; phase 2
+/// expands each candidate to every counterpart in `all`. Group membership,
+/// severity, the `also in …` list, and the `N files` count are therefore computed
+/// from the full corpus exactly as the unscoped path does — only the *set of
+/// groups considered* is narrowed, to those with at least one in-scope member.
+///
+/// `scoped` must be a subset of `all`.
+///
+/// Findings are still emitted for every member of a surviving group, including
+/// out-of-scope files, so the output is literally a subset of
+/// `detect_duplicates(all, convention_methods)`. The engine drops the
+/// out-of-scope ones in its scope filter, which is the same thing that happens
+/// on the unscoped path; restricted to in-scope files the two agree exactly.
+pub(crate) fn detect_duplicates_scoped(
+    scoped: &[&FileFingerprint],
+    all: &[&FileFingerprint],
+    convention_methods: &std::collections::HashSet<String>,
+) -> Vec<Finding> {
+    let hash_groups = build_groups_seeded(scoped, all);
+    duplicate_findings_from_body_hash_groups(&hash_groups, all, convention_methods)
+}
+
+/// Whether a raw `(method_name, body_hash)` group is a reportable duplicate.
+///
+/// Two filters, stated once for both passes below: a group needs at least
+/// `MIN_DUPLICATE_LOCATIONS` locations, and convention-expected methods are
+/// excluded because identical implementations across convention-following files
+/// are by design.
+fn is_reportable_duplicate_group(
+    method_name: &str,
+    locations: &[String],
+    convention_methods: &std::collections::HashSet<String>,
+) -> bool {
+    locations.len() >= MIN_DUPLICATE_LOCATIONS && !convention_methods.contains(method_name)
+}
+
+/// Shared finding-construction phase for both the scoped and unscoped paths.
+fn duplicate_findings_from_body_hash_groups(
+    hash_groups: &BodyHashGroups,
+    all: &[&FileFingerprint],
+    convention_methods: &std::collections::HashSet<String>,
+) -> Vec<Finding> {
+    // Only reportable groups ever ask about inline `cfg(test)` context, so
+    // collect exactly those `(file, method)` pairs first and keep the content
+    // scan off the rest of the corpus.
+    let mut wanted: HashMap<&str, HashSet<&str>> = HashMap::new();
+    for ((method_name, _hash), locations) in hash_groups {
+        if !is_reportable_duplicate_group(method_name, locations, convention_methods) {
             continue;
         }
+        for file in locations {
+            wanted
+                .entry(file.as_str())
+                .or_default()
+                .insert(method_name.as_str());
+        }
+    }
+    let inline_test_methods = inline_test_context_methods_for(all, &wanted);
+    let mut findings = Vec::new();
 
-        // Skip convention-expected methods — identical implementations are by design.
-        if convention_methods.contains(method_name) {
+    for ((method_name, _hash), locations) in hash_groups {
+        if !is_reportable_duplicate_group(method_name, locations, convention_methods) {
             continue;
         }
 

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -238,6 +238,246 @@ fn group_three_way_has_two_removals() {
 }
 
 // ========================================================================
+// Scope-seeded (two-phase) duplication tests — Extra-Chill/homeboy#12583
+// ========================================================================
+
+mod scope_seeded {
+    use super::*;
+
+    fn no_conventions() -> std::collections::HashSet<String> {
+        std::collections::HashSet::new()
+    }
+
+    /// Comparable projection of a finding — `Finding` is not `PartialEq`.
+    fn signature(finding: &Finding) -> String {
+        format!(
+            "{:?}|{:?}|{}|{}|{}",
+            finding.severity, finding.kind, finding.file, finding.description, finding.suggestion
+        )
+    }
+
+    fn signatures(findings: &[Finding]) -> Vec<String> {
+        findings.iter().map(signature).collect()
+    }
+
+    /// The engine's Phase 4p scope filter: only findings whose file is inside
+    /// the touched scope are reportable. Duplication findings for out-of-scope
+    /// files are discarded on both the scoped and unscoped paths, so this is the
+    /// projection the two paths must agree on.
+    fn reportable(findings: &[Finding], scope: &[&str]) -> Vec<String> {
+        findings
+            .iter()
+            .filter(|finding| scope.contains(&finding.file.as_str()))
+            .map(signature)
+            .collect()
+    }
+
+    fn group_signatures(groups: &[DuplicateGroup]) -> Vec<String> {
+        groups
+            .iter()
+            .map(|group| {
+                format!(
+                    "{}|{}|{}",
+                    group.function_name,
+                    group.canonical_file,
+                    group.remove_from.join(",")
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn seeding_from_the_full_corpus_is_a_no_op_filter() {
+        // This is what lets the unscoped entry points delegate to the scoped
+        // ones: with the whole corpus as the seed, every key is a candidate, so
+        // the seeded expansion reproduces `build_groups` exactly — same keys,
+        // same locations, same location order.
+        let fp1 = make_fingerprint(
+            "src/a.rs",
+            &["shared", "unique_a"],
+            &[("shared", "same"), ("unique_a", "hash_a")],
+        );
+        let fp2 = make_fingerprint(
+            "src/b.rs",
+            &["shared", "unique_b"],
+            &[("shared", "same"), ("unique_b", "hash_b")],
+        );
+        let fp3 = make_fingerprint("src/c.rs", &["shared"], &[("shared", "same")]);
+        let all = [&fp1, &fp2, &fp3];
+
+        assert_eq!(build_groups_seeded(&all, &all), build_groups(&all));
+    }
+
+    #[test]
+    fn duplicate_pair_entirely_in_scope_matches_unscoped() {
+        let fp1 = make_fingerprint("src/a.rs", &["helper"], &[("helper", "h1")]);
+        let fp2 = make_fingerprint("src/b.rs", &["helper"], &[("helper", "h1")]);
+        let all = [&fp1, &fp2];
+
+        let unscoped = detect_duplicates(&all, &no_conventions());
+        let scoped = detect_duplicates_scoped(&all, &all, &no_conventions());
+
+        assert_eq!(scoped.len(), 2, "both locations flagged");
+        assert_eq!(signatures(&scoped), signatures(&unscoped));
+        assert_eq!(
+            group_signatures(&detect_duplicate_groups_scoped(&all, &all)),
+            group_signatures(&detect_duplicate_groups(&all))
+        );
+    }
+
+    #[test]
+    fn duplicate_pair_with_one_member_out_of_scope_keeps_counterpart_evidence() {
+        let in_scope = make_fingerprint("src/changed.rs", &["helper"], &[("helper", "h1")]);
+        let out_of_scope = make_fingerprint("src/untouched.rs", &["helper"], &[("helper", "h1")]);
+        let all = [&in_scope, &out_of_scope];
+        let scoped_subset = [&in_scope];
+        let scope = ["src/changed.rs"];
+
+        let unscoped = detect_duplicates(&all, &no_conventions());
+        let scoped = detect_duplicates_scoped(&scoped_subset, &all, &no_conventions());
+
+        // The out-of-scope counterpart was pulled in by the expansion phase, so
+        // the whole group — and therefore every finding — is identical.
+        assert_eq!(signatures(&scoped), signatures(&unscoped));
+        assert_eq!(
+            reportable(&scoped, &scope),
+            reportable(&unscoped, &scope),
+            "the in-scope finding is the same on both paths"
+        );
+        assert_eq!(reportable(&scoped, &scope).len(), 1);
+        assert!(
+            scoped.iter().any(|finding| finding.file == "src/changed.rs"
+                && finding.description.contains("also in src/untouched.rs")
+                && finding.suggestion.contains("2 files")),
+            "in-scope finding still names its out-of-scope counterpart: {:?}",
+            signatures(&scoped)
+        );
+    }
+
+    #[test]
+    fn duplicate_group_with_one_member_out_of_scope_keeps_canonical_choice() {
+        // The canonical file is the OUT-OF-SCOPE one (`utils/` wins the
+        // heuristic), which is only reachable when expansion sees the full
+        // corpus. Seeding alone would have picked the in-scope file.
+        let in_scope =
+            make_fingerprint("src/core/deep/nested/helper.rs", &["foo"], &[("foo", "h1")]);
+        let out_of_scope = make_fingerprint("src/utils/shared.rs", &["foo"], &[("foo", "h1")]);
+        let all = [&in_scope, &out_of_scope];
+
+        let scoped = detect_duplicate_groups_scoped(&[&in_scope], &all);
+
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].canonical_file, "src/utils/shared.rs");
+        assert_eq!(
+            scoped[0].remove_from,
+            vec!["src/core/deep/nested/helper.rs"]
+        );
+        assert_eq!(
+            group_signatures(&scoped),
+            group_signatures(&detect_duplicate_groups(&all))
+        );
+    }
+
+    #[test]
+    fn duplicate_pair_entirely_out_of_scope_has_no_reportable_finding() {
+        let changed = make_fingerprint("src/changed.rs", &["only_here"], &[("only_here", "h9")]);
+        let far_a = make_fingerprint("src/far_a.rs", &["helper"], &[("helper", "h1")]);
+        let far_b = make_fingerprint("src/far_b.rs", &["helper"], &[("helper", "h1")]);
+        let all = [&changed, &far_a, &far_b];
+        let scope = ["src/changed.rs"];
+
+        let unscoped = detect_duplicates(&all, &no_conventions());
+        let scoped = detect_duplicates_scoped(&[&changed], &all, &no_conventions());
+
+        // Unscoped finds the far pair, but both findings are filtered out by
+        // scope. The scoped path never builds the group in the first place.
+        assert_eq!(unscoped.len(), 2);
+        assert!(reportable(&unscoped, &scope).is_empty());
+        assert!(scoped.is_empty());
+        assert_eq!(reportable(&scoped, &scope), reportable(&unscoped, &scope));
+
+        // Same for the fixer's grouped output.
+        assert_eq!(detect_duplicate_groups(&all).len(), 1);
+        assert!(detect_duplicate_groups_scoped(&[&changed], &all).is_empty());
+    }
+
+    #[test]
+    fn seed_key_is_name_and_body_hash_not_name_alone() {
+        // An in-scope `helper` with a DIFFERENT body must not seed the
+        // out-of-scope `helper` group — the candidate key is (name, body_hash).
+        let in_scope = make_fingerprint("src/changed.rs", &["helper"], &[("helper", "h2")]);
+        let far_a = make_fingerprint("src/far_a.rs", &["helper"], &[("helper", "h1")]);
+        let far_b = make_fingerprint("src/far_b.rs", &["helper"], &[("helper", "h1")]);
+        let all = [&in_scope, &far_a, &far_b];
+        let scope = ["src/changed.rs"];
+
+        let unscoped = detect_duplicates(&all, &no_conventions());
+        let scoped = detect_duplicates_scoped(&[&in_scope], &all, &no_conventions());
+
+        assert!(
+            scoped.is_empty(),
+            "different body hash is a different group: {:?}",
+            signatures(&scoped)
+        );
+        assert_eq!(unscoped.len(), 2, "the far pair is still a duplicate");
+        assert_eq!(reportable(&scoped, &scope), reportable(&unscoped, &scope));
+    }
+
+    #[test]
+    fn out_of_scope_counterpart_still_decides_severity() {
+        // `make_fp` sits in the inline `#[cfg(test)]` block of two production
+        // files, only one of which is in scope. Severity is Info only when
+        // EVERY member is recognized as test scaffolding, so the expansion
+        // phase has to scan the out-of-scope member's content too.
+        let mut in_scope = make_fingerprint("src/a.rs", &["make_fp"], &[("make_fp", "h1")]);
+        in_scope.content =
+            "fn prod() {}\n\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp { Fp::default() }\n}\n"
+                .to_string();
+        let mut out_of_scope = make_fingerprint("src/b.rs", &["make_fp"], &[("make_fp", "h1")]);
+        out_of_scope.content =
+            "fn other() {}\n\n#[cfg(test)]\nmod tests {\n    fn make_fp() -> Fp { Fp::default() }\n}\n"
+                .to_string();
+        let all = [&in_scope, &out_of_scope];
+
+        let unscoped = detect_duplicates(&all, &no_conventions());
+        let scoped = detect_duplicates_scoped(&[&in_scope], &all, &no_conventions());
+
+        assert_eq!(signatures(&scoped), signatures(&unscoped));
+        assert!(
+            scoped
+                .iter()
+                .all(|finding| finding.severity == Severity::Info),
+            "inline cfg(test) duplication stays Info on the scoped path: {:?}",
+            signatures(&scoped)
+        );
+    }
+
+    #[test]
+    fn convention_methods_are_skipped_on_the_scoped_path() {
+        let in_scope = make_fingerprint("src/a.rs", &["__construct"], &[("__construct", "h1")]);
+        let out_of_scope = make_fingerprint("src/b.rs", &["__construct"], &[("__construct", "h1")]);
+        let all = [&in_scope, &out_of_scope];
+        let mut conventions = std::collections::HashSet::new();
+        conventions.insert("__construct".to_string());
+
+        assert!(detect_duplicates(&all, &conventions).is_empty());
+        assert!(detect_duplicates_scoped(&[&in_scope], &all, &conventions).is_empty());
+    }
+
+    #[test]
+    fn empty_scope_seeds_nothing() {
+        let fp1 = make_fingerprint("src/a.rs", &["helper"], &[("helper", "h1")]);
+        let fp2 = make_fingerprint("src/b.rs", &["helper"], &[("helper", "h1")]);
+        let all = [&fp1, &fp2];
+        let empty: [&FileFingerprint; 0] = [];
+
+        assert!(detect_duplicates_scoped(&empty, &all, &no_conventions()).is_empty());
+        assert!(detect_duplicate_groups_scoped(&empty, &all).is_empty());
+        assert_eq!(detect_duplicates(&all, &no_conventions()).len(), 2);
+    }
+}
+
+// ========================================================================
 // Near-duplicate detection tests
 // ========================================================================
 


### PR DESCRIPTION
## Summary

Second half of #12583, on a different file from #12586 so they do not collide.

Phase 4b2's own comment names whole-tree detector runs as *"the root cause of the changed-scope timeout"* — but the cross-file duplication family still consumes the **full corpus** on every scoped run, so that scoping could not close the timeout it was written to close.

## The insight

The full-corpus reasoning is sound: a duplicate needs its counterpart, which may be out of scope. But the corpus is only needed as **counterpart evidence**, never as a source of reportable findings — every finding is keyed to one file, and out-of-scope findings are discarded by the Phase 4p filter anyway.

```
phase 1  seed candidate (name, body_hash) keys from the scoped subset
phase 2  expand each surviving key against the full corpus
```

Cost becomes proportional to the change rather than the repository. Findings are identical.

## How the existing algorithm works

`build_groups` keys on **name + normalized body hash** (not name alone — `detect_cross_name_duplicates` owns hash-only). `detect_duplicates` filters to ≥2 locations, drops `convention_methods`, votes severity on whether *every* location is test code, and emits one finding per location whose description lists the sorted others and whose suggestion embeds `locations.len()`. `detect_duplicate_groups` picks a canonical via `pick_canonical` over **all** locations.

## New entry points

```rust
pub(crate) fn detect_duplicates_scoped(
    scoped: &[&FileFingerprint], all: &[&FileFingerprint],
    convention_methods: &HashSet<String>,
) -> Vec<Finding>

pub(crate) fn detect_duplicate_groups_scoped(
    scoped: &[&FileFingerprint], all: &[&FileFingerprint],
) -> Vec<DuplicateGroup>
```

The existing functions now **delegate** by passing the full corpus as both seed and corpus. That is verified, not assumed: with every key a candidate, `build_groups_seeded(all, all)` reproduces `build_groups(all)` exactly, including location order, and a test pins it. Delegation also keeps every new function reachable, so the wiring window does not trip the `-Dwarnings` gate.

## Equivalence argument

1. The Phase 4p finding filter (`f.file.contains(scope)`) uses **literally the same predicate** as the Phase 4b2 fingerprint subset (`fp.relative_path.contains(scope)`). A duplication finding survives iff its file is a scoped fingerprint.
2. Every surviving finding belongs to a group with ≥1 scoped member, and that member contributes exactly the group's key — so seeding from scoped keys cannot drop a surviving finding.
3. For a surviving key, phase 2 rebuilds the **complete** location list. Membership, `locations.len()`, the sorted `also in …` list, `pick_canonical`, `remove_from`, and the all-locations severity vote are all computed from the same data. Inline-`cfg(test)` evidence is gathered for out-of-scope members too, so severity cannot drift.
4. Groups are independent, and the final `(file, description)` sort key is unique per finding, so output order is fully determined.

<h3>Expansion is load-bearing, not a nicety</h3>

`homeboy-refactor`'s duplicate fixer branches on `1 + group.remove_from.len()` against `MIN_EXTRACT_GROUP_SIZE = 4`. **Seed-only grouping would have silently changed the fix strategy.** That is exactly the "threshold that depends on total group size" hazard, and phase-2 expansion neutralizes it.

## Where this is a deliberate narrowing, not a strict identity

Both documented in the code:

- **Entirely-out-of-scope groups are dropped.** Invisible for findings (Phase 4p discarded them anyway; a test asserts both paths agree on the reportable set). But `duplicate_groups` has **no downstream scope filter**, so the fixer sees a smaller group set in scoped mode. Every dropped group has *all* members out of scope, so none could have mutated an in-scope file — it is the intended semantics of a changed-scope run.
- **Precondition `scoped ⊆ all`.** The engine satisfies it by construction (the subset is filtered from `all_fingerprints`), but it is a contract the code cannot enforce.
- **Pre-existing, unchanged:** `detect_duplicate_groups` sorts by `function_name` only, so same-name-different-hash groups already have HashMap-order-dependent relative order. Scoped output is a subsequence of that already-unspecified order; not tightened, since that would be a behavior change.

## Side benefit on the unscoped path

The inline-`cfg(test)` evidence scan no longer walks every file's content, only the `(file, method)` pairs that are actually members of a reportable group. Membership is decided per pair independently, so every query gets the same answer.

## Tests

9 new in `mod scope_seeded`, comparing by finding signature since `Finding` is not `PartialEq`, plus a `reportable()` helper modelling the Phase 4p filter:

- the delegation's justification — `build_groups_seeded(all, all) == build_groups(all)`
- pair entirely in scope; pair with one member out of scope (finding still says "also in …" and "2 files")
- group whose canonical resolves to the **out-of-scope** `src/utils/shared.rs` — only passes if expansion ran
- pair entirely out of scope: unscoped emits 2 findings, all scope-filtered; scoped emits none
- seed key is name **and** hash, not name alone
- out-of-scope counterpart still decides severity (covers the restricted inline-test scan)
- convention methods skipped on the scoped path; empty scope seeds nothing

## Compatibility

`engine.rs` untouched — **wiring the new entry points is a deliberate follow-up**, kept separate so #12586 and this PR do not conflict. Existing signatures and behavior unchanged.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and test authoring. Review by hand; compilation deferred to CI.

Refs #12583