### PR TITLE
Root the workspace-authority gates in homeboy-agents

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -28,10 +28,29 @@ pub(super) fn lab_handoff_acceptance_timeout_seconds() -> i64 {
 /// A per-run advisory lock makes concurrent status/artifact/Cook readers
 /// reread and persist one coherent aggregate and terminal projection.
 pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
-    let run_id = resolve_run_id(run_id)?;
-    let lock_path = paths::homeboy_data()?
-        .join("agent-task-runs")
-        .join(&run_id)
+    reconcile_deferred_candidate_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+    )
+}
+
+/// The store-rooted counterpart of [`reconcile_deferred_candidate`].
+///
+/// The advisory lock is the whole point of this operation, so it must be taken
+/// in the same installation the record, aggregate, plan, and terminal
+/// projection are read and written in. The ambient form resolved the data root
+/// for the lock separately from the root every `store::` shim below it resolved
+/// for itself, which is a lock that excludes nobody as soon as the two differ
+/// (#7505). Deriving it from `run_dir` also makes the lock path agree with the
+/// aggregate path, which already sanitized the resolved run id when the lock
+/// did not.
+pub(crate) fn reconcile_deferred_candidate_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    let lock_path = lifecycle_store
+        .run_dir(&run_id)
         .join("deferred-candidate.lock");
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent).map_err(|error| Error::internal_io(error.to_string(), None))?;
@@ -50,8 +69,8 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
         })?;
     let _lock = DeferredCandidateLock::lock(file)?;
 
-    let mut record = store::read_record(&run_id)?;
-    let mut aggregate = match store::read_aggregate(&run_id) {
+    let mut record = lifecycle_store.read_record(&run_id)?;
+    let mut aggregate = match lifecycle_store.read_aggregate(&run_id) {
         Ok(aggregate) => aggregate,
         // The worker may finish before the aggregate is committed. A later
         // read retries from durable state rather than inventing a projection.
@@ -177,13 +196,16 @@ pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
         return Ok(false);
     }
 
-    let plan = store::read_controller_plan(&run_id)?;
+    let plan = lifecycle_store.read_controller_plan(&run_id)?;
     aggregate.status = aggregate_status(&aggregate.outcomes);
     aggregate.totals = aggregate_totals(plan.tasks.len(), &aggregate.outcomes);
-    let aggregate_path = store::aggregate_path(&run_id)?.display().to_string();
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&run_id)
+        .display()
+        .to_string();
     apply_aggregate_to_record(&mut record, &plan, &aggregate, aggregate_path);
-    store::write_aggregate_and_record(&record, &aggregate)?;
-    record_terminal_artifact_projection(&mut record, &aggregate)?;
+    lifecycle_store.write_aggregate_and_record(&record, &aggregate)?;
+    record_terminal_artifact_projection_in_store(lifecycle_store, &mut record, &aggregate)?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -55,6 +55,26 @@ impl WorkspaceTerminalAuthorityStore {
         }
     }
 
+    /// Bind terminal workspace authority to explicit roots (#7505).
+    pub(crate) fn from_roots(roots: &paths::PathRoots) -> Self {
+        Self::new(roots.data().to_path_buf(), roots.config().to_path_buf())
+    }
+
+    /// Resolve the process roots *once* for one whole authority operation.
+    ///
+    /// Every public entry point below used to resolve them again per path
+    /// helper: `resolve_workspace_terminal_authority` read the data root once
+    /// for the receipt and again for the release marker, then a third time —
+    /// plus the ambient config root — when a substituted job identity drove it
+    /// into `begin_workspace_terminal_authority_release`. A repoint between two
+    /// of those reads let a receipt that failed the exact-binding check be
+    /// frozen in a different installation than the one that rejected it, which
+    /// is precisely the split #7505 exists to remove. Resolving here and
+    /// threading `&self` means one authority decision reads and writes one home.
+    fn from_environment() -> Result<Self> {
+        Ok(Self::new(paths::homeboy_data()?, paths::homeboy()?))
+    }
+
     fn run_index_path(&self, run_id: &str) -> PathBuf {
         let mut digest = Sha256::new();
         digest.update(run_id.as_bytes());
@@ -143,6 +163,179 @@ impl WorkspaceTerminalAuthorityStore {
             )
         })
     }
