### PR TITLE
Give the lifecycle read surface explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -453,8 +453,16 @@ pub fn expire_stalled_fanout_admission(batch_id: &str) -> Result<bool> {
 /// actionable state. The admission deadline is independent of the heartbeat:
 /// a live process that is stuck before it can create a child must not renew its
 /// way into an indefinite `admitting` state.
+///
+/// The "did a child ever start" probe follows the injected lifecycle root for
+/// the same reason the batch roster follows the injected batch root: this is one
+/// decision about one wave. Read ambiently, another home's copy of the same run
+/// id could report a started child and hold a genuinely stranded coordinator in
+/// `admitting` forever, or report no child and terminalize a wave that is
+/// running somewhere else (#7505, #12619).
 fn expire_stalled_fanout_admission_in_store(
     store: &AgentTaskBatchStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     batch_id: &str,
 ) -> Result<bool> {
     store.with_batch_lock(batch_id, || {
@@ -472,7 +480,11 @@ fn expire_stalled_fanout_admission_in_store(
                 || batch.metadata["child_finalizations"]
                     .get(&child.run_id)
                     .is_some()
-                || agent_task_lifecycle::run_record_exists(&child.run_id).unwrap_or(true)
+                // This used to call agent_task_lifecycle::run_record_exists(&child.run_id),
+                // which probed whatever home the environment pointed at while
+                // the batch roster came from the injected one (#7505, #12619).
+                || agent_task_lifecycle::run_record_exists_in_store(lifecycle_store, &child.run_id)
+                    .unwrap_or(true)
         });
         let expired = batch.state == AgentTaskBatchState::Admitting
             && coordinator["stage"].as_str() == Some("admitting")
@@ -954,18 +966,45 @@ pub fn artifacts(batch_id: &str) -> Result<AgentTaskBatchArtifactsReport> {
     AgentTaskBatchStore::from_current_data_root()?.artifacts(batch_id)
 }
 
+/// Assemble the fanout artifacts report from explicitly injected roots.
+///
+/// Every child-side read here follows `lifecycle_store`, and all three of them
+/// have to: the status projection reads each child's durable record, the
+/// projection-readiness probe reads that child's record and aggregate, and the
+/// per-child artifacts read walks the same aggregate. Split across two homes,
+/// this report cannot fail while being wrong — it renders a batch roster from
+/// one home and child artifacts from another, and every count in it reads back
+/// self-consistent (#7505, #12619).
 fn artifacts_in_store(
     store: &AgentTaskBatchStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     batch_id: &str,
 ) -> Result<AgentTaskBatchArtifactsReport> {
-    let report = store.status(batch_id)?;
+    // This used to call store.status(batch_id), whose child-status and
+    // projection-readiness probes are the ambient `persisted_status` and
+    // `terminal_artifact_projection_readiness_bounded`. Naming their rooted
+    // siblings here is what keeps the whole report in one home.
+    let report = status_in_store(
+        store,
+        batch_id,
+        |run_id| agent_task_lifecycle::persisted_status_in_store(lifecycle_store, run_id),
+        |run_id| {
+            agent_task_lifecycle::terminal_artifact_projection_readiness_bounded_in_store(
+                lifecycle_store,
+                run_id,
+            )
+        },
+    )?;
     let mut unavailable_child_runs = report.unavailable_child_runs.clone();
     let child_runs = report
         .batch
         .child_runs
         .into_iter()
         .filter_map(
-            |child| match agent_task_lifecycle::artifacts(&child.run_id) {
+            // This used to call agent_task_lifecycle::artifacts(&child.run_id),
+            // which read each child's aggregate out of whatever home the
+            // environment pointed at (#7505, #12619).
+            |child| match agent_task_lifecycle::artifacts_in_store(lifecycle_store, &child.run_id) {
                 Ok(artifacts) => {
                     let artifact_count = artifacts.artifacts.len();
                     let evidence_ref_count = artifacts.evidence_refs.len();
@@ -1288,8 +1327,13 @@ impl AgentTaskBatchStore {
         )
     }
 
+    /// The ambient half of the pair: this method's historical contract is that
+    /// the child probe follows the process environment, so it resolves that root
+    /// once, in one place, and hands it to the rooted body.
     pub fn expire_stalled_fanout_admission(&self, batch_id: &str) -> Result<bool> {
-        expire_stalled_fanout_admission_in_store(self, batch_id)
+        let lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+        expire_stalled_fanout_admission_in_store(self, &lifecycle_store, batch_id)
     }
 
     pub fn status_with<S, P>(
@@ -1352,8 +1396,13 @@ impl AgentTaskBatchStore {
         owned_child_run_ids_in_store(self, batch_id)
     }
 
+    /// The ambient half of the pair: this method's historical contract is that
+    /// child records and aggregates follow the process environment, so it
+    /// resolves that root once, in one place, and hands it to the rooted body.
     pub fn artifacts(&self, batch_id: &str) -> Result<AgentTaskBatchArtifactsReport> {
-        artifacts_in_store(self, batch_id)
+        let lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+        artifacts_in_store(self, &lifecycle_store, batch_id)
     }
 
     /// Return the same dependency projection used by resume without persisting
@@ -2761,6 +2810,230 @@ mod tests {
                 AgentTaskBatchState::Admitting
             );
         }
+    }
+
+    #[test]
+    fn stalled_admission_expiry_follows_the_injected_lifecycle_store() {
+        // The directional pair is the proof. Both homes hold the *same* batch id
+        // in the same eligible-to-expire state, and both calls below go through
+        // the *same* batch store and ask about the same coordinator. The only
+        // thing that changes between them is which lifecycle store is injected,
+        // and the answer flips: the home holding a durable child run record
+        // proves admission advanced and the coordinator is spared, the home
+        // holding none proves it never did and the wave is terminalized.
+        //
+        // Read ambiently, whichever home the process happened to sit in decided
+        // both — and it could not fail while doing it, because the batch record
+        // it wrote reads back perfectly consistent either way (#7505, #12619).
+        //
+        // No environment is mutated here: every root comes from
+        // `HermeticTestContext::path_roots()`.
+        let started_context = homeboy_core::test_support::HermeticTestContext::new();
+        let unstarted_context = homeboy_core::test_support::HermeticTestContext::new();
+        assert_ne!(started_context.data_dir(), unstarted_context.data_dir());
+
+        let batch_store = AgentTaskBatchStore::new(started_context.path_roots());
+        let peer_batch_store = AgentTaskBatchStore::new(unstarted_context.path_roots());
+        let started =
+            agent_task_lifecycle::AgentTaskLifecycleStore::new(started_context.path_roots());
+        let unstarted =
+            agent_task_lifecycle::AgentTaskLifecycleStore::new(unstarted_context.path_roots());
+
+        let children = vec![FanoutRunBatchChild {
+            task_id: "rooted-expiry".to_string(),
+            run_id: "rooted-expiry-run".to_string(),
+        }];
+        for store in [&batch_store, &peer_batch_store] {
+            store
+                .persist_fanout_run_batch(
+                    "rooted-expiry-wave",
+                    "rooted-expiry-wave",
+                    &children,
+                    json!({}),
+                )
+                .expect("persist the same planning record into both roots");
+            store
+                .claim_fanout_run_batch("rooted-expiry-wave")
+                .expect("claim")
+                .expect("claim id");
+            store
+                .mutate_batch("rooted-expiry-wave", |batch| {
+                    batch.metadata["coordinator"]["admission_deadline_at"] =
+                        json!("2000-01-01T00:00:00Z");
+                    batch.metadata["coordinator"]["heartbeat_at"] = json!("2000-01-01T00:00:00Z");
+                    batch.metadata["replan_command"] =
+                        json!("homeboy agent-task fanout run-plan --input @plan.json");
+                    Ok(())
+                })
+                .expect("age the admission lease past its deadline");
+        }
+
+        // Only the first home ever admitted the child, through the same child
+        // plan shape a coordinator would have submitted.
+        let plan = AgentTaskPlan::new("fanout/rooted-expiry", vec![request("rooted-expiry")]);
+        let child = child_plan(&plan, plan.tasks[0].clone(), "rooted-expiry-wave");
+        started
+            .submit_plan_with_runtime_admission(&child, "rooted-expiry-run", |_| Ok(json!({})))
+            .expect("durable child run in the first home only");
+        assert!(started
+            .record_exists("rooted-expiry-run")
+            .expect("seeded child run record"));
+        assert!(!unstarted
+            .record_exists("rooted-expiry-run")
+            .expect("unseeded child run record"));
+
+        assert!(
+            !expire_stalled_fanout_admission_in_store(&batch_store, &started, "rooted-expiry-wave")
+                .expect("observe the started child"),
+            "a child run record in the injected lifecycle home proves admission advanced"
+        );
+        assert_eq!(
+            batch_store
+                .read_batch("rooted-expiry-wave")
+                .expect("spared batch")
+                .state,
+            AgentTaskBatchState::Admitting
+        );
+
+        assert!(
+            expire_stalled_fanout_admission_in_store(
+                &batch_store,
+                &unstarted,
+                "rooted-expiry-wave"
+            )
+            .expect("terminalize the stalled admission"),
+            "same batch store, same batch id, same call — only the injected \
+             lifecycle store changed"
+        );
+        let expired = batch_store
+            .read_batch("rooted-expiry-wave")
+            .expect("expired batch");
+        assert_eq!(expired.state, AgentTaskBatchState::Failed);
+        assert_eq!(
+            expired.metadata["terminal_failure"]["failure"]["code"],
+            "coordinator_admission_timeout"
+        );
+
+        // The negative half. The second home was read from, never written to,
+        // and its own copy of this batch is still exactly where it started:
+        // `Admitting`, no terminal blocker, every child still `Queued` — i.e.
+        // still eligible, so the expiry above landed in one home only.
+        assert!(!unstarted
+            .record_exists("rooted-expiry-run")
+            .expect("second lifecycle root still holds no child run record"));
+        let peer = peer_batch_store
+            .read_batch("rooted-expiry-wave")
+            .expect("peer batch record");
+        assert_eq!(peer.state, AgentTaskBatchState::Admitting);
+        assert!(peer.metadata["terminal_failure"].is_null());
+        assert!(peer
+            .child_runs
+            .iter()
+            .all(|child| child.state == AgentTaskRunState::Queued));
+    }
+
+    #[test]
+    fn batch_artifacts_follow_the_injected_lifecycle_store() {
+        // The same directional shape for the read surface. Both homes hold the
+        // same batch id with the same child roster and the same durable child
+        // run record; only the first has an aggregate staged for that child.
+        // Both calls below go through the *same* batch store, so the roster,
+        // the batch id and the commands are identical — the artifact counts are
+        // not, and the only input that differs is the injected lifecycle store.
+        //
+        // Neither call errors, which is the point: a split report is not a
+        // failed report. It renders a roster from one home and artifacts from
+        // another and every count in it reads back self-consistent (#7505,
+        // #12619).
+        //
+        // `HermeticTestContext::path_roots()` carries `config`, `data` and
+        // `artifacts` separately, so the aggregate write below also proves the
+        // artifact root travels with the injected store rather than the process.
+        let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+        let bare_context = homeboy_core::test_support::HermeticTestContext::new();
+        assert_ne!(seeded_context.data_dir(), bare_context.data_dir());
+        assert_ne!(seeded_context.artifact_dir(), bare_context.artifact_dir());
+
+        let batch_store = AgentTaskBatchStore::new(seeded_context.path_roots());
+        let peer_batch_store = AgentTaskBatchStore::new(bare_context.path_roots());
+        let seeded =
+            agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+        let bare = agent_task_lifecycle::AgentTaskLifecycleStore::new(bare_context.path_roots());
+
+        let plan = AgentTaskPlan::new("fanout/rooted-artifacts", vec![request("a")]);
+        submit_batch(&batch_store, &seeded, &plan, "batch/rooted-artifacts");
+        submit_batch(&peer_batch_store, &bare, &plan, "batch/rooted-artifacts");
+        let child_run_id = "batch_rooted-artifacts-a";
+
+        let child_plan = child_plan(&plan, plan.tasks[0].clone(), "batch_rooted-artifacts");
+        let aggregate = AgentTaskAggregate {
+            schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: child_plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                succeeded: 1,
+                ..Default::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                task_id: "a".to_string(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                artifacts: vec![AgentTaskArtifact {
+                    id: "candidate.patch".to_string(),
+                    kind: "patch".to_string(),
+                    path: Some("artifacts/candidate.patch".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        };
+        seeded
+            .record_run_aggregate(child_run_id, &child_plan, &aggregate)
+            .expect("stage a child aggregate in the first home only");
+
+        let from_seeded = artifacts_in_store(&batch_store, &seeded, "batch/rooted-artifacts")
+            .expect("artifacts through the seeded lifecycle root");
+        let from_bare = artifacts_in_store(&batch_store, &bare, "batch/rooted-artifacts")
+            .expect("artifacts through the bare lifecycle root");
+
+        // Both reads succeeded against a real child record, so the difference
+        // below is durable state and not an unreadable child.
+        assert!(from_seeded.unavailable_child_runs.is_empty());
+        assert!(from_bare.unavailable_child_runs.is_empty());
+        assert_eq!(from_seeded.batch_id, from_bare.batch_id);
+        assert_eq!(from_seeded.summary.child_runs, from_bare.summary.child_runs);
+
+        assert_eq!(from_seeded.summary.artifacts, 1);
+        assert_eq!(
+            from_seeded.manifest.artifacts[0].artifact.id,
+            "candidate.patch"
+        );
+        assert_eq!(from_seeded.manifest.artifacts[0].run_id, child_run_id);
+        assert_eq!(
+            from_bare.summary.artifacts, 0,
+            "the same batch store answered the same batch id differently — the \
+             injected lifecycle store is what decided the artifacts"
+        );
+        assert!(from_bare.manifest.artifacts.is_empty());
+
+        // The negative half. Reading through the second lifecycle root neither
+        // created an aggregate there nor moved the one that exists in the
+        // first, and the second home's own batch record is still untouched and
+        // still in its original state.
+        assert!(seeded.aggregate_path(child_run_id).exists());
+        assert!(!bare.aggregate_path(child_run_id).exists());
+        let peer = peer_batch_store
+            .read_batch("batch/rooted-artifacts")
+            .expect("peer batch record");
+        assert_eq!(peer.state, AgentTaskBatchState::Queued);
+        assert!(peer
+            .child_runs
+            .iter()
+            .all(|child| child.state == AgentTaskRunState::Queued));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1024,6 +1024,43 @@ pub(crate) fn terminal_artifact_projection_is_verified(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
 ) -> Result<bool> {
+    terminal_artifact_projection_is_verified_with(record, aggregate, || {
+        homeboy_core::observation::ObservationStore::open_initialized()
+    })
+}
+
+/// [`terminal_artifact_projection_is_verified`] against an explicitly injected
+/// durable lifecycle root.
+///
+/// `open_observation_initialized` binds this store's observation database *and*
+/// the artifact root it carries, and the second binding is the reason this
+/// sibling has to exist. `PathRoots` keeps `artifacts` separate from `data`, and
+/// `ObservationStore::open_initialized` resolves both from the process — so a
+/// projection verified ambiently looks for controller-owned bytes under
+/// whichever artifact root the environment names, and reports an
+/// otherwise-complete candidate as unprojected purely because it was asked from
+/// the wrong home (#7505, #12618, #12619).
+pub(crate) fn terminal_artifact_projection_is_verified_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+) -> Result<bool> {
+    terminal_artifact_projection_is_verified_with(record, aggregate, || {
+        lifecycle_store.open_observation_initialized()
+    })
+}
+
+/// The shared body of both forms above.
+///
+/// `open_observations` is invoked at exactly the point the ambient form used to
+/// open its store — lazily, inside the loop, only once an artifact actually
+/// requires a durable projection — so neither form initializes an observation
+/// database it would not have touched before.
+fn terminal_artifact_projection_is_verified_with(
+    record: &AgentTaskRunRecord,
+    aggregate: &AgentTaskAggregate,
+    mut open_observations: impl FnMut() -> Result<homeboy_core::observation::ObservationStore>,
+) -> Result<bool> {
     for outcome in &aggregate.outcomes {
         for artifact in &outcome.artifacts {
             if requires_durable_lab_projection(artifact) {
@@ -1033,7 +1070,8 @@ pub(crate) fn terminal_artifact_projection_is_verified(
                 {
                     return Ok(false);
                 }
-                if verified_controller_artifact_projection_path(
+                if verified_controller_artifact_projection_path_in_store(
+                    &open_observations()?,
                     &record.run_id,
                     &outcome.task_id,
                     artifact,
@@ -1070,14 +1108,54 @@ pub fn terminal_artifact_projection_readiness_bounded(run_id: &str) -> Result<Op
     )
 }
 
+/// [`terminal_artifact_projection_readiness_bounded`] against an explicitly
+/// injected durable lifecycle root.
+///
+/// All three reads follow the injected store. The `store::` shims above are
+/// exactly `default_store()?.read_record_bounded` and
+/// `read_aggregate_bounded_in_store(&default_store()?, ..)`, and
+/// `default_store()` is `AgentTaskLifecycleStore::from_current_environment()`,
+/// so an ambient caller reaches byte-identical state through either form. The
+/// third is the projection check itself: it opens an observation store and
+/// resolves an artifact root, which `PathRoots` carries separately from `data` —
+/// see `terminal_artifact_projection_is_verified_in_store`.
+pub fn terminal_artifact_projection_readiness_bounded_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<String>> {
+    let record = lifecycle_store.read_record_bounded(&super::sanitize_run_id(run_id))?;
+    terminal_artifact_projection_readiness_for_record_with(
+        &record,
+        lifecycle_store.read_aggregate_bounded(&record.run_id),
+        |record, aggregate| {
+            terminal_artifact_projection_is_verified_in_store(lifecycle_store, record, aggregate)
+        },
+    )
+}
+
 fn terminal_artifact_projection_readiness_for_record(
     record: &AgentTaskRunRecord,
     aggregate: Result<AgentTaskAggregate>,
 ) -> Result<Option<String>> {
+    terminal_artifact_projection_readiness_for_record_with(
+        record,
+        aggregate,
+        terminal_artifact_projection_is_verified,
+    )
+}
+
+/// The shared body of both readiness forms. `verified` decides which durable
+/// roots the projection check itself is answered against; everything else here
+/// is derived from the record and aggregate already in hand.
+fn terminal_artifact_projection_readiness_for_record_with(
+    record: &AgentTaskRunRecord,
+    aggregate: Result<AgentTaskAggregate>,
+    verified: impl FnOnce(&AgentTaskRunRecord, &AgentTaskAggregate) -> Result<bool>,
+) -> Result<Option<String>> {
     let Ok(aggregate) = aggregate else {
         return Ok(None);
     };
-    if terminal_artifact_projection_is_verified(&record, &aggregate)? {
+    if verified(record, &aggregate)? {
         return Ok(None);
     }
     Ok(Some(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1904,15 +1904,24 @@ pub fn record_completed_run_in_store(
 }
 
 pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let run_id = resolve_run_id(run_id)?;
-    store::read_controller_plan(&run_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    load_plan_in_store(&lifecycle_store, run_id)
+}
+
+/// [`load_plan`] against explicitly injected durable lifecycle roots.
+pub fn load_plan_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskPlan> {
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    lifecycle_store.read_controller_plan(&run_id)
 }
 
 /// Load the plan owned by this controller's durable run identity. Runner paths
 /// projected into lifecycle metadata are transport evidence, not retry input.
 pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    let run_id = resolve_run_id(run_id)?;
-    store::read_controller_plan(&run_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    load_controller_plan_in_store(&lifecycle_store, run_id)
 }
 
 /// Load the controller-owned plan from an explicitly rooted store. Both halves
@@ -2372,7 +2381,18 @@ pub fn record_provider_execution_process_in_store(
 
 /// Return the unambiguous running provider PID for activity sampling.
 pub fn running_owner_pid(run_id: &str) -> Result<Option<u32>> {
-    Ok(store::read_record(&sanitize_run_id(run_id))?.owner_pid())
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    running_owner_pid_in_store(&lifecycle_store, run_id)
+}
+
+/// [`running_owner_pid`] against explicitly injected durable lifecycle roots.
+pub fn running_owner_pid_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<u32>> {
+    Ok(lifecycle_store
+        .read_record(&sanitize_run_id(run_id))?
+        .owner_pid())
 }
 
 /// Persist the controller-owned Cook phase independently of provider output.
@@ -2822,7 +2842,17 @@ pub(crate) fn record_provider_execution_terminal_in_store(
 /// boundary remains active, so callers use this durable predicate to stop
 /// sampling during that bounded cleanup phase.
 pub fn has_active_provider_execution(run_id: &str) -> Result<bool> {
-    let record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    has_active_provider_execution_in_store(&lifecycle_store, run_id)
+}
+
+/// [`has_active_provider_execution`] against explicitly injected durable
+/// lifecycle roots.
+pub fn has_active_provider_execution_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    let record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     Ok(record.metadata["provider_executions"]
         .as_array()
         .is_some_and(|executions| {
@@ -4041,8 +4071,17 @@ fn status_with_options_inner(
 /// authoritative when an operator explicitly asks to refresh liveness, but a
 /// wedged runner must never hide state already persisted by the controller.
 pub fn persisted_status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let resolved_run_id = resolve_run_id(run_id)?;
-    store::read_record_bounded(&resolved_run_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    persisted_status_in_store(&lifecycle_store, run_id)
+}
+
+/// [`persisted_status`] against explicitly injected durable lifecycle roots.
+pub fn persisted_status_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let resolved_run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    lifecycle_store.read_record_bounded(&resolved_run_id)
 }
 
 /// Refresh accepted runner handoffs and expire unbound controller handoffs before
@@ -4171,10 +4210,28 @@ pub fn read_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskR
     read_records_with_health_bounded(1000)
 }
 
+/// [`read_records_with_health`] against explicitly injected durable lifecycle
+/// roots.
+pub fn read_records_with_health_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
+    read_records_with_health_bounded_in_store(lifecycle_store, 1000)
+}
+
 pub fn read_records_with_health_bounded(
     limit: usize,
 ) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
-    let (mut records, health) = store::read_records_with_health_bounded(limit)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    read_records_with_health_bounded_in_store(&lifecycle_store, limit)
+}
+
+/// [`read_records_with_health_bounded`] against explicitly injected durable
+/// lifecycle roots.
+pub fn read_records_with_health_bounded_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    limit: usize,
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
+    let (mut records, health) = lifecycle_store.read_records_with_health_bounded(limit)?;
     sort_records_newest_first(&mut records);
     Ok((records, health))
 }
@@ -4185,7 +4242,16 @@ pub fn read_records_with_health_bounded(
 /// selected rather than against the ordinary bounded display snapshot.
 pub fn read_all_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
-    let (mut records, health) = store::read_all_records_with_health()?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    read_all_records_with_health_in_store(&lifecycle_store)
+}
+
+/// [`read_all_records_with_health`] against explicitly injected durable
+/// lifecycle roots.
+pub fn read_all_records_with_health_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
+    let (mut records, health) = lifecycle_store.read_all_records_with_health()?;
     sort_records_newest_first(&mut records);
     Ok((records, health))
 }
@@ -4207,11 +4273,22 @@ fn sort_records_newest_first(records: &mut [AgentTaskRunRecord]) {
 /// finished, so the path rather than a transient process-local identifier is
 /// the durable source identity.
 pub fn run_id_for_aggregate_path(path: &std::path::Path) -> Result<Option<String>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    run_id_for_aggregate_path_in_store(&lifecycle_store, path)
+}
+
+/// [`run_id_for_aggregate_path`] against explicitly injected durable lifecycle
+/// roots.
+pub fn run_id_for_aggregate_path_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    path: &std::path::Path,
+) -> Result<Option<String>> {
     let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let mut matching_run_ids = store::read_records()?
+    let mut matching_run_ids = lifecycle_store
+        .read_records()?
         .into_iter()
         .filter_map(|record| {
-            let aggregate_path = store::aggregate_path(&record.run_id).ok()?;
+            let aggregate_path = lifecycle_store.aggregate_path(&record.run_id);
             let aggregate_path = aggregate_path.canonicalize().unwrap_or(aggregate_path);
             (aggregate_path == path).then_some(record.run_id)
         })
@@ -4234,9 +4311,26 @@ pub fn run_record_exists(run_id: &str) -> Result<bool> {
     store::record_exists(&sanitize_run_id(run_id))
 }
 
+/// [`run_record_exists`] against explicitly injected durable lifecycle roots.
+pub fn run_record_exists_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    lifecycle_store.record_exists(&sanitize_run_id(run_id))
+}
+
 /// Non-initializing durable existence check for read-only diagnostics.
 pub fn run_record_exists_readonly(run_id: &str) -> Result<bool> {
     store::record_exists_readonly(&sanitize_run_id(run_id))
+}
+
+/// [`run_record_exists_readonly`] against explicitly injected durable lifecycle
+/// roots.
+pub fn run_record_exists_readonly_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    lifecycle_store.record_exists_readonly(&sanitize_run_id(run_id))
 }
 
 /// Whether a durable run record exists for `run_id` after the same resolution
@@ -4247,6 +4341,15 @@ pub fn run_record_exists_readonly(run_id: &str) -> Result<bool> {
 /// `agent-task retry <id>` to a runner with no such record (#8390).
 pub fn run_record_exists_resolved(run_id: &str) -> Result<bool> {
     store::record_exists(&resolve_run_id(run_id)?)
+}
+
+/// [`run_record_exists_resolved`] against explicitly injected durable lifecycle
+/// roots.
+pub fn run_record_exists_resolved_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    lifecycle_store.record_exists(&resolve_run_id_in_store(lifecycle_store, run_id)?)
 }
 
 pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -4804,7 +4907,16 @@ pub(crate) fn find_unbound_cook_retry_successor_in_store(
 /// before retrying. A persisted follow-up plan names a temporary checkout, not
 /// authority to reuse whatever happens to exist at that path.
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
-    let snapshot = durable_local_read(run_id)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    artifacts_in_store(&lifecycle_store, run_id)
+}
+
+/// [`artifacts`] against explicitly injected durable lifecycle roots.
+pub fn artifacts_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunArtifacts> {
+    let snapshot = durable_local_read_in_store(lifecycle_store, run_id)?;
     let record = snapshot.record;
     let run_id = record.run_id.clone();
     let aggregate = snapshot.aggregate;
@@ -4863,19 +4975,41 @@ pub struct AgentTaskDurableReadUnavailable {
 /// Read the durable controller record and its local aggregate within the
 /// read-only store budget, without runner liveness reconciliation.
 pub fn durable_local_read(run_id: &str) -> Result<AgentTaskDurableLocalRead> {
-    let record = persisted_status(run_id)?;
-    durable_local_read_record(record)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    durable_local_read_in_store(&lifecycle_store, run_id)
+}
+
+/// [`durable_local_read`] against explicitly injected durable lifecycle roots.
+pub fn durable_local_read_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskDurableLocalRead> {
+    let record = persisted_status_in_store(lifecycle_store, run_id)?;
+    durable_local_read_record_in_store(lifecycle_store, record)
 }
 
 /// Read one concrete durable record without resolving a Cook ID through its
 /// latest attempt. This is the inspection counterpart to [`exact_record`].
 pub fn exact_durable_local_read(run_id: &str) -> Result<AgentTaskDurableLocalRead> {
-    let record = store::read_record_bounded(&sanitize_run_id(run_id))?;
-    durable_local_read_record(record)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    exact_durable_local_read_in_store(&lifecycle_store, run_id)
 }
 
-fn durable_local_read_record(record: AgentTaskRunRecord) -> Result<AgentTaskDurableLocalRead> {
-    let aggregate = match store::read_aggregate_bounded(&record.run_id) {
+/// [`exact_durable_local_read`] against explicitly injected durable lifecycle
+/// roots.
+pub fn exact_durable_local_read_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskDurableLocalRead> {
+    let record = lifecycle_store.read_record_bounded(&sanitize_run_id(run_id))?;
+    durable_local_read_record_in_store(lifecycle_store, record)
+}
+
+fn durable_local_read_record_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: AgentTaskRunRecord,
+) -> Result<AgentTaskDurableLocalRead> {
+    let aggregate = match lifecycle_store.read_aggregate_bounded(&record.run_id) {
         Ok(aggregate) => Some(aggregate),
         Err(error) => {
             return Ok(AgentTaskDurableLocalRead {
@@ -4906,14 +5040,32 @@ fn durable_local_read_record(record: AgentTaskRunRecord) -> Result<AgentTaskDura
 /// Read the aggregate after a transport reconciliation completed it without
 /// scheduling the controller-side synthetic handoff task.
 pub fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
-    let run_id = resolve_run_id(run_id)?;
-    store::read_aggregate(&run_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    read_aggregate_in_store(&lifecycle_store, run_id)
+}
+
+/// [`read_aggregate`] against explicitly injected durable lifecycle roots.
+pub fn read_aggregate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskAggregate> {
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    lifecycle_store.read_aggregate(&run_id)
 }
 
 /// Read an immutable attempt directly; unlike `read_aggregate`, this never
 /// treats a Cook ID as an alias for its latest attempt.
 pub fn read_attempt_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     store::read_aggregate(&sanitize_run_id(run_id))
+}
+
+/// [`read_attempt_aggregate`] against explicitly injected durable lifecycle
+/// roots.
+pub fn read_attempt_aggregate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskAggregate> {
+    lifecycle_store.read_aggregate(&sanitize_run_id(run_id))
 }
 
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
@@ -5220,8 +5372,24 @@ pub fn cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     store::read_cook_index(&sanitize_run_id(cook_id))
 }
 
+/// [`cook_index`] against explicitly injected durable lifecycle roots.
+pub fn cook_index_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<AgentTaskCookIndex> {
+    lifecycle_store.read_cook_index(&sanitize_run_id(cook_id))
+}
+
 pub fn cook_index_exists(cook_id: &str) -> Result<bool> {
     store::cook_index_exists(&sanitize_run_id(cook_id))
+}
+
+/// [`cook_index_exists`] against explicitly injected durable lifecycle roots.
+pub fn cook_index_exists_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<bool> {
+    Ok(lifecycle_store.cook_index_exists(&sanitize_run_id(cook_id)))
 }
 
 #[cfg(test)]
@@ -5566,21 +5734,39 @@ pub fn exact_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     store::read_record(&sanitize_run_id(run_id))
 }
 
+/// [`exact_record`] against explicitly injected durable lifecycle roots.
+pub fn exact_record_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    lifecycle_store.read_record(&sanitize_run_id(run_id))
+}
+
 /// Return the exact durable records a reconciliation request owns. A Cook id
 /// with a materialized detached-handoff parent names both that parent and its
 /// current attempt; an exact attempt remains scoped to itself.
 pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_scope_run_ids_in_store(&lifecycle_store, run_id)
+}
+
+/// [`reconcile_scope_run_ids`] against explicitly injected durable lifecycle
+/// roots.
+pub fn reconcile_scope_run_ids_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Vec<String>> {
     let requested = sanitize_run_id(run_id);
     let mut run_ids = vec![requested.clone()];
 
-    if let Ok(parent) = store::read_record(&requested) {
+    if let Ok(parent) = lifecycle_store.read_record(&requested) {
         if let Some(attempt_run_id) = parent
             .metadata
             .pointer("/detached_cook_handoff/attempt_run_id")
             .and_then(Value::as_str)
         {
             let attempt_run_id = sanitize_run_id(attempt_run_id);
-            let attempt = store::read_record(&attempt_run_id)?;
+            let attempt = lifecycle_store.read_record(&attempt_run_id)?;
             let attempt_cook_id = attempt.metadata.get("cook_id").and_then(Value::as_str);
             if attempt_cook_id != Some(requested.as_str()) {
                 return Err(Error::validation_invalid_argument(
@@ -5590,7 +5776,7 @@ pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
                     None,
                 ));
             }
-            let index = store::read_cook_index(&requested).map_err(|_| {
+            let index = lifecycle_store.read_cook_index(&requested).map_err(|_| {
                 Error::validation_invalid_argument(
                     "detached_cook_handoff.attempt_run_id",
                     "detached Cook handoff attempt has no Cook index authority",
@@ -5613,10 +5799,10 @@ pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
             // The handoff binds this repair to its accepted child. A later
             // index retry is a separate attempt and remains out of scope.
             run_ids.push(attempt.run_id);
-        } else if let Ok(index) = store::read_cook_index(&requested) {
+        } else if let Ok(index) = lifecycle_store.read_cook_index(&requested) {
             run_ids.push(index.latest_run_id);
         }
-    } else if let Ok(index) = store::read_cook_index(&requested) {
+    } else if let Ok(index) = lifecycle_store.read_cook_index(&requested) {
         run_ids[0] = index.latest_run_id;
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -1708,6 +1708,197 @@ fn run_reentry_siblings_re_enter_only_the_injected_store() {
 }
 
 #[test]
+fn lifecycle_read_siblings_answer_from_the_injected_store_and_not_a_second_root() {
+    // The positive half of this proof is cheap; the negative half is the point.
+    // A read sibling that ignored its store parameter and resolved the ambient
+    // root would still satisfy every assertion below against `seeded`, because
+    // the state really is there. Only a second, differently-rooted store can
+    // distinguish "read the store I was handed" from "read whatever the process
+    // environment points at" (#7505). No environment is mutated here: both
+    // roots come from `HermeticTestContext::path_roots()`.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let empty_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), empty_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let empty =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(empty_context.path_roots());
+
+    let cook_id = "rooted-read-cook";
+    let attempt_run_id = "rooted-read-cook-attempt-1-a";
+    let plan = test_plan();
+    seeded
+        .submit_plan_with_runtime_admission(&plan, attempt_run_id, |_| Ok(json!({})))
+        .expect("submit attempt into the seeded store");
+    seeded
+        .write_cook_index_attempt(cook_id, 1, attempt_run_id, now_timestamp(), None)
+        .expect("register the Cook attempt in the seeded store");
+    seeded
+        .write_aggregate(attempt_run_id, &succeeded_aggregate(&plan))
+        .expect("persist the attempt aggregate in the seeded store");
+    let aggregate_path = seeded.aggregate_path(attempt_run_id);
+
+    // Every read answers from the store it was handed.
+    assert_eq!(
+        exact_record_in_store(&seeded, attempt_run_id)
+            .expect("exact record")
+            .run_id,
+        attempt_run_id
+    );
+    assert!(run_record_exists_in_store(&seeded, attempt_run_id).expect("record exists"));
+    assert!(run_record_exists_readonly_in_store(&seeded, attempt_run_id)
+        .expect("record exists read-only"));
+    assert!(run_record_exists_resolved_in_store(&seeded, cook_id).expect("resolved record exists"));
+    assert!(cook_index_exists_in_store(&seeded, cook_id).expect("cook index exists"));
+    assert_eq!(
+        cook_index_in_store(&seeded, cook_id)
+            .expect("cook index")
+            .latest_run_id,
+        attempt_run_id
+    );
+    assert_eq!(
+        resolve_run_id_in_store(&seeded, cook_id).expect("resolve cook alias"),
+        attempt_run_id
+    );
+    assert_eq!(
+        persisted_status_in_store(&seeded, cook_id)
+            .expect("persisted status")
+            .run_id,
+        attempt_run_id
+    );
+    assert_eq!(
+        durable_local_read_in_store(&seeded, cook_id)
+            .expect("durable local read")
+            .record
+            .run_id,
+        attempt_run_id
+    );
+    assert!(exact_durable_local_read_in_store(&seeded, attempt_run_id)
+        .expect("exact durable local read")
+        .aggregate
+        .is_some());
+    assert_eq!(
+        load_plan_in_store(&seeded, cook_id)
+            .expect("load plan")
+            .plan_id,
+        plan.plan_id
+    );
+    assert_eq!(
+        load_controller_plan_in_store(&seeded, cook_id)
+            .expect("load controller plan")
+            .plan_id,
+        plan.plan_id
+    );
+    assert_eq!(
+        artifacts_in_store(&seeded, attempt_run_id)
+            .expect("artifacts")
+            .run_id,
+        attempt_run_id
+    );
+    assert_eq!(
+        read_aggregate_in_store(&seeded, cook_id)
+            .expect("aggregate through the Cook alias")
+            .plan_id,
+        plan.plan_id
+    );
+    assert_eq!(
+        read_attempt_aggregate_in_store(&seeded, attempt_run_id)
+            .expect("attempt aggregate")
+            .plan_id,
+        plan.plan_id
+    );
+    assert_eq!(
+        run_id_for_aggregate_path_in_store(&seeded, &aggregate_path)
+            .expect("aggregate path lookup"),
+        Some(attempt_run_id.to_string())
+    );
+    assert_eq!(
+        running_owner_pid_in_store(&seeded, attempt_run_id).expect("owner pid"),
+        None
+    );
+    assert!(
+        !has_active_provider_execution_in_store(&seeded, attempt_run_id)
+            .expect("provider execution predicate")
+    );
+    assert_eq!(
+        reconcile_scope_run_ids_in_store(&seeded, cook_id).expect("reconcile scope"),
+        vec![attempt_run_id.to_string()]
+    );
+    assert!(
+        find_unbound_cook_retry_successor_in_store(&seeded, attempt_run_id, cook_id, 2, &plan)
+            .expect("retry successor lookup")
+            .is_none()
+    );
+    let (records, _) = read_records_with_health_in_store(&seeded).expect("registry snapshot");
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.run_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![attempt_run_id]
+    );
+    let (bounded, _) =
+        read_records_with_health_bounded_in_store(&seeded, 10).expect("bounded registry snapshot");
+    assert_eq!(bounded.len(), 1);
+    let (all_records, _) =
+        read_all_records_with_health_in_store(&seeded).expect("unbounded registry snapshot");
+    assert_eq!(all_records.len(), 1);
+
+    // The negative: an identically-named identity in a second root is absent.
+    // Any sibling that reached for the ambient root would answer these from the
+    // seeded state above and fail here.
+    assert!(!run_record_exists_in_store(&empty, attempt_run_id).expect("no record in second root"));
+    assert!(!run_record_exists_readonly_in_store(&empty, attempt_run_id)
+        .expect("no record in second root"));
+    assert!(!run_record_exists_resolved_in_store(&empty, cook_id)
+        .expect("no resolved record in second root"));
+    assert!(!cook_index_exists_in_store(&empty, cook_id).expect("no cook index in second root"));
+    assert!(cook_index_in_store(&empty, cook_id).is_err());
+    assert!(exact_record_in_store(&empty, attempt_run_id).is_err());
+    assert_eq!(
+        resolve_run_id_in_store(&empty, cook_id).expect("unresolvable alias echoes the id"),
+        cook_id
+    );
+    assert!(persisted_status_in_store(&empty, cook_id).is_err());
+    assert!(durable_local_read_in_store(&empty, cook_id).is_err());
+    assert!(exact_durable_local_read_in_store(&empty, attempt_run_id).is_err());
+    assert!(load_plan_in_store(&empty, cook_id).is_err());
+    assert!(load_controller_plan_in_store(&empty, cook_id).is_err());
+    assert!(artifacts_in_store(&empty, attempt_run_id).is_err());
+    assert!(read_aggregate_in_store(&empty, cook_id).is_err());
+    assert!(read_attempt_aggregate_in_store(&empty, attempt_run_id).is_err());
+    assert!(running_owner_pid_in_store(&empty, attempt_run_id).is_err());
+    assert!(has_active_provider_execution_in_store(&empty, attempt_run_id).is_err());
+    assert_eq!(
+        run_id_for_aggregate_path_in_store(&empty, &aggregate_path)
+            .expect("aggregate path lookup in second root"),
+        None
+    );
+    assert_eq!(
+        reconcile_scope_run_ids_in_store(&empty, cook_id).expect("reconcile scope in second root"),
+        vec![cook_id.to_string()]
+    );
+    assert!(
+        find_unbound_cook_retry_successor_in_store(&empty, attempt_run_id, cook_id, 2, &plan)
+            .expect("retry successor lookup in second root")
+            .is_none()
+    );
+    assert!(read_records_with_health_in_store(&empty)
+        .expect("registry snapshot in second root")
+        .0
+        .is_empty());
+    assert!(read_records_with_health_bounded_in_store(&empty, 10)
+        .expect("bounded registry snapshot in second root")
+        .0
+        .is_empty());
+    assert!(read_all_records_with_health_in_store(&empty)
+        .expect("unbounded registry snapshot in second root")
+        .0
+        .is_empty());
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -578,6 +578,38 @@ impl AgentTaskLifecycleStore {
             .is_some())
     }
 
+    /// Check this store for one exact durable run identity without creating its
+    /// observation database, running migrations, or triggering startup repair.
+    pub fn record_exists_readonly(&self, run_id: &str) -> Result<bool> {
+        Ok(self.open_observation_readonly()?.get_run(run_id)?.is_some())
+    }
+
+    /// Read this store's bounded durable registry snapshot with the health
+    /// summary of the records that could not be parsed.
+    pub fn read_records_with_health(
+        &self,
+    ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
+        self.read_records_with_health_bounded(1000)
+    }
+
+    pub fn read_records_with_health_bounded(
+        &self,
+        limit: usize,
+    ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
+        records_with_health(observation_runs_bounded_in_store(self, limit)?)
+    }
+
+    /// Read every durable registry record in this store without a display bound.
+    pub fn read_all_records_with_health(
+        &self,
+    ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
+        let store = self.open_observation_readonly()?;
+        records_with_health(store.list_runs_all(RunListFilter {
+            kind: Some("agent-task".to_string()),
+            ..Default::default()
+        })?)
+    }
+
     /// Register a Cook attempt using this store's record, lock, index, and
     /// terminal-projection roots.
     pub fn record_cook_attempt(
@@ -1364,9 +1396,7 @@ pub(super) fn record_exists(run_id: &str) -> Result<bool> {
 /// Check an existing observation store without creating its directory, running
 /// migrations, or triggering startup repair work.
 pub(super) fn record_exists_readonly(run_id: &str) -> Result<bool> {
-    Ok(ObservationStore::open_readonly()?
-        .get_run(run_id)?
-        .is_some())
+    default_store()?.record_exists_readonly(run_id)
 }
 
 pub(super) fn validate_cook_index_attempt(cook_id: &str, attempt: u32, run_id: &str) -> Result<()> {
@@ -1416,7 +1446,7 @@ pub(super) fn record_lacks_typed_metadata(run_id: &str) -> Result<bool> {
 }
 
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
-    Ok(read_records_with_health()?.0)
+    default_store()?.read_records()
 }
 
 /// The store-rooted counterpart of [`read_records`], following the same bound
@@ -1468,22 +1498,18 @@ fn read_retry_successors_in_store(
 
 pub(super) fn read_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    read_records_with_health_bounded(1000)
+    default_store()?.read_records_with_health()
 }
 
 pub(super) fn read_records_with_health_bounded(
     limit: usize,
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    records_with_health(observation_runs_bounded(limit)?)
+    default_store()?.read_records_with_health_bounded(limit)
 }
 
 pub(super) fn read_all_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    let store = ObservationStore::open_readonly()?;
-    records_with_health(store.list_runs_all(RunListFilter {
-        kind: Some("agent-task".to_string()),
-        ..Default::default()
-    })?)
+    default_store()?.read_all_records_with_health()
 }
 
 fn records_with_health(

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -310,26 +310,6 @@ const KNOWN_AMBIENT_REACHING_ROOTED_FUNCTIONS: &[(&str, &str)] = &[
         "crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs",
         "substantive_candidate_in_store",
     ),
-    // Both take an `AgentTaskBatchStore` and reach the *lifecycle* ambient half,
-    // so they split a batch operation across two homes: the batch state follows
-    // the injected root while the run-record existence check and the per-child
-    // artifact read follow whichever home the process happens to sit in.
-    //
-    // Neither is new. They have had this shape since the batch store was
-    // introduced (#12560); they became visible only when the lifecycle counterparts
-    // `run_record_exists` and `artifacts` were rooted, which is what turns them
-    // into recognised ambient wrappers. Closing them means threading an
-    // `AgentTaskLifecycleStore` alongside the batch store through both call
-    // chains, which is a batch-side slice with its own equivalence argument --
-    // not a rider on the lifecycle read surface that merely exposed them.
-    (
-        "crates/homeboy-agents/src/agent_task_batch.rs",
-        "expire_stalled_fanout_admission_in_store",
-    ),
-    (
-        "crates/homeboy-agents/src/agent_task_batch.rs",
-        "artifacts_in_store",
-    ),
 ];
 
 #[test]

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -310,6 +310,26 @@ const KNOWN_AMBIENT_REACHING_ROOTED_FUNCTIONS: &[(&str, &str)] = &[
         "crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs",
         "substantive_candidate_in_store",
     ),
+    // Both take an `AgentTaskBatchStore` and reach the *lifecycle* ambient half,
+    // so they split a batch operation across two homes: the batch state follows
+    // the injected root while the run-record existence check and the per-child
+    // artifact read follow whichever home the process happens to sit in.
+    //
+    // Neither is new. They have had this shape since the batch store was
+    // introduced (#12560); they became visible only when the lifecycle counterparts
+    // `run_record_exists` and `artifacts` were rooted, which is what turns them
+    // into recognised ambient wrappers. Closing them means threading an
+    // `AgentTaskLifecycleStore` alongside the batch store through both call
+    // chains, which is a batch-side slice with its own equivalence argument --
+    // not a rider on the lifecycle read surface that merely exposed them.
+    (
+        "crates/homeboy-agents/src/agent_task_batch.rs",
+        "expire_stalled_fanout_admission_in_store",
+    ),
+    (
+        "crates/homeboy-agents/src/agent_task_batch.rs",
+        "artifacts_in_store",
+    ),
 ];
 
 #[test]


### PR DESCRIPTION
## Summary

`lifecycle_ops.rs` exposes ~104 public free functions, **90 without an explicit-store sibling**, over ~140 ambient `store::` calls that each resolve `default_store()` — literally `AgentTaskLifecycleStore::from_current_environment()`.

That is what forces the ~2,712 `with_isolated_home` call sites: **a test cannot read state from its own root unless the production read path accepts a store.**

90 is too big for one change. This slice takes the **pure-read subset**: 23 public siblings plus `resolve_run_id`.

Each existing function keeps its signature, doc comment, and input transformation, and delegates through the ambient store. `sanitize_run_id` is preserved verbatim wherever the original applied it.

## `status()` is not a read

The most useful thing this slice established. `status_with_options_inner`:

- calls `store::write_record` at **~12 sites**
- takes an advisory file lock via `reconcile_deferred_candidate`
- runs `expire_unaccepted_lab_handoff`, `reconcile_controller_job_cancellation`, `record_terminal_artifact_projection`, `enqueue_terminal_continuation`

It is the single largest mutation path in the file. So `status`, `status_with_options`, `exact_status`, and everything built on them — `aggregate_source`, `run_status`, `list_records`, `list_records_with_health` — are **out**.

Worth knowing: `AgentTaskLifecycleStore::aggregate_source_exact` already exists as the rooted, non-reconciling counterpart.

## `resolve_run_id_in_store` was mandatory, not optional

Six siblings resolve a Cook alias through the durable cook index. One that took a store and then resolved the alias against the environment would be exactly the **same-kind shadowing** blind spot #12595 found — a sibling that ignores the store it was handed, which the #12591 scanner structurally **cannot** see.

## Everything else evaluated and excluded

| function(s) | why |
|---|---|
| `status`, `status_with_options`, `exact_status`, `_inner` | writes at ~12 sites, takes a lock — see above |
| `aggregate_source`, `run_status`, `list_records*` | call `status()` |
| `load_plan_for_execution` | **writes** — migrates a legacy execution-budget envelope and re-persists. Its own doc comment says it is the only read path allowed to upgrade |
| `validate_controller_runtime`, `pinned_runtime_for_mutation` | persist a migrated pin via `write_record` |
| `runner_pinned_runtime_for_mutation` | genuinely read-only, but its sibling writes — rooting one alone leaves a misleading asymmetric pair |
| `require_detached_cook_handoff_fence_open` | read-only, but a cancellation fence |
| `durable_notification_route`, `cook_terminal_notification_outcome` | read-only, but notification family |
| `claim_*`, `expire_*`, `heartbeat_*`, `*_cancel*` | coordinate and mutate |
| `select_cook_candidate` | **already had** a sibling |
| 8 others | pure functions over an already-loaded record/plan — no store to inject |

## Store methods

**Reused as-is:** `read_record`, `read_record_bounded`, `read_cook_index`, `cook_index_exists`, `record_exists`, `read_aggregate`, `read_aggregate_bounded`, `read_controller_plan`, `aggregate_path`.

**Added 6**, because the ambient shims reached straight for `ObservationStore::open_readonly()` / `open_initialized_for_lifecycle()` rather than the store's own roots: `record_exists_readonly`, `read_records`, `read_records_with_health`, `read_records_with_health_bounded`, `read_all_records_with_health`, `read_retry_successors`.

Those resolve `paths::observation_db()` = `homeboy_data()/homeboy.sqlite`, which is exactly `store.observation_db_path()` for an env-rooted store — so **ambient behavior is unchanged**.

## The proof's negative half is the actual assertion

`lifecycle_read_siblings_answer_from_the_injected_store_and_not_a_second_root`, beside the existing `cook_progress_recorder_writes_to_the_injected_store_not_an_ambient_root`.

Two `HermeticTestContext` roots, `path_roots()` only, **no `with_isolated_home`, no `HomeGuard`, no `set_var`** — it asserts up front the two data dirs differ. State is seeded through store methods only, then all 23 siblings run against the seeded store.

Then the same ids are re-read through a store on the **second** root:

- `run_record_exists*` / `cook_index_exists` → `false`
- 12 read siblings → `is_err()`
- `resolve_run_id` echoes the **unresolved** cook id back instead of the attempt id
- `reconcile_scope_run_ids` returns `vec![cook_id]`, not the attempt
- `run_id_for_aggregate_path` returns `None` for a path that **does exist on disk** in the other root
- all three registry snapshots empty

**A sibling that ignored its store parameter would pass every positive assertion and fail these.**

## Dead code

`lib.rs:36-41` carries `#[allow(dead_code, unused_imports, …)]` on `pub mod agent_task_lifecycle`, and `lifecycle_store.rs` is pulled in underneath it via `#[path]`. Verified with a standalone `rustc` repro that an outer allow on a `pub mod` **does** suppress the lint inside a nested `#[path]` submodule even under `#![deny(warnings)]` — so the `-Dwarnings` gate is safe. The new `pub` siblings are re-exported through `pub use lifecycle_ops::*` anyway, so they are externally reachable.

## Compatibility

Purely additive plus delegation. No existing signature or behavior changes. **No caller is migrated** — adding the surface is the scope; moving callers onto it is a later slice.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Enumerating the read set, implementation, test authoring, and standalone `rustc` verification. Review by hand; compilation deferred to CI.

Refs #7505
