### PR TITLE
Fix reconstructed Cook workspace admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4630,7 +4630,7 @@ where
             }
             let mut failed_dispatch_plan = None;
             let execution = (|| {
-                if options.attempt_dispatcher.is_none() {
+                if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
                     validate_cook_workspace(&options)?;
                 }
                 if options.attempt_dispatcher.is_none() {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3569,9 +3569,12 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
             ],
         );
 
+        let dispatches = Arc::new(AtomicUsize::new(0));
         let mut options = batch_cook_options(
             "removed-managed-continuation",
-            Arc::new(AcceptedDetachedAttemptDispatcher),
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: dispatches.clone(),
+            }),
         );
         options.to_worktree = "fixture@removed-continuation".to_string();
         options.source_worktree_path = Some(target.clone());
@@ -3579,7 +3582,9 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
         let recipe = super::super::load_recipe(&options.cook_id).expect("load Cook recipe");
         let reconstructed = super::super::reconstruct_options_with_dispatcher(
             &recipe,
-            Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+            Some(Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: dispatches.clone(),
+            })),
         )
         .expect("reconstruct persisted Cook options");
 
@@ -3625,6 +3630,7 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
             .expect("durable Cook failure report before provider execution");
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "pre_execution_failure");
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
     });
 }
 
@@ -5141,8 +5147,22 @@ fn cook_failure_context_counts_preflight_cook_alias_as_zero_execution() {
         let provider_run_id = format!("{cook_id}-attempt-2");
         super::super::record_recipe_attempt(cook_id, 2, &provider_run_id, &options.initial_plan)
             .expect("append provider attempt to recipe");
-        super::super::materialize_cook_attempt(cook_id, &provider_run_id, &options.initial_plan)
-            .expect("materialize provider attempt");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&provider_run_id))
+            .expect("submit provider attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, &provider_run_id)
+            .expect("index provider attempt");
+        assert_eq!(
+            agent_task_lifecycle::status(cook_id)
+                .expect("resolve Cook alias to provider attempt")
+                .run_id,
+            provider_run_id
+        );
+        assert_eq!(
+            agent_task_lifecycle::exact_record(cook_id)
+                .expect("retain exact preflight record")
+                .metadata["provider_executions_consumed"],
+            0
+        );
         assert_eq!(
             agent_task_lifecycle::reserve_provider_execution(
                 &provider_run_id,
@@ -6678,7 +6698,7 @@ fn run_cook_persists_recipe_in_explicit_store_only() {
         let result = run_cook_with_store(&store, options, UnusedExecutor)
             .expect("Cook reports the lifecycle materialization failure");
 
-        assert_eq!(result.value.status, "durable_failure");
+        assert_eq!(result.value.status, "pre_execution_failure");
         assert!(store.recipe_exists(cook_id));
         assert!(!super::super::recipe_exists(cook_id).expect("ambient recipe lookup"));
     });


### PR DESCRIPTION
## Summary
- validate reconstructed detached Cooks before dispatch when they still depend on a controller-local source workspace
- prove removed managed worktrees never reach the detached attempt dispatcher
- preserve the strengthened detached cancellation fence while updating accounting and explicit-store fixtures to their current lifecycle contracts

Closes #12558.

## Verification
- `cargo test -p homeboy-agents cook_failure_context_counts_preflight_cook_alias_as_zero_execution --lib`
- `cargo test -p homeboy-agents reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution --lib`
- `cargo test -p homeboy-agents run_cook_persists_recipe_in_explicit_store_only --lib`
- `cargo test -p homeboy-agents dirty_explicit_cwd_blocks_detached_provider_dispatch --lib`
- `cargo test -p homeboy-agents cook_publishes_durable_identity_before_materialization_and_survives_interruption --lib`
- `cargo test -p homeboy-agents cancellation_fence_rejects_a_cook_index_published_after_cancellation --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo nextest run -p homeboy-agents --lib` reached 472 passes before stopping on seven inherited process/network fixture failures already present on the current baseline: three failures and four timeouts outside the changed Cook paths.

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode traced the explicit-store and reconstructed-workspace regressions, implemented the dispatch guard and fixture corrections, and ran verification. Chris Huber reviewed and remains responsible for every line.