### PR TITLE
test: repair candidate baseline across all shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,9 +241,10 @@ jobs:
     # archive instead of recompiled in every shard), and #379 (a passing
     # candidate no longer reruns its baseline), #380 (the differential audit is
     # changed-scoped instead of scanning the whole repository), #381 (shard
-    # partitioning coverage), and #402 (immutable extension revisions). Refs
+    # partitioning coverage), #402 (immutable extension revisions), and #405
+    # (downloaded Test archives stay out of consumer Git state). Refs
     # #10997 and #11751 W1-2, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@dc9284c9fdab54dca08c4b389294f37406a2b0a6
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@ae5161e2ce2d5818c41a4b09ae811d1521bb4f95
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
       args: --skip-lint
       expected-commands: review audit,review lint,review test
       component: homeboy
-      extension-ref: aeb1babffa6a3cd22301846302a2769d92e4ee13
+      extension-ref: 691d0527d7a4b3917649043a7f91a81913a139ab
       source: .
       scope: auto
       differential-gating: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
     if: ${{ needs.pr-state.outputs.active == 'true' }}
-    # v2.11.26, DEREFERENCED to its commit. These tags are annotated, so the tag
+    # Pinned to a commit. Release tags are annotated, so the tag
     # ref's own object SHA is a tag object, which `uses:` cannot resolve — pinning
     # one fails the whole workflow at startup with zero jobs scheduled (#12153).
     # Always pin `git rev-parse v<tag>^{commit}`.
@@ -240,9 +240,10 @@ jobs:
     # no-enforcement green), #378 (test binaries built once into a nextest
     # archive instead of recompiled in every shard), and #379 (a passing
     # candidate no longer reruns its baseline), #380 (the differential audit is
-    # changed-scoped instead of scanning the whole repository) and #381 (shard
-    # partitioning coverage). Refs #10997 and #11751 W1-2, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@3b20c22160bceb5c324fb2643ab7215e7cf73a53
+    # changed-scoped instead of scanning the whole repository), #381 (shard
+    # partitioning coverage), and #402 (immutable extension revisions). Refs
+    # #10997 and #11751 W1-2, W1-7, W1-10.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@dc9284c9fdab54dca08c4b389294f37406a2b0a6
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which
@@ -257,6 +258,7 @@ jobs:
       args: --skip-lint
       expected-commands: review audit,review lint,review test
       component: homeboy
+      extension-ref: aeb1babffa6a3cd22301846302a2769d92e4ee13
       source: .
       scope: auto
       differential-gating: 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "homeboy-core",
+ "homeboy-rig",
  "serde",
  "serde_json",
 ]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4635,7 +4635,7 @@ where
             }
             let mut failed_dispatch_plan = None;
             let execution = (|| {
-                if options.attempt_dispatcher.is_none() {
+                if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
                     validate_cook_workspace(&options)?;
                 }
                 if options.attempt_dispatcher.is_none() {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4243,7 +4243,7 @@ where
     // requiring one here turns an accepted detached retry into a local failure.
     if cook_attempt_needs_execution_with_store(lifecycle_store, &options.initial_run_id)
         && !cook_workspace_lookup_pending(&options.initial_plan)
-        && options.attempt_dispatcher.is_none()
+        && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(&options)?;
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6718,7 +6718,7 @@ fn run_cook_persists_recipe_in_explicit_store_only() {
         let result = run_cook_with_store(&store, options, UnusedExecutor)
             .expect("Cook reports the lifecycle materialization failure");
 
-        assert_eq!(result.value.status, "pre_execution_failure");
+        assert_eq!(result.value.status, "durable_failure");
         assert!(store.recipe_exists(cook_id));
         assert!(!super::super::recipe_exists(cook_id).expect("ambient recipe lookup"));
     });

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5168,7 +5168,21 @@ fn cook_failure_context_counts_preflight_cook_alias_as_zero_execution() {
         super::super::record_recipe_attempt(cook_id, 2, &provider_run_id, &options.initial_plan)
             .expect("append provider attempt to recipe");
         agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&provider_run_id))
-            .expect("materialize independent provider attempt");
+            .expect("submit provider attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, &provider_run_id)
+            .expect("index provider attempt");
+        assert_eq!(
+            agent_task_lifecycle::status(cook_id)
+                .expect("resolve Cook alias to provider attempt")
+                .run_id,
+            provider_run_id
+        );
+        assert_eq!(
+            agent_task_lifecycle::exact_record(cook_id)
+                .expect("retain exact preflight record")
+                .metadata["provider_executions_consumed"],
+            0
+        );
         assert_eq!(
             agent_task_lifecycle::reserve_provider_execution(
                 &provider_run_id,
@@ -6704,7 +6718,7 @@ fn run_cook_persists_recipe_in_explicit_store_only() {
         let result = run_cook_with_store(&store, options, UnusedExecutor)
             .expect("Cook reports the lifecycle materialization failure");
 
-        assert_eq!(result.value.status, "durable_failure");
+        assert_eq!(result.value.status, "pre_execution_failure");
         assert!(store.recipe_exists(cook_id));
         assert!(!super::super::recipe_exists(cook_id).expect("ambient recipe lookup"));
     });

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3589,9 +3589,12 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
             ],
         );
 
+        let dispatches = Arc::new(AtomicUsize::new(0));
         let mut options = batch_cook_options(
             "removed-managed-continuation",
-            Arc::new(AcceptedDetachedAttemptDispatcher),
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: dispatches.clone(),
+            }),
         );
         options.to_worktree = "fixture@removed-continuation".to_string();
         options.source_worktree_path = Some(target.clone());
@@ -3599,7 +3602,9 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
         let recipe = super::super::load_recipe(&options.cook_id).expect("load Cook recipe");
         let reconstructed = super::super::reconstruct_options_with_dispatcher(
             &recipe,
-            Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+            Some(Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: dispatches.clone(),
+            })),
         )
         .expect("reconstruct persisted Cook options");
 
@@ -3644,7 +3649,8 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
         let result = run_cook(reconstructed, UnusedExecutor)
             .expect("durable Cook failure report before provider execution");
         assert_eq!(result.exit_code, 1);
-        assert_eq!(result.value.status, "pre_execution_failure");
+        assert_eq!(result.value.status, "durable_failure");
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
     });
 }
 
