### PR TITLE
Root the release, deploy, rig, and tunnel filesystem reaches

### DIFF
--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -400,17 +400,23 @@ pub fn run_multi(
         }
     );
 
+    // One resolution for the whole run. Every checkpoint read and write below
+    // addresses this data root, so a resumed run cannot read its checkpoint
+    // from one home and then record target outcomes into another (#7505). The
+    // observation store admitted alongside it still resolves its own roots
+    // inside `homeboy-core`, which is not reachable from here.
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let identity = lifecycle_identity(project_ids, component_ids, config);
     let mut lifecycle_run = if config.dry_run || config.check {
         None
     } else if let Some(id) = config.resume_run_id.as_deref() {
-        let mut run = lifecycle::load(id)?;
+        let mut run = lifecycle::load_in_roots(roots.data(), id)?;
         run.resume(&identity)?;
-        lifecycle::save(&run)?;
+        lifecycle::save_in_roots(roots.data(), &run)?;
         Some(run)
     } else {
         let run = lifecycle::DeployLifecycleRun::new(Uuid::new_v4().to_string(), identity.clone());
-        lifecycle::save(&run)?;
+        lifecycle::save_in_roots(roots.data(), &run)?;
         Some(run)
     };
     let checkpoint_run_id = lifecycle_run.as_ref().map(|run| run.id.clone());
@@ -506,7 +512,7 @@ pub fn run_multi(
                 None,
                 None,
             );
-            lifecycle::save(run)?;
+            lifecycle::save_in_roots(roots.data(), run)?;
         }
         let mut timer = PhaseTimer::new();
         let result = timer.time("resolve_source", || {
@@ -549,7 +555,7 @@ pub fn run_multi(
                             project_results.last().and_then(|entry| entry.error.clone()),
                             Some(timings.clone()),
                         );
-                        lifecycle::save(run)?;
+                        lifecycle::save_in_roots(roots.data(), run)?;
                     }
                     failed += 1;
                 } else if is_planned {
@@ -580,7 +586,7 @@ pub fn run_multi(
                             None,
                             Some(timings.clone()),
                         );
-                        lifecycle::save(run)?;
+                        lifecycle::save_in_roots(roots.data(), run)?;
                     }
                     succeeded += 1;
                 }
@@ -618,7 +624,7 @@ pub fn run_multi(
                         Some(e.to_string()),
                         Some(timings),
                     );
-                    lifecycle::save(run)?;
+                    lifecycle::save_in_roots(roots.data(), run)?;
                 }
                 failed += 1;
             }

--- a/crates/homeboy-deploy/src/lifecycle.rs
+++ b/crates/homeboy-deploy/src/lifecycle.rs
@@ -1,14 +1,13 @@
 //! Durable, versioned lifecycle records for resumable multi-target deploys.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::observation::{NewRunRecord, ObservationStore, RunStatus};
-use homeboy_core::paths;
 use homeboy_core::phase_timing::PhaseTimingReport;
 
 const SCHEMA_VERSION: u32 = 1;
@@ -258,14 +257,20 @@ impl DeployLifecycleRun {
     }
 }
 
