### PR TITLE
Give run-outcome recording explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -727,7 +727,13 @@ pub(crate) fn record_aggregate_in_store(
     crate::controller_scratch::finalize_run_at(&lifecycle_store.data_root(), &record.run_id)?;
     lifecycle_store.write_aggregate_and_record(record, aggregate)?;
     record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
-    update_cook_candidate_after_completion(record, aggregate, None)?;
+    // The Cook index this completion updates belongs to the same store the
+    // aggregate was just committed into. Resolving it ambiently made this
+    // rooted function write its substantive-candidate pointer into whatever
+    // home the environment pointed at, which no positive assertion here can
+    // see: every record and aggregate read back from the injected store is
+    // already correct at that point (#7505).
+    update_cook_candidate_after_completion_in_store(lifecycle_store, record, aggregate, None)?;
     Ok(record.clone())
 }
 
@@ -739,7 +745,7 @@ pub(crate) fn record_terminal_artifact_projection(
     record_terminal_artifact_projection_in_store(&lifecycle_store, record, aggregate)
 }
 
-fn record_terminal_artifact_projection_in_store(
+pub(crate) fn record_terminal_artifact_projection_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -898,7 +898,22 @@ pub fn normalize_missing_execution_placement_decision(
     run_id: &str,
     decision: &homeboy_lab_runner_contract::ExecutionPlacementDecision,
 ) -> Result<bool> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    normalize_missing_execution_placement_decision_in_store(&lifecycle_store, run_id, decision)
+}
+
+/// Adopt a canonical placement decision inside an explicitly rooted store.
+///
+/// The persisted-decision read and the adoption write are one decision, so they
+/// share one store. Read ambiently, a decision already recorded in another home
+/// could veto an adoption here, or a supersedable submission stamp found there
+/// could authorize a write into this store that its own record never justified.
+pub fn normalize_missing_execution_placement_decision_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    decision: &homeboy_lab_runner_contract::ExecutionPlacementDecision,
+) -> Result<bool> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let persisted =
         serde_json::from_value::<homeboy_lab_runner_contract::ExecutionPlacementDecision>(
             record.metadata["execution_placement_decision"].clone(),
@@ -924,7 +939,7 @@ pub fn normalize_missing_execution_placement_decision(
         "reason": reason,
         "adopted_decision_id": decision.decision_id,
     });
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(true)
 }
 
@@ -935,7 +950,24 @@ pub fn record_execution_placement_outcome(
     run_id: &str,
     outcome: homeboy_lab_runner_contract::ExecutionPlacementOutcome,
 ) -> Result<()> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_execution_placement_outcome_in_store(&lifecycle_store, run_id, outcome)
+}
+
+/// Append a provider-verified placement outcome inside an explicitly rooted
+/// store.
+///
+/// The decision this outcome is checked against and the record it is appended
+/// to are read and written through the same store. Reading the decision
+/// ambiently would let another home's routing decide whether a verified
+/// execution here is a stale replay, and would fail closed or open on evidence
+/// that never described this run.
+pub fn record_execution_placement_outcome_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    outcome: homeboy_lab_runner_contract::ExecutionPlacementOutcome,
+) -> Result<()> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let decision: homeboy_lab_runner_contract::ExecutionPlacementDecision = serde_json::from_value(
         record.metadata["execution_placement_decision"].clone(),
     )
@@ -970,7 +1002,7 @@ pub fn record_execution_placement_outcome(
                 Some("serialize placement outcome".to_string()),
             )
         })?;
-    store::write_record(&record)
+    lifecycle_store.write_record(&record)
 }
 
 /// Restore an explicit plan placement decision onto a legacy run record.
