### PR TITLE
Give the detached-handoff cluster explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -311,11 +311,38 @@ pub fn submit_plan(
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
-    submit_plan_with_runtime_admission(plan, requested_run_id, |run_id| {
-        homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(run_id, || {
-            Ok(store::read_record(run_id)?.state.is_terminal())
-        })
-    })
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    submit_plan_in_store(&lifecycle_store, plan, requested_run_id)
+}
+
+/// Submit a plan into an explicitly rooted store.
+///
+/// The admission cancellation check is the reach that has to move with the
+/// submission: it decides whether to abandon a queued admission by reading the
+/// run's own terminal state. Reading that ambiently would let another home's
+/// record of the same identity abandon this store's admission, or leave a
+/// cancellation recorded here unseen while the controller waits on the
+/// admission lock. The controller-runtime store itself stays process-global by
+/// design; only the lifecycle read is rooted here.
+pub(crate) fn submit_plan_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    submit_plan_with_runtime_admission_in_store(
+        lifecycle_store,
+        plan,
+        requested_run_id,
+        execution_runner_id(),
+        None,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        |run_id| {
+            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+                run_id,
+                || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
+            )
+        },
+    )
 }
 
 /// Persist the parent for a locally detached Cook before the detached process
@@ -325,8 +352,25 @@ pub fn submit_plan(
 /// An empty plan is intentional: this record owns only the handoff lifecycle,
 /// while the detached Cook persists the immutable execution plan and attempt.
 pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_detached_cook_handoff_parent_in_store(&lifecycle_store, cook_id)
+}
+
+/// Persist a detached Cook's handoff parent inside an explicitly rooted store.
+///
+/// Both admission guards read the store the parent is written into. The alias
+/// guard consults this store's own Cook index, so an attempt published in
+/// another home can neither reject a fresh parent here nor let one be minted
+/// over an attempt that already exists here. The collision guard is the same
+/// decision for the record: read ambiently, an unrelated run in another home
+/// could veto this parent, or the idempotent re-record of a live handoff could
+/// be misread as a collision.
+pub(crate) fn record_detached_cook_handoff_parent_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
-    let resolved_run_id = resolve_run_id(&cook_id)?;
+    let resolved_run_id = resolve_run_id_in_store(lifecycle_store, &cook_id)?;
     if resolved_run_id != cook_id {
         return Err(Error::validation_invalid_argument(
             "run_id",
@@ -335,7 +379,7 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
             None,
         ));
     }