@@ -5161,8 +5167,8 @@ fn cook_failure_context_counts_preflight_cook_alias_as_zero_execution() {
         let provider_run_id = format!("{cook_id}-attempt-2");
         super::super::record_recipe_attempt(cook_id, 2, &provider_run_id, &options.initial_plan)
             .expect("append provider attempt to recipe");
-        super::super::materialize_cook_attempt(cook_id, &provider_run_id, &options.initial_plan)
-            .expect("materialize provider attempt");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&provider_run_id))
+            .expect("materialize independent provider attempt");
         assert_eq!(
             agent_task_lifecycle::reserve_provider_execution(
                 &provider_run_id,
@@ -5966,7 +5972,7 @@ fn cook_publishes_durable_identity_before_materialization_and_survives_interrupt
 
         // 3. The interruption left a named, recoverable record — not an
         //    anonymous reservation an operator has to hunt for.
-        assert_eq!(result.value.status, "durable_failure");
+        assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("record survives interruption");
         assert_eq!(
             record.metadata["pre_execution_failure"]["phase"],

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -2378,7 +2378,7 @@ fn detached_cook_without_a_lab_runner_does_not_fall_back_to_local_execution() {
 }
 
 #[test]
-fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry() {
+fn lab_cook_defers_provider_destination_and_retry_refuses_unbound_plan() {
     crate::test_support::with_isolated_home(|_| {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path());
@@ -2490,10 +2490,10 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
         let plan = materialize_agent_task_cook_plan(&cook_cli, None)
             .expect("materialize cook plan")
             .expect("cook plan");
-        let expected_root = provider_workspace.display().to_string();
+        assert_eq!(plan.tasks[0].workspace.root, None);
         assert_eq!(
-            plan.tasks[0].workspace.root.as_deref(),
-            Some(expected_root.as_str())
+            plan.tasks[0].metadata["worktree_provision"]["action"],
+            "lookup_pending"
         );
         assert_eq!(
             plan.tasks[0].metadata["worktree_provision"]["handle"],
@@ -2513,18 +2513,13 @@ fn lab_cook_materializes_derived_provider_destination_and_preserves_it_for_retry
             .map(str::to_string)
             .collect::<Vec<_>>();
         let retry_cli = Cli::parse_from(&retry_args);
-        let handoff = materialize_agent_task_retry_handoff(&retry_cli, &retry_args)
-            .expect("materialize retry handoff")
-            .expect("retry handoff");
-
-        assert_eq!(
-            handoff.primary_workspace,
-            provider_workspace.canonicalize().expect("root")
-        );
-        assert_eq!(
-            handoff.plan.tasks[0].workspace.root.as_deref(),
-            Some(expected_root.as_str())
-        );
+        let error = match materialize_agent_task_retry_handoff(&retry_cli, &retry_args) {
+            Err(error) => error,
+            Ok(_) => {
+                panic!("retry must not substitute the controller cwd for an unresolved workspace")
+            }
+        };
+        assert!(error.message.contains("original persisted plan has none"));
     });
 }
 

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -2229,7 +2229,8 @@ mod tests {
                     assert_eq!(report.components.len(), 1);
                     assert_eq!(report.components[0].id, "wordpress-playground");
                     assert_eq!(
-                        std::path::Path::new(&report.components[0].path)
+                        std::path::Path::new(&report.context.cwd)
+                            .join(&report.components[0].path)
                             .canonicalize()
                             .expect("reported component path"),
                         repo.canonicalize().expect("fixture component path")

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -847,12 +847,31 @@ fn run_path_status(
 ) -> CmdResult<StatusResult> {
     let path = args.scope.path.as_deref();
     timer.begin("resolve_path_component");
-    let component = component::resolve_effective(args.target.as_deref(), path, None)?;
+    let mut component = component::resolve_effective(args.target.as_deref(), path, None)?;
+    if let Some(path) = path {
+        // An explicit ID gives this report its stable identity; `--path` is the
+        // checkout override and must remain the component's inspected source.
+        component.local_path = path.to_string();
+    }
     timer.finish("resolve_path_component");
 
     if args.full {
+        let component_id = component.id.clone();
+        let component_path = component.local_path.clone();
         let mut report = context::build_report_for_component(args.all, "status", component, path)?;
         report.command = "status".to_string();
+        // The focused component may have been resolved through an explicit ID,
+        // but `--path` remains the context the operator asked to inspect.
+        if let Some(path) = path {
+            report.context.cwd = path.to_string();
+        }
+        if let Some(summary) = report
+            .components
+            .iter_mut()
+            .find(|summary| summary.id == component_id)
+        {
+            summary.path = component_path;
+        }
         return Ok((StatusResult::Full(Box::new(report)), 0));
     }
 

--- a/crates/homeboy-cli/src/commands/utils/scope_boundary_tests.rs
+++ b/crates/homeboy-cli/src/commands/utils/scope_boundary_tests.rs
@@ -2,7 +2,8 @@
 //!
 //! #10312 asked for `Scope` to be promoted to a clap arg group and flattened
 //! into eight commands. Three of them (`triage landing`, `build`, `status`)
-//! migrated in #10510. The other five did **not**, and each refusal is a real
+//! migrated in #10510. `build` later moved under `review`; the other five did
+//! **not** migrate, and each refusal is a real
 //! property of that command's argument shape rather than an omission:
 //!
 //! | Command | Why it is not one scope |
@@ -29,7 +30,7 @@ use clap::{Command, CommandFactory, Parser};
 const SHARED_GROUP: [&str; 6] = ["project", "fleet", "component", "rig", "path", "workspace"];
 
 /// The command nodes #10510 migrated onto the shared group.
-const MIGRATED: [&[&str]; 3] = [&["triage", "landing"], &["build"], &["status"]];
+const MIGRATED: [&[&str]; 2] = [&["triage", "landing"], &["status"]];
 
 fn parses(argv: &[&str]) -> bool {
     Cli::try_parse_from(argv).is_ok()

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -1818,6 +1818,14 @@ pub fn recover_missing_child_identity(
             None,
         )
     })?;
+    if pid_is_running(recorded_daemon_pid) {
+        return Err(Error::validation_invalid_argument(
+            "recorded_daemon_pid",
+            "recorded daemon PID became live or was reused during recovery",
+            Some(recorded_daemon_pid.to_string()),
+            None,
+        ));
+    }
     let store = super::JobStore::open_without_reconciliation(crate::paths::daemon_jobs_file()?)?;
     store.recover_missing_child_identity_with_linux_evidence(
         expected_lease_id,

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -1649,6 +1649,7 @@ mod tests {
                 .expect("observe original exit"),
             "the pidfd must observe its bound process exiting"
         );
+        original.wait().expect("reap original process");
         let mut replacement = Command::new("sh")
             .args(["-c", "while :; do sleep 1; done"])
             .spawn()
@@ -1666,7 +1667,6 @@ mod tests {
         );
         assert!(pid_is_running(replacement.id()));
 
-        original.wait().expect("reap original process");
         replacement.kill().expect("cleanup replacement process");
         replacement.wait().expect("reap replacement process");
     }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -24,6 +24,8 @@ use super::delegated::{
 use super::resource_monitor::ChildResourceMonitor;
 use super::CommandOutput;
 
+const PIPED_STDIN_FINISH_GRACE: Duration = Duration::from_millis(100);
+
 pub fn execute_local_command(command: &str) -> CommandOutput {
     execute_local_command_in_dir(command, None, None)
 }
@@ -303,13 +305,20 @@ pub(crate) enum StdinSource {
 pub(crate) struct StdinPump {
     cancelled: Arc<AtomicBool>,
     cancellable: bool,
+    completed: std::sync::mpsc::Receiver<()>,
     handle: thread::JoinHandle<std::io::Result<()>>,
 }
 
 impl StdinPump {
     pub(crate) fn finish_after_child(self) -> Option<std::io::Result<()>> {
         if self.cancellable {
-            self.cancelled.store(true, Ordering::Release);
+            if self
+                .completed
+                .recv_timeout(PIPED_STDIN_FINISH_GRACE)
+                .is_err()
+            {
+                self.cancelled.store(true, Ordering::Release);
+            }
         }
         self.handle.join().ok()
     }
@@ -324,13 +333,19 @@ pub(crate) fn spawn_stdin_pump(pipe: ChildStdin, source: StdinSource) -> StdinPu
         .metadata()
         .map(|metadata| metadata.file_type().is_file())
         .unwrap_or(false));
-    let handle = thread::spawn(move || match source {
-        StdinSource::Reader(mut reader) => copy_stdin_to_child(reader.as_mut(), pipe),
-        StdinSource::Piped(reader) => copy_piped_stdin_to_child(reader, pipe, pump_cancelled),
+    let (completed_tx, completed) = std::sync::mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = match source {
+            StdinSource::Reader(mut reader) => copy_stdin_to_child(reader.as_mut(), pipe),
+            StdinSource::Piped(reader) => copy_piped_stdin_to_child(reader, pipe, pump_cancelled),
+        };
+        let _ = completed_tx.send(());
+        result
     });
     StdinPump {
         cancelled,
         cancellable,
+        completed,
         handle,
     }
 }
@@ -994,6 +1009,28 @@ fn bounded_redacted_tail(output: &str, redaction_values: &[String]) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn assert_pid_reaped(pid: libc::pid_t) {
+        assert!(
+            !crate::process::pid_is_running(pid as u32),
+            "process {pid} was not reaped"
+        );
+    }
+
+    #[cfg(unix)]
+    fn pipe_files() -> (std::fs::File, std::fs::File) {
+        use std::os::fd::FromRawFd;
+
+        let mut descriptors = [0; 2];
+        assert_eq!(unsafe { libc::pipe(descriptors.as_mut_ptr()) }, 0, "pipe");
+        unsafe {
+            (
+                std::fs::File::from_raw_fd(descriptors[0]),
+                std::fs::File::from_raw_fd(descriptors[1]),
+            )
+        }
+    }
+
     fn supervision_output(run_dir: &tempfile::TempDir) -> serde_json::Value {
         let payload = std::fs::read_to_string(
             run_dir
@@ -1032,12 +1069,55 @@ mod tests {
         #[cfg(unix)]
         {
             let pid = supervision["child_pid"].as_i64().expect("child pid") as libc::pid_t;
-            assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child was reaped");
-            assert_eq!(
-                std::io::Error::last_os_error().raw_os_error(),
-                Some(libc::ESRCH)
-            );
+            assert_pid_reaped(pid);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn finite_piped_stdin_drains_before_child_completion_is_collected() {
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        let output_path = output.path().to_string_lossy().to_string();
+        let (reader, mut writer) = pipe_files();
+        writer
+            .write_all(b"finite piped stdin")
+            .expect("write input");
+        drop(writer);
+
+        let result = execute_local_command_in_dir_impl(
+            &format!("cat > {}", crate::engine::shell::quote_arg(&output_path)),
+            None,
+            None,
+            None,
+            Some(StdinSource::Piped(reader)),
+        );
+
+        assert!(result.success, "{}", result.stderr);
+        assert_eq!(
+            std::fs::read(output.path()).expect("read output"),
+            b"finite piped stdin"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idle_piped_stdin_is_cancelled_after_child_completion() {
+        let (reader, _writer) = pipe_files();
+        let started = Instant::now();
+
+        let result = execute_local_command_in_dir_impl(
+            "exit 0",
+            None,
+            None,
+            None,
+            Some(StdinSource::Piped(reader)),
+        );
+
+        assert!(result.success, "{}", result.stderr);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "idle stdin forwarding must remain bounded"
+        );
     }
 
     #[test]
@@ -1122,11 +1202,7 @@ mod tests {
         assert_eq!(supervision["status"], "interrupted");
         assert_eq!(supervision["cancellation_reason"], "signal:15");
         let pid = supervision["child_pid"].as_i64().expect("child pid") as libc::pid_t;
-        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child was reaped");
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::ESRCH)
-        );
+        assert_pid_reaped(pid);
     }
 
     #[cfg(unix)]
@@ -1141,10 +1217,6 @@ mod tests {
             .stdout
             .parse::<libc::pid_t>()
             .expect("descendant pid");
-        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "descendant was reaped");
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::ESRCH)
-        );
+        assert_pid_reaped(pid);
     }
 }

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2314,12 +2314,11 @@ mod tests {
     #[cfg(unix)]
     fn assert_pid_reaped(pid: libc::pid_t) {
         let deadline = Instant::now() + Duration::from_secs(2);
-        while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+        while crate::process::pid_is_running(pid as u32) && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }
-        assert_ne!(
-            unsafe { libc::kill(pid, 0) },
-            0,
+        assert!(
+            !crate::process::pid_is_running(pid as u32),
             "hermetic cleanup left descendant {pid} alive"
         );
     }

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -358,7 +358,30 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                That emptiness is not laundered into a release, because \
                `release-asset-completeness.sh` independently requires every declared sidecar to \
                be present and non-empty before publication -- this script normalizes bytes, that \
-               one decides.",
+                one decides.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the only green outcome is `executed`, after every declared required \
+               context has been independently observed in this run with a success conclusion and \
+               every dependency result is success. Both the declared policy population and the \
+               observed jobs are non-empty before this aggregate can pass; unreadable run jobs, \
+               missing contexts, skipped dependencies, and failed contexts all exit 1.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: every non-executed outcome is a refusal: absent or unreadable input, \
+               no declared contexts, a skipped dependency, a missing job, or a non-success \
+               conclusion. This terminal exit cannot manufacture a green verdict; it is \
+               registered so the scan records the script's complete terminal contract.",
     },
     GateLayerSite {
         file: ".github/ci-required-gates-executed.sh",

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -361,6 +361,22 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                one decides.",
     },
     GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the terminal gate first proves the declared context population is non-empty, then evaluates every required dependency and check-run conclusion before passing.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 1",
+        basis: MeasurementBasis::Projection,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: projects a refusal after the script establishes an inactive run, missing context, skipped dependency, or non-successful gate. A non-zero exit cannot manufacture a pass.",
+    },
+    GateLayerSite {
         file: ".github/release-asset-completeness.sh",
         decision: "exit 0",
         basis: MeasurementBasis::PerUnitEvaluation,

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -814,9 +814,19 @@ fn persisted_session_version_drift_rejects_admission_with_bounded_recovery() {
     );
     assert_eq!(warning.session_homeboy_version, "0.327.9");
     assert_eq!(warning.active_daemon_control_plane_version, "0.328.0");
+    let actions = warning.safe_recovery_actions();
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].id, "runner.refresh_homeboy");
     assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
+        actions[0].args,
+        [
+            "runner",
+            "refresh-homeboy",
+            "homeboy-lab",
+            "--ref",
+            "1e63f1ae0369",
+            "--reconnect",
+        ]
     );
 }
 
@@ -1069,9 +1079,10 @@ fn dirty_controller_preserves_a_runner_side_daemon_recovery() {
         warning.mismatch_predicate,
         "active_daemon_control_plane_version != job_command_binary_version"
     );
-    assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
+    let actions = warning.safe_recovery_actions();
+    assert!(
+        actions.is_empty(),
+        "the active daemon does not verify this recovery target"
     );
     assert!(!warning.message.contains("upgrade --force"));
 }
@@ -1209,10 +1220,9 @@ fn runtime_path_diagnostics_redact_sensitive_values_without_hiding_path_drift() 
     assert!(!serialized.contains("old-secret"));
     assert!(!serialized.contains("new-secret"));
     assert!(serialized.contains("/srv/extensions?token=[REDACTED]"));
-    assert_eq!(
-        warning.recovery_commands,
-        ["homeboy runner refresh-homeboy homeboy-lab --ref 1e63f1ae0369 --reconnect"]
-    );
+    let actions = warning.safe_recovery_actions();
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].id, "runner.refresh_homeboy");
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -278,6 +278,15 @@ fn probe_daemon_health_until_durable(
             Ok(report) => return Err(DaemonHealthProbeFailure::IdentityMismatch(Box::new(report))),
             Err(message) => {
                 attempts.push(format!("durability observation {observation}: {message}"));
+                if !tunnel_process_identity_matches(tunnel_pid, tunnel_process_start_identity) {
+                    attempts.push(format!(
+                        "durability observation {observation}: owned tunnel process exited or changed identity after health failure"
+                    ));
+                    return Err(DaemonHealthProbeFailure::TunnelExited {
+                        message: "owned SSH tunnel exited or changed identity after a health failure during the post-establishment durability window".to_string(),
+                        attempts,
+                    });
+                }
                 return Err(DaemonHealthProbeFailure::Unreachable {
                     message: format!("remote daemon health endpoint failed during post-establishment durability observation {observation}"),
                     attempts,
@@ -1349,6 +1358,67 @@ mod tests {
             started.elapsed() < Duration::from_secs(5),
             "an exited tunnel must fail within the bounded durability window"
         );
+        assert!(child.wait().expect("reap tunnel child").success());
+        server.join().expect("server");
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn durability_health_failure_rechecks_tunnel_identity() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let body = serde_json::json!({
+            "freshness": report("lease-live", 7331).freshness,
+            "pid": 7331,
+        })
+        .to_string();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("initial health request");
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).expect("read request");
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(), body
+                    )
+                    .as_bytes(),
+                )
+                .expect("health response");
+            let (second, _) = listener.accept().expect("durability health request");
+            std::thread::sleep(Duration::from_millis(100));
+            drop(second);
+        });
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.3")
+            .spawn()
+            .expect("start tunnel child");
+        let pid = child.id();
+        let identity = super::super::capture_tunnel_process_start_identity(Some(pid))
+            .expect("capture child identity")
+            .expect("child identity");
+        let daemon = RemoteDaemon {
+            address: address.to_string(),
+            pid: Some(7331),
+            lease_id: Some("lease-live".to_string()),
+            version: None,
+            build_identity: None,
+            inspected_freshness: None,
+        };
+
+        let failure = probe_daemon_health_until_durable(
+            &format!("http://{address}"),
+            &daemon,
+            Some(pid),
+            Some(&identity),
+        )
+        .expect_err("exited tunnel after durability health failure is terminal");
+        assert!(matches!(
+            failure,
+            DaemonHealthProbeFailure::TunnelExited { .. }
+        ));
+        assert_eq!(failure_stage(&failure), "tunnel_durability");
         assert!(child.wait().expect("reap tunnel child").success());
         server.join().expect("server");
     }

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -3096,13 +3096,12 @@ mod tests {
     }
 
     #[test]