@@ -979,7 +1011,22 @@ pub fn record_execution_placement_outcome(
 /// decision must remain unclassified rather than acquiring a synthetic local
 /// contract that could contradict later runner evidence.
 pub fn normalize_local_execution_placement(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    normalize_local_execution_placement_in_store(&lifecycle_store, run_id)
+}
+
+/// Restore an explicit plan placement decision onto a legacy record inside an
+/// explicitly rooted store.
+///
+/// The plan read moves with the record. `load_plan` resolves a Cook alias
+/// against the ambient index and then reads the ambient run directory, so an
+/// ambient reach here could copy another home's plan decision onto this store's
+/// record — the one restoration this operation exists to make trustworthy.
+pub fn normalize_local_execution_placement_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     if record
         .metadata
         .get("execution_placement_decision")
@@ -987,7 +1034,7 @@ pub fn normalize_local_execution_placement(run_id: &str) -> Result<AgentTaskRunR
     {
         return Ok(record);
     }
-    let plan = load_plan(&record.run_id)?;
+    let plan = load_controller_plan_in_store(lifecycle_store, &record.run_id)?;
     let Some(decision) = plan
         .metadata
         .get("execution_placement_decision")
@@ -1002,7 +1049,7 @@ pub fn normalize_local_execution_placement(run_id: &str) -> Result<AgentTaskRunR
         "execution_placement_normalization".to_string(),
         json!({ "source": "controller_plan", "reason": "legacy_or_null_record_decision" }),
     );
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -1848,8 +1895,30 @@ pub fn record_completed_run(
     aggregate: &AgentTaskAggregate,
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
-    let mut record = submit_plan(plan, requested_run_id)?;
-    record_aggregate(&mut record, plan, aggregate)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_completed_run_in_store(&lifecycle_store, plan, aggregate, requested_run_id)
+}
+
+/// Submit and immediately terminalize one run inside an explicitly rooted
+/// store.
+///
+/// Both halves follow the injected root. Splitting them is the failure this
+/// sibling exists to make impossible: a submission in one home followed by an
+/// aggregate write in another leaves a queued record that never completes and a
+/// terminal projection with no run behind it, and neither write ever fails.
+///
+/// The controller-runtime admission that `submit_plan_in_store` performs stays
+/// process-global by design — it is a content-addressed executable pin shared
+/// across homes, not durable lifecycle state, so it is not one of this store's
+/// roots.
+pub fn record_completed_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+    requested_run_id: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = submit_plan_in_store(lifecycle_store, plan, requested_run_id)?;
+    record_aggregate_in_store(lifecycle_store, &mut record, plan, aggregate)
 }
 
 pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
@@ -2244,9 +2313,29 @@ pub fn record_provider_execution_process(
     attempt: u32,
     pid: u32,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_provider_execution_process_in_store(&lifecycle_store, run_id, task_id, attempt, pid)
+}
+
+/// Bind a reserved provider execution to its subprocess inside an explicitly
+/// rooted store.
+///
+/// The reservation this binding looks for was made in one store, so the lookup
+/// has to happen there too. An ambient reach would either find no reservation
+/// and reject a legitimate process, or bind this run's provider PID onto
+/// another home's identically-keyed execution — and process liveness read back
+/// from the wrong record is exactly the evidence this write exists to keep
+/// separate across child runs.
+pub fn record_provider_execution_process_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    pid: u32,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let key = format!("{task_id}:{attempt}");
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(execution) = record.metadata["provider_executions"]
             .as_array_mut()
             .and_then(|executions| {
@@ -2339,8 +2428,23 @@ pub fn record_cook_controller_failure_in_store(
 /// controller failure remains in the failed continuation artifact, but must not
 /// be presented as the cause of a later terminal promotion or finalization.
 pub fn clear_cook_controller_failure(run_id: &str) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    clear_cook_controller_failure_in_store(&lifecycle_store, run_id)
+}
+
+/// Clear a durable controller failure inside an explicitly rooted store.
+///
+/// This is the erasing half of [`record_cook_controller_failure_in_store`] and
+/// has to follow the same root. An ambient reach would leave the injected
+/// store's failure standing — so a rearmed continuation would still be
+/// presented as the cause of a later promotion — while silently erasing a
+/// failure in whatever home the environment pointed at.
+pub fn clear_cook_controller_failure_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<()> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         record
             .ensure_metadata_object()
             .remove("cook_controller_failure")
@@ -3401,7 +3505,27 @@ pub(crate) fn record_run_aggregate_in_store(
 /// recovery path for historical runner results whose aggregate was persisted
 /// before the controller finalized its artifact-byte projection.
 pub fn reconcile_terminal_artifact_projection(run_id: &str) -> Result<bool> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_terminal_artifact_projection_in_store(&lifecycle_store, run_id)
+}
+
+/// Reproject terminal artifacts inside an explicitly rooted store.
+///
+/// Every input and every output follows the injected root: the terminal record,
+/// the controller-owned plan, the aggregate the byte checks are derived from,
+/// and the observation registry the projection is published into. That last one
+/// is the reason this sibling exists — `record_terminal_artifact_projection`
+/// opens the observation database and resolves the artifact root ambiently, so
+/// a reprojection driven from one home's aggregate would have registered its
+/// controller-owned bytes under another home's artifact root while every
+/// positive assertion still passed. `PathRoots` carries `artifacts` separately
+/// from `data`, and `open_observation_initialized` is what binds both to this
+/// store.
+pub fn reconcile_terminal_artifact_projection_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     if !record.state.is_terminal() {
         return Ok(false);
     }
@@ -3409,10 +3533,10 @@ pub fn reconcile_terminal_artifact_projection(run_id: &str) -> Result<bool> {
     // Require the controller-owned plan as part of the durable lifecycle
     // contract even though artifact projection derives its byte checks from the
     // aggregate. The runner staging plan is never a recovery input.
-    let _plan = store::read_controller_plan(&record.run_id)?;
-    let aggregate = store::read_aggregate(&record.run_id)?;
-    record_terminal_artifact_projection(&mut record, &aggregate)?;
-    update_cook_candidate_after_completion(&record, &aggregate, None)?;
+    let _plan = lifecycle_store.read_controller_plan(&record.run_id)?;
+    let aggregate = lifecycle_store.read_aggregate(&record.run_id)?;
+    record_terminal_artifact_projection_in_store(lifecycle_store, &mut record, &aggregate)?;
+    update_cook_candidate_after_completion_in_store(lifecycle_store, &record, &aggregate, None)?;
     Ok(true)
 }
 
@@ -4801,8 +4925,35 @@ pub fn invalidate_cook_finalization_for_dependency(
     dependency_revision: &str,
     next_command: &str,
 ) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    invalidate_cook_finalization_for_dependency_in_store(
+        &lifecycle_store,
+        run_id,
+        dependency_revision,
+        next_command,
+    )
+}
+
+/// Re-arm a finalized candidate inside an explicitly rooted store.
+///
+/// This is the invalidating half of [`record_cook_finalization_in_store`], and
+/// like [`clear_cook_moving_base_recovery_in_store`] it has to erase from the
+/// same root that recorded. Its idempotence guard reads the checkpoint it is
+/// about to write, so an ambient reach would decide "already re-armed" from
+/// another home's evidence and leave this store's finalization standing — the
+/// exact state that lets a stale review be published as if its gates had been
+/// rerun.
+///
+/// The unchanged-record fallback read follows the injected store too, so the
+/// record handed back to the caller is always the one this call operated on.
+pub fn invalidate_cook_finalization_for_dependency_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    dependency_revision: &str,
+    next_command: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let metadata = record.ensure_metadata_object();
         // Retrying the same invalidation after an interrupted coordinator must
         // preserve the original review evidence and leave its timestamp stable.
@@ -4847,7 +4998,7 @@ pub fn invalidate_cook_finalization_for_dependency(
     })?;
     match record {
         Some(record) => Ok(record),
-        None => store::read_record(&run_id),
+        None => lifecycle_store.read_record(&run_id),
     }
 }
 
