### PR TITLE
fix(agent-task): preserve durable Cook entry contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -42,7 +42,7 @@ use super::cook_pre_execution::{
     materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores,
     pre_execution_failure_details, pre_execution_failure_phase, pre_execution_failure_report,
     record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
-    with_pre_execution_phase,
+    with_pre_execution_phase, CookExecutionPreparation,
 };
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
@@ -55,9 +55,9 @@ use super::cook_promotion::{
 };
 use super::cook_recipe::CookRecipeStore;
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
-use super::execution::{
-    run_loaded_plan_with_derived_cook_baseline, run_loaded_plan_with_derived_cook_baseline_in_store,
-};
+#[cfg(test)]
+use super::execution::run_loaded_plan_with_derived_cook_baseline;
+use super::execution::run_loaded_plan_with_derived_cook_baseline_in_store;
 use super::AgentTaskRunResult;
 
 /// Lease window for a cook promotion operation claim. Long enough that a healthy
@@ -3605,6 +3605,19 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
     validate_cook_candidate_group(&options.initial_plan)
 }
 
+fn reserve_cook_materialization_capacity(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    workspace: &std::path::Path,
+) -> Result<homeboy_core::capacity::CapacityReservation> {
+    let demand = homeboy_core::capacity::demand_for_tree(workspace)?;
+    homeboy_core::capacity::reserve_projected_capacity(
+        &lifecycle_store.controller_scratch_root(),
+        "Cook controller scratch and workspace materialization",
+        demand,
+        homeboy_core::capacity::CapacityReserve::configured(),
+    )
+}
+
 pub fn run_cook<E>(
     options: AgentTaskCookServiceOptions,
     executor: E,
@@ -4150,14 +4163,12 @@ where
     }
     // The durable reconstruction boundary must exist before an external provider
     // can accept the first attempt.
-    let adopted_model = if moving_base_continuation || verification_pending_continuation {
-        lifecycle_store.read_record(&options.initial_run_id).ok()
-    } else {
-        agent_task_lifecycle::status(&options.initial_run_id).ok()
-    }
-    .map(|record| adopted_attempt_is_ready_for_cook_continuation(&record))
-    .transpose()?
-    .flatten();
+    let adopted_model = lifecycle_store
+        .read_record(&options.initial_run_id)
+        .ok()
+        .map(|record| adopted_attempt_is_ready_for_cook_continuation(&record))
+        .transpose()?
+        .flatten();
     let existing_recipe = store.recipe_exists(&options.cook_id);
     // A form-only continuation has already appended and persisted its exact
     // attempt. Re-persisting it as a fresh initial recipe would falsely look
@@ -4251,15 +4262,7 @@ where
                 .and_then(|task| task.workspace.root.as_deref())
                 .map(std::path::Path::new)
         })
-        .map(|workspace| {
-            let demand = homeboy_core::capacity::demand_for_tree(workspace)?;
-            homeboy_core::capacity::reserve_projected_capacity(
-                &homeboy_core::paths::controller_scratch_store()?,
-                "Cook controller scratch and workspace materialization",
-                demand,
-                homeboy_core::capacity::CapacityReserve::configured(),
-            )
-        })
+        .map(|workspace| reserve_cook_materialization_capacity(lifecycle_store, workspace))
         .transpose()?;
     agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
     if cook_workspace_lookup_pending(&options.initial_plan) {
@@ -4291,7 +4294,8 @@ where
                         Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
                         Err(mpsc::RecvTimeoutError::Timeout) => {}
                     }
-                    if agent_task_lifecycle::status(&lookup_run_id)
+                    if lookup_lifecycle_store
+                        .read_record(&lookup_run_id)
                         .ok()
                         .is_some_and(|record| {
                             record.state == agent_task_lifecycle::AgentTaskRunState::Cancelled
@@ -4316,13 +4320,14 @@ where
             });
             let result = homeboy_core::worktree_providers::with_worktree_provider_command_control(
                 lookup_control,
-                || materialize_pending_cook_workspace(&mut options),
+                || materialize_pending_cook_workspace(lifecycle_store, &mut options),
             );
             let _ = lookup_stop.send(());
             result
         });
         if let Err(error) = lookup_result {
-            if agent_task_lifecycle::status(&options.initial_run_id)
+            if lifecycle_store
+                .read_record(&options.initial_run_id)
                 .ok()
                 .is_some_and(|record| {
                     record.state == agent_task_lifecycle::AgentTaskRunState::Cancelled
@@ -4340,17 +4345,18 @@ where
                 }));
             }
             let error = with_pre_execution_phase(error, "worktree_provider_lookup");
