### PR TITLE
Inject filesystem roots at the CLI command boundary

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2773,9 +2773,16 @@ fn load_batch_cook_fanout_plan(
     args: &AgentTaskFanoutInputArgs,
     allow_private_execution_input: bool,
 ) -> Result<BatchCookFanoutPlan> {
+    // Both private-plan reads below answer the same security question — is the
+    // supplied path THE controller-owned artifact? — so they have to agree on
+    // where that artifact lives. Resolving the data root twice let the
+    // pre-read permission validation and the path authorization consult two
+    // different answers: a plan whose parent missed the first check could still
+    // satisfy the second, and the owner-only permission gate would be skipped.
+    let data_root = homeboy::core::paths::homeboy_data()?;
     let raw = if let Some(path) = args.input.strip_prefix('@') {
         let path = PathBuf::from(path);
-        if path.parent() == Some(private_batch_plan_dir()?.as_path()) {
+        if path.parent() == Some(private_batch_plan_dir_in_roots(&data_root).as_path()) {
             validate_private_plan_path_before_read(&path)?;
         }
         read_batch_plan_input(path)?
@@ -2806,7 +2813,7 @@ fn load_batch_cook_fanout_plan(
                 None,
             )
         })?;
-        let expected_path = private_batch_plan_path(fanout_id)?;
+        let expected_path = private_batch_plan_path_in_roots(&data_root, fanout_id);
         let supplied_path = args
             .input
             .strip_prefix('@')
@@ -2955,16 +2962,27 @@ fn private_plan_digest(plan: &Value) -> Result<String> {
 }
 
 fn private_batch_plan_path(fanout_id: &str) -> Result<PathBuf> {
-    Ok(private_batch_plan_dir()?.join(format!(
+    Ok(private_batch_plan_path_in_roots(
+        &homeboy::core::paths::homeboy_data()?,
+        fanout_id,
+    ))
+}
+
+fn private_batch_plan_path_in_roots(data_root: &Path, fanout_id: &str) -> PathBuf {
+    private_batch_plan_dir_in_roots(data_root).join(format!(
         "{}.json",
         homeboy::core::paths::sanitize_path_segment(fanout_id)
-    )))
+    ))
 }
 
 fn private_batch_plan_dir() -> Result<PathBuf> {
-    Ok(homeboy::core::paths::homeboy_data()?
-        .join("agent-task")
-        .join("private-batch-plans"))
+    Ok(private_batch_plan_dir_in_roots(
+        &homeboy::core::paths::homeboy_data()?,
+    ))
+}
+
+fn private_batch_plan_dir_in_roots(data_root: &Path) -> PathBuf {
+    data_root.join("agent-task").join("private-batch-plans")
 }
 
 fn validate_private_plan_path_before_read(path: &PathBuf) -> Result<()> {

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -776,11 +776,22 @@ fn runtime_tmp_retained_record(row: engine::temp::RuntimeTempCleanupRow) -> Reta
 }
 
 fn retained_storage_filesystem_inventory() -> homeboy::core::Result<RetainedStorageFilesystem> {
-    let root = homeboy::core::paths::homeboy_data()?;
-    let config_root = homeboy::core::paths::homeboy()?;
-    let artifact_root = homeboy::core::artifacts::root()?;
+    // One resolution for the whole report. The data, config, and artifact roots
+    // are compared against each other below (`starts_with` containment decides
+    // what is double-counted), so three independent resolutions could have
+    // described three different installations and reported a disjoint pair as
+    // nested — or the reverse.
+    //
+    // The shared Cargo target store stays outside the trio on purpose: it is a
+    // content-addressed cache keyed to the real machine, not to a Homeboy home.
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
     let cargo_target_root = cleanup::shared_cargo_target_root()?;
-    retained_storage_filesystem_inventory_for(root, config_root, artifact_root, cargo_target_root)
+    retained_storage_filesystem_inventory_for(
+        roots.data().to_path_buf(),
+        roots.config().to_path_buf(),
+        roots.artifacts().to_path_buf(),
+        cargo_target_root,
+    )
 }
 
 fn retained_storage_filesystem_inventory_for(

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -69,10 +69,15 @@ pub fn run(args: DeferredWorkloadArgs) -> CmdResult<serde_json::Value> {
             ))
         }
         DeferredWorkloadCommand::Status => {
+            // One resolution for the whole command: the worker status file and
+            // the record store are two files under the same root, and reading
+            // them from two independently resolved roots is how a status report
+            // ends up describing two different Homeboy installations.
+            let config_root = homeboy::core::paths::homeboy()?;
             let output = DeferredWorkloadStatusOutput {
                 schema: "homeboy/deferred-workload-status/v1",
-                worker: deferred_workload::worker_status()?,
-                records: deferred_workload::records()?
+                worker: deferred_workload::worker_status_in_roots(&config_root)?,
+                records: deferred_workload::records_in_roots(&config_root)?
                     .iter()
                     .map(redacted_record)
                     .collect(),
@@ -125,12 +130,19 @@ struct DeferredWorkloadOrphan {
 /// prove from its own environment, so a foreign process that happens to share
 /// the command name is never signaled on that basis (#12081).
 fn reconcile_workers(dry_run: bool) -> homeboy::core::Result<DeferredWorkloadReconcileOutput> {
+    reconcile_workers_in_roots(&homeboy::core::paths::homeboy()?, dry_run)
+}
+
+fn reconcile_workers_in_roots(
+    config_root: &Path,
+    dry_run: bool,
+) -> homeboy::core::Result<DeferredWorkloadReconcileOutput> {
     let deadline = Instant::now() + RECONCILE_BUDGET;
-    let status = deferred_workload::worker_status()?;
+    let status = deferred_workload::worker_status_in_roots(config_root)?;
     let owner_is_live = status
         .as_ref()
-        .is_some_and(deferred_workload::worker_is_live);
-    let pending_work = deferred_workload::has_pending_work()?;
+        .is_some_and(|status| deferred_workload::worker_is_live_in_roots(config_root, status));
+    let pending_work = deferred_workload::has_pending_work_in_roots(config_root)?;
     let processes = deferred_workload::worker_processes()?;
     let scanned = processes.len();
     let mut retained = Vec::new();
@@ -171,7 +183,9 @@ fn reconcile_workers(dry_run: bool) -> homeboy::core::Result<DeferredWorkloadRec
         // Release before signaling: a killed worker cannot hand its claim back,
         // and the record would otherwise sit out the full lease.
         let released_workload_ids = match process.startup_token.as_deref() {
-            Some(token) => deferred_workload::release_claims_for_owner(token)?,
+            Some(token) => {
+                deferred_workload::release_claims_for_owner_in_roots(config_root, token)?
+            }
             None => Vec::new(),
         };
         let (terminated, error) = match homeboy::core::process::terminate_process_tree_with_grace(
@@ -190,10 +204,13 @@ fn reconcile_workers(dry_run: bool) -> homeboy::core::Result<DeferredWorkloadRec
             Err(error) => (false, Some(error.message)),
         };
         if terminated {
-            let _ = deferred_workload::append_worker_log(format!(
-                "reconcile terminated worker pid={} reason={reason}",
-                process.pid
-            ));
+            let _ = deferred_workload::append_worker_log_in_roots(
+                config_root,
+                format!(
+                    "reconcile terminated worker pid={} reason={reason}",
+                    process.pid
+                ),
+            );
         }
         orphaned.push(DeferredWorkloadOrphan {
             process,
@@ -221,88 +238,121 @@ fn reconcile_workers(dry_run: bool) -> homeboy::core::Result<DeferredWorkloadRec
 }
 
 pub fn ensure_worker() -> homeboy::core::Result<()> {
-    let _start_lock = deferred_workload::acquire_worker_start_lock()?;
-    ensure_worker_with(deferred_workload::worker_is_live, || {
-        let executable = std::env::current_exe().map_err(|error| {
-            homeboy::core::Error::internal_io(
-                error.to_string(),
-                Some("resolve deferred worker executable".to_string()),
-            )
-        })?;
-        let mut command = Command::new(executable);
-        let startup_token = uuid::Uuid::new_v4().to_string();
-        command.args([
-            "deferred-workload",
-            "worker",
-            "--startup-token",
-            &startup_token,
-        ]);
-        // The ownership probe reads `/proc/<pid>/environ`, which the kernel
-        // populates at execve. The marker must therefore be set on the child
-        // command, not by the child once it is running (#12081).
-        command.env(deferred_workload::WORKER_OWNER_ENV, &startup_token);
-        // A singleton that outlives this command must not hold its working
-        // directory open. Inheriting it left workers pinned to worktrees that
-        // were finalized and deleted underneath them.
-        command.current_dir(deferred_workload::worker_root()?);
-        // A detached worker must not keep an invoking client's capture pipes
-        // open after the foreground command exits.
-        command
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            unsafe {
-                command.pre_exec(|| {
-                    if libc::setsid() == -1 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    Ok(())
-                });
-            }
-        }
-        command.spawn().map_err(|error| {
-            homeboy::core::Error::internal_io(
-                error.to_string(),
-                Some("spawn deferred workload worker".to_string()),
-            )
-        })?;
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        while std::time::Instant::now() < deadline {
-            if deferred_workload::worker_status()?
-                .as_ref()
-                .is_some_and(deferred_workload::worker_is_live)
+    ensure_worker_in_roots(&homeboy::core::paths::homeboy()?)
+}
+
+/// Spawn the singleton worker against an already-resolved config root.
+///
+/// The start lock, the liveness probe, the worker's working directory, the
+/// readiness poll, and the pending-record check are five reads of the same
+/// Homeboy installation. Resolving them independently let a five-second poll
+/// re-resolve the root up to 250 times, and left the spawned worker free to
+/// disagree with the probe that was waiting on it.
+fn ensure_worker_in_roots(config_root: &Path) -> homeboy::core::Result<()> {
+    let _start_lock = deferred_workload::acquire_worker_start_lock_in_roots(config_root)?;
+    ensure_worker_with(
+        config_root,
+        |status: &deferred_workload::DeferredWorkloadWorkerStatus| {
+            deferred_workload::worker_is_live_in_roots(config_root, status)
+        },
+        || {
+            let executable = std::env::current_exe().map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some("resolve deferred worker executable".to_string()),
+                )
+            })?;
+            let mut command = Command::new(executable);
+            let startup_token = uuid::Uuid::new_v4().to_string();
+            command.args([
+                "deferred-workload",
+                "worker",
+                "--startup-token",
+                &startup_token,
+            ]);
+            // The ownership probe reads `/proc/<pid>/environ`, which the kernel
+            // populates at execve. The marker must therefore be set on the child
+            // command, not by the child once it is running (#12081).
+            command.env(deferred_workload::WORKER_OWNER_ENV, &startup_token);
+            // A singleton that outlives this command must not hold its working
+            // directory open. Inheriting it left workers pinned to worktrees that
+            // were finalized and deleted underneath them.
+            command.current_dir(deferred_workload::worker_root_in_roots(config_root)?);
+            // A detached worker must not keep an invoking client's capture pipes
+            // open after the foreground command exits.
+            command
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            #[cfg(unix)]
             {
-                return Ok(());
+                use std::os::unix::process::CommandExt;
+                unsafe {
+                    command.pre_exec(|| {
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    });
+                }
             }
-            thread::sleep(Duration::from_millis(20));
-        }
-        if deferred_workload::records()?.iter().any(|record| {
-            matches!(
-                record.state,
-                deferred_workload::DeferredWorkloadState::Deferred
-                    | deferred_workload::DeferredWorkloadState::Claimed
-            )
-        }) {
-            return Err(homeboy::core::Error::internal_unexpected(
-                "deferred workload worker did not publish live ownership within 5 seconds",
-            ));
-        }
-        Ok(())
-    })
+            command.spawn().map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some("spawn deferred workload worker".to_string()),
+                )
+            })?;
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                if deferred_workload::worker_status_in_roots(config_root)?
+                    .as_ref()
+                    .is_some_and(|status| {
+                        deferred_workload::worker_is_live_in_roots(config_root, status)
+                    })
+                {
+                    return Ok(());
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            if deferred_workload::records_in_roots(config_root)?
+                .iter()
+                .any(|record| {
+                    matches!(
+                        record.state,
+                        deferred_workload::DeferredWorkloadState::Deferred
+                            | deferred_workload::DeferredWorkloadState::Claimed
+                    )
+                })
+            {
+                return Err(homeboy::core::Error::internal_unexpected(
+                    "deferred workload worker did not publish live ownership within 5 seconds",
+                ));
+            }
+            Ok(())
+        },
+    )
 }
 
 pub fn restart_worker_if_pending() -> homeboy::core::Result<()> {
-    restart_worker_if_pending_with(deferred_workload::worker_is_live, ensure_worker)
+    restart_worker_if_pending_in_roots(&homeboy::core::paths::homeboy()?)
+}
+
+fn restart_worker_if_pending_in_roots(config_root: &Path) -> homeboy::core::Result<()> {
+    restart_worker_if_pending_with_in_roots(
+        config_root,
+        |status: &deferred_workload::DeferredWorkloadWorkerStatus| {
+            deferred_workload::worker_is_live_in_roots(config_root, status)
+        },
+        || ensure_worker_in_roots(config_root),
+    )
 }
 
 fn ensure_worker_with(
+    config_root: &Path,
     is_live: impl Fn(&deferred_workload::DeferredWorkloadWorkerStatus) -> bool,
     spawn: impl FnOnce() -> homeboy::core::Result<()>,
 ) -> homeboy::core::Result<()> {
-    if deferred_workload::worker_status()?
+    if deferred_workload::worker_status_in_roots(config_root)?
         .as_ref()
         .is_some_and(is_live)
     {
@@ -315,14 +365,25 @@ fn restart_worker_if_pending_with(
     is_live: impl Fn(&deferred_workload::DeferredWorkloadWorkerStatus) -> bool,
     spawn: impl FnOnce() -> homeboy::core::Result<()>,
 ) -> homeboy::core::Result<()> {
-    if deferred_workload::records()?.iter().any(|record| {
-        matches!(
-            record.state,
-            deferred_workload::DeferredWorkloadState::Deferred
-                | deferred_workload::DeferredWorkloadState::Claimed
-        )
-    }) {
-        ensure_worker_with(is_live, spawn)?;
+    restart_worker_if_pending_with_in_roots(&homeboy::core::paths::homeboy()?, is_live, spawn)
+}
+
+fn restart_worker_if_pending_with_in_roots(
+    config_root: &Path,
+    is_live: impl Fn(&deferred_workload::DeferredWorkloadWorkerStatus) -> bool,
+    spawn: impl FnOnce() -> homeboy::core::Result<()>,
+) -> homeboy::core::Result<()> {
+    if deferred_workload::records_in_roots(config_root)?
+        .iter()
+        .any(|record| {
+            matches!(
+                record.state,
+                deferred_workload::DeferredWorkloadState::Deferred
+                    | deferred_workload::DeferredWorkloadState::Claimed
+            )
+        })
+    {
+        ensure_worker_with(config_root, is_live, spawn)?;
     }
     Ok(())
 }
@@ -331,13 +392,28 @@ fn run_worker(startup_token: &str) -> homeboy::core::Result<()> {
     if std::env::var(deferred_workload::WORKER_OWNER_ENV).as_deref() != Ok(startup_token) {
         return reexec_with_owner_marker(startup_token);
     }
-    let Some(lock) = deferred_workload::try_acquire_worker_lock()? else {
+    // The worker process resolves its installation once and then never again.
+    // Everything below — the singleton lock, the status file, the log, the
+    // claim/terminalize protocol, and the dispatch heartbeat — is the same
+    // durable store, and an unbounded loop that re-resolved it per iteration
+    // could drift onto a different one mid-lease.
+    let config_root = homeboy::core::paths::homeboy()?;
+    let Some(lock) = deferred_workload::try_acquire_worker_lock_in_roots(&config_root)? else {
         return Ok(());
     };
     let owner = startup_token.to_string();
-    deferred_workload::write_worker_status(&owner, "starting", "probing runner readiness")?;
-    deferred_workload::append_worker_log(format!("worker started owner={owner}"))?;
+    deferred_workload::write_worker_status_in_roots(
+        &config_root,
+        &owner,
+        "starting",
+        "probing runner readiness",
+    )?;
+    deferred_workload::append_worker_log_in_roots(
+        &config_root,
+        format!("worker started owner={owner}"),
+    )?;
     run_worker_while_holding_lock(
+        &config_root,
         &lock,
         &owner,
         || {
@@ -357,7 +433,12 @@ fn run_worker(startup_token: &str) -> homeboy::core::Result<()> {
                 })
             })
         },
-        dispatch_record,
+        // A bare `dispatch_record` reference would keep heartbeating against
+        // its own ambient resolution while the loop around it used the injected
+        // root — the split-home shape this campaign exists to remove.
+        |record: &deferred_workload::DeferredWorkload, runner_id: &str, owner: &str| {
+            dispatch_record(config_root.as_path(), record, runner_id, owner)
+        },
         deferred_workload_now_ms,
         thread::sleep,
     )
@@ -406,6 +487,7 @@ fn reexec_with_owner_marker(startup_token: &str) -> homeboy::core::Result<()> {
 }
 
 fn run_worker_while_holding_lock(
+    config_root: &Path,
     _lock: &deferred_workload::DeferredWorkloadWorkerLock,
     owner: &str,
     readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
@@ -417,10 +499,35 @@ fn run_worker_while_holding_lock(
     now: impl Fn() -> u64,
     sleep: impl FnMut(Duration),
 ) -> homeboy::core::Result<()> {
-    run_worker_with(owner, readiness, dispatch, now, sleep)
+    run_worker_with_in_roots(config_root, owner, readiness, dispatch, now, sleep)
 }
 
+/// Ambient entry point for the worker loop, retained for callers that own no
+/// resolved root (the hermetic tests). Production runs
+/// [`run_worker_with_in_roots`] from the single resolution `run_worker` makes.
 pub(crate) fn run_worker_with(
+    owner: &str,
+    readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
+    dispatch: impl FnMut(
+        &deferred_workload::DeferredWorkload,
+        &str,
+        &str,
+    ) -> homeboy::core::Result<bool>,
+    now: impl Fn() -> u64,
+    sleep: impl FnMut(Duration),
+) -> homeboy::core::Result<()> {
+    run_worker_with_in_roots(
+        &homeboy::core::paths::homeboy()?,
+        owner,
+        readiness,
+        dispatch,
+        now,
+        sleep,
+    )
+}
+
+pub(crate) fn run_worker_with_in_roots(
+    config_root: &Path,
     owner: &str,
     mut readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
     mut dispatch: impl FnMut(
@@ -432,21 +539,29 @@ pub(crate) fn run_worker_with(
     mut sleep: impl FnMut(Duration),
 ) -> homeboy::core::Result<()> {
     loop {
-        let pending = deferred_workload::records()?.into_iter().any(|record| {
-            matches!(
-                record.state,
-                deferred_workload::DeferredWorkloadState::Deferred
-                    | deferred_workload::DeferredWorkloadState::Claimed
-            )
-        });
+        let pending = deferred_workload::records_in_roots(config_root)?
+            .into_iter()
+            .any(|record| {
+                matches!(
+                    record.state,
+                    deferred_workload::DeferredWorkloadState::Deferred
+                        | deferred_workload::DeferredWorkloadState::Claimed
+                )
+            });
         if !pending {
-            deferred_workload::write_worker_status(owner, "idle", "no deferred workloads")?;
+            deferred_workload::write_worker_status_in_roots(
+                config_root,
+                owner,
+                "idle",
+                "no deferred workloads",
+            )?;
             return Ok(());
         }
         let inventory = match readiness() {
             Ok(Some(inventory)) => inventory,
             Ok(None) => {
-                deferred_workload::write_worker_status(
+                deferred_workload::write_worker_status_in_roots(
+                    config_root,
                     owner,
                     "waiting_for_runner",
                     "no ready runner",
@@ -455,19 +570,26 @@ pub(crate) fn run_worker_with(
                 continue;
             }
             Err(error) => {
-                deferred_workload::write_worker_status(owner, "waiting_for_runner", error.message)?;
+                deferred_workload::write_worker_status_in_roots(
+                    config_root,
+                    owner,
+                    "waiting_for_runner",
+                    error.message,
+                )?;
                 sleep(POLL_INTERVAL);
                 continue;
             }
         };
-        let Some(record) = deferred_workload::claim_next_matching_at(
+        let Some(record) = deferred_workload::claim_next_matching_at_in_roots(
+            config_root,
             &inventory.runner_id,
             owner,
             now(),
             |candidate| runner_satisfies_requirements(candidate, &inventory),
         )?
         else {
-            deferred_workload::write_worker_status(
+            deferred_workload::write_worker_status_in_roots(
+                config_root,
                 owner,
                 "waiting_for_runner",
                 "no claimable workload for selected runner",
@@ -479,37 +601,47 @@ pub(crate) fn run_worker_with(
         // Replaying it from wherever the worker happens to stand would sync the
         // wrong source tree, so the record fails here instead (#12081).
         if let Some(missing) = missing_source_directory(&record) {
-            deferred_workload::terminalize(&record.id, false)?;
-            deferred_workload::append_worker_log(format!(
-                "failed {} source worktree {missing} no longer exists",
-                record.id
-            ))?;
+            deferred_workload::terminalize_in_roots(config_root, &record.id, false)?;
+            deferred_workload::append_worker_log_in_roots(
+                config_root,
+                format!(
+                    "failed {} source worktree {missing} no longer exists",
+                    record.id
+                ),
+            )?;
             continue;
         }
         let runner_id = &inventory.runner_id;
-        deferred_workload::write_worker_status(
+        deferred_workload::write_worker_status_in_roots(
+            config_root,
             owner,
             "dispatching",
             format!("{} via {runner_id}", record.id),
         )?;
-        deferred_workload::append_worker_log(format!("claimed {} via {runner_id}", record.id))?;
+        deferred_workload::append_worker_log_in_roots(
+            config_root,
+            format!("claimed {} via {runner_id}", record.id),
+        )?;
         let success = match dispatch(&record, runner_id, owner) {
             Ok(success) => success,
             Err(error) if error.message == CAPABILITY_MISMATCH_ERROR => {
-                deferred_workload::defer_claim(&record.id, owner)?;
-                deferred_workload::append_worker_log(format!(
-                    "deferred {} after runner capability preflight mismatch",
-                    record.id
-                ))?;
+                deferred_workload::defer_claim_in_roots(config_root, &record.id, owner)?;
+                deferred_workload::append_worker_log_in_roots(
+                    config_root,
+                    format!(
+                        "deferred {} after runner capability preflight mismatch",
+                        record.id
+                    ),
+                )?;
                 continue;
             }
             Err(error) => return Err(error),
         };
-        deferred_workload::terminalize(&record.id, success)?;
-        deferred_workload::append_worker_log(format!(
-            "terminalized {} success={success}",
-            record.id
-        ))?;
+        deferred_workload::terminalize_in_roots(config_root, &record.id, success)?;
+        deferred_workload::append_worker_log_in_roots(
+            config_root,
+            format!("terminalized {} success={success}", record.id),
+        )?;
     }
 }
 
@@ -535,7 +667,14 @@ fn deferred_workload_now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Dispatch a claimed record and heartbeat its lease under the caller's root.
+///
+/// The heartbeat writes the same store the claim came from, so the root is
+/// injected rather than re-resolved: a dispatch that renewed a lease in one
+/// installation while the loop had claimed it in another would silently let the
+/// claim expire under the worker.
 fn dispatch_record(
+    config_root: &Path,
     record: &deferred_workload::DeferredWorkload,
     runner_id: &str,
     owner: &str,
@@ -582,7 +721,7 @@ fn dispatch_record(
             }
             return Ok(status.success());
         }
-        if !deferred_workload::heartbeat(&record.id, owner)? {
+        if !deferred_workload::heartbeat_in_roots(config_root, &record.id, owner)? {
             return Ok(false);
         }
         thread::sleep(Duration::from_secs(1));

--- a/crates/homeboy-cli/src/commands/runner/doctor/local.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/local.rs
@@ -1,17 +1,26 @@
 use super::*;
 use types::*;
 
+/// Probe the local runner.
+///
+/// `artifact_root` is injected rather than resolved here: the doctor reports
+/// the artifact root it probed, and a probe that answered from a root the
+/// command around it never resolved is exactly the readiness lie #7505 is
+/// about. `None` means the caller could not resolve one, which keeps the
+/// historical workspace-relative fallback below.
 pub fn report(
     runner_id: &str,
     runner: Option<&Runner>,
     options: &RunnerDoctorOptions,
+    artifact_root: Option<&Path>,
 ) -> RunnerDoctorOutput {
     let workspace_root = runner
         .and_then(|runner| runner.workspace_root.as_ref())
         .map(PathBuf::from)
         .unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-    let artifact_root = crate::core::paths::artifact_root()
-        .unwrap_or_else(|_| workspace_root.join(".homeboy-artifacts"));
+    let artifact_root = artifact_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| workspace_root.join(".homeboy-artifacts"));
     let mut checks = Vec::new();
     let mut tools = BTreeMap::new();
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -58,7 +58,14 @@ pub fn run_with_options(
 ) -> CmdResult<RunnerDoctorOutput> {
     let target = target::resolve(runner_id)?;
     let mut report = match &target {
-        target::RunnerTarget::Local { id, runner } => local::report(id, runner.as_ref(), &options),
+        target::RunnerTarget::Local { id, runner } => {
+            // The local probe's artifact root is the only filesystem root this
+            // command reads, so it is resolved once here at the entry point
+            // rather than inside the probe. The SSH branch resolves its root on
+            // the remote host and deliberately does not take this one.
+            let artifact_root = crate::core::paths::artifact_root().ok();
+            local::report(id, runner.as_ref(), &options, artifact_root.as_deref())
+        }
         target::RunnerTarget::Ssh {
             id,
             runner,

--- a/crates/homeboy-cli/src/commands/runs/gh_actions.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions.rs
@@ -24,7 +24,7 @@ use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Cursor, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use serde::{Deserialize, Serialize};
@@ -119,6 +119,12 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
     gh.ensure_ready()?;
     let repo = gh.repo_path()?.to_string();
 
+    // The command boundary resolves the roots exactly once. The HTTP cache
+    // lives under the config root and the downloaded artifacts under the data
+    // root; below this line an import that walks hundreds of artifact files
+    // writes all of them into one installation instead of re-resolving per file.
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+
     let store = ObservationStore::open_initialized()?;
     let pattern = compile_glob(&args.artifact_glob)?;
 
@@ -128,7 +134,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
         let workflow = args.workflow.as_deref().ok_or_else(|| {
             Error::validation_missing_argument(vec!["--workflow or --run-id".to_string()])
         })?;
-        list_workflow_runs(&gh, workflow, &args.since)?
+        list_workflow_runs(roots.config(), &gh, workflow, &args.since)?
     };
     let runs_inspected = runs.len().min(args.limit);
     let runs_to_process: Vec<&GhWorkflowRun> = runs.iter().take(args.limit).collect();
@@ -199,12 +205,14 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                     continue;
                 }
 
-                let stored_path = crate::commands::runs::gh_actions_cache::persist_artifact_file(
-                    &homeboy_run_id,
-                    &artifact_id,
-                    &file_name,
-                    &json_bytes,
-                )?;
+                let stored_path =
+                    crate::commands::runs::gh_actions_cache::persist_artifact_file_in_roots(
+                        roots.data(),
+                        &homeboy_run_id,
+                        &artifact_id,
+                        &file_name,
+                        &json_bytes,
+                    )?;
                 let sha = content_hash::sha256_hex(&json_bytes);
                 let size = i64::try_from(json_bytes.len()).ok();
                 let artifact_record = homeboy::core::observation::ArtifactRecord {
@@ -399,14 +407,15 @@ impl From<GhWorkflowRunRaw> for GhWorkflowRun {
 /// List workflow runs via `gh api`, with ETag caching to keep us off
 /// GitHub's primary rate limit on re-runs of the ingestor.
 fn list_workflow_runs(
+    config_root: &Path,
     gh: &GhClient,
     workflow: &str,
     since: &str,
 ) -> homeboy::core::Result<(Vec<GhWorkflowRun>, bool)> {
     let repo = gh.repo_path()?;
     let cache_key = list_runs_cache_key(repo, workflow);
-    let etag_path = list_runs_cache_path(&cache_key, "etag")?;
-    let body_path = list_runs_cache_path(&cache_key, "json")?;
+    let etag_path = list_runs_cache_path(config_root, &cache_key, "etag")?;
+    let body_path = list_runs_cache_path(config_root, &cache_key, "json")?;
 
     // Build the API path. We list with --paginate and let `gh` walk pages
     // (it caps via per_page=100). `created` filter narrows to recent runs.
@@ -708,8 +717,16 @@ mod helpers {
         content_hash::sha256_hex(composite.as_bytes())
     }
 
-    pub fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::core::Result<PathBuf> {
-        crate::commands::runs::gh_actions_cache::list_runs_cache_path(key, ext)
+    pub fn list_runs_cache_path(
+        config_root: &Path,
+        key: &str,
+        ext: &str,
+    ) -> homeboy::core::Result<PathBuf> {
+        crate::commands::runs::gh_actions_cache::list_runs_cache_path_in_roots(
+            config_root,
+            key,
+            ext,
+        )
     }
 
     // ── Glob compilation ────────────────────────────────────────────────────

--- a/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
@@ -24,10 +24,29 @@ pub fn persist_artifact_file(
     file_name: &str,
     bytes: &[u8],
 ) -> Result<PathBuf> {
+    persist_artifact_file_in_roots(
+        &paths::homeboy_data()?,
+        homeboy_run_id,
+        artifact_id,
+        file_name,
+        bytes,
+    )
+}
+
+/// Materialize a downloaded artifact file under an already-resolved data root.
+///
+/// An import walks every artifact of every run; resolving the data root per
+/// file made the destination of one import depend on process-global state that
+/// could change between two files of the same run.
+pub fn persist_artifact_file_in_roots(
+    data_root: &Path,
+    homeboy_run_id: &str,
+    artifact_id: &str,
+    file_name: &str,
+    bytes: &[u8],
+) -> Result<PathBuf> {
     let safe_name = sanitize_artifact_file_name(file_name);
-    let target_dir = paths::homeboy_data()?
-        .join("artifacts")
-        .join(homeboy_run_id);
+    let target_dir = data_root.join("artifacts").join(homeboy_run_id);
     fs::create_dir_all(&target_dir).map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -49,7 +68,16 @@ pub fn persist_artifact_file(
 /// Creates `<homeboy>/cache/gh-actions-runs/` and returns the path for
 /// `<key>.<ext>`. Errors propagate.
 pub fn list_runs_cache_path(key: &str, ext: &str) -> Result<PathBuf> {
-    let base = paths::homeboy()?.join("cache").join("gh-actions-runs");
+    list_runs_cache_path_in_roots(&paths::homeboy()?, key, ext)
+}
+
+/// Compute (and ensure) a list-runs cache entry under an injected config root.
+///
+/// The body and the ETag of one cache entry are two files that must live beside
+/// each other; resolving the root once per file let a 304 be validated against
+/// an ETag from a different installation.
+pub fn list_runs_cache_path_in_roots(config_root: &Path, key: &str, ext: &str) -> Result<PathBuf> {
+    let base = config_root.join("cache").join("gh-actions-runs");
     fs::create_dir_all(&base).map_err(|e| {
         Error::internal_io(
             e.to_string(),

--- a/crates/homeboy-cli/src/deferred_workload.rs
+++ b/crates/homeboy-cli/src/deferred_workload.rs
@@ -127,7 +127,24 @@ pub struct DeferredWorkloadWorkerStartLock {
     _file: File,
 }
 
+/// Resolve the ambient Homeboy config root this store lives under.
+///
+/// Every `_in_roots` entry point below takes that root as a parameter instead.
+/// The ambient wrappers exist so external callers keep their signatures; a
+/// caller that already holds a resolved root must use the rooted variant so a
+/// single command does not mix an injected root with an ambient one.
+fn ambient_config_root() -> Result<PathBuf> {
+    homeboy_core::paths::homeboy()
+}
+
 pub fn defer(input: DeferredWorkloadInput) -> Result<DeferredWorkload> {
+    defer_in_roots(&ambient_config_root()?, input)
+}
+
+pub fn defer_in_roots(
+    config_root: &Path,
+    input: DeferredWorkloadInput,
+) -> Result<DeferredWorkload> {
     if input
         .job_overrides
         .secret_env_names
@@ -144,7 +161,7 @@ pub fn defer(input: DeferredWorkloadInput) -> Result<DeferredWorkload> {
             ]),
         ));
     }
-    update(|records| {
+    update_in_roots(config_root, |records| {
         let fingerprint = fingerprint(&input)?;
         if let Some(existing) = records.iter().find(|record| {
             record.fingerprint == fingerprint
@@ -188,7 +205,16 @@ pub fn claim(
     runner_id: &str,
     owner: &str,
 ) -> Result<Option<DeferredWorkload>> {
-    update(|records| {
+    claim_in_roots(&ambient_config_root()?, input, runner_id, owner)
+}
+
+pub fn claim_in_roots(
+    config_root: &Path,
+    input: &DeferredWorkloadInput,
+    runner_id: &str,
+    owner: &str,
+) -> Result<Option<DeferredWorkload>> {
+    update_in_roots(config_root, |records| {
         let fingerprint = fingerprint(input)?;
         let now = now_ms();
         for record in records
@@ -241,7 +267,17 @@ pub fn claim_next_matching_at(
     now: u64,
     accepts: impl Fn(&DeferredWorkload) -> bool,
 ) -> Result<Option<DeferredWorkload>> {
-    update(|records| {
+    claim_next_matching_at_in_roots(&ambient_config_root()?, runner_id, owner, now, accepts)
+}
+
+pub fn claim_next_matching_at_in_roots(
+    config_root: &Path,
+    runner_id: &str,
+    owner: &str,
+    now: u64,
+    accepts: impl Fn(&DeferredWorkload) -> bool,
+) -> Result<Option<DeferredWorkload>> {
+    update_in_roots(config_root, |records| {
         for record in records.iter_mut() {
             if record.state == DeferredWorkloadState::Claimed
                 && record
@@ -271,7 +307,11 @@ pub fn claim_next_matching_at(
 }
 
 pub fn heartbeat(id: &str, owner: &str) -> Result<bool> {
-    update(|records| {
+    heartbeat_in_roots(&ambient_config_root()?, id, owner)
+}
+
+pub fn heartbeat_in_roots(config_root: &Path, id: &str, owner: &str) -> Result<bool> {
+    update_in_roots(config_root, |records| {
         let Some(record) = records.iter_mut().find(|record| record.id == id) else {
             return Ok(false);
         };
@@ -288,7 +328,11 @@ pub fn heartbeat(id: &str, owner: &str) -> Result<bool> {
 }
 
 pub fn terminalize(id: &str, succeeded: bool) -> Result<()> {
-    update(|records| {
+    terminalize_in_roots(&ambient_config_root()?, id, succeeded)
+}
+
+pub fn terminalize_in_roots(config_root: &Path, id: &str, succeeded: bool) -> Result<()> {
+    update_in_roots(config_root, |records| {
         if let Some(record) = records.iter_mut().find(|record| record.id == id) {
             record.state = if succeeded {
                 DeferredWorkloadState::Dispatched
@@ -306,7 +350,11 @@ pub fn terminalize(id: &str, succeeded: bool) -> Result<()> {
 /// Return a claimed workload to the queue when runner preflight discovers that
 /// the selected runner no longer satisfies its persisted contract.
 pub fn defer_claim(id: &str, owner: &str) -> Result<()> {
-    update(|records| {
+    defer_claim_in_roots(&ambient_config_root()?, id, owner)
+}
+
+pub fn defer_claim_in_roots(config_root: &Path, id: &str, owner: &str) -> Result<()> {
+    update_in_roots(config_root, |records| {
         if let Some(record) = records.iter_mut().find(|record| record.id == id) {
             if record.state == DeferredWorkloadState::Claimed
                 && record.claim_owner.as_deref() == Some(owner)
@@ -328,7 +376,11 @@ pub fn defer_claim(id: &str, owner: &str) -> Result<()> {
 /// its claims must not sit out the full lease before another worker may take
 /// them. Returns the ids that were released.
 pub fn release_claims_for_owner(owner: &str) -> Result<Vec<String>> {
-    update(|records| {
+    release_claims_for_owner_in_roots(&ambient_config_root()?, owner)
+}
+
+pub fn release_claims_for_owner_in_roots(config_root: &Path, owner: &str) -> Result<Vec<String>> {
+    update_in_roots(config_root, |records| {
         let now = now_ms();
         let mut released = Vec::new();
         for record in records.iter_mut() {
@@ -349,12 +401,20 @@ pub fn release_claims_for_owner(owner: &str) -> Result<Vec<String>> {
 }
 
 pub fn records() -> Result<Vec<DeferredWorkload>> {
-    read_store(&store_path()?)
+    records_in_roots(&ambient_config_root()?)
+}
+
+pub fn records_in_roots(config_root: &Path) -> Result<Vec<DeferredWorkload>> {
+    read_store(&store_path_in_roots(config_root))
 }
 
 /// Whether any record still needs a worker.
 pub fn has_pending_work() -> Result<bool> {
-    Ok(records()?.iter().any(|record| {
+    has_pending_work_in_roots(&ambient_config_root()?)
+}
+
+pub fn has_pending_work_in_roots(config_root: &Path) -> Result<bool> {
+    Ok(records_in_roots(config_root)?.iter().any(|record| {
         matches!(
             record.state,
             DeferredWorkloadState::Deferred | DeferredWorkloadState::Claimed
@@ -369,7 +429,11 @@ pub fn has_pending_work() -> Result<bool> {
 /// ephemeral worktree open, because worktree cleanup then leaves the process
 /// anchored to a deleted directory (#12081).
 pub fn worker_root() -> Result<PathBuf> {
-    let root = homeboy_core::paths::homeboy()?;
+    worker_root_in_roots(&ambient_config_root()?)
+}
+
+pub fn worker_root_in_roots(config_root: &Path) -> Result<PathBuf> {
+    let root = config_root.to_path_buf();
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -388,7 +452,13 @@ pub fn worker_root() -> Result<PathBuf> {
 }
 
 pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
-    let root = worker_root()?;
+    try_acquire_worker_lock_in_roots(&ambient_config_root()?)
+}
+
+pub fn try_acquire_worker_lock_in_roots(
+    config_root: &Path,
+) -> Result<Option<DeferredWorkloadWorkerLock>> {
+    let root = worker_root_in_roots(config_root)?;
     let file = File::open(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -409,7 +479,13 @@ pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
 }
 
 pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
-    let root = homeboy_core::paths::homeboy()?;
+    acquire_worker_start_lock_in_roots(&ambient_config_root()?)
+}
+
+pub fn acquire_worker_start_lock_in_roots(
+    config_root: &Path,
+) -> Result<DeferredWorkloadWorkerStartLock> {
+    let root = config_root.to_path_buf();
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -440,7 +516,11 @@ pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
 }
 
 pub fn worker_status() -> Result<Option<DeferredWorkloadWorkerStatus>> {
-    let path = store_path()?.with_extension("worker-status.json");
+    worker_status_in_roots(&ambient_config_root()?)
+}
+
+pub fn worker_status_in_roots(config_root: &Path) -> Result<Option<DeferredWorkloadWorkerStatus>> {
+    let path = store_path_in_roots(config_root).with_extension("worker-status.json");
     if !path.exists() {
         return Ok(None);
     }
@@ -453,13 +533,22 @@ pub fn worker_status() -> Result<Option<DeferredWorkloadWorkerStatus>> {
 }
 
 pub fn worker_is_live(status: &DeferredWorkloadWorkerStatus) -> bool {
+    // An unresolvable root is indistinguishable from an unacquirable lock here:
+    // both mean this process cannot prove the singleton is alive.
+    let Ok(config_root) = ambient_config_root() else {
+        return false;
+    };
+    worker_is_live_in_roots(&config_root, status)
+}
+
+pub fn worker_is_live_in_roots(config_root: &Path, status: &DeferredWorkloadWorkerStatus) -> bool {
     if matches!(status.state.as_str(), "idle" | "stopped") {
         return false;
     }
     if status.owner_token.is_empty() {
         return false;
     }
-    let Ok(lock) = try_acquire_worker_lock() else {
+    let Ok(lock) = try_acquire_worker_lock_in_roots(config_root) else {
         return false;
     };
     // A status file is advisory. The singleton lock is the authority.
@@ -716,7 +805,16 @@ pub fn write_worker_status(
     state: &str,
     detail: impl Into<String>,
 ) -> Result<()> {
-    let path = store_path()?.with_extension("worker-status.json");
+    write_worker_status_in_roots(&ambient_config_root()?, owner_token, state, detail)
+}
+
+pub fn write_worker_status_in_roots(
+    config_root: &Path,
+    owner_token: &str,
+    state: &str,
+    detail: impl Into<String>,
+) -> Result<()> {
+    let path = store_path_in_roots(config_root).with_extension("worker-status.json");
     let value = DeferredWorkloadWorkerStatus {
         schema: "homeboy/deferred-workload-worker-status/v1".to_string(),
         pid: std::process::id(),
@@ -740,7 +838,11 @@ pub fn write_worker_status(
 }
 
 pub fn append_worker_log(message: impl AsRef<str>) -> Result<()> {
-    let path = store_path()?.with_extension("worker.log");
+    append_worker_log_in_roots(&ambient_config_root()?, message)
+}
+
+pub fn append_worker_log_in_roots(config_root: &Path, message: impl AsRef<str>) -> Result<()> {
+    let path = store_path_in_roots(config_root).with_extension("worker.log");
     let line = format!("{} {}\n", now_ms(), message.as_ref());
     use std::io::Write;
     OpenOptions::new()
@@ -777,12 +879,30 @@ fn fingerprint(input: &DeferredWorkloadInput) -> Result<String> {
     Ok(sha256_hex(&value))
 }
 
+/// Ambient store path. No production caller resolves here any more: every
+/// public entry point either takes a root or resolves one exactly once and
+/// delegates to [`store_path_in_roots`]. Retained for the hermetic tests, which
+/// assert against the store the isolated home owns.
+#[cfg(test)]
 fn store_path() -> Result<PathBuf> {
-    Ok(homeboy_core::paths::homeboy()?.join("deferred-workloads.json"))
+    Ok(store_path_in_roots(&ambient_config_root()?))
 }
 
+fn store_path_in_roots(config_root: &Path) -> PathBuf {
+    config_root.join("deferred-workloads.json")
+}
+
+/// Ambient mutation. Test-only for the same reason as [`store_path`].
+#[cfg(test)]
 fn update<T>(mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>) -> Result<T> {
-    let path = store_path()?;
+    update_in_roots(&ambient_config_root()?, mutate)
+}
+
+fn update_in_roots<T>(
+    config_root: &Path,
+    mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>,
+) -> Result<T> {
+    let path = store_path_in_roots(config_root);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             Error::internal_io(


### PR DESCRIPTION
## Summary

The CLI is the outermost boundary, so it is the right place for **exactly one** ambient resolution per command. This collapses scattered per-helper resolutions into one at each command entry and threads `&PathRoots` down.

**15 non-test call sites → 8 command-boundary resolutions.** Two of those were unbounded:

| command | before | after |
|---|---|---|
| `deferred-workload worker` | **unbounded** — 8 per loop iteration, forever | 1 |
| `ensure_worker` | up to **~505** (250-iteration poll × 2) | 1 |
| `deferred-workload reconcile` | 3 + 2N | 1 |
| `runs import --from-gh-actions` | 2 + N per artifact file | 1 |
| `cleanup` storage report | 3 | 1 |

Longest chain is 5 hops (`run_worker` → `run_worker_while_holding_lock` → `run_worker_with_in_roots` → 8 store ops → `dispatch_record` → `heartbeat_in_roots`).

<callout accent="#ef4444">
## The bare-function-reference blind spot, caught live

`dispatch_record` is passed as a **bare function reference**: `run_worker_while_holding_lock(…, dispatch_record, …)`. A `name(` grep does not see it.

It heartbeats the claim lease. Rooting the loop and leaving this alone would mean **the loop claims in one installation while the heartbeat renews in another — the claim silently expires under a running worker.** It is now a closure taking the injected root.
</callout>

## Two more split-home hazards, both pre-existing

**A permission gate that could be skipped.** `load_batch_cook_fanout_plan` resolved the data root **twice inside one security check** — `fanout.rs:2778` gating owner-only permission validation, `:2809` authorizing the path. Two answers meant a plan whose parent failed the first check could still satisfy the second. Now one resolution.

**A storage report that lies.** `retained_storage_filesystem_inventory` resolved three roots and then compared them against each other with `starts_with` containment. Three independent resolutions can report a disjoint pair as nested, or vice versa — precisely when you are reading it during an outage.

## Not closed, deliberately

- `local_detach.rs:602`, `local_detach_fanout.rs:432` — callers also hit `record_detached_cook_handoff_parent` and `read_batch_record`, both ambient in `homeboy-agents`. The rooted counterpart is `pub(crate)` there, unreachable from the CLI. **Threading only the session root would manufacture a split.**
- `remote_artifact.rs:380`, `handlers.rs:998` — conditional leaf resolutions; hoisting would make an unconditional resolution out of a conditional one for zero reduction.
- Worker `readiness` closure → `homeboy-lab-runner` internals (out of scope; separate state, so not a split today).

## Public signatures changed

**None.** Every changed signature is private or `pub(crate)` with all call sites in-crate. `run_worker_with` (9 test call sites) kept its exact signature as an ambient wrapper.

## Verification

`rustfmt --check` parses all 8 files. **Zero newly-introduced duplicate definitions** (verified against `origin/main`, not just within-file). Every changed-arity signature grep-verified against all call sites including `tests/`.

Not verified without cargo: closure inference for the `impl Fn(&Status) -> bool` params (annotated explicitly to force the higher-ranked signature), `&PathBuf → &Path` coercions, and dead-code lints on the now-test-only `run_worker_with`/`restart_worker_if_pending_with`.

One behavior note: `worker_is_live` now resolves the root *before* the `"idle"/"stopped"` early return. Both paths return `false` on failure so the result is identical — reasoned, not tested.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