@@ -5441,9 +5592,65 @@ pub fn record_acceptance_verdict(
     record_acceptance_verdict_with_feedback(run_id, verdict, evidence_refs, token, None)
 }
 
+/// Record a verdict against an explicitly rooted store. The thin delegation to
+/// the feedback-bearing sibling mirrors the ambient pair exactly.
+pub fn record_acceptance_verdict_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    verdict: AgentTaskAcceptanceVerdict,
+    evidence_refs: Vec<String>,
+    token: String,
+) -> Result<AgentTaskRunRecord> {
+    record_acceptance_verdict_with_feedback_in_store(
+        lifecycle_store,
+        run_id,
+        verdict,
+        evidence_refs,
+        token,
+        None,
+    )
+}
+
 /// Record a verdict with bounded reviewer feedback for the single durable Cook
 /// remediation that follows a rejection.
 pub fn record_acceptance_verdict_with_feedback(
+    run_id: &str,
+    verdict: AgentTaskAcceptanceVerdict,
+    evidence_refs: Vec<String>,
+    token: String,
+    feedback: Option<String>,
+) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_acceptance_verdict_with_feedback_in_store(
+        &lifecycle_store,
+        run_id,
+        verdict,
+        evidence_refs,
+        token,
+        feedback,
+    )
+}
+
+/// Record an authority verdict inside an explicitly rooted store.
+///
+/// The pre-verification binding read, the drift comparison made again under the
+/// record mutation, and the durable verdict write are one compare-and-swap and
+/// all three follow the injected root. Read ambiently, the binding this call
+/// sends to the authority would describe another home's applied promotion,
+/// while the verdict it produced landed here — a signed attestation bound to a
+/// candidate this store never promoted, with the drift guard that exists to
+/// catch exactly that comparing the wrong two records.
+///
+/// The bounded validation guards are repeated here rather than moved behind the
+/// ambient entry point: a blank token, an empty evidence list, oversized
+/// feedback, and feedback on a non-rejection are refused before any store is
+/// touched, exactly as they are today.
+///
+/// The acceptance verifier registry is deliberately left process-global. It is
+/// configured trust material and a subprocess contract, not durable lifecycle
+/// state, so it is not one of this store's roots.
+pub fn record_acceptance_verdict_with_feedback_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     verdict: AgentTaskAcceptanceVerdict,
     evidence_refs: Vec<String>,
@@ -5481,7 +5688,7 @@ pub fn record_acceptance_verdict_with_feedback(
             None,
         ));
     }
-    let existing = store::read_record(&run_id)?;
+    let existing = lifecycle_store.read_record(&run_id)?;
     let acceptance = existing.acceptance.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "acceptance",
