### PR TITLE
Give every derived path resolver a root-taking sibling

### DIFF
--- a/crates/homeboy-engine-primitives/src/local_files.rs
+++ b/crates/homeboy-engine-primitives/src/local_files.rs
@@ -96,17 +96,32 @@ pub fn local() -> LocalFs {
 }
 
 /// Ensure all app directories exist
+///
+/// The config root is resolved exactly once and threaded into every derived
+/// location. This used to be seven independent resolutions of the same root —
+/// `paths::homeboy()` plus six derived resolvers that each re-resolved it
+/// internally — on the startup path. A repoint of the home root between the
+/// first and the last built half a config tree in one home and half in another
+/// (#7505).
 pub fn ensure_app_dirs() -> Result<()> {
+    ensure_app_dirs_in_root(&homeboy_paths::homeboy()?)
+}
+
+/// Ensure all app directories exist below an already-resolved config root.
+///
+/// Every segment name is owned by `homeboy-paths`; none is inlined here, so the
+/// two cannot drift.
+pub fn ensure_app_dirs_in_root(config_root: &Path) -> Result<()> {
     use homeboy_paths as paths;
 
     let dirs = [
-        paths::homeboy()?,
-        paths::projects()?,
-        paths::servers()?,
-        paths::components()?,
-        paths::extensions()?,
-        paths::keys()?,
-        paths::backups()?,
+        config_root.to_path_buf(),
+        paths::projects_in_root(config_root),
+        paths::servers_in_root(config_root),
+        paths::components_in_root(config_root),
+        paths::extensions_in_root(config_root),
+        paths::keys_in_root(config_root),
+        paths::backups_in_root(config_root),
     ];
 
     let fs = local();

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -31,8 +31,15 @@ impl PathRoots {
     }
 
     /// Resolve the current process configuration once.
+    ///
+    /// The data root is resolved exactly once and reused as the artifact-root
+    /// default, so a repoint between the two cannot split this value across two
+    /// homes.
     pub fn from_environment() -> Result<Self> {
-        Ok(Self::new(homeboy()?, homeboy_data()?, artifact_root()?))
+        let config = homeboy()?;
+        let data = homeboy_data()?;
+        let artifacts = artifact_root_in_root(&data);
+        Ok(Self::new(config, data, artifacts))
     }
 
     pub fn config(&self) -> &Path {
@@ -183,9 +190,14 @@ pub fn homeboy() -> Result<PathBuf> {
     }
 }
 
+/// Global product config file path below an already-resolved config root.
+pub fn homeboy_json_in_root(config_root: &Path) -> PathBuf {
+    homeboy_product_identity::PRODUCT_IDENTITY.config_file(config_root.to_path_buf())
+}
+
 /// Global product config file path
 pub fn homeboy_json() -> Result<PathBuf> {
-    Ok(homeboy_product_identity::PRODUCT_IDENTITY.config_file(homeboy()?))
+    Ok(homeboy_json_in_root(&homeboy()?))
 }
 
 /// Base Homeboy data directory for local observed state.
@@ -251,9 +263,19 @@ pub fn homeboy_data() -> Result<PathBuf> {
     }
 }
 
+/// Local SQLite observation-store path below an already-resolved data root.
+pub fn observation_db_in_root(data_root: &Path) -> PathBuf {
+    data_root.join("homeboy.sqlite")
+}
+
 /// Local SQLite observation-store path.
 pub fn observation_db() -> Result<PathBuf> {
-    Ok(homeboy_data()?.join("homeboy.sqlite"))
+    Ok(observation_db_in_root(&homeboy_data()?))
+}
+
+/// Resolve a named store below an already-resolved Homeboy data root.
+pub fn homeboy_data_store_in_root(data_root: &Path, name: &str) -> PathBuf {
+    data_root.join(name)
 }
 
 /// Resolve a named store below the Homeboy data root.
