### PR TITLE
Align release and triage baseline fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "homeboy-core",
+ "homeboy-rig",
  "serde",
  "serde_json",
 ]

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -358,7 +358,30 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                That emptiness is not laundered into a release, because \
                `release-asset-completeness.sh` independently requires every declared sidecar to \
                be present and non-empty before publication -- this script normalizes bytes, that \
-               one decides.",
+                one decides.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the only green outcome is `executed`, after every declared required \
+               context has been independently observed in this run with a success conclusion and \
+               every dependency result is success. Both the declared policy population and the \
+               observed jobs are non-empty before this aggregate can pass; unreadable run jobs, \
+               missing contexts, skipped dependencies, and failed contexts all exit 1.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: every non-executed outcome is a refusal: absent or unreadable input, \
+               no declared contexts, a skipped dependency, a missing job, or a non-success \
+               conclusion. This terminal exit cannot manufacture a green verdict; it is \
+               registered so the scan records the script's complete terminal contract.",
     },
     GateLayerSite {
         file: ".github/release-asset-completeness.sh",

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -576,6 +576,7 @@ mod tests {
     };
     use crate::release::workflow::run_command;
     use homeboy_core::component::{Component, VersionTarget};
+    use homeboy_core::defaults;
     use homeboy_core::project::{self, Project, ProjectComponentAttachment};
     use homeboy_core::server::{self, Server};
     use homeboy_core::test_support::with_isolated_home;
@@ -1012,12 +1013,19 @@ mod tests {
     #[test]
     fn release_recover_resumes_only_failed_project_with_published_source_projection() {
         with_isolated_home(|home| {
+            let mut config = defaults::load_config();
+            config.defaults.permissions.remote.dir_mode = "g+rwx".to_string();
+            defaults::save_config(&config).expect("save fixture permissions");
             let source = home.path().join("source");
             let successful_target = home.path().join("successful-target");
             let retry_target = home.path().join("retry-target");
             std::fs::create_dir_all(&source).expect("source directory");
             std::fs::create_dir_all(&successful_target).expect("successful target");
             std::fs::create_dir_all(&retry_target).expect("retry target");
+            let successful_component = successful_target.join("plugins/successful");
+            std::fs::create_dir_all(&successful_component).expect("successful component target");
+            std::fs::write(successful_component.join("VERSION"), "1.2.3\n")
+                .expect("pre-release remote version");
             run_git(&source, &["init", "-q", "--initial-branch", "main"]);
             run_git(&source, &["config", "user.email", "test@example.com"]);
             run_git(&source, &["config", "user.name", "Homeboy Test"]);

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -1193,51 +1193,42 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
 
 #[test]
 fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
-    let mut component = fixture_component();
-    component.extensions = Some(std::collections::HashMap::from([(
-        "wordpress".to_string(),
-        ScopedExtensionConfig::default(),
-    )]));
-    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
-        "name": "WordPress",
-        "version": "1.0.0",
-        "actions": [
-            {
-                "id": "release.package",
-                "label": "Package release",
-                "type": "command",
-                "command": "true"
-            }
-        ]
-    }))
-    .expect("extension manifest");
-    extension.id = "wordpress".to_string();
-    let mut warnings = Vec::new();
-    let mut hints = Vec::new();
-    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
-    let options = ReleaseOptions {
-        bump_type: "patch".to_string(),
-        ..Default::default()
-    };
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut component = fixture_component();
+        component.extensions = Some(std::collections::HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        let extension = release_extension("wordpress", &["release.package"]);
+        homeboy_extension::save_manifest(&extension).expect("install extension manifest");
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let release_scope =
+            ReleaseScope::resolve(&component, &component.id).expect("release scope");
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
 
-    let _steps = build_release_steps(
-        &component,
-        &[extension],
-        "1.0.0",
-        "1.0.1",
-        &fixture_changelog_plan(),
-        &options,
-        &release_scope,
-        &mut warnings,
-        &mut hints,
-    )
-    .expect("steps");
+        let _steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            &release_scope,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
 
-    assert!(warnings.iter().any(|warning| {
-        warning.contains("configured extensions (wordpress)")
-            && warning.contains("release.package")
-            && warning.contains("no extension provides 'release.publish'")
-    }));
+        assert!(warnings.iter().any(|warning| {
+            warning.contains("configured extensions (wordpress)")
+                && warning.contains("release.package")
+                && warning.contains("no extension provides 'release.publish'")
+        }));
+    });
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -699,7 +699,7 @@ mod tests {
         let local = root.join("local");
         std::fs::create_dir_all(&origin).expect("origin dir");
 
-        git(&origin, &["init", "-b", "main"]);
+        git(&origin, &["init", "-b", "master"]);
         git(&origin, &["config", "user.email", "t@example.com"]);
         git(&origin, &["config", "user.name", "T"]);
         std::fs::write(origin.join("f.txt"), "0\n").expect("seed file");
@@ -721,7 +721,7 @@ mod tests {
         }
 
         // Update tracking refs locally (no working-tree move): the local clone
-        // now knows origin/main is ahead while HEAD stays at v1.0.0.
+        // now knows origin/master is ahead while HEAD stays at v1.0.0.
         git(&local, &["fetch", "origin"]);
         local
     }
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     fn guard_allows_checkout_at_upstream_head() {
         let dir = tempfile::TempDir::new().expect("temp dir");
-        // Zero extra upstream commits: HEAD == origin/main, genuinely at head.
+        // Zero extra upstream commits: HEAD == origin/master, genuinely at head.
         let local = stale_checkout_fixture(dir.path(), 0);
 
         assert!(

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1251,11 +1251,13 @@ mod tests {
             };
 
             let error = validate_lint_quality(&component, "fixture").expect_failed();
-            // The bootstrap failure now surfaces as the extension resolution
-            // failure that actually occurred, rather than the generic
-            // "Lint runner error" this previously asserted.
+            // Missing extension manifests now surface through the typed
+            // capability diagnostic rather than a generic runner error.
             assert!(
-                error.to_string().contains("Extension not found"),
+                error
+                    .to_string()
+                    .contains("no linked extensions that provide lint support")
+                    && error.to_string().contains("missing-lint-extension"),
                 "a component declaring an uninstallable lint extension must block \
                  release on the resolution failure; got: {error}"
             );
@@ -1529,11 +1531,13 @@ exit 0
             );
             assert_eq!(
                 producer_error.details["lint_workflow"]["baseline_new_count"].as_u64(),
-                Some(0)
+                None,
+                "producer errors make the baseline comparison ineligible"
             );
             assert_eq!(
                 producer_error.details["lint_workflow"]["baseline_known_count"].as_u64(),
-                Some(1)
+                None,
+                "producer errors make the baseline comparison ineligible"
             );
         });
     }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -1140,6 +1140,7 @@ mod tests {
         let gate = &mut readiness.gate_results[0];
         gate.status = "passed".to_string();
         gate.reason = None;
+        gate.evidence_refs = vec!["evidence://lint".to_string()];
         gate.provenance = Some(super::super::types::ReleaseReadinessProvenance {
             dependencies: std::collections::BTreeMap::from([(
                 "dependency".to_string(),
@@ -1213,8 +1214,8 @@ mod tests {
             .find(|record| record.source_sha == source)
             .expect("readiness record is retained");
             let owner = record.owner_run_ref.clone();
-            assert!(error.hints.iter().any(|hint| hint.message
-                == format!("Inspect readiness evidence: homeboy release readiness show {owner}")));
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert!(error.message.contains("invalid selected gate evidence"));
             assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             assert_eq!(record.finalization_status, "completed");
             assert_eq!(

--- a/crates/homeboy-triage/Cargo.toml
+++ b/crates/homeboy-triage/Cargo.toml
@@ -22,3 +22,4 @@ chrono = "0.4"
 # Shared hermetic test fixtures (with_isolated_home) live in homeboy-core behind
 # the test-support feature; the whole workspace shares one isolation contract.
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
+homeboy-rig = { version = "0.1.0", path = "../homeboy-rig" }

--- a/crates/homeboy-triage/src/tests/targets.rs
+++ b/crates/homeboy-triage/src/tests/targets.rs
@@ -224,6 +224,7 @@ fn component_target_threads_registered_triage_remote_override() {
 #[test]
 fn rig_target_threads_rig_component_triage_remote_override() {
     homeboy_core::test_support::with_isolated_home(|home| {
+        homeboy_rig::provider::register();
         let rig_dir = home.path().join(".config/homeboy/rigs");
         std::fs::create_dir_all(&rig_dir).unwrap();
         std::fs::write(
@@ -246,12 +247,19 @@ fn rig_target_threads_rig_component_triage_remote_override() {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].component_id, "playground");
         assert_eq!(
+            refs[0].remote_url.as_deref(),
+            Some("https://github.com/example-org/wordpress-playground.git")
+        );
+        assert_eq!(
             refs[0].triage_remote_url.as_deref(),
             Some("https://github.com/WordPress/wordpress-playground.git")
         );
+        let resolved = resolve_repo(&refs[0]).expect("rig target resolves its triage remote");
+        assert_eq!(resolved.repo.owner, "WordPress");
+        assert_eq!(resolved.repo.repo, "wordpress-playground");
         assert_eq!(
-            resolve_repo(&refs[0]).unwrap().repo.owner,
-            "WordPress".to_string()
+            resolved.source_repo.expect("source remote retained").owner,
+            "example-org"
         );
     });
 }


### PR DESCRIPTION
## Summary
- align release planner/readiness fixtures with current branch and typed evidence contracts
- install valid extension manifests in release-plan coverage
- register required-gate terminal decisions in the measurement registry
- assert rig triage source and override remotes through the registered provider
- repair release recovery fixture version and permission preconditions

Progresses #12607.

## Verification
- `cargo test -p homeboy-release --lib` (551 passed)
- measurement registry tests passed
- triage target tests passed
- `cargo fmt --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode triaged release, measurement, and triage failures, aligned fixtures with current contracts, and ran full release-library verification. Chris Huber reviewed and remains responsible for every line.