+
+    fn resolve_authority(
+        &self,
+        run_id: &str,
+        runner_id: &str,
+        remote_workspace: &str,
+        job_id: Option<&str>,
+    ) -> Result<Option<WorkspaceTerminalAuthorityReceipt>> {
+        let path = self.receipt_path(run_id, runner_id, remote_workspace);
+        let release_path = self.release_path(run_id, runner_id, remote_workspace);
+        if release_path.exists() {
+            let release = read_release(&release_path, run_id, runner_id, remote_workspace)?;
+            return match release.state.as_str() {
+                "pending" | "released" => Err(Error::validation_invalid_argument(
+                    "workspace_terminal_authority",
+                    format!("workspace terminal authority release is {}", release.state),
+                    Some(release_path.display().to_string()),
+                    None,
+                )),
+                _ => Err(invalid_release_error(&release_path)),
+            };
+        }
+        if !path.exists() {
+            return Ok(None);
+        }
+        let receipt: WorkspaceTerminalAuthorityReceipt =
+            serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?)
+            .map_err(|error| {
+                Error::internal_json(error.to_string(), Some(path.display().to_string()))
+            })?;
+        let substituted_job = job_id.is_some_and(|job_id| job_id != receipt.runner_job_id);
+        let valid = receipt.schema == WORKSPACE_TERMINAL_AUTHORITY_SCHEMA
+            && receipt.run_id == run_id
+            && receipt.runner_id == runner_id
+            && receipt.remote_workspace == remote_workspace
+            && !receipt.runner_job_id.is_empty()
+            && job_id.is_none_or(|job_id| job_id == receipt.runner_job_id);
+        valid.then_some(receipt).map(Some).ok_or_else(|| {
+            // A substituted job identity is a conflicting authority assertion.
+            // Freeze cleanup so later compaction cannot make the workspace appear
+            // safely addressable after a failed exact-binding check.
+            //
+            // This freeze must land in the same installation whose receipt just
+            // failed the check. It used to call the ambient
+            // begin_workspace_terminal_authority_release, which re-resolved the
+            // data root a third time inside one authority decision (#7505).
+            if substituted_job {
+                let _ = self.begin_release(run_id, runner_id, remote_workspace);
+            }
+            Error::validation_invalid_argument(
+                "workspace_terminal_authority",
+                "workspace terminal authority receipt is malformed or contradicts workspace ownership",
+                Some(path.display().to_string()),
+                None,
+            )
+        })
+    }
+
+    fn resolve_retained_workspace(&self, run_id: &str) -> Result<RetainedWorkspace> {
+        let index_path = self.run_index_path(run_id);
+        if !index_path.exists() {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                "agent task has no retained Lab workspace record",
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+        let receipt: WorkspaceTerminalAuthorityReceipt =
+            serde_json::from_slice(&std::fs::read(&index_path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(index_path.display().to_string()))
+            })?)
+            .map_err(|error| {
+                Error::internal_json(error.to_string(), Some(index_path.display().to_string()))
+            })?;
+        let receipt = self
+            .resolve_authority(
+                run_id,
+                &receipt.runner_id,
+                &receipt.remote_workspace,
+                Some(&receipt.runner_job_id),
+            )?
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "run_id",
+                    "retained Lab workspace authority is unavailable; the workspace may have been reaped before artifacts were attached",
+                    Some(run_id.to_string()),
+                    None,
+                )
+            })?;
+        Ok(RetainedWorkspace {
+            run_id: receipt.run_id,
+            runner_id: receipt.runner_id,
+            runner_job_id: receipt.runner_job_id,
+            remote_workspace: receipt.remote_workspace,
+        })
+    }
+
+    fn release_is_pending(
+        &self,
+        run_id: &str,
+        runner_id: &str,
+        remote_workspace: &str,
+    ) -> Result<bool> {
+        let path = self.release_path(run_id, runner_id, remote_workspace);
+        if !path.exists() {
+            return Ok(false);
+        }
+        Ok(read_release(&path, run_id, runner_id, remote_workspace)?.state == "pending")
+    }
+
+    fn begin_release(&self, run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<()> {
+        let path = self.release_path(run_id, runner_id, remote_workspace);
+        homeboy_core::config::with_config_lock_at(&self.config_root, || {
+            if path.exists() {
+                let release = read_release(&path, run_id, runner_id, remote_workspace)?;
+                return match release.state.as_str() {
+                    "pending" => Ok(()),
+                    "released" => Err(Error::validation_invalid_argument(
+                        "workspace_terminal_authority",
+                        "workspace terminal authority was already released",
+                        Some(path.display().to_string()),
+                        None,
+                    )),
+                    _ => Err(invalid_release_error(&path)),
+                };
+            }
+            write_release(&path, run_id, runner_id, remote_workspace, "pending")
+        })
+    }
+
+    fn abort_release(&self, run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<()> {
+        let path = self.release_path(run_id, runner_id, remote_workspace);
+        homeboy_core::config::with_config_lock_at(&self.config_root, || {
+            if !path.exists() {
+                return Ok(());
+            }
+            let release = read_release(&path, run_id, runner_id, remote_workspace)?;
+            if release.state != "pending" {
+                return Err(invalid_release_error(&path));
+            }
+            std::fs::remove_file(&path).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })
+        })
+    }
+
+    fn remove_authority(
+        &self,
+        run_id: &str,
+        runner_id: &str,
+        remote_workspace: &str,
+    ) -> Result<()> {
+        let path = self.receipt_path(run_id, runner_id, remote_workspace);
+        let release_path = self.release_path(run_id, runner_id, remote_workspace);
+        homeboy_core::config::with_config_lock_at(&self.config_root, || {
+            write_release(
+                &release_path,
+                run_id,
+                runner_id,
+                remote_workspace,
+                "released",
+            )?;
+            if path.exists() {
+                std::fs::remove_file(&path).map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(path.display().to_string()))
+                })?;
+            }
+            Ok(())
+        })
+    }
 }
 
 fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> String {
@@ -155,34 +348,12 @@ fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> St
     format!("{:x}", digest.finalize())
 }
 
