### PR TITLE
refactor(agent-task): root reserved handoff cancellation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -64,6 +64,246 @@ pub fn cancel_exact_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskR
     cancel_resolved_run(&sanitize_run_id(run_id), reason)
 }
 
+/// Cancel one literal run through an explicitly selected lifecycle store.
+///
+/// Reserved handoff reconciliation needs exact-record semantics, but must not
+/// cross into another root merely because two test or controller roots use the
+/// same run ID.
+pub(super) fn cancel_exact_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    reason: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let committed = lifecycle_store.with_config_lock(|| {
+        let record = lifecycle_store.read_record(&run_id)?;
+        ensure_rooted_exact_cancellation_supported(&record)?;
+        if successful_provider_execution_is_pending_import(&record) {
+            let mut blocker = None;
+            return lifecycle_store
+                .mutate_record_locked_without_terminal_projection(&run_id, |record| {
+                    if record.state.is_terminal() {
+                        return false;
+                    }
+                    if let Err(error) = ensure_rooted_exact_cancellation_supported(record) {
+                        blocker = Some(error);
+                        return false;
+                    }
+                    defer_cancellation_for_terminal_provider(record, reason)
+                })
+                .and_then(|record| match blocker {
+                    Some(error) => Err(error),
+                    None => Ok(record),
+                });
+        }
+        let service_cleanup = if record.metadata.get("managed_service_supervisor").is_some() {
+            let services = crate::agent_task_scheduler::managed_services::reconcile_run_services_at(
+                &lifecycle_store.data_root(),
+                &record.run_id,
+                reason.unwrap_or("cancelled"),
+            )
+            .map_err(Error::internal_unexpected)?;
+            Some(json!({ "transport": "local", "services": services }))
+        } else {
+            None
+        };
+        let cancellation = if record.state == AgentTaskRunState::Running
+            || (record.state == AgentTaskRunState::Queued
+                && record.runner_id().is_some()
+                && record.runner_job_id().is_some())
+        {
+            classify_live_cancellation(&record)?
+        } else {
+            LiveCancellationOutcome::NotRunning
+        };
+        if let LiveCancellationOutcome::RunnerJobCancelled { job, .. } = &cancellation {
+            if job.status.is_terminal() && job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
+                return Err(Error::validation_invalid_argument(
+                    "run_id",
+                    "runner completed before rooted cancellation could be projected; refusing to overwrite its terminal result",
+                    Some(record.run_id),
+                    None,
+                ));
+            }
+        }
+        let mut blocker = None;
+        lifecycle_store.mutate_record_locked_without_terminal_projection(&run_id, |record| {
+            if record.state.is_terminal() {
+                return false;
+            }
+            if let Err(error) = ensure_rooted_exact_cancellation_supported(record) {
+                blocker = Some(error);
+                return false;
+            }
+            if successful_provider_execution_is_pending_import(record) {
+                return defer_cancellation_for_terminal_provider(record, reason);
+            }
+            let cancelled_at = now_timestamp();
+            record.updated_at = Some(cancelled_at.clone());
+            set_run_state(record, AgentTaskRunState::Cancelled);
+            for task in &mut record.tasks {
+                if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+                    task.state = AgentTaskState::Cancelled;
+                }
+            }
+            let runner_id = record.runner_id().map(str::to_string);
+            let runner_job_id = record.runner_job_id().map(str::to_string);
+            let metadata = record.ensure_metadata_object();
+            terminalize_running_provider_executions(metadata, &cancelled_at);
+            metadata.insert("cancelled_at".to_string(), json!(cancelled_at));
+            metadata.insert("cancelled_by_pid".to_string(), json!(std::process::id()));
+            metadata.insert(
+                "cancel_reason".to_string(),
+                json!(reason.unwrap_or("cancel requested")),
+            );
+            if let Some(service_cleanup) = service_cleanup.clone() {
+                metadata.insert("managed_service_cleanup".to_string(), service_cleanup);
+            }
+            match &cancellation {
+                LiveCancellationOutcome::Terminated(termination) => {
+                    metadata.insert(
+                        "live_cancellation".to_string(),
+                        json!({
+                            "owner_pid": termination.owner_pid,
+                            "descendant_pids": termination.descendant_pids,
+                            "signalled_pids": termination.signalled_pids,
+                            "signal": termination.signal,
+                            "killed_pids": termination.killed_pids,
+                            "surviving_pids": termination.surviving_pids,
+                            "recovery_commands": termination.recovery_commands,
+                        }),
+                    );
+                }
+                LiveCancellationOutcome::RunnerJobCancelled { job, events } => {
+                    metadata.insert(
+                        "live_cancellation".to_string(),
+                        json!({
+                            "runner_id": runner_id,
+                            "runner_job_id": runner_job_id,
+                            "runner_job_status": job.status,
+                            "runner_job_events": events,
+                            "cancellation": "runner_job_cancel",
+                        }),
+                    );
+                }
+                LiveCancellationOutcome::Unsupported(unsupported) => {
+                    metadata.insert(
+                        "live_cancellation_unsupported".to_string(),
+                        json!({
+                            "reason": unsupported.reason,
+                            "owner_pid": unsupported.owner_pid,
+                            "runner_id": unsupported.runner_id,
+                            "runner_job_id": unsupported.runner_job_id,
+                            "recovery_commands": unsupported.recovery_commands,
+                        }),
+                    );
+                }
+                LiveCancellationOutcome::NotRunning => {}
+            }
+            true
+        })
+        .and_then(|record| match blocker {
+            Some(error) => Err(error),
+            None => Ok(record),
+        })
+    })?;
+    if let Some(record) = committed.as_ref() {
+        lifecycle_store.project_terminal_record_after_unlock(&record.run_id)?;
+    }
+    let record = committed.unwrap_or(lifecycle_store.read_record(&run_id)?);
+    if record.state == AgentTaskRunState::Cancelled {
+        crate::controller_scratch::finalize_run_at_explicit_roots(
+            &lifecycle_store.data_root(),
+            &lifecycle_store.artifact_root(),
+            &run_id,
+        )?;
+        homeboy_core::controller_runtime::cancel_admission_at(
+            &lifecycle_store.data_root().join("controller-runtimes"),
+            &run_id,
+        )?;
+    }
+    Ok(record)
+}
+
+fn ensure_rooted_exact_cancellation_supported(record: &AgentTaskRunRecord) -> Result<()> {
+    if record.state.is_terminal() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already terminal with state {:?}",
+                record.run_id, record.state
+            ),
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    // These paths bind or project durable lifecycle records through ambient
+    // stores today. Refuse before any lifecycle mutation rather than splitting
+    // ownership across roots.
+    if record.candidate_adoption.as_ref().is_some_and(|attempt| {
+        attempt.is_active()
+            || attempt.state == "cancel_requested"
+            || attempt.phase == "gate_orphaned"
+    }) || record
+        .metadata
+        .get("lab_staging_controller_job_id")
+        .is_some()
+        || record
+            .metadata
+            .pointer("/runner_submission_intent/state")
+            .and_then(Value::as_str)
+            == Some("pending")
+    {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "rooted exact cancellation cannot reconcile controller-owned or pending runner work without an explicit lifecycle-store transport",
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    if record
+        .metadata
+        .get("managed_service_supervisor")
+        .and_then(Value::as_object)
+        .and_then(|owner| owner.get("runner_id"))
+        .is_some()
+    {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "rooted exact cancellation cannot reconcile runner-owned managed services without an explicit lifecycle-store transport",
+            Some(record.run_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn defer_cancellation_for_terminal_provider(
+    record: &mut AgentTaskRunRecord,
+    reason: Option<&str>,
+) -> bool {
+    record.ensure_metadata_object().insert(
+        "cancellation_deferred_for_terminal_provider".to_string(),
+        json!({
+            "requested_at": now_timestamp(),
+            "reason": reason.unwrap_or("cancel requested"),
+        }),
+    );
+    true
+}
+
+fn successful_provider_execution_is_pending_import(record: &AgentTaskRunRecord) -> bool {
+    record.state == AgentTaskRunState::Running
+        && !record.is_runner_backed()
+        && record.metadata["provider_executions"]
+            .as_array()
+            .is_some_and(|executions| {
+                executions
+                    .iter()
+                    .any(|execution| execution["state"] == json!("succeeded"))
+            })
+}
+
 fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
     // Cook IDs are stable aliases. Match status and logs by following an
     // materialized attempt once one exists; before then the handoff parent is
@@ -925,6 +1165,73 @@ mod tests {
                 "an unattached child must observe the durable fence before it can materialize"
             );
         });
+    }
+
+    #[test]
+    fn rooted_exact_cancellation_terminalizes_a_running_reserved_child() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+        let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+        let run_id = "same-running-reserved-child";
+
+        for store in [&left, &right] {
+            store
+                .submit_plan_with_runtime_admission(
+                    &AgentTaskPlan::new("running-reserved-child", Vec::new()),
+                    run_id,
+                    |_| Ok(json!({})),
+                )
+                .expect("submit isolated child");
+            store
+                .mutate_record(run_id, |record| {
+                    set_run_state(record, AgentTaskRunState::Running);
+                    true
+                })
+                .expect("mark isolated child running");
+        }
+
+        cancel_exact_run_in_store(&left, run_id, Some("parent cancelled"))
+            .expect("cancel running child in selected root");
+
+        assert_eq!(
+            left.read_record(run_id).expect("read left child").state,
+            AgentTaskRunState::Cancelled
+        );
+        assert_eq!(
+            right.read_record(run_id).expect("read right child").state,
+            AgentTaskRunState::Running
+        );
+    }
+
+    #[test]
+    fn rooted_exact_cancellation_preserves_success_pending_aggregate_import() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let store = AgentTaskLifecycleStore::new(context.path_roots());
+        let run_id = "rooted-success-pending-import";
+        store
+            .submit_plan_with_runtime_admission(
+                &AgentTaskPlan::new("success-pending-import", Vec::new()),
+                run_id,
+                |_| Ok(json!({})),
+            )
+            .unwrap();
+        store
+            .mutate_record(run_id, |record| {
+                set_run_state(record, AgentTaskRunState::Running);
+                record.metadata["provider_executions"] = json!([{ "state": "succeeded" }]);
+                true
+            })
+            .unwrap();
+
+        let record = cancel_exact_run_in_store(&store, run_id, Some("parent cancelled"))
+            .expect("defer cancellation for successful provider");
+
+        assert_eq!(record.state, AgentTaskRunState::Running);
+        assert_eq!(
+            record.metadata["cancellation_deferred_for_terminal_provider"]["reason"],
+            "parent cancelled"
+        );
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -516,8 +516,16 @@ pub(crate) fn reserve_detached_cook_handoff_materialization_in_store(
 /// cancelled before the Cook index could be published. The reservation is the
 /// durable link that keeps this otherwise-unindexed record reachable.
 pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id: &str) -> Result<bool> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(&lifecycle_store, cook_id)
