### PR TITLE
Root the separable path reaches in audit and extension

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
+++ b/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
@@ -36,9 +36,36 @@ pub(crate) fn run_report(component_id: &str) -> ArtifactPortabilityReport {
     run_report_with_config(component_id, &ArtifactPortabilityConfig::default())
 }
 
+/// Ambient boundary for the portability scan: resolve the artifact root once,
+/// then run rooted.
+///
+/// The boundary deliberately stops here rather than moving out into
+/// `engine::audit_internal`. The recorded runs this detector scans arrive from
+/// `recorded_artifacts::recent_recorded_runs`, which dispatches through a
+/// process-global provider registry whose only real implementation
+/// (`homeboy_core::observation::audit_artifact_provider`) opens the observation
+/// store from the *ambient* data root. Threading `PathRoots` into the audit
+/// engine would therefore honor an injected artifact root while still reading
+/// an ambient store — the split-home shape this campaign exists to remove
+/// (#7505). Rooting the audit engine has to wait for the provider contract to
+/// carry roots.
 pub(crate) fn run_report_with_config(
     component_id: &str,
     config: &ArtifactPortabilityConfig,
+) -> ArtifactPortabilityReport {
+    let artifact_root = homeboy_paths::artifact_root().ok();
+    run_report_with_config_in_roots(component_id, config, artifact_root.as_deref())
+}
+
+/// Portability scan against an explicitly supplied artifact root.
+///
+/// `None` retains the historical degrade-to-no-root behavior: without a root
+/// there is no store-anchored exemption, so only relative and non-temp paths
+/// read as portable.
+pub(crate) fn run_report_with_config_in_roots(
+    component_id: &str,
+    config: &ArtifactPortabilityConfig,
+    artifact_root: Option<&Path>,
 ) -> ArtifactPortabilityReport {
     let run_window = config
         .observation_run_window
@@ -49,7 +76,6 @@ pub(crate) fn run_report_with_config(
         ..Default::default()
     };
     let runs = crate::recorded_artifacts::recent_recorded_runs(component_id, run_window);
-    let artifact_root = homeboy_paths::artifact_root().ok();
     let path_policy = config.with_generic_defaults();
 
     for run in runs {
@@ -64,17 +90,13 @@ pub(crate) fn run_report_with_config(
             if artifact.artifact_type != "file" && artifact.artifact_type != "directory" {
                 continue;
             }
-            if artifact_path_is_portable(&artifact.path, artifact_root.as_deref(), &path_policy) {
+            if artifact_path_is_portable(&artifact.path, artifact_root, &path_policy) {
                 continue;
             }
             report.findings.push(artifact_path_finding(&run, artifact));
         }
-        let metadata_scan = metadata_path_findings(
-            &run,
-            &artifact_paths,
-            artifact_root.as_deref(),
-            &path_policy,
-        );
+        let metadata_scan =
+            metadata_path_findings(&run, &artifact_paths, artifact_root, &path_policy);
         report.metadata_fields_scanned += metadata_scan.fields_scanned;
         report.findings.extend(metadata_scan.findings);
     }

--- a/crates/homeboy-extension/src/runtime_helper.rs
+++ b/crates/homeboy-extension/src/runtime_helper.rs
@@ -6,7 +6,7 @@ use homeboy_extension_contract::RuntimeHelperRequirement;
 use serde::Deserialize;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 mod assets;
 
@@ -160,15 +160,39 @@ fn helper_revision(helper: &RuntimeHelper) -> String {
     )
 }
 
+/// Runtime-helper directory below an injected Homeboy config root.
+fn runtime_dir_in_roots(config_root: &Path) -> PathBuf {
+    config_root.join("runtime")
+}
+
+/// Ambient runtime-helper directory.
+///
+/// This is the boundary for the `<config>/runtime` tree, and it cannot move
+/// outward: the only production caller of [`ensure_all_helpers`] is
+/// `execution::build_exec_env`, which constructs the *subprocess environment*
+/// and is deliberately left ambient. An unresolvable config root still degrades
+/// to a process temp directory rather than failing helper materialization.
+fn ambient_runtime_dir() -> PathBuf {
+    paths::homeboy()
+        .map(|config_root| runtime_dir_in_roots(&config_root))
+        .unwrap_or_else(|_| env::temp_dir().join("homeboy-runtime"))
+}
+
 /// Materialize manifest-declared helpers under an identity-and-revision path.
 /// The content-addressed path keeps an admitted extension's helper immutable if
 /// another command later refreshes the core runtime helpers.
 pub fn provision_declared_helpers(
     requirements: &[RuntimeHelperRequirement],
 ) -> Result<Vec<RuntimeHelperProvision>> {
-    let runtime_dir = paths::homeboy()
-        .map(|path| path.join("runtime/helpers"))
-        .unwrap_or_else(|_| env::temp_dir().join("homeboy-runtime/helpers"));
+    provision_declared_helpers_in_dir(&ambient_runtime_dir().join("helpers"), requirements)
+}
+
+/// Materialize manifest-declared helpers below an explicitly supplied
+/// content-addressed helper directory.
+fn provision_declared_helpers_in_dir(
+    runtime_dir: &Path,
+    requirements: &[RuntimeHelperRequirement],
+) -> Result<Vec<RuntimeHelperProvision>> {
     let mut provisions = Vec::with_capacity(requirements.len());
     for requirement in requirements {
         let id = requirement.id.trim();
@@ -288,10 +312,17 @@ fn declared_helpers() -> Result<Vec<DeclaredRuntimeHelper>> {
 
 /// Ensure all runtime helpers are written and return (env_var, path) pairs.
 pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
-    let runtime_dir = paths::homeboy()
-        .map(|path| path.join("runtime"))
-        .unwrap_or_else(|_| env::temp_dir().join("homeboy-runtime"));
-    fs::create_dir_all(&runtime_dir).map_err(|e| {
+    ensure_all_helpers_in_dir(&ambient_runtime_dir())
+}
+
+/// Ensure all runtime helpers are written below an explicitly supplied runtime
+/// directory and return (env_var, path) pairs.
+///
+/// The returned pairs are handed to subprocess environment construction by the
+/// caller; this function resolves and writes files, it does not read process
+/// environment for path roots.
+fn ensure_all_helpers_in_dir(runtime_dir: &Path) -> Result<Vec<(String, String)>> {
+    fs::create_dir_all(runtime_dir).map_err(|e| {
         Error::internal_io(
             e.to_string(),
             Some("create homeboy runtime directory".to_string()),
@@ -300,7 +331,7 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
 
     let mut env_pairs = Vec::with_capacity(HELPERS.len());
     for helper in HELPERS {
-        let path = ensure_helper(&runtime_dir, helper)?;
+        let path = ensure_helper(runtime_dir, helper)?;
         env_pairs.push((
             helper.env_var.to_string(),
             path.to_string_lossy().to_string(),
@@ -308,7 +339,7 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
     }
 
     for helper in declared_helpers()? {
-        let path = ensure_declared_helper(&runtime_dir, &helper)?;
+        let path = ensure_declared_helper(runtime_dir, &helper)?;
         env_pairs.push((helper.env_var, path.to_string_lossy().to_string()));
     }
 

--- a/crates/homeboy-extension/src/setup_env.rs
+++ b/crates/homeboy-extension/src/setup_env.rs
@@ -15,7 +15,7 @@
 //! env/settings manually after setup succeeds.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy_core::error::Result;
 use homeboy_core::paths;
@@ -24,15 +24,16 @@ use homeboy_engine_primitives::local_files;
 /// Schema marker for the persisted setup-env document.
 const SETUP_ENV_SCHEMA: &str = "homeboy/extension-setup-env/v1";
 
-/// Directory (under the machine-local homeboy data root) that stores persisted
-/// per-extension setup runtime env documents.
-fn setup_env_dir() -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?.join("extension-setup-env"))
+/// Directory that stores persisted per-extension setup runtime env documents,
+/// below an injected Homeboy data root.
+fn setup_env_dir_in_roots(data_root: &Path) -> PathBuf {
+    data_root.join("extension-setup-env")
 }
 
-/// Path to the persisted setup-env document for a single extension.
-fn setup_env_path(extension_id: &str) -> Result<PathBuf> {
-    Ok(setup_env_dir()?.join(format!("{}.json", sanitize_extension_id(extension_id))))
+/// Path to the persisted setup-env document for a single extension, below an
+/// injected Homeboy data root.
+fn setup_env_path_in_roots(data_root: &Path, extension_id: &str) -> PathBuf {
+    setup_env_dir_in_roots(data_root).join(format!("{}.json", sanitize_extension_id(extension_id)))
 }
 
 /// Keep file names filesystem-safe regardless of extension id formatting.
@@ -55,7 +56,21 @@ fn sanitize_extension_id(extension_id: &str) -> String {
 /// removes any previously persisted document so stale values never leak into a
 /// later capability execution.
 pub(crate) fn persist(extension_id: &str, env: &[(String, String)]) -> Result<()> {
-    let path = setup_env_path(extension_id)?;
+    let roots = paths::PathRoots::from_environment()?;
+    persist_in_roots(&roots, extension_id, env)
+}
+
+/// Persist the setup-discovered runtime env below explicitly supplied roots.
+///
+/// Only the data root is consulted. The env pairs themselves are opaque
+/// payload: this function stores them, it does not resolve or reinterpret any
+/// path inside them, and it is not part of subprocess environment construction.
+pub(crate) fn persist_in_roots(
+    roots: &paths::PathRoots,
+    extension_id: &str,
+    env: &[(String, String)],
+) -> Result<()> {
+    let path = setup_env_path_in_roots(roots.data(), extension_id);
 
     if env.is_empty() {
         if path.exists() {
@@ -98,9 +113,15 @@ pub(crate) fn persist(extension_id: &str, env: &[(String, String)]) -> Result<()
 /// persisted (or the document is unreadable/malformed — replay must never hard
 /// fail capability execution).
 pub(crate) fn load(extension_id: &str) -> Vec<(String, String)> {
-    let Ok(path) = setup_env_path(extension_id) else {
+    let Ok(roots) = paths::PathRoots::from_environment() else {
         return Vec::new();
     };
+    load_in_roots(&roots, extension_id)
+}
+
+/// Load the persisted setup runtime env below explicitly supplied roots.
+pub(crate) fn load_in_roots(roots: &paths::PathRoots, extension_id: &str) -> Vec<(String, String)> {
+    let path = setup_env_path_in_roots(roots.data(), extension_id);
     if !path.exists() {
         return Vec::new();
     }

--- a/crates/homeboy-extension/src/trace/overlay_lock.rs
+++ b/crates/homeboy-extension/src/trace/overlay_lock.rs
@@ -49,12 +49,27 @@ pub struct TraceOverlayLockCleanupResult {
 }
 
 impl TraceOverlayLock {
+    /// Ambient boundary: resolve the data root once, then acquire rooted.
     pub(super) fn acquire(
         component_path: &Path,
         overlay_paths: &[String],
         run_dir: &RunDir,
     ) -> Result<Self> {
-        let lock_dir = trace_overlay_lock_dir()?;
+        let roots = paths::PathRoots::from_environment()?;
+        Self::acquire_in_roots(&roots, component_path, overlay_paths, run_dir)
+    }
+
+    /// Acquire the component's overlay lock below explicitly supplied roots.
+    ///
+    /// `run_dir` is already an injected value, so the data root is the only
+    /// ambient reach this path had.
+    fn acquire_in_roots(
+        roots: &paths::PathRoots,
+        component_path: &Path,
+        overlay_paths: &[String],
+        run_dir: &RunDir,
+    ) -> Result<Self> {
+        let lock_dir = trace_overlay_lock_dir_in_roots(roots.data())?;
         let normalized_component_path = normalize_component_path(component_path);
         let path = lock_dir.join(format!(
             "{}.lock",
@@ -110,8 +125,17 @@ impl Drop for TraceOverlayLock {
     }
 }
 
+/// Ambient boundary: resolve the data root once, then list rooted.
 pub fn list_trace_overlay_locks() -> Result<Vec<TraceOverlayLockRecord>> {
-    let lock_dir = trace_overlay_lock_dir()?;
+    let roots = paths::PathRoots::from_environment()?;
+    list_trace_overlay_locks_in_roots(&roots)
+}
+
+/// List the overlay locks recorded below explicitly supplied roots.
+fn list_trace_overlay_locks_in_roots(
+    roots: &paths::PathRoots,
+) -> Result<Vec<TraceOverlayLockRecord>> {
+    let lock_dir = trace_overlay_lock_dir_in_roots(roots.data())?;
     let entries = fs::read_dir(&lock_dir).map_err(|e| {
         Error::internal_io(
             format!(
@@ -140,8 +164,18 @@ pub fn list_trace_overlay_locks() -> Result<Vec<TraceOverlayLockRecord>> {
     Ok(records)
 }
 
+/// Ambient boundary: resolve the data root once, then clean up rooted.
 pub fn cleanup_stale_trace_overlay_locks(force: bool) -> Result<TraceOverlayLockCleanupResult> {
-    let locks = list_trace_overlay_locks()?;
+    let roots = paths::PathRoots::from_environment()?;
+    cleanup_stale_trace_overlay_locks_in_roots(&roots, force)
+}
+
+/// Remove stale overlay locks recorded below explicitly supplied roots.
+fn cleanup_stale_trace_overlay_locks_in_roots(
+    roots: &paths::PathRoots,
+    force: bool,
+) -> Result<TraceOverlayLockCleanupResult> {
+    let locks = list_trace_overlay_locks_in_roots(roots)?;
     let mut removed = Vec::new();
     let mut kept = Vec::new();
     for lock in locks {
@@ -166,8 +200,17 @@ pub fn cleanup_stale_trace_overlay_locks(force: bool) -> Result<TraceOverlayLock
     Ok(TraceOverlayLockCleanupResult { removed, kept })
 }
 
-fn trace_overlay_lock_dir() -> Result<PathBuf> {
-    let lock_dir = paths::homeboy_data()?.join("trace-overlay-locks");
+/// Overlay lock directory below an injected Homeboy data root.
+///
+/// The boundary stops at this module's public entry points rather than moving
+/// out into `trace::run::workflow`. That workflow also calls
+/// `runner::resolve_trace_baseline_root`, which resolves `paths::rig_baseline_root`
+/// — the *rig registry* root, selected by `HOMEBOY_RIG_REGISTRY_ROOT` and not
+/// modeled by `PathRoots` at all. Threading roots into the workflow would make
+/// the overlay locks honor an injected data root while the trace baseline still
+/// came from ambient rig state: a split home (#7505).
+fn trace_overlay_lock_dir_in_roots(data_root: &Path) -> Result<PathBuf> {
+    let lock_dir = data_root.join("trace-overlay-locks");
     fs::create_dir_all(&lock_dir).map_err(|e| {
         Error::internal_io(
             format!(
@@ -179,6 +222,16 @@ fn trace_overlay_lock_dir() -> Result<PathBuf> {
         )
     })?;
     Ok(lock_dir)
+}
+
+/// Ambient resolution of the overlay lock directory.
+///
+/// Retained for in-crate tests that write lock fixtures directly; production
+/// callers reach the directory through the rooted entry points above.
+#[cfg(test)]
+fn trace_overlay_lock_dir() -> Result<PathBuf> {
+    let roots = paths::PathRoots::from_environment()?;
+    trace_overlay_lock_dir_in_roots(roots.data())
 }
 
 fn read_trace_overlay_lock_record(lock_path: &Path) -> TraceOverlayLockRecord {


### PR DESCRIPTION
## Summary

Two independent units in one commit: the audit engine and the extension loader do not share state.

**`homeboy-code-audit`** — `artifact_portability::run_report_with_config` becomes the ambient boundary, delegating to a new `_in_roots` sibling taking `Option<&Path>`.

> `Option` was kept deliberately. Existing behavior on an unresolvable artifact root is **degrade** (no store-anchored exemption), not **fail**. Making it `&Path` would convert a silent degrade into a hard error on `audit_path_with_id`.

**`homeboy-extension`** — three chains, one hop each:

| module | root | rooted |
|---|---|---|
| `setup_env` | data | `setup_env_dir_in_roots`, `setup_env_path_in_roots`, `persist_in_roots`, `load_in_roots` |
| `trace/overlay_lock` | data | `trace_overlay_lock_dir_in_roots`, `acquire_in_roots`, `list_…_in_roots`, `cleanup_stale_…_in_roots` |
| `runtime_helper` | config | `runtime_dir_in_roots` + `ambient_runtime_dir`, `ensure_all_helpers_in_dir`, `provision_declared_helpers_in_dir` |

The two `runtime_helper` workers are `_in_dir`, not `_in_roots`, because their honest dependency is an already-resolved directory — the historical fallback is `<temp>/homeboy-runtime`, which is **not derivable from any config root**, so folding it in would have silently changed the fallback path.

<callout accent="#ef4444">
## Highest-value finding: the audit engine cannot be rooted yet

If someone threads `PathRoots` into `engine::audit_internal`, `artifact_portability` would compare recorded artifact paths against an **injected** artifact root while `recent_recorded_runs` reads the **ambient** observation store — so **every artifact from the real store reads as non-portable** against the injected root.

The blocker is `provider_registry!` indirection: `recorded_artifacts.rs:70` → `audit_artifact_provider.rs:20` `ObservationStore::open_initialized()`, behind a public trait contract in `homeboy-core`. Same shape in `extension_manifests.rs` and `component_provider.rs`.

Documented in a doc comment on `run_report_with_config` so the next person does not walk into it.
</callout>

**Second hazard: `trace/run/workflow.rs` is a live two-root call site.** It calls `acquire_trace_overlay_locks` (data root, now rooted) *and* `resolve_trace_baseline_root` (rig registry root, **not modelled by `PathRoots` at all**) at lines 88/236 and 335. Threading roots there would make overlay locks honor an injected root while baselines come from ambient rig state. That is exactly why the overlay-lock boundary stops at the module.

## Subprocess env: not touched, and how they were told apart

Untouched: `execution::build_exec_env`, `build_capability_env_with_additional_providers`, `execute_capability_script`, `env_provider::env_vars`, `runtime_helper::declared_helpers`.

Two tests, both had to pass:
1. **Does it resolve a path from a process-global root** (`$HOME`, `XDG_*`, `HOMEBOY_ARTIFACT_ROOT`, `HOMEBOY_DATA_DIR`)? → rooted.
2. **Is the env var part of the contract handed to a child process?** → left alone. `HOMEBOY_RUNTIME_HELPERS_JSON` is an *input from* a parent; `HOMEBOY_RUNTIME_*` helper paths are *outputs to* a child. Neither is a root.

The instructive boundary case: `build_capability_env_with_additional_providers` calls `setup_env::load` and splices the result into the subprocess env. **How `load` finds its file** is rooted; **the returned pairs** are untouched — and the doc comment on `persist_in_roots` says so, so a future reader does not "helpfully" root the payload.

## Also not closed

`repair.rs`, `lifecycle/*`, `maintenance.rs`, `build/mod.rs` — every site sits beside `homeboy_core::extension_store`, `config::check_id_collision`, or `local_files::ensure_app_dirs` (which resolves seven config-root paths in one go). **Rooting the extension side alone is a guaranteed split.**

`test/differential/cache.rs:57` left alone: `BaselineCache::at()` is already the injection point and `default_root()` is already the correct ambient boundary — an `_in_roots` there would be pure ceremony.

## Public signatures changed

**None.** Every rooted inner is new; every existing entry point kept its exact signature and arity, so there were no call sites to update. `setup_env_dir`/`setup_env_path` were the only removed names — zero remaining references tree-wide.

## Verification

`rustfmt --check` parses all four files. **Zero newly-introduced duplicate definitions** (verified against `origin/main`; the `process_is_alive`/`last_errno` pairs in `overlay_lock.rs` are pre-existing `#[cfg]` platform variants). Every new function has ≥1 caller — no `dead_code` regression, which was the binding design constraint.

Not verified without cargo: clippy (`too_many_arguments` in particular — the audit boundary was deliberately **not** pushed into `engine::audit_root_only`, which already has 7 params), and whether new surface produces audit findings absent from the `baselines.audit` baseline.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