-fn run_index_path(run_id: &str) -> Result<PathBuf> {
-    Ok(
-        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
-            .run_index_path(run_id),
-    )
-}
-
-fn receipt_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
-    Ok(
-        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
-            .receipt_path(run_id, runner_id, remote_workspace),
-    )
-}
-
-fn release_path(run_id: &str, runner_id: &str, remote_workspace: &str) -> Result<PathBuf> {
-    Ok(
-        WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
-            .release_path(run_id, runner_id, remote_workspace),
-    )
-}
-
 pub(crate) fn persist_terminal_from_record(record: &AgentTaskRunRecord) -> Result<()> {
-    WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?)
-        .persist_terminal_from_record(record)
+    WorkspaceTerminalAuthorityStore::from_environment()?.persist_terminal_from_record(record)
 }
 
 fn persist_workspace_terminal_authority(receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
-    WorkspaceTerminalAuthorityStore::new(paths::homeboy_data()?, paths::homeboy()?).persist(receipt)
+    WorkspaceTerminalAuthorityStore::from_environment()?.persist(receipt)
 }
 
 fn read_receipt(path: &std::path::Path) -> Result<WorkspaceTerminalAuthorityReceipt> {
@@ -210,57 +381,22 @@ pub fn persist_workspace_terminal_authority_for_test(
     })
 }
 