@@ -261,19 +283,33 @@ pub fn observation_db() -> Result<PathBuf> {
 /// Storage owners use this rather than rebuilding paths so reporting and future
 /// placement policy can refer to the same stable store identities.
 pub fn homeboy_data_store(name: &str) -> Result<PathBuf> {
-    Ok(homeboy_data()?.join(name))
+    Ok(homeboy_data_store_in_root(&homeboy_data()?, name))
 }
 
+/// Content-addressed cargo target cache.
+///
+/// Deliberately NOT given a root-taking sibling: this store is keyed to the
+/// real machine and is shared process-globally on purpose (#7505). Rooting it
+/// per-workload would fragment the cache it exists to share.
 pub fn cargo_targets_store() -> Result<PathBuf> {
     homeboy_data_store(CARGO_TARGETS_STORE)
 }
 
+/// Content-addressed controller runtime store.
+///
+/// Deliberately NOT given a root-taking sibling, for the same reason as
+/// [`cargo_targets_store`].
 pub fn controller_runtimes_store() -> Result<PathBuf> {
     homeboy_data_store(CONTROLLER_RUNTIMES_STORE)
 }
 
+/// Controller scratch store below an already-resolved data root.
+pub fn controller_scratch_store_in_root(data_root: &Path) -> PathBuf {
+    homeboy_data_store_in_root(data_root, CONTROLLER_SCRATCH_STORE)
+}
+
 pub fn controller_scratch_store() -> Result<PathBuf> {
-    homeboy_data_store(CONTROLLER_SCRATCH_STORE)
+    Ok(controller_scratch_store_in_root(&homeboy_data()?))
 }
 
 /// Root directory for copied run artifacts.
@@ -284,27 +320,53 @@ pub fn controller_scratch_store() -> Result<PathBuf> {
 /// 3. global config `/artifact_root`
 /// 4. historical default: `<homeboy_data>/artifacts`
 pub fn artifact_root() -> Result<PathBuf> {
+    // Resolved lazily: an override short-circuits before `homeboy_data()`, so a
+    // process given an explicit artifact root still resolves one without a
+    // resolvable data root. That is the pre-injection behavior, preserved.
+    match resolved_artifact_root_override() {
+        Some(path) => Ok(path),
+        None => homeboy_data_store("artifacts"),
+    }
+}
+
+/// Root directory for copied run artifacts, defaulting below an
+/// already-resolved *data* root.
+///
+/// The CLI override, `HOMEBOY_ARTIFACT_ROOT`, and the config-level resolver all
+/// still outrank the supplied root, exactly as they outrank `homeboy_data()` on
+/// the ambient path — the injected root replaces only the historical default.
+///
+/// This shares [`resolved_artifact_root_override`] with [`artifact_root`], so
+/// the pair cannot disagree about override precedence.
+pub fn artifact_root_in_root(data_root: &Path) -> PathBuf {
+    resolved_artifact_root_override()
+        .unwrap_or_else(|| homeboy_data_store_in_root(data_root, "artifacts"))
+}
+
+/// Tiers 1-3 of the artifact-root precedence chain, shared by the ambient and
+/// rooted resolvers so neither can drift from the other.
+fn resolved_artifact_root_override() -> Option<PathBuf> {
     if let Some(path) = artifact_root_override()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone()
     {
-        return Ok(expand_tilde_path(path));
+        return Some(expand_tilde_path(path));
     }
 
     if let Ok(path) = env::var("HOMEBOY_ARTIFACT_ROOT") {
         if !path.trim().is_empty() {
-            return Ok(expand_tilde_path(path));
+            return Some(expand_tilde_path(path));
         }
     }
 
     if let Some(path) = resolved_config_artifact_root() {
         if !path.trim().is_empty() {
-            return Ok(expand_tilde_path(path));
+            return Some(expand_tilde_path(path));
         }
     }
 
-    homeboy_data_store("artifacts")
+    None
 }
 
 /// Expand a leading tilde in a local path.
@@ -444,24 +506,48 @@ pub fn resolve_contained_local_path(
     }
 }
 
+/// Extension directory path below an already-resolved config root.
+pub fn extension_in_root(config_root: &Path, id: &str) -> PathBuf {
+    extensions_in_root(config_root).join(id)
+}
+
 /// Extension directory path
 pub fn extension(id: &str) -> Result<PathBuf> {
-    Ok(extensions()?.join(id))
+    Ok(extension_in_root(&homeboy()?, id))
+}
+
+/// Extension manifest file path below an already-resolved config root.
+pub fn extension_manifest_in_root(config_root: &Path, id: &str) -> PathBuf {
+    extensions_in_root(config_root)
+        .join(id)
+        .join(format!("{}.json", id))
 }
 
 /// Extension manifest file path
 pub fn extension_manifest(id: &str) -> Result<PathBuf> {
-    Ok(extensions()?.join(id).join(format!("{}.json", id)))
+    Ok(extension_manifest_in_root(&homeboy()?, id))
+}
+
+/// Agent runtime manifest file path below an already-resolved config root.
+pub fn agent_runtime_manifest_in_root(config_root: &Path, id: &str) -> PathBuf {
+    agent_runtimes_in_root(config_root)
+        .join(id)
+        .join(format!("{}.json", id))
 }
 
 /// Agent runtime manifest file path
 pub fn agent_runtime_manifest(id: &str) -> Result<PathBuf> {
-    Ok(agent_runtimes()?.join(id).join(format!("{}.json", id)))
+    Ok(agent_runtime_manifest_in_root(&homeboy()?, id))
+}
+
+/// Key file path below an already-resolved config root.
+pub fn key_in_root(config_root: &Path, server_id: &str) -> PathBuf {
+    keys_in_root(config_root).join(format!("{}_id_rsa", server_id))
 }
 
 /// Key file path
 pub fn key(server_id: &str) -> Result<PathBuf> {
-    Ok(keys()?.join(format!("{}_id_rsa", server_id)))
+    Ok(key_in_root(&homeboy()?, server_id))
 }
 
 /// Resolve path that may be absolute or relative to base.

--- a/crates/homeboy-paths/src/locations.rs
+++ b/crates/homeboy-paths/src/locations.rs
@@ -1,58 +1,111 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy_error::Result;
 
 use super::homeboy;
 
+/// Projects directory below an already-resolved config root.
+pub fn projects_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("projects")
+}
+
 /// Projects directory
 pub fn projects() -> Result<PathBuf> {
-    Ok(homeboy()?.join("projects"))
+    Ok(projects_in_root(&homeboy()?))
+}
+
+/// Project directory path below an already-resolved config root.
+pub fn project_dir_in_root(config_root: &Path, id: &str) -> PathBuf {
+    projects_in_root(config_root).join(id)
 }
 
 /// Project directory path (e.g., ~/.config/homeboy/projects/{id}/)
 pub fn project_dir(id: &str) -> Result<PathBuf> {
-    Ok(projects()?.join(id))
+    Ok(project_dir_in_root(&homeboy()?, id))
+}
+
+/// Project config file path below an already-resolved config root.
+pub fn project_config_in_root(config_root: &Path, id: &str) -> PathBuf {
+    projects_in_root(config_root)
+        .join(id)
+        .join(format!("{}.json", id))
 }
 
 /// Project config file path (e.g., ~/.config/homeboy/projects/{id}/{id}.json)
 pub fn project_config(id: &str) -> Result<PathBuf> {
-    Ok(projects()?.join(id).join(format!("{}.json", id)))
+    Ok(project_config_in_root(&homeboy()?, id))
+}
+
+/// Servers directory below an already-resolved config root.
+pub fn servers_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("servers")
 }
 
 /// Servers directory
 pub fn servers() -> Result<PathBuf> {
-    Ok(homeboy()?.join("servers"))
+    Ok(servers_in_root(&homeboy()?))
+}
+
+/// Components directory below an already-resolved config root.
+pub fn components_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("components")
 }
 
 /// Components directory
 pub fn components() -> Result<PathBuf> {
-    Ok(homeboy()?.join("components"))
+    Ok(components_in_root(&homeboy()?))
+}
+
+/// Extensions directory below an already-resolved config root.
+pub fn extensions_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("extensions")
 }
 
 /// Extensions directory
 pub fn extensions() -> Result<PathBuf> {
-    Ok(homeboy()?.join("extensions"))
+    Ok(extensions_in_root(&homeboy()?))
+}
+
+/// Agent runtime package directory below an already-resolved config root.
+///
+/// This is the documented and process-stable runtime boundary. Generation
+/// activation changes only runtime-generations/current behind this path.
+pub fn agent_runtimes_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("agent-runtimes")
 }
 
 /// Agent runtime package directory
 pub fn agent_runtimes() -> Result<PathBuf> {
-    // This is the documented and process-stable runtime boundary. Generation
-    // activation changes only runtime-generations/current behind this path.
-    Ok(homeboy()?.join("agent-runtimes"))
+    Ok(agent_runtimes_in_root(&homeboy()?))
+}
+
+/// Legacy runtime package directory below an already-resolved config root.
+pub fn legacy_agent_runtimes_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("agent-runtimes")
 }
 
 /// Legacy runtime package directory, used only while migrating it into a
 /// generation. Runtime consumers must use [`agent_runtimes`].
 pub fn legacy_agent_runtimes() -> Result<PathBuf> {
-    Ok(homeboy()?.join("agent-runtimes"))
+    Ok(legacy_agent_runtimes_in_root(&homeboy()?))
+}
+
+/// Keys directory below an already-resolved config root.
+pub fn keys_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("keys")
 }
 
 /// Keys directory
 pub fn keys() -> Result<PathBuf> {
-    Ok(homeboy()?.join("keys"))
+    Ok(keys_in_root(&homeboy()?))
+}
+
+/// Backups directory below an already-resolved config root.
+pub fn backups_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("backups")
 }
 
 /// Backups directory
 pub fn backups() -> Result<PathBuf> {
-    Ok(homeboy()?.join("backups"))
+    Ok(backups_in_root(&homeboy()?))
 }