-pub(super) fn lifecycle_path(id: &str) -> Result<PathBuf> {
-    Ok(paths::homeboy_data()?
-        .join("deploy-runs")
-        .join(format!("{id}.json")))
+/// The deploy lifecycle checkpoint below an explicitly injected data root.
+///
+/// Rooted rather than wrapped: `run_multi` resolves once and every checkpoint
+/// read and write in that run addresses the same home. The ambient form
+/// resolved the data root independently on each of the seven calls a multi
+/// target deploy makes, so a repoint mid-run could have resumed from one home's
+/// checkpoint and then recorded target outcomes into another's — the resumed
+/// run would silently redo targets it had already succeeded (#7505).
+fn lifecycle_path_in_roots(data_root: &Path, id: &str) -> PathBuf {
+    data_root.join("deploy-runs").join(format!("{id}.json"))
 }
 
-pub(super) fn load(id: &str) -> Result<DeployLifecycleRun> {
-    let path = lifecycle_path(id)?;
+pub(super) fn load_in_roots(data_root: &Path, id: &str) -> Result<DeployLifecycleRun> {
+    let path = lifecycle_path_in_roots(data_root, id);
     let contents = fs::read_to_string(&path).map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -280,8 +285,8 @@ pub(super) fn load(id: &str) -> Result<DeployLifecycleRun> {
     })
 }
 
-pub(super) fn save(run: &DeployLifecycleRun) -> Result<()> {
-    let path = lifecycle_path(&run.id)?;
+pub(super) fn save_in_roots(data_root: &Path, run: &DeployLifecycleRun) -> Result<()> {
+    let path = lifecycle_path_in_roots(data_root, &run.id);
     let parent = path.parent().expect("deploy lifecycle path has parent");
     fs::create_dir_all(parent).map_err(|error| {
         Error::internal_io(
@@ -359,6 +364,7 @@ mod tests {
     #[test]
     fn durable_record_round_trips_target_state_and_partial_timing_evidence() {
         with_isolated_home(|_| {
+            let roots = homeboy_core::paths::PathRoots::from_environment().expect("path roots");
             let mut run = DeployLifecycleRun::new("run".to_string(), identity());
             let mut timer = homeboy_core::phase_timing::PhaseTimer::new();
             timer.record_failed("transfer", std::time::Duration::from_millis(1));
@@ -368,9 +374,9 @@ mod tests {
                 Some("connection lost".to_string()),
                 Some(timer.into_report()),
             );
-            save(&run).expect("persist run before retryable remote work");
+            save_in_roots(roots.data(), &run).expect("persist run before retryable remote work");
 
-            let restored = load("run").expect("read durable run");
+            let restored = load_in_roots(roots.data(), "run").expect("read durable run");
             assert_eq!(restored.schema_version, SCHEMA_VERSION);
             assert_eq!(restored.targets[1].status, DeployTargetStatus::Failed);
             assert_eq!(

--- a/crates/homeboy-deploy/src/receipt.rs
+++ b/crates/homeboy-deploy/src/receipt.rs
@@ -59,7 +59,13 @@ pub(super) fn load(
     version: &str,
     exclusions: &[String],
 ) -> Result<Option<DeployedPackageReceipt>, Error> {
-    let path = path(project, component_id, target, version)?;
+    let path = path_in_roots(
+        homeboy_paths::PathRoots::from_environment()?.data(),
+        project,
+        component_id,
+        target,
+        version,
+    );
     if !path.exists() {
         return Ok(None);
     }
@@ -99,7 +105,13 @@ pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
         build_provenance,
         exclusions,
     } = input;
-    let path = path(project, component_id, target, version)?;
+    let path = path_in_roots(
+        homeboy_paths::PathRoots::from_environment()?.data(),
+        project,
+        component_id,
+        target,
+        version,
+    );
     let parent = path.parent().expect("receipt path has a parent");
     fs::create_dir_all(parent)
         .map_err(|error| receipt_io_error(&error, "create deploy receipt directory", parent))?;
@@ -191,7 +203,13 @@ pub(super) fn invalidate(
     target: &str,
     version: &str,
 ) -> Result<(), Error> {
-    let path = path(project, component_id, target, version)?;
+    let path = path_in_roots(
+        homeboy_paths::PathRoots::from_environment()?.data(),
+        project,
+        component_id,
+        target,
+        version,
+    );
     match fs::remove_file(&path) {
         Ok(()) => sync_directory(path.parent().expect("receipt path has a parent")),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -249,22 +267,28 @@ fn sync_directory(path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-fn path(
+/// The receipt path for one deployment identity, below an explicitly injected
+/// data root.
+///
+/// Infallible now that the root is supplied: resolution was the only fallible
+/// step. The `homeboy_data` error it used to propagate is raised once by the
+/// caller's `PathRoots::from_environment`, which reports the same coded error
+/// rather than flattening a missing or unwritable data root into a sentence.
+fn path_in_roots(
+    data_root: &Path,
     project: &Project,
     component_id: &str,
     target: &str,
     version: &str,
-) -> Result<PathBuf, Error> {
+) -> PathBuf {
     let mut hash = Sha256::new();
     for value in [&project.id, component_id, target, version] {
         hash.update(value.as_bytes());
         hash.update([0]);
     }
-    // `homeboy_data` already reports a coded error; propagate it rather than
-    // flattening a missing/unwritable data root into a sentence.
-    Ok(homeboy_paths::homeboy_data()?
+    data_root
         .join("deploy-receipts")
-        .join(format!("{:x}.json", hash.finalize())))
+        .join(format!("{:x}.json", hash.finalize()))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -4,6 +4,7 @@ use homeboy_deploy::{
 };
 use std::collections::BTreeMap;
 use std::fs;
+use std::path::Path;
 
 use super::executor::release_cleanup_paths;
 use super::types::{
@@ -406,13 +407,38 @@ struct DeploymentRecovery {
     package_owned_paths: Vec<String>,
 }
 
-fn recovery_path(component_id: &str) -> Result<std::path::PathBuf> {
-    Ok(homeboy_core::paths::homeboy_data()?
+/// The release deploy recovery checkpoint below an explicitly injected data
+/// root.
+///
+/// Infallible: every caller already resolves the root once at its own
+/// boundary, so the only fallible step left is resolution itself.
+fn recovery_path_in_roots(data_root: &Path, component_id: &str) -> std::path::PathBuf {
+    data_root
         .join("release-deploy-runs")
-        .join(format!("{}.json", component_id.replace('/', "_"))))
+        .join(format!("{}.json", component_id.replace('/', "_")))
 }
 
 fn save_recovery(
+    component: &homeboy_core::component::Component,
+    expected_version: Option<&str>,
+    projects: &[String],
+    config: &DeployConfig,
+    deploy_run_id: &str,
+    package_owned_paths: &[String],
+) -> Result<()> {
+    save_recovery_in_roots(
+        homeboy_core::paths::PathRoots::from_environment()?.data(),
+        component,
+        expected_version,
+        projects,
+        config,
+        deploy_run_id,
+        package_owned_paths,
+    )
+}
+
+fn save_recovery_in_roots(
+    data_root: &Path,
     component: &homeboy_core::component::Component,
     expected_version: Option<&str>,
     projects: &[String],
@@ -436,7 +462,7 @@ fn save_recovery(
         component_path: component.local_path.clone(),
         package_owned_paths: package_owned_paths.to_vec(),
     };
-    let path = recovery_path(&component.id)?;
+    let path = recovery_path_in_roots(data_root, &component.id);
     fs::create_dir_all(path.parent().expect("recovery path parent"))
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     let temporary = path.with_extension("json.tmp");
@@ -453,15 +479,30 @@ fn save_recovery(
 }
 
 fn remove_recovery(component_id: &str) -> Result<()> {
-    let path = recovery_path(component_id)?;
+    remove_recovery_in_roots(
+        homeboy_core::paths::PathRoots::from_environment()?.data(),
+        component_id,
+    )
+}
+
+fn remove_recovery_in_roots(data_root: &Path, component_id: &str) -> Result<()> {
+    let path = recovery_path_in_roots(data_root, component_id);
     if path.exists() {
         fs::remove_file(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
     }
     Ok(())
 }
 
+/// Resume a checkpointed release deployment.
+///
+/// The checkpoint read and the checkpoint removal below share one resolution,
+/// so a run cannot consume a record from one home and then clear the record in
+/// another. The redeploy between them — `deploy::run_multi` — still resolves
+/// its own roots inside `homeboy-deploy`; that boundary is not reachable from
+/// here without changing a public signature (#7505).
 pub(super) fn resume_deployment(component_id: &str) -> Result<Option<ReleaseDeploymentResult>> {
-    let path = recovery_path(component_id)?;
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let path = recovery_path_in_roots(roots.data(), component_id);
     if !path.exists() {
         return Ok(None);
     }
@@ -505,7 +546,7 @@ pub(super) fn resume_deployment(component_id: &str) -> Result<Option<ReleaseDepl
         if !record.component_path.is_empty() {
             cleanup_release_artifacts(&record.component_path, &record.package_owned_paths);
         }
-        remove_recovery(component_id)?;
+        remove_recovery_in_roots(roots.data(), component_id)?;
     }
     Ok(Some(deployment))
 }
@@ -582,6 +623,16 @@ mod tests {
     use homeboy_core::test_support::with_isolated_home;
     use std::io::Write;
     use std::path::Path;
+
+    /// The checkpoint path for the ambient home these tests already isolate.
+    fn recovery_path(component_id: &str) -> std::path::PathBuf {
+        super::recovery_path_in_roots(
+            homeboy_core::paths::PathRoots::from_environment()
+                .expect("path roots")
+                .data(),
+            component_id,
+        )
+    }
 
     fn run_git(path: &Path, args: &[&str]) -> String {
         let output = std::process::Command::new("git")
@@ -1130,9 +1181,7 @@ mod tests {
             assert!(successful_target
                 .join("plugins/successful/plugin.txt")
                 .exists());
-            assert!(super::recovery_path("fixture")
-                .expect("recovery path")
-                .exists());
+            assert!(recovery_path("fixture").exists());
             assert!(source.join("build/intermediate").is_file());
             assert!(source.join("fixture-1.2.4.tgz").is_file());
 
@@ -1204,9 +1253,7 @@ mod tests {
                 release_commit
             );
             assert!(
-                !super::recovery_path("fixture")
-                    .expect("recovery path")
-                    .exists(),
+                !recovery_path("fixture").exists(),
                 "terminal success clears the durable checkpoint"
             );
 

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -37,7 +37,8 @@ pub use github_release::release_notes_path;
 pub(crate) use github_release::release_notes_path as github_release_notes_path;
 pub(crate) use github_release::run_github_release;
 pub(crate) use package::{
-    build_release_payload, run_extension_release_preflight, run_package, PackageRequest,
+    build_release_payload, run_extension_release_preflight, run_package, run_package_in_roots,
+    PackageRequest,
 };
 pub(crate) use publish::{publish_response_output, run_publish};
 pub(crate) use tagging::{
@@ -364,7 +365,26 @@ pub(crate) fn run_cleanup(
     component: &Component,
     state: &ReleaseState,
 ) -> Result<ReleaseStepResult> {
-    let failed_package_paths = package::failed_package_owned_paths(component)?;
+    run_cleanup_in_roots(
+        homeboy_core::paths::PathRoots::from_environment()?.data(),
+        component,
+        state,
+    )
+}
+
+/// [`run_cleanup`] against an explicitly injected data root.
+///
+/// Reading the failed-attempt ownership record and acknowledging it are one
+/// transaction over one file. The ambient form resolved the data root once per
+/// call, so a repoint between them could have removed paths recorded in one
+/// home and then acknowledged a record in another, permanently stranding the
+/// first home's entries (#7505).
+pub(crate) fn run_cleanup_in_roots(
+    data_root: &std::path::Path,
+    component: &Component,
+    state: &ReleaseState,
+) -> Result<ReleaseStepResult> {
+    let failed_package_paths = package::failed_package_owned_paths_in_roots(data_root, component)?;
     let mut package_owned_paths = state.package_owned_paths.clone();
     package_owned_paths.extend(failed_package_paths.iter().cloned());
     package_owned_paths.sort();
@@ -384,7 +404,11 @@ pub(crate) fn run_cleanup(
         })?;
         removed_paths.push(path.display().to_string());
     }
-    package::acknowledge_failed_package_owned_paths(component, &failed_package_paths)?;
+    package::acknowledge_failed_package_owned_paths_in_roots(
+        data_root,
+        component,
+        &failed_package_paths,
+    )?;
 
     let data = serde_json::json!({
         "action": "cleanup",

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -44,6 +44,38 @@ pub(crate) fn run_package(
     component_local_path: &str,
     request: PackageRequest<'_>,
 ) -> Result<ReleaseStepResult> {
+    run_package_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        extensions,
+        state,
+        component,
+        component_id,
+        component_local_path,
+        request,
+    )
+}
+
+/// [`run_package`] against explicitly injected roots.
+///
+/// Both halves of this step are Homeboy state and both are injected together,
+/// on purpose. The durable artifact copies land under `roots.artifacts()` and
+/// the failed-attempt ownership record lands under `roots.data()`; the ambient
+/// form resolved each independently, so a repoint between them could leave the
+/// bytes in one home and the record describing them in another (#7505).
+///
+/// What is deliberately NOT rooted here: `build_declared_component_artifact`
+/// and `run_package_action_with_retry` hand work to a *subprocess* — the
+/// component's own build script and the extension's `release.package` action.
+/// Those children read their own environment by design and must keep doing so.
+pub(crate) fn run_package_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    extensions: &[ExtensionManifest],
+    state: &mut ReleaseState,
+    component: &Component,
+    component_id: &str,
+    component_local_path: &str,
+    request: PackageRequest<'_>,
+) -> Result<ReleaseStepResult> {
     let PackageRequest {
         component_source_path,
         declared_build_artifact,
@@ -60,7 +92,8 @@ pub(crate) fn run_package(
             build_declared_component_artifact(component, declared_build_artifact)?;
         let declared_artifact_built = component_build.is_some();
         if declared_artifact_built {
-            collect_declared_build_artifact(
+            collect_declared_build_artifact_in_roots(
+                roots.artifacts(),
                 state,
                 declared_build_artifact,
                 component_id,
@@ -114,8 +147,14 @@ pub(crate) fn run_package(
                 artifact.phase = "final".to_string();
                 artifact.producer = format!("extension:{}", extension.id);
             }
-            persist_package_artifacts(state, artifact_start, component_id, component_local_path)
-                .map_err(|err| package_provider_error(&extension.id, err))?;
+            persist_package_artifacts_in_roots(
+                roots.artifacts(),
+                state,
+                artifact_start,
+                component_id,
+                component_local_path,
+            )
+            .map_err(|err| package_provider_error(&extension.id, err))?;
             responses.push(serde_json::json!({
                 "extension": extension.id,
                 "response": response,
@@ -123,7 +162,8 @@ pub(crate) fn run_package(
         }
 
         if !declared_artifact_built {
-            collect_declared_build_artifact(
+            collect_declared_build_artifact_in_roots(
+                roots.artifacts(),
                 state,
                 declared_build_artifact,
                 component_id,
@@ -156,7 +196,7 @@ pub(crate) fn run_package(
     })();
 
     if result.is_err() {
-        record_failed_package_owned_paths(component, &cleanup_before)?;
+        record_failed_package_owned_paths_in_roots(roots.data(), component, &cleanup_before)?;
     }
 
     result
@@ -179,7 +219,8 @@ struct OwnedPackagePath {
 /// Persist the exact outputs left by a failed package attempt outside the
 /// checkout. A later successful release can clean them only if the same
 /// component, checkout revision, and output bytes are still present.
-fn record_failed_package_owned_paths(
+fn record_failed_package_owned_paths_in_roots(
+    data_root: &Path,
     component: &Component,
     before: &BTreeSet<String>,
 ) -> Result<()> {
@@ -205,11 +246,20 @@ fn record_failed_package_owned_paths(
         head_commit: homeboy_core::git::get_head_commit(&component.local_path).ok(),
         paths,
     };
-    write_failed_package_ownership(&record)
+    write_failed_package_ownership_in_roots(data_root, &record)
 }
 
-pub(crate) fn failed_package_owned_paths(component: &Component) -> Result<Vec<String>> {
-    let Some(record) = read_failed_package_ownership(&component.id)? else {
+/// The ownership record left by a failed package attempt, below an explicitly
+/// injected data root.
+///
+/// Rooted rather than wrapped: the only caller is `run_cleanup`, which reads
+/// this record and then acknowledges it, and both halves must name the same
+/// home or cleanup would forget paths it just removed.
+pub(crate) fn failed_package_owned_paths_in_roots(
+    data_root: &Path,
+    component: &Component,
+) -> Result<Vec<String>> {
+    let Some(record) = read_failed_package_ownership_in_roots(data_root, &component.id)? else {
         return Ok(Vec::new());
     };
     if record.component_path != canonical_component_path(&component.local_path)
@@ -229,14 +279,15 @@ pub(crate) fn failed_package_owned_paths(component: &Component) -> Result<Vec<St
         .collect())
 }
 
-pub(crate) fn acknowledge_failed_package_owned_paths(
+pub(crate) fn acknowledge_failed_package_owned_paths_in_roots(
+    data_root: &Path,
     component: &Component,
     removed_paths: &[String],
 ) -> Result<()> {
     if removed_paths.is_empty() {
         return Ok(());
     }
-    let Some(mut record) = read_failed_package_ownership(&component.id)? else {
+    let Some(mut record) = read_failed_package_ownership_in_roots(data_root, &component.id)? else {
         return Ok(());
     };
     if record.component_path != canonical_component_path(&component.local_path) {
@@ -246,27 +297,28 @@ pub(crate) fn acknowledge_failed_package_owned_paths(
         .paths
         .retain(|owned| !removed_paths.contains(&owned.path));
     if record.paths.is_empty() {
-        let path = failed_package_ownership_path(&component.id)?;
+        let path = failed_package_ownership_path_in_roots(data_root, &component.id);
         if path.exists() {
             fs::remove_file(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
         }
     } else {
-        write_failed_package_ownership(&record)?;
+        write_failed_package_ownership_in_roots(data_root, &record)?;
     }
     Ok(())
 }
 
-fn failed_package_ownership_path(component_id: &str) -> Result<PathBuf> {
-    Ok(homeboy_core::paths::homeboy_data()?
-        .join("release-package-ownership")
-        .join(format!(
-            "{}.json",
-            homeboy_core::paths::sanitize_path_segment(component_id)
-        )))
+fn failed_package_ownership_path_in_roots(data_root: &Path, component_id: &str) -> PathBuf {
+    data_root.join("release-package-ownership").join(format!(
+        "{}.json",
+        homeboy_core::paths::sanitize_path_segment(component_id)
+    ))
 }
 
-fn read_failed_package_ownership(component_id: &str) -> Result<Option<FailedPackageOwnership>> {
-    let path = failed_package_ownership_path(component_id)?;
+fn read_failed_package_ownership_in_roots(
+    data_root: &Path,
+    component_id: &str,
+) -> Result<Option<FailedPackageOwnership>> {
+    let path = failed_package_ownership_path_in_roots(data_root, component_id);
     if !path.exists() {
         return Ok(None);
     }
@@ -279,8 +331,11 @@ fn read_failed_package_ownership(component_id: &str) -> Result<Option<FailedPack
     .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
 }
 
-fn write_failed_package_ownership(record: &FailedPackageOwnership) -> Result<()> {
-    let path = failed_package_ownership_path(&record.component_id)?;
+fn write_failed_package_ownership_in_roots(
+    data_root: &Path,
+    record: &FailedPackageOwnership,
+) -> Result<()> {
+    let path = failed_package_ownership_path_in_roots(data_root, &record.component_id);
     fs::create_dir_all(path.parent().expect("ownership parent"))
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     let temporary = path.with_extension("json.tmp");
@@ -519,7 +574,8 @@ mod build_failure_tests {
 
 /// Add a component-owned deploy artifact even when its packaging provider also
 /// emits unrelated release artifacts (for example, a registry tarball).
-fn collect_declared_build_artifact(
+fn collect_declared_build_artifact_in_roots(
+    artifact_root: &Path,
     state: &mut ReleaseState,
     declared_build_artifact: Option<&str>,
     component_id: &str,
@@ -572,7 +628,13 @@ fn collect_declared_build_artifact(
         sha256: None,
         publication_authority: false,
     });
-    persist_package_artifacts(state, artifact_start, component_id, component_local_path)
+    persist_package_artifacts_in_roots(
+        artifact_root,
+        state,
+        artifact_start,
+        component_id,
+        component_local_path,
+    )
 }
 
 /// Execute a `release.package` action with a bounded retry for transient
@@ -867,13 +929,20 @@ pub(super) fn store_artifacts_from_output(
     Ok(())
 }
 
-fn persist_package_artifacts(
+/// Copy the newly emitted artifacts into the durable release cache below an
+/// explicitly injected artifact root.
+///
+/// The `source.starts_with(artifact_root)` short-circuit below is why this must
+/// be the *same* root the copies are written under: judging "already durable"
+/// against one home while copying into another would re-copy every artifact, or
+/// worse, declare a foreign path durable.
+fn persist_package_artifacts_in_roots(
+    artifact_root: &Path,
     state: &mut ReleaseState,
     artifact_start: usize,
     component_id: &str,
     component_local_path: &str,
 ) -> Result<()> {
-    let artifact_root = homeboy_core::paths::artifact_root()?;
     let version = state
         .version
         .as_deref()
@@ -890,7 +959,7 @@ fn persist_package_artifacts(
             continue;
         }
 
-        if source.starts_with(&artifact_root) {
+        if source.starts_with(artifact_root) {
             artifact.durable_path = Some(source.display().to_string());
             continue;
         }

--- a/crates/homeboy-release/src/release/operation_record.rs
+++ b/crates/homeboy-release/src/release/operation_record.rs
@@ -61,8 +61,27 @@ impl OperationRecordStore {
         owner_run_ref: &str,
         update: impl FnOnce(Option<OperationRecord>) -> Result<OperationRecord>,
     ) -> Result<OperationRecord> {
-        let _lock = lock()?;
-        let path = record_path(owner_run_ref)?;
+        Self::update_in_roots(
+            paths::PathRoots::from_environment()?.data(),
+            owner_run_ref,
+            update,
+        )
+    }
+
+    /// [`update`](Self::update) against an explicitly injected data root.
+    ///
+    /// The lock and the record path are now derived from one resolution. The
+    /// ambient form resolved the data root twice — once inside `lock()` and
+    /// again inside `record_path()` — so a repoint between them could have
+    /// serialized against one home's `.lock` while replacing the other home's
+    /// record (#7505).
+    fn update_in_roots(
+        data_root: &Path,
+        owner_run_ref: &str,
+        update: impl FnOnce(Option<OperationRecord>) -> Result<OperationRecord>,
+    ) -> Result<OperationRecord> {
+        let _lock = lock_in_roots(data_root)?;
+        let path = record_path_in_roots(data_root, owner_run_ref);
         let current = read_path(&path)?;
         let next = update(current)?;
         if next.owner_run_ref != owner_run_ref {
@@ -86,8 +105,9 @@ impl OperationRecordStore {
     }
 
     pub fn load(owner_run_ref: &str) -> Result<Option<OperationRecord>> {
-        let _lock = lock()?;
-        read_path(&record_path(owner_run_ref)?)
+        let roots = paths::PathRoots::from_environment()?;
+        let _lock = lock_in_roots(roots.data())?;
+        read_path(&record_path_in_roots(roots.data(), owner_run_ref))
     }
 
     /// Claims finalization before an external provider call. A live lease is
@@ -196,8 +216,9 @@ impl OperationRecordStore {
         subject: &str,
         pending_only: bool,
     ) -> Result<Vec<OperationRecord>> {
-        let _lock = lock()?;
-        let dir = store_dir()?;
+        let roots = paths::PathRoots::from_environment()?;
+        let _lock = lock_in_roots(roots.data())?;
+        let dir = store_dir_in_roots(roots.data());
         let mut records = Vec::new();
         if !dir.exists() {
             return Ok(records);
@@ -232,23 +253,27 @@ fn now_ms() -> u128 {
         .as_millis()
 }
 
-fn store_dir() -> Result<PathBuf> {
-    let database = paths::observation_db()?;
-    let root = database
-        .parent()
-        .ok_or_else(|| Error::internal_unexpected("observation database has no parent"))?;
-    Ok(root.join("operation-records"))
+/// The operation-record store below an explicitly injected data root.
+///
+/// The ambient form resolved `paths::observation_db()` and took its parent.
+/// `observation_db()` is `homeboy_data()?.join("homeboy.sqlite")`, so that
+/// parent is exactly the data root: the database path was only ever a detour
+/// through it, and this store has never read or written the database itself.
+/// Naming the data root directly removes both the detour and the infallible
+/// `parent()` failure branch it required.
+fn store_dir_in_roots(data_root: &Path) -> PathBuf {
+    data_root.join("operation-records")
 }
 
-fn record_path(owner_run_ref: &str) -> Result<PathBuf> {
-    Ok(store_dir()?.join(format!(
+fn record_path_in_roots(data_root: &Path, owner_run_ref: &str) -> PathBuf {
+    store_dir_in_roots(data_root).join(format!(
         "{}.json",
         paths::sanitize_path_segment(owner_run_ref)
-    )))
+    ))
 }
 
-fn lock() -> Result<std::fs::File> {
-    let dir = store_dir()?;
+fn lock_in_roots(data_root: &Path) -> Result<std::fs::File> {
+    let dir = store_dir_in_roots(data_root);
     fs::create_dir_all(&dir)
         .map_err(|error| Error::internal_io(error.to_string(), Some(dir.display().to_string())))?;
     let file = OpenOptions::new()

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -10,7 +10,7 @@ use super::context::{load_component, resolve_extensions};
 use super::executor::artifacts::{
     PACKAGE_RECOVERY_MANIFEST_SCHEMA, PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
 };
-use super::executor::{run_package, PackageRequest};
+use super::executor::{run_cleanup_in_roots, run_package_in_roots, PackageRequest};
 use super::types::{ReleaseArtifact, ReleaseOptions, ReleaseState, ReleaseStepResult};
 
 #[derive(Debug, Clone, Serialize)]
@@ -27,6 +27,14 @@ pub struct ReleasePackageResult {
     pub package_step: ReleaseStepResult,
 }
 
+/// Regenerate the release package for an already-published tag.
+///
+/// Resolves the Homeboy roots exactly once for the whole recovery. Packaging,
+/// the durable recovery directory, and the checkout cleanup that follows all
+/// address the same home; the ambient form resolved a root independently
+/// inside each of them, so a repoint mid-operation could have written the
+/// deliverables to one artifact root, recorded the failed-attempt ownership in
+/// another data root, and then cleaned the checkout against a third (#7505).
 pub fn package_existing_tag(
     component_id: &str,
     path_override: Option<String>,
@@ -34,6 +42,7 @@ pub fn package_existing_tag(
     skip_build_validation: bool,
     expected_source: Option<&str>,
 ) -> Result<ReleasePackageResult> {
+    let roots = paths::PathRoots::from_environment()?;
     let component = load_component(
         component_id,
         &ReleaseOptions {
@@ -61,7 +70,8 @@ pub fn package_existing_tag(
         ..Default::default()
     };
 
-    let package_step = run_package(
+    let package_step = run_package_in_roots(
+        &roots,
         &extensions,
         &mut state,
         &component,
@@ -80,7 +90,7 @@ pub fn package_existing_tag(
     }
     super::executor::artifacts::establish_publication_authority(&mut state)?;
 
-    let artifact_dir = release_package_dir(component_id, tag)?;
+    let artifact_dir = release_package_dir_in_roots(roots.artifacts(), component_id, tag);
     fs::create_dir_all(&artifact_dir).map_err(|error| {
         Error::internal_io(
             format!(
@@ -125,7 +135,7 @@ pub fn package_existing_tag(
 
     // The durable recovery directory now owns the deliverables. Remove only
     // checkout paths proven to have been created by this package invocation.
-    super::executor::run_cleanup(&component, &state)?;
+    run_cleanup_in_roots(roots.data(), &component, &state)?;
 
     homeboy_core::log_status!(
         "release",
@@ -202,11 +212,11 @@ fn validate_existing_tag_at_head(local_path: &str, tag: &str, head_commit: &str)
     Ok(())
 }
 
-fn release_package_dir(component_id: &str, tag: &str) -> Result<PathBuf> {
-    Ok(paths::artifact_root()?
+fn release_package_dir_in_roots(artifact_root: &Path, component_id: &str, tag: &str) -> PathBuf {
+    artifact_root
         .join("release-packages")
         .join(paths::sanitize_path_segment(component_id))
-        .join(paths::sanitize_path_segment(tag)))
+        .join(paths::sanitize_path_segment(tag))
 }
 
 fn copy_release_artifacts(

--- a/crates/homeboy-rig/src/artifact_index.rs
+++ b/crates/homeboy-rig/src/artifact_index.rs
@@ -53,7 +53,30 @@ pub fn for_completed_rig_run(
     status: &str,
     pipeline: Option<&PipelineOutcome>,
 ) -> Option<RigRunArtifactIndex> {
-    let artifact_root = homeboy_core::artifact_root().ok()?;
+    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
+    for_completed_rig_run_in_roots(roots.artifacts(), store, rig, run_id, status, pipeline)
+}
+
+/// [`for_completed_rig_run`] against an explicitly injected artifact root.
+///
+/// The injection point exists because this function writes the index file
+/// under the artifact root and then records that same path *into* `store`. The
+/// ambient form resolved the root with no reference to whichever home `store`
+/// was opened against, so a caller holding a non-ambient store would index a
+/// file that store's home does not contain. Callers that own both should pass
+/// the root the store was opened with.
+///
+/// `ObservationStore` does not expose the roots it resolved, so the ambient
+/// wrapper above is currently the only production caller; closing that half
+/// needs `homeboy-core` (#7505).
+pub fn for_completed_rig_run_in_roots(
+    artifact_root: &Path,
+    store: &ObservationStore,
+    rig: &RigSpec,
+    run_id: &str,
+    status: &str,
+    pipeline: Option<&PipelineOutcome>,
+) -> Option<RigRunArtifactIndex> {
     let run_artifact_root = artifact_root.join(run_id);
     let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
     let artifacts = store.list_artifacts(run_id).unwrap_or_default();
@@ -61,7 +84,7 @@ pub fn for_completed_rig_run(
         &rig.id,
         run_id,
         status,
-        &artifact_root,
+        artifact_root,
         &artifact_index_path,
         &artifacts,
         pipeline.map(failed_step_refs).unwrap_or_default(),
@@ -87,17 +110,39 @@ pub fn for_run_with_artifacts(
     run: &RunRecord,
     artifacts: &[ArtifactRecord],
 ) -> Option<RigRunArtifactIndex> {
+    // Guard before resolving. This is called once per run while rendering a
+    // run listing, and the ambient form only reached the artifact root after
+    // rejecting non-rig runs; resolving first would put three environment
+    // reads on every non-rig row.
+    if run.rig_id.is_none() || run.kind != "rig" {
+        return None;
+    }
+    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
+    for_run_with_artifacts_in_roots(roots.artifacts(), run, artifacts)
+}
+
+/// [`for_run_with_artifacts`] against an explicitly injected artifact root.
+///
+/// Read-only: this reports where the index for an already-recorded run lives.
+/// It is rooted anyway because the paths it renders are handed to operators as
+/// retrieval commands, and a report naming one home's index while the records
+/// came from another is exactly the kind of quiet disagreement #7505 exists to
+/// remove.
+pub fn for_run_with_artifacts_in_roots(
+    artifact_root: &Path,
+    run: &RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> Option<RigRunArtifactIndex> {
     let rig_id = run.rig_id.as_ref()?;
     if run.kind != "rig" {
         return None;
     }
-    let artifact_root = homeboy_core::artifact_root().ok()?;
     let artifact_index_path = artifact_root.join(&run.id).join("rig-artifact-index.json");
     Some(build(
         rig_id,
         &run.id,
         &run.status,
-        &artifact_root,
+        artifact_root,
         &artifact_index_path,
         artifacts,
         failed_step_refs_from_metadata(&run.metadata_json),

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -87,6 +87,39 @@ impl DependencyMaterializationCache {
         step: &DependencyMaterializationStepSpec,
         settings: &[(String, String)],
     ) -> Result<Option<Self>> {
+        // Decline before resolving. Most materialization steps declare no
+        // cache key, and the ambient form returned `Ok(None)` for them without
+        // ever touching the data root — turning that into a resolution (and,
+        // on failure, into a hard error that fails the step) would be a
+        // behavior change, not a refactor.
+        if step.cache_key_inputs.is_empty() || step.expected_outputs.is_empty() {
+            return Ok(None);
+        }
+        Self::new_in_roots(
+            homeboy_paths::PathRoots::from_environment()?.data(),
+            rig,
+            step,
+            settings,
+        )
+    }
+
+    /// [`new`](Self::new) against an explicitly injected data root.
+    ///
+    /// The root is consumed once, here, and stored as `self.root`. Every later
+    /// operation on this type — the entry directory, the `.lock` file, and the
+    /// evidence JSON — derives from `self.root`, so nothing on the constructed
+    /// value can reach back into ambient state (#7505).
+    ///
+    /// The cache *key* deliberately still reads process state: the platform
+    /// triple, the resolved toolchain executables, and the step's own declared
+    /// environment describe the machine the materialization ran on, which is
+    /// what makes the entry safe to reuse. That is identity, not location.
+    pub fn new_in_roots(
+        data_root: &Path,
+        rig: &RigSpec,
+        step: &DependencyMaterializationStepSpec,
+        settings: &[(String, String)],
+    ) -> Result<Option<Self>> {
         if step.cache_key_inputs.is_empty() || step.expected_outputs.is_empty() {
             return Ok(None);
         }
@@ -193,7 +226,7 @@ impl DependencyMaterializationCache {
                 )
             })?,
         );
-        let root = cache_root()?;
+        let root = cache_root_in_roots(data_root);
         Ok(Some(Self {
             entry: root.join(&key),
             root,
@@ -384,10 +417,17 @@ impl DependencyMaterializationCache {
 /// Durable root shared by local and runner-side Homeboy processes. Lab invokes
 /// the same rig materialization contract on the runner outside its workspace.
 pub fn cache_root() -> Result<PathBuf> {
-    Ok(homeboy_paths::homeboy_data()?
+    Ok(cache_root_in_roots(
+        homeboy_paths::PathRoots::from_environment()?.data(),
+    ))
+}
+
+/// [`cache_root`] below an explicitly injected data root.
+pub fn cache_root_in_roots(data_root: &Path) -> PathBuf {
+    data_root
         .join("cache")
         .join("dependency-materialization")
-        .join("v1"))
+        .join("v1")
 }
 
 fn resolved_tool_identities(

--- a/crates/homeboy-tunnel/src/entity.rs
+++ b/crates/homeboy-tunnel/src/entity.rs
@@ -1,9 +1,7 @@
 use homeboy_engine_primitives::content_hash;
-use std::path::PathBuf;
 
 use homeboy_core::config::ConfigEntity;
 use homeboy_core::error::{Error, Result};
-use homeboy_core::paths;
 
 use super::types::*;
 use super::validation::validate_service_tunnel;
@@ -44,11 +42,13 @@ impl ConfigEntity for ServiceTunnel {
         Error::service_tunnel_not_found(id, suggestions)
     }
 
-    fn config_path(id: &str) -> Result<PathBuf> {
-        Ok(paths::homeboy()?
-            .join("service-tunnels")
-            .join(format!("{}.json", id)))
-    }
+    // `config_path` is deliberately not overridden. The override this replaces
+    // was `paths::homeboy()?.join("service-tunnels").join("{id}.json")` — byte
+    // for byte what the trait default produces, because `DIR_NAME` is already
+    // `"service-tunnels"`. It was this crate's only ambient root resolution,
+    // and deleting it moves the reach to `ConfigEntity::config_dir`, the single
+    // place the campaign can root it once for every entity (#7505). `Runner`,
+    // `Fleet`, and `Schedule` already rely on the same default.
 
     fn validate(&self) -> Result<()> {
         validate_service_tunnel(self)


### PR DESCRIPTION
## Summary

Five crates, ~10 non-test ambient reaches, all closed except one that is deliberately left and documented.

**`homeboy-release`** — 5 sites. `OperationRecordStore` (`update`/`load`/`for_subject` → `_in_roots` family), `deployment.rs` recovery paths, and `executor/package.rs` (2–3 hops through `run_package_in_roots` → `collect_declared_build_artifact_in_roots` → `persist_package_artifacts_in_roots`). `package_recovery.rs:206` is the outward push — `package_existing_tag` resolves **once** and feeds three consumers.

**`homeboy-deploy`** — 2 sites. `run_multi` resolves once and threads the data root into all 7 `lifecycle::load_in_roots`/`save_in_roots` calls; `receipt::path_in_roots` is now infallible.

**`homeboy-rig`** — 3 sites. `for_completed_rig_run_in_roots`, `for_run_with_artifacts_in_roots`, and `DependencyMaterializationCache::new_in_roots` → `cache_root_in_roots` (root consumed once into `self.root`; nothing on the constructed value reaches ambient again).

**`homeboy-tunnel`** — 1 site, **eliminated rather than rooted**. `ServiceTunnel::config_path` was byte-for-byte identical to the `ConfigEntity` trait default (`DIR_NAME` is already `"service-tunnels"`; `Runner`/`Fleet`/`Schedule` all use the default). Deleting it takes the crate to zero ambient reaches and moves resolution to `ConfigEntity::config_dir`, where the campaign can root it once for every entity.

> **This is the one hunk a reviewer might want dropped** — flag it if the redundancy was deliberate.

<callout accent="#ef4444">
## Highest-value finding: `ensure_app_dirs` is a seven-way split home

`homeboy-engine-primitives/src/local_files.rs:121` resolves `paths::homeboy()` directly, then calls six derived resolvers (`projects`, `servers`, `components`, `extensions`, `keys`, `backups`) that **each resolve it again internally**.

A repoint between the first and the last creates **half a config tree in one home and half in another**. That is the campaign's bug class, present before any injection was attempted — and it is on the **startup path** (`config.rs:680`, `config.rs:1077`, three sites in `homeboy-extension`).

Not closed, deliberately: injecting a config root would let only the bare `homeboy()` follow it while the six stayed ambient — **strictly worse than uniform ambience**. Rebuilding the six as `config_root.join("projects")` would duplicate names `homeboy-paths::locations` owns, and they would drift.

**The fix belongs in `homeboy-paths`** as root-taking siblings for the derived resolvers.
</callout>

## Other reaches not closed

- `homeboy-rig/src/artifact_index.rs` — writes the index under the injected artifact root, then records that path *into* an `ObservationStore` it cannot interrogate. `ObservationStore` does not expose its roots.
- `release/deployment.rs:505` — `resume_deployment` reads its checkpoint rooted, then calls `deploy::run_multi`, which resolves its own. Not closable without a public signature change.
- `deploy/lifecycle.rs:37` (+`safety_and_artifact.rs:586,896`) — `ObservationStore::open_initialized()` resolves **both** ambient data and artifact roots inside `homeboy-core`.
- `release/execution_dispatch.rs:136,247` — per-step dispatcher calls the ambient wrappers; threading needs roots on the step context.
- Derived `homeboy-paths` resolvers bottoming out in `homeboy()`/`homeboy_data()`: `deploy/policy.rs:85,99`; tunnel `service_tunnel_runtime_*` / `preview_ingress_route*` (8); rig `rig_*`/`stack_*` (~30).
- `homeboy-rig/src/app.rs:217` reads `$HOME` for a Linux `.desktop` install dir — user desktop, not Homeboy state.

## Subprocess env: not touched

Told apart by asking **who reads the path**. `build_declared_component_artifact` (component's own `scripts.build`) and `run_package_action_with_retry` (extension's `release.package` action) hand work to a child that resolves its own environment — left alone, and the distinction is recorded on `run_package_in_roots`.

Same reasoning kept the `DependencyMaterializationCache` **cache key** reading process state (target triple, resolved toolchain executables, declared step env): that is *machine identity*, which is what makes an entry safe to reuse — not a location.

## Behavior-ordering care — a real trap, hit twice

An ambient wrapper resolves **earlier** than the original did, which can change outcomes:

- `DependencyMaterializationCache::new` now declines a step with no cache key **before** resolving — the ambient form returned `Ok(None)` without touching the data root, and a resolution failure would otherwise hard-fail the step.
- `for_run_with_artifacts` guards non-rig runs **before** resolving — it is called once per row while rendering a run listing.
- One place *does* resolve earlier: `run_package`. Its "no packaging provider and no build contract" validation error is now preceded by root resolution. That path is only reachable after component config was loaded from the config root, so resolution cannot newly fail there.

## Public signatures changed

**None.** Five additive public functions; `pub(super)`/`pub(crate)` privates renamed in place where a wrapper would have been dead code, with every caller updated and re-grepped.

## Verification

`cargo fmt --all --check` passes → every touched file parses. **Zero newly-introduced duplicate definitions** (verified against `origin/main`, all 12 files). Every renamed symbol grepped workspace-wide; every unchanged-signature wrapper's callers re-grepped (12 `run_package`, 5 `run_cleanup`, 40+ `OperationRecordStore::*`, 5 `DependencyMaterializationCache::new`).

Import hygiene traced by hand: removed now-unused `use` in `deploy/lifecycle.rs` and `tunnel/entity.rs`, added/widened in `release/deployment.rs`.

Not verified without cargo: borrowck at the `&PathRoots::from_environment()?` temporary sites, that `homeboy_error::Error` and `homeboy_core::error::Error` unify in `receipt.rs`, and clippy (`run_package_in_roots` has 7 params).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