@@ -5548,7 +5755,7 @@ pub fn record_acceptance_verdict_with_feedback(
         return Ok(existing);
     }
     let mut promotion_drifted = false;
-    let record = store::mutate_record(&run_id, |record| {
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
         let Some(acceptance) = record.acceptance.as_mut() else {
             promotion_drifted = true;
             return false;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -957,6 +957,454 @@ fn detached_handoff_siblings_advance_only_the_injected_store() {
     );
 }
 
+/// The authority fixture used by the run-outcome rooting proof.
+///
+/// The verifier registry is process-global by design — it is configured trust
+/// material and a subprocess contract, not a durable lifecycle root — so it is
+/// installed through the serializing test guard rather than by mutating any
+/// environment.
+struct RootedAcceptanceVerifier;
+
+impl AgentTaskAcceptanceVerifier for RootedAcceptanceVerifier {
+    fn provenance(&self) -> AgentTaskAcceptanceVerifierProvenance {
+        AgentTaskAcceptanceVerifierProvenance {
+            verifier: "rooted-independent-review".to_string(),
+            configuration: "rooted-policy-revision-1".to_string(),
+        }
+    }
+
+    fn verify_acceptance(
+        &self,
+        request: &AgentTaskAcceptanceVerificationRequest,
+    ) -> Result<AgentTaskAcceptanceAttestation> {
+        if request.token != "rooted-token" {
+            return Err(Error::validation_invalid_argument(
+                "token",
+                "rooted fixture verifier rejected token",
+                None,
+                None,
+            ));
+        }
+        Ok(AgentTaskAcceptanceAttestation {
+            actor: "rooted-reviewer".to_string(),
+            authority: request.requirement.authority.clone(),
+            policy: request.requirement.policy.clone(),
+            issued_at: "2020-01-01T00:00:00Z".to_string(),
+            provider_ref: "rooted://acceptance/1".to_string(),
+            signature: "rooted-signature".to_string(),
+            key_id: "rooted-key".to_string(),
+        })
+    }
+
+    fn revalidate_attestation(
+        &self,
+        request: &AgentTaskAcceptanceVerificationRequest,
+        attestation: &AgentTaskAcceptanceAttestation,
+    ) -> Result<()> {
+        if attestation.signature != "rooted-signature"
+            || attestation.authority != request.requirement.authority
+            || attestation.policy != request.requirement.policy
+        {
+            return Err(Error::validation_invalid_argument(
+                "acceptance",
+                "rooted fixture attestation did not match the signed request",
+                None,
+                None,
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A routed placement decision that a controller-local outcome verifies.
+///
+/// Deliberately *not* a submission stamp: `normalize_missing_execution_placement_decision_in_store`
+/// only supersedes a stamp, and the outcome recorder compares `decision_id`,
+/// which is a deterministic content identity and therefore identical in both
+/// roots.
+fn rooted_placement_decision() -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
+    homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+        "rooted-run-outcome-policy",
+        "1",
+        homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+            repository: "repo".to_string(),
+            workspace: "workspace".to_string(),
+            task: "task-a".to_string(),
+            candidate: None,
+            base: None,
+        },
+        homeboy_lab_runner_contract::Placement::Auto,
+        homeboy_lab_runner_contract::ExecutionPlacementRequirement::Either,
+        homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local,
+        None,
+        homeboy_lab_runner_contract::ExecutionPlacementFallback {
+            local_allowed: false,
+            reason: None,
+        },
+        homeboy_lab_runner_contract::ExecutionPlacementOverrideAuthorization {
+            authorized: false,
+            authority: None,
+        },
+    )
+}
+
+/// An applied promotion complete enough to open acceptance.
+fn rooted_applied_promotion() -> Value {
+    json!({
+        "status": "applied",
+        "verified_base": { "sha": "rooted-base" },
+        "provenance": { "candidate": { "fingerprint": {
+            "schema": "homeboy/agent-task-candidate-fingerprint/v1",
+            "target_path": "/repo",
+            "head": "rooted-candidate",
+            "base": "rooted-candidate-parent",
+            "changed_files": ["src/lib.rs"],
+            "sha256": "rooted-candidate-sha",
+            "tree": "rooted-candidate-tree",
+        } } },
+    })
+}
+
+#[test]
+fn run_outcome_siblings_record_only_into_the_injected_store() {
+    // The run-outcome family writes the evidence a run is *judged* by: the
+    // verified placement of the execution, the authority verdict on its
+    // candidate, the terminal artifact projection, the durable controller
+    // failure, and the finalization that a dependency rebase re-arms. Absence
+    // in a second root is far too weak a negative for that — every one of these
+    // writes is equally "absent" from a root the work simply never reached.
+    //
+    // So both roots are seeded with the *same* run identity in the *same*
+    // pre-outcome shape: the same submission stamp, the same applied promotion,
+    // the same pending acceptance, the same reserved provider execution, the
+    // same recorded controller failure, the same finalization, the same
+    // terminal state, and the same aggregate. Every act below is made through a
+    // sibling handed `seeded`. The second root is then asserted to be *still in
+    // its original state* — still accepting the same verdict, still
+    // un-completed, still un-projected, still un-invalidated, still bindable —
+    // which is what a leak into an ambient root cannot satisfy while every
+    // positive assertion here still passes (#7505).
+    //
+    // Two guards are proved directionally rather than by absence: the same call
+    // with the same run id and the same argument is answered one way by one root
+    // and the opposite way by the other, decided only by which store was
+    // injected.
+    //
+    // No environment is mutated: both roots come from
+    // `HermeticTestContext::path_roots()`. The acceptance verifier registry is
+    // process-global trust material, not a lifecycle root, and is installed
+    // through its own serializing guard.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let other_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), other_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let other =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(other_context.path_roots());
+
+    let run_id = "rooted-run-outcome";
+    let mut plan = test_plan();
+    plan.metadata = json!({
+        "acceptance": { "authority": "rooted-review", "policy": "rooted-release" },
+    });
+    let aggregate = succeeded_aggregate(&plan);
+    let decision = rooted_placement_decision();
+    let outcome = decision
+        .outcome(
+            homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local,
+            None,
+        )
+        .expect("a controller-local outcome verifies a local decision");
+
+    for lifecycle_store in [&seeded, &other] {
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+            .expect("submit the same run identity into both roots");
+        // A reserved provider execution, reproduced rather than produced.
+        // `reserve_provider_execution_in_store` is a claim-family sibling that a
+        // prior slice already rooted; what this test needs is the durable shape
+        // it leaves behind, so the binding recorder has something to find.
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                record.ensure_metadata_object().insert(
+                    "provider_executions".to_string(),
+                    json!([{
+                        "key": "task-a:1",
+                        "task_id": "task-a",
+                        "attempt": 1,
+                        "state": "running",
+                    }]),
+                );
+                true
+            })
+            .expect("seed the same reserved provider execution into both roots");
+        record_cook_controller_failure_in_store(
+            lifecycle_store,
+            run_id,
+            &json!({ "reason": "rooted-controller-failure" }),
+        )
+        .expect("seed the same controller failure into both roots");
+        record_cook_finalization_in_store(
+            lifecycle_store,
+            run_id,
+            json!({ "status": "published", "pr": 1 }),
+        )
+        .expect("seed the same finalization into both roots");
+        record_promotion_in_store(lifecycle_store, run_id, rooted_applied_promotion())
+            .expect("seed the same applied promotion into both roots");
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                set_run_state(record, AgentTaskRunState::Succeeded);
+                record.updated_at = Some(now_timestamp());
+                true
+            })
+            .expect("terminalize the same run in both roots");
+        lifecycle_store
+            .write_aggregate(run_id, &aggregate)
+            .expect("seed the same durable aggregate into both roots");
+        assert_eq!(
+            lifecycle_store
+                .read_record(run_id)
+                .expect("read the seeded record back")
+                .acceptance
+                .expect("an applied promotion opens acceptance")
+                .verdict,
+            AgentTaskAcceptanceVerdict::Pending,
+            "both roots start from the identical pending verdict"
+        );
+    }
+
+    // Adopt the routed decision over the submission stamp — in the first root
+    // only. The second root keeps the stamp it was submitted with, which is
+    // what makes the outcome recorder answer directionally below.
+    assert!(
+        normalize_missing_execution_placement_decision_in_store(&seeded, run_id, &decision)
+            .expect("adopt a canonical decision in the injected store"),
+        "a submission stamp is superseded by a routed decision"
+    );
+
+    // DIRECTIONAL PAIR 1. The identical verified outcome, for the identical run
+    // id, is accepted by the root that adopted the decision it names and refused
+    // by the root that did not. Nothing about the call distinguishes them.
+    record_execution_placement_outcome_in_store(&seeded, run_id, outcome.clone())
+        .expect("the injected store owns the decision this outcome verifies");
+    let contradicted = record_execution_placement_outcome_in_store(&other, run_id, outcome.clone())
+        .expect_err("the second root's own decision contradicts this outcome");
+    assert_eq!(
+        contradicted.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert_eq!(
+        contradicted.message,
+        "verified placement outcome contradicts the durable routing decision"
+    );
+
+    record_provider_execution_process_in_store(&seeded, run_id, "task-a", 1, 515_151)
+        .expect("bind the provider process in the injected store");
+
+    let _verifier = AcceptanceVerifierTestGuard::install(Box::new(RootedAcceptanceVerifier));
+    let accepted = record_acceptance_verdict_in_store(
+        &seeded,
+        run_id,
+        AgentTaskAcceptanceVerdict::Accepted,
+        vec!["review://rooted/1".to_string()],
+        "rooted-token".to_string(),
+    )
+    .expect("record the authority verdict into the injected store");
+    assert_eq!(
+        accepted
+            .acceptance
+            .as_ref()
+            .expect("acceptance record")
+            .verdict,
+        AgentTaskAcceptanceVerdict::Accepted
+    );
+
+    clear_cook_controller_failure_in_store(&seeded, run_id)
+        .expect("clear the controller failure in the injected store");
+    let invalidated = invalidate_cook_finalization_for_dependency_in_store(
+        &seeded,
+        run_id,
+        "dependency-sha",
+        "homeboy agent-task cook-continue",
+    )
+    .expect("re-arm the finalization in the injected store");
+    assert_eq!(
+        invalidated.metadata["latest_promotion"]["status"],
+        "verification_pending"
+    );
+    assert!(
+        reconcile_terminal_artifact_projection_in_store(&seeded, run_id)
+            .expect("reproject terminal artifacts in the injected store"),
+        "a terminal record with a durable plan and aggregate is reprojectable"
+    );
+
+    // The positive: every outcome is durable in the store that was handed in.
+    let persisted = seeded
+        .read_record(run_id)
+        .expect("read the seeded record back");
+    assert_eq!(
+        persisted.metadata["execution_placement_decision"]["decision_id"],
+        decision.decision_id
+    );
+    assert_eq!(
+        persisted.metadata["execution_placement_normalized"]["reason"],
+        "durable run carried a submission-derived placement decision"
+    );
+    assert_eq!(
+        persisted.metadata["execution_placement_outcome"]["decision_id"],
+        decision.decision_id
+    );
+    assert_eq!(
+        persisted.metadata["provider_executions"][0]["owner_pid"],
+        515_151
+    );
+    let acceptance = persisted
+        .acceptance
+        .as_ref()
+        .expect("durable acceptance record");
+    assert_eq!(acceptance.verdict, AgentTaskAcceptanceVerdict::Accepted);
+    assert_eq!(acceptance.actor.as_deref(), Some("rooted-reviewer"));
+    assert_eq!(acceptance.signature.as_deref(), Some("rooted-signature"));
+    assert!(persisted.metadata.get("cook_controller_failure").is_none());
+    assert!(persisted.metadata.get("cook_finalization").is_none());
+    assert_eq!(
+        persisted.metadata["cook_recovery_source_checkpoint"]["dependency_revision"],
+        "dependency-sha"
+    );
+    assert_eq!(
+        persisted.metadata["latest_promotion"]["status"],
+        "verification_pending"
+    );
+    assert_eq!(
+        persisted.metadata["artifact_projection"]["status"],
+        "complete"
+    );
+
+    // The negative, absence first: the second root holds the same run identity
+    // and observed none of it.
+    let untouched = other
+        .read_record(run_id)
+        .expect("the second root still has its own record");
+    assert_eq!(
+        untouched.metadata["execution_placement_decision"]["policy_id"],
+        homeboy_lab_runner_contract::CONTROLLER_LOCAL_SUBMISSION_POLICY_ID,
+        "the second root's decision must still be the stamp it was submitted with"
+    );
+    for key in [
+        "execution_placement_normalized",
+        "execution_placement_outcome",
+        "artifact_projection",
+        "cook_recovery_source_checkpoint",
+    ] {
+        assert!(
+            untouched.metadata.get(key).is_none(),
+            "second root must not observe `{key}` written through the injected store"
+        );
+    }
+    assert!(
+        untouched.metadata["provider_executions"][0]
+            .get("owner_pid")
+            .is_none(),
+        "second root must not observe the provider process bound through the injected store"
+    );
+
+    // Then the stronger half: the second root is not merely missing the
+    // evidence, it is still in its *original* state. Its controller failure
+    // still stands, its finalization is still published, its promotion is still
+    // applied, and its verdict is still pending — none of which is true of
+    // outcome state some other call already recorded.
+    assert_eq!(
+        untouched.metadata["cook_controller_failure"]["reason"], "rooted-controller-failure",
+        "clearing the injected store's failure must not clear the second root's"
+    );
+    assert_eq!(
+        untouched.metadata["cook_finalization"]["status"],
+        "published"
+    );
+    assert_eq!(untouched.metadata["latest_promotion"]["status"], "applied");
+    assert_eq!(
+        untouched
+            .acceptance
+            .as_ref()
+            .expect("the second root keeps its own acceptance record")
+            .verdict,
+        AgentTaskAcceptanceVerdict::Pending
+    );
+
+    // And it is still *eligible*: every operation the injected store already
+    // performed can still be performed here, on the second root's own state.
+    let second_verdict = record_acceptance_verdict_in_store(
+        &other,
+        run_id,
+        AgentTaskAcceptanceVerdict::Accepted,
+        vec!["review://rooted/2".to_string()],
+        "rooted-token".to_string(),
+    )
+    .expect("the second root still accepts the same verdict")
+    .acceptance
+    .expect("acceptance record");
+    assert_eq!(second_verdict.verdict, AgentTaskAcceptanceVerdict::Accepted);
+    assert!(
+        second_verdict.history.is_empty(),
+        "the second root moved from pending, so the injected store's verdict was never recorded here"
+    );
+    record_provider_execution_process_in_store(&other, run_id, "task-a", 1, 626_262)
+        .expect("the second root's reservation is still bindable");
+    clear_cook_controller_failure_in_store(&other, run_id)
+        .expect("the second root still owns its controller failure");
+    assert!(
+        reconcile_terminal_artifact_projection_in_store(&other, run_id)
+            .expect("the second root is still reprojectable"),
+        "the injected store's projection must not consume the second root's"
+    );
+    let second_invalidated = invalidate_cook_finalization_for_dependency_in_store(
+        &other,
+        run_id,
+        "dependency-sha",
+        "homeboy agent-task cook-continue",
+    )
+    .expect("the second root's finalization is still invalidatable");
+    assert!(
+        second_invalidated
+            .metadata
+            .get("cook_finalization")
+            .is_none(),
+        "the second root still had a finalization of its own to re-arm"
+    );
+
+    let second_root = other
+        .read_record(run_id)
+        .expect("read the second root's record back");
+    assert_eq!(
+        second_root.metadata["provider_executions"][0]["owner_pid"],
+        626_262
+    );
+    assert!(second_root
+        .metadata
+        .get("cook_controller_failure")
+        .is_none());
+    assert_eq!(
+        second_root.metadata["artifact_projection"]["status"],
+        "complete"
+    );
+
+    // DIRECTIONAL PAIR 2. The identical adoption offer, for the identical run
+    // id, is refused by the root that already holds this decision and accepted
+    // by the root whose submission stamp was never superseded.
+    assert!(
+        !normalize_missing_execution_placement_decision_in_store(&seeded, run_id, &decision)
+            .expect("re-offering the adopted decision is answered, not errored"),
+        "the injected store already carries this exact decision"
+    );
+    assert!(
+        normalize_missing_execution_placement_decision_in_store(&other, run_id, &decision)
+            .expect("the second root still holds an unsuperseded submission stamp"),
+        "an adoption made in the injected store must not decide the second root"
+    );
+}
+
 #[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"


### PR DESCRIPTION
## Summary

Continues rooting `lifecycle_ops.rs` after the read surface (#12603), Cook writes (#12604), the run-claim family (#12608), and the detached-handoff cluster (#12614). This takes **run-outcome and execution recording** — 10 siblings.

| function | note |
|---|---|
| `record_acceptance_verdict` | |
| `record_acceptance_verdict_with_feedback` | |
| `record_completed_run` | |
| `record_execution_placement_outcome` | |
| `record_provider_execution_process` | |
| `clear_cook_controller_failure` | erasing half of an already-rooted recorder |
| `invalidate_cook_finalization_for_dependency` | invalidating half of another |
| `reconcile_terminal_artifact_projection` | had the artifact-root reach |
| **`normalize_missing_execution_placement_decision`** | **not in scope — see below** |
| **`normalize_local_execution_placement`** | **not in scope — see below** |

## The most important find is a pre-existing defect in already-rooted code

<callout accent="#ef4444">
`record_aggregate_in_store` — a **rooted** function shipped by an earlier slice — reached the **ambient** `update_cook_candidate_after_completion`.

So a completed run would have committed its aggregate into the injected store and written the Cook substantive-candidate pointer **into the ambient one**.

Nothing fails. Every record and aggregate read back from the injected store is correct at that point. This is exactly the same-kind shadowing blind spot #12595 identified, and it was **already in main** inside a function the campaign had declared done.
</callout>

Rerouted to the rooted form. The ambient caller is unaffected, because there the store *is* the ambient store.

## Two more that had to be rooted

`normalize_missing_execution_placement_decision` and `normalize_local_execution_placement` are the other two durable writers of the execution placement decision. Leaving them would have made the family **half-rooted in the sharpest possible way**: the rooted outcome recorder *fails closed* against a decision, and the two functions that write that decision would have written it somewhere else.

## Path re-rooting

**`reconcile_terminal_artifact_projection`** — chain was `record_terminal_artifact_projection` → `ObservationStore::open_initialized()` → `crate::paths::artifact_root()`.

A reprojection driven from one home's aggregate would have **registered controller-owned bytes under another home's artifact root**, while still writing `artifact_projection: {"status":"complete"}` to the injected record. Rerouted through the store's own opener, which binds both the `data` and the separately-carried `artifacts` root of `PathRoots`.

**`normalize_local_execution_placement`** reached `load_plan`, which resolves the Cook alias against the *ambient* index and then reads the *ambient* run directory — so it would have copied another home's plan decision onto the injected record. That is the one restoration the function exists to make trustworthy.

## Deliberately left process-global

The **acceptance verifier registry** is a `provider_registry!` process-global: configured trust material and a subprocess contract, not a lifecycle root. Same treatment as the controller-runtime pin store in prior slices, and documented as such.

## Residual debt, deliberately not fixed

`substantive_candidate_in_aggregate` calls the ambient `verified_controller_artifact_projection_path`, reachable from two already-rooted functions.

The rooted opener is `open_initialized_for_lifecycle_at_roots`, which sets `maintain_artifacts = false`; the ambient `open_initialized()` first runs `reconcile_unfinished_artifact_publications_with_retry`. **Swapping them would change what an existing ambient caller can see** — a behavior change. Rooting it properly needs a core-side `open_initialized_at_roots` that keeps maintenance on. Separate slice.

It degrades to "no candidate recorded" rather than a cross-home write, and is unreachable in this family unless the record carries `cook_id` — which the test deliberately does not seed, so the suite never touches the operator's real observation DB.

## Shadowing audit

All ten new sibling bodies extracted and scanned for `store::`, `default_store`, `paths::`, `from_current_environment`, `ObservationStore::`, `open_readonly()` — **zero hits** across 428 body lines.

The #12591 scanner's logic run over `crates/homeboy-agents/src`: **1 finding**, `run_cook_with_boundaries_reported` — the sole pre-existing allowlist row. No new findings, none stale.

**Duplicate-definition check** (the silent-merge failure mode recent rebases hit): `lifecycle_ops.rs` 209 unique, `failure_recording.rs` 46 unique, `submit_and_persist.rs` 47 unique — **zero duplicates**.

## What could not be driven hermetically

`record_completed_run_in_store`. Its first half is `submit_plan_in_store` → `controller_runtime::admit_current_for_with_cancellation_check`, which writes under `paths::controller_runtimes_store()` — **the operator's real home** — and takes a machine-global admission lock that would serialize against every peer test. Same boundary #12614 documented.

So the test drives the **aggregate half** — `record_aggregate_in_store`, the exact body it delegates to, and the one where the ambient Cook-index reach was fixed. No `set_var`, no faked admission.

## The proof

`run_outcome_siblings_record_only_into_the_injected_store`. Two `HermeticTestContext::path_roots()` roots — no `with_isolated_home`, no `HomeGuard`, no `set_var`. (The acceptance verifier goes in via `AcceptanceVerifierTestGuard`, a serializing registry install, not an environment mutation.)

Both roots seeded with the **same** run identity in the **same** pre-outcome shape — same submission stamp, reserved provider execution, recorded controller failure, published finalization, applied promotion, resulting pending acceptance, terminal state, aggregate — with an explicit assertion in the seeding loop that both start at `Pending`.

**Past absence — the second root is still in its original state:**
- `cook_controller_failure.reason` still `"rooted-controller-failure"` — clearing the injected store's failure did not clear this one
- `cook_finalization.status` still `"published"`, `latest_promotion.status` still `"applied"`
- acceptance verdict still `Pending`

**Then still eligible**, which a leak cannot satisfy:
- `record_acceptance_verdict_in_store(&other, …)` still succeeds **and its `history` is empty** — it moved from Pending, so the injected store's verdict was never recorded here
- `record_provider_execution_process_in_store(&other, …)` still finds a bindable reservation
- `reconcile_terminal_artifact_projection_in_store(&other, …)` still returns `true` and projects
- `invalidate_cook_finalization_for_dependency_in_store(&other, …)` still had a finalization of its own to remove

**Two directional pairs:**

1. The **identical** `ExecutionPlacementOutcome` for the **identical** run id is accepted by `seeded` and refused by `other` with `ValidationInvalidArgument` / *"verified placement outcome contradicts the durable routing decision"*.
2. The **identical** adoption offer of the **identical** decision answers `Ok(false)` from `seeded` (already holds it) and `Ok(true)` from `other` (stamp never superseded).

Nothing about either call distinguishes them but the store.

## Compatibility

Purely additive plus delegation, with one visibility raise (`record_terminal_artifact_projection_in_store` module-private → `pub(crate)`) and the two ambient-reach fixes described above, both behavior-preserving for existing callers. No caller migrated.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Implementation, helper threading, test authoring, and mechanical audits. Review by hand; compilation deferred to CI.

Refs #7505