--- a/crates/homeboy-paths/src/rigs.rs
+++ b/crates/homeboy-paths/src/rigs.rs
@@ -5,17 +5,23 @@ use std::path::{Path, PathBuf};
 /// Environment variable selecting the root for rig-specific mutable state.
 pub const RIG_REGISTRY_ROOT_ENV: &str = "HOMEBOY_RIG_REGISTRY_ROOT";
 
+/// Root for rig-specific mutable state, defaulting to an already-resolved
+/// config root.
+///
+/// `RIG_REGISTRY_ROOT_ENV` still outranks the supplied root, exactly as it
+/// outranks `homeboy()` on the ambient path — the injected root replaces the
+/// *default*, not the operator override.
+pub fn rig_registry_root_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_from_env(env::var(RIG_REGISTRY_ROOT_ENV).ok(), config_root)
+}
+
 /// Root for rig-specific mutable state.
 ///
 /// An unset or blank override retains the historical `homeboy()` root. This
 /// intentionally scopes only rig registries; general Homeboy configuration is
 /// unaffected.
 pub fn rig_registry_root() -> Result<PathBuf> {
-    let default_root = homeboy()?;
-    Ok(rig_registry_root_from_env(
-        env::var(RIG_REGISTRY_ROOT_ENV).ok(),
-        &default_root,
-    ))
+    Ok(rig_registry_root_in_root(&homeboy()?))
 }
 
 /// Resolve a rig registry root from an explicit environment value.
