### PR TITLE
Root adoption finalization and shrink the allowlist

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -36,8 +36,8 @@ use super::cook::{
     CookFollowUpBudgetScope, CookFollowUpDispatch,
 };
 use super::cook_promotion::{
-    cook_report, finalize_or_load_cook_pr_with_backend_with_store, persisted_promotion_for_attempt,
-    promotion_source, CookReportInput,
+    cook_report, finalize_or_load_cook_pr_with_backend_with_stores,
+    persisted_promotion_for_attempt, promotion_source, CookReportInput,
 };
 use super::cook_recipe::CookRecipeStore;
 use super::AgentTaskRunResult;
@@ -239,6 +239,16 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     backend: &mut B,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let store = CookRecipeStore::from_current_data_root()?;
+    // Adoption is an env-resolving entry point: nothing above it can inject a
+    // root, because every one of its callers is a frozen `pub` signature. Both
+    // durable roots are therefore resolved here, adjacent and visible, so the
+    // pair handed to remediation dispatch and to finalization is provably the
+    // same pair. Resolving the lifecycle root here surfaces no failure earlier
+    // than before: `agent_task_lifecycle::load_plan` below runs unconditionally
+    // ahead of every return in this function and already resolves this exact
+    // constructor through its own default store.
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     let (record, recipe) = resolve_adoption_target_with_attempt(cook_or_run_id, attempt)?;
     let cook_id = &recipe.cook_id;
     let mut options = super::reconstruct_adoption_options(&recipe)?;
@@ -681,8 +691,6 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             },
             Err(error) => return Err(error),
         };
-        let lifecycle_store =
-            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
         let dispatch = dispatch_cook_follow_up(
             (&store, &lifecycle_store),
             &options,
@@ -722,8 +730,13 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     options,
                     executor,
                     |options, run_id, promotion| {
-                        finalize_or_load_cook_pr_with_backend_with_store(
-                            &store, options, run_id, promotion, backend,
+                        finalize_or_load_cook_pr_with_backend_with_stores(
+                            &store,
+                            &lifecycle_store,
+                            options,
+                            run_id,
+                            promotion,
+                            backend,
                         )
                     },
                 )?;
@@ -835,8 +848,9 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         "finalization",
         "finalize pull request",
     )?;
