### PR TITLE
Give the run re-entry family explicit stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cook_workspace_restore.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cook_workspace_restore.rs
@@ -9,7 +9,27 @@ use homeboy_core::{Error, Result};
 
 use crate::agent_task_scheduler::AgentTaskPlan;
 
-pub(super) fn restore_follow_up_cook_candidate_workspace(plan: &mut AgentTaskPlan) -> Result<()> {
+/// Restore a Cook follow-up candidate workspace under an explicitly named
+/// artifact root.
+///
+/// The baseline this materializes is a whole working-tree checkout, and it is
+/// published under an artifact root rather than a process temp dir so it can be
+/// seen and reaped (#11128). Resolved ambiently, a retry driven from an
+/// explicitly rooted store would write that checkout under another home's
+/// artifact root and then hand the retried plan a workspace path outside the
+/// root that owns the run — the same class of cross-home artifact write #12618
+/// found in the terminal projection.
+///
+/// The durable promotion below is *not* rooted here, deliberately.
+/// `persisted_promotion_for_attempt` reads through `agent_task_lifecycle::status`,
+/// which reconciles and writes as it reads; its `_in_store` sibling is a plain
+/// record read instead. Substituting one for the other would change what an
+/// existing caller of the ambient retry sees, so rooting it waits on the slice
+/// that roots `status` itself (#7505).
+pub(super) fn restore_follow_up_cook_candidate_workspace_in_root(
+    plan: &mut AgentTaskPlan,
+    artifact_root: &Path,
+) -> Result<()> {
     let candidate_tasks = plan
         .tasks
         .iter()
@@ -100,8 +120,9 @@ pub(super) fn restore_follow_up_cook_candidate_workspace(plan: &mut AgentTaskPla
             None,
         ));
     }
-    let baseline = crate::agent_task_service::materialize_follow_up_baseline(
+    let baseline = crate::agent_task_service::materialize_follow_up_baseline_in_root(
         &promotion,
+        artifact_root,
         source_run_id,
         &task.task_id,
     )?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1379,28 +1379,10 @@ where
     )
 }
 
-fn submit_plan_with_runtime_admission_on_runner_with_metadata<F, A>(
-    plan: &AgentTaskPlan,
-    requested_run_id: Option<&str>,
-    execution_runner_id: Option<String>,
-    submission_metadata: Option<serde_json::Map<String, Value>>,
-    admit_runtime: F,
-) -> Result<AgentTaskRunRecord>
-where
-    F: FnOnce(&str) -> Result<A>,
-    A: RuntimeAdmissionEvidence,
-{
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    submit_plan_with_runtime_admission_in_store(
-        &lifecycle_store,
-        plan,
-        requested_run_id,
-        execution_runner_id,
-        submission_metadata,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
-        admit_runtime,
-    )
-}
+// `submit_plan_with_runtime_admission_on_runner_with_metadata` lived here. Its
+// only caller was the retry admission, which now calls
+// `submit_plan_with_runtime_admission_in_store` with the store it was handed
+// rather than resolving a second one from the environment (#7505).
 
 pub(crate) fn submit_plan_with_runtime_admission_in_store<F, A>(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -2128,7 +2110,32 @@ pub fn recover_controller_runtime(
     artifact: Option<&std::path::Path>,
     source: Option<&std::path::Path>,
 ) -> Result<Value> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    recover_controller_runtime_in_store(&lifecycle_store, run_id, artifact, source)
+}
+
+/// Repair a run's pinned controller executable against an explicitly rooted
+/// store.
+///
+/// This is the re-entry repair step: a run whose pin no longer resolves cannot
+/// be resumed or retried until the provenance it names is restored. Both
+/// lifecycle halves follow the injected root — the record the provenance is read
+/// from and the record the recovered pin is written back to — because recovering
+/// against one home's provenance and persisting into another leaves the run this
+/// operator is trying to re-enter still holding the broken pin.
+///
+/// The immutable controller-runtime store that `recover_pin_and_persist`
+/// republishes into is deliberately left process-global, for the same reason
+/// `validate_controller_runtime_in_store` leaves it alone: it is a
+/// content-addressed executable cache shared across homes, not durable lifecycle
+/// state, so it is not one of this store's roots.
+pub(crate) fn recover_controller_runtime_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    artifact: Option<&std::path::Path>,
+    source: Option<&std::path::Path>,
+) -> Result<Value> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let runtime = record
         .metadata
         .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
@@ -2148,7 +2155,7 @@ pub fn recover_controller_runtime(
         |recovered| {
             record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
                 recovered.clone();
-            store::write_record(&record)
+            lifecycle_store.write_record(&record)
         },
     )?;
     Ok(recovered)
