### PR TITLE
Give the run-claim family explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -558,15 +558,32 @@ pub fn fail_detached_cook_handoff_parent(
     cook_id: &str,
     reason: &str,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    fail_detached_cook_handoff_parent_in_store(&lifecycle_store, cook_id, reason)
+}
+
+/// Terminalize a still-pending handoff parent inside an explicitly rooted
+/// store.
+///
+/// The two protections that make a parent authoritative — a published Cook
+/// index, and a materializing attempt whose record already exists — are read
+/// from the same store the mutation lands in. Reading them ambiently would let
+/// another home's index or attempt record veto, or fail to veto, a terminal
+/// transition in this one.
+pub(crate) fn fail_detached_cook_handoff_parent_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    reason: &str,
+) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
-    let record = store::mutate_record(&cook_id, |record| {
+    let record = lifecycle_store.mutate_record(&cook_id, |record| {
         if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id
             || record.state.is_terminal()
             || record.metadata["detached_cook_handoff"]["state"] != "pending"
-            || store::read_cook_index(&cook_id).is_ok()
+            || lifecycle_store.read_cook_index(&cook_id).is_ok()
             || record.metadata["detached_cook_handoff"]["materializing_attempt_run_id"]
                 .as_str()
-                .is_some_and(|run_id| store::read_record(run_id).is_ok())
+                .is_some_and(|run_id| lifecycle_store.read_record(run_id).is_ok())
         {
             return false;
         }
@@ -588,7 +605,7 @@ pub fn fail_detached_cook_handoff_parent(
     })?;
     // A protected parent is a successful no-op: it is the authoritative result
     // of materialization or a prior terminal transition, not a missing parent.
-    Ok(record.unwrap_or(store::read_record(&cook_id)?))
+    Ok(record.unwrap_or(lifecycle_store.read_record(&cook_id)?))
 }
 
 fn complete_detached_cook_handoff_parent_in_store(
@@ -661,11 +678,26 @@ pub fn has_expired_detached_cook_admission(
 }
 
 pub fn expire_detached_cook_admission(cook_id: &str) -> Result<bool> {
-    let record = store::read_record(cook_id)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    expire_detached_cook_admission_in_store(&lifecycle_store, cook_id)
+}
+
+/// Expire a detached Cook's admission lease inside an explicitly rooted store.
+///
+/// The liveness read and the terminal handoff write share one store, so an
+/// expiry decided from one queue's evidence can never terminalize a parent
+/// admission in another. Liveness itself is computed from the record and the
+/// process table, both of which are already root-free.
+pub fn expire_detached_cook_admission_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<bool> {
+    let record = lifecycle_store.read_record(cook_id)?;
     if !has_expired_detached_cook_admission(&record, chrono::Utc::now()) {
         return Ok(false);
     }
-    let terminal = fail_detached_cook_handoff_parent(
+    let terminal = fail_detached_cook_handoff_parent_in_store(
+        lifecycle_store,
         cook_id,
         "detached Cook admission lease expired before child or supervisor ownership attached",
     )?;
@@ -1623,7 +1655,30 @@ pub fn claim_cook_terminal_notification(cook_id: &str, delivered_by: &str) -> Re
     if cook_id.trim().is_empty() {
         return Ok(false);
     }
-    store::claim_cook_notification(
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    claim_cook_terminal_notification_in_store(&lifecycle_store, cook_id, delivered_by)
+}
+
+/// Claim a Cook's single terminal notification within an explicitly rooted
+/// store. The `O_EXCL` marker is created beside that store's own Cook index, so
+/// two stores are two independent claims and neither consumes the other's
+/// exactly-once eligibility.
+///
+/// The empty-id guard is repeated here rather than delegated to the ambient
+/// entry point. A blank Cook id is not an identity: `sanitize_run_id` turns
+/// `""` into a freshly minted `agent-task-<uuid>` and `"   "` into `___`,
+/// either of which would win a durable claim keyed to a Cook nobody can name.
+/// The ambient shim keeps its own copy so a broken environment still answers
+/// `Ok(false)` without constructing a store, exactly as it does today.
+pub fn claim_cook_terminal_notification_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    delivered_by: &str,
+) -> Result<bool> {
+    if cook_id.trim().is_empty() {
+        return Ok(false);
+    }
+    lifecycle_store.claim_cook_notification(
         cook_id,
         &json!({
             "at": now_timestamp(),
@@ -1635,7 +1690,23 @@ pub fn claim_cook_terminal_notification(cook_id: &str, delivered_by: &str) -> Re
 /// Persist a confirmed terminal delivery, which is the point at which its
 /// exactly-once eligibility is consumed.
 pub fn confirm_cook_terminal_notification(cook_id: &str, delivered_by: &str) -> Result<()> {
-    store::confirm_cook_notification(
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    confirm_cook_terminal_notification_in_store(&lifecycle_store, cook_id, delivered_by)
+}
+
+/// Persist a confirmed terminal delivery beside the injected store's own Cook
+/// index. Like the claim it commits, this is a bare filesystem write with no
+/// record read in front of it, so an ambient reach here would consume the wrong
+/// root's eligibility without ever failing.
+///
+/// No empty-id guard is added: the ambient function has never had one, and a
+/// sibling that refused an id its pair accepts would not be the same operation.
+pub fn confirm_cook_terminal_notification_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    delivered_by: &str,
+) -> Result<()> {
+    lifecycle_store.confirm_cook_notification(
         cook_id,
         &json!({
             "at": now_timestamp(),
@@ -1696,6 +1767,17 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
     store::read_controller_plan(&run_id)
 }
 
+/// Load the controller-owned plan from an explicitly rooted store. Both halves
+/// follow the injected root: the Cook alias is resolved against that store's
+/// own index, and the plan is read from that store's own run directory.
+pub(crate) fn load_controller_plan_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskPlan> {
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    lifecycle_store.read_controller_plan(&run_id)
+}
+
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
@@ -1705,8 +1787,24 @@ pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
 
 /// Validate a queued lifecycle's pinned controller without scheduling provider work.
 pub fn validate_controller_runtime(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    migrate_record_controller_runtime(&mut record)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    validate_controller_runtime_in_store(&lifecycle_store, run_id)
+}
+
+/// Validate a queued lifecycle's pinned controller against an explicitly rooted
+/// store.
+///
+/// The record read and the legacy-pin migration write both follow
+/// `lifecycle_store`. The immutable controller-runtime pin store that
+/// `controller_runtime::validate` consults is deliberately left process-global:
+/// it is a content-addressed executable cache shared across homes, not durable
+/// lifecycle state, so it is not one of this store's roots.
+pub(crate) fn validate_controller_runtime_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
+    migrate_record_controller_runtime_in_store(lifecycle_store, &mut record)?;
     homeboy_core::controller_runtime::validate(
         record
             .metadata
@@ -2757,12 +2855,32 @@ pub fn claim_next_eligible_queued_run() -> Result<AgentTaskQueuedRunClaim> {
     claim_next_eligible_queued_run_with_preflight(|_, _| Ok(()))
 }
 
+/// Claim the oldest executable queued record from an explicitly rooted store.
+pub fn claim_next_eligible_queued_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<AgentTaskQueuedRunClaim> {
+    claim_next_eligible_queued_run_with_preflight_in_store(lifecycle_store, |_, _| Ok(()))
+}
+
 /// Claim the oldest executable queued record after caller-supplied admission
 /// checks have validated its durable plan, but before the atomic Running claim.
 pub fn claim_next_eligible_queued_run_with_preflight(
     preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
 ) -> Result<AgentTaskQueuedRunClaim> {
     claim_next_eligible_queued_run_with_preflight_and_filter(|_| true, preflight)
+}
+
+/// Preflighted admission against an explicitly rooted store. The preflight
+/// closure is the caller's own, so it is passed through untouched.
+pub fn claim_next_eligible_queued_run_with_preflight_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
+) -> Result<AgentTaskQueuedRunClaim> {
+    claim_next_eligible_queued_run_with_preflight_and_filter_in_store(
+        lifecycle_store,
+        |_| true,
+        preflight,
+    )
 }
 
 /// Claim the oldest eligible queued record that matches a caller-owned scope.
@@ -2779,6 +2897,21 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter(
     )
 }
 
+/// Scoped, preflighted admission against an explicitly rooted store, using the
+/// same default admission budget as the ambient pair.
+pub fn claim_next_eligible_queued_run_with_preflight_and_filter_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    include: impl Fn(&AgentTaskRunRecord) -> bool,
+    preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
+) -> Result<AgentTaskQueuedRunClaim> {
+    claim_next_eligible_queued_run_with_preflight_and_filter_and_limit_in_store(
+        lifecycle_store,
+        include,
+        MAX_QUEUE_ADMISSION_RECORDS,
+        preflight,
+    )
+}
+
 /// Scoped queued admission with an explicit remaining budget shared with other
 /// admission phases in the same dispatch invocation.
 pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
@@ -2786,7 +2919,39 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
     limit: usize,
     preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
 ) -> Result<AgentTaskQueuedRunClaim> {
-    let mut queued: Vec<AgentTaskRunRecord> = store::read_records()?
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    claim_next_eligible_queued_run_with_preflight_and_filter_and_limit_in_store(
+        &lifecycle_store,
+        include,
+        limit,
+        preflight,
+    )
+}
+
+/// The whole claim, taken through one explicitly injected store.
+///
+/// This is the single body of the claim chain; every other `claim_next_*`
+/// entry point narrows its arguments and delegates here. Each step is rooted in
+/// `lifecycle_store` rather than the process environment:
+///
+/// * the queue scan reads that store's own observation database, so a claim
+///   never inspects one queue and then wins a run in another,
+/// * the controller-runtime and durable-plan preflight read that store's own
+///   record and run directory,
+/// * quarantine of invalid provenance mutates that store's own record, and
+/// * the atomic Running transition takes that store's own config lock through
+///   [`mark_running_in_store`].
+///
+/// The `include` and `preflight` closures belong to the caller and are passed
+/// through unchanged; neither is given a store it did not already have.
+pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    include: impl Fn(&AgentTaskRunRecord) -> bool,
+    limit: usize,
+    preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
+) -> Result<AgentTaskQueuedRunClaim> {
+    let mut queued: Vec<AgentTaskRunRecord> = lifecycle_store
+        .read_records()?
         .into_iter()
         .filter(|record| {
             record.state == AgentTaskRunState::Queued
@@ -2813,22 +2978,22 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
             });
         }
         inspected += 1;
-        let plan = match validate_controller_runtime(&record.run_id)
-            .and_then(|_| load_controller_plan(&record.run_id))
+        let plan = match validate_controller_runtime_in_store(lifecycle_store, &record.run_id)
+            .and_then(|_| load_controller_plan_in_store(lifecycle_store, &record.run_id))
         {
             Ok(plan) => plan,
             Err(error) => {
-                quarantine_queued_run(&record, None, &error)?;
+                quarantine_queued_run_in_store(lifecycle_store, &record, None, &error)?;
                 skipped.push(queue_skip(&record, None, &error));
                 continue;
             }
         };
         if let Err(error) = preflight(&record, &plan) {
-            quarantine_queued_run(&record, Some(&plan), &error)?;
+            quarantine_queued_run_in_store(lifecycle_store, &record, Some(&plan), &error)?;
             skipped.push(queue_skip(&record, Some(&plan), &error));
             continue;
         }
-        match mark_running(&record.run_id) {
+        match mark_running_in_store(lifecycle_store, &record.run_id) {
             Ok(claimed) => {
                 return Ok(AgentTaskQueuedRunClaim {
                     record: Some(claimed),
@@ -2838,7 +3003,7 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
                 })
             }
             Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
-                quarantine_queued_run(&record, Some(&plan), &error)?;
+                quarantine_queued_run_in_store(lifecycle_store, &record, Some(&plan), &error)?;
                 skipped.push(queue_skip(&record, Some(&plan), &error));
             }
             Err(error) => return Err(error),
@@ -2855,6 +3020,14 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
 
 pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
     Ok(claim_next_eligible_queued_run()?.record)
+}
+
+/// Claim the oldest executable queued record from an explicitly rooted store,
+/// discarding the skip diagnostics exactly as the ambient pair does.
+pub fn claim_next_queued_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<Option<AgentTaskRunRecord>> {
+    Ok(claim_next_eligible_queued_run_in_store(lifecycle_store)?.record)
 }
 
 fn queue_skip(
@@ -2900,8 +3073,21 @@ fn quarantine_queued_run(
     plan: Option<&AgentTaskPlan>,
     error: &Error,
 ) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    quarantine_queued_run_in_store(&lifecycle_store, record, plan, error)
+}
+
+/// Retain the redacted admission diagnostic on the record inside the store the
+/// claim is scanning. A quarantine written into another root would leave the
+/// scanned queue permanently re-inspecting the same bad record.
+fn quarantine_queued_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &AgentTaskRunRecord,
+    plan: Option<&AgentTaskPlan>,
+    error: &Error,
+) -> Result<()> {
     let diagnostic = redacted_queue_diagnostic(plan, error);
-    let _ = store::mutate_record(&record.run_id, |quarantined| {
+    let _ = lifecycle_store.mutate_record(&record.run_id, |quarantined| {
         if quarantined.state != AgentTaskRunState::Queued
             || quarantined.metadata.get("queue_quarantine").is_some()
         {
@@ -4991,6 +5177,24 @@ pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
 pub(crate) fn resolve_run_id(run_id: &str) -> Result<String> {
     let run_id = sanitize_run_id(run_id);
     match store::read_cook_index(&run_id) {
+        Ok(index) => Ok(index.latest_run_id),
+        Err(_) => Ok(run_id),
+    }
+}
+
+/// The store-rooted counterpart of [`resolve_run_id`], consulting the injected
+/// store's own Cook index.
+///
+/// This is deliberately a sibling rather than a delegation target for the
+/// ambient function. [`resolve_run_id`] swallows every index read failure and
+/// therefore cannot fail; routing it through a store constructor would let an
+/// unresolvable environment turn a total function into a fallible one.
+pub(crate) fn resolve_run_id_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<String> {
+    let run_id = sanitize_run_id(run_id);
+    match lifecycle_store.read_cook_index(&run_id) {
         Ok(index) => Ok(index.latest_run_id),
         Err(_) => Ok(run_id),
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -397,6 +397,286 @@ fn cook_write_siblings_persist_into_the_injected_store_and_not_a_second_root() {
 }
 
 #[test]
+fn claim_family_siblings_coordinate_only_inside_the_injected_store() {
+    // The claim family decides which worker wins a run, so its negative half
+    // has to be sharper than absence: both roots are seeded with the *same*
+    // queue, the same detached-admission parent, and the same Cook
+    // notification identity, and every coordinating call below is made through
+    // a sibling handed `seeded`. The second root is then asserted to be
+    // *untouched* — still queued, still pending, still able to win its own
+    // notification claim and expire its own lease. A claim that leaked into an
+    // ambient root would satisfy every positive assertion here and still fail
+    // that (#7505).
+    //
+    // No environment is mutated: both roots come from
+    // `HermeticTestContext::path_roots()`.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let other_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), other_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let other =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(other_context.path_roots());
+
+    let queued_run_id = "rooted-claim-queued";
+    let handoff_cook_id = "rooted-claim-detached-parent";
+    let notification_cook_id = "rooted-claim-notification";
+    let plan = test_plan();
+
+    for lifecycle_store in [&seeded, &other] {
+        for run_id in [queued_run_id, handoff_cook_id] {
+            lifecycle_store
+                .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+                .expect("submit the same queue into both roots");
+            // Remove the admission-supplied runtime pin rather than leaving a
+            // malformed one. An invalid *present* pin sends
+            // `validate_controller_runtime_in_store` through
+            // `migrate_legacy_pin_and_persist`, which creates and locks the
+            // process-global controller-runtime store — the one root that is
+            // deliberately not a lifecycle root, and the one this test must not
+            // touch. With no pin at all the preflight fails on the record
+            // itself, entirely inside the injected store.
+            lifecycle_store
+                .mutate_record(run_id, |record| {
+                    record
+                        .ensure_metadata_object()
+                        .remove(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+                        .is_some()
+                })
+                .expect("strip the controller runtime pin");
+        }
+        lifecycle_store
+            .mutate_record(handoff_cook_id, |record| {
+                record.ensure_metadata_object().insert(
+                    "detached_cook_handoff".to_string(),
+                    json!({
+                        "cook_id": handoff_cook_id,
+                        "state": "pending",
+                        "admission_deadline_at": "2020-01-01T00:00:00Z",
+                    }),
+                );
+                true
+            })
+            .expect("seed an expired detached Cook admission into both roots");
+    }
+
+    let notification_claim_path =
+        |lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore| {
+            lifecycle_store
+                .cook_index_path(notification_cook_id)
+                .with_file_name("notification-claim.json")
+        };
+    let notification_path =
+        |lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore| {
+            lifecycle_store
+                .cook_index_path(notification_cook_id)
+                .with_file_name("notification.json")
+        };
+
+    // Expire the detached parent first so it is terminal, and therefore no
+    // longer queued, before the queue scan below runs.
+    assert!(
+        expire_detached_cook_admission_in_store(&seeded, handoff_cook_id)
+            .expect("expire the detached admission lease in the injected store")
+    );
+
+    // A budget of zero is refused before anything is inspected, and a scope
+    // that matches nothing inspects nothing. Neither writes, so both are safe
+    // to run before the one call that quarantines.
+    let budgeted = claim_next_eligible_queued_run_with_preflight_and_filter_and_limit_in_store(
+        &seeded,
+        |_| true,
+        0,
+        |_, _| unreachable!("preflight cannot run inside an exhausted admission budget"),
+    )
+    .expect("exhausted budget is not an error");
+    assert!(budgeted.admission_limit_reached);
+    assert_eq!(budgeted.inspected, 0);
+    assert!(budgeted.record.is_none());
+    assert!(budgeted.skipped.is_empty());
+
+    let scoped = claim_next_eligible_queued_run_with_preflight_and_filter_in_store(
+        &seeded,
+        |_| false,
+        |_, _| unreachable!("preflight cannot run for a record outside the caller's scope"),
+    )
+    .expect("an empty scope is not an error");
+    assert_eq!(scoped.inspected, 0);
+    assert!(scoped.record.is_none());
+    assert!(scoped.skipped.is_empty());
+
+    // The one coordinating write. The preflight closure is never reached: the
+    // pinless record fails controller-runtime validation first, which is the
+    // branch that quarantines and skips.
+    let claim = claim_next_eligible_queued_run_with_preflight_in_store(&seeded, |_, _| {
+        unreachable!("preflight runs only after the durable plan and runtime validate")
+    })
+    .expect("scan the injected store's queue");
+    assert!(claim.record.is_none());
+    assert!(!claim.admission_limit_reached);
+    assert_eq!(
+        claim.inspected, 1,
+        "the scan must see the injected store's own queue; an ambient observation \
+         database holds none of these records and would inspect nothing"
+    );
+    assert_eq!(claim.skipped.len(), 1);
+    assert_eq!(claim.skipped[0].run_id, queued_run_id);
+    assert_eq!(
+        claim.skipped[0].category,
+        "queue_admission_preflight_failed"
+    );
+    assert_eq!(
+        claim.skipped[0].error_code,
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+
+    // The quarantine landed in the scanned store, so the next scan of that same
+    // store has nothing left to inspect.
+    let rescan =
+        claim_next_eligible_queued_run_in_store(&seeded).expect("rescan the injected store");
+    assert_eq!(rescan.inspected, 0);
+    assert!(rescan.skipped.is_empty());
+    assert!(claim_next_queued_run_in_store(&seeded)
+        .expect("the thin claim delegate shares the injected store")
+        .is_none());
+
+    // The Cook notification claim is an `O_EXCL` marker file, not a record
+    // write, so it is checked at the path each store owns.
+    assert!(claim_cook_terminal_notification_in_store(
+        &seeded,
+        notification_cook_id,
+        "fixture-notifier"
+    )
+    .expect("win the terminal notification claim in the injected store"));
+    assert!(
+        !claim_cook_terminal_notification_in_store(
+            &seeded,
+            notification_cook_id,
+            "second-notifier"
+        )
+        .expect("a held claim is answered, not errored"),
+        "the injected store's claim is exactly-once within that store"
+    );
+    confirm_cook_terminal_notification_in_store(&seeded, notification_cook_id, "fixture-notifier")
+        .expect("confirm the delivery in the injected store");
+    assert!(!claim_cook_terminal_notification_in_store(
+        &seeded,
+        notification_cook_id,
+        "late-notifier"
+    )
+    .expect("a delivered notification is answered, not errored"));
+    // The empty-id guard is preserved. Without it `sanitize_run_id` would turn
+    // `""` into a freshly minted `agent-task-<uuid>` and `"   "` into `___`,
+    // and each would create a durable claim marker under its own directory.
+    for blank in ["", "   "] {
+        assert!(
+            !claim_cook_terminal_notification_in_store(&seeded, blank, "fixture-notifier")
+                .expect("a blank Cook id is answered, not errored")
+        );
+    }
+
+    // The positive: every coordinating write is durable in the store handed in.
+    let quarantined = seeded
+        .read_record(queued_run_id)
+        .expect("read the scanned queue's record back");
+    assert_eq!(quarantined.state, AgentTaskRunState::Queued);
+    assert_eq!(
+        quarantined.metadata["queue_quarantine"]["category"],
+        "queue_admission_preflight_failed"
+    );
+    let expired = seeded
+        .read_record(handoff_cook_id)
+        .expect("read the detached parent back");
+    assert_eq!(expired.state, AgentTaskRunState::Failed);
+    assert_eq!(
+        expired.metadata["detached_cook_handoff"]["state"],
+        "exited_before_handoff"
+    );
+    assert_eq!(
+        expired.metadata["detached_cook_handoff"]["admission_state"],
+        "failed"
+    );
+    assert!(notification_claim_path(&seeded).exists());
+    assert!(notification_path(&seeded).exists());
+    // A blank Cook id must not have minted a durable Cook directory beside the
+    // one this test named.
+    let cook_root = seeded
+        .cook_index_path(notification_cook_id)
+        .parent()
+        .expect("a Cook index lives in its own directory")
+        .parent()
+        .expect("Cook directories share one root")
+        .to_path_buf();
+    let mut cook_directories: Vec<String> = std::fs::read_dir(&cook_root)
+        .expect("read the injected store's Cook root")
+        .map(|entry| {
+            entry
+                .expect("read a Cook directory entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    cook_directories.sort();
+    assert_eq!(cook_directories, vec![notification_cook_id.to_string()]);
+
+    // The negative: the second root holds the same identities and saw none of
+    // it. Absence first.
+    let untouched_queue = other
+        .read_record(queued_run_id)
+        .expect("the second root still has its own queued record");
+    assert_eq!(untouched_queue.state, AgentTaskRunState::Queued);
+    assert!(
+        untouched_queue.metadata.get("queue_quarantine").is_none(),
+        "second root must not observe a quarantine written through the injected store"
+    );
+    let untouched_parent = other
+        .read_record(handoff_cook_id)
+        .expect("the second root still has its own detached parent");
+    assert_eq!(untouched_parent.state, AgentTaskRunState::Queued);
+    assert_eq!(
+        untouched_parent.metadata["detached_cook_handoff"]["state"],
+        "pending"
+    );
+    for key in ["admission_state", "reason"] {
+        assert!(
+            untouched_parent.metadata["detached_cook_handoff"]
+                .get(key)
+                .is_none(),
+            "second root must not observe `{key}` written through the injected store"
+        );
+    }
+    assert!(!notification_claim_path(&other).exists());
+    assert!(!notification_path(&other).exists());
+
+    // Then the stronger half: the second root is not merely missing the
+    // evidence, it is still *eligible*. Its queued run is still inspectable,
+    // its notification claim is still winnable, and its admission lease is
+    // still expirable — none of which is true of state some other call already
+    // consumed.
+    let still_eligible = claim_next_eligible_queued_run_with_preflight_and_filter_in_store(
+        &other,
+        |record| record.run_id == queued_run_id,
+        |_, _| unreachable!("preflight runs only after the durable plan and runtime validate"),
+    )
+    .expect("scan the second root's own queue");
+    assert_eq!(still_eligible.inspected, 1);
+    assert_eq!(still_eligible.skipped.len(), 1);
+    assert_eq!(still_eligible.skipped[0].run_id, queued_run_id);
+    assert!(
+        claim_cook_terminal_notification_in_store(&other, notification_cook_id, "second-root")
+            .expect("the second root owns its own notification claim"),
+        "the injected store's claim must not consume the second root's eligibility"
+    );
+    assert!(
+        expire_detached_cook_admission_in_store(&other, handoff_cook_id)
+            .expect("the second root owns its own admission lease"),
+        "the injected store's expiry must not consume the second root's lease"
+    );
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -515,8 +515,32 @@ impl AgentTaskLifecycleStore {
         write_cook_notification_outcome_in_store(self, cook_id, outcome)
     }
 
+    /// Claim the one terminal notification this store's Cook may deliver.
+    ///
+    /// The `O_EXCL` marker is created beside this store's own Cook index, so
+    /// two stores hold two independent claims rather than contending for the
+    /// ambient one.
+    pub fn claim_cook_notification(&self, cook_id: &str, marker: &Value) -> Result<bool> {
+        claim_cook_notification_in_store(self, cook_id, marker)
+    }
+
+    /// Commit a confirmed terminal delivery beside this store's own Cook index.
+    pub fn confirm_cook_notification(&self, cook_id: &str, marker: &Value) -> Result<()> {
+        confirm_cook_notification_in_store(self, cook_id, marker)
+    }
+
     pub fn read_record(&self, run_id: &str) -> Result<AgentTaskRunRecord> {
         read_record_in_store(self, run_id)
+    }
+
+    /// List every durable agent-task record from this store's own observation
+    /// database.
+    ///
+    /// Queue scanning is a read of the observation DB, not of the record files,
+    /// so a scan that resolved it ambiently would inspect one queue while the
+    /// claim it produced mutated another (#7505).
+    pub fn read_records(&self) -> Result<Vec<AgentTaskRunRecord>> {
+        read_records_in_store(self)
     }
 
     pub(crate) fn record_run_aggregate(
@@ -1181,8 +1205,21 @@ pub(super) fn cook_index_exists(cook_id: &str) -> Result<bool> {
 /// because it is keyed on a `runs` row and a Cook id is an alias with no row
 /// of its own.
 pub(super) fn claim_cook_notification(cook_id: &str, marker: &Value) -> Result<bool> {
-    let delivered_path =
-        cook_index_path(&sanitize_run_id(cook_id))?.with_file_name("notification.json");
+    claim_cook_notification_in_store(&default_store()?, cook_id, marker)
+}
+
+/// Claim within one explicitly rooted store. `cook_index_path` as a free
+/// function is `default_store()?`, so the store's own method is used here: the
+/// claim marker is a bare filesystem create with no record read in front of it,
+/// and an ambient reach would land the marker in another home without failing.
+fn claim_cook_notification_in_store(
+    store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    marker: &Value,
+) -> Result<bool> {
+    let delivered_path = store
+        .cook_index_path(&sanitize_run_id(cook_id))
+        .with_file_name("notification.json");
     if delivered_path.exists() {
         return Ok(false);
     }
@@ -1240,8 +1277,17 @@ pub(super) fn claim_cook_notification(cook_id: &str, marker: &Value) -> Result<b
 /// Commit a successful notification claim. Only a confirmed transport delivery
 /// becomes the durable exactly-once marker.
 pub(super) fn confirm_cook_notification(cook_id: &str, marker: &Value) -> Result<()> {
-    let delivered_path =
-        cook_index_path(&sanitize_run_id(cook_id))?.with_file_name("notification.json");
+    confirm_cook_notification_in_store(&default_store()?, cook_id, marker)
+}
+
+fn confirm_cook_notification_in_store(
+    store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    marker: &Value,
+) -> Result<()> {
+    let delivered_path = store
+        .cook_index_path(&sanitize_run_id(cook_id))
+        .with_file_name("notification.json");
     write_private_json(&delivered_path, marker)
 }
 
@@ -1356,6 +1402,15 @@ pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
     Ok(read_records_with_health()?.0)
 }
 
+/// The store-rooted counterpart of [`read_records`], following the same bound
+/// and the same health projection but reading this store's own observation
+/// database instead of `paths::observation_db()`.
+fn read_records_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<Vec<AgentTaskRunRecord>> {
+    Ok(records_with_health(observation_runs_bounded_in_store(lifecycle_store, 1000)?)?.0)
+}
+
 /// Bound on a single source run's retry lineage. Deliberately far above any
 /// plausible retry count: an exceeded lineage is reported as an error, and this
 /// is the threshold at which "this is a runaway, not a lineage" becomes true.
@@ -1425,12 +1480,24 @@ pub(super) fn observation_runs() -> Result<Vec<RunRecord>> {
 
 fn observation_runs_bounded(limit: usize) -> Result<Vec<RunRecord>> {
     let store = ObservationStore::open_readonly()?;
-    let filter = RunListFilter {
+    store.list_runs(bounded_agent_task_filter(limit))
+}
+
+fn observation_runs_bounded_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    limit: usize,
+) -> Result<Vec<RunRecord>> {
+    lifecycle_store
+        .open_observation_readonly()?
+        .list_runs(bounded_agent_task_filter(limit))
+}
+
+fn bounded_agent_task_filter(limit: usize) -> RunListFilter {
+    RunListFilter {
         kind: Some("agent-task".to_string()),
         limit: Some(i64::try_from(limit.clamp(1, 1000)).expect("bounded record limit")),
         ..Default::default()
-    };
-    store.list_runs(filter)
+    }
 }
 
 fn observation_metadata(


### PR DESCRIPTION
## Summary

Continues rooting `lifecycle_ops.rs` after the read subset (#12603) and the Cook write family (#12604). This takes the **claim family** — the scheduler/worker coordination layer — plus the admission-lease and notification-commit halves of the same cluster.

| function | note |
|---|---|
| `claim_next_queued_run` | delegates |
| `claim_next_eligible_queued_run` | delegates |
| `…_with_preflight` | delegates |
| `…_with_preflight_and_filter` | delegates |
| `…_with_preflight_and_filter_and_limit` | **the real body** |
| `claim_cook_terminal_notification` | |
| `expire_detached_cook_admission` | evaluated in — admission-lease half of the same coordination |
| `confirm_cook_terminal_notification` | evaluated in — same `O_EXCL`-marker cluster |
| `record_cook_terminal_notification_outcome` | **skipped** — #12604 already rooted it |

The four narrowing wrappers delegate down exactly the chain their ambient pairs do. Nothing duplicated.

## Five ambient reaches, each of which would have split state silently

<callout accent="#ef4444">
Every one of these fails *quietly* rather than loudly. That is what makes this family dangerous.
</callout>

**1. `read_records` → `ObservationStore::open_readonly()` → `paths::observation_db()`**
A sibling that left this would have **scanned the ambient queue and then claimed and quarantined in the injected one** — exactly the split #7505 exists to remove.

**2. `quarantine_queued_run` → `store::mutate_record`**
Ambient, a claim scans the injected queue, judges a record unadmittable, and writes the quarantine marker *elsewhere* — leaving the injected queue re-inspecting the same bad record on **every claim forever**, with no error.

**3. `fail_detached_cook_handoff_parent`**
Its two guards protecting a live parent (`read_cook_index(...).is_ok()`, `read_record(...).is_ok()`) sit **inside** the `mutate_record` closure. Ambient, another home's Cook index could veto a terminal transition here — or fail to veto one.

**4 & 5. `claim_cook_notification` / `confirm_cook_notification` → private `cook_index_path`**
The exact #12604 trap, one level deeper. Both are bare `create_new` / `write_private_json` with **no record read in front**, so the marker lands in the ambient home while every positive assertion still passes.

Also threaded: `validate_controller_runtime` (persists a migrated pin — a **write** on what reads like a read path) and `load_controller_plan`, which needed `resolve_run_id_in_store` because Cook-alias resolution reads the cook index — an ambient resolve could return **another root's latest attempt id** and then read that run's plan out of the injected root.

`resolve_run_id` itself is deliberately **not** converted: it swallows every index error and is therefore total, and routing it through a store constructor would make it fallible. Additive sibling only.

## The one documented exception

`controller_runtime::validate` consults the process-global controller-runtime pin store (`paths::controller_runtimes_store()`). That is a **content-addressed executable cache shared across homes**, not durable lifecycle state, so it is not one of the store's roots. The metadata write it performs *is* store-rooted. Commented in the code.

## Shadowing audit

Every new `_in_store` body extracted and scanned for `store::`, `default_store`, `paths::`, `from_current_environment`, `ObservationStore::`, `open_readonly()`, `open_initialized_for_lifecycle()`. **18 functions, zero hits.**

Transitive helpers verified root-free by reading: `is_transport_proxy`, `queue_skip`, `redacted_queue_diagnostic`, `trusted_plan_provider_id`, `trusted_plan_environment_variables`, `queue_quarantine_remediation`, `has_expired_detached_cook_admission` and its deadline helpers, `set_run_state`, `records_with_health` → `health::diagnose_run`.

The #12591 scanner's own logic was run over `crates/homeboy-agents/src`: **one finding**, `run_cook_with_boundaries_reported`, which is the single existing allowlist row. No new entries, none stale.

## What could not be driven hermetically

**The successful `mark_running` branch.** It needs `controller_runtime::validate_pin` — a real executable on disk, a matching SHA-256, and a self-identity probe. The only in-process fixture route requires `set_var`, which is forbidden here. Hand-rolling a pin is worse: `migrate_legacy_pin_and_persist` calls `fs::create_dir_all(paths::controller_runtimes_store()?)` **into the operator's real home**.

So the rejection side is proved instead — a genuine coordination write, not a stand-in. That drove one test detail worth flagging: the test **removes** the `controller_runtime` key rather than leaving the admission's `{}`, because a present-but-malformed pin still routes through `migrate_legacy_pin_and_persist` and touches the ambient pin store. Commented at the call site.

## The proof goes past absence

`claim_family_siblings_coordinate_only_inside_the_injected_store`. Two `HermeticTestContext::path_roots()` roots — no `with_isolated_home`, no `HomeGuard`, no `set_var`.

Both roots get the **same** queued run, the **same** pending detached-admission parent with an expired lease, and the **same** Cook notification identity. Every call goes through a sibling handed `seeded`. Chain coverage: limit sibling (budget 0 → `admission_limit_reached`, which also proves the scan saw the *injected* queue), filter, preflight (the one write), bare, and `claim_next_queued_run_in_store`.

**Absence assertions:** `other`'s queued record still `Queued` with no `queue_quarantine`; `other`'s parent still `Queued`, handoff `"pending"`, no `admission_state`, no `reason`; neither marker file exists.

**Then the half absence cannot give you — the second root is still *eligible*:**

- a scoped claim on `other` still reports `inspected == 1`
- `claim_cook_terminal_notification_in_store(&other, …)` still returns **`true`** — the first store's claim did not consume the second root's exactly-once eligibility
- `expire_detached_cook_admission_in_store(&other, …)` still returns **`true`** — the lease was never consumed

Absence alone would not distinguish a leak from a no-op.

Plus the preserved empty-id guard is pinned for `""` and `"   "`, and the injected store's `agent-task-cooks/` is asserted to hold **exactly one** entry — proving no `agent-task-<uuid>` or `___` Cook was minted behind the guard.

## Warning-clean gate — confirmed empirically

`lib.rs:35-41` carries `#[allow(dead_code, unused_imports, …)]` on `pub mod agent_task_lifecycle`, and `lifecycle_store.rs` sits inside it via `#[path]`. Proof rather than assumption: `read_mirrored_aggregate` and `write_cook_notification_outcome` (orphaned by #12604 itself) both have **zero callers on merged main**, and main is green under `-Dwarnings`. The three newly-orphaned ambient shims here are the same shape and are retained as the documented ambient resolution point, matching #12604's convention.

## Compatibility

Purely additive plus delegation. No existing signature or behavior changes. No caller migrated.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Implementation, helper threading, test authoring, and standalone `rustc` verification of closure/borrow shapes. Review by hand; compilation deferred to CI.

Refs #7505
