### PR TITLE
fix(agent-task): bind daemon authority before execution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1296,6 +1296,14 @@ where
     }
     if let Some(runner_id) = execution_runner_id.as_deref() {
         metadata["runner_id"] = json!(runner_id);
+        if let Some(execution_context) =
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::from_direct_daemon_child_environment(
+                &run_id,
+                runner_id,
+            )?
+        {
+            project_runner_execution_context(&mut metadata, &execution_context)?;
+        }
     }
     // The plan is the immutable cross-process carrier. Project the identical
     // decision onto the run record so status, finalization, and PR evidence do
@@ -1498,6 +1506,16 @@ where
         }
     }
     Ok(record)
+}
+
+pub(crate) fn project_runner_execution_context(
+    metadata: &mut Value,
+    execution_context: &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext,
+) -> Result<()> {
+    execution_context.verify_integrity()?;
+    metadata["runner_job_id"] = json!(execution_context.runner_job_id());
+    metadata["runner_execution_context"] = execution_context.evidence_record()?;
+    Ok(())
 }
 
 pub(crate) fn persist_controller_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -18,6 +18,34 @@ use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 #[test]
+fn accepted_daemon_context_keeps_a_pidless_runner_submission_live() {
+    with_isolated_home(|_| {
+        let run_id = "accepted-daemon-runner-submission";
+        let context =
+            homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::direct_daemon(
+                Some(run_id),
+                "runner-1",
+                "00000000-0000-4000-8000-000000000001",
+                "homeboy",
+                "reservation-1",
+            )
+            .expect("accepted context");
+        let mut record = submit_plan(&test_plan(), Some(run_id)).expect("submit run");
+        set_run_state(&mut record, AgentTaskRunState::Running);
+        record.updated_at = Some(now_timestamp());
+        project_runner_execution_context(&mut record.metadata, &context)
+            .expect("project accepted authority");
+        store::write_record(&record).expect("persist runner-local record");
+
+        let status = status(run_id).expect("runner-local status");
+        assert_eq!(status.runner_job_id(), Some(context.runner_job_id()));
+        assert!(status.metadata.get("runner_execution_context").is_some());
+        assert!(status.metadata.get("stale_running").is_none());
+        assert!(status.metadata.get("stale_running_reason").is_none());
+    });
+}
+
+#[test]
 fn retry_first_visible_record_always_has_indexed_predecessor_identity() {
     with_isolated_home(|_| {
         let source_id = "retry-atomic-source";

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -3282,6 +3282,75 @@ impl JobHandle {
             .ok_or_else(|| Error::internal_unexpected("local child reservation is missing"))
     }
 
+    pub(crate) fn accepted_local_child_execution_context(
+        &self,
+        reservation_id: &str,
+        runner_id: &str,
+        durable_run_id: &str,
+        context_id: &str,
+    ) -> Result<Value> {
+        let inner = self.store.inner.lock().expect("job store mutex poisoned");
+        let stored = inner
+            .jobs
+            .get(&self.job_id)
+            .ok_or_else(|| job_not_found(self.job_id))?;
+        let local_runner = stored.local_runner.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_execution_context",
+                "daemon job has no local runner authority",
+                Some(self.job_id.to_string()),
+                None,
+            )
+        })?;
+        let local_child = stored.local_child.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_execution_context",
+                "daemon job has no local child reservation",
+                Some(self.job_id.to_string()),
+                None,
+            )
+        })?;
+        if stored.job.status != JobStatus::Running
+            || local_child.process.is_none()
+            || local_child.reservation_id != reservation_id
+            || local_runner.runner_id != runner_id
+            || stored_job_durable_run_id(stored).as_deref() != Some(durable_run_id)
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner_execution_context",
+                "daemon job does not match the running local child authority",
+                Some(self.job_id.to_string()),
+                None,
+            ));
+        }
+        stored
+            .events
+            .iter()
+            .rev()
+            .filter_map(|event| event.data.as_ref())
+            .filter(|data| {
+                data.get("phase").and_then(Value::as_str)
+                    == Some("runner_job_execution_context_verified")
+            })
+            .filter_map(|data| data.get("execution_context"))
+            .find(|evidence| {
+                evidence
+                    .get("context")
+                    .and_then(|context| context.get("id"))
+                    .and_then(Value::as_str)
+                    == Some(context_id)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "runner_execution_context",
+                    "daemon job has no matching verified execution context",
+                    Some(context_id.to_string()),
+                    None,
+                )
+            })
+    }
+
     pub(crate) fn start_with_reserved_child_identity(
         &self,
         pid: u32,

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -3063,13 +3063,20 @@ fn enqueue_exec_job(
                     "phase": "runner_job_execution_context_verified",
                     "execution_context": execution_context_evidence,
                 }))?;