@@ -3394,62 +3401,99 @@ fn trusted_plan_environment_variables(plan: &AgentTaskPlan) -> Vec<String> {
 
 /// Re-arm a quarantined record by exact durable run ID after its provenance is repaired.
 pub fn rearm_quarantined_run(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    rearm_quarantined_run_in_store(&lifecycle_store, run_id)
+}
+
+/// Re-arm a quarantined record inside an explicitly rooted store.
+///
+/// This is the clearing half of the quarantine pair, and it has to read and
+/// write the same root the quarantine marker was written into. The eligibility
+/// guard — queued, and carrying a `queue_quarantine` marker — is evaluated
+/// inside the mutation closure, so an ambient read decides re-armability from
+/// another home's copy of the identity: a run quarantined here would be reported
+/// as "not quarantined" and refuse to re-arm, while a run quarantined only in
+/// the ambient home would report success and leave this store's queue still
+/// skipping the record on every claim.
+pub(crate) fn rearm_quarantined_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = require_literal_run_id(run_id)?;
-    store::mutate_record(&run_id, |record| {
-        if record.state != AgentTaskRunState::Queued
-            || record.metadata.get("queue_quarantine").is_none()
-        {
-            return false;
-        }
-        record.ensure_metadata_object().remove("queue_quarantine");
-        record.updated_at = Some(now_timestamp());
-        true
-    })?
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            "only an exact queued quarantined run can be re-armed",
-            Some(run_id),
-            None,
-        )
-    })
+    lifecycle_store
+        .mutate_record(&run_id, |record| {
+            if record.state != AgentTaskRunState::Queued
+                || record.metadata.get("queue_quarantine").is_none()
+            {
+                return false;
+            }
+            record.ensure_metadata_object().remove("queue_quarantine");
+            record.updated_at = Some(now_timestamp());
+            true
+        })?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                "only an exact queued quarantined run can be re-armed",
+                Some(run_id),
+                None,
+            )
+        })
 }
 
 /// Quarantine one exact queued run without changing its lifecycle state or
 /// removing any evidence. It can only return through `rearm_quarantined_run`.
 pub fn quarantine_queued_run_exact(run_id: &str, reason: &str) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    quarantine_queued_run_exact_in_store(&lifecycle_store, run_id, reason)
+}
+
+/// Quarantine one exact queued run inside an explicitly rooted store.
+///
+/// The operator quarantine and the automatic one that `quarantine_queued_run_in_store`
+/// writes during a claim are the same durable marker, and a claim scanning this
+/// store must see it. Written ambiently, the operator would be told the run is
+/// quarantined while this store's queue kept handing it out, and
+/// `rearm_quarantined_run_in_store` would then find nothing to clear.
+pub(crate) fn quarantine_queued_run_exact_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    reason: &str,
+) -> Result<AgentTaskRunRecord> {
     let run_id = require_literal_run_id(run_id)?;
     let operator_reason = normalized_operator_quarantine_reason(reason);
-    store::mutate_record(&run_id, |record| {
-        if record.state != AgentTaskRunState::Queued
-            || record.metadata.get("queue_quarantine").is_some()
-        {
-            return false;
-        }
-        let quarantined_at = now_timestamp();
-        let remediation = "repair provenance, then re-arm with: homeboy agent-task rearm <run-id>";
-        record.updated_at = Some(quarantined_at.clone());
-        record.ensure_metadata_object().insert(
-            "queue_quarantine".to_string(),
-            json!({
-                "category": "operator_quarantine",
-                "error_code": "operator_quarantine",
-                "summary": "operator quarantined this queued run",
-                "operator_reason": operator_reason,
-                "quarantined_at": quarantined_at,
-                "remediation": remediation,
-            }),
-        );
-        true
-    })?
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            "only an exact queued non-quarantined run can be quarantined",
-            Some(run_id),
-            None,
-        )
-    })
+    lifecycle_store
+        .mutate_record(&run_id, |record| {
+            if record.state != AgentTaskRunState::Queued
+                || record.metadata.get("queue_quarantine").is_some()
+            {
+                return false;
+            }
+            let quarantined_at = now_timestamp();
+            let remediation =
+                "repair provenance, then re-arm with: homeboy agent-task rearm <run-id>";
+            record.updated_at = Some(quarantined_at.clone());
+            record.ensure_metadata_object().insert(
+                "queue_quarantine".to_string(),
+                json!({
+                    "category": "operator_quarantine",
+                    "error_code": "operator_quarantine",
+                    "summary": "operator quarantined this queued run",
+                    "operator_reason": operator_reason,
+                    "quarantined_at": quarantined_at,
+                    "remediation": remediation,
+                }),
+            );
+            true
+        })?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                "only an exact queued non-quarantined run can be quarantined",
+                Some(run_id),
+                None,
+            )
+        })
 }
 
 fn normalized_operator_quarantine_reason(reason: &str) -> String {
@@ -4206,7 +4250,31 @@ pub fn run_record_exists_resolved(run_id: &str) -> Result<bool> {
 }
 
 pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    mark_resuming_in_store(&lifecycle_store, run_id)
+}
+
+/// Stamp the resume request and re-enter Running inside an explicitly rooted
+/// store.
+///
+/// Every part of this follows the injected root, and each for its own reason.
+/// The terminal guard is decided from this store's own record: read ambiently,
+/// another home's copy of the same identity could refuse a resumable run, or
+/// admit a resume into a lifecycle that already finished here. The resume stamp
+/// then has to land on the same record the guard just read, or the evidence that
+/// a resume was requested ends up in a home that never resumed anything.
+///
+/// The transition itself goes through `mark_running_in_store` rather than the
+/// ambient `mark_running`, and that is the half that matters most: `mark_running`
+/// carries the quarantine, live-owner and terminal guards. Evaluated ambiently,
+/// a run this store has quarantined would be re-armed to Running anyway — the
+/// exact inverse of the quarantine/re-arm pair below — while the state it wrote
+/// landed somewhere the resuming controller never reads.
+pub(crate) fn mark_resuming_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     if matches!(
         record.state,
         AgentTaskRunState::Succeeded
@@ -4228,12 +4296,24 @@ pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
 
     let metadata = record.ensure_metadata_object();
     metadata.insert("resume_requested_at".to_string(), json!(now_timestamp()));
-    store::write_record(&record)?;
-    mark_running(run_id)
+    lifecycle_store.write_record(&record)?;
+    mark_running_in_store(lifecycle_store, run_id)
 }
 
 pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