-            record_pre_execution_failure(
-                &options.initial_plan,
+            CookExecutionPreparation::new(store, lifecycle_store).record_pre_execution_failure(
+                &options.cook_id,
                 &options.initial_run_id,
-                &error,
                 "worktree_provider_lookup",
+                &error,
             )?;
             return Ok(pre_execution_failure_report(
                 options.cook_id.clone(),
                 Vec::new(),
                 pre_execution_failure_details(
-                    agent_task_lifecycle::exact_record(&options.initial_run_id)
+                    lifecycle_store
+                        .read_record(&options.initial_run_id)
                         .ok()
                         .as_ref(),
                     &error,
@@ -4954,7 +4960,8 @@ where
                                 }
                             }
                         });
-                        let result = run_loaded_plan_with_derived_cook_baseline(
+                        let result = run_loaded_plan_with_derived_cook_baseline_in_store(
+                            lifecycle_store,
                             dispatch_plan,
                             Some(&run_id),
                             executor.clone(),
@@ -6392,7 +6399,10 @@ fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
 /// A pending lookup carries no provider path. Resolve the declared exact handle
 /// only after Cook's recipe and first run record exist, then persist that path
 /// before any provider can receive work.
-fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
+fn materialize_pending_cook_workspace(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &mut AgentTaskCookServiceOptions,
+) -> Result<()> {
     let provider_id = options
         .initial_plan
         .metadata
@@ -6495,7 +6505,11 @@ fn materialize_pending_cook_workspace(options: &mut AgentTaskCookServiceOptions)
     options.initial_plan.metadata["cook_provision"]["action"] =
         Value::String("existing".to_string());
     options.source_worktree_path = Some(target);
-    agent_task_lifecycle::persist_controller_plan(&options.initial_run_id, &options.initial_plan)
+    agent_task_lifecycle::persist_controller_plan_in_store(
+        lifecycle_store,
+        &options.initial_run_id,
+        &options.initial_plan,
+    )
 }
 
 /// A deferred provider lookup can prove absence only after Cook owns a durable

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4405,6 +4405,10 @@ fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_t
         assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
         assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("durable failed lookup");
+        assert_eq!(
+            record.state,
+            agent_task_lifecycle::AgentTaskRunState::Failed
+        );
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
         assert_eq!(
             record.metadata["pre_execution_failure"]["phase"],
@@ -4485,6 +4489,212 @@ fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_t
         assert_eq!(
             resumed_plan.tasks[0].workspace.root.as_deref(),
             Some(workspace.to_str().expect("utf8 workspace"))
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn deferred_provider_ensure_materializes_a_durable_cook_workspace_after_its_postcondition() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let root = tempfile::tempdir().expect("workspace root");
+        let source = root.path().join("source");
+        let workspace = root.path().join("workspace");
+        for args in [
+            vec![
+                "init",
+                "--quiet",
+                "-b",
+                "main",
+                source.to_str().expect("source path"),
+            ],
+            vec![
+                "-C",
+                source.to_str().expect("source path"),
+                "config",
+                "user.email",
+                "test@example.com",
+            ],
+            vec![
+                "-C",
+                source.to_str().expect("source path"),
+                "config",
+                "user.name",
+                "Homeboy Test",
+            ],
+            vec![
+                "-C",
+                source.to_str().expect("source path"),
+                "commit",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                "base",
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .status()
+                .expect("git runs")
+                .success());
+        }
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let created = provider_dir.path().join("created");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}'; fi\n  ;;\nensure)\n  git -C '{}' worktree add --quiet -b durable-ensure '{}' HEAD && touch '{}'\n  ;;\nesac\n",
+                created.display(),
+                workspace.display(),
+                source.display(),
+                workspace.display(),
+                created.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    resolve: Some(vec![provider.display().to_string(), "resolve".to_string()]),
+                    ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let cook_id = "durable-ensure";
+        let run_id = "durable-ensure-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+            "provision_intent": {
+                "repo": "fixture",
+                "base": "main",
+                "head": "durable-ensure",
+                "task_url": "https://example.test/issues/12601",
+            },
+        });
+
+        let result =
+            run_cook(options, UnusedExecutor).expect("Cook materializes the ensured workspace");
+
+        assert_eq!(result.exit_code, 0);
+        assert!(created.exists(), "ensure ran after durable Cook admission");
+        let record = agent_task_lifecycle::status(run_id).expect("durable Cook attempt");
+        assert!(record.metadata["pre_execution_failure"].is_null());
+        let plan = agent_task_lifecycle::load_plan(run_id).expect("materialized durable plan");
+        assert_eq!(plan.metadata["cook_provision"]["action"], "existing");
+        assert_eq!(
+            plan.tasks[0].workspace.root.as_deref(),
+            Some(workspace.to_str().expect("workspace path"))
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn deferred_ensure_only_provider_fails_after_durable_cook_admission() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let ensured = provider_dir.path().join("ensured");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!("#!/bin/sh\ntouch '{}'\n", ensured.display()),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    ensure: Some(vec![provider.display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let cook_id = "ensure-only";
+        let run_id = "ensure-only-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+            "provision_intent": {
+                "repo": "fixture",
+                "base": "main",
+                "head": "ensure-only",
+                "task_url": "https://example.test/issues/12601",
+            },
+        });
+
+        let result =
+            run_cook(options, UnusedExecutor).expect("Cook reports the postcondition failure");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "pre_execution_failure");
+        assert!(ensured.exists(), "ensure ran after durable Cook admission");
+        let record = agent_task_lifecycle::exact_record(run_id)
+            .expect("ensure-only postcondition failure has an addressable run");
+        assert_eq!(
+            record.state,
+            agent_task_lifecycle::AgentTaskRunState::Failed
+        );
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "worktree_provider_lookup"
         );
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4495,10 +4495,18 @@ fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_t
 
 #[cfg(unix)]
 #[test]
