### PR TITLE
Root ObservationStore on injected PathRoots

### DIFF
--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -76,8 +76,12 @@ impl AgentTaskLifecycleStore {
             .join("index.json")
     }
 
+    /// The observation database below these roots.
+    ///
+    /// Delegates to `paths` so this can never name a different file than the
+    /// path `ObservationStore::*_in_roots` opens for the same roots.
     pub fn observation_db_path(&self) -> PathBuf {
-        self.roots.data().join("homeboy.sqlite")
+        paths::observation_db_in_root(self.roots.data())
     }
 
     pub(crate) fn data_root(&self) -> PathBuf {
@@ -162,14 +166,17 @@ impl AgentTaskLifecycleStore {
     }
 
     pub fn open_observation_initialized(&self) -> Result<ObservationStore> {
-        ObservationStore::open_initialized_for_lifecycle_at_roots(
-            self.observation_db_path(),
-            self.artifact_root(),
-        )
+        ObservationStore::open_initialized_for_lifecycle_in_roots(&self.roots)
     }
 
+    /// Read the observation store through this store's own roots.
+    ///
+    /// This previously injected only the database path and left artifact
+    /// resolution ambient, so a reader opened from injected roots reported
+    /// artifacts against a different root than the database it read them from
+    /// (#7505).
     pub fn open_observation_readonly(&self) -> Result<ObservationStore> {
-        ObservationStore::open_readonly_at(self.observation_db_path())
+        ObservationStore::open_readonly_in_roots(&self.roots)
     }
 
     pub fn with_config_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {

--- a/crates/homeboy-core/src/observation/store/artifacts.rs
+++ b/crates/homeboy-core/src/observation/store/artifacts.rs
@@ -2640,7 +2640,7 @@ mod tests {
                 connection,
                 path: database.clone(),
                 readonly: false,
-                artifact_root: None,
+                roots: None,
             };
             let staging = home.path().join("retry.staging");
             let final_path = home.path().join("retry.final");

--- a/crates/homeboy-core/src/observation/store/mod.rs
+++ b/crates/homeboy-core/src/observation/store/mod.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use rusqlite::Connection;
 use serde::Serialize;
 
+use crate::paths::PathRoots;
+
 mod artifacts;
 mod findings;
 mod helpers;
@@ -62,7 +64,18 @@ pub struct ObservationStore {
     connection: Connection,
     path: PathBuf,
     readonly: bool,
-    artifact_root: Option<PathBuf>,
+    /// Filesystem roots this store was opened against, when it was opened
+    /// through a rooted constructor.
+    ///
+    /// The store spans TWO roots — `data` locates the SQLite database and
+    /// `artifacts` locates the bytes the database indexes — so they are held
+    /// together rather than as two independently resolvable fields. Resolving
+    /// one from injection and the other from ambient process state is the
+    /// "split home" defect class this field exists to make impossible (#7505).
+    ///
+    /// `None` means the store was opened at the ambient boundary; artifact
+    /// resolution then falls back to `paths::artifact_root()`.
+    roots: Option<PathRoots>,
 }
 
 pub fn database_path() -> Result<PathBuf> {

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use rusqlite::{params, params_from_iter, OptionalExtension, ToSql};
 use uuid::Uuid;
@@ -49,10 +50,31 @@ fn run_page_from_probe(mut runs: Vec<RunRecord>, limit: i64, offset: i64) -> Run
 
 impl ObservationStore {
     /// Open and lazily initialize the local observed-state database.
+    ///
+    /// This is the ambient boundary: the database path comes from
+    /// `paths::observation_db()` and artifact resolution falls back to
+    /// `paths::artifact_root()`. Callers that already hold resolved roots must
+    /// use [`ObservationStore::open_initialized_in_roots`] instead, or they
+    /// index an injected artifact root against an ambient database (#7505).
     pub fn open_initialized() -> Result<Self> {
         Self::open_initialized_at(database_path()?)
     }
 
+    /// Open and initialize the store against injected roots.
+    ///
+    /// BOTH roots come from `roots`: the database below `roots.data()` and the
+    /// artifact tree it indexes below `roots.artifacts()`. Nothing in the
+    /// returned store consults ambient process state for either.
+    pub fn open_initialized_in_roots(roots: &PathRoots) -> Result<Self> {
+        Self::open_in_roots_with_maintenance(roots, true)
+    }
+
+    /// Open and initialize the store at an explicit database path.
+    ///
+    /// This roots only the DATABASE. Artifact resolution still falls back to
+    /// the ambient `paths::artifact_root()`, so a caller that also holds an
+    /// injected artifact root must use
+    /// [`ObservationStore::open_initialized_in_roots`] rather than this.
     pub fn open_initialized_at(path: impl Into<PathBuf>) -> Result<Self> {
         Self::open_initialized_at_with_maintenance(path.into(), true)
     }
@@ -66,21 +88,43 @@ impl ObservationStore {
         Self::open_initialized_for_lifecycle_at(database_path()?)
     }
 
+    /// Lifecycle-mode open against injected roots. See
+    /// [`ObservationStore::open_initialized_for_lifecycle`] for the maintenance
+    /// contract and [`ObservationStore::open_initialized_in_roots`] for the
+    /// rooting contract.
+    pub fn open_initialized_for_lifecycle_in_roots(roots: &PathRoots) -> Result<Self> {
+        Self::open_in_roots_with_maintenance(roots, false)
+    }
+
+    /// Lifecycle-mode open at an explicit database path. Roots only the
+    /// database; see [`ObservationStore::open_initialized_at`].
     pub fn open_initialized_for_lifecycle_at(path: impl Into<PathBuf>) -> Result<Self> {
         Self::open_initialized_at_with_maintenance(path.into(), false)
     }
 
-    pub fn open_initialized_for_lifecycle_at_roots(
-        path: impl Into<PathBuf>,
-        artifact_root: impl Into<PathBuf>,
-    ) -> Result<Self> {
-        let mut store = Self::open_initialized_at_with_maintenance(path.into(), false)?;
-        store.artifact_root = Some(artifact_root.into());
-        Ok(store)
+    fn open_in_roots_with_maintenance(roots: &PathRoots, maintain_artifacts: bool) -> Result<Self> {
+        Self::open_initialized_with_maintenance(
+            crate::paths::observation_db_in_root(roots.data()),
+            Some(roots.clone()),
+            maintain_artifacts,
+        )
     }
 
     fn open_initialized_at_with_maintenance(
         path: PathBuf,
+        maintain_artifacts: bool,
+    ) -> Result<Self> {
+        Self::open_initialized_with_maintenance(path, None, maintain_artifacts)
+    }
+
+    /// Single construction path for every initializing open.
+    ///
+    /// `roots` is installed on the store *before* startup maintenance runs, so
+    /// artifact-touching maintenance can never resolve the ambient root on a
+    /// store the caller asked to be rooted.
+    fn open_initialized_with_maintenance(
+        path: PathBuf,
+        roots: Option<PathRoots>,
         maintain_artifacts: bool,
     ) -> Result<Self> {
         if let Some(parent) = path.parent() {
@@ -98,7 +142,7 @@ impl ObservationStore {
             connection,
             path,
             readonly: false,
-            artifact_root: None,
+            roots,
         };
         if maintain_artifacts {
             // Evidence projections expose opaque handles and failure ranks, so
@@ -117,16 +161,34 @@ impl ObservationStore {
         Self::open_readonly()
     }
 
+    /// Scheduler scan connection against injected roots. See
+    /// [`ObservationStore::open_initialized_in_roots`] for the rooting contract.
+    pub fn open_scheduler_reader_in_roots(roots: &PathRoots) -> Result<Self> {
+        Self::open_readonly_in_roots(roots)
+    }
+
     /// Open the scheduler's bounded claim connection. It performs no startup
     /// maintenance; callers use it only for short durable claim transitions.
     pub fn open_scheduler_writer() -> Result<Self> {
-        let path = database_path()?;
+        Self::open_scheduler_writer_inner(database_path()?, None)
+    }
+
+    /// Scheduler claim connection against injected roots. See
+    /// [`ObservationStore::open_initialized_in_roots`] for the rooting contract.
+    pub fn open_scheduler_writer_in_roots(roots: &PathRoots) -> Result<Self> {
+        Self::open_scheduler_writer_inner(
+            crate::paths::observation_db_in_root(roots.data()),
+            Some(roots.clone()),
+        )
+    }
+
+    fn open_scheduler_writer_inner(path: PathBuf, roots: Option<PathRoots>) -> Result<Self> {
         let connection = schema::open_bounded_writer_connection(&path)?;
         Ok(Self {
             connection,
             path,
             readonly: false,
-            artifact_root: None,
+            roots,
         })
     }
 
@@ -137,8 +199,28 @@ impl ObservationStore {
         Self::open_readonly_at(database_path()?)
     }
 
+    /// Open the store read-only against injected roots.
+    ///
+    /// BOTH roots come from `roots`; see
+    /// [`ObservationStore::open_initialized_in_roots`].
+    pub fn open_readonly_in_roots(roots: &PathRoots) -> Result<Self> {
+        Self::open_readonly_inner(
+            crate::paths::observation_db_in_root(roots.data()),
+            Some(roots.clone()),
+        )
+    }
+
+    /// Open the store read-only at an explicit database path.
+    ///
+    /// This roots only the DATABASE. Artifact resolution still falls back to
+    /// the ambient `paths::artifact_root()`; use
+    /// [`ObservationStore::open_readonly_in_roots`] when the caller holds an
+    /// artifact root too.
     pub fn open_readonly_at(path: impl Into<PathBuf>) -> Result<Self> {
-        let path = path.into();
+        Self::open_readonly_inner(path.into(), None)
+    }
+
+    fn open_readonly_inner(path: PathBuf, roots: Option<PathRoots>) -> Result<Self> {
         if !path.exists() {
             // Preserve the normal "run not found" contract without creating a
             // database merely because a metadata reader was invoked first.
@@ -153,7 +235,7 @@ impl ObservationStore {
                 connection,
                 path,
                 readonly: true,
-                artifact_root: None,
+                roots,
             });
         }
         let connection = schema::open_readonly_connection(&path)?;
@@ -161,14 +243,57 @@ impl ObservationStore {
             connection,
             path,
             readonly: true,
-            artifact_root: None,
+            roots,
         })
     }
 
+    /// The filesystem roots this store was opened against, or `None` when it
+    /// was opened at the ambient boundary.
+    ///
+    /// This is what lets a caller holding its own `PathRoots` ask the store
+    /// which roots it is actually indexing against, rather than independently
+    /// re-resolving the ambient ones and silently comparing two different
+    /// worlds (#7505).
+    pub fn roots(&self) -> Option<&PathRoots> {
+        self.roots.as_ref()
+    }
+
+    /// Whether this store was opened against injected roots.
+    pub fn is_rooted(&self) -> bool {
+        self.roots.is_some()
+    }
+
+    /// The exact SQLite database file backing this store.
+    ///
+    /// Always the truth for this handle and never an ambient re-resolution, so
+    /// it is safe to compare against a caller-held path.
+    pub fn database_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The data root this store's database lives under.
+    ///
+    /// Injected roots answer directly; otherwise the database file's own parent
+    /// directory answers. Both are properties of this handle, so this never
+    /// consults ambient process state.
+    pub fn data_root(&self) -> Option<&Path> {
+        self.roots
+            .as_ref()
+            .map(|roots| roots.data())
+            .or_else(|| self.path.parent())
+    }
+
+    /// The artifact root this store indexes against.
+    ///
+    /// Injected roots answer directly. An ambient store falls back to
+    /// `paths::artifact_root()` — correct for a store that was itself opened
+    /// ambiently, and the reason a caller holding injected roots must open the
+    /// store with [`ObservationStore::open_initialized_in_roots`] rather than
+    /// comparing against this.
     pub fn artifact_root(&self) -> Result<PathBuf> {
-        self.artifact_root
-            .clone()
-            .map(Ok)
+        self.roots
+            .as_ref()
+            .map(|roots| Ok(roots.artifacts().to_path_buf()))
             .unwrap_or_else(crate::paths::artifact_root)
     }
 

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -219,7 +219,7 @@ mod store_init_tests {
                 connection: rusqlite::Connection::open(&path).expect("open test store"),
                 path: path.clone(),
                 readonly: false,
-                artifact_root: None,
+                roots: None,
             };
             let run = store
                 .start_run(sample_run("test", "homeboy"))


### PR DESCRIPTION
> **Stacked on #12632** (`fix/7505-roots-paths`). Rebased onto it and the naming reconciled: this branch originally added `observation_db_in_roots(&PathRoots)`; it now calls #12632's `observation_db_in_root(data_root: &Path)`. Zero stale references remain.

## Summary

`ObservationStore::open_initialized()` resolved **both** the ambient data root and the ambient artifact root internally, and has **469 call sites**. Three independent work-streams each hit it as their hard blocker:

> - lab-runner: *"the lock is rooted, but the lease it arbitrates comes from a core-resolved DB path"*
> - audit: *"would compare recorded artifact paths against an injected artifact root while `recent_recorded_runs` reads the ambient store — every artifact from the real store reads as non-portable"*
> - release/rig: *"records that path INTO an ObservationStore it cannot interrogate. ObservationStore does not expose its roots."*

## New surface

```rust
pub fn open_initialized_in_roots(roots: &PathRoots) -> Result<Self>
pub fn open_initialized_for_lifecycle_in_roots(roots: &PathRoots) -> Result<Self>
pub fn open_readonly_in_roots(roots: &PathRoots) -> Result<Self>
pub fn open_scheduler_reader_in_roots(roots: &PathRoots) -> Result<Self>
pub fn open_scheduler_writer_in_roots(roots: &PathRoots) -> Result<Self>

pub fn roots(&self) -> Option<&PathRoots>   // None = opened ambiently
pub fn is_rooted(&self) -> bool
pub fn database_path(&self) -> &Path
pub fn data_root(&self) -> Option<&Path>
```

**All 469 call sites are untouched.** `open_initialized()` is byte-for-byte what it was.

## Both roots — and a half-rooted store is now unrepresentable

Every `_in_roots` constructor derives the DB from `roots.data()` and artifacts from `roots.artifacts()`. The private field `artifact_root: Option<PathBuf>` was **replaced** by `roots: Option<PathRoots>` specifically so a half-injected store cannot be constructed.

All initializing opens were collapsed into one private constructor that installs `roots` **before** startup artifact maintenance runs. Neither maintenance pass touches `self.artifact_root()` today, but the old ordering set the root *after* them.

<callout accent="#f59e0b">
## One deliberate deviation from the brief

`open_initialized()` was **not** changed to route through `PathRoots::from_environment()`.

`from_environment()` also resolves `homeboy()` (config), which requires `HOME`/`APPDATA` — whereas `observation_db()` short-circuits on `HOMEBOY_DATA_DIR`. That is **a new failure mode on 469 call sites, for a root the store never uses.**
</callout>

## Unblocks

| stream | status |
|---|---|
| lab-runner | **yes** — the missing constructor. Its one ambient open already has an `_in(&store, …)` injection point. |
| release/rig | **yes** — `roots()`/`artifact_root()`/`database_path()` are exactly the interrogation surface requested. |
| audit | **partially — and bluntly, no.** The store is injectable now, but the blocker is one layer up: `AuditRecordedArtifactProvider::recent_runs` is a trait method with **no roots channel**, registered into a process-global `provider_registry!`. Unblocking it needs a roots-carrying `StoreArtifactProvider`, a `register()` taking roots, and the detector taking an artifact root. All outside `ObservationStore`; not guessed at. |

## Split-home: one closed, several documented

**Closed:** `homeboy-agents/src/lifecycle_store.rs:178` `open_observation_readonly` was `open_readonly_at(self.observation_db_path())` — injected DB, **ambient artifacts**. Now `open_readonly_in_roots(&self.roots)`. All 6 callers checked; every one reads run records only.

**Left in place, documented loudly:** `open_initialized_at` / `open_initialized_for_lifecycle_at` / `open_readonly_at` inject the DB path only and leave artifacts ambient — pre-existing public API, ~30 call sites, mostly tests. Each now carries a doc comment saying it roots only the DATABASE and pointing at the `_in_roots` form.

The remaining `runs_service` reaches (`mod.rs:188`, `persisted_cleanup.rs:17`, `orphaned_artifact_bytes.rs:211`, `runner_downloads.rs:293`) are **uniformly** ambient — store and artifact root resolved ambiently *together* — so not splits.

## Verification

All 4 `Self { … }` literals plus 2 test literals migrated; zero `artifact_root: None` remains on any `ObservationStore` literal. Zero references to the removed `open_initialized_for_lifecycle_at_roots`. Duplicate sets identical to `main`'s. No bare function references to any store constructor; no `macro_rules!` expands to `ObservationStore` construction; no trait is implemented `for ObservationStore`, so `roots()`/`database_path()` add no method-resolution ambiguity.

<callout accent="#f59e0b">
**Nothing was type-checked** — no cargo, per the disk constraint. Highest residual risks: `database_path(&self)` shares a name with the free `database_path()` called bare at three sites in the same file (inherent assoc fns are not reachable as bare single-segment paths, so this should be fine); and the conditional move of `roots`/`path` across the early-return in `open_readonly_inner`.

**No test asserts the new behavior.** Nothing checks that a rooted store's `artifact_root()` equals the injected root. That gap is real and belongs in the follow-up that first consumes this API.
</callout>

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and reach analysis. Review by hand.

Refs #7505