-    fn inner_rejects_connected_but_stale_daemon_with_recovery_command() {
+    fn inner_rejects_connected_but_stale_daemon_without_unverified_recovery() {
         // #8811: a runner can be `connected: true` while its daemon is
         // version-stale. The old bare-boolean gate passed such a runner and
         // dispatch then failed opaquely downstream. The unified availability
         // gate must reject it up front with the structured `stale_daemon`
-        // reason and the exact `refresh-homeboy` recovery command that status
-        // already computed, instead of the generic "not connected" message.
+        // reason without promoting legacy command text to executable recovery.
         let mut status = runner_status(true);
         status.stale_daemon = Some(RunnerStaleDaemonWarning {
             severity: "warning",
@@ -3145,8 +3144,8 @@ mod tests {
             "error must preserve the stale_daemon reason: {details}"
         );
         assert!(
-            details.contains("refresh-homeboy"),
-            "error must surface the exact refresh-homeboy recovery command: {details}"
+            !details.contains("refresh-homeboy"),
+            "error must not surface unverified recovery command text: {details}"
         );
     }
 

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -838,7 +838,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_runtime_paths() {
     assert_eq!(
         prepared,
         LabRunnerPreparation::FallBackLocal {
-            reason: "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner refresh-homeboy lab --ref bbbbbbbbbbbb --reconnect`".to_string()
+            reason: "connected runner `lab` daemon runtime is stale after runner-side rebuilds or path changes; restart the active daemon with `homeboy runner doctor lab --scope lab-offload`".to_string()
         }
     );
 }
@@ -887,7 +887,7 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     assert!(err.message.contains("homeboy 0.219.0"));
     assert!(err
         .message
-        .contains("homeboy runner refresh-homeboy lab --ref "));
+        .contains("homeboy runner doctor lab --scope lab-offload"));
     assert!(err
         .details
         .get("tried")
@@ -896,20 +896,11 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
         .flatten()
         .any(|suggestion| suggestion
             .as_str()
-            .is_some_and(|value| value.contains("homeboy runner refresh-homeboy lab --ref "))));
-    let action = &err.details[homeboy_core::error::ACTIONS_DETAILS_KEY][0];
-    assert_eq!(action["id"], "runner.refresh_homeboy");
-    assert_eq!(action["program"], "homeboy");
-    assert_eq!(action["args"][0], "runner");
-    assert_eq!(action["args"][1], "refresh-homeboy");
-    assert_eq!(action["args"][2], "lab");
-    assert_eq!(action["args"][3], "--ref");
-    assert_eq!(action["args"][4], "bbbbbbbbbbbb");
-    assert_eq!(action["args"][5], "--reconnect");
-    assert_eq!(
-        action["evidence"]["recovery_plan"][0],
-        err.details["tried"][0]
-    );
+            .is_some_and(|value| value.contains("homeboy runner doctor lab --scope lab-offload"))));
+    assert!(err
+        .details
+        .get(homeboy_core::error::ACTIONS_DETAILS_KEY)
+        .is_none());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -1113,7 +1113,7 @@ mod tests {
         selection.selector = Some("missing".to_string());
         assert!(runner_provider_unavailable_reason(&providers, &selection)
             .expect("missing selector reason")
-            .contains("does not match any"));
+            .contains("does not match backend"));
 
         let mut ambiguous = providers.clone();
         let mut second = ambiguous[0].clone();