+/// Resolve terminal workspace authority in the process installation.
+///
+/// One resolution of the roots covers the receipt read, the release-marker
+/// read, and the freeze this performs when an exact-binding check fails.
 pub fn resolve_workspace_terminal_authority(
     run_id: &str,
     runner_id: &str,
     remote_workspace: &str,
     job_id: Option<&str>,
 ) -> Result<Option<WorkspaceTerminalAuthorityReceipt>> {
-    let path = receipt_path(run_id, runner_id, remote_workspace)?;
-    let release_path = release_path(run_id, runner_id, remote_workspace)?;
-    if release_path.exists() {
-        let release = read_release(&release_path, run_id, runner_id, remote_workspace)?;
-        return match release.state.as_str() {
-            "pending" | "released" => Err(Error::validation_invalid_argument(
-                "workspace_terminal_authority",
-                format!("workspace terminal authority release is {}", release.state),
-                Some(release_path.display().to_string()),
-                None,
-            )),
-            _ => Err(invalid_release_error(&release_path)),
-        };
-    }
-    if !path.exists() {
-        return Ok(None);
-    }
-    let receipt: WorkspaceTerminalAuthorityReceipt =
-        serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })?)
-        .map_err(|error| {
-            Error::internal_json(error.to_string(), Some(path.display().to_string()))
-        })?;
-    let substituted_job = job_id.is_some_and(|job_id| job_id != receipt.runner_job_id);
-    let valid = receipt.schema == WORKSPACE_TERMINAL_AUTHORITY_SCHEMA
-        && receipt.run_id == run_id
-        && receipt.runner_id == runner_id
-        && receipt.remote_workspace == remote_workspace
-        && !receipt.runner_job_id.is_empty()
-        && job_id.is_none_or(|job_id| job_id == receipt.runner_job_id);
-    valid.then_some(receipt).map(Some).ok_or_else(|| {
-        // A substituted job identity is a conflicting authority assertion.
-        // Freeze cleanup so later compaction cannot make the workspace appear
-        // safely addressable after a failed exact-binding check.
-        if substituted_job {
-            let _ = begin_workspace_terminal_authority_release(run_id, runner_id, remote_workspace);
-        }
-        Error::validation_invalid_argument(
-            "workspace_terminal_authority",
-            "workspace terminal authority receipt is malformed or contradicts workspace ownership",
-            Some(path.display().to_string()),
-            None,
-        )
-    })
+    WorkspaceTerminalAuthorityStore::from_environment()?.resolve_authority(
+        run_id,
+        runner_id,
+        remote_workspace,
+        job_id,
+    )
 }
 
 /// Resolve the retained Lab workspace for a terminal agent task without
