### PR TITLE
Root Cook promotion in paired stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -881,15 +881,6 @@ pub(crate) fn moving_base_recovery_for_run(run_id: &str) -> Result<Option<Moving
     moving_base_recovery_for_run_with_stores(&recipe_store, &lifecycle_store, run_id)
 }
 
-pub(crate) fn moving_base_recovery_for_run_with_store(
-    store: &super::cook_recipe::CookRecipeStore,
-    run_id: &str,
-) -> Result<Option<MovingBaseCookRecovery>> {
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    moving_base_recovery_for_run_with_stores(store, &lifecycle_store, run_id)
-}
-
 pub(crate) fn moving_base_recovery_for_run_with_stores(
     store: &super::cook_recipe::CookRecipeStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
@@ -1634,19 +1625,10 @@ pub(crate) fn finalize_or_load_cook_pr(
     promotion: &AgentTaskPromotionReport,
 ) -> Result<Value> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
-    finalize_or_load_cook_pr_with_store(&store, options, successful_run_id, promotion)
-}
-
-pub(crate) fn finalize_or_load_cook_pr_with_store(
-    store: &super::cook_recipe::CookRecipeStore,
-    options: &AgentTaskCookServiceOptions,
-    successful_run_id: &str,
-    promotion: &AgentTaskPromotionReport,
-) -> Result<Value> {
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     finalize_or_load_cook_pr_with_stores(
-        store,
+        &store,
         &lifecycle_store,
         options,
         successful_run_id,
@@ -1737,20 +1719,10 @@ pub(crate) fn finalize_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     backend: &mut B,
 ) -> Result<Value> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
-    finalize_cook_pr_with_backend_with_store(&store, options, successful_run_id, promotion, backend)
-}
-
-pub(crate) fn finalize_cook_pr_with_backend_with_store<B: AgentTaskPrFinalizationBackend>(
-    store: &super::cook_recipe::CookRecipeStore,
-    options: &AgentTaskCookServiceOptions,
-    successful_run_id: &str,
-    promotion: &AgentTaskPromotionReport,
-    backend: &mut B,
-) -> Result<Value> {
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     finalize_cook_pr_with_backend_with_stores(
-        store,
+        &store,
         &lifecycle_store,
         options,
         successful_run_id,
@@ -1800,20 +1772,10 @@ pub(crate) fn cook_finalization_options(
     overrides: Vec<AgentTaskReviewOverride>,
 ) -> Result<AgentTaskPrFinalizationOptions> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
-    cook_finalization_options_with_store(&store, options, successful_run_id, promotion, overrides)
-}
-
-pub(crate) fn cook_finalization_options_with_store(
-    store: &super::cook_recipe::CookRecipeStore,
-    options: &AgentTaskCookServiceOptions,
-    successful_run_id: &str,
-    promotion: &AgentTaskPromotionReport,
-    overrides: Vec<AgentTaskReviewOverride>,
-) -> Result<AgentTaskPrFinalizationOptions> {
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     cook_finalization_options_with_stores(
-        store,
+        &store,
         &lifecycle_store,
         options,
         successful_run_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11614,6 +11614,140 @@ fn finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store() {
 }
 
 #[test]
+fn cook_promotion_finalizes_into_the_injected_stores_across_split_recipe_and_lifecycle_roots() {
+    let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(recipe_context.data_dir(), lifecycle_context.data_dir());
+
+    let recipe_store = CookRecipeStore::new(recipe_context.path_roots());
+    let lifecycle_store = AgentTaskLifecycleStore::new(lifecycle_context.path_roots());
+
+    let cook_id = "split-root-finalization-cook";
+    let run_id = "split-root-finalization-run";
+    let target = tempfile::tempdir().expect("fixture target");
+    let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.initial_run_id = run_id.to_string();
+    options.initial_plan.tasks[0].executor.model = Some("split-root-model".to_string());
+
+    // The durable recipe lineage is promotion's recipe half; seed it only in the
+    // recipe root.
+    recipe_store
+        .persist_initial_recipe(&options)
+        .expect("persist the recipe in the recipe root");
+    // The run record, the Cook index, and the provider aggregate are promotion's
+    // lifecycle half; seed them only in the lifecycle root.
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
+            Ok(serde_json::json!({}))
+        })
+        .expect("seed the run record in the lifecycle root");
+    lifecycle_store
+        .record_cook_attempt(cook_id, 1, run_id)
+        .expect("record the cook attempt in the lifecycle root");
+    lifecycle_store
+        .record_run_aggregate(
+            run_id,
+            &options.initial_plan,
+            &review_form_aggregate(&options.initial_plan),
+        )
+        .expect("record the review-form aggregate in the lifecycle root");
+
+    let promotion = promotion_with_existing_path(run_id, target.path());
+    // The read half of promotion resolves both stores explicitly: the recipe
+    // lineage from the recipe root, the provider identity from the lifecycle
+    // root's controller plan.
+    let finalization_options = cook_finalization_options_with_stores(
+        &recipe_store,
+        &lifecycle_store,
+        &options,
+        run_id,
+        &promotion,
+        Vec::new(),
+    )
+    .expect("build finalization options through the injected split-root store pair");
+    assert_eq!(
+        finalization_options.review_dossier.ai_assistance.model,
+        "split-root-model"
+    );
+
+    let mut backend = CaptureBackend {
+        synthetic_gate_proof: Some(promotion.clone()),
+        ..Default::default()
+    };
+    let finalization = finalize_or_load_cook_pr_with_backend_with_stores(
+        &recipe_store,
+        &lifecycle_store,
+        &options,
+        run_id,
+        &promotion,
+        &mut backend,
+    )
+    .expect("finalize through the injected split-root store pair");
+
+    assert_eq!(finalization["status"], "review_ready");
+    assert!(backend.created);
+    // The lineage read reached the recipe root: finalization requires the
+    // finalizing run to be declared by the persisted recipe, and only the
+    // recipe root holds one.
+    assert!(recipe_store.recipe_exists(cook_id));
+    assert_eq!(
+        recipe_store
+            .load_recipe(cook_id)
+            .expect("read the recipe in the recipe root")
+            .attempts[0]
+            .run_id,
+        run_id
+    );
+
+    // The finalization receipt and the promotion record landed in the lifecycle
+    // root, not in whatever root ambient state would have resolved.
+    let record = lifecycle_store
+        .read_record(run_id)
+        .expect("read the run record in the lifecycle root");
+    assert!(record.metadata.get("cook_finalization").is_some());
+    assert!(record.metadata.get("promotions").is_some());
+    assert!(lifecycle_store
+        .run_dir(run_id)
+        .starts_with(lifecycle_context.data_dir()));
+    assert_eq!(
+        lifecycle_store
+            .read_cook_index(cook_id)
+            .expect("read the cook index in the lifecycle root")
+            .latest_run_id,
+        run_id
+    );
+
+    // The negatives: a store built on the opposite root sees neither half, so
+    // the injected pair — not an ambient root — decided every read and write.
+    let recipe_root_lifecycle_store = AgentTaskLifecycleStore::new(recipe_context.path_roots());
+    assert!(!recipe_root_lifecycle_store
+        .record_exists(run_id)
+        .expect("no run record in the recipe root"));
+    assert!(!recipe_root_lifecycle_store.cook_index_exists(cook_id));
+    let lifecycle_root_recipe_store = CookRecipeStore::new(lifecycle_context.path_roots());
+    assert!(!lifecycle_root_recipe_store.recipe_exists(cook_id));
+    let error = cook_finalization_options_with_stores(
+        &lifecycle_root_recipe_store,
+        &lifecycle_store,
+        &options,
+        run_id,
+        &promotion,
+        Vec::new(),
+    )
+    .expect_err("the lifecycle root holds no recipe lineage for this Cook");
+    assert_eq!(error.code.as_str(), "internal.io_error");
+    assert!(error.details["context"]
+        .as_str()
+        .expect("the IO error names the recipe path it read")
+        .starts_with(
+            lifecycle_context
+                .data_dir()
+                .to_str()
+                .expect("utf-8 lifecycle data root")
+        ));
+}
+
+#[test]
 fn manual_finalization_identity_resolves_cook_and_failed_attempt_or_reserves_fresh_id() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-11334";


### PR DESCRIPTION
## Summary

Next slice of #7505. Cook promotion carried the **same split-root shape #12565 deleted from pre-execution**: functions taking an explicit `CookRecipeStore` that then resolve `AgentTaskLifecycleStore` from process-global state before delegating to an existing `*_with_stores` variant.

```rust
pub(crate) fn finalize_or_load_cook_pr_with_store(
    store: &CookRecipeStore,                                    // INJECTED
    ...
) -> Result<Value> {
    let lifecycle_store =
        AgentTaskLifecycleStore::from_current_environment()?;    // AMBIENT
    finalize_or_load_cook_pr_with_stores(store, &lifecycle_store, ...)
}
```

A caller that injected explicit roots got its promotion state split across two homes.

## What changed

Five such functions existed. **Four are gone:**

| function | callers | action |
|---|---|---|
| `moving_base_recovery_for_run_with_store` | **0** | deleted |
| `finalize_or_load_cook_pr_with_store` | 1 (wrapper above it) | collapsed + deleted |
| `finalize_cook_pr_with_backend_with_store` | 1 (wrapper above it) | collapsed + deleted |
| `cook_finalization_options_with_store` | 1 (wrapper above it) | collapsed + deleted |
| `finalize_or_load_cook_pr_with_backend_with_store` | **3** | **kept — see below** |

Each collapsed wrapper now resolves both stores in one visible place and calls `*_with_stores` directly.

The plain env-resolving entry points stay. Resolving everything from the environment **in one place** is honest; only the mixed one-injected-one-ambient shape is the bug.

Also inspected and deliberately left alone: `attempt_needs_execution_with_store` and `retryable_provider_discovery_failure_with_store` take only a *lifecycle* store and delegate to the ambient free function **only when `matches_current_environment()` is true** — guarded equivalence, single store, no split.

<h2>The one I refused, and why</h2>

`finalize_or_load_cook_pr_with_backend_with_store` has three callers, not one:

- `cook_promotion.rs:1663` — its own env wrapper, migratable
- `cook_adoption.rs:725` — a `lifecycle_store` **is** in scope
- `cook_adoption.rs:838` — **no lifecycle store in scope**

Giving that last one a store means either threading a parameter through four public ancestors, or hoisting a `from_current_environment()` to the top of the function — which **moves the failure point earlier** and would make `no_finalize` and early-return adoptions start failing on a lifecycle root they never previously touched. That is an observable behavior change, so this slice stops.

Migrating only `:725` would have been churn with zero behavioral effect — the recipe store there is itself `from_current_data_root()`, so both halves are already ambient and un-split — while leaving the mixed function alive anyway.

**Residual hazard, stated precisely:** `cook_promotion.rs:1690` still resolves a lifecycle store from the environment while accepting an injected recipe store. Today it is **latent** — no caller injects a non-ambient recipe store — but a future one would get split promotion state. Closing it requires a decision about `cook_adoption`'s signature chain. Separate slice.

## Dead-code check

Nothing became callerless — every surviving `*_with_stores` verified to have ≥1 caller. Zero remaining references to the four deleted names in `.rs` or `.md`. No `use` became unused. Relevant because CI's warning-clean gate builds with `-Dwarnings`.

## The proof

`cook_promotion_finalizes_into_the_injected_stores_across_split_recipe_and_lifecycle_roots`, beside the existing `finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store`. Two `HermeticTestContext` roots, `path_roots()` only — no `with_isolated_home`, no `HomeGuard`, no `set_var`.

Recipe lineage seeded **only** in the recipe root; run record, Cook index, and review-form aggregate **only** in the lifecycle root.

- **Read half** — `cook_finalization_options_with_stores` succeeds, which it can only do by finding lineage in the recipe root (`cook_ai_lineage_with_stores` hard-errors if the finalizing run is absent from the persisted recipe), while its dossier carries `ai_assistance.model` read from the **lifecycle** root's controller plan.
- **Write half** — `finalize_or_load_cook_pr_with_backend_with_stores` returns `review_ready`, the backend creates the PR, and `cook_finalization` + `promotions` land in the lifecycle root's run record whose `run_dir` starts with that context's data dir.
- **Negatives** — a lifecycle store on the *recipe* root has no run record and no Cook index; a recipe store on the *lifecycle* root has no recipe; and driving finalization with that swapped recipe store fails `internal.io_error` whose `details.context` path is **under the lifecycle data root**, proving the recipe half is read from the injected store rather than an ambient one.

## Compatibility

No public API change — all `pub(crate)`. No observable behavior change; the only difference is that promotion's lifecycle half lands in the injected root instead of an ambient one. `home_lock` / `HomeGuard` / `with_isolated_home` untouched. `finalize_or_load_cook_pr`'s doc comment about not opening a second PR on a restarted continuation preserved verbatim. No other campaign file modified.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and test authoring. Review by hand; compilation deferred to CI.

Refs #7505