+}
+
+pub(crate) fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<bool> {
     let cook_id = sanitize_run_id(cook_id);
-    let Ok(parent) = store::read_record(&cook_id) else {
+    let Ok(parent) = lifecycle_store.read_record(&cook_id) else {
         return Ok(false);
     };
     let handoff = &parent.metadata["detached_cook_handoff"];
@@ -527,7 +535,7 @@ pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id: &str)
     if handoff["cook_id"] != cook_id || parent.state != AgentTaskRunState::Cancelled {
         return Ok(false);
     }
-    let Ok(child) = store::read_record(attempt_run_id) else {
+    let Ok(child) = lifecycle_store.read_record(attempt_run_id) else {
         return Ok(false);
     };
     // The reservation makes an unindexed child reachable, but it does not give
@@ -535,7 +543,11 @@ pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id: &str)
     if child.state.is_terminal() {
         return Ok(false);
     }
-    cancel_exact_run(attempt_run_id, Some("detached Cook handoff cancelled"))?;
+    super::cancellation::cancel_exact_run_in_store(
+        lifecycle_store,
+        attempt_run_id,
+        Some("detached Cook handoff cancelled"),
+    )?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -733,8 +733,16 @@ fn handoff_listener(command: &mut Command, listener: Option<&TcpListener>) -> Re
 }
 
 fn persist_record(run_id: &str, record: &AgentTaskManagedServiceRecord) -> Result<(), String> {
-    let path = homeboy_core::paths::homeboy_data()
-        .map_err(|error| error.message)?
+    let data_root = homeboy_core::paths::homeboy_data().map_err(|error| error.message)?;
+    persist_record_at(&data_root, run_id, record)
+}
+
+fn persist_record_at(
+    data_root: &Path,
+    run_id: &str,
+    record: &AgentTaskManagedServiceRecord,
+) -> Result<(), String> {
+    let path = data_root
         .join("agent-task-runs")
         .join(run_id)
         .join("services")
@@ -1093,8 +1101,18 @@ pub(crate) fn reconcile_run_services(
     run_id: &str,
     reason: &str,
 ) -> Result<Vec<AgentTaskManagedServiceRecord>, String> {
-    let directory = homeboy_core::paths::homeboy_data()
-        .map_err(|error| error.message)?
+    let data_root = homeboy_core::paths::homeboy_data().map_err(|error| error.message)?;
+    reconcile_run_services_at(&data_root, run_id, reason)
+}
+
+/// Reconcile controller-local service ownership below an explicit lifecycle
+/// data root rather than the calling process's ambient data root.
+pub(crate) fn reconcile_run_services_at(
+    data_root: &Path,
+    run_id: &str,
+    reason: &str,
+) -> Result<Vec<AgentTaskManagedServiceRecord>, String> {
+    let directory = data_root
         .join("agent-task-runs")
         .join(run_id)
         .join("services");
@@ -1120,7 +1138,7 @@ pub(crate) fn reconcile_run_services(
                 record.state = "failed".to_string();
                 record.cleanup_outcome = Some("failed_invalid_cleanup_deadline".to_string());
                 record.cleanup = Some(format!("cleanup_failed_invalid_deadline:{reason}:{error}"));
-                persist_record(run_id, &record)?;
+                persist_record_at(data_root, run_id, &record)?;
                 records.push(record);
                 continue;
             }
@@ -1201,7 +1219,7 @@ pub(crate) fn reconcile_run_services(
             });
         }
         record.cleanup = Some(format!("{outcome}:{reason}"));