-fn deferred_provider_ensure_materializes_a_durable_cook_workspace_after_its_postcondition() {
+fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postcondition() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
+        let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();
+        let recipe_store = CookRecipeStore::new(recipe_context.path_roots());
+        let recipe_root_lifecycle_store = AgentTaskLifecycleStore::new(recipe_context.path_roots());
+        let lifecycle_store = AgentTaskLifecycleStore::new(lifecycle_context.path_roots());
+        let ambient_lifecycle_store =
+            AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
+        assert_ne!(recipe_context.data_dir(), lifecycle_context.data_dir());
         let root = tempfile::tempdir().expect("workspace root");
         let source = root.path().join("source");
         let workspace = root.path().join("workspace");
@@ -4608,19 +4616,38 @@ fn deferred_provider_ensure_materializes_a_durable_cook_workspace_after_its_post
             },
         });
 
-        let result =
-            run_cook(options, UnusedExecutor).expect("Cook materializes the ensured workspace");
+        recipe_store
+            .persist_initial_recipe(&options)
+            .expect("persist recipe in the injected recipe store");
+        materialize_initial_cook_attempt_with_stores(&recipe_store, &lifecycle_store, &options)
+            .expect("materialize run in the injected lifecycle store");
+        materialize_pending_cook_workspace(&lifecycle_store, &mut options)
+            .expect("materialize the ensured workspace in the injected lifecycle store");
 
-        assert_eq!(result.exit_code, 0);
         assert!(created.exists(), "ensure ran after durable Cook admission");
