### PR TITLE
Select nextest for local and release runs

### DIFF
--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -38,9 +38,11 @@ Use the slow tier when changing audit detector orchestration, audit fixability p
 
 ## Process-Global Environment and Test Threads
 
-`homeboy.json` caps Cargo with `rust_cargo_test_threads = 1`. Local and release
-tests use that measured fallback. The reusable PR workflow selects nextest only
-for its inventory-bound shard jobs.
+`homeboy.json` selects nextest with `rust_test_runner = "nextest"`, so local and
+release runs get process-per-test isolation and `num-cpus` parallelism. It also
+keeps `rust_cargo_test_threads = 1`, which now applies only to the Cargo
+fallback taken when nextest is not installed. The reusable PR workflow selects
+nextest for its inventory-bound shard jobs.
 
 This is not a performance choice, it is a correctness one. `HomeGuard`
 (`homeboy_core::test_support`) isolates a test by mutating *process-global*
@@ -56,11 +58,20 @@ is no thread-local escape hatch. (Rust made `std::env::set_var` `unsafe` in the
 One thread per test binary closes that window on the Cargo fallback. Nextest
 closes it more directly by running each test in its own process.
 
-The Cargo cap is a fallback workaround, not the primary CI strategy. Sharded
+The Cargo cap is a fallback workaround, not the primary strategy. Sharded
 nextest replay sets `rust_nextest_shard_threads = 0`, selecting nextest's
 process-per-test `num-cpus` parallelism without exposing Cargo's shared-process
-environment mutation. The
-structural fix remains injectable config and path roots so tests never touch
+environment mutation.
+
+Unsharded nextest runs were previously unmeasurable — they emit no
+`test result:` lines, so the cargo-test adapter matched nothing and produced no
+Homeboy test result at all. That is why local and release stayed on serialized
+Cargo even after the underlying race was fixed. `homeboy-extensions` rust
+v1.36.0 derives counts from `libtest-json-plus` instead, which is what made
+selecting nextest here possible. Note that the nextest branch replaces the
+command binary outright, so `rust_cargo_test_threads` is not applied to it.
+
+The structural fix remains injectable config and path roots so tests never touch
 process-global environment at all (#7505), across roughly 2,072
 `with_isolated_home` call sites.
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -1824,6 +1824,7 @@
   "extensions": {
     "rust": {
       "settings": {
+        "rust_test_runner": "nextest",
         "rust_cargo_test_threads": 1,
         "rust_nextest_shard_threads": 0
       }


### PR DESCRIPTION
## Summary

The payoff for homeboy-extensions #2639. **One setting added, one variable changed.**

```diff
   "rust": { "settings": {
+    "rust_test_runner": "nextest",
     "rust_cargo_test_threads": 1,
     "rust_nextest_shard_threads": 0
   } }
```

## The history this closes

```
Aug 2   #11242  set threads=1        emergency lever for the getenv/setenv race
Aug 3   #11266  fixed the race       Mutex-guarded home-root override
Aug 3   #11271  REMOVED threads=1    measured 400-900s vs ~302s for homeboy-agents
Aug 4   #11474  PUT IT BACK          alongside CI sharding
```

`test-tiers.md` records why it had to come back:

> ...unsharded nextest output **is not yet a measured Homeboy result**, so local and release gates remain on serialized Cargo.

True, because nextest emits no `test result:` lines — the cargo-test adapter matched nothing and an unsharded run produced **no counts at all**. So local and release had no parallel option to fall back to, even after the race was gone.

**homeboy-extensions rust v1.36.0** derives counts from `libtest-json-plus` instead. Blocker removed.

## Why this is stronger than removing the cap would have been

Process-per-test isolation is a better guarantee than one thread per binary. As `test-tiers.md` puts it, `HomeGuard`'s `home_lock` mutex serializes *writers* but **cannot serialize readers** — including worker threads a test spawns inside itself, which is exactly why `--test-threads=1` never actually stopped the failures. Separate processes make the question moot.

## `rust_cargo_test_threads = 1` stays, deliberately

The runner's nextest branch **replaces the command binary outright** rather than appending to it. In `rust/scripts/test-runner.sh`, the Cargo branch appends `-- --test-threads=<N>`, and then:

```
if [ "$SELECTED_RUNNER" = "nextest" ]; then
    COMMAND_BINARY=(cargo nextest ...)   # <- discards the appended flag
fi
```

So the cap is **not applied to nextest at all**. It now governs only the Cargo fallback taken when nextest is not installed (`rust_nextest_fallback` defaults true).

Leaving it means **a host without nextest behaves exactly as it does today.** That is the point — this changes one variable, not two. Removing the cap is a separate decision that can be made on evidence once this has run.

## Sharded PR CI is unaffected

`rust_nextest_shard_threads = 0` already selected `num-cpus` there, independent of the cap. That path does not change.

## What to watch on the first run

- The runner now prints its selection: `Rust test runner: cargo nextest (measured counts from libtest-json-plus)`. If a runner lacks nextest you will see the cargo fallback instead, with today's behavior.
- Counts should be present rather than `Unmeasured`. #2639 signals "no structured counts" by *absence of the write*, and treats a measured failure with a zero exit code as a failure.
- One known non-equivalence, documented in #2639: unsharded skip counts differ from Cargo's, because nextest omits never-run tests from its stream so `#[ignore]` membership cannot be reconstructed without a manifest.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude via OpenCode
- **Used for:** Tracing the #11242 → #11266 → #11271 → #11474 history, verifying the runner's thread-argument behavior, and the change.

Refs #7505
