### PR TITLE
Stop shadowing the injected lifecycle store in the reported wrapper

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3953,12 +3953,8 @@ where
             .map(|attempt| attempt.attempt)
             .unwrap_or(1);
         let phase = result.value.disposition.phase();
-        // Last ambient lifecycle reach on this path: run_cook_with_boundaries_reported
-        // has no store in scope, and giving it one requires threading a parameter
-        // through the 3623-3961 boundary chain (#7505).
-        let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
         if let Err(error) = report_cook_progress(
-            &lifecycle_store,
+            lifecycle_store,
             durable_observer,
             &result.value.cook_id,
             run_id,


### PR DESCRIPTION
## Summary

I set out to close the second #12591 allowlist row and **could not** — but found a real bug on the way.

`run_cook_with_boundaries_reported_with_stores` already takes `lifecycle_store` as a parameter, then **shadowed it**:

```rust
fn run_cook_with_boundaries_reported_with_stores(
    store: &CookRecipeStore,
    lifecycle_store: &AgentTaskLifecycleStore,     // ← handed one
    ...
) {
    ...
    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;  // ← ignored it
    report_cook_progress(&lifecycle_store, ...)
}
```

The parameter was ignored on that path.

## Why it survived

It is a leftover from `6ebec0e57`, which moved this body **out** of `run_cook_with_boundaries_reported` into the paired form and carried the ambient reach along. The comment above it still described the *old* host — saying that function has no store in scope, which is untrue of the paired form, which is handed one.

<callout accent="#f59e0b">
Neither guard caught it. The #12591 scanner flags a function resolving a store of a **different** kind than one it was given — this resolved the **same** kind, so the signature and the resolution agreed while the value silently did not. And `lib.rs`'s module-level `#[allow(dead_code, …)]` would not surface it either.

Same-kind shadowing is a blind spot in the scanner worth noting for a future slice.
</callout>

## Compatibility

Unchanged on every existing path. The only caller resolves that exact value one statement earlier, so injected and ambient are the same store today. It removes one fallible resolution that could only have differed if the environment changed between two adjacent statements.

One comment removed — the code it explained is gone and it was already false.

## Why the allowlist row stays

Closing `run_cook_with_boundaries_reported` needs a **scope decision**, not a code change. The chain:

```
run_cook :3608 (pub, env) ─┐
execution.rs :523         ─┤
cook_tests.rs :6617       ─┘
   └─> run_cook_with_store :3621   PUB, re-exported, documented "lifecycle storage remains ambient"
run_cook_with_finalizer :3695 ─┐
cook_adoption.rs :720         ─┘
   └─> run_cook_with_finalizer_with_store :3708
         └─> ..._with_store :3737 → ..._observed_with_store :3812
               → ..._observed_policy_with_store :3855
                 → run_cook_with_boundaries_reported :3891   ← TARGET
```

The recipe store must reach the spine as a `&CookRecipeStore` parameter, so **every** function between those two injectors and the spine already has `CookRecipeStore` in its signature. Wherever the lifecycle resolution lands on those paths, the scanner sees the identical finding under a new name.

**Threading fully would replace one allowlist row with two — and one of them public.** That trade needs to be made deliberately, not inside a cleanup slice.

Escapes considered and rejected as instrument-blinding rather than debt-closing: a `-> Result<AgentTaskLifecycleStore>` helper (breaks the scanner's documented "no function returns either store type" invariant), `Option<&AgentTaskLifecycleStore>` in the signature (same-kind exemption swallows it while the split persists), and deriving the pair from `store.data_root()` — which is out on behavior, since `from_data_root` synthesizes `config=<data>/config` and `artifacts=<data>/artifacts` while `from_current_environment` uses `PathRoots::from_environment()`, so artifact paths would move.

## To actually close it

1. `cook_adoption.rs:720` — pass the `lifecycle_store` already in scope at `:684` into a new `run_cook_with_finalizer_with_stores`, then delete the single-store form. Trivial, but that edit sits inside the same statement #12594 touches, so it belongs with that work.
2. Decide `run_cook_with_store`'s fate — add `pub fn run_cook_with_stores`, migrate `run_cook` and `execution.rs:570`, then either retire the public `run_cook_with_store` (a public-API removal, and `run_cook_persists_recipe_in_explicit_store_only` at `cook_tests.rs:6617` currently **pins** its split-root semantics) or accept that the row moves onto it.

Also noted: `execution.rs:570` resolves the recipe store *outside* a closure while `options` exists only *inside* it, so a resolution hoisted there would surface as a bare `Err` instead of a durable report.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Chain mapping, the shadowing fix, and evaluating closure options. Review by hand; compilation deferred to CI.

Refs #7505