### PR TITLE
Root existing Cook lifecycle write callers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -460,7 +460,8 @@ fn report_cook_progress_with_activity(
             // The observer is the submitting client's output channel. Once the
             // progress record exists, a broken client pipe is evidence about
             // observation, never authority to stop promotion or finalization.
-            let _ = agent_task_lifecycle::record_cook_observer_event(
+            let _ = agent_task_lifecycle::record_cook_observer_event_in_store(
+                lifecycle_store,
                 run_id,
                 phase,
                 bounded_error_diagnostic(&error),
@@ -3978,7 +3979,8 @@ where
             return durable_cook_error_report_with_store(store, &failure_options, error);
         }
         if phase == "terminal" {
-            if let Err(error) = agent_task_lifecycle::record_cook_terminal_result(
+            if let Err(error) = agent_task_lifecycle::record_cook_terminal_result_in_store(
+                lifecycle_store,
                 run_id,
                 result.exit_code == 0,
                 result.exit_code,
@@ -4410,6 +4412,7 @@ where
         {
             let error = with_pre_execution_phase(error, "gate_declaration_preflight");
             record_pre_execution_failure(
+                lifecycle_store,
                 &options.initial_plan,
                 &options.initial_run_id,
                 &error,
@@ -4456,6 +4459,7 @@ where
     if let Err(error) = preflight {
         let error = with_pre_execution_phase(error, "gate_toolchain_preflight");
         record_pre_execution_failure(
+            lifecycle_store,
             &options.initial_plan,
             &options.initial_run_id,
             &error,
@@ -4507,7 +4511,7 @@ where
     if !verification_pending_continuation {
         if let Some(dispatcher) = &options.attempt_dispatcher {
             if let Err(error) = dispatcher.prepare_for_cook() {
-                agent_task_lifecycle::record_pre_execution_failure(
+                lifecycle_store.record_pre_execution_failure(
                     &options.initial_run_id,
                     &options.initial_plan,
                     dispatcher.pre_execution_failure_phase(),
@@ -4862,7 +4866,8 @@ where
                                 // how "was this run expensive?" stops being a
                                 // question only answerable by having watched it.
                                 if !tick.is_empty() {
-                                    let _ = agent_task_lifecycle::record_cook_supervision(
+                                    let _ = agent_task_lifecycle::record_cook_supervision_in_store(
+                                        heartbeat_lifecycle_store,
                                         &heartbeat_run_id,
                                         attempt,
                                         (!tick.sample.is_empty())
@@ -4902,11 +4907,13 @@ where
                                                 ),
                                         }),
                                     };
-                                    let _ = agent_task_lifecycle::record_cook_supervision_stop(
+                                    let _ =
+                                        agent_task_lifecycle::record_cook_supervision_stop_in_store(
+                                            heartbeat_lifecycle_store,
                                         &heartbeat_run_id,
                                         attempt,
                                         outcome,
-                                    );
+                                        );
                                 }
                                 // A deadline that only fired at attempt and
                                 // gate boundaries would not bound a single
@@ -4952,11 +4959,13 @@ where
                                                 ),
                                         }),
                                     };
-                                    let _ = agent_task_lifecycle::record_cook_supervision_stop(
-                                        &heartbeat_run_id,
-                                        attempt,
-                                        outcome,
-                                    );
+                                    let _ =
+                                        agent_task_lifecycle::record_cook_supervision_stop_in_store(
+                                            heartbeat_lifecycle_store,
+                                            &heartbeat_run_id,
+                                            attempt,
+                                            outcome,
+                                        );
                                 }
                             }
                         });
@@ -4979,7 +4988,11 @@ where
                     // Baseline cleanup runs when the dispatch scope exits. Restore
                     // the exact continuation contract only after that cleanup so
                     // retry never loses its controller-owned plan.
-                    agent_task_lifecycle::persist_controller_plan(&run_id, dispatch_plan)?;
+                    agent_task_lifecycle::persist_controller_plan_in_store(
+                        lifecycle_store,
+                        &run_id,
+                        dispatch_plan,
+                    )?;
                 }
                 let record = match agent_task_lifecycle::status(&run_id) {
                     Ok(record)
@@ -4989,7 +5002,13 @@ where
                             &error,
                             options.attempt_dispatcher.as_deref(),
                         );
-                        record_pre_execution_failure(&plan, &run_id, &error, phase)?;
+                        record_pre_execution_failure(
+                            lifecycle_store,
+                            &plan,
+                            &run_id,
+                            &error,
+                            phase,
+                        )?;
                         agent_task_lifecycle::status(&run_id).ok()
                     }
                     Ok(record) => Some(record),
@@ -4998,12 +5017,18 @@ where
                             &error,
                             options.attempt_dispatcher.as_deref(),
                         );
-                        record_pre_execution_failure(&plan, &run_id, &error, phase)?;
+                        record_pre_execution_failure(
+                            lifecycle_store,
+                            &plan,
+                            &run_id,
+                            &error,
+                            phase,
+                        )?;
                         agent_task_lifecycle::status(&run_id).ok()
                     }
                 };
                 let pre_execution_failure = pre_execution_failure_details(record.as_ref(), &error);
