### PR TITLE
Close the mixed-store class and pin it shut

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -272,25 +272,6 @@ fn claim_pre_artifact_interruption_retry(
     )
 }
 
-fn claim_pre_artifact_interruption_retry_with_store(
-    recipe_store: &CookRecipeStore,
-    cook_id: &str,
-    attempt: u32,
-    run_id: &str,
-    plan: &AgentTaskPlan,
-    replace_semantic_attempt: bool,
-) -> Result<Option<(u32, String)>> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    claim_pre_artifact_interruption_retry_with_stores(
-        (recipe_store, &lifecycle_store),
-        cook_id,
-        attempt,
-        run_id,
-        plan,
-        replace_semantic_attempt,
-    )
-}
-
 fn claim_pre_artifact_interruption_retry_with_stores(
     stores: (&CookRecipeStore, &AgentTaskLifecycleStore),
     cook_id: &str,
@@ -4097,30 +4078,6 @@ where
     )
 }
 
-fn run_cook_with_boundaries_observed_inner_with_store<E, S>(
-    store: &CookRecipeStore,
-    options: AgentTaskCookServiceOptions,
-    executor: E,
-    side_effects: S,
-    durable_observer: Option<&CookProgressObserver<'_>>,
-    allow_historical_terminal: bool,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-    S: CookSideEffectService,
-{
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    run_cook_with_boundaries_observed_inner_with_stores(
-        store,
-        &lifecycle_store,
-        options,
-        executor,
-        side_effects,
-        durable_observer,
-        allow_historical_terminal,
-    )
-}
-
 /// The Cook spine, bound to explicit recipe and lifecycle roots. Every durable
 /// write on this path resolves through the two passed stores, so a caller can
 /// place a Cook's recipe and its lifecycle records wherever it owns them
@@ -5219,8 +5176,8 @@ where
                         1,
                     ));
                 }