@@ -29,60 +35,120 @@ pub fn rig_registry_root_from_env(value: Option<String>, default_root: &Path) ->
         .unwrap_or_else(|| default_root.to_path_buf())
 }
 
+/// Rigs directory below an already-resolved config root.
+pub fn rigs_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("rigs")
+}
+
 /// Rigs directory (~/.config/homeboy/rigs/)
 pub fn rigs() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("rigs"))
+    Ok(rigs_in_root(&homeboy()?))
+}
+
+/// Rig config file path below an already-resolved config root.
+pub fn rig_config_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rigs_in_root(config_root).join(format!("{}.json", id))
 }
 
 /// Rig config file path (~/.config/homeboy/rigs/{id}.json)
 pub fn rig_config(id: &str) -> Result<PathBuf> {
-    Ok(rigs()?.join(format!("{}.json", id)))
+    Ok(rig_config_in_root(&homeboy()?, id))
+}
+
+/// Installed rig package directory below an already-resolved config root.
+pub fn rig_packages_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("rig-packages")
 }
 
 /// Installed rig package directory (~/.config/homeboy/rig-packages/)
 pub fn rig_packages() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("rig-packages"))
+    Ok(rig_packages_in_root(&homeboy()?))
+}
+
+/// Cloned rig package path below an already-resolved config root.
+pub fn rig_package_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rig_packages_in_root(config_root).join(id)
 }
 
 /// Cloned rig package path (~/.config/homeboy/rig-packages/{id}/)
 pub fn rig_package(id: &str) -> Result<PathBuf> {
-    Ok(rig_packages()?.join(id))
+    Ok(rig_package_in_root(&homeboy()?, id))
+}
+
+/// Rig source metadata directory below an already-resolved config root.
+pub fn rig_sources_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("rig-sources")
 }
 
 /// Rig source metadata directory (~/.config/homeboy/rig-sources/)
 pub fn rig_sources() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("rig-sources"))
+    Ok(rig_sources_in_root(&homeboy()?))
+}
+
+/// Rig source metadata file below an already-resolved config root.
+pub fn rig_source_metadata_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rig_sources_in_root(config_root).join(format!("{}.json", id))
 }
 
 /// Rig source metadata file (~/.config/homeboy/rig-sources/{id}.json)
 pub fn rig_source_metadata(id: &str) -> Result<PathBuf> {
-    Ok(rig_sources()?.join(format!("{}.json", id)))
+    Ok(rig_source_metadata_in_root(&homeboy()?, id))
+}
+
+/// Stack source metadata directory below an already-resolved config root.
+pub fn stack_sources_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("stack-sources")
 }
 
 /// Stack source metadata directory (~/.config/homeboy/stack-sources/)
 pub fn stack_sources() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("stack-sources"))
+    Ok(stack_sources_in_root(&homeboy()?))
+}
+
+/// Stack source metadata file below an already-resolved config root.
+pub fn stack_source_metadata_in_root(config_root: &Path, id: &str) -> PathBuf {
+    stack_sources_in_root(config_root).join(format!("{}.json", id))
 }
 
 /// Stack source metadata file (~/.config/homeboy/stack-sources/{id}.json)
 pub fn stack_source_metadata(id: &str) -> Result<PathBuf> {
-    Ok(stack_sources()?.join(format!("{}.json", id)))
+    Ok(stack_source_metadata_in_root(&homeboy()?, id))
+}
+
+/// Rig state directory below an already-resolved config root.
+pub fn rig_state_dir_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rigs_in_root(config_root).join(format!("{}.state", id))
 }
 
 /// Rig state directory (~/.config/homeboy/rigs/{id}.state/)
 /// Holds service PIDs, logs, and last check results.
 pub fn rig_state_dir(id: &str) -> Result<PathBuf> {
-    Ok(rigs()?.join(format!("{}.state", id)))
+    Ok(rig_state_dir_in_root(&homeboy()?, id))
+}
+
+/// Rig state file below an already-resolved config root.
+pub fn rig_state_file_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rig_state_dir_in_root(config_root, id).join("state.json")
 }
 
 /// Rig state file (~/.config/homeboy/rigs/{id}.state/state.json)
 pub fn rig_state_file(id: &str) -> Result<PathBuf> {
-    Ok(rig_state_dir(id)?.join("state.json"))
+    Ok(rig_state_file_in_root(&homeboy()?, id))
+}
+
+/// Rig service logs directory below an already-resolved config root.
+pub fn rig_logs_dir_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rig_state_dir_in_root(config_root, id).join("logs")
 }
 
 /// Rig service logs directory (~/.config/homeboy/rigs/{id}.state/logs/)
 pub fn rig_logs_dir(id: &str) -> Result<PathBuf> {
-    Ok(rig_state_dir(id)?.join("logs"))
+    Ok(rig_logs_dir_in_root(&homeboy()?, id))
+}
+
+/// Rig-owned baseline root below an already-resolved config root.
+pub fn rig_baseline_root_in_root(config_root: &Path, id: &str) -> PathBuf {
+    rig_state_dir_in_root(config_root, id).join("baselines")
 }
 
 /// Rig-owned baseline root (~/.config/homeboy/rigs/{id}.state/baselines/).