-        persist_record(run_id, &record)?;
+        persist_record_at(data_root, run_id, &record)?;
         records.push(record);
     }
     Ok(records)

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -1288,7 +1288,12 @@ fn materialize_adoption_attempt_in_stores(
                 Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
                 agent_task_lifecycle::execution_runner_id(),
                 super::cook_pre_execution::production_runtime_admission(lifecycle_store),
-                super::cook_pre_execution::reconcile_reserved_cancellation,
+                |cook_id| {
+                    super::cook_pre_execution::reconcile_reserved_cancellation_in_store(
+                        lifecycle_store,
+                        cook_id,
+                    )
+                },
             )?;
     Ok((record, recipe))
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -267,7 +267,7 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
         Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
-        reconcile_reserved_cancellation,
+        |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )
 }
 
@@ -303,7 +303,7 @@ pub(crate) fn materialize_cook_attempt_with_stores(
         Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
-        reconcile_reserved_cancellation,
+        |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )
 }
 
@@ -350,7 +350,16 @@ fn materialize_cook_attempt_with_stores_and_runtime(
 }
 
 pub(crate) fn reconcile_reserved_cancellation(cook_id: &str) -> Result<()> {
-    agent_task_lifecycle::cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_reserved_cancellation_in_store(&lifecycle_store, cook_id)
+}
+
+pub(crate) fn reconcile_reserved_cancellation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<()> {
+    lifecycle_store
+        .cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id)
         .map(|_| ())
 }
 
