### PR TITLE
refactor(agent-task): root Cook handoff fence reads

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -370,8 +370,16 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
 /// Reject detached Cook work after the pre-spawn parent has been cancelled.
 /// The child reads this durable fence independently of launcher liveness.
 pub fn require_detached_cook_handoff_fence_open(cook_id: &str) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    require_detached_cook_handoff_fence_open_in_store(&lifecycle_store, cook_id)
+}
+
+pub(crate) fn require_detached_cook_handoff_fence_open_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<()> {
     let cook_id = sanitize_run_id(cook_id);
-    let Ok(record) = store::read_record(&cook_id) else {
+    let Ok(record) = lifecycle_store.read_record(&cook_id) else {
         return Ok(());
     };
     if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -150,6 +150,38 @@ fn lifecycle_stores_isolate_identical_ids_and_lock_domains() {
 }
 
 #[test]
+fn detached_handoff_fences_resolve_only_from_the_explicit_lifecycle_root() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let cook_id = "same-handoff-fence-cook";
+
+    for (store, state, fence) in [
+        (&left, AgentTaskRunState::Queued, "open"),
+        (&right, AgentTaskRunState::Cancelled, "cancelled"),
+    ] {
+        let mut handoff = record(store, cook_id, fence);
+        handoff.state = state;
+        handoff.metadata["detached_cook_handoff"] = json!({
+            "cook_id": cook_id,
+            "state": "pending",
+            "cancellation_fence": { "state": fence },
+        });
+        store.write_record(&handoff).unwrap();
+    }
+
+    left.require_detached_cook_handoff_fence_open(cook_id)
+        .expect("left fence remains open");
+    let error = right
+        .require_detached_cook_handoff_fence_open(cook_id)
+        .expect_err("right fence is cancelled");
+
+    assert_eq!(error.details["field"], "cook_id");
+    assert!(error.message.contains("cancelled"));
+}
+
+#[test]
 fn lifecycle_stores_isolate_same_run_record_writes_in_parallel() {
     let left_context = homeboy_core::test_support::HermeticTestContext::new();
     let right_context = homeboy_core::test_support::HermeticTestContext::new();

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4106,7 +4106,7 @@ where
 {
     // The local detached launcher persists this fence before spawn. Recheck it
     // at each durable/external boundary so a dead launcher cannot revive work.
-    agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
+    lifecycle_store.require_detached_cook_handoff_fence_open(&options.cook_id)?;
     // Validate new Cooks before provider discovery, workspace staging, recipe
     // persistence, or a detached handoff can spend provider work. Historical
     // immutable recipes retain their persisted behavior and receive actionable
@@ -4188,7 +4188,7 @@ where
             store.persist_initial_recipe(&options)?
         }
     } else {
-        agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
+        lifecycle_store.require_detached_cook_handoff_fence_open(&options.cook_id)?;
         store.persist_initial_recipe(&options)?
     };
     // A recipe can survive an interruption before its first lifecycle record.
@@ -4266,7 +4266,7 @@ where
         })
         .map(|workspace| reserve_cook_materialization_capacity(lifecycle_store, workspace))
         .transpose()?;
-    agent_task_lifecycle::require_detached_cook_handoff_fence_open(&options.cook_id)?;
+    lifecycle_store.require_detached_cook_handoff_fence_open(&options.cook_id)?;
     if cook_workspace_lookup_pending(&options.initial_plan) {
         report_cook_progress(
             lifecycle_store,
@@ -4601,7 +4601,7 @@ where
         if needs_execution {
             // The local detached launcher persists this fence before spawn.
             // Recheck immediately before this attempt can publish provider work.
-            agent_task_lifecycle::require_detached_cook_handoff_fence_open(&cook_id)?;
+            lifecycle_store.require_detached_cook_handoff_fence_open(&cook_id)?;
             // `provider_start` is a durable lifecycle transition. Create the
             // record before reporting it so a new Cook run is observable before
             // any preflight or provider work can block.

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -311,6 +311,10 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub fn require_detached_cook_handoff_fence_open(&self, cook_id: &str) -> Result<()> {
+        super::lifecycle_ops::require_detached_cook_handoff_fence_open_in_store(self, cook_id)
+    }
+
     pub fn start_candidate_adoption_with_policy(
         &self,
         run_id: &str,


### PR DESCRIPTION
## Summary
- add an explicit-store detached Cook handoff-fence read while retaining the ambient compatibility wrapper
- route all four paired Cook-spine authorization checks through the supplied `AgentTaskLifecycleStore`
- prove identical Cook IDs resolve independently when one lifecycle root is open and another is cancelled

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::lifecycle_store::detached_handoff_fences_resolve_only_from_the_explicit_lifecycle_root -- --exact`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::status_and_recovery::cancelled_or_expired_pending_handoff_never_submits_new_runner_work -- --exact`
- `cargo test --test agent_task_store_injection_test`
- `git diff --check origin/main...HEAD`

A broader pre-rebase `lifecycle_store` substring filter also selected the unrelated `local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores` test; it failed because its temporary pinned controller executable was missing. The owned exact tests and post-rebase gates above pass.

Refs #7505

AI assistance: OpenAI GPT-5.6 Sol via OpenCode traced the Cook authorization call sites, implemented and reviewed the explicit-store migration, and ran the verification listed above. Chris Huber remains responsible for the report and code.