### PR TITLE
Give the Cook write family explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1531,7 +1531,18 @@ pub(crate) fn project_runner_execution_context(
 }
 
 pub(crate) fn persist_controller_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<()> {
-    store::write_plan(run_id, plan).map(|_| ())
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    persist_controller_plan_in_store(&lifecycle_store, run_id, plan)
+}
+
+pub(crate) fn persist_controller_plan_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+) -> Result<()> {
+    lifecycle_store
+        .write_controller_plan(run_id, plan)
+        .map(|_| ())
 }
 
 pub(crate) fn controller_runtime_for_runner_execution(
@@ -1643,7 +1654,20 @@ pub fn release_cook_terminal_notification_claim(cook_id: &str) -> Result<()> {
 /// Store the latest compact notification delivery outcome for Cook/status
 /// readers. The caller supplies an already redacted, bounded projection.
 pub fn record_cook_terminal_notification_outcome(cook_id: &str, outcome: Value) -> Result<()> {
-    store::write_cook_notification_outcome(cook_id, &outcome)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_terminal_notification_outcome_in_store(&lifecycle_store, cook_id, outcome)
+}
+
+/// Store the latest compact notification delivery outcome beside the injected
+/// store's own Cook index. The marker is a file next to `index.json`, not an
+/// observation row, so it follows this store's data root rather than the
+/// ambient one.
+pub fn record_cook_terminal_notification_outcome_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    outcome: Value,
+) -> Result<()> {
+    lifecycle_store.write_cook_notification_outcome(cook_id, &outcome)
 }
 
 /// Read the latest terminal notification outcome without loading Cook attempts.
@@ -2072,15 +2096,42 @@ pub fn record_cook_progress(
     record_cook_progress_with_activity(run_id, phase, attempt, detail, None)
 }
 
+/// Persist the controller-owned Cook phase into an explicitly rooted store.
+pub fn record_cook_progress_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    attempt: u32,
+    detail: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    record_cook_progress_with_activity_in_store(
+        lifecycle_store,
+        run_id,
+        phase,
+        attempt,
+        detail,
+        None,
+    )
+}
+
 /// Retain a redacted, bounded controller failure independently of continuation
 /// claim transitions. Claims describe ownership; they must not replace cause.
 pub fn record_cook_controller_failure(
     run_id: &str,
     diagnostic: &Value,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_controller_failure_in_store(&lifecycle_store, run_id, diagnostic)
+}
+
+pub fn record_cook_controller_failure_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    diagnostic: &Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let diagnostic = diagnostic.clone();
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         record
             .ensure_metadata_object()
             .insert("cook_controller_failure".to_string(), diagnostic);