-                match claim_pre_artifact_interruption_retry_with_store(
-                    store,
+                match claim_pre_artifact_interruption_retry_with_stores(
+                    (store, lifecycle_store),
                     &cook_id,
                     attempt,
                     &run_id,

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -1,0 +1,307 @@
+//! Pins the absence of the mixed-store function shape in `homeboy-agents` (#7505).
+//!
+//! The shape this test forbids is a function that accepts one durable store as
+//! an explicit parameter and then manufactures a *different* one from
+//! process-global state inside its own body:
+//!
+//! ```text
+//! fn something_with_store(recipe_store: &CookRecipeStore, ...) -> Result<...> {
+//!     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+//!     something_with_stores((recipe_store, &lifecycle_store), ...)
+//! }
+//! ```
+//!
+//! A caller that believes it injected explicit roots gets its state split
+//! silently across two homes: the recipe lands where it asked, the lifecycle
+//! records land wherever the environment happens to point. #7505 removed these
+//! one call path at a time, which is exactly the kind of decision that erodes
+//! back in as soon as the next `_with_store` wrapper looks convenient. Asserting
+//! the absence is what stops it, in the manner of
+//! `tests/audit_debt_workflow_test.rs`.
+//!
+//! Two shapes stay legal and are not flagged:
+//!
+//! * an env-resolving entry point that takes no store at all and resolves
+//!   everything it needs in one place (`run_cook_with_boundaries_observed_inner`,
+//!   `claim_pre_artifact_interruption_retry`). Nothing was injected, so nothing
+//!   is split.
+//! * a function that takes a store and delegates to an ambient free function
+//!   only under a `matches_current_environment()` equivalence guard
+//!   (`cook_promotion::attempt_needs_execution_with_store` and
+//!   `retryable_provider_discovery_failure_with_store`). Those bodies name no
+//!   store constructor at all, so the scanner never sees a second root.
+//!
+//! The source walk follows the convention in `tests/release_workflow_test.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A durable store that `homeboy-agents` roots explicitly.
+struct Store {
+    /// The type name as it reads in a parameter position, with or without a
+    /// module qualifier: `&CookRecipeStore`, `&super::cook_recipe::CookRecipeStore`,
+    /// `(&CookRecipeStore, &AgentTaskLifecycleStore)`. Matching the bare name
+    /// covers every spelling. It is safe against matching a *return* type
+    /// because no function in this crate returns either store type — both are
+    /// produced only as `Result<Self>` from their own constructors.
+    type_name: &'static str,
+    /// The constructor that reads process-global state instead of a passed root.
+    env_constructor: &'static str,
+}
+
+const STORES: &[Store] = &[
+    Store {
+        type_name: "CookRecipeStore",
+        env_constructor: "CookRecipeStore::from_current_data_root()",
+    },
+    Store {
+        type_name: "AgentTaskLifecycleStore",
+        env_constructor: "AgentTaskLifecycleStore::from_current_environment()",
+    },
+];
+
+/// Mixed-store functions that #7505 has not reached yet.
+///
+/// Every entry is debt, not a false positive: each one really does have the
+/// shape this test forbids. Each is listed because closing it is its own slice,
+/// with its own call-chain to re-root, not because the scanner is wrong.
+///
+/// Entries may only be removed. A stale entry — one naming a function that no
+/// longer has the shape, or no longer exists — fails this test, so the list
+/// cannot outlive the debt it records. Adding a row is the edit this test exists
+/// to make someone argue for in review.
+const KNOWN_MIXED_STORE_FUNCTIONS: &[(&str, &str)] = &[
+    // Takes `&CookRecipeStore` and resolves the lifecycle store through a
+    // `match` so the *resolution failure* still lands in
+    // `durable_cook_error_report_with_store`, where the spine's own failure used
+    // to land. Its only caller, `run_cook_with_boundaries_observed_policy_with_store`,
+    // holds no lifecycle store, so closing this means threading one through the
+    // entire `run_cook_with_boundaries_observed*` wrapper chain.
+    (
+        "crates/homeboy-agents/src/agent_task_service/cook.rs",
+        "run_cook_with_boundaries_reported",
+    ),
+    // Takes `&super::cook_recipe::CookRecipeStore` and resolves the lifecycle
+    // store with `?`. Three live callers, two of them in `cook_adoption.rs`, so
+    // this is a cook_promotion/cook_adoption slice.
+    (
+        "crates/homeboy-agents/src/agent_task_service/cook_promotion.rs",
+        "finalize_or_load_cook_pr_with_backend_with_store",
+    ),
+];
+
+#[test]
+fn homeboy_agents_never_pairs_an_injected_store_with_an_ambient_one() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let sources_root = root.join("crates/homeboy-agents/src");
+    let mut sources = Vec::new();
+    collect_rust_sources(&sources_root, &mut sources);
+    assert!(
+        !sources.is_empty(),
+        "no Rust sources found under {}; this scanner has lost its target and \
+         would pass vacuously",
+        sources_root.display()
+    );
+
+    let mut findings = Vec::new();
+    for path in &sources {
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        findings.extend(scan_source(&relative, &source));
+    }
+
+    let unexpected: Vec<&Finding> = findings
+        .iter()
+        .filter(|finding| {
+            !KNOWN_MIXED_STORE_FUNCTIONS
+                .contains(&(finding.file.as_str(), finding.function.as_str()))
+        })
+        .collect();
+    assert!(unexpected.is_empty(), "{}", hazard_report(&unexpected));
+
+    let stale: Vec<String> = KNOWN_MIXED_STORE_FUNCTIONS
+        .iter()
+        .filter(|(file, function)| {
+            !findings
+                .iter()
+                .any(|finding| finding.file == *file && finding.function == *function)
+        })
+        .map(|(file, function)| format!("  {file}  {function}"))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "KNOWN_MIXED_STORE_FUNCTIONS names functions that no longer mix an \
+         injected store with an ambient one:\n{}\n\nThat is the good outcome — \
+         delete these rows. The list is only allowed to shrink, and a row that \
+         suppresses nothing would silently re-permit the shape it names.",
+        stale.join("\n")
+    );
+}
+
+struct Finding {
+    file: String,
+    line: usize,
+    function: String,
+    injected: Vec<&'static str>,
+    ambient: Vec<&'static str>,
+}
+
+fn hazard_report(findings: &[&Finding]) -> String {
+    let mut report = String::from(
+        "homeboy-agents has a function that mixes an injected store with an \
+         ambient one:\n\n",
+    );
+    for finding in findings {
+        let file = &finding.file;
+        let line = finding.line;
+        let function = &finding.function;
+        let injected = finding.injected.join(", ");
+        let ambient = finding.ambient.join(", ");
+        report.push_str(&format!(
+            "  {file}:{line}  {function}\n\
+             \x20   injected by the caller: {injected}\n\
+             \x20   built from the process environment in its own body: {ambient}\n",
+        ));
+    }
+    report.push_str(
+        "\nA function that accepts one store as a parameter and constructs a \
+         different one from process-global state splits its caller's durable \
+         state across two roots. The caller believes it injected explicit roots, \
+         but half of its writes land wherever the environment happens to point, \
+         with no error and no evidence (#7505).\n\n\
+         Take both stores as parameters and let the caller pair them, or take \
+         neither and resolve both in a single env-resolving entry point.\n",
+    );
+    report
+}
+
+fn scan_source(file: &str, source: &str) -> Vec<Finding> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut findings = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let Some(function) = function_name(trimmed) else {
+            continue;
+        };
+        let indent = line.len() - trimmed.len();
+        let Some((signature, body)) = function_regions(&lines, index, indent) else {
+            continue;
+        };
+
+        let injected: Vec<&'static str> = STORES
+            .iter()
+            .filter(|store| signature.contains(store.type_name))
+            .map(|store| store.type_name)
+            .collect();
+        if injected.is_empty() {
+            continue;
+        }
+        // Only a store the function was *not* handed is a split root. Resolving
+        // the same kind it already accepts is the guarded-equivalence shape, and
+        // resolving everything while accepting nothing is an entry point.
+        let ambient: Vec<&'static str> = STORES
+            .iter()
+            .filter(|store| !injected.contains(&store.type_name))
+            .filter(|store| body.contains(store.env_constructor))
+            .map(|store| store.type_name)
+            .collect();
+        if ambient.is_empty() {
+            continue;
+        }
+
+        findings.push(Finding {
+            file: file.to_string(),
+            line: index + 1,
+            function: function.to_string(),
+            injected,
+            ambient,
+        });
+    }
+    findings
+}
+
+/// The name of the function declared on a line, if the line declares one.
+fn function_name(trimmed: &str) -> Option<&str> {
+    let mut rest = trimmed;
+    if let Some(after) = rest.strip_prefix("pub(") {
+        rest = after[after.find(')')? + 1..].trim_start();
+    }
+    for prefix in [
+        "pub ",
+        "default ",
+        "const ",
+        "async ",
+        "unsafe ",
+        "extern \"C\" ",
+    ] {
+        if let Some(after) = rest.strip_prefix(prefix) {
+            rest = after.trim_start();
+        }
+    }
+    let name = rest
+        .strip_prefix("fn ")?
+        .trim_start()
+        .split(|character: char| !character.is_alphanumeric() && character != '_')
+        .next()?;
+    (!name.is_empty()).then_some(name)
+}
+
+/// Split a function into its signature text and its body text.
+///
+/// rustfmt is what makes this reliable without a Rust parser: the line that
+/// opens a body is the first one ending in `{`, and the body's closing brace
+/// sits alone at exactly the `fn` keyword's own indentation. Anything that does
+/// not match that shape — a one-line body, a trait method declared without one —
+/// is skipped rather than guessed at, so a miss is a missed finding and never a
+/// misattributed one.
+fn function_regions(lines: &[&str], start: usize, indent: usize) -> Option<(String, String)> {
+    if lines[start].trim_end().ends_with('}') {
+        return None;
+    }
+
+    let mut signature_end = None;
+    for (offset, line) in lines[start..].iter().enumerate() {
+        let line = line.trim_end();
+        if line.ends_with('{') {
+            signature_end = Some(start + offset);
+            break;
+        }
+        if line.ends_with(';') {
+            // Declared without a body: a trait method, or a `fn` pointer type.
+            return None;
+        }
+    }
+    let signature_end = signature_end?;
+
+    let closing = format!("{}}}", " ".repeat(indent));
+    let body_start = signature_end + 1;
+    let body_end = body_start
+        + lines[body_start..]
+            .iter()
+            .position(|line| line.trim_end() == closing)?;
+
+    Some((
+        lines[start..=signature_end].join("\n"),
+        lines[body_start..body_end].join("\n"),
+    ))
+}
+
+fn collect_rust_sources(directory: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            collect_rust_sources(&path, out);
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The defect #7505 has been eliminating across eight PRs is the **mixed-store shape** — a function taking one store as an explicit parameter that then resolves a *different* store from process-global state:

```rust
fn something_with_store(
    recipe_store: &CookRecipeStore,                             // INJECTED
) -> Result<...> {
    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;  // AMBIENT
    something_with_stores((recipe_store, &lifecycle_store), ...)
}
```

A caller that believes it injected explicit roots gets its state split across two homes, silently. Earlier slices deleted these from `cook_pre_execution.rs` (#12563/#12565) and `cook_promotion.rs` (#12590).

## I thought one remained. There were three.

| function | disposition |
|---|---|
| `claim_pre_artifact_interruption_retry_with_store` | **migrated + deleted** |
| `run_cook_with_boundaries_observed_inner_with_store` | **deleted — zero callers** |
| `run_cook_with_boundaries_reported` | refused, allowlisted |

**The second one is the interesting find.** It had no callers anywhere in the tree: **#12582 orphaned it** when it rewired `run_cook_with_boundaries_reported_with_stores` onto the paired form. Nobody noticed because `agent_task_service` carries a module-level `#[allow(dead_code, reason = "Cook adoption helpers…")]` in `lib.rs:73`. So a hazard survived purely because a blanket allow was suppressing the signal that would have found it.

The first migrated cleanly — its single caller sits inside the spine #12582 rooted, which already takes both stores, so nothing needed threading. Verified no shadowing binding between the `fn` line and the call site.

## What was refused

`run_cook_with_boundaries_reported` (`cook.rs:3891`). Its only caller holds no lifecycle store, and closing it means threading one through four ancestors and three other call sites. Its lifecycle resolution also runs through a `match` specifically so the failure lands in `durable_cook_error_report_with_store`, which would have to be preserved. Separate slice.

Also allowlisted, out of this diff's boundary: `finalize_or_load_cook_pr_with_backend_with_store` in `cook_promotion.rs` — the same residual hazard #12590 named, with two of its three callers in `cook_adoption.rs`.

<h2>The durable half: a test that pins the absence</h2>

`tests/agent_task_store_injection_test.rs`. This repo already uses absence-pinning deliberately (`tests/audit_debt_workflow_test.rs`) so a removed design decision cannot creep back.

**How it decides a function is mixed-shape:**
- signature names `CookRecipeStore` or `AgentTaskLifecycleStore`
- body resolves a store of a **different kind** from the environment

Same-kind resolution is not a split root and is not flagged. A function with no store parameter resolving everything in one visible place is the legitimate compatibility shape.

**Deliberate design choices:**
- Splits signature from body using **rustfmt's guarantees**, not a Rust parser — body opens on the first line ending `{`, closes on a line that is exactly `}` at the `fn` keyword's indentation.
- **Skips what it cannot bound confidently** — one-line bodies, bodyless trait declarations. A miss is a missed finding, never a misattributed one.
- **Bare-name type matching**, because the crate spells these fully qualified in several modules (`&super::cook_recipe::CookRecipeStore`). Verified no function in the crate *returns* either type, so a return-position false positive is impossible.
- **The failure message teaches** — names file, line, function, and explains the hazard.

**Verified not flagged**, against a handwritten fixture compiled with `rustc --test`: env-resolving entry points taking no store; same-kind resolution; the `(&CookRecipeStore, &AgentTaskLifecycleStore)` tuple form; trait declarations and empty bodies. Negative control: three fixture hazards all fire, including the reversed direction (lifecycle injected, recipe ambient) and a generic + `match` + fully-qualified spelling.

Notably `attempt_needs_execution_with_store` and `retryable_provider_discovery_failure_with_store` — the guarded-equivalence helpers — **needed no allowlist entry**. Their bodies name no store constructor at all, so the scanner structurally cannot see them.

### The allowlist is self-pruning

Two entries, both real debt rather than false positives, each commented with why closing it is its own slice. A second assertion **fails if an entry no longer has the shape**, with a message saying that is the good outcome and to delete the row.

So it can only shrink, and growing it requires a human edit that review will see. Both failure branches verified.

## Result

```
3 findings  →  1 migrated + deleted
               1 deleted as dead
               2 allowlisted with justification
               0 unexpected
```

## Compatibility

No public API change. No observable behavior change — the migrated call site's lifecycle half now comes from the injected store rather than an ambient one, which today resolve to the same root. `home_lock` / `HomeGuard` / `with_isolated_home` untouched.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and scanner authoring with standalone `rustc` fixture verification. Review by hand; workspace compilation deferred to CI.

Refs #7505