### PR TITLE
Root the lab-runner's ambient filesystem reaches

### DIFF
--- a/crates/homeboy-lab-runner/src/artifact_attach.rs
+++ b/crates/homeboy-lab-runner/src/artifact_attach.rs
@@ -34,6 +34,25 @@ pub fn copy_runner_artifact_source(
     runner: &Runner,
     path: &str,
 ) -> homeboy_core::Result<RunnerAttachSource> {
+    copy_runner_artifact_source_in_roots(
+        homeboy_core::paths::PathRoots::from_environment()?.artifacts(),
+        runner,
+        path,
+    )
+}
+
+/// [`copy_runner_artifact_source`] against an explicitly injected artifact root.
+///
+/// Only the download destination is rooted, because only the download
+/// destination is Homeboy state: the artifact type probe and the transfer both
+/// address the *runner* filesystem through an SSH client. The one remaining
+/// ambient reach on this path is `server::load`, which resolves the config root
+/// inside `homeboy-core` and is out of this crate's reach (#7505).
+pub fn copy_runner_artifact_source_in_roots(
+    artifact_root: &Path,
+    runner: &Runner,
+    path: &str,
+) -> homeboy_core::Result<RunnerAttachSource> {
     match runner.kind {
         RunnerKind::Local => {
             let source = PathBuf::from(path);
@@ -67,7 +86,7 @@ pub fn copy_runner_artifact_source(
                     None,
                 )
             })?;
-            let temp_path = attach_download_path(&runner.id, path)?;
+            let temp_path = attach_download_path_in_roots(artifact_root, &runner.id, path);
             if let Some(parent) = temp_path.parent() {
                 fs::create_dir_all(parent).map_err(|err| {
                     Error::internal_io(
@@ -161,14 +180,14 @@ fn remote_runner_artifact_type(
     ))
 }
 
-fn attach_download_path(runner_id: &str, path: &str) -> homeboy_core::Result<PathBuf> {
+fn attach_download_path_in_roots(artifact_root: &Path, runner_id: &str, path: &str) -> PathBuf {
     let file_name = Path::new(path)
         .file_name()
         .and_then(|name| name.to_str())
         .filter(|name| !name.is_empty())
         .unwrap_or("artifact");
-    Ok(homeboy_core::artifact_root()?
+    artifact_root
         .join("runner-attach")
         .join(runner_id)
-        .join(format!("{}-{file_name}", uuid::Uuid::new_v4())))
+        .join(format!("{}-{file_name}", uuid::Uuid::new_v4()))
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
@@ -120,7 +120,20 @@ impl ControllerFallbackProjectionStore {
     /// Shared controller ledger survives daemon restarts independently of the
     /// runner-owned staging store.
     pub fn open_default() -> Result<Self> {
-        Self::open(homeboy_core::paths::homeboy_data()?.join("controller-fallback-projection.json"))
+        Self::open_in_roots(homeboy_core::paths::PathRoots::from_environment()?.data())
+    }
+
+    /// [`open_default`](Self::open_default) against an explicitly injected data
+    /// root.
+    ///
+    /// The store owns exactly one file below the data root and every later
+    /// operation derives from `self.path` (including the sibling `.lock`), so
+    /// nothing on this type can reach back into ambient state once it is
+    /// constructed. The reconciliation *callbacks* are a separate matter: they
+    /// are supplied by the caller and are ambient in the production wiring —
+    /// see [`reconcile_on_controller_startup`].
+    pub fn open_in_roots(data_root: &Path) -> Result<Self> {
+        Self::open(data_root.join("controller-fallback-projection.json"))
     }
 
     pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
@@ -465,6 +478,12 @@ impl ControllerFallbackProjectionStore {
 
 /// Production startup reconciliation for deferred runner staging. It reads at
 /// most eight runner jobs so ordinary CLI startup remains bounded by work count.
+///
+/// Deliberately has no injected sibling. Both reconciliation callbacks below
+/// are bare ambient function references — `crate::runner_job_log_snapshot`
+/// resolves runner session state and `project_terminal_runner_result` resolves
+/// the durable lifecycle root — so an injected data root here would project a
+/// ledger from one home against lifecycle state from another (#7505).
 pub fn reconcile_on_controller_startup() -> Result<usize> {
     Ok(ControllerFallbackProjectionStore::open_default()?
         .reconcile_after_controller_restart_with(

--- a/crates/homeboy-lab-runner/src/evidence/download.rs
+++ b/crates/homeboy-lab-runner/src/evidence/download.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use reqwest::blocking::Client;
@@ -55,7 +55,15 @@ pub fn download_remote_artifact_with_intent(
     intent: RunnerDownloadIntent,
 ) -> Result<RemoteArtifactDownload> {
     let token = RemoteArtifactToken::parse(path)?;
-    if let Some(download) = download_direct_runner_artifact(&token, output.clone(), intent)? {
+    // One resolution for both transports. The direct-SSH attempt and the relay
+    // fallback below have to place bytes in the same cache, or `runs artifact
+    // get` reports a path from one home while the tag lands in another (#7505).
+    let artifact_root = paths::PathRoots::from_environment()?
+        .artifacts()
+        .to_path_buf();
+    if let Some(download) =
+        download_direct_runner_artifact(&artifact_root, &token, output.clone(), intent)?
+    {
         return Ok(download);
     }
 
@@ -87,7 +95,7 @@ pub fn download_remote_artifact_with_intent(
     // The remote controls `filename` outright, and `token.runner_id` /
     // `token.run_id` are percent-decoded copies of remote-supplied strings.
     // Nothing below is joined until this has proven all three (#10586).
-    let placement = resolve_placement(&token, output, remote_file_name)?;
+    let placement = resolve_placement(&artifact_root, &token, output, remote_file_name)?;
     let output_path = placement.output_path;
     if let Some(parent) = output_path
         .parent()
@@ -154,7 +162,11 @@ pub(super) struct DownloadPlacement {
     pub(super) file_name: String,
 }
 
+/// Decide where one download's bytes go, against an explicitly injected
+/// artifact root. Containment is checked against that same root, so a caller
+/// cannot validate one home and write into another.
 pub(super) fn resolve_placement(
+    artifact_root: &Path,
     token: &RemoteArtifactToken,
     output: Option<PathBuf>,
     remote_file_name: Option<&str>,
@@ -172,13 +184,13 @@ pub(super) fn resolve_placement(
             file_name,
         });
     }
-    // Fail closed. This used to be `.unwrap_or_else(|_| PathBuf::from("."))`,
-    // which silently relocated the whole cache into the process working
-    // directory — neither contained nor predictable — whenever the artifact
-    // root could not be resolved.
-    let artifact_root = paths::artifact_root()?;
+    // Fail closed. The root used to be resolved here as
+    // `paths::artifact_root()?`, itself replacing an
+    // `.unwrap_or_else(|_| PathBuf::from("."))` that silently relocated the
+    // whole cache into the process working directory. It is now supplied by the
+    // caller, which resolves it once for both transports.
     let target = resolve_runner_download_target(
-        &artifact_root,
+        artifact_root,
         &token.runner_id,
         &token.run_id,
         remote_file_name,
@@ -192,6 +204,7 @@ pub(super) fn resolve_placement(
 }
 
 fn download_direct_runner_artifact(
+    artifact_root: &Path,
     token: &RemoteArtifactToken,
     output: Option<PathBuf>,
     intent: RunnerDownloadIntent,
@@ -252,7 +265,7 @@ fn download_direct_runner_artifact(
     // `Content-Disposition` is parsed by splitting on `;` and trimming quotes,
     // so the value reaching here is whatever the daemon sent, `../` included.
     let remote_file_name = content_disposition_filename(&headers).filter(|name| !name.is_empty());
-    let placement = resolve_placement(token, output, remote_file_name.as_deref())?;
+    let placement = resolve_placement(artifact_root, token, output, remote_file_name.as_deref())?;
     let output_path = placement.output_path;
     if let Some(parent) = output_path
         .parent()

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -293,8 +293,8 @@ fn test_download_placement_sanitizes_a_traversal_filename() {
             "..",
             "../../etc/passwd",
         ] {
-            let placement =
-                resolve_placement(&token, None, Some(hostile)).expect("placement resolves");
+            let placement = resolve_placement(&artifact_root, &token, None, Some(hostile))
+                .expect("placement resolves");
             assert_eq!(
                 placement.output_path.parent(),
                 Some(cache.as_path()),
@@ -326,7 +326,10 @@ fn test_download_placement_sanitizes_a_traversal_filename() {
 /// silently rewriting one would put bytes somewhere unpredictable.
 #[test]
 fn test_download_placement_rejects_a_percent_encoded_traversal_token() {
-    homeboy_core::test_support::with_isolated_home(|_| {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        // The root is injected and never consulted: both identifiers are
+        // refused before anything is joined onto it.
+        let artifact_root = home.path().join("artifacts");
         let token = RemoteArtifactToken::parse(
             "runner-artifact://lab/%2E%2E%2F%2E%2E%2F%2E%2E%2Froot%2F.ssh/authorized_keys",
         )
@@ -334,7 +337,7 @@ fn test_download_placement_rejects_a_percent_encoded_traversal_token() {
         // The parser hands the writer an already-decoded traversal.
         assert_eq!(token.run_id, "../../../root/.ssh");
 
-        let error = resolve_placement(&token, None, Some("authorized_keys"))
+        let error = resolve_placement(&artifact_root, &token, None, Some("authorized_keys"))
             .expect_err("the writer must refuse it");
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert!(
@@ -348,7 +351,7 @@ fn test_download_placement_rejects_a_percent_encoded_traversal_token() {
             RemoteArtifactToken::parse("runner-artifact://%2E%2E%2F%2E%2E%2Fetc/run-1/artifact-1")
                 .expect("parse token");
         assert_eq!(runner_token.runner_id, "../../etc");
-        let error = resolve_placement(&runner_token, None, Some("passwd"))
+        let error = resolve_placement(&artifact_root, &runner_token, None, Some("passwd"))
             .expect_err("the writer must refuse it");
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
     });
@@ -362,9 +365,15 @@ fn test_download_placement_honours_an_explicit_output_without_tagging_it() {
         let token = RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1")
             .expect("parse token");
         let explicit = home.path().join("elsewhere").join("report.json");
+        let artifact_root = home.path().join("artifacts");
 
-        let placement =
-            resolve_placement(&token, Some(explicit.clone()), Some("../../evil")).expect("resolve");
+        let placement = resolve_placement(
+            &artifact_root,
+            &token,
+            Some(explicit.clone()),
+            Some("../../evil"),
+        )
+        .expect("resolve");
 
         assert_eq!(placement.output_path, explicit);
         assert!(placement.cache_dir.is_none());
@@ -403,12 +412,10 @@ fn test_content_disposition_traversal_is_neutralized_by_the_writer() {
 
         let token = RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1")
             .expect("parse token");
-        let placement = resolve_placement(&token, None, Some(&parsed)).expect("resolve");
-        let cache = homeboy_core::paths::artifact_root()
-            .expect("artifact root")
-            .join("runner")
-            .join("lab")
-            .join("run-1");
+        let artifact_root = homeboy_core::paths::artifact_root().expect("artifact root");
+        let placement =
+            resolve_placement(&artifact_root, &token, None, Some(&parsed)).expect("resolve");
+        let cache = artifact_root.join("runner").join("lab").join("run-1");
         assert_eq!(placement.output_path.parent(), Some(cache.as_path()));
         assert_eq!(placement.file_name, "etc_cron.d_x");
     });

--- a/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
+++ b/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
@@ -49,6 +49,9 @@ pub fn promote_runner_exec_artifact_dirs(
     }
 
     let store = ObservationStore::open_initialized()?;
+    // Resolved once beside the store so downloaded bytes and the records that
+    // index them cannot land in two different homes (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let runner = match output.mode {
         runner::RunnerExecMode::Local => None,
         runner::RunnerExecMode::Daemon
@@ -59,7 +62,7 @@ pub fn promote_runner_exec_artifact_dirs(
     for declared_dir in artifact_dir_outputs {
         let runner_dir = resolve_runner_exec_artifact_path(&output.remote_cwd, declared_dir);
         let record_dir = if let Some(runner) = runner.as_ref() {
-            copy_runner_exec_artifact_source(runner, &runner_dir)?
+            copy_runner_exec_artifact_source_in_roots(roots.artifacts(), runner, &runner_dir)?
         } else {
             runner_dir.clone()
         };
@@ -301,6 +304,9 @@ fn promote_runner_exec_outputs(
     }
 
     let store = ObservationStore::open_initialized()?;
+    // Resolved once beside the store so downloaded bytes and the records that
+    // index them cannot land in two different homes (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let runner = match output.mode {
         runner::RunnerExecMode::Local => None,
         runner::RunnerExecMode::Daemon
@@ -322,7 +328,7 @@ fn promote_runner_exec_outputs(
                 metadata["source"] = serde_json::json!("runner_path_attach");
                 metadata["runner_id"] = serde_json::json!(runner.id.clone());
                 metadata["runner_path"] = serde_json::json!(runner_path.display().to_string());
-                copy_runner_exec_artifact_source(runner, &runner_path)?
+                copy_runner_exec_artifact_source_in_roots(roots.artifacts(), runner, &runner_path)?
             } else {
                 runner_path.clone()
             };
@@ -480,7 +486,12 @@ fn read_json_file(path: &Path) -> Option<serde_json::Value> {
     serde_json::from_reader(file).ok()
 }
 
-fn copy_runner_exec_artifact_source(
+/// Download an SSH runner's declared output into the injected artifact root.
+///
+/// The artifact root is the caller's, not the environment's, so a promotion
+/// records bytes into the same home its observation store was opened against.
+fn copy_runner_exec_artifact_source_in_roots(
+    artifact_root: &Path,
     runner: &runner::Runner,
     path: &Path,
 ) -> homeboy_core::Result<PathBuf> {
@@ -497,7 +508,8 @@ fn copy_runner_exec_artifact_source(
                     None,
                 )
             })?;
-            let temp_path = runner_exec_attach_download_path(&runner.id, path)?;
+            let temp_path =
+                runner_exec_attach_download_path_in_roots(artifact_root, &runner.id, path);
             if let Some(parent) = temp_path.parent() {
                 fs::create_dir_all(parent).map_err(|err| {
                     Error::internal_io(
@@ -661,16 +673,20 @@ fn allowed_runner_exec_artifact_roots(runner: &runner::Runner) -> Vec<String> {
     roots
 }
 
-fn runner_exec_attach_download_path(runner_id: &str, path: &Path) -> homeboy_core::Result<PathBuf> {
+fn runner_exec_attach_download_path_in_roots(
+    artifact_root: &Path,
+    runner_id: &str,
+    path: &Path,
+) -> PathBuf {
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
         .filter(|name| !name.is_empty())
         .unwrap_or("artifact");
-    Ok(homeboy_core::artifact_root()?
+    artifact_root
         .join("runner-exec-attach")
         .join(runner_id)
-        .join(format!("{}-{file_name}", uuid::Uuid::new_v4())))
+        .join(format!("{}-{file_name}", uuid::Uuid::new_v4()))
 }
 
 fn resolve_runner_exec_artifact_path(remote_cwd: &str, declared: &str) -> PathBuf {

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1285,6 +1285,16 @@ fn restrict_provenance_permissions(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }
 
+/// Deliberately NOT rooted (#7505).
+///
+/// Both reads below describe the *live process environment* a child is about to
+/// be launched from, and they are read as a pair: `HOME` is only an equality
+/// probe against the job's own `HOME`, and the data dir is the answer given
+/// when they differ. Injecting the data root while `HOME` stayed ambient is the
+/// exact split this campaign exists to kill, and injecting both would first
+/// require deciding what `HOME` even means for a caller-supplied root — a
+/// semantics question, not a mechanical refactor. The already-injectable seam
+/// is [`durable_homeboy_data_dir_for_job`], which takes both as parameters.
 fn preserve_durable_homeboy_data_dir(
     command: &mut std::process::Command,
     job_env: &HashMap<String, String>,

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -647,11 +647,19 @@ fn schedule_recovery_children(
 /// Execute one durable child. The filesystem lock is deliberately held for the
 /// complete side-effecting phase: an expired SQLite lease permits a replacement
 /// to *try* takeover, but never to overlap a still-live local process.
+///
+/// The ambient trio is resolved once here and the config root is handed to the
+/// lock. There is deliberately no injected sibling of this function: the child
+/// lease it arbitrates comes from `ObservationStore::open_initialized`, which
+/// resolves its own database path from ambient state inside `homeboy-core`.
+/// Accepting injected roots while the store stayed ambient would let the lock
+/// and the lease disagree about which home they arbitrate (#7505).
 pub fn run_scheduled_terminal_runner_exec_recovery_child(
     child_id: &str,
     child_token: &str,
 ) -> Result<Option<RunnerExecRecoveryDiagnostic>> {
     let store = ObservationStore::open_initialized()?;
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let Some(child) = store.get_run(child_id)? else {
         return Ok(None);
     };
@@ -674,7 +682,7 @@ pub fn run_scheduled_terminal_runner_exec_recovery_child(
             return Ok(None);
         }
     };
-    let Some(_lock) = try_acquire_child_lock(child_id)? else {
+    let Some(_lock) = try_acquire_child_lock_in_roots(roots.config(), child_id)? else {
         let mut metadata = child.metadata_json;
         metadata["phase"] = json!("deferred_live_worker");
         metadata["inspection_action"] = json!(format!("homeboy runs show {child_id}"));
@@ -757,8 +765,17 @@ fn terminalize_child_error(
     Ok(())
 }
 
-fn try_acquire_child_lock(child_id: &str) -> Result<Option<std::fs::File>> {
-    let root = homeboy_core::paths::homeboy()?.join("runner-exec-recovery");
+/// Take the single-writer lock for one recovery child under an explicitly
+/// injected config root.
+///
+/// The lock file has to live in the same home as the observation store that
+/// hands out the child lease, or two controllers on different homes would each
+/// believe they held the only lock for the same child id (#7505).
+fn try_acquire_child_lock_in_roots(
+    config_root: &std::path::Path,
+    child_id: &str,
+) -> Result<Option<std::fs::File>> {
+    let root = config_root.join("runner-exec-recovery");
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
@@ -23,7 +23,14 @@ pub(super) struct DependencyPackage {
     pub files: usize,
 }
 
-pub(super) fn prepare(
+/// Seal (or reuse) a controller dependency package below an explicitly injected
+/// data root.
+///
+/// Reuse and publication share the one root: the `is_file` hit, the staging
+/// file, and the final rename all derive from `root` below, so a package can
+/// never be read out of one home and republished into another (#7505).
+pub(super) fn prepare_in_roots(
+    data_root: &Path,
     workspace: &Path,
     plan: &[homeboy_core::deps::DependencyInstallPlanStep],
 ) -> Result<Option<DependencyPackage>> {
@@ -42,7 +49,7 @@ pub(super) fn prepare(
         },
     )?);
     let key = content_hash::sha256_hex(format!("{key}\0{outputs_identity}").as_bytes());
-    let root = homeboy_core::paths::homeboy_data()?.join("cache/dependency-packages/v1");
+    let root = data_root.join("cache/dependency-packages/v1");
     let path = root.join(format!("{key}.zip"));
     if path.is_file() {
         let bytes = fs::metadata(&path)

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -180,9 +180,14 @@ fn hydrate_lab_workspace_dependencies_with_policy(
         ));
     }
     if offline_only {
-        if let Some(package) =
-            super::dependency_package::prepare(std::path::Path::new(local_path), &plan)?
-        {
+        // Resolved inside the offline branch only: online hydration never
+        // touches the controller package cache, so it keeps resolving nothing
+        // it does not use.
+        if let Some(package) = super::dependency_package::prepare_in_roots(
+            homeboy_core::paths::PathRoots::from_environment()?.data(),
+            std::path::Path::new(local_path),
+            &plan,
+        )? {
             restore_controller_dependency_package(runner_id, remote_path, &package)?;
             return Ok(LabWorkspaceHydrationOutput {
                 schema: HYDRATION_SCHEMA,

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -153,7 +153,11 @@ pub fn sync_workspace(
                 &excludes,
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
+            // Resolved at the point of use rather than at the top of the
+            // function: only the snapshot modes take a filesystem reservation,
+            // so the other sync modes keep resolving nothing they do not use.
             let admission = require_snapshot_filesystem_admission(
+                homeboy_core::paths::PathRoots::from_environment()?.data(),
                 &runner,
                 &local_path,
                 &remote_path,
@@ -1148,17 +1152,22 @@ struct DurablePruneConvergenceReceipt {
     convergence: RunnerWorkspacePruneConvergence,
 }
 
-fn prune_convergence_receipt_path(
+/// Locate one runner/workspace pair's durable prune receipt below an explicitly
+/// injected data root. Resume reads and converge writes both come through here,
+/// so a single injected root keeps a resumed pass reading the receipt the
+/// earlier pass wrote (#7505).
+fn prune_convergence_receipt_path_in_roots(
+    data_root: &Path,
     runner_id: &str,
     workspace_root: &str,
-) -> Result<std::path::PathBuf> {
+) -> std::path::PathBuf {
     use sha2::{Digest, Sha256};
     let digest = Sha256::digest(format!("{runner_id}\0{workspace_root}").as_bytes());
     let name = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&digest[..12]);
-    Ok(homeboy_core::paths::homeboy_data()?
+    data_root
         .join("cleanup")
         .join("workspace-prune")
-        .join(format!("{name}.json")))
+        .join(format!("{name}.json"))
 }
 
 fn write_prune_convergence_receipt(
@@ -1306,10 +1315,15 @@ pub fn prune_workspaces(
     let mut total_candidate_bytes = 0;
     let mut scanned_workspace_count = 0;
     let mut scan_complete = true;
-    let receipt_path = options
-        .converge
-        .then(|| prune_convergence_receipt_path(runner_id, workspace_root))
-        .transpose()?;
+    let receipt_path = if options.converge {
+        Some(prune_convergence_receipt_path_in_roots(
+            homeboy_core::paths::PathRoots::from_environment()?.data(),
+            runner_id,
+            workspace_root,
+        ))
+    } else {
+        None
+    };
     let mut convergence = receipt_path
         .as_ref()
         .map(|path| RunnerWorkspacePruneConvergence {
@@ -2341,6 +2355,7 @@ fn snapshot_filesystem_requirement(
 /// workspace. The controller scratch path and runner destination are probed
 /// independently: a roomy root filesystem cannot mask a constrained `/tmp`.
 fn require_snapshot_filesystem_admission(
+    data_root: &Path,
     runner: &super::super::Runner,
     local_path: &Path,
     remote_path: &str,
@@ -2381,6 +2396,7 @@ fn require_snapshot_filesystem_admission(
         RunnerKind::Ssh => ssh_snapshot_filesystem_probe(runner, remote_path)?,
     };
     let admission = SnapshotFilesystemAdmission::acquire(
+        data_root,
         selected_scratch,
         &[scratch_probe, destination_probe],
         requirement,
@@ -2571,6 +2587,7 @@ impl SnapshotFilesystemAdmission {
     }
 
     fn acquire(
+        data_root: &Path,
         scratch: std::path::PathBuf,
         probes: &[SnapshotFilesystemProbe],
         requirement: SnapshotFilesystemRequirement,
@@ -2583,7 +2600,7 @@ impl SnapshotFilesystemAdmission {
         let lease_id = uuid::Uuid::new_v4().to_string();
         let mut leases = Vec::new();
         for probe in unique.into_values() {
-            let path = snapshot_reservation_path(&probe.identity)?;
+            let path = snapshot_reservation_path_in_roots(data_root, &probe.identity)?;
             let _lock = snapshot_reservation_lock(&path)?;
             let mut records = read_snapshot_reservation_records(&path)?;
             records.retain(snapshot_reservation_is_live);
@@ -2629,10 +2646,16 @@ impl Drop for SnapshotFilesystemAdmission {
     }
 }
 
-fn snapshot_reservation_path(identity: &str) -> Result<std::path::PathBuf> {
+/// Locate one filesystem's reservation ledger below an explicitly injected data
+/// root. Admission and release must agree on the ledger, and `Drop` releases
+/// against the stored path, so the root is fixed once at acquisition (#7505).
+fn snapshot_reservation_path_in_roots(
+    data_root: &Path,
+    identity: &str,
+) -> Result<std::path::PathBuf> {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     identity.hash(&mut hasher);
-    let root = homeboy_core::paths::homeboy_data()?.join("snapshot-filesystem-reservations");
+    let root = data_root.join("snapshot-filesystem-reservations");
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -4187,9 +4210,9 @@ mod tests {
     use super::{
         is_runner_git_auth_or_network_failure, retry_idempotent_ssh_operation,
         runner_workspace_disk_is_critical, snapshot_capacity_error,
-        snapshot_filesystem_requirement, snapshot_reservation_path, snapshot_reservation_records,
-        RunnerWorkspaceDiskProbe, SnapshotFilesystemAdmission, SnapshotFilesystemProbe,
-        SnapshotFilesystemRequirement,
+        snapshot_filesystem_requirement, snapshot_reservation_path_in_roots,
+        snapshot_reservation_records, RunnerWorkspaceDiskProbe, SnapshotFilesystemAdmission,
+        SnapshotFilesystemProbe, SnapshotFilesystemRequirement,
     };
     use homeboy_core::error::{Error, ErrorCode};
     use homeboy_core::server::CommandOutput;
@@ -4394,87 +4417,93 @@ mod tests {
             .any(|hint| hint.message.contains("workspace prune")));
     }
 
+    /// The reservation ledger is the only Homeboy state these two tests touch,
+    /// and it is now injected, so neither needs `with_isolated_home` — no
+    /// environment mutation, no shared home mutex (#7505).
     #[test]
     fn snapshot_reservations_prevent_overcommit_then_release() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let runner = reservation_runner();
-            let requirement = SnapshotFilesystemRequirement {
-                bytes: 100,
-                inodes: 100,
-            };
-            let filesystem = probe("tmpfs-concurrent", 150, 150);
-            let first = SnapshotFilesystemAdmission::acquire(
-                tempfile::tempdir().expect("scratch").keep(),
-                std::slice::from_ref(&filesystem),
-                requirement,
-                &runner,
-            )
-            .expect("first reservation");
-            let error = SnapshotFilesystemAdmission::acquire(
-                tempfile::tempdir().expect("scratch").keep(),
-                std::slice::from_ref(&filesystem),
-                requirement,
-                &runner,
-            )
-            .expect_err("second reservation must not overcommit");
-            assert_eq!(error.retryable, Some(true));
-            assert_eq!(
-                error.details["active_reservations"]
-                    .as_array()
-                    .unwrap()
-                    .len(),
-                1
-            );
-            drop(first);
-            SnapshotFilesystemAdmission::acquire(
-                tempfile::tempdir().expect("scratch").keep(),
-                &[filesystem],
-                requirement,
-                &runner,
-            )
-            .expect("released reservation admits retry");
-        });
+        let data_root = tempfile::tempdir().expect("data root");
+        let runner = reservation_runner();
+        let requirement = SnapshotFilesystemRequirement {
+            bytes: 100,
+            inodes: 100,
+        };
+        let filesystem = probe("tmpfs-concurrent", 150, 150);
+        let first = SnapshotFilesystemAdmission::acquire(
+            data_root.path(),
+            tempfile::tempdir().expect("scratch").keep(),
+            std::slice::from_ref(&filesystem),
+            requirement,
+            &runner,
+        )
+        .expect("first reservation");
+        let error = SnapshotFilesystemAdmission::acquire(
+            data_root.path(),
+            tempfile::tempdir().expect("scratch").keep(),
+            std::slice::from_ref(&filesystem),
+            requirement,
+            &runner,
+        )
+        .expect_err("second reservation must not overcommit");
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(
+            error.details["active_reservations"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        drop(first);
+        SnapshotFilesystemAdmission::acquire(
+            data_root.path(),
+            tempfile::tempdir().expect("scratch").keep(),
+            &[filesystem],
+            requirement,
+            &runner,
+        )
+        .expect("released reservation admits retry");
     }
 
     #[test]
     fn snapshot_reservation_reclaims_dead_lease() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let runner = reservation_runner();
-            let requirement = SnapshotFilesystemRequirement {
+        let data_root = tempfile::tempdir().expect("data root");
+        let runner = reservation_runner();
+        let requirement = SnapshotFilesystemRequirement {
+            bytes: 100,
+            inodes: 100,
+        };
+        let filesystem = probe("root-recovery", 150, 150);
+        let path = snapshot_reservation_path_in_roots(data_root.path(), &filesystem.identity)
+            .expect("ledger path");
+        let _lock = super::snapshot_reservation_lock(&path).expect("lock");
+        super::write_snapshot_reservation_records_unlocked(
+            &path,
+            &[super::SnapshotFilesystemReservationRecord {
+                lease_id: "dead".to_string(),
+                controller_pid: u32::MAX,
+                created_unix_seconds: 0,
                 bytes: 100,
                 inodes: 100,
-            };
-            let filesystem = probe("root-recovery", 150, 150);
-            let path = snapshot_reservation_path(&filesystem.identity).expect("ledger path");
-            let _lock = super::snapshot_reservation_lock(&path).expect("lock");
-            super::write_snapshot_reservation_records_unlocked(
-                &path,
-                &[super::SnapshotFilesystemReservationRecord {
-                    lease_id: "dead".to_string(),
-                    controller_pid: u32::MAX,
-                    created_unix_seconds: 0,
-                    bytes: 100,
-                    inodes: 100,
-                }],
-            )
-            .expect("write stale lease");
-            drop(_lock);
+            }],
+        )
+        .expect("write stale lease");
+        drop(_lock);
 
-            let admission = SnapshotFilesystemAdmission::acquire(
-                tempfile::tempdir().expect("scratch").keep(),
-                &[filesystem],
-                requirement,
-                &runner,
-            )
-            .expect("dead lease must be recovered");
-            assert_eq!(
-                snapshot_reservation_records(&path).expect("records").len(),
-                1
-            );
-            drop(admission);
-            assert!(snapshot_reservation_records(&path)
-                .expect("records")
-                .is_empty());
-        });
+        let admission = SnapshotFilesystemAdmission::acquire(
+            data_root.path(),
+            tempfile::tempdir().expect("scratch").keep(),
+            &[filesystem],
+            requirement,
+            &runner,
+        )
+        .expect("dead lease must be recovered");
+        assert_eq!(
+            snapshot_reservation_records(&path).expect("records").len(),
+            1
+        );
+        drop(admission);
+        assert!(snapshot_reservation_records(&path)
+            .expect("records")
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Nine non-test ambient reaches in `homeboy-lab-runner` are now rooted or documented as deliberate. Eight chains, up to **3 hops** deep.

| chain | hops | root |
|---|---|---|
| `sync_workspace` → `require_snapshot_filesystem_admission` → `SnapshotFilesystemAdmission::acquire` → `snapshot_reservation_path_in_roots` | 3 | data |
| `promote_runner_exec_*` → `copy_runner_exec_artifact_source_in_roots` → `runner_exec_attach_download_path_in_roots` | 2 | artifacts |
| `download_remote_artifact_with_intent` → `download_direct_runner_artifact` → `resolve_placement` | 2 | artifacts |
| `run_scheduled_terminal_runner_exec_recovery_child` → `try_acquire_child_lock_in_roots` | 1 | config |
| `prune_workspaces` → `prune_convergence_receipt_path_in_roots` | 1 | data |
| `hydrate_lab_workspace_dependencies_with_policy` → `dependency_package::prepare_in_roots` | 1 | data |
| `copy_runner_artifact_source` → `attach_download_path_in_roots` | 1 | artifacts |
| `ControllerFallbackProjectionStore::open_default` → `open_in_roots` | 0 | data |

<callout accent="#ef4444">
## Highest-value finding: two transports, two homes

`resolve_placement` was called by **two independent transports** — direct-SSH at `evidence/download.rs:255` and relay at `:90` — each resolving `paths::artifact_root()` on its own entry.

The direct transport tries first and **falls through to the relay** on a non-`DirectSsh` session. So a single `runs artifact get` could resolve the root twice, with a concurrent harness `HOME` repoint in between, and report an `output_path` from one home while `record_download_intent` tagged a cache dir in the other.

Both transports now share one resolution made before either runs.
</callout>

Second: `promote_runner_exec_*` resolved the artifact root inside `runner_exec_attach_download_path`, **three frames below** an `ObservationStore` opened ambiently at the top — downloaded bytes and the artifact records indexing them could disagree. Resolution now sits on the line after the store open.

## The bare-reference blind spot, again

`reconcile_on_controller_startup` passes `crate::runner_job_log_snapshot` and `agent_task_lifecycle::project_terminal_runner_result` as **bare function references** — invisible to a `name(` grep. Both are ambient, so `ControllerFallbackProjectionStore` got an injected constructor but that function deliberately did **not** get an injected sibling: it would project a rooted ledger against ambient lifecycle state.

## Not closed, deliberately

- `execution/process.rs:1288` `preserve_durable_homeboy_data_dir` — reads `homeboy_data()` **in pair with** a raw `std::env::var("HOME")` used as an equality probe against the job's `HOME`. Rooting one half is the exact bug class; rooting both needs a semantics decision about what `HOME` means for an injected root. Documented in place.
- `execution/recovery.rs:654` — the lock is rooted, but the lease it arbitrates comes from a core-resolved DB path.
- `artifact_attach.rs` / `artifact_promotion.rs` — `server::load` resolves the config root inside `homeboy-core` via `entity_crud!`.
- `homeboy-paths`-owned derived resolvers unreachable from here: `runner_sessions_dir` (17), `runner_controller_session_file` (11), `runner_session_file` (9), `rigs` (11), and others — each bottoms out in `homeboy()`/`homeboy_data()`.
- Left process-global on purpose: `controller_runtimes_store()`, `cargo_targets_store()`.

> The 3 sites in `lab_staging_controller.rs` are inside `#[cfg(test)] mod tests`, so they were out of the non-test set.

## Public signatures changed

**None.** Two additive `pub` functions (`ControllerFallbackProjectionStore::open_in_roots`, `copy_runner_artifact_source_in_roots`). The `homeboy-cli` caller at `commands/runs/remote_artifact.rs:75` is untouched.

## Verification

`cargo fmt -p homeboy-lab-runner` exited 0 and reformatted, so rustfmt parsed every file. **Zero newly-introduced duplicate definitions** (verified against `origin/main`). Every renamed symbol grepped repo-wide including `docs/`, `tests/`, `src/` — no stale references.

Not verified without cargo: the `.map(|declared| …)` closure capture in `promote_runner_exec_outputs` (most likely borrowck surprise), edition-2024 `if let` temporary-drop rules in `hydration.rs`, and the two de-isolated tests. One behavior note: `download_remote_artifact_with_intent` now resolves the artifact root eagerly even when the caller passes an explicit `output`; that path already requires `homeboy()` via `load()`/`status()`, so it is judged a non-regression — reasoned, not tested.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