-                plan.env
-                    .insert("HOMEBOY_RUNNER_CHILD_RESERVATION".to_string(), reservation_id);
+                plan.env.insert(
+                    crate::runner_job_execution_context::RUNNER_CHILD_RESERVATION_ENV.to_string(),
+                    reservation_id,
+                );
                 // Runner-local supervisors need the durable job identity to
                 // attach their child-service ledger to this daemon owner.
                 plan.env.insert(
-                    "HOMEBOY_RUNNER_JOB_ID".to_string(),
+                    crate::runner_job_execution_context::RUNNER_JOB_ID_ENV.to_string(),
                     job.job_id().to_string(),
+                );
+                plan.env.insert(
+                    crate::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV
+                        .to_string(),
+                    execution_context.id().to_string(),
                 );
                 let liveness = Arc::new(Mutex::new(ExecLiveness::new(Instant::now())));
                 let cancellation_requested = Arc::new(AtomicBool::new(false));

--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -16,6 +16,9 @@ pub const RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA: &str =
     "homeboy/runner-job-execution-context-evidence/v1";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY: &str = "runner-job-execution-context";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 1;
+pub const RUNNER_JOB_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_ID";
+pub const RUNNER_CHILD_RESERVATION_ENV: &str = "HOMEBOY_RUNNER_CHILD_RESERVATION";
+pub const RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_EXECUTION_CONTEXT_ID";
 const MAX_EVIDENCE_BYTES: usize = 8 * 1024;
 
 /// A worker must explicitly advertise this before the broker will hand it a
@@ -313,6 +316,54 @@ impl RunnerJobExecutionContext {
         self.authenticated && self.verification.state == "local"
     }
 
+    /// Resolve authority inherited by a daemon-local child against the durable
+    /// job store. The environment identifies the claim; the persisted running
+    /// job, reservation, and verified context establish it.
+    pub fn from_direct_daemon_child_environment(
+        expected_run_id: &str,
+        expected_runner_id: &str,
+    ) -> Result<Option<Self>> {
+        let reservation_id = std::env::var(RUNNER_CHILD_RESERVATION_ENV).ok();
+        let context_id = std::env::var(RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV).ok();
+        if reservation_id.is_none() && context_id.is_none() {
+            return Ok(None);
+        }
+        let reservation_id = required_environment(reservation_id, RUNNER_CHILD_RESERVATION_ENV)?;
+        let context_id = required_environment(context_id, RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV)?;
+        let runner_job_id =
+            required_environment(std::env::var(RUNNER_JOB_ID_ENV).ok(), RUNNER_JOB_ID_ENV)?;
+        let job_id = uuid::Uuid::parse_str(&runner_job_id).map_err(|_| {
+            rejected("daemon child runner job identity is not a valid durable job id")
+        })?;
+        let store = crate::api_jobs::JobStore::open_without_reconciliation(
+            crate::paths::daemon_jobs_file()?,
+        )?;
+        let evidence = store
+            .handle(job_id)
+            .accepted_local_child_execution_context(
+                &reservation_id,
+                expected_runner_id,
+                expected_run_id,
+                &context_id,
+            )?;
+        let asserted = Self::from_evidence_record(&evidence)?;
+        let accepted = Self::direct_daemon_with_dispatch_metadata(
+            Some(expected_run_id),
+            Some(&asserted.controller_attempt_id),
+            Some(&asserted.accepted_handoff_id),
+            expected_runner_id,
+            &runner_job_id,
+            &asserted.runtime_id,
+            &reservation_id,
+        )?;
+        if accepted.id != context_id || accepted.evidence_record()? != evidence {
+            return Err(rejected(
+                "daemon child execution context does not match its durable reservation",
+            ));
+        }
+        Ok(Some(accepted))
+    }
+
     /// A single bounded, content-addressed durable record shared by controller
     /// and runner recovery. The complete typed context is retained so a restart
     /// never needs to infer authority from lifecycle or environment state.
@@ -405,6 +456,17 @@ fn required(value: &Option<String>, label: &str) -> Result<String> {
         .ok_or_else(|| rejected(&format!("accepted dispatch is missing its {label} receipt")))
 }
 
