### PR TITLE
refactor(agent-task): root candidate adoption lifecycle stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -98,12 +98,33 @@ pub fn start_candidate_adoption_with_policy(
     rerun_completed_gates: bool,
     replace_interrupted: bool,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        run_id,
+        candidate_sha,
+        ai_model,
+        active_gate,
+        rerun_completed_gates,
+        replace_interrupted,
+    )
+}
+
+pub(crate) fn start_candidate_adoption_with_policy_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    candidate_sha: &str,
+    ai_model: &str,
+    active_gate: &str,
+    rerun_completed_gates: bool,
+    replace_interrupted: bool,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let candidate_sha = candidate_sha.to_string();
     let ai_model = ai_model.to_string();
     let active_gate = active_gate.to_string();
     let mut conflict = false;
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let now = now_timestamp();
         let mut replacement = None;
         if let Some(existing) = record.candidate_adoption.as_mut() {
@@ -196,7 +217,7 @@ pub fn start_candidate_adoption_with_policy(
     })?;
     let record = match record {
         Some(record) => record,
-        None => store::read_record(&run_id)?,
+        None => lifecycle_store.read_record(&run_id)?,
     };
     if conflict {
         return Err(Error::validation_invalid_argument(
@@ -266,8 +287,25 @@ pub fn start_candidate_adoption_gate(
     process_group: u32,
     timeout_seconds: u64,
 ) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    start_candidate_adoption_gate_in_store(
+        &lifecycle_store,
+        run_id,
+        command,
+        process_group,
+        timeout_seconds,
+    )
+}
+
+pub(crate) fn start_candidate_adoption_gate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    command: &str,
+    process_group: u32,
+    timeout_seconds: u64,
+) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let Some(attempt) = record.candidate_adoption.as_mut() else {
             return false;
         };
@@ -298,6 +336,23 @@ pub(crate) fn heartbeat_candidate_adoption_gate(
     reveal_policy: crate::agent_task_gate::AgentTaskGateRevealPolicy,
     status: &crate::agent_task_gate::AgentTaskGateLiveStatus,
 ) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    heartbeat_candidate_adoption_gate_in_store(
+        &lifecycle_store,
+        run_id,
+        visibility,
+        reveal_policy,
+        status,
+    )
+}
+
+pub(crate) fn heartbeat_candidate_adoption_gate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    visibility: crate::agent_task_gate::AgentTaskGateVisibility,
+    reveal_policy: crate::agent_task_gate::AgentTaskGateRevealPolicy,
+    status: &crate::agent_task_gate::AgentTaskGateLiveStatus,
+) -> Result<()> {
     let status = match (visibility, reveal_policy) {
         (
             crate::agent_task_gate::AgentTaskGateVisibility::Private,
@@ -320,7 +375,7 @@ pub(crate) fn heartbeat_candidate_adoption_gate(
         _ => status.clone(),
     };
     let run_id = sanitize_run_id(run_id);
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let Some(attempt) = record.candidate_adoption.as_mut() else {
             return false;
         };
@@ -341,15 +396,34 @@ pub(crate) fn heartbeat_candidate_adoption_gate(
 }
 
 pub fn candidate_adoption_cancel_requested(run_id: &str) -> Result<bool> {
-    Ok(store::read_record(&sanitize_run_id(run_id))?
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    candidate_adoption_cancel_requested_in_store(&lifecycle_store, run_id)
+}
+
+pub(crate) fn candidate_adoption_cancel_requested_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    Ok(lifecycle_store
+        .read_record(&sanitize_run_id(run_id))?
         .candidate_adoption
         .as_ref()
         .is_some_and(|attempt| attempt.state == "cancel_requested" || attempt.state == "cancelled"))
 }
 
 pub fn checkpoint_candidate_adoption(run_id: &str, phase: &str, active_gate: &str) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    checkpoint_candidate_adoption_in_store(&lifecycle_store, run_id, phase, active_gate)
+}
+
+pub(crate) fn checkpoint_candidate_adoption_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    active_gate: &str,
+) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let Some(attempt) = record.candidate_adoption.as_mut() else {
             return false;
         };
@@ -371,8 +445,17 @@ pub fn finish_candidate_adoption(
     run_id: &str,
     error: Option<String>,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    finish_candidate_adoption_in_store(&lifecycle_store, run_id, error)
+}
+
+pub(crate) fn finish_candidate_adoption_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    error: Option<String>,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(attempt) = record.candidate_adoption.as_mut() else {
             return false;
         };
@@ -394,12 +477,21 @@ pub fn finish_candidate_adoption(
         record.updated_at = Some(now);
         true
     })?;
-    Ok(record.unwrap_or(store::read_record(&run_id)?))
+    Ok(record.unwrap_or(lifecycle_store.read_record(&run_id)?))
 }
 
 pub fn record_candidate_adoption_result(run_id: &str, result: Value) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_candidate_adoption_result_in_store(&lifecycle_store, run_id, result)