-    retry_with_force_inner(run_id, requested_run_id, false, false)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    retry_in_store(&lifecycle_store, run_id, requested_run_id)
+}
+
+/// Retry a run inside an explicitly rooted store, without the lineage
+/// reservation. See [`retry_with_runtime_admission_in_store`] for what follows
+/// the injected root.
+pub(crate) fn retry_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    requested_run_id: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    retry_with_force_inner_in_store(lifecycle_store, run_id, requested_run_id, false, false)
 }
 
 /// Whether a persisted plan contains enough source identity to offer a retry
@@ -4297,16 +4377,81 @@ pub fn retry_with_force(
     requested_run_id: Option<&str>,
     force: bool,
 ) -> Result<AgentTaskRunRecord> {
-    retry_with_force_inner(run_id, requested_run_id, force, true)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    retry_with_force_in_store(&lifecycle_store, run_id, requested_run_id, force)
 }
 
-fn retry_with_force_inner(
+/// Reserve one successor for the complete retry lineage inside an explicitly
+/// rooted store. The advisory lock is taken beside that store's own run
+/// directory, so two roots reserve independently instead of contending for the
+/// ambient lineage.
+pub(crate) fn retry_with_force_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+) -> Result<AgentTaskRunRecord> {
+    retry_with_force_inner_in_store(lifecycle_store, run_id, requested_run_id, force, true)
+}
+
+fn retry_with_force_inner_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     requested_run_id: Option<&str>,
     force: bool,
     enforce_lineage_reservation: bool,
 ) -> Result<AgentTaskRunRecord> {
-    let source = store::read_record(&resolve_run_id(run_id)?)?;
+    retry_with_runtime_admission_in_store(
+        lifecycle_store,
+        run_id,
+        requested_run_id,
+        force,
+        enforce_lineage_reservation,
+        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        |run_id| {
+            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+                run_id,
+                || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
+            )
+        },
+    )
+}
+
+/// Admit one retry successor into an explicitly rooted store.
+///
+/// This is the whole re-entry decision, and every input to it follows the
+/// injected root. The source record and the Cook alias that resolves it come
+/// from this store, so a Cook id cannot resolve against another home's index and
+/// mint a successor over a live Cook here. The lineage walk that finds the root
+/// of the `retry_of` chain reads this store's records, the lineage reservation
+/// lock is taken beside this store's own run directory, and the successor scan
+/// that decides "is a retry already active?" reads this store's observation
+/// database — a scan that answered ambiently would refuse a legitimate retry
+/// because another home holds an active successor, or, far worse, admit a second
+/// live successor because the active one it should have seen was recorded here.
+/// The plan, the acceptance-repair lineage write, and the retry lineage stamped
+/// back onto the source and root records all follow the same store.
+///
+/// The controller-runtime admission and its queue projection are deliberately
+/// left as parameters, exactly as `submit_plan_with_runtime_admission_in_store`
+/// leaves them. Admission itself is machine-global by design — it writes under
+/// `paths::controller_runtimes_store()` and takes a cross-process lock — but the
+/// cancellation check inside it reads *lifecycle* state, and that read is rooted
+/// by the caller that owns the store.
+pub(crate) fn retry_with_runtime_admission_in_store<F, A>(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+    enforce_lineage_reservation: bool,
+    admission_status: Option<&dyn Fn(&str) -> Option<Value>>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce(&str) -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
+    let source = lifecycle_store.read_record(&resolve_run_id_in_store(lifecycle_store, run_id)?)?;
     if source.acceptance.as_ref().is_some_and(|acceptance| {
         acceptance.repair_attempts > 1
             || (acceptance.repair_attempts > 0
@@ -4319,17 +4464,22 @@ fn retry_with_force_inner(
             None,
         ));
     }
-    let root_run_id = retry_root_run_id(&source)?;
+    let root_run_id = retry_root_run_id_in_store(lifecycle_store, &source)?;
     let _reservation = enforce_lineage_reservation
-        .then(|| RetryLineageLock::lock(&root_run_id))
+        .then(|| RetryLineageLock::lock_in_store(lifecycle_store, &root_run_id))
         .transpose()?;
     let mut requested_run_id = requested_run_id;
     if enforce_lineage_reservation {
-        let records = store::read_records()?;
+        let records = lifecycle_store.read_records()?;
         let mut successors = records
             .into_iter()
             .filter(|record| record.run_id != root_run_id)
-            .filter(|record| retry_root_run_id(record).ok().as_deref() == Some(&root_run_id))
+            .filter(|record| {
+                retry_root_run_id_in_store(lifecycle_store, record)
+                    .ok()
+                    .as_deref()
+                    == Some(&root_run_id)
+            })
             .collect::<Vec<_>>();
         successors.sort_by(|left, right| left.run_id.cmp(&right.run_id));
         if let Some(active) = successors.iter().find(|record| !record.state.is_terminal()) {
@@ -4358,9 +4508,19 @@ fn retry_with_force_inner(
             ));
         }
     }
-    let mut plan = load_controller_plan(&source.run_id)?;
+    let mut plan = load_controller_plan_in_store(lifecycle_store, &source.run_id)?;
+    // Both restorations below are filesystem work on the plan value rather than
+    // lifecycle-store work: they re-point task workspace roots at durable
+    // checkouts, and both are no-ops for a plan carrying no Cook candidate
+    // evidence. The initial one reads only the workspace it is restoring. The
+    // follow-up one materializes a whole checkout under an artifact root, which
+    // is why it takes this store's own — see its doc comment for the one reach
+    // that remains ambient there.
     super::cook_workspace_restore::restore_initial_cook_candidate_workspace(&mut plan)?;
-    super::cook_workspace_restore::restore_follow_up_cook_candidate_workspace(&mut plan)?;
+    super::cook_workspace_restore::restore_follow_up_cook_candidate_workspace_in_root(
+        &mut plan,
+        &lifecycle_store.artifact_root(),
+    )?;
     if source
         .acceptance
         .as_ref()
@@ -4416,17 +4576,14 @@ fn retry_with_force_inner(
         metadata.insert("retry_root".to_string(), json!(root_run_id));
     }
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
-    let mut record = submit_plan_with_runtime_admission_on_runner_with_metadata(
+    let mut record = submit_plan_with_runtime_admission_in_store(
+        lifecycle_store,
         &plan,
         requested_run_id,
         execution_runner_id(),
         Some(metadata),
-        |run_id| {
-            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
-                run_id,
-                || Ok(store::read_record(run_id)?.state.is_terminal()),
-            )
-        },
+        admission_status,
+        admit_runtime,
     )?;
     if let Some(mut acceptance) = source.acceptance.clone() {
         // A repair is a new candidate, but it retains the rejected verdict and
@@ -4445,7 +4602,7 @@ fn retry_with_force_inner(
             .as_ref()
             .map(|acceptance| acceptance.repair_attempts)
             .unwrap_or_default();
-        if let Some(updated) = store::mutate_record(&record.run_id, |child| {
+        if let Some(updated) = lifecycle_store.mutate_record(&record.run_id, |child| {
             child.acceptance = Some(acceptance.clone());
             child.ensure_metadata_object().insert(
                 "acceptance_repair_lineage".to_string(),
@@ -4457,7 +4614,12 @@ fn retry_with_force_inner(
         }
     }
     if enforce_lineage_reservation {
-        persist_retry_lineage(&source.run_id, &root_run_id, &record.run_id)?;
+        persist_retry_lineage_in_store(
+            lifecycle_store,
+            &source.run_id,
+            &root_run_id,
+            &record.run_id,
+        )?;
     }
     Ok(record)
 }
@@ -4470,8 +4632,19 @@ struct RetryLineageLock {
 }
 
 impl RetryLineageLock {
-    fn lock(root_run_id: &str) -> Result<Self> {
-        let path = paths::homeboy_data()?
+    /// Reserve a lineage beside the injected store's own run directory.
+    ///
+    /// This lock is the whole reservation: it is what makes "does an active
+    /// successor already exist?" a decision one process at a time. Taken at
+    /// `paths::homeboy_data()` while the scan and the successor write went to an
+    /// injected root, two concurrent retries in two roots would serialize
+    /// against each other for no reason, and — the direction that actually
+    /// loses — two retries in the *same* injected root reached from processes
+    /// with different ambient homes would not serialize at all, so both would
+    /// scan, both would see no active successor, and both would allocate one.
+    fn lock_in_store(lifecycle_store: &AgentTaskLifecycleStore, root_run_id: &str) -> Result<Self> {
+        let path = lifecycle_store
+            .data_root()
             .join("agent-task-runs")
             .join("retry-lineages")
             .join(format!("{}.lock", sanitize_run_id(root_run_id)));
@@ -4499,13 +4672,20 @@ impl RetryLineageLock {
     }
 }
 
-fn retry_root_run_id(record: &AgentTaskRunRecord) -> Result<String> {
+/// Walk the `retry_of` chain to the lineage root inside an explicitly rooted
+/// store. The walk decides which lineage lock is taken and which successors
+/// count as this run's own, so a parent read from another home would reserve and
+/// scan a lineage that does not exist here.
+fn retry_root_run_id_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &AgentTaskRunRecord,
+) -> Result<String> {
     let mut current = record.clone();
     for _ in 0..RETRY_LINEAGE_LIMIT {
         let Some(parent) = current.metadata.get("retry_of").and_then(Value::as_str) else {
             return Ok(current.run_id);
         };
-        current = store::read_record(&sanitize_run_id(parent))?;
+        current = lifecycle_store.read_record(&sanitize_run_id(parent))?;
     }
     Err(Error::validation_invalid_argument(
         "retry_of",
@@ -4527,14 +4707,23 @@ fn active_retry_successor_error(record: &AgentTaskRunRecord) -> Error {
     )
 }
 
-fn persist_retry_lineage(source_run_id: &str, root_run_id: &str, child_run_id: &str) -> Result<()> {
+/// Stamp the successor onto the source and root records inside an explicitly
+/// rooted store. This is the durable evidence the next lineage scan reads, so
+/// writing it ambiently would leave the injected root's own lineage empty and
+/// let the following retry allocate beside a successor it cannot see.
+fn persist_retry_lineage_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    source_run_id: &str,
+    root_run_id: &str,
+    child_run_id: &str,
+) -> Result<()> {
     let mut targets = vec![sanitize_run_id(source_run_id)];
     let root_run_id = sanitize_run_id(root_run_id);
     if !targets.contains(&root_run_id) {
         targets.push(root_run_id.clone());
     }
     for run_id in targets {
-        store::mutate_record(&run_id, |record| {
+        lifecycle_store.mutate_record(&run_id, |record| {
             let metadata = record.ensure_metadata_object();
             let lineage = metadata
                 .entry("retries".to_string())
@@ -4567,8 +4756,33 @@ pub fn find_unbound_cook_retry_successor(
     attempt: u32,
     plan: &AgentTaskPlan,
 ) -> Result<Option<AgentTaskRunRecord>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    find_unbound_cook_retry_successor_in_store(
+        &lifecycle_store,
+        source_run_id,
+        cook_id,
+        attempt,
+        plan,
+    )
+}
+
+/// Find the Cook retry reservation inside an explicitly rooted store.
+///
+/// The caller treats `None` as authority to create a reservation, so this read
+/// has to come from the store the reservation was made in. Answered ambiently it
+/// fails in both directions: a successor reserved here reads back as absent and
+/// a second one is minted over it, or an unrelated home's successor is adopted
+/// and this Cook attempt is bound to a run that does not exist in its own root.
+pub(crate) fn find_unbound_cook_retry_successor_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    source_run_id: &str,
+    cook_id: &str,
+    attempt: u32,
+    plan: &AgentTaskPlan,
+) -> Result<Option<AgentTaskRunRecord>> {
     let prefix = format!("{}-attempt-{attempt}-", sanitize_run_id(cook_id));
-    let mut matches = store::read_retry_successors(&sanitize_run_id(source_run_id))?
+    let mut matches = lifecycle_store
+        .read_retry_successors(&sanitize_run_id(source_run_id))?
         .into_iter()
         .filter(|record| record.run_id.starts_with(&prefix))
         .filter(|record| record.plan_id == plan.plan_id)

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -1406,6 +1406,308 @@ fn run_outcome_siblings_record_only_into_the_injected_store() {
 }
 
 #[test]
+fn run_reentry_siblings_re_enter_only_the_injected_store() {
+    // Re-entry is the family that decides whether a durable run may run *again*:
+    // resume, retry, and the quarantine/re-arm pair that gates both. Absence in a
+    // second root is a uselessly weak negative for that — a root the work never
+    // reached is equally "not resumed", "not retried" and "not re-armed". What
+    // separates a leak from a clean rooting is whether the second root is still
+    // *eligible*, so both roots are seeded with the same four identities in the
+    // same pre-re-entry shape: a retry source, a resumable queued run, a clean
+    // queued run, and a quarantined queued run. Every act below is made through
+    // a sibling handed `seeded`, and the second root is then asserted to be
+    // still retryable, still resumable, still quarantinable and still
+    // quarantined — none of which is true of state some other call consumed.
+    //
+    // Four guards are proved directionally rather than by absence: the same call
+    // with the same run id is answered one way by one root and the opposite way
+    // by the other, decided only by which store was injected.
+    //
+    // No environment is mutated: both roots come from
+    // `HermeticTestContext::path_roots()`.
+    let seeded_context = homeboy_core::test_support::HermeticTestContext::new();
+    let other_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(seeded_context.data_dir(), other_context.data_dir());
+
+    let seeded =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(seeded_context.path_roots());
+    let other =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(other_context.path_roots());
+
+    let retry_source = "rooted-reentry-retry-source";
+    let cook_id = "rooted-reentry-cook";
+    let first_successor = "rooted-reentry-cook-attempt-1-successor";
+    let second_successor = "rooted-reentry-retry-second";
+    let resume_target = "rooted-reentry-resume";
+    let quarantine_target = "rooted-reentry-quarantine";
+    let rearm_target = "rooted-reentry-rearm";
+    let plan = test_plan();
+
+    // A run submitted with a stub admission carries `controller_runtime: {}` — a
+    // pin naming no immutable executable. Every lifecycle mutation validates the
+    // pin before it runs, and that validation resolves
+    // `paths::controller_runtimes_store()`, which is machine-global by design
+    // and would be the operator's real home here. A record with no pin at all is
+    // the shape the pin validators explicitly tolerate and return early on, so
+    // the seed drops the stub rather than reaching a root this test does not
+    // own. Controller admission itself is likewise never driven: the retry below
+    // is handed a stub admission and no queue projection, exactly as the
+    // detached-handoff and run-outcome proofs do.
+    let seed_queued = |lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,
+                       run_id: &str| {
+        lifecycle_store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+            .expect("submit the same run identity into both roots");
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                record
+                    .ensure_metadata_object()
+                    .remove(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY);
+                true
+            })
+            .expect("seed an unpinned queued record into both roots");
+    };
+
+    for lifecycle_store in [&seeded, &other] {
+        for run_id in [retry_source, resume_target, quarantine_target, rearm_target] {
+            seed_queued(lifecycle_store, run_id);
+        }
+        // The quarantined half of the pair, identical in both roots.
+        quarantine_queued_run_exact_in_store(lifecycle_store, rearm_target, "seeded quarantine")
+            .expect("seed the same operator quarantine into both roots");
+        assert_eq!(
+            lifecycle_store
+                .read_record(rearm_target)
+                .expect("read the seeded quarantine back")
+                .metadata["queue_quarantine"]["operator_reason"],
+            "seeded quarantine",
+            "both roots start from the identical quarantined state"
+        );
+    }
+
+    // Reserve one retry successor, resume one run, quarantine one clean run and
+    // re-arm the quarantined one — all through siblings handed `seeded`.
+    let reserved = retry_with_runtime_admission_in_store(
+        &seeded,
+        retry_source,
+        Some(first_successor),
+        false,
+        true,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect("reserve a retry successor in the injected store");
+    assert_eq!(reserved.run_id, first_successor);
+
+    let resumed = mark_resuming_in_store(&seeded, resume_target)
+        .expect("resume the queued run in the injected store");
+    assert_eq!(resumed.state, AgentTaskRunState::Running);
+
+    quarantine_queued_run_exact_in_store(&seeded, quarantine_target, "operator halted this run")
+        .expect("quarantine the clean queued run in the injected store");
+    rearm_quarantined_run_in_store(&seeded, rearm_target)
+        .expect("re-arm the quarantined run in the injected store");
+
+    // The positive: every re-entry decision is durable in the store handed in.
+    let reserved_record = seeded
+        .read_record(first_successor)
+        .expect("the injected store holds the reserved successor");
+    assert_eq!(reserved_record.metadata["retry_of"], retry_source);
+    assert_eq!(reserved_record.metadata["retried_from"], retry_source);
+    assert_eq!(reserved_record.metadata["retry_root"], retry_source);
+    let seeded_source = seeded
+        .read_record(retry_source)
+        .expect("read the injected store's retry source back");
+    assert_eq!(seeded_source.metadata["retries"], json!([first_successor]));
+    assert_eq!(seeded_source.metadata["retry_root"], retry_source);
+    let seeded_resume = seeded
+        .read_record(resume_target)
+        .expect("read the injected store's resumed run back");
+    assert_eq!(seeded_resume.state, AgentTaskRunState::Running);
+    assert!(seeded_resume.metadata.get("resume_requested_at").is_some());
+    assert_eq!(
+        seeded
+            .read_record(quarantine_target)
+            .expect("read the injected store's quarantined run back")
+            .metadata["queue_quarantine"]["operator_reason"],
+        "operator halted this run"
+    );
+    assert!(
+        seeded
+            .read_record(rearm_target)
+            .expect("read the injected store's re-armed run back")
+            .metadata
+            .get("queue_quarantine")
+            .is_none(),
+        "the re-arm must clear the marker in the store that was handed in"
+    );
+
+    // The negative, absence first: the second root holds all four identities and
+    // observed none of it. The successor is absent from its records *and* from
+    // its indexed retry lineage, which is the read a claim would double-book on.
+    assert!(
+        other.read_record(first_successor).is_err(),
+        "the second root must not hold a successor reserved through the injected store"
+    );
+    assert!(
+        other
+            .read_retry_successors(retry_source)
+            .expect("the second root's own retry lineage")
+            .is_empty(),
+        "the second root's indexed lineage must not observe the injected store's reservation"
+    );
+    let untouched_source = other
+        .read_record(retry_source)
+        .expect("the second root still has its own retry source");
+    assert!(untouched_source.metadata.get("retries").is_none());
+    assert!(untouched_source.metadata.get("retry_root").is_none());
+    let untouched_resume = other
+        .read_record(resume_target)
+        .expect("the second root still has its own resumable run");
+    assert!(untouched_resume
+        .metadata
+        .get("resume_requested_at")
+        .is_none());
+    assert!(
+        other
+            .read_record(quarantine_target)
+            .expect("the second root still has its own clean queued run")
+            .metadata
+            .get("queue_quarantine")
+            .is_none(),
+        "second root must not observe the quarantine written through the injected store"
+    );
+
+    // Then the stronger half: the second root is not merely missing the
+    // evidence, it is still in its *original eligible* state. Its retry source
+    // is still unreserved, its resumable run is still queued, and its
+    // quarantined run is still quarantined with the reason it was seeded with.
+    assert_eq!(untouched_source.state, AgentTaskRunState::Queued);
+    assert_eq!(untouched_resume.state, AgentTaskRunState::Queued);
+    let untouched_rearm = other
+        .read_record(rearm_target)
+        .expect("the second root still has its own quarantined run");
+    assert_eq!(untouched_rearm.state, AgentTaskRunState::Queued);
+    assert_eq!(
+        untouched_rearm.metadata["queue_quarantine"]["operator_reason"], "seeded quarantine",
+        "a re-arm made through the injected store must not clear the second root's quarantine"
+    );
+
+    // DIRECTIONAL PAIR 1. The identical resume, for the identical run id, is
+    // admitted by the root that re-armed it and refused by the root where it is
+    // still quarantined. The quarantine guard lives inside `mark_running`'s
+    // mutation closure, so this is the assertion that it reads the injected
+    // store rather than an ambient copy of the same identity.
+    assert_eq!(
+        mark_resuming_in_store(&seeded, rearm_target)
+            .expect("the injected store re-armed this run, so it may resume")
+            .state,
+        AgentTaskRunState::Running
+    );
+    let still_quarantined = mark_resuming_in_store(&other, rearm_target)
+        .expect_err("the second root's run is still quarantined and must refuse to resume");
+    assert_eq!(
+        still_quarantined.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert_eq!(
+        still_quarantined.message,
+        "agent-task run is quarantined; re-arm its exact run id after repairing durable provenance"
+    );
+
+    // DIRECTIONAL PAIR 2. The identical re-arm, for the identical run id, is
+    // accepted by the root that holds the quarantine and refused by the root
+    // that never observed it.
+    assert!(rearm_quarantined_run_in_store(&seeded, quarantine_target)
+        .expect("the injected store holds this quarantine and can clear it")
+        .metadata
+        .get("queue_quarantine")
+        .is_none());
+    let never_quarantined = rearm_quarantined_run_in_store(&other, quarantine_target)
+        .expect_err("the second root never observed this quarantine");
+    assert_eq!(
+        never_quarantined.message,
+        "only an exact queued quarantined run can be re-armed"
+    );
+
+    // DIRECTIONAL PAIR 3. The identical Cook retry-successor lookup, for the
+    // identical source and attempt, finds the reservation in the root it was
+    // made in and nothing in the other. A caller reads `None` as authority to
+    // create a reservation, so this is the read that would mint a second
+    // successor over a live one.
+    assert_eq!(
+        find_unbound_cook_retry_successor_in_store(&seeded, retry_source, cook_id, 1, &plan)
+            .expect("the injected store's own retry lineage")
+            .map(|record| record.run_id),
+        Some(first_successor.to_string())
+    );
+    assert!(
+        find_unbound_cook_retry_successor_in_store(&other, retry_source, cook_id, 1, &plan)
+            .expect("the second root's own retry lineage")
+            .is_none(),
+        "a reservation made in the injected store must not be adopted by the second root"
+    );
+
+    // DIRECTIONAL PAIR 4, and the remaining eligibility proofs. The identical
+    // retry request, for the identical source, is refused by the root that
+    // already holds an active successor and admitted by the root that does not —
+    // which is simultaneously the proof that the second root is still retryable.
+    let active = retry_with_runtime_admission_in_store(
+        &seeded,
+        retry_source,
+        Some(second_successor),
+        false,
+        true,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect_err("the injected store's active successor forbids a second reservation");
+    assert_eq!(
+        active.code.as_str(),
+        ErrorCode::ValidationInvalidArgument.as_str()
+    );
+    assert!(
+        active.message.contains(first_successor),
+        "the refusal must name the injected store's own active successor: {}",
+        active.message
+    );
+    assert_eq!(
+        retry_with_runtime_admission_in_store(
+            &other,
+            retry_source,
+            Some(second_successor),
+            false,
+            true,
+            None,
+            |_| Ok(json!({})),
+        )
+        .expect("the second root holds no active successor and is still retryable")
+        .run_id,
+        second_successor
+    );
+
+    // The second root is still resumable and still quarantinable on its own
+    // state, and its own quarantine is still clearable.
+    assert_eq!(
+        mark_resuming_in_store(&other, resume_target)
+            .expect("the second root's queued run is still resumable")
+            .state,
+        AgentTaskRunState::Running
+    );
+    assert_eq!(
+        quarantine_queued_run_exact_in_store(&other, quarantine_target, "second root quarantine")
+            .expect("the second root's clean queued run is still quarantinable")
+            .metadata["queue_quarantine"]["operator_reason"],
+        "second root quarantine"
+    );
+    assert!(rearm_quarantined_run_in_store(&other, rearm_target)
+        .expect("the second root still owns the quarantine it was seeded with")
+        .metadata
+        .get("queue_quarantine")
+        .is_none());
+}
+
+#[test]
 fn a_supervision_stop_survives_an_hour_of_routine_resource_samples() {
     // #7015: the point of the evidence is to answer "why was this stopped?"
     // after the fact. If the decision shared an array with the sample stream, a

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -551,6 +551,15 @@ impl AgentTaskLifecycleStore {
         read_records_in_store(self)
     }
 
+    /// Read every retry successor of `source_run_id` from this store's own
+    /// observation database.
+    pub(crate) fn read_retry_successors(
+        &self,
+        source_run_id: &str,
+    ) -> Result<Vec<AgentTaskRunRecord>> {
+        read_retry_successors_in_store(self, source_run_id)
+    }
+
     pub(crate) fn record_run_aggregate(
         &self,
         run_id: &str,
@@ -1431,11 +1440,23 @@ const RETRY_SUCCESSOR_SCAN_LIMIT: usize = 256;
 /// retry. The page is therefore read with an explicit truncation signal and a
 /// truncated lineage fails loudly rather than answering wrongly (#11177).
 pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTaskRunRecord>> {
-    let page = ObservationStore::open_initialized_for_lifecycle()?.list_runs_by_retry_of_page(
-        "agent-task",
-        source_run_id,
-        RETRY_SUCCESSOR_SCAN_LIMIT,
-    )?;
+    read_retry_successors_in_store(&default_store()?, source_run_id)
+}
+
+/// The store-rooted counterpart of [`read_retry_successors`], reading this
+/// store's own observation database instead of the ambient one.
+///
+/// The truncation contract is the reason this matters more than a plain read:
+/// callers treat "no successor" as authority to create one, so a lineage scanned
+/// in the wrong home answers "none" for a source whose successor is durable here
+/// and double-books the reservation.
+fn read_retry_successors_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    source_run_id: &str,
+) -> Result<Vec<AgentTaskRunRecord>> {
+    let page = lifecycle_store
+        .open_observation_initialized()?
+        .list_runs_by_retry_of_page("agent-task", source_run_id, RETRY_SUCCESSOR_SCAN_LIMIT)?;
     if page.truncated {
         return Err(Error::internal_unexpected(format!(
             "retry lineage for {source_run_id} exceeded {RETRY_SUCCESSOR_SCAN_LIMIT} successors; \


### PR DESCRIPTION
## Summary

Continues rooting `lifecycle_ops.rs` after the read surface (#12603), Cook writes (#12604), run-claim (#12608), detached handoff (#12614), and run outcomes (#12618). This takes **run re-entry**: retry, forced retry, resume, exact-run quarantine, re-arm, plus controller-runtime recovery.

| function | |
|---|---|
| `retry`, `retry_with_force` | |
| `mark_resuming` | |
| `rearm_quarantined_run`, `quarantine_queued_run_exact` | |
| `recover_controller_runtime` | re-entry, not the pin family — see below |
| **`find_unbound_cook_retry_successor`** | **missing from scope — see below** |
| `plan_has_retry_materialization_identity` | **excluded** — pure predicate over a plan value, nothing to root |

Private helpers rooted: `retry_root_run_id`, `persist_retry_lineage`, `RetryLineageLock::lock`, `restore_follow_up_cook_candidate_workspace`. One private function deleted (zero callers once retry was rooted; it existed only to resolve an ambient store).

## The sharpest find: the lineage lock

<callout accent="#ef4444">
`RetryLineageLock::lock` resolved `paths::homeboy_data()` directly — a bare filesystem lock with **no record read in front**.

**The lock *is* the reservation.** Left ambient while the scan and the successor write followed an injected root, two retries into the *same* injected root from processes with different ambient homes **would not serialize at all**: both scan, both see no active successor, **both allocate.**
</callout>

## `find_unbound_cook_retry_successor` — missing, and load-bearing

It answers *"does a retry reservation already exist for this attempt?"* — and its callers in `execution.rs` treat `None` as **authority to create one**. An ambient answer mints a second successor over a live one.

It reached `store::read_retry_successors`, which opened `ObservationStore::open_initialized_for_lifecycle()` — the same ambient-queue-scan shape #12608 found in `read_records`.

## `recover_controller_runtime` belongs here, not with the pins

The pin family (`pin_current_controller_runtime`, `prune_controller_runtime_pins`) does **zero** lifecycle-store work and forwards straight to core. This one does two lifecycle-store operations around the core call — `read_record` for durable provenance, and `write_record` inside the persist closure.

Exactly the shape of `validate_controller_runtime_in_store`, which an earlier slice rooted while explicitly leaving `paths::controller_runtimes_store()` process-global. Followed verbatim and documented.

## Other reaches threaded

- **`mark_resuming` → ambient `mark_running`**, whose **quarantine guard lives inside its `mutate_record` closure** (#12614's trap). A run this store had quarantined would have been re-armed to `Running` anyway, and the transition would have landed in the ambient home — the inverse of the pair this slice protects.
- **`restore_follow_up_cook_candidate_workspace`** materializes a working-tree checkout under the artifact root and writes that path into the retried plan's `task.workspace.root`. Ambient, a retry would have **published the checkout under another home's artifact root and handed the successor a workspace outside its own root** (#12618's class).
- **The lineage walk** decides which lock is taken and which successors count; **the lineage stamp** writes the evidence the *next* scan reads — ambient, the injected root's lineage stays empty and the following retry double-books.
- The alias resolve (#12614's second-parent hazard), the admission cancellation guard inside the submit closure, and the acceptance-repair mutation.

## One reach deliberately left, and named

`restore_follow_up_cook_candidate_workspace_in_root` still calls an ambient promotion read that goes through `agent_task_lifecycle::status` — the reconciling, ~12-write path that is out of scope. Its `_in_store` sibling is a plain `read_record`, so substituting it **would change what an existing ambient `retry` caller sees**. Same argument #12618 used to leave `substantive_candidate_in_aggregate` alone. Waits on the `status` slice.

**The #12619 scanner cannot see it** — two-hop, and the intermediate's own body names no root resolver so it is not derived as a wrapper. That is why it is named here rather than left to the tool.

## Tooling

#12619's scanner compiled and run standalone: **7/7 pass**, including both fixtures that prove it can fail. Its bounding rules were read and respected (one-hop only). Every new sibling body was **still hand-walked transitively** — which is how the artifact-root and promotion reaches above were found, neither being visible to the tool. Neither suppression list touched.

**Duplicate-definition check:** all 14 new/renamed names resolve to exactly one definition crate-wide; no stale references to the renamed or deleted helpers survive. `rustfmt --check` clean on all four files, with insertions only in the test file so no pre-existing code was reflowed.

## What could not be driven hermetically

Controller admission — `admit_current_for_with_cancellation_check` takes a machine-global FIFO lock and copies the **current executable** into a store under the operator's real home. So the rooted retry takes the admission callback and queue projector as **parameters**, exactly as `submit_plan_with_runtime_admission_in_store` does; the ambient path passes the real pair, the test a stub.

Everything else in retry runs end to end: alias resolution, source read, lineage walk, lineage lock, successor scan, plan load, submission, acceptance-repair write, lineage stamp.

A subtler one, stated in the test: a run submitted with a stub admission carries `controller_runtime: {}`, and every lifecycle mutation validates the pin first, so a malformed pin would reach the real runtime store. A record with **no** pin key is the shape validators explicitly tolerate, so the seed drops the stub.

## The proof — four directional pairs

`run_reentry_siblings_re_enter_only_the_injected_store`. Both roots seeded with the same four identities in the same pre-re-entry shape — retry source, resumable queued run, clean queued run, and a queued run quarantined with the same operator reason. No `with_isolated_home`, no `HomeGuard`, no `set_var`.

**Absence:** the successor is missing from the second root's records **and from its indexed retry lineage** — the read a claim would double-book on. No `retries`/`retry_root` on its source, no `resume_requested_at`, no `queue_quarantine` on the clean run.

**Past absence — still eligible:** its source still `Queued` and unreserved, its resumable run still `Queued`, its quarantined run still `Queued` **and still carrying the seeded reason** — then it still performs every operation the injected store already performed.

**Four directional pairs**, same call and same id, decided only by which store was injected:

1. `mark_resuming_in_store` — `seeded` (re-armed there) returns `Running`; `other` (still quarantined there) fails *"agent-task run is quarantined; re-arm its exact run id…"*. **This is the assertion that `mark_running`'s in-closure quarantine guard reads the injected store.**
2. `rearm_quarantined_run_in_store` — `seeded` clears the marker; `other`, which never observed that quarantine, fails *"only an exact queued quarantined run can be re-armed"*.
3. `find_unbound_cook_retry_successor_in_store` — `seeded` finds the reservation; `other` returns `None`. **Since `None` is authority to create one, this is the read that mints a second successor over a live one.**
4. `retry_with_runtime_admission_in_store` — `seeded` refuses, naming its own active successor; `other` admits and creates it. The refusal half and the still-retryable half are the same call.

## Compatibility

Additive plus delegation. No existing public signature or behavior changes. No caller migrated. `home_lock` / `HomeGuard` / `with_isolated_home` untouched.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Implementation, helper threading, test authoring, and standalone `rustc --test` verification. Review by hand; compilation deferred to CI.

Refs #7505