@@ -1122,12 +1122,12 @@ mod tests {
         selection.selector = None;
         assert!(runner_provider_unavailable_reason(&ambiguous, &selection)
             .expect("ambiguous alias reason")
-            .contains("matches extension alias"));
+            .contains("is ambiguous"));
 
         selection.backend = "unknown".to_string();
         assert!(runner_provider_unavailable_reason(&ambiguous, &selection)
             .expect("unknown backend reason")
-            .contains("none declare backend"));
+            .contains("no provider for backend"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
+++ b/crates/homeboy-lab-runner/src/lab/provider_preflight.rs
@@ -668,6 +668,8 @@ fn agent_task_provider_selection_preflight_error(
         format!("Preflight command: `{}`.", redact_argv_shell_display(command)),
     ];
     hints.retain(|hint| !hint.is_empty());
+    let mut seen_hints = std::collections::BTreeSet::new();
+    hints.retain(|hint| seen_hints.insert(hint.clone()));
 
     let problem = format!(
         "Lab runner `{runner_id}` cannot execute agent-task backend `{}` selector `{selector}` before dispatch: {reason}. No task cells were queued. This points to extension/runtime sync drift between the controller and selected runner, not a task failure.",
@@ -1180,6 +1182,35 @@ mod tests {
             err.details["runner_remediation_command"],
             serde_json::json!("homeboy runner disconnect homeboy-lab")
         );
+    }
+
+    #[test]
+    fn provider_preflight_error_deduplicates_machine_facing_availability_hints() {
+        let selection = AgentTaskProviderSelection {
+            backend: "primary".to_string(),
+            selector: None,
+            runtime_identity: None,
+        };
+        let runner_homeboy = serde_json::json!({
+            "refresh_commands": ["homeboy runner refresh-homeboy homeboy-lab --reconnect"]
+        });
+        let err = agent_task_provider_selection_preflight_error(
+            "homeboy-lab",
+            &selection,
+            true,
+            Some(false),
+            &runner_homeboy,
+            None,
+            &["homeboy".to_string(), "agent-task".to_string()],
+            None,
+            None,
+        );
+        let hints = err.details["tried"].as_array().expect("tried hints");
+        let distinct_hints = hints
+            .iter()
+            .map(|hint| hint.as_str().expect("string hint"))
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(hints.len(), distinct_hints.len());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -765,7 +765,9 @@ fn preflight_lab_runner_availability_with(
     connect_authority: Option<&RunnerConnectReport>,
 ) -> Result<(RunnerAvailability, RunnerStatusReport)> {
     let capacity = load(&selection.runner_id)?.settings.concurrency_limit;
-    let loopback_transport = configured_direct_ssh_transport_is_loopback(&selection.runner_id)?;
+    let loopback_transport = loopback_direct_ssh_transport_for_preflight(selection, |runner_id| {
+        configured_direct_ssh_transport_is_loopback(runner_id)
+    })?;
     preflight_lab_runner_availability_from_status_with_transport(
         selection,
         status_fn,
@@ -773,6 +775,17 @@ fn preflight_lab_runner_availability_with(
         connect_authority,
         loopback_transport,
     )
+}
+
+fn loopback_direct_ssh_transport_for_preflight(
+    selection: &LabRunnerSelection,
+    resolve: impl FnOnce(&str) -> Result<bool>,
+) -> Result<bool> {
+    if selection.mode == RunnerTunnelMode::DirectSsh {
+        resolve(&selection.runner_id)
+    } else {
+        Ok(false)
+    }
 }
 
 pub(super) fn preflight_lab_runner_availability_from_status(
@@ -2399,6 +2412,39 @@ mod placement_readiness_tests {
         .expect("preflight");
 
         assert!(availability.accepts_jobs);
+    }
+
+    #[test]
+    fn reverse_preflight_skips_direct_ssh_transport_resolution() {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: RunnerTunnelMode::Reverse,
+        };
+
+        let loopback = loopback_direct_ssh_transport_for_preflight(&selection, |_| {
+            panic!("reverse broker transport must not resolve SSH configuration")
+        })
+        .expect("reverse transport does not need SSH resolution");
+
+        assert!(!loopback);
+    }
+
+    #[test]
+    fn direct_preflight_retains_ssh_transport_resolution() {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: RunnerTunnelMode::DirectSsh,
+        };
+
+        let loopback = loopback_direct_ssh_transport_for_preflight(&selection, |runner_id| {
+            assert_eq!(runner_id, "lab");
+            Ok(true)
+        })
+        .expect("direct SSH transport resolution");
+
+        assert!(loopback);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -1133,7 +1133,12 @@ impl DefaultLabRunnerCandidate {
                 .push("daemon_freshness_unavailable".to_string());
             availability.accepts_jobs = false;
         }
-        if !self.active_jobs_available {
+        if !self.active_jobs_available
+            && !availability
+                .reasons
+                .iter()
+                .any(|reason| reason == "active_jobs_unavailable")
+        {
             availability
                 .reasons
                 .push("active_jobs_unavailable".to_string());

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -75,7 +75,7 @@ fn materialize_lab_stack_from_repository(
     for pr in &stack.prs {
         script.push_str(&format!("; {}", verify(&pr.head)));
         script.push_str(&format!(
-            "; parents=$(git -C {destination} rev-list --parents -n 1 {sha} | wc -w | tr -d ' '); if test \"$parents\" -gt 2; then test -n {mainline}; git -C {destination} cherry-pick --quiet -m {mainline} {sha} >/dev/null; else git -C {destination} cherry-pick --quiet {sha} >/dev/null; fi",
+            "; parents=$(git -C {destination} rev-list --parents -n 1 {sha} | wc -w | tr -d ' '); if test \"$parents\" -gt 2; then test -n {mainline}; env GIT_COMMITTER_NAME='Homeboy Lab Runner' GIT_COMMITTER_EMAIL='homeboy-lab-runner@localhost' git -C {destination} cherry-pick --quiet -m {mainline} {sha} >/dev/null; else env GIT_COMMITTER_NAME='Homeboy Lab Runner' GIT_COMMITTER_EMAIL='homeboy-lab-runner@localhost' git -C {destination} cherry-pick --quiet {sha} >/dev/null; fi",
             destination = q(destination),
             sha = q(&pr.head.sha),
             mainline = q(&pr.merge_mainline.map(|value| value.to_string()).unwrap_or_default()),
@@ -1370,6 +1370,10 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(destination.join("stack.txt")).unwrap(),
             "stack\n"
+        );
+        assert_eq!(
+            git(&destination, &["log", "-1", "--format=%cn <%ce>"]),
+            "Homeboy Lab Runner <homeboy-lab-runner@localhost>"
         );
 
         std::fs::remove_dir_all(&destination).expect("remove successful fixture checkout");

--- a/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
+++ b/crates/homeboy-lab-runner/src/runtime_materialization_status.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_status_renders_control_plane_and_job_binary_hint() {
+    fn stale_status_omits_unverified_recovery_command_text() {
         let report = report(Some(RunnerStaleDaemonWarning::new(
             "homeboy-lab",
             "homeboy 0.259.0".to_string(),
@@ -241,17 +241,8 @@ mod tests {
             &report,
         );
 
-        let hint = status.stale_daemon_hint().expect("stale daemon hint");
         assert!(status.has_drift());
-        assert!(hint.contains("active daemon control plane"));
-        assert!(hint.contains("homeboy 0.259.0+daemon"));
-        assert!(hint.contains("job command binary"));
-        assert!(hint.contains("homeboy 0.262.0+binary"));
-        // The refresh hint now names the `refresh-homeboy --reconnect` recovery
-        // command. Assert its stable shape rather than the embedded `--ref`
-        // version, which tracks the current release and would re-rot the test.
-        assert!(hint.contains("homeboy runner refresh-homeboy homeboy-lab"));
-        assert!(hint.contains("--reconnect"));
+        assert_eq!(status.stale_daemon_hint(), None);
     }
 
     fn report(stale_daemon: Option<RunnerStaleDaemonWarning>) -> RunnerStatusReport {

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -879,7 +879,7 @@ impl RunnerStatusReport {
             .map(|generation| generation.generation.clone());
         let unresolved_generation = generations
             .iter()
-            .find(|generation| generation.active_job_count > 0)
+            .find(|generation| !generation.admission_owner && generation.active_job_count > 0)
             .map(|generation| generation.generation.clone());
         let admission_blocking_job_ids = blocking_generation
             .as_deref()

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -856,7 +856,9 @@ impl RunnerStatusReport {
         let unresolved_generations = generations
             .iter()
             .filter(|generation| {
-                !generation.active_job_count_authoritative && generation.active_job_count > 0
+                (!generation.admission_owner || !connected)
+                    && !generation.active_job_count_authoritative
+                    && generation.active_job_count > 0
             })
             .collect::<Vec<_>>();
         let unresolved_retained_projection_count = unresolved_generations
@@ -1329,8 +1331,8 @@ mod status_serialization_tests {
         );
         assert_eq!(
             summary.next_action.as_deref(),
-            Some("homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect"),
-            "the legacy serialized recovery remains the action source when argv is unavailable"
+            None,
+            "legacy command text must not become executable recovery authority"
         );
         assert!(!summary.safe_to_rotate, "missing daemon evidence is unsafe");
     }
@@ -1363,10 +1365,7 @@ mod status_serialization_tests {
         assert!(summary.daemon_fresh);
         assert!(!summary.daemon_compatible);
         assert!(!summary.accepting_jobs);
-        assert_eq!(
-            summary.next_action.as_deref(),
-            Some("homeboy runner refresh-homeboy homeboy-lab --ref configured --reconnect")
-        );
+        assert_eq!(summary.next_action, None);
     }
 
     #[test]
@@ -1667,7 +1666,7 @@ mod status_serialization_tests {
     }
 
     #[test]
-    fn disconnected_stale_daemon_with_retained_projections_points_to_refresh() {
+    fn disconnected_stale_daemon_with_retained_projections_points_to_reconcile() {
         let mut report = base_report();
         report.connected = false;
         report.state = RunnerSessionState::Disconnected;
@@ -1719,7 +1718,7 @@ mod status_serialization_tests {
         assert_eq!(summary.unresolved_retained_projection_count, 2);
         assert_eq!(
             summary.next_action.as_deref(),
-            Some("homeboy runner refresh-homeboy homeboy-lab --ref c8a6673b6abc --reconnect")
+            Some("homeboy runner reconcile homeboy-lab")
         );
     }
 }

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -853,9 +853,17 @@ mod formatter_visibility {
         let at = line.find("#[path")?;
         let after = &line[at..];
         let eq = after.find('=')?;
-        let open = after[eq..].find('"')? + eq + 1;
+        let open = after[eq..].find('"')? + eq;
         let close = after[open + 1..].find('"')? + open + 1;
         Some(after[open + 1..close].to_string())
+    }
+
+    #[test]
+    fn path_attr_value_preserves_the_first_path_character() {
+        assert_eq!(
+            path_attr_value(r#"#[path = "deps_provider.rs"]"#).as_deref(),
+            Some("deps_provider.rs")
+        );
     }
 
     /// The literal in `include!("...")`. `include!(concat!(env!("OUT_DIR"), ..))`
@@ -1114,7 +1122,8 @@ mod formatter_visibility {
             .into_iter()
             .filter(|path| {
                 let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
-                !rel.replace('\\', "/").starts_with(FIXTURE_PREFIX)
+                let rel = rel.replace('\\', "/");
+                !rel.starts_with(FIXTURE_PREFIX) && !rel.contains(&format!("/{FIXTURE_PREFIX}"))
             })
             .collect()
     }

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -576,6 +576,7 @@ mod tests {
     };
     use crate::release::workflow::run_command;
     use homeboy_core::component::{Component, VersionTarget};
+    use homeboy_core::defaults;
     use homeboy_core::project::{self, Project, ProjectComponentAttachment};
     use homeboy_core::server::{self, Server};
     use homeboy_core::test_support::with_isolated_home;
@@ -1012,12 +1013,19 @@ mod tests {
     #[test]
     fn release_recover_resumes_only_failed_project_with_published_source_projection() {
         with_isolated_home(|home| {
+            let mut config = defaults::load_config();
+            config.defaults.permissions.remote.dir_mode = "g+rwx".to_string();
+            defaults::save_config(&config).expect("save fixture permissions");
             let source = home.path().join("source");
             let successful_target = home.path().join("successful-target");
             let retry_target = home.path().join("retry-target");
             std::fs::create_dir_all(&source).expect("source directory");
             std::fs::create_dir_all(&successful_target).expect("successful target");
             std::fs::create_dir_all(&retry_target).expect("retry target");
+            let successful_component = successful_target.join("plugins/successful");
+            std::fs::create_dir_all(&successful_component).expect("successful component target");
+            std::fs::write(successful_component.join("VERSION"), "1.2.3\n")
+                .expect("pre-release remote version");
             run_git(&source, &["init", "-q", "--initial-branch", "main"]);
             run_git(&source, &["config", "user.email", "test@example.com"]);
             run_git(&source, &["config", "user.name", "Homeboy Test"]);

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -1193,51 +1193,42 @@ fn head_release_skip_publish_still_uploads_existing_artifacts() {
 
 #[test]
 fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
-    let mut component = fixture_component();
-    component.extensions = Some(std::collections::HashMap::from([(
-        "wordpress".to_string(),
-        ScopedExtensionConfig::default(),
-    )]));
-    let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
-        "name": "WordPress",
-        "version": "1.0.0",
-        "actions": [
-            {
-                "id": "release.package",
-                "label": "Package release",
-                "type": "command",
-                "command": "true"
-            }
-        ]
-    }))
-    .expect("extension manifest");
-    extension.id = "wordpress".to_string();
-    let mut warnings = Vec::new();
-    let mut hints = Vec::new();
-    let release_scope = ReleaseScope::resolve(&component, &component.id).expect("release scope");
-    let options = ReleaseOptions {
-        bump_type: "patch".to_string(),
-        ..Default::default()
-    };
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut component = fixture_component();
+        component.extensions = Some(std::collections::HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        let extension = release_extension("wordpress", &["release.package"]);
+        homeboy_extension::save_manifest(&extension).expect("install extension manifest");
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let release_scope =
+            ReleaseScope::resolve(&component, &component.id).expect("release scope");
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
 
-    let _steps = build_release_steps(
-        &component,
-        &[extension],
-        "1.0.0",
-        "1.0.1",
-        &fixture_changelog_plan(),
-        &options,
-        &release_scope,
-        &mut warnings,
-        &mut hints,
-    )
-    .expect("steps");
+        let _steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            &release_scope,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
 
-    assert!(warnings.iter().any(|warning| {
-        warning.contains("configured extensions (wordpress)")
-            && warning.contains("release.package")
-            && warning.contains("no extension provides 'release.publish'")
-    }));
+        assert!(warnings.iter().any(|warning| {
+            warning.contains("configured extensions (wordpress)")
+                && warning.contains("release.package")
+                && warning.contains("no extension provides 'release.publish'")
+        }));
+    });
 }
 
 #[test]

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -699,7 +699,7 @@ mod tests {
         let local = root.join("local");
         std::fs::create_dir_all(&origin).expect("origin dir");
 
-        git(&origin, &["init", "-b", "main"]);
+        git(&origin, &["init", "-b", "master"]);
         git(&origin, &["config", "user.email", "t@example.com"]);
         git(&origin, &["config", "user.name", "T"]);
         std::fs::write(origin.join("f.txt"), "0\n").expect("seed file");
@@ -721,7 +721,7 @@ mod tests {
         }
 
         // Update tracking refs locally (no working-tree move): the local clone
-        // now knows origin/main is ahead while HEAD stays at v1.0.0.
+        // now knows origin/master is ahead while HEAD stays at v1.0.0.
         git(&local, &["fetch", "origin"]);
         local
     }
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     fn guard_allows_checkout_at_upstream_head() {
         let dir = tempfile::TempDir::new().expect("temp dir");
-        // Zero extra upstream commits: HEAD == origin/main, genuinely at head.
+        // Zero extra upstream commits: HEAD == origin/master, genuinely at head.
         let local = stale_checkout_fixture(dir.path(), 0);
 
         assert!(

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1255,10 +1255,13 @@ mod tests {
             // failure that actually occurred, rather than the generic
             // "Lint runner error" this previously asserted.
             assert!(
-                error.to_string().contains("Extension not found"),
+                error
+                    .to_string()
+                    .contains("has no linked extensions that provide lint support"),
                 "a component declaring an uninstallable lint extension must block \
                  release on the resolution failure; got: {error}"
             );
+            assert!(error.to_string().contains("missing-lint-extension"));
         });
     }
 
@@ -1525,14 +1528,6 @@ exit 0
                 .contains("Lint failed (exit code 1,"));
             assert_eq!(
                 producer_error.details["lint_workflow"]["producer_error_count"].as_u64(),
-                Some(1)
-            );
-            assert_eq!(
-                producer_error.details["lint_workflow"]["baseline_new_count"].as_u64(),
-                Some(0)
-            );
-            assert_eq!(
-                producer_error.details["lint_workflow"]["baseline_known_count"].as_u64(),
                 Some(1)
             );
         });

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -1251,9 +1251,8 @@ mod tests {
             };
 
             let error = validate_lint_quality(&component, "fixture").expect_failed();
-            // The bootstrap failure now surfaces as the extension resolution
-            // failure that actually occurred, rather than the generic
-            // "Lint runner error" this previously asserted.
+            // Missing extension manifests now surface through the typed
+            // capability diagnostic rather than a generic runner error.
             assert!(
                 error
                     .to_string()
@@ -1529,6 +1528,16 @@ exit 0
             assert_eq!(
                 producer_error.details["lint_workflow"]["producer_error_count"].as_u64(),
                 Some(1)
+            );
+            assert_eq!(
+                producer_error.details["lint_workflow"]["baseline_new_count"].as_u64(),
+                None,
+                "producer errors make the baseline comparison ineligible"
+            );
+            assert_eq!(
+                producer_error.details["lint_workflow"]["baseline_known_count"].as_u64(),
+                None,
+                "producer errors make the baseline comparison ineligible"
             );
         });
     }

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -119,6 +119,9 @@ pub fn run_command_with_workspace(
                 false,
                 serde_json::json!({ "error": error.to_string() }),
             )?;
+            return Err(error.with_hint(format!(
+                "Inspect readiness evidence: homeboy release readiness show {owner_run_ref}"
+            )));
         }
         return Err(error);
     }
@@ -1140,6 +1143,7 @@ mod tests {
         let gate = &mut readiness.gate_results[0];
         gate.status = "passed".to_string();
         gate.reason = None;
+        gate.evidence_refs = vec!["evidence://lint".to_string()];
         gate.provenance = Some(super::super::types::ReleaseReadinessProvenance {
             dependencies: std::collections::BTreeMap::from([(
                 "dependency".to_string(),

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -1217,8 +1217,8 @@ mod tests {
             .find(|record| record.source_sha == source)
             .expect("readiness record is retained");
             let owner = record.owner_run_ref.clone();
-            assert!(error.hints.iter().any(|hint| hint.message
-                == format!("Inspect readiness evidence: homeboy release readiness show {owner}")));
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
+            assert!(error.message.contains("invalid selected gate evidence"));
             assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             assert_eq!(record.finalization_status, "completed");
             assert_eq!(

--- a/crates/homeboy-triage/Cargo.toml
+++ b/crates/homeboy-triage/Cargo.toml
@@ -22,3 +22,4 @@ chrono = "0.4"
 # Shared hermetic test fixtures (with_isolated_home) live in homeboy-core behind
 # the test-support feature; the whole workspace shares one isolation contract.
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
+homeboy-rig = { version = "0.1.0", path = "../homeboy-rig" }

--- a/crates/homeboy-triage/src/tests/targets.rs
+++ b/crates/homeboy-triage/src/tests/targets.rs
@@ -247,12 +247,19 @@ fn rig_target_threads_rig_component_triage_remote_override() {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].component_id, "playground");
         assert_eq!(
+            refs[0].remote_url.as_deref(),
+            Some("https://github.com/example-org/wordpress-playground.git")
+        );
+        assert_eq!(
             refs[0].triage_remote_url.as_deref(),
             Some("https://github.com/WordPress/wordpress-playground.git")
         );
+        let resolved = resolve_repo(&refs[0]).expect("rig target resolves its triage remote");
+        assert_eq!(resolved.repo.owner, "WordPress");
+        assert_eq!(resolved.repo.repo, "wordpress-playground");
         assert_eq!(
-            resolve_repo(&refs[0]).unwrap().repo.owner,
-            "WordPress".to_string()
+            resolved.source_repo.expect("source remote retained").owner,
+            "example-org"
         );
     });
 }

--- a/crates/homeboy-triage/src/tests/targets.rs
+++ b/crates/homeboy-triage/src/tests/targets.rs
@@ -224,6 +224,7 @@ fn component_target_threads_registered_triage_remote_override() {
 #[test]
 fn rig_target_threads_rig_component_triage_remote_override() {
     homeboy_core::test_support::with_isolated_home(|home| {
+        homeboy_rig::provider::register();
         let rig_dir = home.path().join(".config/homeboy/rigs");
         std::fs::create_dir_all(&rig_dir).unwrap();
         std::fs::write(

--- a/docs/operations/controller-runner-reverse-runner.md
+++ b/docs/operations/controller-runner-reverse-runner.md
@@ -202,13 +202,13 @@ Keep the service disabled for production until #2990 and #2991 are merged. For
 private smoke tests before #2991, use the one-shot worker shape from the active
 implementation branch or PR notes instead of a hand-rolled infinite loop.
 
-## 4. Reverse workspace sync
+## 4. Reverse workspace staging
 
-Reverse workspace sync is gated by #2947. Until it lands, controller-originated
-commands can only smoke simple brokered execution that does not require syncing a
-controller checkout to the runner through the reverse session.
+Controller-originated durable work stages its verified source through the reverse
+broker before the runner executes it. The runner receives the staged workspace
+descriptor and must keep the resulting path beneath its configured workspace root.
 
-Expected modes after #2947:
+Supported source forms are:
 
 - `git`: the runner materializes a repo-backed clean commit/ref itself.
 - `snapshot-over-tunnel`: the controller streams a filtered archive through the reverse
@@ -222,8 +222,8 @@ by `homeboy runner workspace sync`.
 
 ## 5. Minimal end-to-end smoke
 
-Run this only after #2990, #2991, #2992, and #2947 have landed or in an explicit
-private smoke environment that provides equivalent branch builds.
+Run this against a connected reverse runner with a broker endpoint and a configured
+workspace root.
 
 1. Start or verify the controller broker service:
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -1826,7 +1826,7 @@
       "settings": {
         "rust_test_runner": "nextest",
         "rust_cargo_test_threads": 1,
-        "rust_nextest_shard_threads": 0
+        "rust_nextest_shard_threads": 1
       }
     }
   },

--- a/scripts/homeboy-installer.sh
+++ b/scripts/homeboy-installer.sh
@@ -38,7 +38,7 @@ else
 fi
 
 CANDIDATE="${ASSET%.tar.xz}/homeboy"
-MEMBERS="$(tar -tJf "$TMP_DIR/$ASSET" 2>/dev/null || tar -tf "$TMP_DIR/$ASSET")" || {
+MEMBERS="$(env -u TAR_OPTIONS tar -tJf "$TMP_DIR/$ASSET" 2>/dev/null || env -u TAR_OPTIONS tar -tf "$TMP_DIR/$ASSET")" || {
   echo "Unable to list release archive" >&2
   exit 1
 }
@@ -69,7 +69,7 @@ if [ "$CANDIDATE_COUNT" -ne 1 ]; then
   exit 1
 fi
 
-CANDIDATE_DETAILS="$(tar -tvJf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -tvf "$TMP_DIR/$ASSET" "$CANDIDATE")" || {
+CANDIDATE_DETAILS="$(env -u TAR_OPTIONS tar -tvJf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || env -u TAR_OPTIONS tar -tvf "$TMP_DIR/$ASSET" "$CANDIDATE")" || {
   echo "Unable to inspect release candidate" >&2
   exit 1
 }
@@ -82,7 +82,7 @@ case "$CANDIDATE_DETAILS" in
 esac
 
 EXTRACTED_BIN="$TMP_DIR/homeboy"
-(tar -xJOf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || tar -xOf "$TMP_DIR/$ASSET" "$CANDIDATE") > "$EXTRACTED_BIN" || {
+(env -u TAR_OPTIONS tar -xJOf "$TMP_DIR/$ASSET" "$CANDIDATE" 2>/dev/null || env -u TAR_OPTIONS tar -xOf "$TMP_DIR/$ASSET" "$CANDIDATE") > "$EXTRACTED_BIN" || {
   echo "Unable to extract release candidate" >&2
   exit 1
 }

--- a/tests/cli_binary/product_identity_test.rs
+++ b/tests/cli_binary/product_identity_test.rs
@@ -4,9 +4,7 @@ use std::process::Command;
 
 #[test]
 fn shipped_root_binary_reports_root_version_and_source_commit() {
-    let expected_version = env!("CARGO_PKG_VERSION");
-    let expected_commit = git_output(&["rev-parse", "--short=12", "HEAD"]);
-    let expected_dirty = !git_output(&["status", "--porcelain"]).is_empty();
+    let expected = homeboy_product_identity::build_identity();
     let output = Command::new(homeboy_bin())
         .args(["self", "identity"])
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
@@ -15,9 +13,15 @@ fn shipped_root_binary_reports_root_version_and_source_commit() {
 
     assert_eq!(output.status.code(), Some(0));
     let identity: Value = serde_json::from_slice(&output.stdout).expect("identity JSON");
-    assert_eq!(identity["data"]["version"], expected_version);
-    assert_eq!(identity["data"]["git_commit"], expected_commit);
-    assert_eq!(identity["data"]["git_dirty"], expected_dirty);
+    assert_eq!(identity["data"]["version"], expected.version);
+    assert_eq!(
+        identity["data"]["git_commit"],
+        serde_json::to_value(expected.git_commit.clone()).expect("serialize build commit")
+    );
+    assert_eq!(
+        identity["data"]["git_dirty"],
+        serde_json::to_value(expected.git_dirty).expect("serialize dirty marker")
+    );
     let expected_binary = homeboy_bin().to_string_lossy().into_owned();
     assert_eq!(
         identity["data"]["active_binary"].as_str(),
@@ -69,20 +73,13 @@ fn shipped_root_binary_reports_root_version_and_source_commit() {
 
     assert_eq!(output.status.code(), Some(0));
     let version = String::from_utf8(output.stdout).expect("version output is UTF-8");
-    assert!(version.contains(expected_version));
-    assert!(version.contains(&expected_commit));
+    assert!(version.contains(&expected.version));
+    if let Some(commit) = expected.git_commit {
+        assert!(version.contains(&commit));
+    }
     assert!(!version.contains("0.1.0"));
 }
 
 fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
-}
-
-fn git_output(args: &[&str]) -> String {
-    let output = Command::new("git").args(args).output().expect("run git");
-    assert!(output.status.success(), "git command failed");
-    String::from_utf8(output.stdout)
-        .expect("git output is UTF-8")
-        .trim()
-        .to_string()
 }

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -729,5 +729,11 @@ fn cook_help_does_not_advertise_queue_only() {
     assert!(output.status.success());
     let help = String::from_utf8_lossy(&output.stdout);
     assert!(!help.contains("\n      --queue-only\n"));
+    assert!(help.contains("--help-full"), "{help}");
+
+    let output = homeboy(&["agent-task", "cook", "--help-full"]);
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(!help.contains("\n      --queue-only\n"));
     assert!(help.contains("--detach-after-handoff"), "{help}");
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -2826,12 +2826,11 @@ fn wait_for_pid_file(path: &std::path::Path) -> libc::pid_t {
 #[cfg(unix)]
 fn assert_pid_exits(pid: libc::pid_t) {
     let deadline = Instant::now() + Duration::from_secs(2);
-    while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+    while crate::process::pid_is_running(pid as u32) && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(10));
     }
-    assert_ne!(
-        unsafe { libc::kill(pid, 0) },
-        0,
+    assert!(
+        !crate::process::pid_is_running(pid as u32),
         "process {pid} remained live"
     );
 }

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -128,6 +128,8 @@ fn run_installer(
         .env("HOMEBOY_TEST_EVIDENCE", &evidence)
         .env("HOMEBOY_TEST_EVENTS", &events)
         .env("HOMEBOY_TEST_BIN_DIR", &install_dir)
+        // Archive inspection must be independent of caller tar defaults.
+        .env("TAR_OPTIONS", "--invalid-homeboy-installer-option")
         .env("PATH", format!("{}:/usr/bin:/bin", tools.display()));
     if force_sudo {
         command.env("HOMEBOY_INSTALL_USE_SUDO", "true");

--- a/tests/postprocess_worker_startup.rs
+++ b/tests/postprocess_worker_startup.rs
@@ -101,12 +101,8 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
     let _lock = POSTPROCESS_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let home = tempfile::tempdir().expect("home");
-    let artifact_root = home.path().join("artifacts");
-    homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
-    {
+    homeboy::core::test_support::with_isolated_home(|home| {
         install_helper(home.path());
-        std::env::set_var("HOMEBOY_ARTIFACT_ROOT", artifact_root);
         std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
         std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
 
@@ -175,8 +171,7 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
             root.join("claim.json").exists() || root.join("current.json").is_file(),
             "replacement worker completed after the empty pre-claim recovery"
         );
-    }
-    homeboy::core::set_artifact_root_override(None);
+    });
 }
 
 #[test]
@@ -184,46 +179,43 @@ fn scheduler_restart_adopts_a_live_worker_without_reinvoking_helper() {
     let _lock = POSTPROCESS_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let home = tempfile::tempdir().expect("home");
-    let artifact_root = home.path().join("artifacts");
-    homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
-    install_helper(home.path());
-    std::env::set_var("HOMEBOY_ARTIFACT_ROOT", artifact_root);
-    std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
-    std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
+    homeboy::core::test_support::with_isolated_home(|home| {
+        install_helper(home.path());
+        std::env::set_var("HOMEBOY_POSTPROCESS_WORKER", env!("CARGO_BIN_EXE_homeboy"));
+        std::env::set_var("HOMEBOY_POSTPROCESS_WORKER_CLAIM_DELAY_MS", "1500");
 
-    let root = homeboy::core::artifacts::root()
-        .expect("artifact root")
-        .join("agent-task/postprocess/restart-run/compose");
-    let first = thread::spawn(|| {
-        AgentTaskScheduler::new(NoopExecutor)
-            .with_run_id("restart-run")
-            .run(postprocess_plan())
+        let root = homeboy::core::artifacts::root()
+            .expect("artifact root")
+            .join("agent-task/postprocess/restart-run/compose");
+        let first = thread::spawn(|| {
+            AgentTaskScheduler::new(NoopExecutor)
+                .with_run_id("restart-run")
+                .run(postprocess_plan())
+        });
+        let worker_file = root.join("worker.json");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !worker_file.is_file() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            worker_file.is_file(),
+            "first scheduler persisted its worker"
+        );
+
+        let restarted = thread::spawn(|| {
+            AgentTaskScheduler::new(NoopExecutor)
+                .with_run_id("restart-run")
+                .run(postprocess_plan())
+        });
+        let first = first.join().expect("first scheduler");
+        let restarted = restarted.join().expect("restarted scheduler");
+
+        assert_eq!(first.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(restarted.status, AgentTaskAggregateStatus::Succeeded);
+        let versions = std::fs::read_dir(root.join("versions"))
+            .expect("versions")
+            .count();
+        assert_eq!(versions, 1, "live worker helper was invoked once");
+        assert!(root.join("checkpoint.json").is_file());
     });
-    let worker_file = root.join("worker.json");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while !worker_file.is_file() && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(20));
-    }
-    assert!(
-        worker_file.is_file(),
-        "first scheduler persisted its worker"
-    );
-
-    let restarted = thread::spawn(|| {
-        AgentTaskScheduler::new(NoopExecutor)
-            .with_run_id("restart-run")
-            .run(postprocess_plan())
-    });
-    let first = first.join().expect("first scheduler");
-    let restarted = restarted.join().expect("restarted scheduler");
-
-    assert_eq!(first.status, AgentTaskAggregateStatus::Succeeded);
-    assert_eq!(restarted.status, AgentTaskAggregateStatus::Succeeded);
-    let versions = std::fs::read_dir(root.join("versions"))
-        .expect("versions")
-        .count();
-    assert_eq!(versions, 1, "live worker helper was invoked once");
-    assert!(root.join("checkpoint.json").is_file());
-    homeboy::core::set_artifact_root_override(None);
 }

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -241,7 +241,7 @@ fn pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_l
     let ssh = context.root().join("ssh");
     std::fs::write(
         &ssh,
-        "#!/bin/sh\nfor argument do command=$argument; done\ncase \"$command\" in\n  *'self identity'*) identity=\"${HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY:?}\"; version=\"${identity#homeboy }\"; version=\"${version%%+*}\"; printf '{\"version\":\"%s\",\"display\":\"%s\"}\\n' \"$version\" \"$identity\" ;;\n  *'daemon status'*) printf '%s\\n' '{\"success\":true,\"data\":{\"running\":false,\"fresh\":true,\"reachable\":true,\"active_jobs\":0}}' ;;\n  *'df -Pk'*) printf '%s\\n' 'fixture-device 5242880 1048576' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
+        "#!/bin/sh\nif [ \"${1:-}\" = -G ]; then\n  printf '%s\\n' 'hostname reverse-fixture.invalid' 'port 22' 'proxycommand fixture-proxy'\n  exit 0\nfi\nfor argument do command=$argument; done\ncase \"$command\" in\n  *'self identity'*) identity=\"${HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY:?}\"; version=\"${identity#homeboy }\"; version=\"${version%%+*}\"; printf '{\"version\":\"%s\",\"display\":\"%s\"}\\n' \"$version\" \"$identity\" ;;\n  *'daemon status'*) printf '%s\\n' '{\"success\":true,\"data\":{\"running\":false,\"fresh\":true,\"reachable\":true,\"active_jobs\":0}}' ;;\n  *'df -Pk'*) printf '%s\\n' 'fixture-device 5242880 1048576' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
     )
     .expect("write capability probe SSH shim");
     std::fs::set_permissions(&ssh, std::fs::Permissions::from_mode(0o755))


### PR DESCRIPTION
## Summary

Combines the focused repairs needed to validate the current-`main` candidate baseline through all four immutable Test shards.

This integrates:

- repaired bounded archive replay tooling from #12596
- Cook workspace reconstruction coverage from #12602
- release and triage fixture alignment from #12610
- Core process lifecycle repairs from #12611
- CLI and installer fixture isolation from #12612
- Lab runner lifecycle repairs from #12613

Tracks #12607. The issue should remain open until this combined candidate is green and #12527-#12530 are refreshed against the repaired baseline.

## Verification

- focused Cook, Core, CLI, Lab, reverse Cook acceptance, measurement, triage, and release tests pass
- `cargo test -p homeboy-release --lib` passes (551 tests)
- `cargo fmt --all -- --check` passes
- `git diff --check origin/main...HEAD` passes

The required CI candidate shards provide the Linux and full-workspace proof.

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode classified the baseline failures, implemented and integrated the focused repairs, resolved merge conflicts, and ran the listed verification. Chris Huber reviewed and remains responsible for every line.