### PR TITLE
Use the scoped duplication path in the engine

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -165,6 +165,14 @@ fn pick_canonical(locations: &[String]) -> String {
 /// Detect duplicate groups with canonical file selection.
 ///
 /// Returns structured data the fixer uses to remove duplicates.
+///
+/// Since #12583 the engine calls [`detect_duplicate_groups_scoped`] on both the
+/// scoped and unscoped paths (unscoped passes the full corpus as its own seed),
+/// so this wrapper's only remaining callers are the tests that use it as the
+/// unscoped oracle for the scope-seeded equivalence assertions. It stays compiled
+/// in release builds as the documented unscoped entry point; the `cfg_attr` only
+/// keeps `dead_code` quiet where nothing but tests reach it.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
     detect_duplicate_groups_scoped(fingerprints, fingerprints)
 }
@@ -312,6 +320,14 @@ fn is_test_location(
 /// `convention_methods` are excluded — identical implementations across
 /// convention-following files are expected behavior (e.g. `__construct`,
 /// `checkPermission`, interface methods with identical bodies).
+///
+/// Since #12583 the engine calls [`detect_duplicates_scoped`] on both the scoped
+/// and unscoped paths (unscoped passes the full corpus as its own seed), so this
+/// wrapper's only remaining callers are the tests that use it as the unscoped
+/// oracle for the scope-seeded equivalence assertions. It stays compiled in
+/// release builds as the documented unscoped entry point; the `cfg_attr` only
+/// keeps `dead_code` quiet where nothing but tests reach it.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn detect_duplicates(
     fingerprints: &[&FileFingerprint],
     convention_methods: &std::collections::HashSet<String>,

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -293,6 +293,18 @@ pub(super) fn audit_internal(
     // Cross-file detectors (duplication, dead code) still receive the full
     // corpus below because their correctness for an in-scope file depends on
     // evidence from out-of-scope files (matching bodies, external references).
+    //
+    // The two exact-duplicate passes are the exception, and the reason the
+    // narrowing above could not close the timeout on its own: the duplication
+    // family is this repository's largest finding population and it consumed the
+    // whole corpus. `detect_duplicates_scoped` / `detect_duplicate_groups_scoped`
+    // (#12587) split that cross-file work in two — seed the candidate
+    // `(method_name, body_hash)` keys from the scoped subset, then expand each
+    // surviving key against the FULL corpus for counterpart evidence. So they
+    // still see every out-of-scope counterpart, and the subset is passed only as
+    // the seed, never as a replacement for the corpus. The remaining five passes
+    // (intra-method, near-duplicate, cross-name, skeleton, parallel
+    // implementation) have no scoped variant and stay on the full corpus.
     let scoped_fingerprints: Option<(HashSet<String>, Vec<&fingerprint::FileFingerprint>)> =
         scoped_execution.file_filter.map(|filter| {
             let scope_started = std::time::Instant::now();
@@ -343,6 +355,13 @@ pub(super) fn audit_internal(
 
     // Per-file detector input: the scoped subset when in changed-scope mode,
     // else the full corpus. Cross-file detectors keep using `all_fingerprints`.
+    //
+    // It doubles as the duplication family's SEED corpus (the scoped entry points
+    // take both, and still expand against `all_fingerprints`). Both arms satisfy
+    // the `scoped ⊆ all` precondition those entry points require: the changed-scope
+    // arm is a `filter` over `all_fingerprints`, and the unscoped arm is
+    // `all_fingerprints` itself — which is exactly the `(all, all)` delegation the
+    // unscoped `detect_duplicates` / `detect_duplicate_groups` already perform.
     let per_file_fingerprints: &[&fingerprint::FileFingerprint] = scoped_fingerprints
         .as_ref()
         .map(|(_, subset)| subset.as_slice())
@@ -398,7 +417,13 @@ pub(super) fn audit_internal(
     let (duplication_unit, descriptor_outcomes, artifact_portability_unit) =
         std::thread::scope(|scope| {
             let duplication = spawn_or_run(scope, || {
-                run_duplication_family(plan, &all_fingerprints, &convention_methods, &audit_config)
+                run_duplication_family(
+                    plan,
+                    per_file_fingerprints,
+                    &all_fingerprints,
+                    &convention_methods,
+                    &audit_config,
+                )
             });
             let artifact = spawn_or_run(scope, || {
                 run_artifact_portability(plan, component_id, &audit_config)
@@ -694,8 +719,20 @@ struct DuplicationUnit {
 /// serial one span for span. Under
 /// `HOMEBOY_AUDIT_DETECTOR_THREADS=1`, `spawn_or_run` runs each pass inline at its
 /// start point, which reproduces the original serial execution exactly.
+///
+/// `scoped_fingerprints` is the changed-scope seed corpus (#12583). The two
+/// exact-duplicate passes use the scope-seeded entry points, which seed candidate
+/// `(method_name, body_hash)` keys from it and then expand each candidate against
+/// the full `all_fingerprints` corpus, so counterpart evidence from out-of-scope
+/// files is still found. It must be a SUBSET of `all_fingerprints`; in unscoped
+/// mode the caller passes `all_fingerprints` itself, which is the same `(all, all)`
+/// delegation the unscoped `detect_duplicates` / `detect_duplicate_groups` perform.
+/// The other five passes have no scoped variant and take the full corpus, so this
+/// adds a third immutable input without adding a data dependency: every pass is
+/// still a pure function of borrowed, shared inputs.
 fn run_duplication_family(
     plan: &AuditExecutionPlan,
+    scoped_fingerprints: &[&fingerprint::FileFingerprint],
     all_fingerprints: &[&fingerprint::FileFingerprint],
     convention_methods: &HashSet<String>,
     audit_config: &AuditConfig,
@@ -707,7 +744,13 @@ fn run_duplication_family(
             time_audit_detector_isolated(
                 "detector.duplication.exact",
                 enabled,
-                || duplication::detect_duplicates(all_fingerprints, convention_methods),
+                || {
+                    duplication::detect_duplicates_scoped(
+                        scoped_fingerprints,
+                        all_fingerprints,
+                        convention_methods,
+                    )
+                },
                 Vec::new,
             )
         });
@@ -715,7 +758,12 @@ fn run_duplication_family(
             time_audit_detector_isolated(
                 "detector.duplication.groups",
                 enabled,
-                || duplication::detect_duplicate_groups(all_fingerprints),
+                || {
+                    duplication::detect_duplicate_groups_scoped(
+                        scoped_fingerprints,
+                        all_fingerprints,
+                    )
+                },
                 Vec::new,
             )
         });
@@ -972,3 +1020,7 @@ fn audit_root_only(
 #[cfg(test)]
 #[path = "engine_corpus_test.rs"]
 mod engine_corpus_test;
+
+#[cfg(test)]
+#[path = "engine_duplication_scope_test.rs"]
+mod engine_duplication_scope_test;

--- a/crates/homeboy-code-audit/src/engine_duplication_scope_test.rs
+++ b/crates/homeboy-code-audit/src/engine_duplication_scope_test.rs
@@ -1,0 +1,255 @@
+//! Wiring invariants for the duplication family's changed-scope seed (#12583).
+//!
+//! Wired into `engine.rs` via
+//! `#[cfg(test)] #[path = ...] mod engine_duplication_scope_test`.
+//!
+//! WHY THIS EXISTS: #12587 added `detect_duplicates_scoped` /
+//! `detect_duplicate_groups_scoped` and proved their EQUIVALENCE against the
+//! unscoped functions, in `duplication/tests.rs`. Nothing called them, so the
+//! whole optimization was dormant and every one of those equivalence tests kept
+//! passing. Equivalence tests cannot see a missing call site.
+//!
+//! So these tests assert the WIRING instead: that `run_duplication_family`
+//! actually threads its `scoped_fingerprints` argument into those two passes, and
+//! that the five passes without a scoped variant still consume the full corpus.
+//! Together with #12587's equivalence proofs that is the whole risk surface of
+//! the wiring slice.
+
+use super::*;
+use crate::conventions::Language;
+
+/// A structural twin body, 3 body lines so it clears the near-duplicate
+/// trivial-body floor (`MIN_BODY_LINES`). Same shape as `duplication/tests.rs`.
+const TWIN_A: &str = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_A);\n    Some(file)\n}\n";
+const TWIN_B: &str = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_B);\n    Some(file)\n}\n";
+
+fn fp(
+    path: &str,
+    content: &str,
+    method_hashes: &[(&str, &str)],
+    structural_hashes: &[(&str, &str)],
+) -> fingerprint::FileFingerprint {
+    fingerprint::FileFingerprint {
+        relative_path: path.to_string(),
+        language: Language::Rust,
+        content: content.to_string(),
+        method_hashes: method_hashes
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect(),
+        structural_hashes: structural_hashes
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+/// Four-file corpus with two independent exact-duplicate groups:
+///
+/// * `compute_alpha` in `alpha_one.rs` + `alpha_two.rs`
+/// * `compute_beta` in `beta_one.rs` + `beta_two.rs`
+///
+/// The two beta files additionally carry a `cache_path` structural twin, which
+/// only the (unscoped) near-duplicate pass can see. Scoping to `alpha_one.rs`
+/// therefore distinguishes all three behaviors at once: the alpha group must
+/// survive WITH its out-of-scope counterpart, the beta group must be dropped, and
+/// the near-duplicate pass must still find the beta twins.
+fn corpus() -> Vec<fingerprint::FileFingerprint> {
+    vec![
+        fp(
+            "src/core/alpha_one.rs",
+            "fn compute_alpha() {}\n",
+            &[("compute_alpha", "h_alpha")],
+            &[],
+        ),
+        fp(
+            "src/core/alpha_two.rs",
+            "fn compute_alpha() {}\n",
+            &[("compute_alpha", "h_alpha")],
+            &[],
+        ),
+        fp(
+            "src/core/beta_one.rs",
+            TWIN_A,
+            &[("compute_beta", "h_beta"), ("cache_path", "hash_a")],
+            &[("cache_path", "SAME_STRUCT")],
+        ),
+        fp(
+            "src/core/beta_two.rs",
+            TWIN_B,
+            &[("compute_beta", "h_beta"), ("cache_path", "hash_b")],
+            &[("cache_path", "SAME_STRUCT")],
+        ),
+    ]
+}
+
+fn run(
+    scoped: &[&fingerprint::FileFingerprint],
+    all: &[&fingerprint::FileFingerprint],
+) -> DuplicationUnit {
+    run_duplication_family(
+        &AuditExecutionPlan::full(),
+        scoped,
+        all,
+        &HashSet::new(),
+        &AuditConfig::default(),
+    )
+}
+
+fn files(items: &[findings::Finding]) -> Vec<&str> {
+    let mut out: Vec<&str> = items.iter().map(|f| f.file.as_str()).collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn changed_scope_seeds_the_exact_duplicate_passes_from_the_scoped_subset() {
+    let owned = corpus();
+    let all: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+    // The engine builds its subset by filtering `all_fingerprints`, so the
+    // `scoped ⊆ all` precondition holds by construction. Mirror that here.
+    let scoped: Vec<&fingerprint::FileFingerprint> = all
+        .iter()
+        .copied()
+        .filter(|fp| fp.relative_path == "src/core/alpha_one.rs")
+        .collect();
+
+    let unit = run(&scoped, &all);
+
+    // Seeded from the scoped subset: the beta group has no in-scope member, so
+    // it is dropped. If the engine still passed the full corpus as the seed,
+    // `compute_beta` findings would be here.
+    assert_eq!(
+        files(&unit.exact),
+        vec!["src/core/alpha_one.rs", "src/core/alpha_two.rs"],
+        "exact pass must be seeded from the scoped subset, and expanded against the full corpus"
+    );
+    assert!(
+        unit.exact
+            .iter()
+            .all(|f| f.description.contains("compute_alpha")),
+        "the out-of-scope-only group must not be reported: {:?}",
+        unit.exact
+            .iter()
+            .map(|f| f.description.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    let group_names: Vec<&str> = unit
+        .groups
+        .iter()
+        .map(|g| g.function_name.as_str())
+        .collect();
+    assert_eq!(
+        group_names,
+        vec!["compute_alpha"],
+        "groups pass must be seeded from the scoped subset too"
+    );
+    // Expansion still walked the full corpus: the counterpart is out of scope.
+    assert_eq!(
+        unit.groups[0].remove_from,
+        vec!["src/core/alpha_two.rs".to_string()],
+        "counterpart evidence must come from the full corpus, not the seed"
+    );
+}
+
+#[test]
+fn the_five_passes_without_a_scoped_variant_still_see_the_full_corpus() {
+    let owned = corpus();
+    let all: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+    let scoped: Vec<&fingerprint::FileFingerprint> = all
+        .iter()
+        .copied()
+        .filter(|fp| fp.relative_path == "src/core/alpha_one.rs")
+        .collect();
+
+    let scoped_run = run(&scoped, &all);
+    let unscoped_run = run(&all, &all);
+
+    // `cache_path` lives only in the two out-of-scope beta files. A near-duplicate
+    // pass narrowed to the seed would find nothing.
+    assert_eq!(
+        files(&scoped_run.near_duplicate),
+        vec!["src/core/beta_one.rs", "src/core/beta_two.rs"],
+        "near_duplicate must stay on the full corpus"
+    );
+    // And the seed must make no difference to it at all.
+    assert_eq!(
+        files(&scoped_run.near_duplicate),
+        files(&unscoped_run.near_duplicate)
+    );
+    assert_eq!(
+        files(&scoped_run.intra_method),
+        files(&unscoped_run.intra_method)
+    );
+    assert_eq!(
+        files(&scoped_run.cross_name),
+        files(&unscoped_run.cross_name)
+    );
+    assert_eq!(files(&scoped_run.skeleton), files(&unscoped_run.skeleton));
+    assert_eq!(
+        files(&scoped_run.parallel_implementation),
+        files(&unscoped_run.parallel_implementation)
+    );
+}
+
+#[test]
+fn unscoped_mode_passes_the_full_corpus_as_its_own_seed() {
+    let owned = corpus();
+    let all: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+
+    // What `audit_internal` does when `scoped_fingerprints` is `None`:
+    // `per_file_fingerprints` IS `all_fingerprints`, which is the same `(all, all)`
+    // delegation the unscoped `detect_duplicates` / `detect_duplicate_groups`
+    // perform, so nothing is narrowed.
+    let unit = run(&all, &all);
+
+    assert_eq!(
+        files(&unit.exact),
+        vec![
+            "src/core/alpha_one.rs",
+            "src/core/alpha_two.rs",
+            "src/core/beta_one.rs",
+            "src/core/beta_two.rs"
+        ],
+        "unscoped mode must report both groups"
+    );
+
+    let mut group_names: Vec<&str> = unit
+        .groups
+        .iter()
+        .map(|g| g.function_name.as_str())
+        .collect();
+    group_names.sort();
+    assert_eq!(group_names, vec!["compute_alpha", "compute_beta"]);
+}
+
+#[test]
+fn span_order_is_pass_order_regardless_of_the_seed() {
+    let owned = corpus();
+    let all: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
+    let scoped: Vec<&fingerprint::FileFingerprint> = all
+        .iter()
+        .copied()
+        .filter(|fp| fp.relative_path == "src/core/alpha_one.rs")
+        .collect();
+
+    let expected = vec![
+        "detector.duplication.exact",
+        "detector.duplication.groups",
+        "detector.duplication.intra_method",
+        "detector.duplication.near_duplicate",
+        "detector.duplication.cross_name_duplicate",
+        "detector.duplication.skeleton_duplicate",
+        "detector.duplication.parallel_implementation",
+    ];
+
+    for unit in [run(&scoped, &all), run(&all, &all)] {
+        let ids: Vec<&str> = unit.spans.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            ids, expected,
+            "threading the seed must not reorder the timing spans"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Final slice of #12583. **#12587's work was dormant** — it added scope-seeded duplication entry points and nothing called them. The engine still handed the full corpus to the two passes that have a scoped variant, which is the cost the changed-scope timeout is made of.

```
#12586  parallelized the detector phase + timing visibility     merged
#12587  scope-seeded duplication entry points (dormant)         merged
#12588  ← makes them live
```

## What changed

`run_duplication_family` now takes the scoped subset alongside the full corpus and routes two passes through the scoped path:

| pass | before | after |
|---|---|---|
| `detector.duplication.exact` | `detect_duplicates(all, cm)` | `detect_duplicates_scoped(scoped, all, cm)` |
| `detector.duplication.groups` | `detect_duplicate_groups(all)` | `detect_duplicate_groups_scoped(scoped, all)` |

Candidate keys are seeded from the change; every surviving key is still expanded against the whole corpus for counterpart evidence.

## The precondition, satisfied on both arms

The scoped entry points require **`scoped ⊆ all`**. The value threaded in is `per_file_fingerprints`:

- **changed-scope arm** — built as `all_fingerprints.iter().copied().filter(…)`, a filter over the same corpus. Subset by construction.
- **unscoped arm** — it *is* `all_fingerprints`, so the call becomes `(all, all)`. That is exactly the delegation the unscoped wrappers already perform internally (`duplication.rs:169`, `:319`) and is documented as equivalent. Reflexive subset holds.

## The other five passes are untouched

`intra_method`, `near_duplicate`, `cross_name_duplicate`, `skeleton_duplicate`, `parallel_implementation` are byte-identical and still whole-corpus. They have no scoped variant, and giving them one needs its own equivalence argument.

## #12586's guarantees preserved

Seven `spawn_or_run` starts in pass order, seven joins in pass order, seven `spans.extend` in that order, one span per pass. The new parameter is a `Copy` shared slice captured into the closures — it adds an *input* without adding a *data dependency*, so `HOMEBOY_AUDIT_DETECTOR_THREADS=1` still runs each pass inline at its start point.

Borrows were verified by modelling the exact shape (two `&[&Fp]` params, `thread::scope` + `spawn_or_run` with `F: FnOnce() -> T + Send + 'scope`, nested outer scope) in a standalone file and compiling it with plain `rustc`.

<h2>The landmine this slice had to defuse</h2>

With both call sites moved, `detect_duplicates` and `detect_duplicate_groups` have **no non-test callers left**. A `pub(crate)` fn used only from `#[cfg(test)]` code emits `dead_code` — and the **warning-clean** gate builds with `RUSTFLAGS=-Dwarnings`. Doing nothing would have turned main red.

Both wrappers get `#[cfg_attr(not(test), allow(dead_code))]` plus a doc note. **No logic changed.**

The `cfg_attr` form is deliberate, chosen over two alternatives with evidence:
- over `#[cfg(test)]` — it keeps them compiled in release builds
- over a bare `#[allow(dead_code)]` — the audit's **own** dead-code detector emits an Info `DeadCodeMarker` for bare markers. `crates/homeboy-lab-runner/src/resource_metrics.rs` has seven `cfg_attr(…, allow(dead_code))` and **zero** baseline entries in `homeboy.json`, while three bare-marker files **do** have entries — good evidence the `cfg_attr` form is not detected, so this introduces no new audit finding.

**Reviewer choice:** the alternative is to branch in the engine (`Some(scoped) => …_scoped(…)`, `None => detect_duplicates(…)`) and keep both alive. Three lines either way — happy to switch if you prefer keeping the unscoped path reachable.

## Test

`engine_duplication_scope_test.rs`, wired via `#[cfg(test)] #[path = …]`. Four tests over a cheap 4-fingerprint fixture — no tempdirs, no real discovery:

1. **changed-scope seeds from the subset** — the `compute_alpha` group survives *with its out-of-scope counterpart* (proves expansion walked `all`), the out-of-scope-only `compute_beta` group is dropped (proves the seed was the subset), and `remove_from` names the out-of-scope file
2. **the five unscoped passes still see the full corpus** — a `cache_path` structural twin exists **only** in the two out-of-scope files and `near_duplicate` still finds it; all five fields asserted identical between scoped and unscoped runs
3. unscoped mode reports both groups (the `(all, all)` path)
4. span ids equal pass order in both modes

Type-checked with plain `rustc --test` against stub definitions mirroring the real signatures.

## Comments extended, never replaced

The Phase 4b2 block keeps its original *"cross-file detectors still receive the full corpus"* sentence **verbatim** — still true, since `all_fingerprints` is still passed — and gains a paragraph naming the seed-and-expand exception and listing the five passes that stay whole-corpus. Same for the `per_file_fingerprints` comment and `run_duplication_family`'s doc comment.

## Compatibility

Behavior-preserving. Findings are identical; #12587 carries the equivalence proof and its nine tests. This slice's risk is purely *is it wired correctly*, which tests 1 and 2 above pin from both directions.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, test authoring, and standalone `rustc` verification. Review by hand; workspace compilation deferred to CI.

Refs #12583