-    if let Ok(record) = store::read_record(&cook_id) {
+    if let Ok(record) = lifecycle_store.read_record(&cook_id) {
         if record.metadata["detached_cook_handoff"]["cook_id"] == cook_id {
             return Ok(record);
         }
@@ -348,7 +392,7 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
     }
 
     let plan = AgentTaskPlan::new(format!("detached-cook-handoff-{cook_id}"), Vec::new());
-    let mut record = submit_plan(&plan, Some(&cook_id))?;
+    let mut record = submit_plan_in_store(lifecycle_store, &plan, Some(&cook_id))?;
     record.metadata["detached_cook_handoff"] = json!({
         "state": "pending",
         "admission_state": "pre_supervisor",
@@ -358,8 +402,9 @@ pub fn record_detached_cook_handoff_parent(cook_id: &str) -> Result<AgentTaskRun
         "cook_id": cook_id,
         "cancellation_fence": { "state": "open" },
     });
-    store::write_record(&record)?;
-    record_cook_progress(
+    lifecycle_store.write_record(&record)?;
+    record_cook_progress_in_store(
+        lifecycle_store,
         &record.run_id,
         "detached_handoff_pending",
         0,
@@ -374,6 +419,15 @@ pub fn require_detached_cook_handoff_fence_open(cook_id: &str) -> Result<()> {
     require_detached_cook_handoff_fence_open_in_store(&lifecycle_store, cook_id)
 }
 
+/// Read the durable cancellation fence from an explicitly rooted store.
+///
+/// The fence is a field on the handoff parent record, not a separate marker
+/// file, so rooting the record read roots the whole decision. It has to be the
+/// store the child will materialize its attempt into: a fence read from another
+/// home would let a cancelled handoff proceed here, or let an open one be
+/// refused because an unrelated parent elsewhere was cancelled. An absent or
+/// unreadable record is still an open fence — a parent that was never persisted
+/// cannot have been cancelled.
 pub(crate) fn require_detached_cook_handoff_fence_open_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
@@ -405,8 +459,26 @@ pub fn record_detached_cook_handoff_child(
     pid: u32,
     start_identity: homeboy_core::process::ProcessStartIdentity,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_detached_cook_handoff_child_in_store(&lifecycle_store, cook_id, pid, start_identity)
+}
+
+/// Attach the spawned child's identity inside an explicitly rooted store.
+///
+/// The cancellation state this write reads — the record's own run state and the
+/// fence it carries forward — is read inside the mutation, from the same store
+/// the mutation lands in. Ambient, another home's parent could decide whether
+/// this child is recorded as pending or already cancelled, and the durable
+/// identity cancellation later signals on could be attached to a record no
+/// cancellation in this store would ever reach.
+pub(crate) fn record_detached_cook_handoff_child_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    pid: u32,
+    start_identity: homeboy_core::process::ProcessStartIdentity,
+) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
-    let record = store::mutate_record(&cook_id, |record| {
+    let record = lifecycle_store.mutate_record(&cook_id, |record| {
         let cancelled = record.state == AgentTaskRunState::Cancelled;
         let state = if cancelled { "cancelled" } else { "pending" };
         let cancellation_fence =
@@ -431,9 +503,26 @@ pub fn record_detached_cook_handoff_child(
 
 /// Persist the daemon job that supervises this locally launched Cook.
 pub fn record_detached_cook_supervisor(cook_id: &str, job_id: &str) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_detached_cook_supervisor_in_store(&lifecycle_store, cook_id, job_id)
+}
+
+/// Persist the supervising daemon job inside an explicitly rooted store.
+///
+/// The ownership guard — that this record really is the named Cook's handoff
+/// parent — sits inside the mutation closure, so it is read from the store the
+/// write lands in. This is also the transition to `supervising`, the admission
+/// state that makes a lease live indefinitely, so a supervisor recorded against
+/// another home's parent would leave this store's admission to expire while a
+/// daemon was in fact supervising it.
+pub(crate) fn record_detached_cook_supervisor_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    cook_id: &str,
+    job_id: &str,
+) -> Result<()> {
     let cook_id = sanitize_run_id(cook_id);
     let job_id = job_id.to_string();
-    let _ = store::mutate_record(&cook_id, |record| {
+    let _ = lifecycle_store.mutate_record(&cook_id, |record| {
         if record.metadata["detached_cook_handoff"]["cook_id"] != cook_id {
             return false;
         }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -677,6 +677,287 @@ fn claim_family_siblings_coordinate_only_inside_the_injected_store() {
 }
 
 #[test]
+fn detached_handoff_siblings_advance_only_the_injected_store() {
+    // The detached-handoff cluster is admission state: a pending parent, the
+    // durable cancellation fence a child reads before it may materialize, and
+    // the child and supervisor identities that keep the admission lease live.
+    // Absence in a second root is too weak a negative for that — every one of
+    // these writes is equally "absent" from a root the work simply never
+    // reached. So both roots are seeded with the *same* parent in the *same*
+    // pre-supervisor shape, every act below is made through a sibling handed
+    // `seeded`, and the second root is then asserted to be still **eligible**:
+    // its handoff still pending, its fence still open, its admission still
+    // live, and its parent still able to take a child and a supervisor of its
+    // own. A write that leaked into an ambient root satisfies every positive
+    // assertion here and fails that (#7505).
+    //
+    // The two admission guards are proved directionally rather than by absence:
+    // the same call with the same Cook id is refused by one root and answered
+    // by the other, decided only by which store was injected.
+    //
+    // No environment is mutated: both roots come from
+    // `HermeticTestContext::path_roots()`.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let other_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), other_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let other =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(other_context.path_roots());
+
+    let handoff_cook_id = "rooted-detached-handoff-parent";
+    let indexed_cook_id = "rooted-detached-handoff-indexed";
+    let collision_cook_id = "rooted-detached-handoff-collision";
+    let indexed_attempt_run_id = "rooted-detached-handoff-indexed-attempt-1";
+    let plan = test_plan();
+
+    // The parent shape is reproduced rather than produced. The submit branch of
+    // `record_detached_cook_handoff_parent_in_store` runs controller admission,
+    // which is deliberately *not* a lifecycle root: it writes under
+    // `paths::controller_runtimes_store()` and takes a machine-global admission
+    // lock. Driving it here would reach the operator's real home and serialize
+    // against every peer test, so this test exercises the branches that decide
+    // *whether* to submit and never the submit itself. Every other function in
+    // this cluster is driven end to end.
+    let seed_pending_parent =
+        |lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore, cook_id: &str| {
+            lifecycle_store
+                .submit_plan_with_runtime_admission(&plan, cook_id, |_| Ok(json!({})))
+                .expect("submit a detached handoff parent identity");
+            lifecycle_store
+                .mutate_record(cook_id, |record| {
+                    record.ensure_metadata_object().insert(
+                        "detached_cook_handoff".to_string(),
+                        json!({
+                            "state": "pending",
+                            "admission_state": "pre_supervisor",
+                            "admission_deadline_at": (chrono::Utc::now()
+                                + chrono::Duration::seconds(3_600))
+                            .to_rfc3339(),
+                            "cook_id": cook_id,
+                            "cancellation_fence": { "state": "open" },
+                        }),
+                    );
+                    true
+                })
+                .expect("seed the pre-supervisor handoff shape");
+        };
+
+    for lifecycle_store in [&seeded, &other] {
+        seed_pending_parent(lifecycle_store, handoff_cook_id);
+        seed_pending_parent(lifecycle_store, indexed_cook_id);
+    }
+    // The collision guard's two answers, one per root, under one Cook id: an
+    // unrelated run in the first, this Cook's own handoff parent in the second.
+    seeded
+        .submit_plan_with_runtime_admission(&plan, collision_cook_id, |_| Ok(json!({})))
+        .expect("submit an unrelated run under the Cook id in the first root");
+    seed_pending_parent(&other, collision_cook_id);
+    // The alias guard's evidence, published in the first root only.
+    seeded
+        .write_cook_index_attempt(
+            indexed_cook_id,
+            1,
+            indexed_attempt_run_id,
+            now_timestamp(),
+            None,
+        )
+        .expect("publish a Cook attempt alias in the first root only");
+
+    // Re-recording a live handoff parent is the idempotent branch: it answers
+    // from the injected store's own record instead of submitting a second one.
+    let readmitted = record_detached_cook_handoff_parent_in_store(&seeded, handoff_cook_id)
+        .expect("re-record the live handoff parent in the injected store");
+    assert_eq!(readmitted.run_id, handoff_cook_id);
+    assert_eq!(
+        readmitted.metadata["detached_cook_handoff"]["admission_state"],
+        "pre_supervisor"
+    );
+    assert!(
+        readmitted.metadata.get("cook_progress").is_none(),
+        "the idempotent branch must answer from the durable parent, not submit a new one"
+    );
+
+    // The alias guard, both directions. Only the first root published the Cook
+    // index, so only the first root refuses.
+    let aliased = record_detached_cook_handoff_parent_in_store(&seeded, indexed_cook_id)
+        .expect_err("an indexed Cook attempt refuses a fresh handoff parent");
+    assert_eq!(
+        aliased.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert_eq!(
+        aliased.message,
+        "detached Cook id already resolves to an existing Cook attempt"
+    );
+    assert_eq!(
+        record_detached_cook_handoff_parent_in_store(&other, indexed_cook_id)
+            .expect("the second root published no alias and answers from its own parent")
+            .metadata["detached_cook_handoff"]["admission_state"],
+        "pre_supervisor",
+        "an alias published in the injected store must not decide the second root"
+    );
+
+    // The collision guard, both directions, under one Cook id.
+    let collided = record_detached_cook_handoff_parent_in_store(&seeded, collision_cook_id)
+        .expect_err("an unrelated run under the Cook id refuses a handoff parent");
+    assert_eq!(
+        collided.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert_eq!(
+        collided.message,
+        "detached Cook id collides with an existing non-handoff run"
+    );
+    assert_eq!(
+        record_detached_cook_handoff_parent_in_store(&other, collision_cook_id)
+            .expect("the second root holds this Cook's own handoff parent")
+            .run_id,
+        collision_cook_id
+    );
+
+    // The fence is open in both roots, so the child may proceed in either.
+    require_detached_cook_handoff_fence_open_in_store(&seeded, handoff_cook_id)
+        .expect("an open fence admits the child in the injected store");
+
+    // Attach the child, then the supervisor, through the injected store only.
+    let child_pid = 424_242;
+    let start_identity = homeboy_core::process::ProcessStartIdentity::Linux {
+        starttime_ticks: 4_242,
+    };
+    let attached = record_detached_cook_handoff_child_in_store(
+        &seeded,
+        handoff_cook_id,
+        child_pid,
+        start_identity.clone(),
+    )
+    .expect("attach the child identity in the injected store");
+    assert_eq!(
+        attached.metadata["detached_cook_handoff"]["admission_state"],
+        "child_attached"
+    );
+    assert_eq!(
+        attached.metadata["detached_cook_handoff"]["child_pid"],
+        child_pid
+    );
+    assert_eq!(
+        attached.metadata["detached_cook_handoff"]["cancellation_fence"]["state"], "open",
+        "attaching a child carries the durable fence forward"
+    );
+
+    record_detached_cook_supervisor_in_store(&seeded, handoff_cook_id, "daemon-job-rooted")
+        .expect("attach the supervising daemon job in the injected store");
+
+    // The positive: every write is durable in the store that was handed in.
+    let supervised = seeded
+        .read_record(handoff_cook_id)
+        .expect("read the injected store's handoff parent back");
+    assert_eq!(
+        supervised.metadata["detached_cook_handoff"]["supervisor_job_id"],
+        "daemon-job-rooted"
+    );
+    assert_eq!(
+        supervised.metadata["detached_cook_handoff"]["admission_state"],
+        "supervising"
+    );
+    assert_eq!(
+        supervised.metadata["detached_cook_handoff"]["reattach_command"],
+        format!("homeboy agent-task status {handoff_cook_id} --full")
+    );
+    // A supervised admission is live without consulting the process table, so
+    // the predicates are decided by the record alone.
+    let now = chrono::Utc::now();
+    assert!(has_pending_detached_cook_handoff(&supervised));
+    assert!(detached_cook_admission_is_live(&supervised, now));
+    assert!(!has_expired_detached_cook_admission(&supervised, now));
+
+    // Close the fence in the injected store only. The fence is the one piece of
+    // handoff state a *child process* reads on its own, so proving it is read
+    // from the store it was handed is the point of this pair.
+    seeded
+        .mutate_record(handoff_cook_id, |record| {
+            record.metadata["detached_cook_handoff"]["cancellation_fence"]["state"] =
+                json!("cancelled");
+            true
+        })
+        .expect("close the injected store's cancellation fence");
+    let fenced = require_detached_cook_handoff_fence_open_in_store(&seeded, handoff_cook_id)
+        .expect_err("a cancelled fence refuses the child in the store that holds it");
+    assert_eq!(
+        fenced.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert_eq!(
+        fenced.message,
+        "detached Cook handoff was cancelled before its attempt could materialize"
+    );
+
+    // The negative: the second root holds the same identity and saw none of it.
+    // Absence first.
+    let untouched = other
+        .read_record(handoff_cook_id)
+        .expect("the second root still has its own handoff parent");
+    assert_eq!(untouched.state, AgentTaskRunState::Queued);
+    assert_eq!(
+        untouched.metadata["detached_cook_handoff"]["admission_state"],
+        "pre_supervisor"
+    );
+    for key in [
+        "child_pid",
+        "child_start_identity",
+        "child_supervisor_deadline_at",
+        "supervisor_job_id",
+        "reattach_command",
+    ] {
+        assert!(
+            untouched.metadata["detached_cook_handoff"]
+                .get(key)
+                .is_none(),
+            "second root must not observe `{key}` written through the injected store"
+        );
+    }
+
+    // Then the stronger half: the second root is not merely missing the
+    // evidence, it is still *eligible*. Its handoff is still pending, its fence
+    // is still open, its admission lease is still live, and its parent will
+    // still accept the child and supervisor the injected store already took —
+    // none of which is true of state some other call already consumed.
+    assert!(has_pending_detached_cook_handoff(&untouched));
+    assert!(
+        detached_cook_admission_is_live(&untouched, now),
+        "the injected store's supervisor must not have consumed the second root's lease"
+    );
+    assert!(!has_expired_detached_cook_admission(&untouched, now));
+    assert_eq!(
+        untouched.metadata["detached_cook_handoff"]["cancellation_fence"]["state"],
+        "open"
+    );
+    require_detached_cook_handoff_fence_open_in_store(&other, handoff_cook_id)
+        .expect("the fence closed in the injected store must leave the second root's fence open");
+    assert_eq!(
+        record_detached_cook_handoff_child_in_store(
+            &other,
+            handoff_cook_id,
+            child_pid,
+            start_identity,
+        )
+        .expect("the second root's parent still accepts its own child")
+        .metadata["detached_cook_handoff"]["admission_state"],
+        "child_attached"
+    );
+    record_detached_cook_supervisor_in_store(&other, handoff_cook_id, "daemon-job-second-root")
+        .expect("the second root's parent still accepts its own supervisor");
+    assert_eq!(
+        other
+            .read_record(handoff_cook_id)
+            .expect("read the second root's parent back")
+            .metadata["detached_cook_handoff"]["supervisor_job_id"],
+        "daemon-job-second-root"
+    );
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a


### PR DESCRIPTION
## Summary

Continues rooting `lifecycle_ops.rs` after the read surface (#12603), the Cook write family (#12604), and the run-claim family (#12608). This takes the **detached Cook handoff cluster**, including `require_detached_cook_handoff_fence_open` — which **#12582 named as one of the Cook spine's remaining ambient reaches.**

| function | ambient reach it had |
|---|---|
| `record_detached_cook_handoff_parent` | `resolve_run_id`, `store::read_record`, `submit_plan`, `store::write_record`, `record_cook_progress` |
| `require_detached_cook_handoff_fence_open` | `store::read_record` |
| `record_detached_cook_handoff_child` | `store::mutate_record` |
| `record_detached_cook_supervisor` | `store::mutate_record` |
| **`submit_plan`** | **not in the original scope — see below** |

Already rooted by prior slices and untouched: `reserve_detached_cook_handoff_materialization`, `cancel_reserved_detached_cook_handoff_attempt_if_cancelled`, `fail_detached_cook_handoff_parent`, `expire_detached_cook_admission`.

## Three deliberately get no sibling

`has_pending_detached_cook_handoff`, `detached_cook_admission_is_live`, and `has_expired_detached_cook_admission` are **pure** over a `&AgentTaskRunRecord`, a caller-supplied `now`, and the process table. Their only helpers are a kernel start-identity check and an RFC3339 parse of record metadata — neither touches a root. #12608's own doc comment on `expire_detached_cook_admission_in_store` already asserts this, and it holds.

A sibling here would take a parameter it could not use — noise, and worse, it would imply a rooting decision exists where none does. They are **exercised** by the new test instead, on records read out of each store.

## One that was missing from the cluster

**`submit_plan`.** The parent recorder calls it, and its admission closure is `Ok(store::read_record(run_id)?.state.is_terminal())` — evaluated while queued on the admission lock. Rooted as a sibling rather than inlined, so the ambient wiring (`execution_runner_id()`, the admission-status probe) does not exist in two places and drift.

## The guards are why this matters — each fails silently in the dangerous direction

<callout accent="#ef4444">
**Alias guard** (`resolve_run_id`) — ambient, **this store's own published attempt goes unseen and a second parent is minted over a live Cook.**

**Collision guard** (`store::read_record`) — decides between returning the live parent idempotently and refusing an id belonging to someone else. Ambient, **a re-record of a live handoff reads as absent and falls through to submit a second record.**

**Return value** — the parent recorder's return is a `record_cook_progress` call. Ambient, the parent lands in the injected store while the `detached_handoff_pending` marker lands elsewhere, **and the caller gets the ambient record back.** Exactly the #12604 shape.
</callout>

The child and supervisor guards live **inside** their `mutate_record` closures and read only the record handed to them, so rooting the mutation roots them — verified they read no second source. The supervisor one also drives the transition to `admission_state: "supervising"`, the state that makes a lease live indefinitely: a supervisor attached to the wrong home's parent would leave *this* store's admission to expire under a daemon that is in fact supervising it.

## No sidecar files here — checked specifically

Unlike the Cook-notification cluster that bit #12604 and #12608, this one has **no marker file**. The cancellation fence, admission deadline, `child_pid`, `child_start_identity`, and `supervisor_job_id` are all **fields on the handoff parent record**, so rooting the record read/write roots the entire fence-and-lease surface.

The one path-derived thing in reach is the Cook index, consulted only through `lifecycle_store.read_cook_index` via `resolve_run_id_in_store` — already rooted, **not** the module-private `cook_index_path()` that bit #12604.

## The root deliberately not moved

`controller_runtime`'s store (`paths::controller_runtimes_store()`), reached by `admit_current_for_with_cancellation_check` inside `submit_plan_in_store`. Process-global by design — #12608 already documented it as "the one root that is deliberately not a lifecycle root". Only the lifecycle read inside its closure moved. Said so in the doc comment so nobody later reads it as a miss.

## Shadowing audit

Each new sibling body extracted and scanned for `store::`, `default_store`, `paths::`, `from_current_environment`, `from_data_root`, `ObservationStore::`, `open_readonly()`:

```
submit_plan_in_store                                14 lines   clean
record_detached_cook_handoff_parent_in_store        41 lines   clean
require_detached_cook_handoff_fence_open_in_store   18 lines   clean
record_detached_cook_handoff_child_in_store         22 lines   clean
record_detached_cook_supervisor_in_store            13 lines   clean
```

The #12591 scanner's logic was also run over `crates/homeboy-agents/src`: **one finding**, `run_cook_with_boundaries_reported`, the sole existing allowlist row. No new entry, none stale.

## What could not be driven hermetically

The **submit branch** of the parent recorder. It reaches `admit_current_for_with_cancellation_check`, which `create_dir_all`s and writes an active-generation file under `paths::controller_runtimes_store()` — **the operator's real home** — and takes a machine-global advisory lock that would serialize against every peer test. Driving it needs `with_isolated_home`, which is exactly what this campaign is retiring.

So the test proves the branches that decide **whether** to submit — alias guard, collision guard, idempotent return — in both directions, and not the submit itself. Same class of limit #12608 hit with `mark_running`. Parent shape is seeded by hand rather than scaffolding around the global lock.

## The proof goes past absence into eligibility

`detached_handoff_siblings_advance_only_the_injected_store`. Two `HermeticTestContext::path_roots()` roots — no `with_isolated_home`, no `HomeGuard`, no `set_var`. Both roots seeded with the **same** cook id in the **same** `pre_supervisor` / `pending` / fence-`open` shape.

**Absence:** the second root shows no `child_pid`, `child_start_identity`, `child_supervisor_deadline_at`, `supervisor_job_id`, or `reattach_command`; still `Queued`, still `pre_supervisor`.

**Past absence — still eligible:**

- `has_pending_detached_cook_handoff(&untouched)` — handoff still pending
- fence still `"open"`, and `require_detached_cook_handoff_fence_open_in_store(&other, …)` returns `Ok` **after the same fence was closed in `seeded`**
- `detached_cook_admission_is_live(&untouched, now)` — `seeded`'s supervisor did not consume it
- `record_detached_cook_handoff_child_in_store(&other, …)` still reaches `child_attached`; the supervisor recorder still records its own job

**Two directional pairs**, sharper than absence — the *same call on the same cook id* gets opposite answers decided only by which store was injected:

- **alias guard** — `seeded` fails `validation.invalid_argument` / *"already resolves to an existing Cook attempt"*, while `other` answers `pre_supervisor` from its own parent
- **collision guard** — `seeded` fails *"collides with an existing non-handoff run"*, `other` returns the parent

Plus one small load-bearing positive: the idempotent branch's returned record has **no `cook_progress`**, proving it answered from the injected store's durable parent rather than falling through and submitting a second one.

## Compatibility

Purely additive plus delegation. No existing signature or behavior changes. No caller migrated. `home_lock` / `HomeGuard` / `with_isolated_home` untouched.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Implementation, guard threading, test authoring, and mechanical shadowing audit. Review by hand; compilation deferred to CI.

Refs #7505