@@ -268,42 +404,7 @@ pub fn resolve_workspace_terminal_authority(
 /// fails closed so callers can distinguish a reaped workspace from an empty
 /// discovery result.
 pub fn resolve_retained_workspace(run_id: &str) -> Result<RetainedWorkspace> {
-    let index_path = run_index_path(run_id)?;
-    if !index_path.exists() {
-        return Err(Error::validation_invalid_argument(
-            "run_id",
-            "agent task has no retained Lab workspace record",
-            Some(run_id.to_string()),
-            None,
-        ));
-    }
-    let receipt: WorkspaceTerminalAuthorityReceipt =
-        serde_json::from_slice(&std::fs::read(&index_path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(index_path.display().to_string()))
-        })?)
-        .map_err(|error| {
-            Error::internal_json(error.to_string(), Some(index_path.display().to_string()))
-        })?;
-    let receipt = resolve_workspace_terminal_authority(
-        run_id,
-        &receipt.runner_id,
-        &receipt.remote_workspace,
-        Some(&receipt.runner_job_id),
-    )?
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            "retained Lab workspace authority is unavailable; the workspace may have been reaped before artifacts were attached",
-            Some(run_id.to_string()),
-            None,
-        )
-    })?;
-    Ok(RetainedWorkspace {
-        run_id: receipt.run_id,
-        runner_id: receipt.runner_id,
-        runner_job_id: receipt.runner_job_id,
-        remote_workspace: receipt.remote_workspace,
-    })
+    WorkspaceTerminalAuthorityStore::from_environment()?.resolve_retained_workspace(run_id)
 }
 
 pub fn workspace_terminal_authority_release_is_pending(
@@ -311,11 +412,11 @@ pub fn workspace_terminal_authority_release_is_pending(
     runner_id: &str,
     remote_workspace: &str,
 ) -> Result<bool> {
-    let path = release_path(run_id, runner_id, remote_workspace)?;
-    if !path.exists() {
-        return Ok(false);
-    }
-    Ok(read_release(&path, run_id, runner_id, remote_workspace)?.state == "pending")
+    WorkspaceTerminalAuthorityStore::from_environment()?.release_is_pending(
+        run_id,
+        runner_id,
+        remote_workspace,
+    )
 }
 
 pub fn begin_workspace_terminal_authority_release(
@@ -323,23 +424,11 @@ pub fn begin_workspace_terminal_authority_release(
     runner_id: &str,
     remote_workspace: &str,
 ) -> Result<()> {
-    let path = release_path(run_id, runner_id, remote_workspace)?;
-    homeboy_core::config::with_config_lock(|| {
-        if path.exists() {
-            let release = read_release(&path, run_id, runner_id, remote_workspace)?;
-            return match release.state.as_str() {
-                "pending" => Ok(()),
-                "released" => Err(Error::validation_invalid_argument(
-                    "workspace_terminal_authority",
-                    "workspace terminal authority was already released",
-                    Some(path.display().to_string()),
-                    None,
-                )),
-                _ => Err(invalid_release_error(&path)),
-            };
-        }
-        write_release(&path, run_id, runner_id, remote_workspace, "pending")
-    })
+    WorkspaceTerminalAuthorityStore::from_environment()?.begin_release(
+        run_id,
+        runner_id,
+        remote_workspace,
+    )
 }
 
 pub fn abort_workspace_terminal_authority_release(
@@ -347,19 +436,11 @@ pub fn abort_workspace_terminal_authority_release(
     runner_id: &str,
     remote_workspace: &str,
 ) -> Result<()> {
-    let path = release_path(run_id, runner_id, remote_workspace)?;
-    homeboy_core::config::with_config_lock(|| {
-        if !path.exists() {
-            return Ok(());
-        }
-        let release = read_release(&path, run_id, runner_id, remote_workspace)?;
-        if release.state != "pending" {
-            return Err(invalid_release_error(&path));
-        }
-        std::fs::remove_file(&path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })
-    })
+    WorkspaceTerminalAuthorityStore::from_environment()?.abort_release(
+        run_id,
+        runner_id,
+        remote_workspace,
+    )
 }
 
 pub fn remove_workspace_terminal_authority(
@@ -367,23 +448,11 @@ pub fn remove_workspace_terminal_authority(
     runner_id: &str,
     remote_workspace: &str,
 ) -> Result<()> {
-    let path = receipt_path(run_id, runner_id, remote_workspace)?;
-    let release_path = release_path(run_id, runner_id, remote_workspace)?;
-    homeboy_core::config::with_config_lock(|| {
-        write_release(
-            &release_path,
-            run_id,
-            runner_id,
-            remote_workspace,
-            "released",
-        )?;
-        if path.exists() {
-            std::fs::remove_file(&path).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(path.display().to_string()))
-            })?;
-        }
-        Ok(())
-    })
+    WorkspaceTerminalAuthorityStore::from_environment()?.remove_authority(
+        run_id,
+        runner_id,
+        remote_workspace,
+    )
 }
 
 fn write_release(
@@ -541,8 +610,9 @@ mod tests {
     #[test]
     fn malformed_or_mixed_version_receipts_fail_closed() {
         homeboy_core::test_support::with_isolated_home(|_| {
-            let path =
-                receipt_path("run-1", "runner-1", "/runner/workspace").expect("receipt path");
+            let path = WorkspaceTerminalAuthorityStore::from_environment()
+                .expect("authority store")
+                .receipt_path("run-1", "runner-1", "/runner/workspace");
             homeboy_core::engine::local_files::write_json_file_owner_only(
                 &path,
                 &serde_json::json!({

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -47,6 +47,26 @@ pub enum TerminalWorkspaceAuthorityResolution {
 pub fn resolve_terminal_workspace_authority(
     record: &TaskWorktreeRecord,
 ) -> Result<TerminalWorkspaceAuthorityResolution> {
+    resolve_terminal_workspace_authority_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        record,
+    )
+}
+
+/// The store-rooted counterpart of [`resolve_terminal_workspace_authority`].
+///
+/// This is a permission gate over destroying a retained workspace, and it used
+/// to consult two independently resolved data roots: the durable controller run
+/// came from the ambient lifecycle store, the owner lease from a claim store
+/// built out of a second `paths::homeboy_data()` read. When those two disagree
+/// the lease lookup finds no file, `validate_owner` answers `Ok(false)`, and the
+/// gate concludes "no live local workspace owner" for a workspace that is still
+/// owned — a fail-open on the exact check that is supposed to fail closed
+/// (#7505). One store now roots both reads.
+pub(crate) fn resolve_terminal_workspace_authority_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &TaskWorktreeRecord,
+) -> Result<TerminalWorkspaceAuthorityResolution> {
     let workspace = record.effective_workspace_identity()?;
     let authority_set = match configured_terminal_authorities() {
         Ok(authorities) => authorities,
@@ -80,7 +100,7 @@ pub fn resolve_terminal_workspace_authority(
             observations: Vec::new(),
         });
     };
-    let controller = match store::read_record(run_id) {
+    let controller = match lifecycle_store.read_record(run_id) {
         Ok(record) => record,
         Err(_) => {
             return Ok(TerminalWorkspaceAuthorityResolution::Refused {
@@ -108,7 +128,10 @@ pub fn resolve_terminal_workspace_authority(
     if controller
         .workspace_owner_lease
         .as_ref()
-        .is_some_and(|lease| validate_local_workspace_owner(lease).unwrap_or(true))
+        .is_some_and(|lease| {
+            validate_local_workspace_owner_in_store(&lifecycle_store.workspace_claim_store(), lease)
+                .unwrap_or(true)
+        })
     {
         return Ok(TerminalWorkspaceAuthorityResolution::Refused {
             reason: "controller still has a live local workspace owner lease".into(),
@@ -1236,15 +1259,32 @@ fn now_ms() -> u64 {
 /// Inventory is local-controller evidence only. Runner authority composition is
 /// deliberately delegated to `RunnerContinuationProvider` in a later layer.
 pub fn local_workspace_authority_inventory() -> Result<Vec<AgentTaskRunRecord>> {
-    store::read_records().map(|records| {
+    local_workspace_authority_inventory_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+    )
+}
+
+/// The store-rooted counterpart of [`local_workspace_authority_inventory`].
+///
+/// The records and the owner leases that qualify them must come from one
+/// installation. Reading records from the ambient lifecycle store and then
+/// validating each lease against a separately resolved claim store degrades to
+/// an empty inventory rather than an error, and callers treat an empty
+/// inventory as "no live authority" — the composite acquisition gate clears a
+/// token-free intent marker on exactly that answer (#7505).
+pub(crate) fn local_workspace_authority_inventory_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<Vec<AgentTaskRunRecord>> {
+    let claim_store = lifecycle_store.workspace_claim_store();
+    lifecycle_store.read_records().map(|records| {
         records
             .into_iter()
             .filter(|record| {
                 !record.state.is_terminal()
-                    && record
-                        .workspace_owner_lease
-                        .as_ref()
-                        .is_some_and(|lease| validate_local_workspace_owner(lease).unwrap_or(false))
+                    && record.workspace_owner_lease.as_ref().is_some_and(|lease| {
+                        validate_local_workspace_owner_in_store(&claim_store, lease)
+                            .unwrap_or(false)
+                    })
             })
             .collect()
     })
@@ -1339,6 +1379,20 @@ pub(crate) fn renew_record_workspace_owner_in_store(
 }
 
 pub(crate) fn ensure_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
+    ensure_record_workspace_owner_in_store(&store()?, record)
+}
+
+/// The store-rooted counterpart of [`ensure_record_workspace_owner`].
+///
+/// Validating an existing lease and registering its replacement are one
+/// decision: "is this record still the owner, and if not, make it one." The
+/// ambient form resolved a claim store for each half, so a repoint between them
+/// could reject a live lease in one home and register its successor in another,
+/// leaving two installations each believing they own the workspace (#7505).
+pub(crate) fn ensure_record_workspace_owner_in_store(
+    store: &WorkspaceClaimStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<()> {
     let Some(identity) = record.workspace_identity.clone() else {
         return Ok(());
     };
@@ -1347,12 +1401,16 @@ pub(crate) fn ensure_record_workspace_owner(record: &mut AgentTaskRunRecord) -> 
         if lease.workspace == identity
             && lease.owner_id == record.run_id
             && lease.lifecycle_revision == record.workspace_lifecycle_revision
-            && validate_local_workspace_owner(lease)?
+            && validate_local_workspace_owner_in_store(store, lease)?
         {
             return Ok(());
         }
     }
-    record.workspace_owner_lease = Some(register_local_workspace_owner(identity, &record.run_id)?);
+    record.workspace_owner_lease = Some(register_local_workspace_owner_in_store(
+        store,
+        identity,
+        &record.run_id,
+    )?);
     record.workspace_lifecycle_revision = record
         .workspace_owner_lease
         .as_ref()

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -102,6 +102,17 @@ impl AgentTaskLifecycleStore {
         super::workspace_claims::workspace_claim_store_at(self.data_root())
     }
 
+    /// Terminal workspace authority bound to this store's own roots.
+    ///
+    /// Authority receipts and their release markers are a permission gate over
+    /// a retained runner workspace, so they must be read and written in the
+    /// same installation the record lives in (#7505).
+    pub(crate) fn workspace_terminal_authority_store(
+        &self,
+    ) -> super::workspace_authority::WorkspaceTerminalAuthorityStore {
+        super::workspace_authority::WorkspaceTerminalAuthorityStore::from_roots(&self.roots)
+    }
+
     /// Submit an exact run identity using this store's durable lifecycle roots.
     /// The admission callback supplies runtime evidence without coupling tests to
     /// the ambient controller runtime.
@@ -691,17 +702,14 @@ impl AgentTaskLifecycleStore {
     /// receipt first, then the workspace owner lease.
     pub(crate) fn project_terminal_record_after_unlock(&self, run_id: &str) -> Result<()> {
         let record = self.read_record(run_id)?;
-        super::workspace_authority::WorkspaceTerminalAuthorityStore::new(
-            self.data_root(),
-            self.roots.config().to_path_buf(),
-        )
-        .persist_terminal_from_record(&record)
-        .and_then(|_| {
-            super::workspace_claims::release_terminal_record_workspace_owner_in_store(
-                &super::workspace_claims::workspace_claim_store_at(self.data_root()),
-                &record,
-            )
-        })
+        self.workspace_terminal_authority_store()
+            .persist_terminal_from_record(&record)
+            .and_then(|_| {
+                super::workspace_claims::release_terminal_record_workspace_owner_in_store(
+                    &super::workspace_claims::workspace_claim_store_at(self.data_root()),
+                    &record,
+                )
+            })
     }
 
     pub fn write_aggregate_and_record(


### PR DESCRIPTION
## Summary

The path-root dimension in `homeboy-agents` that the store campaign did not cover. Four clusters, all in the **workspace-authority gates** — the code that decides whether a retained workspace may be destroyed.

- **`workspace_authority.rs`** — 5 ambient sites → 0. The six public entry points moved onto `WorkspaceTerminalAuthorityStore`; the three free path helpers were **deleted** rather than re-rooted, so there is no second way in. Added `from_roots(&PathRoots)`.
- **`lifecycle_store.rs`** — new `workspace_terminal_authority_store()` accessor mirroring the existing `workspace_claim_store()`.
- **`workspace_claims.rs`** — 3 gates, one hop each.
- **`lifecycle_ops.rs`** — `reconcile_deferred_candidate`; six ambient reaches collapsed to one store.

**Scanner: 7/7 pass.** No allowlist row added or removed — both existing rows are store-injection debt, orthogonal to this dimension.

<callout accent="#ef4444">
## The gate failed OPEN

`resolve_terminal_workspace_authority` read the controller run from the **ambient lifecycle store** and the owner lease from a claim store built out of a **second** `paths::homeboy_data()`.

If those diverge the lease file simply isn't there, `validate_owner` returns `Ok(false)`, and the gate concludes **"no live local workspace owner" — clearing a workspace that is still owned.**

The `.unwrap_or(true)` fail-closed default does **not** protect this, because the divergent read *succeeds*. This is a permission gate over destroying a retained workspace.
</callout>

## Four more, same class

**`resolve_workspace_terminal_authority` resolved the data root 2–3× inside one authority decision** — receipt path, release path, and on a substituted job identity the freeze via the ambient wrapper, adding a fourth read plus the ambient *config* root. The freeze is the fail-closed half of the exact-binding check, and could land in a different installation than the receipt that just failed it.

**`local_workspace_authority_inventory`** — same two-root split, but degrades to an **empty** inventory rather than an error. `composite_acquisition_intent_for_workspace` reads empty as "no live authority" and clears a token-free intent marker on it.

**`ensure_record_workspace_owner`** — validated a lease in one claim store, registered its successor in another. Two installations each believing they own the workspace.

**`reconcile_deferred_candidate`** — advisory lock under a directly resolved data root while every `store::` shim below resolved its own. *A lock in the wrong home excludes nobody.* Secondary find: the lock path did **not** sanitize the resolved run id while `store::aggregate_path` did, so they could already point at different directories **within** one home. `run_dir` fixes both.

## A new scanner blind spot (not committed — your call)

`workspace_claims.rs:1205` has a module-local `fn store()` resolving `paths::homeboy_data()`. The scanner cannot see it: it matches neither `default_store(` nor `store::`, and isn't `_in_store`-suffixed. **Any future `*_in_store` function in that file calling `&store()?` would be invisible.**

Adding one row to `ADDITIONAL_ROOT_REACHES` — `needle: "store()"` — keeps all 7 tests green today, and `contains_token`'s bounds correctly exclude `default_store()`, `.workspace_claim_store()`, `open_observation_store()`. Left uncommitted: it is a shared file with parallel streams in flight, and strengthening the scanner is the campaign owner's call.

## Not closed, with reasons

- **`workspace_claims.rs:925,929,1206`** — the composite claim subsystem (~20 functions, ~40 call sites) is **uniformly** ambient and its only callers (`homeboy-cli/src/commands/worktree.rs:252/334/345`) are unrooted, so **there is no live split**. Closing it blind was judged worse than the currently-zero bug it fixes. Deserves a dedicated slice.
- **`managed_services.rs`** (5 sites) — reached only from `agent_task_scheduler/engine.rs`, which holds no root. The one rooted caller (`cancellation.rs:100`) already uses the fully-rooted `reconcile_run_services_at`. No leak.
- **`lifecycle_ops.rs:236` `LabHandoffLock::lock`** — latent, not live; all four callers are ambient. A `lock_in_store` sibling was deliberately **not** added: that name makes `lock` a scanner-recognised wrapper, and `contains_token(body, "lock(")` would then fire on `DeferredCandidateLock::lock(file)` — a false positive requiring an allowlist row.
- **`agent_task_gate.rs:1803`** — `controller-state/gate-rust-cache` is content-addressed and keyed by `rust_cache_identity(cwd)`, same class as `cargo_targets_store()`. **Deliberately machine-global; do not root.**
- Loop-controller, `artifact_materialization`, `agent_task_secrets`, `agent_task_prompts`, `fanout_supervisor` — uniformly ambient, no rooted caller.

## On `record_detached_cook_handoff_parent_in_store` visibility

Recommend widening to `pub` — the `pub(crate)` is an artifact of nothing outside needing it, not a boundary decision, and `AgentTaskLifecycleStore` is already `pub` and externally constructible, so it leaks no capability.

**But it is the smaller half of the CLI's problem.** It only unblocks `local_detach.rs:602` / `local_detach_fanout.rs:432` if `agent_tasks::batch::read_batch_record` is rooted too, and that one is a real gap, not a visibility flag. Not changed here: it belongs to the store campaign, and doing it without the batch half leaves those CLI sites split anyway.

## Verification

`cargo fmt --check` exit 0. **Scanner 7/7.** No newly-introduced duplicate definitions (diffed against `origin/main`; the new same-name pairs are inherent-method/free-wrapper in distinct namespaces). **No public or `pub(crate)` signature changed.**

Dead-code risk assessed rather than assumed: these edits make `validate_local_workspace_owner`/`register_local_workspace_owner` callerless, but three sibling functions are *already* callerless on `main` and it compiles — so this shape does not trip the lint in this module.

Not verified without cargo: borrowck on the `WorkspaceClaimStore` temporary constructed inside the `is_some_and` closure, and the `#[cfg(test)]` paths. One behavior change: the `run_dir` sanitisation in `reconcile_deferred_candidate_in_store` alters a resulting path — argued *toward* agreement with `aggregate_path`, but a test asserting the old unsanitised lock path would fail.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