-        let record = agent_task_lifecycle::status(run_id).expect("durable Cook attempt");
-        assert!(record.metadata["pre_execution_failure"].is_null());
-        let plan = agent_task_lifecycle::load_plan(run_id).expect("materialized durable plan");
+        assert!(recipe_store.recipe_exists(cook_id));
+        let record = lifecycle_store
+            .read_record(run_id)
+            .expect("injected lifecycle store has the exact materialized run");
+        assert_eq!(record.run_id, run_id);
+        let plan = lifecycle_store
+            .read_controller_plan(run_id)
+            .expect("injected lifecycle store has the materialized plan");
         assert_eq!(plan.metadata["cook_provision"]["action"], "existing");
+        assert_eq!(
+            options.source_worktree_path.as_deref(),
+            Some(workspace.as_path())
+        );
         assert_eq!(
             plan.tasks[0].workspace.root.as_deref(),
             Some(workspace.to_str().expect("workspace path"))
         );
+        assert!(!recipe_root_lifecycle_store
+            .record_exists(run_id)
+            .expect("recipe root has no lifecycle state"));
+        assert!(!ambient_lifecycle_store
+            .record_exists(run_id)
+            .expect("ambient lifecycle state remains untouched"));
     });
 }
 
@@ -4696,6 +4723,103 @@ fn deferred_ensure_only_provider_fails_after_durable_cook_admission() {
             record.metadata["pre_execution_failure"]["phase"],
             "worktree_provider_lookup"
         );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn deferred_ensure_only_failure_uses_injected_recipe_and_lifecycle_stores() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();
+        let recipe_store = CookRecipeStore::new(recipe_context.path_roots());
+        let recipe_root_lifecycle_store = AgentTaskLifecycleStore::new(recipe_context.path_roots());
+        let lifecycle_store = AgentTaskLifecycleStore::new(lifecycle_context.path_roots());
+        let ambient_lifecycle_store =
+            AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
+        assert_ne!(recipe_context.data_dir(), lifecycle_context.data_dir());
+
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let ensured = provider_dir.path().join("ensured");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!("#!/bin/sh\ntouch '{}'\n", ensured.display()),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    ensure: Some(vec![provider.display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let cook_id = "split-ensure-only";
+        let run_id = "split-ensure-only-run";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+            "provision_intent": {
+                "repo": "fixture",
+                "base": "main",
+                "head": "split-ensure-only",
+                "task_url": "https://example.test/issues/12601",
+            },
+        });
+
+        let result = run_cook_with_boundaries_observed_inner_with_stores(
+            &recipe_store,
+            &lifecycle_store,
+            options,
+            UnusedExecutor,
+            DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+            None,
+            false,
+        )
+        .expect("Cook reports the injected-store postcondition failure");
+
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "pre_execution_failure");
+        assert!(ensured.exists(), "ensure ran after durable Cook admission");
+        assert!(recipe_store.recipe_exists(cook_id));
+        let record = lifecycle_store
+            .read_record(run_id)
+            .expect("injected lifecycle store has the exact failed run");
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "worktree_provider_lookup"
+        );
+        assert!(!recipe_root_lifecycle_store
+            .record_exists(run_id)
+            .expect("recipe root has no lifecycle state"));
+        assert!(!ambient_lifecycle_store
+            .record_exists(run_id)
+            .expect("ambient lifecycle state remains untouched"));
     });
 }
 
@@ -5161,7 +5285,9 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
             "worktree_provider_id": "z-original",
         });
 
