### PR TITLE
Repair CLI and installer baseline fixtures

### DIFF
--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -847,12 +847,31 @@ fn run_path_status(
 ) -> CmdResult<StatusResult> {
     let path = args.scope.path.as_deref();
     timer.begin("resolve_path_component");
-    let component = component::resolve_effective(args.target.as_deref(), path, None)?;
+    let mut component = component::resolve_effective(args.target.as_deref(), path, None)?;
+    if let Some(path) = path {
+        // An explicit ID gives this report its stable identity; `--path` is the
+        // checkout override and must remain the component's inspected source.
+        component.local_path = path.to_string();
+    }
     timer.finish("resolve_path_component");
 
     if args.full {
+        let component_id = component.id.clone();
+        let component_path = component.local_path.clone();
         let mut report = context::build_report_for_component(args.all, "status", component, path)?;
         report.command = "status".to_string();
+        // The focused component may have been resolved through an explicit ID,
+        // but `--path` remains the context the operator asked to inspect.
+        if let Some(path) = path {
+            report.context.cwd = path.to_string();
+        }
+        if let Some(summary) = report
+            .components
+            .iter_mut()
+            .find(|summary| summary.id == component_id)
+        {
+            summary.path = component_path;
+        }
         return Ok((StatusResult::Full(Box::new(report)), 0));
     }
 

--- a/docs/operations/controller-runner-reverse-runner.md
+++ b/docs/operations/controller-runner-reverse-runner.md
@@ -202,13 +202,13 @@ Keep the service disabled for production until #2990 and #2991 are merged. For
 private smoke tests before #2991, use the one-shot worker shape from the active
 implementation branch or PR notes instead of a hand-rolled infinite loop.
 
-## 4. Reverse workspace sync
+## 4. Reverse workspace staging
 
-Reverse workspace sync is gated by #2947. Until it lands, controller-originated
-commands can only smoke simple brokered execution that does not require syncing a
-controller checkout to the runner through the reverse session.
+Controller-originated durable work stages its verified source through the reverse
+broker before the runner executes it. The runner receives the staged workspace
+descriptor and must keep the resulting path beneath its configured workspace root.
 
-Expected modes after #2947:
+Supported source forms are:
 
 - `git`: the runner materializes a repo-backed clean commit/ref itself.
 - `snapshot-over-tunnel`: the controller streams a filtered archive through the reverse
@@ -222,8 +222,8 @@ by `homeboy runner workspace sync`.
 
 ## 5. Minimal end-to-end smoke
 
-Run this only after #2990, #2991, #2992, and #2947 have landed or in an explicit
-private smoke environment that provides equivalent branch builds.
+Run this against a connected reverse runner with a broker endpoint and a configured
+workspace root.
 
 1. Start or verify the controller broker service:
 

--- a/scripts/homeboy-installer.sh
+++ b/scripts/homeboy-installer.sh
@@ -38,7 +38,7 @@ else
 fi
 
 CANDIDATE="${ASSET%.tar.xz}/homeboy"
-MEMBERS="$(tar -tJf "$TMP_DIR/$ASSET" 2>/dev/null || tar -tf "$TMP_DIR/$ASSET")" || {
+MEMBERS="$(env -u TAR_OPTIONS tar -tJf "$TMP_DIR/$ASSET" 2>/dev/null || env -u TAR_OPTIONS tar -tf "$TMP_DIR/$ASSET")" || {
   echo "Unable to list release archive" >&2
   exit 1
 }
@@ -69,7 +69,7 @@ if [ "$CANDIDATE_COUNT" -ne 1 ]; then
   exit 1
 fi
 
-CANDIDATE_DETAILS="$(tar -tvJf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -tvf "$TMP_DIR/$ASSET" "$CANDIDATE")" || {
+CANDIDATE_DETAILS="$(env -u TAR_OPTIONS tar -tvJf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || env -u TAR_OPTIONS tar -tvf "$TMP_DIR/$ASSET" "$CANDIDATE")" || {
   echo "Unable to inspect release candidate" >&2
   exit 1
 }
@@ -82,7 +82,7 @@ case "$CANDIDATE_DETAILS" in
 esac
 
 EXTRACTED_BIN="$TMP_DIR/homeboy"
-(tar -xJOf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -xOf "$TMP_DIR/$ASSET" "$CANDIDATE") > "$EXTRACTED_BIN" || {
+(env -u TAR_OPTIONS tar -xJOf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || env -u TAR_OPTIONS tar -xOf "$TMP_DIR/$ASSET" "$CANDIDATE") > "$EXTRACTED_BIN" || {
   echo "Unable to extract release candidate" >&2
   exit 1
 }

--- a/tests/cli_binary/product_identity_test.rs
+++ b/tests/cli_binary/product_identity_test.rs
@@ -4,9 +4,7 @@ use std::process::Command;
 
 #[test]
 fn shipped_root_binary_reports_root_version_and_source_commit() {
-    let expected_version = env!("CARGO_PKG_VERSION");
-    let expected_commit = git_output(&["rev-parse", "--short=12", "HEAD"]);
-    let expected_dirty = !git_output(&["status", "--porcelain"]).is_empty();
+    let expected = homeboy_product_identity::build_identity();
     let output = Command::new(homeboy_bin())
         .args(["self", "identity"])
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
@@ -15,9 +13,15 @@ fn shipped_root_binary_reports_root_version_and_source_commit() {
 
     assert_eq!(output.status.code(), Some(0));
     let identity: Value = serde_json::from_slice(&output.stdout).expect("identity JSON");
-    assert_eq!(identity["data"]["version"], expected_version);
-    assert_eq!(identity["data"]["git_commit"], expected_commit);
-    assert_eq!(identity["data"]["git_dirty"], expected_dirty);
+    assert_eq!(identity["data"]["version"], expected.version);
+    assert_eq!(
+        identity["data"]["git_commit"],
+        serde_json::to_value(expected.git_commit.clone()).expect("serialize build commit")
+    );
+    assert_eq!(
+        identity["data"]["git_dirty"],
+        serde_json::to_value(expected.git_dirty).expect("serialize dirty marker")
+    );
     let expected_binary = homeboy_bin().to_string_lossy().into_owned();
     assert_eq!(
         identity["data"]["active_binary"].as_str(),
@@ -69,20 +73,13 @@ fn shipped_root_binary_reports_root_version_and_source_commit() {
 
     assert_eq!(output.status.code(), Some(0));
     let version = String::from_utf8(output.stdout).expect("version output is UTF-8");
-    assert!(version.contains(expected_version));
-    assert!(version.contains(&expected_commit));
+    assert!(version.contains(&expected.version));
+    if let Some(commit) = expected.git_commit {
+        assert!(version.contains(&commit));
+    }
     assert!(!version.contains("0.1.0"));
 }
 
 fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
-}
-
-fn git_output(args: &[&str]) -> String {
-    let output = Command::new("git").args(args).output().expect("run git");
-    assert!(output.status.success(), "git command failed");
-    String::from_utf8(output.stdout)
-        .expect("git output is UTF-8")
-        .trim()
-        .to_string()
 }

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -128,6 +128,8 @@ fn run_installer(
         .env("HOMEBOY_TEST_EVIDENCE", &evidence)
         .env("HOMEBOY_TEST_EVENTS", &events)
         .env("HOMEBOY_TEST_BIN_DIR", &install_dir)
+        // Archive inspection must be independent of caller tar defaults.
+        .env("TAR_OPTIONS", "--invalid-homeboy-installer-option")
         .env("PATH", format!("{}:/usr/bin:/bin", tools.display()));
     if force_sudo {
         command.env("HOMEBOY_INSTALL_USE_SUDO", "true");

--- a/tests/postprocess_worker_startup.rs
+++ b/tests/postprocess_worker_startup.rs
@@ -101,12 +101,8 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
     let _lock = POSTPROCESS_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let home = tempfile::tempdir().expect("home");
-    let artifact_root = home.path().join("artifacts");
-    homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
-    {
+    homeboy::core::test_support::with_isolated_home(|home| {
         install_helper(home.path());
-        std::env::set_var("HOMEBOY_ARTIFACT_ROOT", artifact_root);
         std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
         std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
 
@@ -175,8 +171,7 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
             root.join("claim.json").exists() || root.join("current.json").is_file(),
             "replacement worker completed after the empty pre-claim recovery"
         );
-    }
-    homeboy::core::set_artifact_root_override(None);
+    });
 }
 
 #[test]
@@ -184,46 +179,43 @@ fn scheduler_restart_adopts_a_live_worker_without_reinvoking_helper() {
     let _lock = POSTPROCESS_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let home = tempfile::tempdir().expect("home");
-    let artifact_root = home.path().join("artifacts");
-    homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
-    install_helper(home.path());
-    std::env::set_var("HOMEBOY_ARTIFACT_ROOT", artifact_root);
-    std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
-    std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
+    homeboy::core::test_support::with_isolated_home(|home| {
+        install_helper(home.path());
+        std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
+        std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
 
-    let root = homeboy::core::artifacts::root()
-        .expect("artifact root")
-        .join("agent-task/postprocess/restart-run/compose");
-    let first = thread::spawn(|| {
-        AgentTaskScheduler::new(NoopExecutor)
-            .with_run_id("restart-run")
-            .run(postprocess_plan())
+        let root = homeboy::core::artifacts::root()
+            .expect("artifact root")
+            .join("agent-task/postprocess/restart-run/compose");
+        let first = thread::spawn(|| {
+            AgentTaskScheduler::new(NoopExecutor)
+                .with_run_id("restart-run")
+                .run(postprocess_plan())
+        });
+        let worker_file = root.join("worker.json");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !worker_file.is_file() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            worker_file.is_file(),
+            "first scheduler persisted its worker"
+        );
+
+        let restarted = thread::spawn(|| {
+            AgentTaskScheduler::new(NoopExecutor)
+                .with_run_id("restart-run")
+                .run(postprocess_plan())
+        });
+        let first = first.join().expect("first scheduler");
+        let restarted = restarted.join().expect("restarted scheduler");
+
+        assert_eq!(first.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(restarted.status, AgentTaskAggregateStatus::Succeeded);
+        let versions = std::fs::read_dir(root.join("versions"))
+            .expect("versions")
+            .count();
+        assert_eq!(versions, 1, "live worker helper was invoked once");
+        assert!(root.join("checkpoint.json").is_file());
     });
-    let worker_file = root.join("worker.json");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while !worker_file.is_file() && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(20));
-    }
-    assert!(
-        worker_file.is_file(),
-        "first scheduler persisted its worker"
-    );
-
-    let restarted = thread::spawn(|| {
-        AgentTaskScheduler::new(NoopExecutor)
-            .with_run_id("restart-run")
-            .run(postprocess_plan())
-    });
-    let first = first.join().expect("first scheduler");
-    let restarted = restarted.join().expect("restarted scheduler");
-
-    assert_eq!(first.status, AgentTaskAggregateStatus::Succeeded);
-    assert_eq!(restarted.status, AgentTaskAggregateStatus::Succeeded);
-    let versions = std::fs::read_dir(root.join("versions"))
-        .expect("versions")
-        .count();
-    assert_eq!(versions, 1, "live worker helper was invoked once");
-    assert!(root.join("checkpoint.json").is_file());
-    homeboy::core::set_artifact_root_override(None);
 }


### PR DESCRIPTION
## Summary
- preserve explicit `--path` checkout authority in full status output
- isolate scheduler restart fixtures under the shared hermetic home
- make installer archive handling independent of ambient `TAR_OPTIONS`
- compare shipped identity against compile-time provenance instead of live worktree dirtiness
- refresh reverse-runner staging documentation

Progresses #12607.

## Verification
- installer integration tests passed
- product identity binary tests passed
- postprocess worker startup tests passed
- explicit path full-status regression passed
- `cargo fmt --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode triaged CLI and integration failures, implemented fixture isolation and path-authority repairs, and ran focused verification. Chris Huber reviewed and remains responsible for every line.