### PR TITLE
refactor(agent-task): root Cook scratch capacity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -80,6 +80,14 @@ fn lifecycle_stores_isolate_identical_ids_and_lock_domains() {
         right.cook_index_path(cook_id)
     );
     assert_ne!(left.observation_db_path(), right.observation_db_path());
+    assert_ne!(
+        left.controller_scratch_root(),
+        right.controller_scratch_root()
+    );
+    assert!(left.controller_scratch_root().starts_with(left.data_root()));
+    assert!(right
+        .controller_scratch_root()
+        .starts_with(right.data_root()));
     assert_eq!(
         left.read_controller_plan(run_id).unwrap().plan_id,
         "left-plan"

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -55,9 +55,9 @@ use super::cook_promotion::{
 };
 use super::cook_recipe::CookRecipeStore;
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
-use super::execution::{
-    run_loaded_plan_with_derived_cook_baseline, run_loaded_plan_with_derived_cook_baseline_in_store,
-};
+#[cfg(test)]
+use super::execution::run_loaded_plan_with_derived_cook_baseline;
+use super::execution::run_loaded_plan_with_derived_cook_baseline_in_store;
 use super::AgentTaskRunResult;
 
 /// Lease window for a cook promotion operation claim. Long enough that a healthy
@@ -3605,6 +3605,19 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
     validate_cook_candidate_group(&options.initial_plan)
 }
 
+fn reserve_cook_materialization_capacity(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    workspace: &std::path::Path,
+) -> Result<homeboy_core::capacity::CapacityReservation> {
+    let demand = homeboy_core::capacity::demand_for_tree(workspace)?;
+    homeboy_core::capacity::reserve_projected_capacity(
+        &lifecycle_store.controller_scratch_root(),
+        "Cook controller scratch and workspace materialization",
+        demand,
+        homeboy_core::capacity::CapacityReserve::configured(),
+    )
+}
+
 pub fn run_cook<E>(
     options: AgentTaskCookServiceOptions,
     executor: E,
@@ -4251,15 +4264,7 @@ where
                 .and_then(|task| task.workspace.root.as_deref())
                 .map(std::path::Path::new)
         })
-        .map(|workspace| {
-            let demand = homeboy_core::capacity::demand_for_tree(workspace)?;
-            homeboy_core::capacity::reserve_projected_capacity(
-                &homeboy_core::paths::controller_scratch_store()?,
-                "Cook controller scratch and workspace materialization",
-                demand,
-                homeboy_core::capacity::CapacityReserve::configured(),
-            )
-        })
+        .map(|workspace| reserve_cook_materialization_capacity(lifecycle_store, workspace))
         .transpose()?;
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     if cook_workspace_lookup_pending(&options.initial_plan) {
@@ -4954,7 +4959,8 @@ where
                                 }
                             }
                         });
-                        let result = run_loaded_plan_with_derived_cook_baseline(
+                        let result = run_loaded_plan_with_derived_cook_baseline_in_store(
+                            lifecycle_store,
                             dispatch_plan,
                             Some(&run_id),
                             executor.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1769,6 +1769,26 @@ fn fresh_cook_review_form_has_bounded_budget_independent_of_code_execution() {
 }
 
 #[test]
+fn cook_materialization_capacity_targets_the_explicit_lifecycle_scratch_root() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left_store = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right_store = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let workspace = tempfile::tempdir().unwrap();
+    std::fs::write(workspace.path().join("source"), "fixture").unwrap();
+
+    let left = reserve_cook_materialization_capacity(&left_store, workspace.path()).unwrap();
+    let right = reserve_cook_materialization_capacity(&right_store, workspace.path()).unwrap();
+
+    assert_eq!(left.root(), left_store.data_root().canonicalize().unwrap());
+    assert_eq!(
+        right.root(),
+        right_store.data_root().canonicalize().unwrap()
+    );
+    assert_ne!(left.root(), right.root());
+}
+
+#[test]
 fn gate_feedback_child_budget_preserves_declared_retry_and_rotation_capacity() {
     let declared = crate::agent_task_scheduler::AgentTaskExecutionBudget::new(3, 1, 1);
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -88,6 +88,10 @@ impl AgentTaskLifecycleStore {
         self.roots.artifacts().to_path_buf()
     }
 
+    pub(crate) fn controller_scratch_root(&self) -> PathBuf {
+        self.data_root().join("controller-scratch")
+    }
+
     pub(crate) fn matches_current_environment(&self) -> Result<bool> {
         Ok(self.roots == paths::PathRoots::from_environment()?)
     }

--- a/crates/homeboy-core/src/capacity.rs
+++ b/crates/homeboy-core/src/capacity.rs
@@ -131,6 +131,14 @@ const RESERVATION_TTL: Duration = Duration::from_secs(30 * 60);
 pub struct CapacityReservation {
     ledger: PathBuf,
     id: String,
+    root: PathBuf,
+}
+
+impl CapacityReservation {
+    /// Existing filesystem ancestor used for the reservation's capacity probe.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
 }
 
 impl Drop for CapacityReservation {
@@ -270,6 +278,7 @@ fn reserve_projected_capacity_in(
     Ok(CapacityReservation {
         ledger: input.ledger.to_path_buf(),
         id,
+        root: input.root.to_path_buf(),
     })
 }
 


### PR DESCRIPTION
## Summary
- reserve projected Cook scratch capacity against the supplied lifecycle store data root
- route initial Cook execution through the existing store-aware scheduler, matching follow-up attempts
- preserve the machine-global capacity ledger so independent controllers still cannot overcommit one filesystem
- add fresh-root capacity and same-ID scratch isolation coverage

This is a prerequisite for rooted candidate-adoption remediation. The broad remediation `matches_current_environment` guard remains intact until the remaining Cook lifecycle and runtime-coordination boundaries are explicit.

Progresses #7505.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents --lib --no-run`
- `cargo test -p homeboy-agents cook_materialization_capacity_targets_the_explicit_lifecycle_scratch_root --lib`
- `cargo test -p homeboy-agents local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores --lib`
- `cargo test -p homeboy-agents lifecycle_stores_isolate_identical_ids_and_lock_domains --lib`
- `cargo test -p homeboy-core capacity::tests --lib` (16 passed)
- `cargo test --test agent_task_store_injection_test`
- `git diff --check origin/main...HEAD`

## AI Assistance
OpenAI GPT-5.6 Sol was used through OpenCode to trace the blocked adoption-remediation tail, distinguish machine-global coordination from lifecycle-rooted scratch ownership, implement the capacity and initial-execution changes, add behavioral isolation coverage, review the result, and run verification. Chris Huber reviewed and remains responsible for every line.