+}
+
+pub(crate) fn record_candidate_adoption_result_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    result: Value,
+) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
-    store::mutate_record(&run_id, |record| {
+    lifecycle_store.mutate_record(&run_id, |record| {
         let Some(attempt) = record.candidate_adoption.as_mut() else {
             return false;
         };

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3136,7 +3136,7 @@ fn child_execution_budget(
     }
 }
 
-fn validate_cook_follow_up_stores(
+pub(super) fn validate_cook_follow_up_stores(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -24,7 +24,8 @@ use crate::agent_task_finalization::{
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::resolve_candidate_revision;
 use crate::agent_task_promotion::{
-    promote_with_checkpoint, AgentTaskPromotionOptions, AgentTaskPromotionReport,
+    promote_with_checkpoint_in_observation_store, AgentTaskPromotionOptions,
+    AgentTaskPromotionReport,
 };
 use crate::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy_core::cook_status::CookDisposition;
@@ -37,7 +38,7 @@ use super::cook::{
 };
 use super::cook_promotion::{
     cook_report, finalize_or_load_cook_pr_with_backend_with_stores,
-    persisted_promotion_for_attempt, promotion_source, CookReportInput,
+    persisted_promotion_for_attempt_in_store, promotion_source_in_store, CookReportInput,
 };
 use super::cook_recipe::CookRecipeStore;
 use super::AgentTaskRunResult;
@@ -48,8 +49,12 @@ struct CandidateAdoptionTerminalResult {
     stop_reason: Option<String>,
 }
 
-fn persist_adoption_terminal_result(run_id: &str, report: &AgentTaskCookReport) -> Result<()> {
-    agent_task_lifecycle::record_candidate_adoption_result(
+fn persist_adoption_terminal_result(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+    report: &AgentTaskCookReport,
+) -> Result<()> {
+    lifecycle_store.record_candidate_adoption_result(
         run_id,
         serde_json::to_value(CandidateAdoptionTerminalResult {
             status: report.status.clone(),
@@ -80,10 +85,11 @@ fn legacy_adoption_budget_failure(
 /// the original agent emitted is recorded on its aggregate. Absent/invalid here
 /// re-triggers the review-form gate exactly as it would for a fresh cook.
 fn adopted_review_form(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,
     allow_missing_aggregate: bool,
 ) -> Result<Option<crate::agent_task_review_dossier::AiFilledReviewForm>> {
-    let aggregate = match agent_task_lifecycle::read_aggregate(run_id) {
+    let aggregate = match lifecycle_store.read_aggregate(run_id) {
         Ok(aggregate) => aggregate,
         Err(_) if allow_missing_aggregate => return Ok(None),
         Err(error) => return Err(error),
@@ -238,18 +244,45 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     executor: E,
     backend: &mut B,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
-    let store = CookRecipeStore::from_current_data_root()?;
-    // Adoption is an env-resolving entry point: nothing above it can inject a
-    // root, because every one of its callers is a frozen `pub` signature. Both
-    // durable roots are therefore resolved here, adjacent and visible, so the
-    // pair handed to remediation dispatch and to finalization is provably the
-    // same pair. Resolving the lifecycle root here surfaces no failure earlier
-    // than before: `agent_task_lifecycle::load_plan` below runs unconditionally
-    // ahead of every return in this function and already resolves this exact
-    // constructor through its own default store.
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    let (record, recipe) = resolve_adoption_target_with_attempt(cook_or_run_id, attempt)?;
+    adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_stores(
+        &recipe_store,
+        &lifecycle_store,
+        cook_or_run_id,
+        attempt,
+        candidate_ref,
+        adoption,
+        reconstruct_dispatcher,
+        executor,
+        backend,
+    )
+}
+
+pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_stores<
+    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
+    B: AgentTaskPrFinalizationBackend,
+>(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    cook_or_run_id: &str,
+    attempt: Option<u32>,
+    candidate_ref: &str,
+    adoption: AgentTaskCandidateAdoptionOptions,
+    reconstruct_dispatcher: impl FnOnce(
+        &Value,
+    ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
+    executor: E,
+    backend: &mut B,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    super::cook::validate_cook_follow_up_stores(recipe_store, lifecycle_store)?;
+    let (record, recipe) = resolve_adoption_target_with_attempt_in_stores(
+        recipe_store,
+        lifecycle_store,
+        cook_or_run_id,
+        attempt,
+    )?;
     let cook_id = &recipe.cook_id;
     let mut options = super::reconstruct_adoption_options(&recipe)?;
     // Adoption is a separate explicit authorization. The durable recipe keeps
@@ -257,7 +290,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     // immutable-baseline matches produced below.
     options.gates.accept_inherited_failures = adoption.accept_inherited_failures;
     let run_id = record.run_id.clone();
-    let plan = agent_task_lifecycle::load_plan(&run_id)?;
+    let plan = lifecycle_store.read_controller_plan(&run_id)?;
     let recipe_attempt = recipe
         .attempts
         .iter()
@@ -289,7 +322,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             None,
         ));
     }
-    let (source, source_path, recovery) = candidate_adoption_source(&record, &source_request)?;
+    let (source, source_path, recovery) =
+        candidate_adoption_source_in_store(lifecycle_store, &record, &source_request)?;
     let (adoption_ai_model, ai_model_source) = match adoption.ai_model {
         Some(model) => (concrete_adoption_ai_model(&model)?, "candidate_input"),
         None => (
@@ -327,7 +361,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         // failed attempt is archived when the new adoption starts.
         && !legacy_adoption_budget_failure(&recipe, &run_id, persisted_adoption_result)
     {
-        let persisted_promotion = persisted_promotion_for_attempt(&record.run_id)?;
+        let persisted_promotion =
+            persisted_promotion_for_attempt_in_store(lifecycle_store, &record.run_id)?;
         let inherited_failure_requires_authorization =
             persisted_promotion.as_ref().is_some_and(|promotion| {
                 promotion.deterministic_gates.iter().any(|gate| {
@@ -395,14 +430,15 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 invocation_latest_run_id: Some(record.run_id.as_str()),
             }));
         }
-        let promotion = persisted_promotion_for_attempt(&record.run_id)?.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "candidate_ref",
-                "completed candidate adoption is missing its persisted promotion result",
-                Some(candidate_sha.clone()),
-                None,
-            )
-        })?;
+        let promotion = persisted_promotion_for_attempt_in_store(lifecycle_store, &record.run_id)?
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "candidate_ref",
+                    "completed candidate adoption is missing its persisted promotion result",
+                    Some(candidate_sha.clone()),
+                    None,
+                )
+            })?;
         if inherited_failure_requires_authorization && !adoption.accept_inherited_failures {
             return Ok(cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
@@ -433,7 +469,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             source_run_id: Some(record.run_id.clone()),
             current_diff: String::new(),
             require_review_form: true,
-            review_form: adopted_review_form(&record.run_id, recovery.is_some())?,
+            review_form: adopted_review_form(lifecycle_store, &record.run_id, recovery.is_some())?,
             metadata: serde_json::json!({"adopted_candidate_ref": candidate_ref}),
         });
         let finalization = record.metadata.get("cook_finalization").cloned();
@@ -474,7 +510,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     let attempt_dispatcher =
         reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
     options.attempt_dispatcher = attempt_dispatcher;
-    agent_task_lifecycle::start_candidate_adoption_with_policy(
+    lifecycle_store.start_candidate_adoption_with_policy(
         &record.run_id,
         &candidate_sha,
         &adoption_ai_model,
@@ -483,88 +519,97 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         adoption.replace_interrupted,
     )?;
     let gate_run_id = record.run_id.clone();
-    let promotion = match reusable_applied_adoption_promotion(&record, &candidate_sha) {
-        Some(promotion) => promotion,
-        None => crate::agent_task_promotion::with_gate_supervision(
-            crate::agent_task_gate::GateSupervision {
-                timeout: options.gates.gate_timeout(),
-                no_progress_timeout: options.gates.gate_no_progress_timeout(),
-                heartbeat_interval: options.gates.gate_heartbeat_interval(),
-                on_spawn: Arc::new({
-                    let run_id = gate_run_id.clone();
-                    move |pid, command| {
-                        agent_task_lifecycle::start_candidate_adoption_gate(
-                            &run_id,
-                            command,
-                            pid,
-                            options.gates.gate_timeout_seconds,
-                        )
-                    }
-                }),
-                on_heartbeat: Arc::new({
-                    let run_id = gate_run_id.clone();
-                    move |status| {
-                        agent_task_lifecycle::heartbeat_candidate_adoption_gate(
-                            &run_id,
-                            status.visibility,
-                            status.reveal_policy,
-                            status,
-                        )
-                    }
-                }),
-                is_cancelled: Arc::new(move || {
-                    agent_task_lifecycle::candidate_adoption_cancel_requested(&gate_run_id)
-                        .unwrap_or(false)
-                }),
-            },
-            || {
-                promote_with_checkpoint(
-                    AgentTaskPromotionOptions {
-                        source,
-                        source_run_id: Some(record.run_id.clone()),
-                        source_path,
-                        source_worktree_path: options.source_worktree_path.clone(),
-                        base_ref: Some(options.base.clone()),
-                        task_base_sha: options.task_base_sha.clone(),
-                        candidate_ref: Some(candidate_sha.clone()),
-                        to_worktree: options.to_worktree.clone(),
-                        task_id: None,
-                        artifact_id: None,
-                        dry_run: false,
-                        gates: options.gates.clone(),
-                        provider_command: options.provider_command.clone(),
-                        provider_invocation: options.provider_invocation.clone(),
-                    },
-                    |checkpoint| {
-                        let checkpoint = serde_json::to_value(checkpoint).map_err(|error| {
-                            Error::internal_json(
-                                error.to_string(),
-                                Some("serialize adopted candidate checkpoint".to_string()),
+    let gate_lifecycle_store = lifecycle_store.clone();
+    let promotion =
+        match reusable_applied_adoption_promotion(lifecycle_store, &record, &candidate_sha) {
+            Some(promotion) => promotion,
+            None => crate::agent_task_promotion::with_gate_supervision(
+                crate::agent_task_gate::GateSupervision {
+                    timeout: options.gates.gate_timeout(),
+                    no_progress_timeout: options.gates.gate_no_progress_timeout(),
+                    heartbeat_interval: options.gates.gate_heartbeat_interval(),
+                    on_spawn: Arc::new({
+                        let run_id = gate_run_id.clone();
+                        let lifecycle_store = gate_lifecycle_store.clone();
+                        move |pid, command| {
+                            lifecycle_store.start_candidate_adoption_gate(
+                                &run_id,
+                                command,
+                                pid,
+                                options.gates.gate_timeout_seconds,
                             )
-                        })?;
-                        agent_task_lifecycle::checkpoint_candidate_adoption(
-                            &record.run_id,
-                            "post_apply_verification",
-                            &gate_identity,
-                        )?;
-                        agent_task_lifecycle::record_promotion(&record.run_id, checkpoint)
-                            .map(|_| ())
-                    },
-                )
-            },
-        ),
-    };
+                        }
+                    }),
+                    on_heartbeat: Arc::new({
+                        let run_id = gate_run_id.clone();
+                        let lifecycle_store = gate_lifecycle_store.clone();
+                        move |status| {
+                            lifecycle_store.heartbeat_candidate_adoption_gate(
+                                &run_id,
+                                status.visibility,
+                                status.reveal_policy,
+                                status,
+                            )
+                        }
+                    }),
+                    is_cancelled: Arc::new({
+                        let lifecycle_store = gate_lifecycle_store.clone();
+                        move || {
+                            lifecycle_store
+                                .candidate_adoption_cancel_requested(&gate_run_id)
+                                .unwrap_or(false)
+                        }
+                    }),
+                },
+                || {
+                    let observation_store = lifecycle_store.open_observation_initialized()?;
+                    promote_with_checkpoint_in_observation_store(
+                        AgentTaskPromotionOptions {
+                            source,
+                            source_run_id: Some(record.run_id.clone()),
+                            source_path,
+                            source_worktree_path: options.source_worktree_path.clone(),
+                            base_ref: Some(options.base.clone()),
+                            task_base_sha: options.task_base_sha.clone(),
+                            candidate_ref: Some(candidate_sha.clone()),
+                            to_worktree: options.to_worktree.clone(),
+                            task_id: None,
+                            artifact_id: None,
+                            dry_run: false,
+                            gates: options.gates.clone(),
+                            provider_command: options.provider_command.clone(),
+                            provider_invocation: options.provider_invocation.clone(),
+                        },
+                        &observation_store,
+                        |checkpoint| {
+                            let checkpoint = serde_json::to_value(checkpoint).map_err(|error| {
+                                Error::internal_json(
+                                    error.to_string(),
+                                    Some("serialize adopted candidate checkpoint".to_string()),
+                                )
+                            })?;
+                            lifecycle_store.checkpoint_candidate_adoption(
+                                &record.run_id,
+                                "post_apply_verification",
+                                &gate_identity,
+                            )?;
+                            lifecycle_store
+                                .record_promotion(&record.run_id, checkpoint)
+                                .map(|_| ())
+                        },
+                    )
+                },
+            ),
+        };
     let mut promotion = match promotion {
         Ok(promotion) => promotion,
         Err(error) => {
-            agent_task_lifecycle::finish_candidate_adoption(
-                &record.run_id,
-                Some(error.message.clone()),
-            )?;
+            lifecycle_store
+                .finish_candidate_adoption(&record.run_id, Some(error.message.clone()))?;
             return Err(error);
         }
     };
-    if agent_task_lifecycle::candidate_adoption_cancel_requested(&record.run_id)? {
+    if lifecycle_store.candidate_adoption_cancel_requested(&record.run_id)? {
         return Err(Error::validation_invalid_argument(
             "run_id",
             "candidate adoption was cancelled before baseline verification",
@@ -589,14 +634,14 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         &candidate_base_sha,
         options.gates.gate_timeout(),
         |compared, total| {
-            agent_task_lifecycle::checkpoint_candidate_adoption(
+            lifecycle_store.checkpoint_candidate_adoption(
                 &record.run_id,
                 "baseline_verification",
                 &format!("baseline gate {compared}/{total}"),
             )
         },
     )?;
-    if agent_task_lifecycle::candidate_adoption_cancel_requested(&record.run_id)? {
+    if lifecycle_store.candidate_adoption_cancel_requested(&record.run_id)? {
         return Err(Error::validation_invalid_argument(
             "run_id",
             "candidate adoption was cancelled before promotion could finalize",
@@ -620,7 +665,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     });
     let promotion_value = serde_json::to_value(&promotion)
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
-    agent_task_lifecycle::record_promotion(&record.run_id, promotion_value)?;
+    lifecycle_store.record_promotion(&record.run_id, promotion_value)?;
     let feedback = evaluate_cook_loop(AgentTaskCookLoopOptions {
         source_request,
         promotion_report: promotion.clone(),
@@ -629,7 +674,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         source_run_id: Some(record.run_id.clone()),
         current_diff: gate_feedback_current_diff(&promotion),
         require_review_form: true,
-        review_form: adopted_review_form(&record.run_id, recovery.is_some())?,
+        review_form: adopted_review_form(lifecycle_store, &record.run_id, recovery.is_some())?,
         metadata: serde_json::json!({"adopted_candidate_ref": candidate_ref}),
     });
     let attempt = AgentTaskCookAttemptReport {
@@ -642,7 +687,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     };
     if feedback.status == AgentTaskCookLoopStatus::RetryRequested {
         let Some(mut follow_up_request) = feedback.follow_up_request.clone() else {
-            agent_task_lifecycle::finish_candidate_adoption(
+            lifecycle_store.finish_candidate_adoption(
                 &record.run_id,
                 Some(
                     "candidate adoption feedback requested retry without a follow-up request"
@@ -662,7 +707,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                 exit_code: 1,
                 invocation_latest_run_id: Some(record.run_id.as_str()),
             });
-            persist_adoption_terminal_result(&record.run_id, &report.value)?;
+            persist_adoption_terminal_result(lifecycle_store, &record.run_id, &report.value)?;
             return Ok(report);
         };
         // An authenticated pre-provider recovery has no aggregate executor
@@ -672,7 +717,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         follow_up_request.executor.model = Some(adoption_ai_model.clone());
         let budget = plan.options.execution_budget.clone();
         let mut remediation_usage = Default::default();
-        let aggregate = match agent_task_lifecycle::read_aggregate(&record.run_id) {
+        let aggregate = match lifecycle_store.read_aggregate(&record.run_id) {
             Ok(aggregate) => aggregate,
             Err(_) if recovery.is_some() => crate::agent_task_scheduler::AgentTaskAggregate {
                 schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
@@ -691,8 +736,18 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             },
             Err(error) => return Err(error),
         };
+        if !lifecycle_store.matches_current_environment()? {
+            let message = "candidate adoption remediation requires the explicit lifecycle store to match the current Cook runtime root";
+            lifecycle_store.finish_candidate_adoption(&record.run_id, Some(message.to_string()))?;
+            return Err(Error::validation_invalid_argument(
+                "stores",
+                message,
+                Some(lifecycle_store.data_root().display().to_string()),
+                None,
+            ));
+        }
         let dispatch = dispatch_cook_follow_up(
-            (&store, &lifecycle_store),
+            (recipe_store, lifecycle_store),
             &options,
             executor.clone(),
             cook_id,
@@ -710,8 +765,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         )?;
         return match dispatch {
             CookFollowUpDispatch::Dispatched { run_id } => {
-                agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
-                options.initial_plan = store.load_recipe(cook_id)?
+                lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
+                options.initial_plan = recipe_store.load_recipe(cook_id)?
                     .attempts
                     .into_iter()
                     .find(|attempt| attempt.run_id == run_id)
@@ -726,13 +781,13 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     })?;
                 options.initial_run_id = run_id;
                 let mut result = super::cook::run_cook_with_finalizer_with_store(
-                    &store,
+                    recipe_store,
                     options,
                     executor,
                     |options, run_id, promotion| {
                         finalize_or_load_cook_pr_with_backend_with_stores(
-                            &store,
-                            &lifecycle_store,
+                            recipe_store,
+                            lifecycle_store,
                             options,
                             run_id,
                             promotion,
@@ -759,8 +814,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     exit_code: 1,
                     invocation_latest_run_id: Some(record.run_id.as_str()),
                 });
-                persist_adoption_terminal_result(&record.run_id, &report.value)?;
-                agent_task_lifecycle::finish_candidate_adoption(
+                persist_adoption_terminal_result(lifecycle_store, &record.run_id, &report.value)?;
+                lifecycle_store.finish_candidate_adoption(
                     &record.run_id,
                     Some("candidate remediation budget exhausted".to_string()),
                 )?;
@@ -777,8 +832,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
                     exit_code: 1,
                     invocation_latest_run_id: Some(record.run_id.as_str()),
                 });
-                persist_adoption_terminal_result(&record.run_id, &report.value)?;
-                agent_task_lifecycle::finish_candidate_adoption(&record.run_id, Some(reason))?;
+                persist_adoption_terminal_result(lifecycle_store, &record.run_id, &report.value)?;
+                lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason))?;
                 Ok(report)
             }
         };
@@ -789,10 +844,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             // durable baseline proof and must not spend another provider attempt.
         } else {
             let reason = "candidate and immutable baseline failed the same required gate; repair the inherited infrastructure or gate environment before retrying adoption";
-            agent_task_lifecycle::finish_candidate_adoption(
-                &record.run_id,
-                Some(reason.to_string()),
-            )?;
+            lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason.to_string()))?;
             return Ok(cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
                 status: "baseline_red",
@@ -810,7 +862,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             && options.gates.accept_inherited_failures
             && promotion.finalization_eligible(true))
     {
-        agent_task_lifecycle::finish_candidate_adoption(
+        lifecycle_store.finish_candidate_adoption(
             &record.run_id,
             Some("adopted candidate did not pass the original deterministic gates".to_string()),
         )?;
@@ -828,7 +880,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
         }));
     }
     if options.no_finalize {
-        agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
+        lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "green_no_finalize",
@@ -843,14 +895,14 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
             invocation_latest_run_id: Some(record.run_id.as_str()),
         }));
     }
-    agent_task_lifecycle::checkpoint_candidate_adoption(
+    lifecycle_store.checkpoint_candidate_adoption(
         &record.run_id,
         "finalization",
         "finalize pull request",
     )?;
     let mut finalization = match finalize_or_load_cook_pr_with_backend_with_stores(
-        &store,
-        &lifecycle_store,
+        recipe_store,
+        lifecycle_store,
         &options,
         &record.run_id,
         &promotion,
@@ -858,15 +910,13 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     ) {
         Ok(finalization) => finalization,
         Err(error) => {
-            agent_task_lifecycle::finish_candidate_adoption(
-                &record.run_id,
-                Some(error.message.clone()),
-            )?;
+            lifecycle_store
+                .finish_candidate_adoption(&record.run_id, Some(error.message.clone()))?;
             return Err(error);
         }
     };
     project_execution_placement(&mut finalization, &record.metadata);
-    agent_task_lifecycle::finish_candidate_adoption(&record.run_id, None)?;
+    lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
     let status = finalization["status"]
         .as_str()
         .unwrap_or("unknown")
@@ -900,10 +950,12 @@ fn project_execution_placement(finalization: &mut Value, metadata: &Value) {
 }
 
 fn reusable_applied_adoption_promotion(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     candidate_sha: &str,
 ) -> Option<Result<AgentTaskPromotionReport>> {
-    let promotion = match persisted_promotion_for_attempt(&record.run_id) {
+    let promotion = match persisted_promotion_for_attempt_in_store(lifecycle_store, &record.run_id)
+    {
         Ok(Some(promotion))
             if promotion.status
                 == crate::agent_task_promotion::AgentTaskPromotionStatus::Applied =>
@@ -974,6 +1026,16 @@ pub(crate) fn candidate_adoption_source(
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     source_request: &AgentTaskRequest,
 ) -> Result<(String, Option<PathBuf>, Option<Value>)> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    candidate_adoption_source_in_store(&lifecycle_store, record, source_request)
+}
+
+fn candidate_adoption_source_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+    source_request: &AgentTaskRequest,
+) -> Result<(String, Option<PathBuf>, Option<Value>)> {
     // The authenticated recovery marker is authoritative over a canonical
     // pre-execution aggregate, which exists only to record the transport error.
     if let Some(outcome) =
@@ -991,10 +1053,10 @@ pub(crate) fn candidate_adoption_source(
             Some(recovery),
         ));
     }
-    if let Ok((source, path)) = agent_task_lifecycle::aggregate_source(&record.run_id) {
+    if let Ok((source, path)) = lifecycle_store.aggregate_source_exact(&record.run_id) {
         return Ok((source, Some(path), None));
     }
-    let (source, path) = promotion_source(&record.run_id)?;
+    let (source, path) = promotion_source_in_store(lifecycle_store, &record.run_id)?;
     Ok((source, path, None))
 }
 
@@ -1044,13 +1106,33 @@ pub(crate) fn resolve_adoption_target_with_attempt(
     agent_task_lifecycle::AgentTaskRunRecord,
     super::AgentTaskCookRecipe,
 )> {
-    let declared_attempt_recipe = super::load_recipe_for_attempt(cook_or_run_id)?;
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    resolve_adoption_target_with_attempt_in_stores(
+        &recipe_store,
+        &lifecycle_store,
+        cook_or_run_id,
+        selected_attempt,
+    )
+}
+
+fn resolve_adoption_target_with_attempt_in_stores(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    cook_or_run_id: &str,
+    selected_attempt: Option<u32>,
+) -> Result<(
+    agent_task_lifecycle::AgentTaskRunRecord,
+    super::AgentTaskCookRecipe,
+)> {
+    let declared_attempt_recipe = recipe_store.load_recipe_for_attempt(cook_or_run_id)?;
     // A durable Cook id names its immutable recipe, not whichever attempt the
     // mutable Cook index most recently observed. Resolve recipes before run
     // records so a later failed attempt cannot steal adoption ownership from
     // the original equivalent source attempt.
-    if super::recipe_exists(cook_or_run_id)? {
-        let recipe = super::load_recipe(cook_or_run_id)?;
+    if recipe_store.recipe_exists(cook_or_run_id) {
+        let recipe = recipe_store.load_recipe(cook_or_run_id)?;
         if let Some(attempt_recipe) = &declared_attempt_recipe {
             if attempt_recipe.cook_id != recipe.cook_id {
                 return Err(Error::validation_invalid_argument(
@@ -1085,13 +1167,18 @@ pub(crate) fn resolve_adoption_target_with_attempt(
                         None,
                     )
                 })?,
-            None => resolve_cook_adoption_attempt(&recipe)?,
+            None => resolve_cook_adoption_attempt_in_store(lifecycle_store, &recipe)?,
         };
-        if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
-            return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
+        if lifecycle_store.record_exists(&attempt.run_id)? {
+            return Ok((lifecycle_store.read_record(&attempt.run_id)?, recipe));
         }
         let run_id = attempt.run_id.clone();
-        return materialize_adoption_attempt(recipe, run_id);
+        return materialize_adoption_attempt_in_stores(
+            recipe_store,
+            lifecycle_store,
+            recipe,
+            run_id,
+        );
     }
 
     // Runner-side lifecycle projection can omit the controller's `cook_id`
@@ -1126,11 +1213,16 @@ pub(crate) fn resolve_adoption_target_with_attempt(
                 .find(|attempt| attempt.run_id == cook_or_run_id)
                 .expect("attempt lookup returns a recipe that declares the run id"),
         };
-        if agent_task_lifecycle::run_record_exists(&attempt.run_id)? {
-            return Ok((agent_task_lifecycle::status(&attempt.run_id)?, recipe));
+        if lifecycle_store.record_exists(&attempt.run_id)? {
+            return Ok((lifecycle_store.read_record(&attempt.run_id)?, recipe));
         }
         let run_id = attempt.run_id.clone();
-        return materialize_adoption_attempt(recipe, run_id);
+        return materialize_adoption_attempt_in_stores(
+            recipe_store,
+            lifecycle_store,
+            recipe,
+            run_id,
+        );
     }
 
     if selected_attempt.is_some() {
@@ -1142,15 +1234,15 @@ pub(crate) fn resolve_adoption_target_with_attempt(
         ));
     }
 
-    if agent_task_lifecycle::run_record_exists(cook_or_run_id)? {
-        let record = agent_task_lifecycle::status(cook_or_run_id)?;
+    if lifecycle_store.record_exists(cook_or_run_id)? {
+        let record = lifecycle_store.read_record(cook_or_run_id)?;
         let cook_id = record
             .metadata
             .get("cook_id")
             .and_then(Value::as_str)
             .unwrap_or(cook_or_run_id)
             .to_string();
-        return Ok((record, super::load_recipe(&cook_id)?));
+        return Ok((record, recipe_store.load_recipe(&cook_id)?));
     }
 
     Err(Error::validation_invalid_argument(
@@ -1168,13 +1260,36 @@ fn materialize_adoption_attempt(
     agent_task_lifecycle::AgentTaskRunRecord,
     super::AgentTaskCookRecipe,
 )> {
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    materialize_adoption_attempt_in_stores(&recipe_store, &lifecycle_store, recipe, run_id)
+}
+
+fn materialize_adoption_attempt_in_stores(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    recipe: super::AgentTaskCookRecipe,
+    run_id: String,
+) -> Result<(
+    agent_task_lifecycle::AgentTaskRunRecord,
+    super::AgentTaskCookRecipe,
+)> {
     let attempt = recipe
         .attempts
         .iter()
         .find(|attempt| attempt.run_id == run_id)
         .expect("selected adoption attempt remains in its recipe");
     let record =
-        super::cook_pre_execution::recover_adoption_attempt(&recipe.cook_id, &attempt.run_id)?;
+        super::cook_pre_execution::CookExecutionPreparation::new(recipe_store, lifecycle_store)
+            .recover_for_adoption_with_runtime(
+                &recipe.cook_id,
+                &attempt.run_id,
+                Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+                agent_task_lifecycle::execution_runner_id(),
+                super::cook_pre_execution::production_runtime_admission(lifecycle_store),
+                super::cook_pre_execution::reconcile_reserved_cancellation,
+            )?;
     Ok((record, recipe))
 }
 
@@ -1184,7 +1299,16 @@ fn materialize_adoption_attempt(
 fn resolve_cook_adoption_attempt(
     recipe: &super::AgentTaskCookRecipe,
 ) -> Result<&super::AgentTaskCookRecipeAttempt> {
-    if let Ok(selection) = agent_task_lifecycle::select_cook_candidate(&recipe.cook_id) {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    resolve_cook_adoption_attempt_in_store(&lifecycle_store, recipe)
+}
+
+fn resolve_cook_adoption_attempt_in_store<'a>(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    recipe: &'a super::AgentTaskCookRecipe,
+) -> Result<&'a super::AgentTaskCookRecipeAttempt> {
+    if let Ok(selection) = lifecycle_store.select_cook_candidate(&recipe.cook_id) {
         if selection.reason
             != "no_substantive_candidate_evidence_preserve_latest_attempt_compatibility"
         {

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -141,7 +141,7 @@ impl<'a> CookExecutionPreparation<'a> {
         )
     }
 
-    fn recover_for_adoption_with_runtime(
+    pub(crate) fn recover_for_adoption_with_runtime(
         &self,
         cook_id: &str,
         run_id: &str,
@@ -349,12 +349,12 @@ fn materialize_cook_attempt_with_stores_and_runtime(
     Ok(())
 }
 
-fn reconcile_reserved_cancellation(cook_id: &str) -> Result<()> {
+pub(crate) fn reconcile_reserved_cancellation(cook_id: &str) -> Result<()> {
     agent_task_lifecycle::cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id)
         .map(|_| ())
 }
 
-fn production_runtime_admission(
+pub(crate) fn production_runtime_admission(
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> impl FnOnce(&str) -> Result<Value> + '_ {
     move |run_id| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -80,7 +80,7 @@ pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     ))
 }
 
-fn promotion_source_in_store(
+pub(crate) fn promotion_source_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<(String, Option<PathBuf>)> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -31,7 +31,7 @@ use crate::agent_task_finalization::{
     AgentTaskPrRef, AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
     RealAgentTaskPrFinalizationBackend,
 };
-use crate::agent_task_lifecycle::AgentTaskRunState;
+use crate::agent_task_lifecycle::{AgentTaskLifecycleStore, AgentTaskRunState};
 use crate::agent_task_scheduler::AgentTaskState;
 use homeboy_core::run_lifecycle_record::{
     ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
@@ -1968,6 +1968,67 @@ fn moving_base_recovery_isolates_identical_attempts_across_explicit_stores() {
     assert_ne!(
         left_lifecycle_store.run_dir(run_id),
         right_lifecycle_store.run_dir(run_id)
+    );
+}
+
+#[test]
+fn candidate_adoption_lifecycle_and_promotion_evidence_do_not_alias_across_explicit_roots() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-adoption-cook";
+    let run_id = "same-adoption-run";
+    let options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+
+    for (store, candidate_sha, model, root) in [
+        (&left_store, "left-candidate", "left-model", "left"),
+        (&right_store, "right-candidate", "right-model", "right"),
+    ] {
+        store
+            .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
+                Ok(serde_json::json!({ "root": root }))
+            })
+            .unwrap();
+        store.record_cook_attempt(cook_id, 1, run_id).unwrap();
+        store
+            .start_candidate_adoption_with_policy(
+                run_id,
+                candidate_sha,
+                model,
+                "verification",
+                false,
+                false,
+            )
+            .unwrap();
+        store
+            .checkpoint_candidate_adoption(run_id, "finalization", "finalize pull request")
+            .unwrap();
+        store
+            .record_promotion(run_id, serde_json::json!({ "root": root }))
+            .unwrap();
+        store
+            .record_candidate_adoption_result(run_id, serde_json::json!({ "root": root }))
+            .unwrap();
+        store.finish_candidate_adoption(run_id, None).unwrap();
+    }
+
+    for (store, candidate_sha, model, root) in [
+        (&left_store, "left-candidate", "left-model", "left"),
+        (&right_store, "right-candidate", "right-model", "right"),
+    ] {
+        let record = store.read_record(run_id).unwrap();
+        let adoption = record.candidate_adoption.unwrap();
+        assert_eq!(adoption.candidate_sha, candidate_sha);
+        assert_eq!(adoption.ai_model, model);
+        assert_eq!(adoption.result.unwrap()["root"], root);
+        assert_eq!(record.metadata["latest_promotion"]["root"], root);
+    }
+
+    assert_ne!(left_store.run_dir(run_id), right_store.run_dir(run_id));
+    assert_ne!(
+        left_store.cook_index_path(cook_id),
+        right_store.cook_index_path(cook_id)
     );
 }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -298,6 +298,92 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub fn start_candidate_adoption_with_policy(
+        &self,
+        run_id: &str,
+        candidate_sha: &str,
+        ai_model: &str,
+        active_gate: &str,
+        rerun_completed_gates: bool,
+        replace_interrupted: bool,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_candidate_adoption::start_candidate_adoption_with_policy_in_store(
+            self,
+            run_id,
+            candidate_sha,
+            ai_model,
+            active_gate,
+            rerun_completed_gates,
+            replace_interrupted,
+        )
+    }
+
+    pub fn start_candidate_adoption_gate(
+        &self,
+        run_id: &str,
+        command: &str,
+        process_group: u32,
+        timeout_seconds: u64,
+    ) -> Result<()> {
+        super::lifecycle_candidate_adoption::start_candidate_adoption_gate_in_store(
+            self,
+            run_id,
+            command,
+            process_group,
+            timeout_seconds,
+        )
+    }
+
+    pub(crate) fn heartbeat_candidate_adoption_gate(
+        &self,
+        run_id: &str,
+        visibility: crate::agent_task_gate::AgentTaskGateVisibility,
+        reveal_policy: crate::agent_task_gate::AgentTaskGateRevealPolicy,
+        status: &crate::agent_task_gate::AgentTaskGateLiveStatus,
+    ) -> Result<()> {
+        super::lifecycle_candidate_adoption::heartbeat_candidate_adoption_gate_in_store(
+            self,
+            run_id,
+            visibility,
+            reveal_policy,
+            status,
+        )
+    }
+
+    pub fn candidate_adoption_cancel_requested(&self, run_id: &str) -> Result<bool> {
+        super::lifecycle_candidate_adoption::candidate_adoption_cancel_requested_in_store(
+            self, run_id,
+        )
+    }
+
+    pub fn checkpoint_candidate_adoption(
+        &self,
+        run_id: &str,
+        phase: &str,
+        active_gate: &str,
+    ) -> Result<()> {
+        super::lifecycle_candidate_adoption::checkpoint_candidate_adoption_in_store(
+            self,
+            run_id,
+            phase,
+            active_gate,
+        )
+    }
+
+    pub fn finish_candidate_adoption(
+        &self,
+        run_id: &str,
+        error: Option<String>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_candidate_adoption::finish_candidate_adoption_in_store(self, run_id, error)
+    }
+
+    pub fn record_candidate_adoption_result(&self, run_id: &str, result: Value) -> Result<()> {
+        super::lifecycle_candidate_adoption::record_candidate_adoption_result_in_store(
+            self, run_id, result,
+        )
+    }
+
     pub fn record_promotion(&self, run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {
         super::lifecycle_ops::record_promotion_in_store(self, run_id, promotion)
     }


### PR DESCRIPTION
## Summary
- add explicit-store candidate-adoption lifecycle operations for claims, gate progress, cancellation, checkpoints, completion, and terminal receipts
- route adoption target resolution, plans, aggregates, promotion checkpoints, candidate selection, and finalization through one recipe/lifecycle store pair
- prove identical Cook/run IDs retain distinct adoption state and promotion evidence across roots
- fail before remediation dispatch when an injected lifecycle root is not the current Cook runtime root, pending complete remediation-spine rooting

Progresses #7505.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::adoption_ --lib` (23 passed)
- `cargo test -p homeboy-agents candidate_adoption_lifecycle_and_promotion_evidence_do_not_alias_across_explicit_roots --lib`
- `cargo test -p homeboy-agents explicit_candidate_adoption_ignores_recoverable_provider_patch_selection --lib`
- `cargo test -p homeboy-agents explicit_candidate_adoption_materializes_verified_patch_with_provenance --lib`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to trace candidate-adoption store ownership, implement the rooted lifecycle boundary, reconcile overlapping #7505 changes, add collision coverage, review split-root behavior, and run verification. Chris Huber reviewed and remains responsible for every line.