-                agent_task_lifecycle::record_cook_attempt(&cook_id, attempt, &run_id)?;
+                lifecycle_store.record_cook_attempt(&cook_id, attempt, &run_id)?;
                 attempts.push(AgentTaskCookAttemptReport {
                     attempt,
                     run_id: run_id.clone(),
@@ -5366,7 +5391,8 @@ where
                 } else {
                     "promotion provider response was rejected. The successful candidate remains durable; use failure_context to inspect or continue the Cook.".to_string()
                 };
-                agent_task_lifecycle::record_cook_controller_failure(
+                agent_task_lifecycle::record_cook_controller_failure_in_store(
+                    lifecycle_store,
                     &run_id,
                     &bounded_error_diagnostic(&error),
                 )?;

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -609,15 +609,16 @@ pub(crate) fn pre_execution_failure_report(
 /// Pre-execution failures happen before a provider can receive work. Persist a
 /// normal terminal run so the Cook alias can expose its complete retry history.
 pub(crate) fn record_pre_execution_failure(
+    lifecycle_store: &AgentTaskLifecycleStore,
     plan: &AgentTaskPlan,
     run_id: &str,
     error: &Error,
     phase: &str,
 ) -> Result<()> {
-    if !agent_task_lifecycle::run_record_exists(run_id)? {
-        agent_task_lifecycle::submit_plan(plan, Some(run_id))?;
+    if !lifecycle_store.record_exists(run_id)? {
+        lifecycle_store.submit_plan_with_current_runtime(plan, run_id)?;
     }
-    agent_task_lifecycle::record_pre_execution_failure(run_id, plan, phase, error)?;
+    lifecycle_store.record_pre_execution_failure(run_id, plan, phase, error)?;
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12051,6 +12051,56 @@ fn finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store() {
 }
 
 #[test]
+fn cook_observer_failures_write_only_to_the_explicit_lifecycle_store() {
+    let left_context = homeboy_core::test_support::HermeticTestContext::new();
+    let right_context = homeboy_core::test_support::HermeticTestContext::new();
+    assert_ne!(left_context.data_dir(), right_context.data_dir());
+
+    let left = AgentTaskLifecycleStore::new(left_context.path_roots());
+    let right = AgentTaskLifecycleStore::new(right_context.path_roots());
+    let run_id = "same-cook-observer-run";
+    let plan = AgentTaskPlan::new("observer-root-proof", Vec::new());
+
+    for store in [&left, &right] {
+        store
+            .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(serde_json::json!({})))
+            .expect("seed the same run id in each lifecycle root");
+    }
+    let right_before = right.read_record(run_id).expect("right record before");
+    let observer = |_: &CookProgressEvent<'_>| {
+        Err(Error::internal_io(
+            "Broken pipe (os error 32)",
+            Some("write submitting client stdout".to_string()),
+        ))
+    };
+
+    report_cook_progress_with_activity(
+        &left,
+        Some(&observer),
+        "same-cook-observer",
+        run_id,
+        "promotion",
+        1,
+        None,
+        None,
+    )
+    .expect("observer failure remains non-authoritative");
+
+    let left_record = left.read_record(run_id).expect("left record after");
+    assert_eq!(
+        left_record.metadata["cook_observer_events"][0]["kind"],
+        "delivery_failed"
+    );
+    assert_eq!(
+        left_record.metadata["cook_observer_events"][0]["phase"],
+        "promotion"
+    );
+    let right_after = right.read_record(run_id).expect("right record after");
+    assert_eq!(right_after.metadata, right_before.metadata);
+    assert_eq!(right_after.updated_at, right_before.updated_at);
+}
+
+#[test]
 fn cook_promotion_finalizes_into_the_injected_stores_across_split_recipe_and_lifecycle_roots() {
     let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
     let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();


### PR DESCRIPTION
## Summary
- route Cook observer, terminal-result, pre-execution, attempt, supervision, controller-plan, and controller-failure writes through the supplied `AgentTaskLifecycleStore`
- make the shared Cook pre-execution helper use its explicit lifecycle root for record existence, submission, and failure persistence
- prove a failed observer delivery with the same run ID mutates only the supplied lifecycle root

This consumes the explicit-store write APIs added by #12604. It does not add the rooted metadata-helper surface still needed for `cook_selection_required`, worktree warnings/admission, or continuation-admission traces; those remain follow-up work under #7505. Machine-global runtime promotion and ambient-only durable error reporting remain unchanged.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --all-targets`
- `cargo test -p homeboy-agents cook_observer_failures_write_only_to_the_explicit_lifecycle_store --lib`
- `cargo test --test agent_task_store_injection_test`
- `git diff --check origin/main...HEAD`

Refs #7505

AI assistance: OpenAI GPT-5.6 Sol via OpenCode identified the caller migration, implemented and reviewed the explicit-store threading, and ran the verification above. Chris Huber remains responsible for the report and code.