@@ -482,7 +491,7 @@ pub(crate) fn recover_recipe_attempt_with_stores(
         Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
-        reconcile_reserved_cancellation,
+        |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )
 }
 
@@ -510,7 +519,7 @@ pub(crate) fn recover_adoption_attempt_with_stores(
         Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
-        reconcile_reserved_cancellation,
+        |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )
 }
 
@@ -982,6 +991,71 @@ mod tests {
                 .plan_id,
             "right-recovery-plan"
         );
+    }
+
+    #[test]
+    fn reserved_cancellation_reconciliation_mutates_only_the_explicit_lifecycle_root() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+        let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+        let cook_id = "same-reserved-cancellation-cook";
+        let run_id = "same-reserved-cancellation-run";
+
+        for (store, root) in [(&left_store, "left"), (&right_store, "right")] {
+            store
+                .submit_plan_with_runtime_admission(
+                    &AgentTaskPlan::new(format!("{root}-parent"), Vec::new()),
+                    cook_id,
+                    |_| Ok(serde_json::json!({ "root": root })),
+                )
+                .unwrap();
+            store
+                .mutate_record(cook_id, |record| {
+                    record.metadata["detached_cook_handoff"] = serde_json::json!({
+                        "state": "pending",
+                        "cook_id": cook_id,
+                        "cancellation_fence": { "state": "open" },
+                    });
+                    true
+                })
+                .unwrap();
+            agent_task_lifecycle::reserve_detached_cook_handoff_materialization_in_store(
+                store, cook_id, run_id,
+            )
+            .unwrap();
+            store
+                .mutate_record(cook_id, |record| {
+                    record.state = agent_task_lifecycle::AgentTaskRunState::Cancelled;
+                    record.metadata["detached_cook_handoff"]["cancellation_fence"]["state"] =
+                        serde_json::json!("cancelled");
+                    true
+                })
+                .unwrap();
+            store
+                .submit_plan_with_runtime_admission(
+                    &plan(&format!("{root}-child"), root),
+                    run_id,
+                    |_| Ok(serde_json::json!({ "root": root })),
+                )
+                .unwrap();
+            store.record_cook_attempt(cook_id, 1, run_id).unwrap();
+        }
+
+        reconcile_reserved_cancellation_in_store(&left_store, cook_id).unwrap();
+
+        let left = left_store.read_record(run_id).unwrap();
+        let right = right_store.read_record(run_id).unwrap();
+        assert_eq!(
+            left.state,
+            agent_task_lifecycle::AgentTaskRunState::Cancelled
+        );
+        assert_eq!(
+            left.metadata["cancel_reason"],
+            "detached Cook handoff cancelled"
+        );
+        assert_eq!(right.state, agent_task_lifecycle::AgentTaskRunState::Queued);
+        assert!(right.metadata.get("cancelled_at").is_none());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -826,6 +826,18 @@ pub(crate) fn finalize_run_at(data_root: &Path, run_id: &str) -> Result<()> {
     )
 }
 