-    let mut finalization = match finalize_or_load_cook_pr_with_backend_with_store(
+    let mut finalization = match finalize_or_load_cook_pr_with_backend_with_stores(
         &store,
+        &lifecycle_store,
         &options,
         &record.run_id,
         &promotion,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1660,28 +1660,10 @@ pub(crate) fn finalize_or_load_cook_pr_with_backend<B: AgentTaskPrFinalizationBa
     backend: &mut B,
 ) -> Result<Value> {
     let store = super::cook_recipe::CookRecipeStore::from_current_data_root()?;
-    finalize_or_load_cook_pr_with_backend_with_store(
-        &store,
-        options,
-        successful_run_id,
-        promotion,
-        backend,
-    )
-}
-
-pub(crate) fn finalize_or_load_cook_pr_with_backend_with_store<
-    B: AgentTaskPrFinalizationBackend,
->(
-    store: &super::cook_recipe::CookRecipeStore,
-    options: &AgentTaskCookServiceOptions,
-    successful_run_id: &str,
-    promotion: &AgentTaskPromotionReport,
-    backend: &mut B,
-) -> Result<Value> {
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     finalize_or_load_cook_pr_with_backend_with_stores(
-        store,
+        &store,
         &lifecycle_store,
         options,
         successful_run_id,

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -81,13 +81,6 @@ const KNOWN_MIXED_STORE_FUNCTIONS: &[(&str, &str)] = &[
         "crates/homeboy-agents/src/agent_task_service/cook.rs",
         "run_cook_with_boundaries_reported",
     ),
-    // Takes `&super::cook_recipe::CookRecipeStore` and resolves the lifecycle
-    // store with `?`. Three live callers, two of them in `cook_adoption.rs`, so
-    // this is a cook_promotion/cook_adoption slice.
-    (
-        "crates/homeboy-agents/src/agent_task_service/cook_promotion.rs",
-        "finalize_or_load_cook_pr_with_backend_with_store",
-    ),
 ];
 
 #[test]


### PR DESCRIPTION
## Summary

Closes one of the two rows #12591 left in `KNOWN_MIXED_STORE_FUNCTIONS`.

## #12590's premise was wrong

#12590 examined `finalize_or_load_cook_pr_with_backend_with_store` and **refused** it:

> `cook_adoption.rs:838` — the main finalization path. **No lifecycle store in scope**... hoisting a `from_current_environment()` call to the top of that function... would make `no_finalize`/early-return adoptions start failing on lifecycle-root resolution **they never previously touched**.

That was the right instinct on the wrong facts. `adopt_cook_candidate_with_dispatcher_and_backend_for_attempt` **already** calls `agent_task_lifecycle::load_plan` unconditionally at `:250`:

```
load_plan → store::read_controller_plan → read_controller_plan_in_store(&default_store()?, …)
default_store()  ==  AgentTaskLifecycleStore::from_current_environment()
```

Lines 241–266 are **straight-line with no branches**, and the first `return` is at `:275`. So `no_finalize` (`:817`), `gate_failed` (`:804`), `baseline_red` (`:783`) and every replay early-return already propagate lifecycle-root resolution failure — **550+ lines before they are reached.** They do not never touch it; they touch it much earlier than the refusal assumed.

## What changed

Resolution is hoisted beside the recipe store at the top of that function, the mid-body resolution at `:684` is deleted, and both finalization sites take the parameter. `cook_promotion`'s env wrapper now resolves both itself in the same order as before, and `finalize_or_load_cook_pr_with_backend_with_store` is **deleted**.

The entry point now matches the second shape the scanner explicitly blesses: **takes no store, resolves everything it needs in one visible place.**

## Residual, stated rather than hidden

Hoisting moves resolution ahead of three fallible operations (`:241`/`:242`/`:244`). In an environment where the config or artifact root is unresolvable **and** the caller passes an unknown cook id, you now get the path error rather than "unknown agent-task run or durable cook id".

That environment cannot complete any adoption today either — it dies at `:250` — so this is **error-message ordering inside an already-fatal environment**, not a new failure class.

The `:838` cleanup path is preserved: resolution now fails before `start_candidate_adoption_with_policy` (`:467`), so there is no in-flight adoption for the deleted `finish_candidate_adoption` to close, and that `match` arm is untouched for every failure that can still reach it.

<h2>The variant I deliberately did not add</h2>

The obvious move is `adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_stores`. I didn't, for two reasons:

1. **It would have no injecting caller.** All five ancestors are `pub` and re-exported through `agent_tasks.rs:468-471`, with one called from `homeboy-cli`. Under the no-public-signature-change constraint the chain is one level deep, so the variant's only non-test caller would be its own wrapper.
2. **It would be a lie, and a scanner-invisible one.** That body makes ~21 direct ambient `agent_task_lifecycle::*` free-function calls — 10× `finish_candidate_adoption`, 3× `checkpoint_candidate_adoption`, 3× `candidate_adoption_cancel_requested`, 2× `record_promotion`, plus others — and indirect ones through `persist_adoption_terminal_result`, `adopted_review_form`, and `resolve_adoption_target_with_attempt`, which also reads the **ambient recipe root**.

A signature advertising `(&CookRecipeStore, &AgentTaskLifecycleStore)` over a body where ~25 operations go to process-global roots is precisely the "caller believes it injected explicit roots" hazard #7505 exists to kill — **and the scanner could not catch it**, because both types appear in the signature so its `ambient` set computes empty.

Closing one listed landmine by burying an unlisted one is not progress. If you want the variant anyway as a staging point for a later slice that also re-roots those 21 calls, say so.

## Verification

The scanner is std-only, so I compiled it with plain `rustc --test` (no cargo) and ran it **both ways**:

- against `HEAD`'s sources with the shrunk allowlist → **fails**, naming exactly `cook_promotion.rs:1672 finalize_or_load_cook_pr_with_backend_with_store`
- against this tree → **passes**, and the surviving `run_cook_with_boundaries_reported` row is confirmed non-stale

Nothing became callerless — verified by explicit grep across `crates/`, `src/`, `tests/`, not by the compiler, since `lib.rs`'s module-level `#[allow(dead_code, …)]` would have hidden it.

## Test

No new test. The adoption path is the heavy-fixtures case — with the entry point taking no stores there is nothing to inject, so a split-root proof would need `with_isolated_home` plus a durable recipe, run record, observation store, a git worktree with a real candidate commit, and gate execution. `finalize_or_load_cook_pr_with_backend_with_stores` is already proven across split roots by #12590's own test including negatives, and this slice's deliverable is the shape's absence — which the scanner run above proves mechanically.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, code edits, and standalone scanner verification. Review by hand; compilation deferred to CI.

Refs #7505