@@ -91,22 +157,37 @@ pub fn rig_logs_dir(id: &str) -> Result<PathBuf> {
 /// in the target component checkout. The component repo may be unrelated to
 /// Homeboy and must stay clean.
 pub fn rig_baseline_root(id: &str) -> Result<PathBuf> {
-    Ok(rig_state_dir(id)?.join("baselines"))
+    Ok(rig_baseline_root_in_root(&homeboy()?, id))
+}
+
+/// Active rig run leases below an already-resolved config root.
+pub fn rig_leases_dir_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("rig-leases")
 }
 
 /// Active rig run leases (~/.config/homeboy/rig-leases/).
 pub fn rig_leases_dir() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("rig-leases"))
+    Ok(rig_leases_dir_in_root(&homeboy()?))
+}
+
+/// Stacks directory below an already-resolved config root.
+pub fn stacks_in_root(config_root: &Path) -> PathBuf {
+    rig_registry_root_in_root(config_root).join("stacks")
 }
 
 /// Stacks directory (~/.config/homeboy/stacks/)
 pub fn stacks() -> Result<PathBuf> {
-    Ok(rig_registry_root()?.join("stacks"))
+    Ok(stacks_in_root(&homeboy()?))
+}
+
+/// Stack config file path below an already-resolved config root.
+pub fn stack_config_in_root(config_root: &Path, id: &str) -> PathBuf {
+    stacks_in_root(config_root).join(format!("{}.json", id))
 }
 
 /// Stack config file path (~/.config/homeboy/stacks/{id}.json)
 pub fn stack_config(id: &str) -> Result<PathBuf> {
-    Ok(stacks()?.join(format!("{}.json", id)))
+    Ok(stack_config_in_root(&homeboy()?, id))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy_error::Result;
 
@@ -9,72 +9,186 @@ use super::{homeboy, homeboy_data, sanitize_path_segment};
 /// and normal config resolution intact for generation-scoped daemon processes.
 pub const DAEMON_STATE_DIR_ENV: &str = "HOMEBOY_DAEMON_STATE_DIR";
 
-fn daemon_state_dir() -> Result<PathBuf> {
-    if let Ok(path) = std::env::var(DAEMON_STATE_DIR_ENV) {
-        if !path.trim().is_empty() {
-            return Ok(PathBuf::from(path));
-        }
+/// The `DAEMON_STATE_DIR_ENV` override, if it names a non-blank directory.
+fn daemon_state_dir_override() -> Option<PathBuf> {
+    std::env::var(DAEMON_STATE_DIR_ENV)
+        .ok()
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+/// Daemon runtime state directory below an already-resolved config root.
+///
+/// `DAEMON_STATE_DIR_ENV` still outranks the supplied root, exactly as it
+/// outranks `homeboy()` on the ambient path — the injected root replaces only
+/// the historical default.
+fn daemon_state_dir_in_root(config_root: &Path) -> PathBuf {
+    daemon_state_dir_override().unwrap_or_else(|| config_root.join("daemon"))
+}
+
+/// The config root the ambient daemon helpers hang from.
+///
+/// When `DAEMON_STATE_DIR_ENV` is set, `daemon_state_dir_in_root` replaces the
+/// whole daemon directory and never joins its `config_root` argument into a
+/// path — so home resolution is skipped rather than run and discarded. That
+/// keeps a generation-scoped daemon carrying an explicit state directory from
+/// newly failing on an unresolvable home, which is the pre-injection behavior.
+fn ambient_daemon_config_root() -> Result<PathBuf> {
+    if daemon_state_dir_override().is_some() {
+        return Ok(PathBuf::new());
     }
-    Ok(homeboy()?.join("daemon"))
+    homeboy()
+}
+
+/// Daemon runtime state file below an already-resolved config root.
+pub fn daemon_state_file_in_root(config_root: &Path) -> PathBuf {
+    daemon_state_dir_in_root(config_root).join("state.json")
 }
 
 /// Daemon runtime state file (~/.config/homeboy/daemon/state.json).
 pub fn daemon_state_file() -> Result<PathBuf> {
-    Ok(daemon_state_dir()?.join("state.json"))
+    Ok(daemon_state_file_in_root(&ambient_daemon_config_root()?))
+}
+
+/// Machine-global coordination directory for Homeboy runtime binary promotion,
+/// below an already-resolved data root.
+pub fn runtime_promotion_dir_in_root(data_root: &Path) -> PathBuf {
+    data_root.join("runtime-promotion")
 }
 
 /// Machine-global coordination directory for Homeboy runtime binary promotion.
 pub fn runtime_promotion_dir() -> Result<PathBuf> {
-    Ok(homeboy_data()?.join("runtime-promotion"))
+    Ok(runtime_promotion_dir_in_root(&homeboy_data()?))
+}
+
+/// Daemon durable job state file below an already-resolved config root.
+pub fn daemon_jobs_file_in_root(config_root: &Path) -> PathBuf {
+    daemon_state_dir_in_root(config_root).join("jobs.json")
 }
 
 /// Daemon durable job state file (~/.config/homeboy/daemon/jobs.json).
 pub fn daemon_jobs_file() -> Result<PathBuf> {
-    Ok(daemon_state_dir()?.join("jobs.json"))
+    Ok(daemon_jobs_file_in_root(&ambient_daemon_config_root()?))
+}
+
+/// Latest bounded launcher-owned termination evidence below an already-resolved
+/// config root.
+pub fn daemon_termination_file_in_root(config_root: &Path) -> PathBuf {
+    daemon_state_dir_in_root(config_root).join("termination.json")
 }
 
 /// Latest bounded launcher-owned termination evidence for this daemon store.
 pub fn daemon_termination_file() -> Result<PathBuf> {
-    Ok(daemon_state_dir()?.join("termination.json"))
+    Ok(daemon_termination_file_in_root(
+        &ambient_daemon_config_root()?,
+    ))
+}
+
+/// Exact state-loss recovery receipt below an already-resolved config root.
+pub fn daemon_state_loss_recovery_receipt_file_in_root(
+    config_root: &Path,
+    lease_id: &str,
+) -> PathBuf {
+    daemon_state_dir_in_root(config_root)
+        .join("state-loss-recovery")
+        .join(format!("{}.json", sanitize_path_segment(lease_id)))
 }
 
 /// Exact state-loss recovery receipt keyed by the operator-supplied lease.
 pub fn daemon_state_loss_recovery_receipt_file(lease_id: &str) -> Result<PathBuf> {
-    Ok(daemon_state_dir()?
-        .join("state-loss-recovery")
-        .join(format!("{}.json", sanitize_path_segment(lease_id))))
+    Ok(daemon_state_loss_recovery_receipt_file_in_root(
+        &ambient_daemon_config_root()?,
+        lease_id,
+    ))
+}
+
+/// Exact replacement receipt for an approved lease-less recovery, below an
+/// already-resolved config root.
+pub fn daemon_leaseless_recovery_receipt_file_in_root(config_root: &Path) -> PathBuf {
+    daemon_state_dir_in_root(config_root).join("leaseless-recovery.json")
 }
 
 /// Exact replacement receipt for an approved lease-less recovery.
 pub fn daemon_leaseless_recovery_receipt_file() -> Result<PathBuf> {
-    Ok(daemon_state_dir()?.join("leaseless-recovery.json"))
+    Ok(daemon_leaseless_recovery_receipt_file_in_root(
+        &ambient_daemon_config_root()?,
+    ))
+}
+
+/// Runner connection session state directory below an already-resolved config root.
+pub fn runner_sessions_dir_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("runner-sessions")
 }
 
 /// Runner connection session state directory (~/.config/homeboy/runner-sessions/).
 pub fn runner_sessions_dir() -> Result<PathBuf> {
-    Ok(homeboy()?.join("runner-sessions"))
+    Ok(runner_sessions_dir_in_root(&homeboy()?))
+}
+
+/// Runner connection session state file below an already-resolved config root.
+pub fn runner_session_file_in_root(config_root: &Path, id: &str) -> PathBuf {
+    runner_sessions_dir_in_root(config_root).join(format!("{}.json", id))
 }
 
 /// Runner connection session state file (~/.config/homeboy/runner-sessions/{id}.json).
 pub fn runner_session_file(id: &str) -> Result<PathBuf> {
-    Ok(runner_sessions_dir()?.join(format!("{}.json", id)))
+    Ok(runner_session_file_in_root(&homeboy()?, id))
+}
+
+/// Controller-local runner connection state below an already-resolved config root.
+pub fn runner_controller_session_file_in_root(
+    config_root: &Path,
+    id: &str,
+    controller_id: &str,
+) -> PathBuf {
+    runner_sessions_dir_in_root(config_root)
+        .join(sanitize_path_segment(id))
+        .join(format!("{}.json", sanitize_path_segment(controller_id)))
 }
 
 /// Controller-local runner connection state. The runner-level file remains the
 /// lease record for the remote daemon; local tunnels belong to one controller.
 pub fn runner_controller_session_file(id: &str, controller_id: &str) -> Result<PathBuf> {
-    Ok(runner_sessions_dir()?
-        .join(sanitize_path_segment(id))
-        .join(format!("{}.json", sanitize_path_segment(controller_id))))
+    Ok(runner_controller_session_file_in_root(
+        &homeboy()?,
+        id,
+        controller_id,
+    ))
+}
+
+/// Controller-owned lease evidence below an already-resolved config root.
+pub(crate) fn runner_lease_evidence_file_in_root(
+    config_root: &Path,
+    runner_id: &str,
+    lease_id: &str,
+) -> PathBuf {
+    config_root
+        .join("runner-lease-evidence")
+        .join(sanitize_path_segment(runner_id))
+        .join(format!("{}.json", sanitize_path_segment(lease_id)))
 }
 
 /// Controller-owned lease evidence retained after an ephemeral runner session
 /// or remote daemon state file disappears.
 pub(crate) fn runner_lease_evidence_file(runner_id: &str, lease_id: &str) -> Result<PathBuf> {
-    Ok(homeboy()?
-        .join("runner-lease-evidence")
+    Ok(runner_lease_evidence_file_in_root(
+        &homeboy()?,
+        runner_id,
+        lease_id,
+    ))
+}
+
+/// Runner-owned durable reverse-execution evidence below an already-resolved
+/// config root.
+pub fn runner_job_execution_context_evidence_file_in_root(
+    config_root: &Path,
+    runner_id: &str,
+    context_id: &str,
+) -> PathBuf {
+    config_root
+        .join("runner-job-execution-context")
         .join(sanitize_path_segment(runner_id))
-        .join(format!("{}.json", sanitize_path_segment(lease_id))))
+        .join(format!("{}.json", sanitize_path_segment(context_id)))
 }
 
 /// Runner-owned durable reverse-execution evidence. This is distinct from the
@@ -84,30 +198,56 @@ pub fn runner_job_execution_context_evidence_file(
     runner_id: &str,
     context_id: &str,
 ) -> Result<PathBuf> {
-    Ok(homeboy()?
-        .join("runner-job-execution-context")
-        .join(sanitize_path_segment(runner_id))
-        .join(format!("{}.json", sanitize_path_segment(context_id))))
+    Ok(runner_job_execution_context_evidence_file_in_root(
+        &homeboy()?,
+        runner_id,
+        context_id,
+    ))
+}
+
+/// Managed service tunnel runtime state directory below an already-resolved
+/// data root.
+pub fn service_tunnel_runtime_dir_in_root(data_root: &Path, id: &str) -> PathBuf {
+    data_root
+        .join("service-tunnels")
+        .join(sanitize_path_segment(id))
 }
 
 /// Managed service tunnel runtime state directory (~/.local/share/homeboy/service-tunnels/{id}/).
 pub fn service_tunnel_runtime_dir(id: &str) -> Result<PathBuf> {
-    Ok(homeboy_data()?
-        .join("service-tunnels")
-        .join(sanitize_path_segment(id)))
+    Ok(service_tunnel_runtime_dir_in_root(&homeboy_data()?, id))
+}
+
+/// Managed service tunnel runtime state file below an already-resolved data root.
+pub fn service_tunnel_runtime_state_file_in_root(data_root: &Path, id: &str) -> PathBuf {
+    service_tunnel_runtime_dir_in_root(data_root, id).join("state.json")
 }
 
 /// Managed service tunnel runtime state file.
 pub fn service_tunnel_runtime_state_file(id: &str) -> Result<PathBuf> {
-    Ok(service_tunnel_runtime_dir(id)?.join("state.json"))
+    Ok(service_tunnel_runtime_state_file_in_root(
+        &homeboy_data()?,
+        id,
+    ))
+}
+
+/// Preview ingress route declarations below an already-resolved config root.
+pub fn preview_ingress_routes_dir_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("preview-ingress").join("routes")
 }
 
 /// Preview ingress route declarations (~/.config/homeboy/preview-ingress/routes/).
 pub fn preview_ingress_routes_dir() -> Result<PathBuf> {
-    Ok(homeboy()?.join("preview-ingress").join("routes"))
+    Ok(preview_ingress_routes_dir_in_root(&homeboy()?))
+}
+
+/// Preview ingress route declaration file below an already-resolved config root.
+pub fn preview_ingress_route_file_in_root(config_root: &Path, id: &str) -> PathBuf {
+    preview_ingress_routes_dir_in_root(config_root)
+        .join(format!("{}.json", sanitize_path_segment(id)))
 }
 
 /// Preview ingress route declaration file.
 pub fn preview_ingress_route_file(id: &str) -> Result<PathBuf> {
-    Ok(preview_ingress_routes_dir()?.join(format!("{}.json", sanitize_path_segment(id))))
+    Ok(preview_ingress_route_file_in_root(&homeboy()?, id))
 }


### PR DESCRIPTION
## Summary

`homeboy-paths` is the foundational crate every other crate resolves through. Its **derived** resolvers (`projects()`, `servers()`, `rigs()`, `runner_sessions_dir()`, …) each independently re-resolved the ambient config or data root internally — so **no downstream crate could be fully rooted until these had root-taking counterparts**.

**50 new siblings added; every existing ambient function keeps its exact signature and delegates.** Zero call sites needed updating.

| file | siblings added |
|---|---|
| `lib.rs` | 9 — `homeboy_json`, `observation_db`, `homeboy_data_store`, `controller_scratch_store`, `artifact_root`, `extension`, `extension_manifest`, `agent_runtime_manifest`, `key` |
| `locations.rs` | 10 — `projects`, `project_dir`, `project_config`, `servers`, `components`, `extensions`, `agent_runtimes`, `legacy_agent_runtimes`, `keys`, `backups` |
| `rigs.rs` | 16 |
| `runtime.rs` | 15 + 1 private |

## Naming: `_in_root`, and why

The brief said `_in_roots`. **That was wrong and the convention was checked rather than assumed.** The repo's actual precedent is `_in_root` — `materialize_follow_up_baseline_in_root` (`cook_baseline.rs:283`) and `restore_follow_up_cook_candidate_workspace_in_root` (`cook_workspace_restore.rs:29`). `grep -rn "_in_roots"` across the workspace returns **zero** hits on `main`.

No `_in_roots(&PathRoots)` variant was added here, because **no function in this crate needs more than one root** — every derived resolver hangs off *either* config *or* data. The one function that touched two was `PathRoots::from_environment` itself.

Siblings are **infallible** (`-> PathBuf`, not `-> Result<PathBuf>`): root resolution was the only fallible step, so dropping `Result` makes "this function resolves nothing" a type-level fact rather than a doc-comment claim.

<callout accent="#ef4444">
## The override-precedence trap — found in this change's own first draft

The initial version made the ambient wrapper `artifact_root_in_root(&homeboy_data()?)`. **Correct on value, but it regressed laziness.** On `main` an override short-circuits at tier 1–3 and `homeboy_data()` is never called — so a process launched with `homeboy --artifact-root <path>` but no resolvable `HOME` used to succeed, and would have started failing.

Rewritten so both paths share one private `resolved_artifact_root_override()` covering all three tiers. **The pair now cannot disagree about precedence, because there is only one copy of the precedence logic.**

Identical hazard, identical fix for the `daemon_*` family: `DAEMON_STATE_DIR_ENV` replaces the daemon directory wholesale, so the five ambient wrappers go through `ambient_daemon_config_root()`, which skips `homeboy()` when the override is set rather than resolving and discarding.
</callout>

## The seven-way split home, now closed

`engine-primitives/src/local_files.rs:121` — `ensure_app_dirs` resolved `paths::homeboy()` then called six derived resolvers **that each resolved it again**. Seven independent resolutions building one config tree, **on the startup path**.

A prior wave found this and correctly refused to fix it: injecting a root would let only the bare `homeboy()` follow it while the six stayed ambient — *strictly worse than uniform ambience* — and inlining `config_root.join("projects")` would duplicate names this crate owns.

Both objections are removed by the siblings. Now:

```rust
pub fn ensure_app_dirs() -> Result<()> {
    ensure_app_dirs_in_root(&homeboy_paths::homeboy()?)   // the only resolution
}
```

Every callee traced to a leaf: all six siblings are `config_root.join("<name>")`, one line, no env, no override, no further call. `LocalFs::ensure_dir` is `exists()` + `create_dir_all`. **No path segment is hand-inlined** — every name still comes from `homeboy-paths`, so the drift objection is closed rather than traded away.

The same defect in miniature was fixed in `PathRoots::from_environment`, which resolved `homeboy_data()` and then `artifact_root()` — which resolved `homeboy_data()` *again*.

## Not closed — a genuine remaining hole

**`DAEMON_STATE_DIR_ENV` and `HOMEBOY_RIG_REGISTRY_ROOT` outrank the injected root.** A caller passing an explicit config root to `daemon_state_file_in_root` or `rigs_in_root` does **not** get full isolation if those env vars are set. Preserved because changing it would silently alter ambient behavior too, and that choice belongs to whoever owns those env contracts. Documented on both functions.

Also: `.join("components")` / `.join("projects")` / etc. appear hand-inlined in ~20 places across `homeboy-core`, `homeboy-deploy`, `homeboy-extension`, `homeboy-lab-runner`. **All verified inside `#[cfg(test)]`** — no production drift, but they duplicate names this crate owns.

Deliberately left process-global and documented in place: `cargo_targets_store()`, `controller_runtimes_store()` — content-addressed caches keyed to the real machine; rooting them per-workload would fragment the cache they exist to share.

One private zero-caller function was removed: `runtime::daemon_state_dir()`, masked by the module's `#[allow(dead_code)]`.

## Verification

`cargo fmt --check` exit 0 — a full parse of every touched file. **No newly-introduced duplicate definitions** (diffed per-file against `origin/main`; the two in `lib.rs` are pre-existing helpers in separate `#[cfg(test)]` modules).

**No existing signature changed**, proven by set-diffing all `fn` signatures against `origin/main` rather than by grep — the only entry in the "on main, absent now" column across all five files is the private zero-caller `daemon_state_dir()`. Bare function references (`controller_scratch.rs:818,824` pass `paths::artifact_root` as a value) therefore keep compiling. No `macro_rules!` body in the workspace expands to a `paths::` call.

Not verified without cargo: borrowck on `&homeboy()?` temporaries, clippy on the identical bodies of `agent_runtimes_in_root`/`legacy_agent_runtimes_in_root`, and the laziness-preservation argument for `artifact_root` — that is a reading of control flow, not a measured result. The test to pin it: set the override, unset `HOME`, assert `artifact_root()` still returns `Ok`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and convention verification. Review by hand.

Refs #7505