-        materialize_pending_cook_workspace(&mut options)
+        let lifecycle_store =
+            AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
+        materialize_pending_cook_workspace(&lifecycle_store, &mut options)
             .expect("materialize original provider workspace");
 
         assert_eq!(

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1688,8 +1688,19 @@ fn preflight_hot_command(
     output_file: Option<&str>,
     command_identity: &output::CommandIdentity,
 ) -> Option<i32> {
+    preflight_hot_command_with(cli, output_file, command_identity, || {
+        crate::commands::resources::run_preflight()
+    })
+}
+
+fn preflight_hot_command_with(
+    cli: &Cli,
+    output_file: Option<&str>,
+    command_identity: &output::CommandIdentity,
+    preflight: impl FnOnce() -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput>,
+) -> Option<i32> {
     if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
-        if let Ok((resources, _)) = crate::commands::resources::run_preflight() {
+        if let Ok((resources, _)) = preflight() {
             let mut lab_readiness = if hot_command.lab_offload_supported {
                 crate::runner::lab_runner_readiness().ok()
             } else {
@@ -2352,6 +2363,43 @@ mod tests {
             lab_offload_unsupported_reason: None,
             allows_warm_runner_coordination: true,
             offload_only_when_hot: false,
+        }
+    }
+
+    #[test]
+    fn cook_preview_never_consults_resource_preflight() {
+        for placement in [
+            vec!["--placement", "lab"],
+            vec!["--placement", "auto"],
+            vec!["--runner", "homeboy-lab"],
+        ] {
+            let mut args = vec!["homeboy"];
+            args.extend(placement.iter().copied());
+            args.extend([
+                "agent-task",
+                "cook",
+                "--preview",
+                "--prompt",
+                "inspect the task",
+                "--to-worktree",
+                "fixture@preview",
+                "--verify",
+                "true",
+            ]);
+            let cli = Cli::parse_from(args);
+
+            assert_eq!(
+                preflight_hot_command_with(
+                    &cli,
+                    None,
+                    &output::CommandIdentity::with_operation("agent-task", "cook"),
+                    || -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput> {
+                        panic!("Cook preview must not run resource preflight")
+                    },
+                ),
+                None,
+                "{placement:?}"
+            );
         }
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1683,7 +1683,8 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             && provider.apply_enabled
             && (provider.commands.resolve_identity.is_some()
                 || provider.commands.resolve.is_some()
-                || provider.commands.list.is_some())
+                || provider.commands.list.is_some()
+                || provider.commands.ensure.is_some())
     }) {
         return Ok(serde_json::json!({
             "action": "lookup_pending",

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -1704,6 +1704,69 @@ fn cook_defers_provider_lookup_failures_until_durable_admission() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn cook_defers_an_issue_destination_with_an_ensure_only_provider() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("provider tempdir");
+        let ensured = temp.path().join("ensured");
+        let provider = temp.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!("#!/bin/sh\ntouch '{}'\n", ensured.display()),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    ensure: Some(vec![provider.display().to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "create the issue worktree".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--task-url".to_string(),
+            "https://github.com/Extra-Chill/homeboy/issues/12601".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("derive issue destination without provisioning it");
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("ensure-only provider is deferred until durable Cook admission");
+
+        assert_eq!(provision["action"], "lookup_pending");
+        assert!(
+            !ensured.exists(),
+            "provider ensure must wait for durable Cook admission"
+        );
+    });
+}
+
 #[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {
     let repo = tempfile::tempdir().expect("repo dir");

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -47,6 +47,13 @@ pub fn route_after_parse_with_provenance(
     // cannot honor (#10917).
     reject_contradictory_cook_arguments(cli)?;
 
+    // Preview is a controller-local read-only compilation. It must bypass every
+    // placement route before runner selection or split Cook materialization can
+    // create durable state or dispatch a provider.
+    if resource_policy::is_cook_preview(&cli.command) {
+        return Ok(None);
+    }
+
     // A managed runner executes the controller-selected command once. Its argv
     // retains the controller's explicit placement for provenance, but must not
     // recursively route back through a runner-side controller daemon.

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -73,10 +73,10 @@ const LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV: &str = "HOMEBOY_LOCAL_COOK_LAUNCH_TOKEN_
 /// off again; ambient environment variables cannot bypass supervision.
 fn is_unsupervised_local_cook(cli: &Cli) -> bool {
     matches!(
-        cli.command,
+        &cli.command,
         Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
-            command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
-        })
+            command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+        }) if !cook.preview
     ) && !consume_local_cook_launch_token()
 }
 
@@ -991,13 +991,31 @@ mod tests {
         );
     }
 
-    /// Every unsupervised local Cook is intercepted; non-local and non-Cook
-    /// invocations continue through normal routing untouched.
+    /// Executing local Cooks are intercepted, while read-only previews and
+    /// non-local invocations continue through normal routing untouched.
     /// These cases must not spawn anything.
     #[test]
     fn only_a_local_cook_is_intercepted() {
         let (local, _) = cook_cli(&[]);
         assert!(is_unsupervised_local_cook(&local));
+
+        let preview = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "repo@branch",
+            "--verify",
+            "true",
+            "--preview",
+        ])
+        .expect("parse preview cook invocation");
+        assert!(
+            !is_unsupervised_local_cook(&preview),
+            "preview must bypass detached Cook interception"
+        );
 
         let (auto, normalized) = cook_cli(&["--placement", "auto"]);
         assert!(is_unsupervised_local_cook(&auto));

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -227,6 +227,49 @@ fn explicit_local_promotion_defers_target_resolution_to_promotion() {
 
     assert_eq!(route_after_parse(&cli, &normalized, None).unwrap(), None);
 }