+fn required_environment(value: Option<String>, name: &str) -> Result<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            rejected(&format!(
+                "daemon child is missing required environment {name}"
+            ))
+        })
+}
+
 fn non_empty(value: &str, label: &str) -> Result<String> {
     value
         .trim()
@@ -449,6 +511,10 @@ pub(crate) fn rejected(reason: &str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api_jobs::{
+        LocalChildStartDiscriminator, LocalRunnerJob, RunnerJobLifecycleMetadata,
+    };
+    use crate::test_support::{with_isolated_home, EnvVarGuard};
 
     #[test]
     fn local_context_is_explicit_and_never_nullable() {
@@ -560,5 +626,71 @@ mod tests {
         assert!(!serialized.contains(secret));
         assert!(!evidence.contains(secret));
         assert!(serialized.contains("claim_ref"));
+    }
+
+    #[test]
+    fn daemon_child_environment_resolves_only_the_accepted_running_job() {
+        with_isolated_home(|_| {
+            let store = crate::api_jobs::JobStore::open_without_reconciliation(
+                crate::paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("job store");
+            let run_id = "runner-local-run";
+            let runner_id = "runner-1";
+            let job = store.create_test_local_runner_job(Some(LocalRunnerJob {
+                runner_id: runner_id.to_string(),
+                command: vec!["homeboy".to_string()],
+                cwd: None,
+                lifecycle: Some(RunnerJobLifecycleMetadata {
+                    durable_run_id: Some(run_id.to_string()),
+                    ..RunnerJobLifecycleMetadata::default()
+                }),
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
+            }));
+            store.reserve_local_child(job.id).expect("reserve child");
+            let handle = store.handle(job.id);
+            let reservation_id = handle.local_child_reservation_id().expect("reservation id");
+            let context = RunnerJobExecutionContext::direct_daemon(
+                Some(run_id),
+                runner_id,
+                &job.id.to_string(),
+                "homeboy",
+                &reservation_id,
+            )
+            .expect("context");
+            handle
+                .progress(serde_json::json!({
+                    "phase": "runner_job_execution_context_verified",
+                    "execution_context": context.evidence_record().expect("evidence"),
+                }))
+                .expect("record context");
+            handle
+                .start_with_reserved_child_identity(
+                    std::process::id(),
+                    None,
+                    LocalChildStartDiscriminator::Unsupported {
+                        evidence: "test process".to_string(),
+                    },
+                )
+                .expect("start child");
+
+            let _job = EnvVarGuard::set(RUNNER_JOB_ID_ENV, job.id.to_string());
+            let _reservation = EnvVarGuard::set(RUNNER_CHILD_RESERVATION_ENV, &reservation_id);
+            let _context = EnvVarGuard::set(RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV, context.id());
+            let resolved =
+                RunnerJobExecutionContext::from_direct_daemon_child_environment(run_id, runner_id)
+                    .expect("resolve accepted authority")
+                    .expect("direct daemon authority");
+            assert_eq!(resolved.id(), context.id());
+            assert_eq!(resolved.runner_job_id(), job.id.to_string());
+            assert!(resolved.verify_integrity().is_ok());
+
+            let _forged = EnvVarGuard::set(RUNNER_CHILD_RESERVATION_ENV, "forged-reservation");
+            assert!(
+                RunnerJobExecutionContext::from_direct_daemon_child_environment(run_id, runner_id,)
+                    .is_err()
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary
- validate daemon-local child authority against the durable running job, reservation, runner, run, and execution context
- project the accepted runner job into the lifecycle record during submission, before PID ownership is available
- retain fail-closed cleanup for forged authority and genuinely ownerless runs

Fixes #12531.

## Verification
- `cargo test -p homeboy-core runner_job_execution_context::tests`
- `cargo test -p homeboy-agents accepted_daemon_context_keeps_a_pidless_runner_submission_live`
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests`
- `cargo check -p homeboy-lab-runner -p homeboy-cli`
- `git diff --check`

Strict workspace Clippy remains blocked by nine pre-existing warnings outside this patch in `cleanup.rs`, `git/release_download.rs`, `http_api.rs`, `notify_outbox.rs`, and `server/client/host.rs`.

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode traced the runner-local cancellation race, implemented the durable authority binding and regressions, and ran the verification commands. Chris Huber reviewed and remains responsible for every line.