@@ -2193,10 +2244,20 @@ pub fn record_cook_observer_event(
     phase: &str,
     diagnostic: Value,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_observer_event_in_store(&lifecycle_store, run_id, phase, diagnostic)
+}
+
+pub fn record_cook_observer_event_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    diagnostic: Value,
+) -> Result<AgentTaskRunRecord> {
     const MAX_EVENTS: usize = 16;
 
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let metadata = record.ensure_metadata_object();
         let events = metadata
             .entry("cook_observer_events".to_string())
@@ -2246,8 +2307,19 @@ pub fn record_cook_supervision(
     sample: Option<Value>,
     decisions: Vec<Value>,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_supervision_in_store(&lifecycle_store, run_id, attempt, sample, decisions)
+}
+
+pub fn record_cook_supervision_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    attempt: u32,
+    sample: Option<Value>,
+    decisions: Vec<Value>,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let now = now_timestamp();
         let metadata = record.ensure_metadata_object();
         if let Some(sample) = sample {
@@ -2302,8 +2374,18 @@ pub fn record_cook_supervision_stop(
     attempt: u32,
     outcome: Value,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_supervision_stop_in_store(&lifecycle_store, run_id, attempt, outcome)
+}
+
+pub fn record_cook_supervision_stop_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    attempt: u32,
+    outcome: Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let metadata = record.ensure_metadata_object();
         let events = metadata
             .entry("cook_supervision_events".to_string())
@@ -2334,8 +2416,18 @@ pub fn record_cook_terminal_result(
     terminal_success: bool,
     exit_code: i32,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_terminal_result_in_store(&lifecycle_store, run_id, terminal_success, exit_code)
+}
+
+pub fn record_cook_terminal_result_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    terminal_success: bool,
+    exit_code: i32,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(progress) = record
             .ensure_metadata_object()
             .get_mut("cook_progress")
@@ -4386,13 +4478,23 @@ pub fn record_cook_recovery_checkpoint(
     phase: &str,
     next_command: &str,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_recovery_checkpoint_in_store(&lifecycle_store, run_id, phase, next_command)
+}
+
+pub fn record_cook_recovery_checkpoint_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    next_command: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let checkpoint = json!({
         "schema": "homeboy/agent-task-cook-recovery-checkpoint/v1",
         "phase": phase,
         "next_command": next_command,
     });
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("cook_recovery_checkpoint") == Some(&checkpoint) {
             return false;
         }
@@ -4404,7 +4506,7 @@ pub fn record_cook_recovery_checkpoint(
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }
 
@@ -5250,8 +5352,17 @@ pub fn record_cook_force_with_lease_receipt(
     run_id: &str,
     receipt: Value,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_cook_force_with_lease_receipt_in_store(&lifecycle_store, run_id, receipt)
+}
+
+pub fn record_cook_force_with_lease_receipt_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    receipt: Value,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         if record.metadata.get("cook_force_with_lease_receipt") == Some(&receipt) {
             return false;
         }
@@ -5263,7 +5374,7 @@ pub fn record_cook_force_with_lease_receipt(
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -248,6 +248,155 @@ fn cook_progress_recorder_writes_to_the_injected_store_not_an_ambient_root() {
 }
 
 #[test]
+fn cook_write_siblings_persist_into_the_injected_store_and_not_a_second_root() {
+    // The negative half is the proof. Both roots are given the *same* run
+    // identity, and every write below is made through a sibling that was handed
+    // `seeded`. A sibling that ignored its parameter and resolved a root from
+    // the process environment would leave `seeded` empty, or — if the ambient
+    // root ever coincided with `other` — would show up in the second store.
+    // Asserting that `other` still reads its own untouched record is what
+    // distinguishes "wrote where I was told" from "wrote wherever the
+    // environment points" (#7505). No environment is mutated here: both roots
+    // come from `HermeticTestContext::path_roots()`.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let other_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), other_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let other =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(other_context.path_roots());
+
+    let run_id = "rooted-cook-write";
+    let cook_id = "rooted-cook-write-cook";
+    let plan_only_run_id = "rooted-cook-write-plan-only";
+    let plan = test_plan();
+    for lifecycle_store in [&seeded, &other] {
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+            .expect("submit the same run identity into both roots");
+    }
+
+    // The terminal notification outcome is a file beside the Cook index rather
+    // than an observation row, so it is checked at the path each store owns.
+    let notification_outcome_path =
+        |lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore| {
+            lifecycle_store
+                .cook_index_path(cook_id)
+                .with_file_name("notification-outcome.json")
+        };
+
+    persist_controller_plan_in_store(&seeded, plan_only_run_id, &plan)
+        .expect("persist a controller plan into the injected store");
+    let progress = record_cook_progress_in_store(&seeded, run_id, "terminal", 1, Some("rooted"))
+        .expect("record Cook progress into the injected store");
+    assert_eq!(progress.metadata["cook_progress"]["phase"], "terminal");
+    let terminal = record_cook_terminal_result_in_store(&seeded, run_id, true, 0)
+        .expect("record the terminal Cook result into the injected store");
+    assert_eq!(terminal.metadata["cook_progress"]["terminal_success"], true);
+    record_cook_controller_failure_in_store(&seeded, run_id, &json!({ "reason": "rooted" }))
+        .expect("record a controller failure into the injected store");
+    record_cook_observer_event_in_store(&seeded, run_id, "terminal", json!({ "code": "rooted" }))
+        .expect("record an observer event into the injected store");
+    record_cook_supervision_in_store(
+        &seeded,
+        run_id,
+        1,
+        Some(json!({ "cpu_seconds": 7 })),
+        vec![json!({ "budget": "wall_clock" })],
+    )
+    .expect("record a supervision tick into the injected store");
+    record_cook_supervision_stop_in_store(&seeded, run_id, 1, json!({ "signalled": true }))
+        .expect("record a supervision stop into the injected store");
+    record_cook_recovery_checkpoint_in_store(
+        &seeded,
+        run_id,
+        "verification_pending",
+        "homeboy agent-task cook-continue",
+    )
+    .expect("record a recovery checkpoint into the injected store");
+    record_cook_force_with_lease_receipt_in_store(
+        &seeded,
+        run_id,
+        json!({ "remote_sha": "abc123" }),
+    )
+    .expect("record a force-with-lease receipt into the injected store");
+    record_cook_terminal_notification_outcome_in_store(
+        &seeded,
+        cook_id,
+        json!({ "state": "delivered" }),
+    )
+    .expect("record a terminal notification outcome into the injected store");
+
+    // The positive: every write is durable in the store that was handed in.
+    let persisted = seeded
+        .read_record(run_id)
+        .expect("read the seeded record back");
+    assert_eq!(persisted.metadata["cook_progress"]["phase"], "terminal");
+    assert_eq!(
+        persisted.metadata["cook_progress"]["terminal_success"],
+        true
+    );
+    assert_eq!(persisted.metadata["cook_progress"]["exit_code"], 0);
+    assert_eq!(
+        persisted.metadata["cook_controller_failure"]["reason"],
+        "rooted"
+    );
+    assert_eq!(
+        persisted.metadata["cook_observer_events"][0]["phase"],
+        "terminal"
+    );
+    assert_eq!(
+        persisted.metadata["cook_resource_timeline"][0]["sample"]["cpu_seconds"],
+        7
+    );
+    let supervision_events = persisted.metadata["cook_supervision_events"]
+        .as_array()
+        .expect("supervision events are an array");
+    assert_eq!(supervision_events.len(), 2);
+    assert_eq!(supervision_events[0]["kind"], "budget_breached");
+    assert_eq!(supervision_events[1]["kind"], "stop_executed");
+    assert_eq!(
+        persisted.metadata["cook_recovery_checkpoint"]["phase"],
+        "verification_pending"
+    );
+    assert_eq!(
+        persisted.metadata["cook_force_with_lease_receipt"]["remote_sha"],
+        "abc123"
+    );
+    assert_eq!(
+        seeded
+            .read_controller_plan(plan_only_run_id)
+            .expect("the injected store owns the persisted plan")
+            .plan_id,
+        plan.plan_id
+    );
+    assert!(notification_outcome_path(&seeded).exists());
+
+    // The negative: the second root holds the same run identity and saw none of
+    // it. Any sibling that ignored the store it was handed fails here.
+    let untouched = other
+        .read_record(run_id)
+        .expect("the second root still has its own record");
+    for key in [
+        "cook_progress",
+        "cook_controller_failure",
+        "cook_observer_events",
+        "cook_resource_timeline",
+        "cook_supervision_events",
+        "cook_recovery_checkpoint",
+        "cook_force_with_lease_receipt",
+    ] {
+        assert!(
+            untouched.metadata.get(key).is_none(),
+            "second root must not observe `{key}` written through the injected store"
+        );
+    }
+    assert!(other.read_controller_plan(plan_only_run_id).is_err());
+    assert!(!notification_outcome_path(&other).exists());
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -509,6 +509,12 @@ impl AgentTaskLifecycleStore {
         self.cook_index_path(cook_id).exists()
     }
 
+    /// Persist the latest bounded, secret-safe terminal notification outcome
+    /// beside this store's own Cook index rather than the ambient one.
+    pub fn write_cook_notification_outcome(&self, cook_id: &str, outcome: &Value) -> Result<()> {
+        write_cook_notification_outcome_in_store(self, cook_id, outcome)
+    }
+
     pub fn read_record(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_in_store(self, run_id)
     }
@@ -1256,8 +1262,17 @@ pub(super) fn release_cook_notification_claim(cook_id: &str) -> Result<()> {
 
 /// Persist the latest bounded, secret-safe terminal notification outcome.
 pub(super) fn write_cook_notification_outcome(cook_id: &str, outcome: &Value) -> Result<()> {
-    let path =
-        cook_index_path(&sanitize_run_id(cook_id))?.with_file_name("notification-outcome.json");
+    write_cook_notification_outcome_in_store(&default_store()?, cook_id, outcome)
+}
+
+fn write_cook_notification_outcome_in_store(
+    store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    outcome: &Value,
+) -> Result<()> {
+    let path = store
+        .cook_index_path(&sanitize_run_id(cook_id))
+        .with_file_name("notification-outcome.json");
     write_private_json(&path, outcome)
 }
 


### PR DESCRIPTION
## Summary

Continues rooting `lifecycle_ops.rs` after the read subset (#12603). This takes the **Cook write family** — the nine `record_cook_*` functions plus `persist_controller_plan`, which **#12582 specifically named as the Cook spine's remaining ambient reaches.**

Each existing function keeps its signature, doc comment, and input transformation, and becomes a thin ambient resolve-and-delegate. `sanitize_run_id` is applied exactly once per sibling, at the same point as the original.

| function | store method |
|---|---|
| `record_cook_controller_failure` | `mutate_record` |
| `record_cook_force_with_lease_receipt` | `mutate_record`, `read_record` |
| `record_cook_observer_event` | `mutate_record` |
| `record_cook_progress` | delegates to the existing `record_cook_progress_with_activity_in_store` |
| `record_cook_recovery_checkpoint` | `mutate_record`, `read_record` |
| `record_cook_supervision` | `mutate_record` |
| `record_cook_supervision_stop` | `mutate_record` |
| `record_cook_terminal_notification_outcome` | **new** `write_cook_notification_outcome` |
| `record_cook_terminal_result` | `mutate_record` |
| `persist_controller_plan` | existing `write_controller_plan` |

## The one that mattered

`record_cook_terminal_notification_outcome` called `store::write_cook_notification_outcome`, whose body reached a module-private `cook_index_path` helper that is `default_store()?`.

<callout accent="#ef4444">
Left alone, the sibling would have **accepted a store and written the outcome marker into the ambient data root.**

Nothing would have caught it. It is a bare filesystem write with no record read to fail first — so **even the positive half of a test would have passed** while the file landed under the ambient home.
</callout>

The helper is now threaded and the ambient shim delegates.

Its **double** `sanitize_run_id` application was preserved rather than tidied: the original sanitizes and then calls a method that sanitizes again. Behavior-identical for real ids, but not for an empty one, since `sanitize_run_id("")` mints a fresh `default_run_id()`.

## Evaluated and excluded

- **`record_run_aggregate`** — already has `record_run_aggregate_in_store` at `lifecycle_ops.rs:3015`, surfaced as `AgentTaskLifecycleStore::record_run_aggregate`. Fits the shape exactly; it was just already done.
- **`record_cook_progress`** forwards to the existing `record_cook_progress_with_activity_in_store` with `activity: None` rather than duplicating its body, mirroring the ambient pair one-for-one.

## Shadowing audit

Every sibling body was scanned for `store::`, `default_store`, `paths::`, and `from_current_environment` — the same-kind shadowing blind spot #12595 found, which the #12591 scanner structurally **cannot** see. None present.

The remaining helpers in these bodies (`sanitize_run_id`, `now_timestamp`, `ensure_metadata_object`, `update_lifecycle_heartbeat`, `is_runner_backed`) are pure; `update_lifecycle_heartbeat` touches only the record and `std::process::id()`.

`KNOWN_MIXED_STORE_FUNCTIONS` is untouched and non-stale — no new function mentions `CookRecipeStore`, and the ambient wrappers name neither store type in their signatures, so they classify as env-resolving entry points.

## No observation-store access in this family

The eight record writers go through `mutate_record`, which already resolves the observation DB from the store's own `observation_db_path()`. The one non-record write is a JSON file beside `index.json` under the store's data root, not an `ObservationStore` row. So no `paths::observation_db()` reach exists and none was added — unlike #12603, which hit that and needed six store methods.

## The proof's negative half is deliberately sharper than absence

`cook_write_siblings_persist_into_the_injected_store_and_not_a_second_root`, beside the existing `cook_progress_recorder_writes_to_the_injected_store_not_an_ambient_root`.

Two `HermeticTestContext` roots, `path_roots()` only, **no `with_isolated_home`, no `HomeGuard`, no `set_var`**.

**Both roots receive the same run identity**, so the second store is asserted to hold *its own untouched record* rather than merely to be missing one:

- `other.read_record(run_id)` **succeeds**, and its metadata has none of `cook_progress`, `cook_controller_failure`, `cook_observer_events`, `cook_resource_timeline`, `cook_supervision_events`, `cook_recovery_checkpoint`, `cook_force_with_lease_receipt`
- `other.read_controller_plan(plan_only_run_id)` is `Err`
- the notification-outcome file does **not** exist at `other.cook_index_path(cook_id).with_file_name(...)`

The positive side reads back through `seeded.read_record` rather than trusting the returned value, including the two-element supervision array ordered `budget_breached` then `stop_executed`, so the timeline/events split from #7015 is preserved through the rooted path.

## Warnings

`lib.rs`'s module-level `#[allow(dead_code, unused_imports, …)]` on `pub mod agent_task_lifecycle` reaches `pub(super)` items in `#[path]`-included descendants — confirmed with a standalone `rustc` repro under `#![deny(warnings)]` rather than assumed. That covers the now-callerless `store::write_cook_notification_outcome` shim and `persist_controller_plan_in_store`. The audit's `UnreferencedExport` will not newly fire: `lifecycle_ops.rs` is already baselined for it.

## Compatibility

Purely additive plus delegation. No existing signature or behavior changes. **No caller is migrated** — adding the surface is the scope.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Implementation, helper threading, test authoring, and standalone `rustc` verification. Review by hand; compilation deferred to CI.

Refs #7505