+pub(crate) fn finalize_run_at_explicit_roots(
+    data_root: &Path,
+    artifact_root: &Path,
+    run_id: &str,
+) -> Result<()> {
+    finalize_run_at_index(
+        data_root.join("controller-scratch/resources.json"),
+        || Ok(artifact_root.to_path_buf()),
+        run_id,
+    )
+}
+
 #[cfg(test)]
 fn finalize_run_at_roots(index_path: PathBuf, artifact_root: PathBuf, run_id: &str) -> Result<()> {
     finalize_run_at_index(index_path, || Ok(artifact_root.clone()), run_id)

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -298,6 +298,15 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled(
+        &self,
+        cook_id: &str,
+    ) -> Result<bool> {
+        super::lifecycle_ops::cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(
+            self, cook_id,
+        )
+    }
+
     pub fn start_candidate_adoption_with_policy(
         &self,
         run_id: &str,

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -899,7 +899,19 @@ pub fn admission_status(request_id: &str) -> Result<Value> {
 /// the advisory lock remains the authority while a process is alive.
 pub fn cancel_admission(request_id: &str) -> Result<()> {
     let root = runtime_root()?;
-    let lock_path = root.join(ADMISSION_LOCK_DIR);
+    cancel_admission_at(&root, request_id)
+}
+
+/// Remove a waiting request from an explicitly selected controller-runtime
+/// store. Lifecycle stores use this to keep same-ID isolated roots independent.
+pub fn cancel_admission_at(runtime_root: &Path, request_id: &str) -> Result<()> {
+    fs::create_dir_all(runtime_root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create controller runtime directory".to_string()),
+        )
+    })?;
+    let lock_path = runtime_root.join(ADMISSION_LOCK_DIR);
     update_admission_queue(&lock_path, |queue| {
         queue["requests"] = queue["requests"]
             .as_array()
@@ -3279,6 +3291,30 @@ mod tests {
         assert!(!summary.contains("unavailable"), "{summary}");
         assert!(summary.contains("agent-task-queued"), "{summary}");
         assert!(summary.contains("pid=4294967294"), "{summary}");
+    }
+
+    #[test]
+    fn rooted_admission_cancellation_does_not_remove_the_same_id_from_another_root() {
+        let left = tempfile::tempdir().expect("left runtime root");
+        let right = tempfile::tempdir().expect("right runtime root");
+        let request_id = "same-run-id";
+        for root in [left.path(), right.path()] {
+            enqueue_admission_request(&root.join(ADMISSION_LOCK_DIR), request_id)
+                .expect("enqueue isolated waiter");
+        }
+
+        cancel_admission_at(left.path(), request_id).expect("cancel left waiter");
+
+        assert!(read_admission_queue(&left.path().join(ADMISSION_LOCK_DIR))
+            .expect("read left queue")["requests"]
+            .as_array()
+            .expect("left requests")
+            .is_empty());
+        assert_eq!(
+            read_admission_queue(&right.path().join(ADMISSION_LOCK_DIR)).expect("read right queue")
+                ["requests"][0]["request_id"],
+            request_id
+        );
     }
 
     /// A contended admission failure must carry machine-readable evidence, not


### PR DESCRIPTION
## Summary
- reconcile reserved detached-Cook cancellation through the supplied lifecycle store instead of ambient run records
- preserve queued and local-running cancellation under one store lock, including provider-success arbitration and terminal projection
- root managed-service, controller-scratch, and controller-runtime admission cleanup
- prove identical Cook/run IDs and admission waiters remain isolated across roots

Ambient compatibility entry points remain unchanged. Adoption, staging, pending-runner, and runner-owned-service cases fail before mutation until their deeper cancellation transports accept explicit stores.

Progresses #7505.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents cancellation --lib` (20 passed)
- `cargo test -p homeboy-agents cook_pre_execution --lib` (5 passed)
- `cargo test -p homeboy-core rooted_admission_cancellation_does_not_remove_the_same_id_from_another_root --lib`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to trace reserved-handoff cancellation ownership, implement explicit-root lifecycle/runtime/scratch/service primitives, identify and fix cancellation races, add same-ID collision coverage, review compatibility, and run verification. Chris Huber reviewed and remains responsible for every line.