+
+#[test]
+fn cook_preview_bypasses_every_placement_route_without_durable_state() {
+    crate::test_support::with_isolated_home(|home| {
+        for placement in [
+            vec!["--placement", "local"],
+            vec!["--placement", "auto"],
+            vec!["--placement", "lab"],
+            vec!["--runner", "homeboy-lab"],
+        ] {
+            let mut args = vec!["homeboy"];
+            args.extend(placement.iter().copied());
+            args.extend([
+                "agent-task",
+                "cook",
+                "--preview",
+                "--prompt",
+                "inspect the task",
+                "--to-worktree",
+                "fixture@preview",
+                "--verify",
+                "true",
+            ]);
+            let normalized = args
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
+            let cli = Cli::parse_from(&normalized);
+            let before = std::fs::read_dir(home).expect("read isolated home").count();
+
+            assert_eq!(
+                route_after_parse(&cli, &normalized, None).expect("preview bypasses placement"),
+                None,
+                "{placement:?}"
+            );
+            assert_eq!(
+                std::fs::read_dir(home).expect("read isolated home").count(),
+                before,
+                "{placement:?} preview created durable routing state"
+            );
+        }
+    });
+}
 use clap::Parser;
 use std::fs;
 use std::path::Path;

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -215,7 +215,8 @@ fn runner_selection_context(
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
-    if is_plan_only_command(command)
+    if is_cook_preview(command)
+        || is_plan_only_command(command)
         || is_controller_owned_fanout_coordination(command)
         || is_bounded_agent_task_metadata_read(command)
         || is_local_registry_management(command)
@@ -294,6 +295,15 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
             Some(HotCommand::local_only(contract.hot_label, Some(reason)))
         }
     }
+}
+
+pub(crate) fn is_cook_preview(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Cook(cook),
+        }) if cook.preview
+    )
 }
 
 pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<ResourcePolicyWarning> {


### PR DESCRIPTION
Closes #12601

## Summary
- classify Cook previews as non-hot and bypass every placement/detach route before runner preflight or durable mutation
- defer every ensure-capable missing destination until after the Cook recipe and first lifecycle attempt are persisted
- preserve mandatory provider postcondition checks while reporting ensure-only failures on an addressable structured terminal Cook
- cover preview placements, ensure-only terminal failure, and resolver-backed ensure success

## Testing
- `cargo test -p homeboy-cli cook_preview_never_consults_resource_preflight`
- `cargo test -p homeboy-cli cook_preview_bypasses_every_placement_route_without_durable_state`
- `cargo test -p homeboy-cli cook_defers_an_issue_destination_with_an_ensure_only_provider`
- `cargo test -p homeboy-agents deferred_ensure_only_provider_fails_after_durable_cook_admission`
- `cargo test -p homeboy-agents deferred_provider_ensure_materializes_a_durable_cook_workspace_after_its_postcondition`
- `cargo fmt --all --check`
- `git diff --check`

Broader nextest runs were attempted but stopped on unrelated existing timeout-sensitive tests; all affected-path tests above pass.

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode was used to investigate the lifecycle ordering, implement the fix and regression coverage, and review the resulting patch. Chris Huber reviewed and remains responsible for every line.