### PR TITLE
Root homeboy-core's filesystem reaches through PathRoots

### DIFF
--- a/crates/homeboy-core/src/broker_auth.rs
+++ b/crates/homeboy-core/src/broker_auth.rs
@@ -32,7 +32,7 @@
 //! is never installed on runner enforcement hosts.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
@@ -415,7 +415,12 @@ pub fn extract_bearer_token(header_lines: &str) -> Option<String> {
 
 /// Path to the broker auth store on disk.
 pub fn store_path() -> Result<PathBuf> {
-    Ok(paths::homeboy()?.join("broker_auth.json"))
+    Ok(store_path_in_root(&paths::homeboy()?))
+}
+
+/// [`store_path`] below an explicitly injected config root.
+pub fn store_path_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("broker_auth.json")
 }
 
 fn sha256_hex(token: &str) -> String {

--- a/crates/homeboy-core/src/capacity.rs
+++ b/crates/homeboy-core/src/capacity.rs
@@ -296,7 +296,12 @@ fn existing_ancestor(path: &Path) -> PathBuf {
 }
 
 fn capacity_ledger_path(filesystem: &str) -> Result<PathBuf> {
-    let root = crate::paths::homeboy_data()?.join("controller-state/capacity-reservations");
+    capacity_ledger_path_in_root(&crate::paths::homeboy_data()?, filesystem)
+}
+
+/// [`capacity_ledger_path`] below an explicitly injected data root.
+fn capacity_ledger_path_in_root(data_root: &Path, filesystem: &str) -> Result<PathBuf> {
+    let root = data_root.join("controller-state/capacity-reservations");
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -128,7 +128,17 @@ pub struct ArtifactCleanupOptions {
 /// ordering and limit, so a small root cannot consume the budget before a
 /// larger eligible artifact is considered.
 pub fn run_automatic_artifact_retention(roots: Vec<PathBuf>) -> Result<ArtifactCleanupOutput> {
-    try_run_automatic_artifact_retention(roots)?.ok_or_else(|| {
+    let data_root = homeboy_paths::homeboy_data()?;
+    run_automatic_artifact_retention_in_root(&data_root, roots)
+}
+
+/// [`run_automatic_artifact_retention`] against an explicitly injected data
+/// root, which is where the cross-process retention lock lives.
+pub fn run_automatic_artifact_retention_in_root(
+    data_root: &Path,
+    roots: Vec<PathBuf>,
+) -> Result<ArtifactCleanupOutput> {
+    try_run_automatic_artifact_retention_in_root(data_root, roots)?.ok_or_else(|| {
         Error::internal_unexpected(
             "automatic artifact retention is already running; remeasure capacity before admitting work",
         )
@@ -143,6 +153,16 @@ pub fn run_automatic_artifact_retention(roots: Vec<PathBuf>) -> Result<ArtifactC
 /// whether an artifact is safe to remove. An unmeasurable filesystem is not
 /// rejected; that is distinct from a measured reserve breach.
 pub fn admit_reconstructable_artifact_work(roots: Vec<PathBuf>) -> Result<()> {
+    let data_root = homeboy_paths::homeboy_data()?;
+    admit_reconstructable_artifact_work_in_root(&data_root, roots)
+}
+
+/// [`admit_reconstructable_artifact_work`] against an explicitly injected data
+/// root, which is where the cross-process retention lock lives.
+pub fn admit_reconstructable_artifact_work_in_root(
+    data_root: &Path,
+    roots: Vec<PathBuf>,
+) -> Result<()> {
     let retention = crate::defaults::load_config().retention;
     let roots = existing_unique_roots(roots);
     if roots.is_empty() || retention.reconstructable_artifact_reserve_bytes == 0 {
@@ -170,7 +190,7 @@ pub fn admit_reconstructable_artifact_work(roots: Vec<PathBuf>) -> Result<()> {
 
     // A busy owner is not treated as success: every caller still measures below
     // and deterministically admits or refuses from the current filesystem facts.
-    let _ = try_run_automatic_artifact_retention_with_config(&roots, &retention)?;
+    let _ = try_run_automatic_artifact_retention_with_config(data_root, &roots, &retention)?;
 
     for (root, reserve_bytes) in pressured {
         let budget = disk_budget(
@@ -198,11 +218,28 @@ pub fn admit_reconstructable_artifact_work(roots: Vec<PathBuf>) -> Result<()> {
 pub fn try_run_automatic_artifact_retention(
     roots: Vec<PathBuf>,
 ) -> Result<Option<ArtifactCleanupOutput>> {
+    let data_root = homeboy_paths::homeboy_data()?;
+    try_run_automatic_artifact_retention_in_root(&data_root, roots)
+}
+
+/// [`try_run_automatic_artifact_retention`] against an explicitly injected data
+/// root.
+///
+/// The cross-process exclusion this pass depends on is an `FsIndexLock` under
+/// the data root, while the roots it reclaims from are supplied by the caller.
+/// Resolving the lock's root ambiently meant two passes over the *same*
+/// repository roots could take locks in two different installations and fail to
+/// exclude each other.
+pub fn try_run_automatic_artifact_retention_in_root(
+    data_root: &Path,
+    roots: Vec<PathBuf>,
+) -> Result<Option<ArtifactCleanupOutput>> {
     let retention = crate::defaults::load_config().retention;
-    try_run_automatic_artifact_retention_with_config(&roots, &retention)
+    try_run_automatic_artifact_retention_with_config(data_root, &roots, &retention)
 }
 
 fn try_run_automatic_artifact_retention_with_config(
+    data: &Path,
     roots: &[PathBuf],
     retention: &crate::defaults::RetentionConfig,
 ) -> Result<Option<ArtifactCleanupOutput>> {
@@ -212,7 +249,6 @@ fn try_run_automatic_artifact_retention_with_config(
     else {
         return Ok(None);
     };
-    let data = homeboy_paths::homeboy_data()?;
     let lock = FsIndexLockConfig {
         // Retention has its own deadline. An extra minute avoids stealing a
         // live owner at that boundary while recovering a crashed owner.
@@ -223,7 +259,7 @@ fn try_run_automatic_artifact_retention_with_config(
         ),
         ..AUTOMATIC_ARTIFACT_RETENTION_LOCK
     };
-    let Some(_cross_process_owner) = FsIndexLock::try_acquire_in(&data, lock)? else {
+    let Some(_cross_process_owner) = FsIndexLock::try_acquire_in(data, lock)? else {
         return Ok(None);
     };
     run_automatic_artifact_retention_in(roots, retention, SystemTime::now()).map(Some)
@@ -2616,6 +2652,7 @@ mod tests {
                 .expect("hold retention owner");
 
             let result = try_run_automatic_artifact_retention_with_config(
+                &homeboy_paths::homeboy_data().expect("data root"),
                 &[repo.path().to_path_buf()],
                 &crate::defaults::RetentionConfig::default(),
             )

--- a/crates/homeboy-core/src/daemon/artifact_download.rs
+++ b/crates/homeboy-core/src/daemon/artifact_download.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 use std::fs::{self, File};
 use std::io::Write;
 use std::net::TcpStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::artifact_links::{public_artifact_url, viewer_links};
 use crate::error::{Error, Result};
@@ -117,7 +117,12 @@ fn resolve_artifact_download(
         match store.get_artifact_for_run_token(run_id, &decoded_artifact_token)? {
             Some(artifact) => artifact,
             None => {
-                return artifact_store_download(run_id, artifact_token, &decoded_artifact_token)
+                return artifact_store_download(
+                    &store.artifact_root()?,
+                    run_id,
+                    artifact_token,
+                    &decoded_artifact_token,
+                )
             }
         }
     } else {
@@ -267,11 +272,15 @@ fn resolve_artifact_store_download(
     run_id: &str,
     artifact_token: &str,
 ) -> Result<ResolvedArtifactResponse> {
+    // This route resolves a locator directly and never consults the run store,
+    // so the ambient artifact root is the honest boundary here.
+    let artifact_root = paths::artifact_root()?;
     let decoded = decode_uri_component(artifact_token);
-    artifact_store_download(run_id, artifact_token, &decoded)
+    artifact_store_download(&artifact_root, run_id, artifact_token, &decoded)
 }
 
 fn artifact_store_download(
+    artifact_root: &Path,
     run_id: &str,
     artifact_token: &str,
     decoded_artifact_token: &str,
@@ -287,7 +296,7 @@ fn artifact_store_download(
             None,
         )
     })?;
-    let path = safe_artifact_store_path(&locator)?;
+    let path = safe_artifact_store_path_in_root(artifact_root, &locator)?;
     let metadata = fs::metadata(&path).map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -339,7 +348,7 @@ fn artifact_store_download(
     )))
 }
 
-fn safe_artifact_store_path(locator: &str) -> Result<PathBuf> {
+fn safe_artifact_store_path_in_root(artifact_root: &Path, locator: &str) -> Result<PathBuf> {
     let locator_path = PathBuf::from(locator);
     if locator_path.is_absolute()
         || locator_path
@@ -353,7 +362,7 @@ fn safe_artifact_store_path(locator: &str) -> Result<PathBuf> {
             None,
         ));
     }
-    Ok(paths::artifact_root()?.join(locator_path))
+    Ok(artifact_root.join(locator_path))
 }
 
 fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -2098,9 +2098,21 @@ fn validate_admission_lease(expected_lease_id: &str, actual_lease_id: &str) -> R
 }
 
 fn daemon_workspace_claim_store() -> Result<crate::workspace_claim::WorkspaceClaimStore> {
-    Ok(crate::workspace_claim::WorkspaceClaimStore::new(
-        crate::paths::homeboy_data()?.join("daemon-workspace-claims"),
+    Ok(daemon_workspace_claim_store_in_root(
+        &crate::paths::homeboy_data()?,
     ))
+}
+
+/// [`daemon_workspace_claim_store`] below an explicitly injected data root.
+///
+/// Every register/renew/release of a workspace owner lease currently calls the
+/// ambient form independently, so the acquire and its heartbeat only agree
+/// because the process environment happens to be stable. A caller that holds a
+/// root should build the store once and reuse it.
+fn daemon_workspace_claim_store_in_root(
+    data_root: &std::path::Path,
+) -> crate::workspace_claim::WorkspaceClaimStore {
+    crate::workspace_claim::WorkspaceClaimStore::new(data_root.join("daemon-workspace-claims"))
 }
 
 fn workspace_claim_now_ms() -> u64 {

--- a/crates/homeboy-core/src/daemon/patch_capture.rs
+++ b/crates/homeboy-core/src/daemon/patch_capture.rs
@@ -76,6 +76,16 @@ pub(super) fn capture_baseline(
     cwd: &str,
     source_snapshot: Option<&SourceSnapshot>,
 ) -> Result<BaselineCapture> {
+    let artifact_root = paths::artifact_root()?;
+    capture_baseline_in_root(&artifact_root, cwd, source_snapshot)
+}
+
+/// [`capture_baseline`] against an explicitly injected artifact root.
+pub(super) fn capture_baseline_in_root(
+    artifact_root: &Path,
+    cwd: &str,
+    source_snapshot: Option<&SourceSnapshot>,
+) -> Result<BaselineCapture> {
     let cwd_path = Path::new(cwd);
     if !cwd_path.is_dir() {
         return Err(Error::validation_invalid_argument(
@@ -85,7 +95,7 @@ pub(super) fn capture_baseline(
             None,
         ));
     }
-    let scratch = create_scratch_dir("baseline")?;
+    let scratch = create_scratch_dir_in_root(artifact_root, "baseline")?;
     let baseline_path = scratch.path.join("baseline");
     let excludes = source_snapshot
         .map(|snapshot| snapshot.sync_excludes.clone())
@@ -107,7 +117,40 @@ pub(super) fn capture_patch_report(
     baseline: &BaselineCapture,
     exit_code: i32,
 ) -> Result<PatchCaptureReport> {
-    let after_scratch = create_scratch_dir("after")?;
+    let artifact_root = paths::artifact_root()?;
+    capture_patch_report_in_root(
+        &artifact_root,
+        job_id,
+        runner_id,
+        cwd,
+        command,
+        source_snapshot,
+        baseline,
+        exit_code,
+    )
+}
+
+/// [`capture_patch_report`] against an explicitly injected artifact root.
+///
+/// The scratch directory and the published `.diff` artifact now come from one
+/// resolution. They used to resolve `artifact_root()` independently inside a
+/// single capture, so the path recorded in the run record could name a
+/// different installation from the one the diff was computed in.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Mirrors capture_patch_report with the artifact root made explicit."
+)]
+pub(super) fn capture_patch_report_in_root(
+    artifact_root: &Path,
+    job_id: uuid::Uuid,
+    runner_id: &str,
+    cwd: &str,
+    command: &[String],
+    source_snapshot: Option<&SourceSnapshot>,
+    baseline: &BaselineCapture,
+    exit_code: i32,
+) -> Result<PatchCaptureReport> {
+    let after_scratch = create_scratch_dir_in_root(artifact_root, "after")?;
     let after_path = after_scratch.path.join("after");
     let cwd_path = Path::new(cwd);
     copy_dir_filtered(cwd_path, &after_path, cwd_path, &baseline.excludes)?;
@@ -119,7 +162,12 @@ pub(super) fn capture_patch_report(
     let patch_artifact_path = if patch.trim().is_empty() {
         None
     } else {
-        Some(write_patch_artifact(&run_id, &artifact_id, &patch)?)
+        Some(write_patch_artifact_in_root(
+            artifact_root,
+            &run_id,
+            &artifact_id,
+            &patch,
+        )?)
     };
     let patch_artifact_path_string = patch_artifact_path
         .as_ref()
@@ -153,8 +201,8 @@ pub(super) fn capture_patch_report(
     Ok(report)
 }
 
-fn create_scratch_dir(label: &str) -> Result<ScratchDir> {
-    let path = paths::artifact_root()?
+fn create_scratch_dir_in_root(artifact_root: &Path, label: &str) -> Result<ScratchDir> {
+    let path = artifact_root
         .join("_scratch")
         .join(format!("patch-{label}-{}", uuid::Uuid::new_v4()));
     fs::create_dir_all(&path).map_err(|err| {
@@ -166,8 +214,13 @@ fn create_scratch_dir(label: &str) -> Result<ScratchDir> {
     Ok(ScratchDir { path })
 }
 
-fn write_patch_artifact(run_id: &str, artifact_id: &str, patch: &str) -> Result<PathBuf> {
-    let path = paths::artifact_root()?
+fn write_patch_artifact_in_root(
+    artifact_root: &Path,
+    run_id: &str,
+    artifact_id: &str,
+    patch: &str,
+) -> Result<PathBuf> {
+    let path = artifact_root
         .join(run_id)
         .join(format!("{artifact_id}.diff"));
     if let Some(parent) = path.parent() {

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -1017,9 +1017,16 @@ fn parse_body<T: for<'de> Deserialize<'de>>(body: Option<Value>, label: &str) ->
 }
 
 fn workspace_claim_store() -> Result<crate::workspace_claim::WorkspaceClaimStore> {
-    Ok(crate::workspace_claim::WorkspaceClaimStore::new(
-        paths::homeboy_data()?.join("reverse-broker-workspace-claims"),
-    ))
+    Ok(workspace_claim_store_in_root(&paths::homeboy_data()?))
+}
+
+/// [`workspace_claim_store`] below an explicitly injected data root.
+fn workspace_claim_store_in_root(
+    data_root: &std::path::Path,
+) -> crate::workspace_claim::WorkspaceClaimStore {
+    crate::workspace_claim::WorkspaceClaimStore::new(
+        data_root.join("reverse-broker-workspace-claims"),
+    )
 }
 
 fn workspace_claim_now_ms() -> u64 {

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -7,7 +7,9 @@ mod io;
 mod policy;
 
 pub use io::{
-    config_exists, config_file_value, config_path, load_config, reset_config, save_config,
+    config_exists, config_exists_in_root, config_file_value, config_file_value_in_root,
+    config_path, config_path_in_root, load_config, load_config_uncached_in_root, reset_config,
+    reset_config_in_root, save_config, save_config_in_root,
 };
 pub use policy::resolve_release_gate_local_hot_policy_from;
 pub use policy::{

--- a/crates/homeboy-core/src/defaults/io.rs
+++ b/crates/homeboy-core/src/defaults/io.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
 use serde_json::Value;
@@ -8,25 +9,46 @@ use crate::paths;
 
 use super::HomeboyConfig;
 
+/// The product config file below an explicitly resolved config root.
+///
+/// This is exactly what [`paths::homeboy_json`] computes, minus the ambient
+/// resolution of the root itself.
+fn config_file_path_in_root(config_root: &Path) -> PathBuf {
+    paths::homeboy_json_in_root(config_root)
+}
+
 /// Load the full product config, falling back to defaults on any error.
 /// Warns to stderr if the file exists but fails to parse, so the user knows
 /// their config is being ignored rather than silently resetting to defaults.
+///
+/// The memoized value is process-global and is deliberately keyed on nothing:
+/// it caches the *ambient* configuration only. The rooted siblings below never
+/// read or write it, so injecting a root cannot be answered out of another
+/// root's cache.
 pub fn load_config() -> HomeboyConfig {
     if let Some(config) = cached_config() {
         return config;
     }
 
-    let config = load_config_uncached();
+    let config = match paths::homeboy() {
+        Ok(config_root) => load_config_uncached_in_root(&config_root),
+        // An unresolvable config root is exactly what `homeboy_json()` used to
+        // fail on here: `load_config_from_file` surfaced it as an error, and
+        // `config_exists()` was false, so this degraded to defaults silently.
+        Err(_) => HomeboyConfig::default(),
+    };
     store_cached_config(&config);
     config
 }
 
-fn load_config_uncached() -> HomeboyConfig {
-    match load_config_from_file() {
+/// [`load_config`] against an explicitly injected config root, without the
+/// process-global memoization.
+pub fn load_config_uncached_in_root(config_root: &Path) -> HomeboyConfig {
+    match load_config_from_file_in_root(config_root) {
         Ok(config) => config,
         Err(err) => {
             // Only warn if the file actually exists — missing file is expected
-            if config_exists() {
+            if config_exists_in_root(config_root) {
                 log_status!(
                     "config",
                     "Warning: failed to load {} ({}), using defaults",
@@ -71,8 +93,8 @@ pub fn reset_config_cache_for_test() {
 }
 
 /// Attempt to load config from the product config file.
-fn load_config_from_file() -> crate::Result<HomeboyConfig> {
-    let path = paths::homeboy_json()?;
+fn load_config_from_file_in_root(config_root: &Path) -> crate::Result<HomeboyConfig> {
+    let path = config_file_path_in_root(config_root);
 
     if !path.exists() {
         return Err(crate::Error::internal_io(
@@ -102,7 +124,18 @@ fn load_config_from_file() -> crate::Result<HomeboyConfig> {
 
 /// Save config to the product config file (creates if missing).
 pub fn save_config(config: &HomeboyConfig) -> crate::Result<()> {
-    let path = paths::homeboy_json()?;
+    let config_root = paths::homeboy()?;
+    save_config_in_root(&config_root, config)?;
+    // Priming the memo stays on the ambient path deliberately. The memo is not
+    // keyed by root, so a rooted write that primed it would make a later
+    // ambient `load_config()` answer out of a foreign installation.
+    store_cached_config(config);
+    Ok(())
+}
+
+/// [`save_config`] against an explicitly injected config root.
+pub fn save_config_in_root(config_root: &Path, config: &HomeboyConfig) -> crate::Result<()> {
+    let path = config_file_path_in_root(config_root);
 
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
@@ -114,14 +147,20 @@ pub fn save_config(config: &HomeboyConfig) -> crate::Result<()> {
     let content = crate::config::to_string_pretty(config)?;
 
     local_files::write_file_atomic(&path, &content, &format!("write {}", path.display()))?;
-    store_cached_config(config);
 
     Ok(())
 }
 
 /// Check if the product config file exists.
 pub fn config_exists() -> bool {
-    paths::homeboy_json().map(|p| p.exists()).unwrap_or(false)
+    paths::homeboy()
+        .map(|root| config_exists_in_root(&root))
+        .unwrap_or(false)
+}
+
+/// [`config_exists`] against an explicitly injected config root.
+pub fn config_exists_in_root(config_root: &Path) -> bool {
+    config_file_path_in_root(config_root).exists()
 }
 
 /// Return an explicitly configured value from the on-disk file.
@@ -129,7 +168,13 @@ pub fn config_exists() -> bool {
 /// The effective configuration adds serde defaults, so callers that need to
 /// report ownership must distinguish a file override from a built-in value.
 pub fn config_file_value(pointer: &str) -> Option<Value> {
-    let path = paths::homeboy_json().ok()?;
+    let config_root = paths::homeboy().ok()?;
+    config_file_value_in_root(&config_root, pointer)
+}
+
+/// [`config_file_value`] against an explicitly injected config root.
+pub fn config_file_value_in_root(config_root: &Path, pointer: &str) -> Option<Value> {
+    let path = config_file_path_in_root(config_root);
     let content = local_files::read_file(&path, &format!("read {}", path.display())).ok()?;
     serde_json::from_str::<HomeboyConfig>(&content).ok()?;
     let value = serde_json::from_str::<Value>(&content).ok()?;
@@ -140,7 +185,16 @@ pub fn config_file_value(pointer: &str) -> Option<Value> {
 
 /// Delete the product config file (reset to defaults).
 pub fn reset_config() -> crate::Result<bool> {
-    let path = paths::homeboy_json()?;
+    let config_root = paths::homeboy()?;
+    reset_config_in_root(&config_root)
+}
+
+/// [`reset_config`] against an explicitly injected config root.
+///
+/// Invalidating the unkeyed memo from a rooted call is conservative: it can
+/// only force a re-read, never serve another root's value.
+pub fn reset_config_in_root(config_root: &Path) -> crate::Result<bool> {
+    let path = config_file_path_in_root(config_root);
 
     if path.exists() {
         fs::remove_file(&path).map_err(|e| {
@@ -156,5 +210,11 @@ pub fn reset_config() -> crate::Result<bool> {
 
 /// Get the product config path (for display purposes).
 pub fn config_path() -> crate::Result<String> {
-    Ok(paths::homeboy_json()?.display().to_string())
+    let config_root = paths::homeboy()?;
+    Ok(config_path_in_root(&config_root))
+}
+
+/// [`config_path`] against an explicitly injected config root.
+pub fn config_path_in_root(config_root: &Path) -> String {
+    config_file_path_in_root(config_root).display().to_string()
 }

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -16,7 +16,7 @@ use crate::observation::{
     RunListFilter, RunRecord, RunStatus, MAX_RUN_PAGE_LIMIT,
     OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES,
 };
-use crate::{activity, component, git, paths};
+use crate::{activity, component, git};
 
 mod analysis_job_runner;
 mod sandbox_tools;
@@ -560,7 +560,12 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
     crate::artifacts::index_remote_published_artifact_refs_for_run(&store, run_id)?;
     let decoded_artifact_id = crate::execution_contract::decode_uri_component(artifact_id);
     let Some(artifact) = store.get_artifact_for_run_token(run_id, &decoded_artifact_id)? else {
-        return artifact_store_content(run_id, artifact_id, &decoded_artifact_id);
+        return artifact_store_content(
+            &store.artifact_root()?,
+            run_id,
+            artifact_id,
+            &decoded_artifact_id,
+        );
     };
     if artifact.artifact_type != "file" {
         if artifact.artifact_type == "remote_file"
@@ -653,6 +658,7 @@ fn artifact_content_response(
 }
 
 fn artifact_store_content(
+    artifact_root: &std::path::Path,
     run_id: &str,
     artifact_id: &str,
     decoded_artifact_id: &str,
@@ -668,7 +674,7 @@ fn artifact_store_content(
             None,
         )
     })?;
-    let path = safe_artifact_store_path(&locator)?;
+    let path = safe_artifact_store_path_in_root(artifact_root, &locator)?;
     let content = std::fs::read(&path).map_err(|err| {
         Error::internal_io(
             err.to_string(),
@@ -704,7 +710,10 @@ fn inline_content_retrieval() -> Value {
     })
 }
 
-fn safe_artifact_store_path(locator: &str) -> Result<std::path::PathBuf> {
+fn safe_artifact_store_path_in_root(
+    artifact_root: &std::path::Path,
+    locator: &str,
+) -> Result<std::path::PathBuf> {
     let locator_path = std::path::PathBuf::from(locator);
     if locator_path.is_absolute()
         || locator_path
@@ -718,7 +727,7 @@ fn safe_artifact_store_path(locator: &str) -> Result<std::path::PathBuf> {
             None,
         ));
     }
-    Ok(paths::artifact_root()?.join(locator_path))
+    Ok(artifact_root.join(locator_path))
 }
 
 fn path_segments(path: &str) -> Vec<String> {

--- a/crates/homeboy-core/src/publication_artifacts.rs
+++ b/crates/homeboy-core/src/publication_artifacts.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 
 use crate::execution_contract::{decode_uri_component, EXECUTION_CONTRACT};
 use crate::observation::{ArtifactRecord, ObservationStore};
-use crate::{paths, Result};
+use crate::Result;
 
 pub(crate) fn index_published_artifact_refs(
     store: &ObservationStore,
@@ -25,7 +25,11 @@ pub(crate) fn index_published_artifact_refs(
         Err(_) => return Ok(()),
     };
 
-    let artifact_root = paths::artifact_root()?;
+    // The store's own root, not the ambient one. Every locator resolved below
+    // is checked for existence and materialized under this root, so a store
+    // opened on an injected root would otherwise have its artifacts looked for
+    // in a different installation and reported `Missing`.
+    let artifact_root = store.artifact_root()?;
     let mut source_bases = Vec::new();
     for source_path in source_paths {
         if let Some(parent) = source_path.parent() {

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -85,20 +85,38 @@ pub fn refresh(
     source: &str,
     revision: Option<&str>,
 ) -> Result<RuntimePackageRefreshResult> {
-    config::with_config_lock(|| refresh_locked(runtime_id, source, revision))
+    let config_root = paths::homeboy()?;
+    refresh_in_root(&config_root, runtime_id, source, revision)
 }
 
-fn refresh_locked(
+/// [`refresh`] against an explicitly injected config root.
+///
+/// The root is resolved once and the config lock is taken under that same
+/// root. `with_config_lock` would have resolved it a second time, so a refresh
+/// could have serialized on one installation's `config.lock` while publishing
+/// generations into another's.
+pub fn refresh_in_root(
+    config_root: &Path,
+    runtime_id: &str,
+    source: &str,
+    revision: Option<&str>,
+) -> Result<RuntimePackageRefreshResult> {
+    config::with_config_lock_at(config_root, || {
+        refresh_locked_in_root(config_root, runtime_id, source, revision)
+    })
+}
+
+fn refresh_locked_in_root(
+    config_root: &Path,
     runtime_id: &str,
     source: &str,
     revision: Option<&str>,
 ) -> Result<RuntimePackageRefreshResult> {
     let runtime_id = identifier::slugify_id(runtime_id, "runtime_id")?;
-    let config_root = paths::homeboy()?;
     let store = config_root.join(GENERATIONS);
     fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
     recover(&store)?;
-    bootstrap_stable_runtime_boundary(&config_root, &store)?;
+    bootstrap_stable_runtime_boundary(config_root, &store)?;
     crash_after_boundary_bootstrap()?;
 
     let source_stage = store.join(format!("source-{}-{}", runtime_id, nonce()));
@@ -132,7 +150,7 @@ fn refresh_locked(
     let generation_name = format!("{}-{}", runtime_id, nonce());
     let stage = store.join("staging").join(&generation_name);
     remove_if_exists(&stage, "clean runtime generation stage")?;
-    seed_generation(&config_root, &store, &stage)?;
+    seed_generation(config_root, &store, &stage)?;
     let dependencies = materialize_declared_assets(manifest_root, &stage, &runtime_id)?;
 
     let staged_package = stage.join("agent-runtimes").join(&runtime_id);
@@ -148,7 +166,9 @@ fn refresh_locked(
     validate_local_module_closure(&stage, &staged_package)?;
     sync_tree(&stage)?;
 
-    let replaced_existing = paths::agent_runtimes()?.join(&runtime_id).exists();
+    let replaced_existing = paths::agent_runtimes_in_root(config_root)
+        .join(&runtime_id)
+        .exists();
     write_journal(
         &store,
         &RefreshJournal {
@@ -173,7 +193,7 @@ fn refresh_locked(
     sync_dir(&store)?;
     remove_if_exists(&source_stage, "clean runtime refresh source")?;
 
-    let path = paths::agent_runtimes()?.join(&runtime_id);
+    let path = paths::agent_runtimes_in_root(config_root).join(&runtime_id);
     Ok(RuntimePackageRefreshResult {
         runtime_id: runtime_id.clone(),
         source: source.to_string(),
@@ -187,22 +207,32 @@ fn refresh_locked(
 /// Snapshot root-manifest runtime assets into a new generation. Linked extension
 /// installs call this instead of writing through the stable runtime boundary.
 pub fn refresh_shared_assets(source_root: &Path) -> Result<()> {
-    config::with_config_lock(|| refresh_shared_assets_locked(source_root))
+    let config_root = paths::homeboy()?;
+    refresh_shared_assets_in_root(&config_root, source_root)
 }
 
-fn refresh_shared_assets_locked(source_root: &Path) -> Result<()> {
-    let config_root = paths::homeboy()?;
+/// [`refresh_shared_assets`] against an explicitly injected config root.
+///
+/// As with [`refresh_in_root`], the lock and the generation store are taken
+/// under one resolution rather than two.
+pub fn refresh_shared_assets_in_root(config_root: &Path, source_root: &Path) -> Result<()> {
+    config::with_config_lock_at(config_root, || {
+        refresh_shared_assets_locked_in_root(config_root, source_root)
+    })
+}
+
+fn refresh_shared_assets_locked_in_root(config_root: &Path, source_root: &Path) -> Result<()> {
     let store = config_root.join(GENERATIONS);
     fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
     recover(&store)?;
-    bootstrap_stable_runtime_boundary(&config_root, &store)?;
+    bootstrap_stable_runtime_boundary(config_root, &store)?;
     crash_after_boundary_bootstrap()?;
     let source_root =
         canonical_contained_directory(source_root, source_root, "resolve linked runtime source")?;
     let generation_name = format!("extension-assets-{}", nonce());
     let stage = store.join("staging").join(&generation_name);
     remove_if_exists(&stage, "clean linked runtime generation stage")?;
-    seed_generation(&config_root, &store, &stage)?;
+    seed_generation(config_root, &store, &stage)?;
     materialize_all_declared_runtime_assets(&source_root, &stage)?;
     sync_tree(&stage)?;
     write_journal(
@@ -243,7 +273,11 @@ fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()>
 fn seed_legacy_generation(config_root: &Path, stage: &Path) -> Result<()> {
     // First activation migrates the runtime surface only; all unrelated Homeboy
     // configuration remains in place and is never renamed or copied.
-    let legacy = paths::legacy_agent_runtimes()?;
+    //
+    // The shared-asset loop below already joins `config_root`; resolving the
+    // legacy runtime directory ambiently would seed a generation from one
+    // installation's runtimes and another's shared assets.
+    let legacy = paths::legacy_agent_runtimes_in_root(config_root);
     if legacy.is_dir() {
         reject_symlink_tree_except_root(&legacy)?;
         copy_regular_tree(
@@ -638,7 +672,11 @@ fn switch_current(store: &Path, generation: &str) -> Result<()> {
 }
 
 fn ensure_stable_runtime_boundary(config_root: &Path) -> Result<()> {
-    let boundary = paths::legacy_agent_runtimes()?;
+    // Derived from the injected root, never re-resolved: the backup and
+    // temporary siblings below are already `config_root`-relative, so an
+    // ambient `legacy_agent_runtimes()` here would rename a boundary in one
+    // installation into a backup name recorded in another.
+    let boundary = paths::legacy_agent_runtimes_in_root(config_root);
     let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
     if fs::read_link(&boundary).ok().as_deref() == Some(expected.as_path()) {
         return Ok(());
@@ -766,7 +804,11 @@ fn recover_boundary_migration(config_root: &Path) -> Result<()> {
         &migration.temporary,
         "runtime_boundary",
     )?);
-    let boundary = paths::legacy_agent_runtimes()?;
+    // `recover` derives `config_root` from the generation store's parent, so
+    // this recovery already runs against one specific installation. Resolving
+    // the boundary ambiently could restore a backup recorded here over an
+    // unrelated installation's live boundary.
+    let boundary = paths::legacy_agent_runtimes_in_root(config_root);
     let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
 
     if fs::read_link(&boundary).ok().as_deref() != Some(expected.as_path()) {

--- a/crates/homeboy-core/src/schedule/mod.rs
+++ b/crates/homeboy-core/src/schedule/mod.rs
@@ -27,7 +27,10 @@ pub use execution::{
     raw_digest, result_digest, run_schedule, sequence_digest, ScheduleCommandResult,
     ScheduleCommandRunner, ScheduleRunOutcome, ScheduleStepOutcome, SubprocessRunner,
 };
-pub use state::{load_state, remove_state, save_state, ScheduleState};
+pub use state::{
+    load_state, load_state_in_root, remove_state, remove_state_in_root, save_state,
+    save_state_in_root, ScheduleState,
+};
 pub use ticker::{reclaim_stale_runs, ScheduleTicker};
 pub use types::{
     Cadence, ExecCommand, NotifyPolicy, OverlapPolicy, Schedule, ScheduleStep, ScheduledCommand,

--- a/crates/homeboy-core/src/schedule/state.rs
+++ b/crates/homeboy-core/src/schedule/state.rs
@@ -93,29 +93,41 @@ impl ScheduleState {
     }
 }
 
-fn state_path(id: &str) -> Result<std::path::PathBuf> {
+/// A schedule's runtime state file below an explicitly injected data root.
+fn state_path_in_root(data_root: &std::path::Path, id: &str) -> std::path::PathBuf {
     let segment = paths::sanitize_path_segment(id);
-    Ok(paths::homeboy_data()?
-        .join("schedules")
-        .join(segment)
-        .join("state.json"))
+    data_root.join("schedules").join(segment).join("state.json")
 }
 
 /// Read a schedule's runtime state, treating absent or unreadable state as
 /// "never run" rather than an error — a missing record must not stop a
 /// schedule from running for the first time.
 pub fn load_state(id: &str) -> ScheduleState {
-    let Ok(path) = state_path(id) else {
+    let Ok(data_root) = paths::homeboy_data() else {
         return ScheduleState::default();
     };
-    let Ok(raw) = std::fs::read_to_string(&path) else {
+    load_state_in_root(&data_root, id)
+}
+
+/// [`load_state`] against an explicitly injected data root.
+pub fn load_state_in_root(data_root: &std::path::Path, id: &str) -> ScheduleState {
+    let Ok(raw) = std::fs::read_to_string(state_path_in_root(data_root, id)) else {
         return ScheduleState::default();
     };
     serde_json::from_str(&raw).unwrap_or_default()
 }
 
 pub fn save_state(id: &str, state: &ScheduleState) -> Result<()> {
-    let path = state_path(id)?;
+    save_state_in_root(&paths::homeboy_data()?, id, state)
+}
+
+/// [`save_state`] against an explicitly injected data root.
+pub fn save_state_in_root(
+    data_root: &std::path::Path,
+    id: &str,
+    state: &ScheduleState,
+) -> Result<()> {
+    let path = state_path_in_root(data_root, id);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|error| {
             crate::error::Error::internal_io(
@@ -141,10 +153,16 @@ pub fn save_state(id: &str, state: &ScheduleState) -> Result<()> {
 /// Drop a schedule's runtime state. Best effort: removing a schedule must not
 /// fail because its state was already gone.
 pub fn remove_state(id: &str) {
-    if let Ok(path) = state_path(id) {
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::remove_dir_all(parent);
-        }
+    if let Ok(data_root) = paths::homeboy_data() {
+        remove_state_in_root(&data_root, id);
+    }
+}
+
+/// [`remove_state`] against an explicitly injected data root.
+pub fn remove_state_in_root(data_root: &std::path::Path, id: &str) {
+    let path = state_path_in_root(data_root, id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_dir_all(parent);
     }
 }
 

--- a/crates/homeboy-core/src/update_check_cache.rs
+++ b/crates/homeboy-core/src/update_check_cache.rs
@@ -13,7 +13,7 @@
 use crate::paths;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Current unix timestamp in seconds. Returns `0` if the system clock is
@@ -29,14 +29,27 @@ pub fn now_unix() -> u64 {
 /// `None` when the homeboy directory cannot be resolved (matching the
 /// prior per-module behavior — callers treat this as "no cache").
 pub fn cache_path(filename: &str) -> Option<PathBuf> {
-    paths::homeboy().ok().map(|path| path.join(filename))
+    paths::homeboy()
+        .ok()
+        .map(|root| cache_path_in_root(&root, filename))
+}
+
+/// [`cache_path`] below an explicitly injected config root.
+pub fn cache_path_in_root(config_root: &Path, filename: &str) -> PathBuf {
+    config_root.join(filename)
 }
 
 /// Read and deserialize a cache payload from `filename` under the
 /// homeboy data directory. Returns `None` on any I/O or JSON error so
 /// the caller falls through to a fresh fetch.
 pub fn read_cache<T: DeserializeOwned>(filename: &str) -> Option<T> {
-    let path = cache_path(filename)?;
+    let config_root = paths::homeboy().ok()?;
+    read_cache_in_root(&config_root, filename)
+}
+
+/// [`read_cache`] against an explicitly injected config root.
+pub fn read_cache_in_root<T: DeserializeOwned>(config_root: &Path, filename: &str) -> Option<T> {
+    let path = cache_path_in_root(config_root, filename);
     let content = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&content).ok()
 }
@@ -48,10 +61,19 @@ pub fn write_cache<T: Serialize>(filename: &str, payload: &T) {
     let Some(path) = cache_path(filename) else {
         return;
     };
+    write_cache_at(&path, payload);
+}
+
+/// [`write_cache`] against an explicitly injected config root.
+pub fn write_cache_in_root<T: Serialize>(config_root: &Path, filename: &str, payload: &T) {
+    write_cache_at(&cache_path_in_root(config_root, filename), payload);
+}
+
+fn write_cache_at<T: Serialize>(path: &Path, payload: &T) {
     let Ok(content) = serde_json::to_string_pretty(payload) else {
         return;
     };
-    let _ = std::fs::write(&path, content);
+    let _ = std::fs::write(path, content);
 }
 
 /// Pure time-based freshness check: `now - checked_at < interval_secs`.

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -1085,27 +1085,41 @@ pub(super) fn normalize_missing_path(path: &Path) -> PathBuf {
 }
 
 pub(super) fn metadata_dir() -> Result<PathBuf> {
-    let observation_db = paths::observation_db()?;
-    let data_root = observation_db.parent().ok_or_else(|| {
-        Error::internal_unexpected(format!(
-            "observation database path `{}` has no parent directory",
-            observation_db.display()
-        ))
-    })?;
+    Ok(metadata_dir_in_root(&data_root_of(
+        &paths::observation_db()?,
+    )?))
+}
 
-    Ok(data_root.join("task-worktrees"))
+/// [`metadata_dir`] below an explicitly injected data root.
+pub(super) fn metadata_dir_in_root(data_root: &Path) -> PathBuf {
+    data_root.join("task-worktrees")
 }
 
 pub(super) fn adopted_metadata_dir() -> Result<PathBuf> {
-    let observation_db = paths::observation_db()?;
-    let data_root = observation_db.parent().ok_or_else(|| {
-        Error::internal_unexpected(format!(
-            "observation database path `{}` has no parent directory",
-            observation_db.display()
-        ))
-    })?;
+    Ok(adopted_metadata_dir_in_root(&data_root_of(
+        &paths::observation_db()?,
+    )?))
+}
 
-    Ok(data_root.join("adopted-workspaces"))
+/// [`adopted_metadata_dir`] below an explicitly injected data root.
+pub(super) fn adopted_metadata_dir_in_root(data_root: &Path) -> PathBuf {
+    data_root.join("adopted-workspaces")
+}
+
+/// The data root that owns an observation database file.
+///
+/// Both registries are siblings of the SQLite store, so they are derived from
+/// one resolution rather than each re-resolving the data root.
+fn data_root_of(observation_db: &Path) -> Result<PathBuf> {
+    observation_db
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "observation database path `{}` has no parent directory",
+                observation_db.display()
+            ))
+        })
 }
 
 pub(super) fn record_path(store_dir: &Path, id: &str) -> PathBuf {


### PR DESCRIPTION
> **Stacked on #12632** (`fix/7505-roots-paths`) — it consumes the `_in_root` siblings that PR adds. Rebased onto it; the duplicate `homeboy-paths` additions this branch originally carried were dropped in favour of #12632's, and **all call sites verified to resolve against that API**.

## Summary

~50 ambient reaches across `homeboy-core`, excluding `observation/` (owned by #12634).

| module | rooted | hops |
|---|---|---|
| `runtime_package.rs` | `refresh`, `refresh_shared_assets` → `_in_root` → `_locked_in_root` → `bootstrap_stable_runtime_boundary` → `seed_generation` → `seed_legacy_generation` | **5** |
| `defaults/io.rs` | all 6 public + 2 private | 1 |
| `cleanup.rs` | 3 retention entry points | 2 |
| `daemon/patch_capture.rs` | `capture_baseline`, `capture_patch_report` | 2 |
| `daemon/artifact_download.rs`, `http_api.rs` | `safe_artifact_store_path` | 2 |
| `schedule/state.rs` | `load_state`, `save_state`, `remove_state` | 2 |
| `update_check_cache.rs`, `worktree/store_ops.rs`, `broker_auth.rs`, `capacity.rs` | 1 each | 1 |

**Not reached:** `notify_outbox`, `engine/invocation`, `engine/temp`, `config::ConfigEntity`, `extension_store`, `component/inventory`, `project/`, `deps_provider`, `source_snapshot`.

## Five split-home hazards, all fixed

<callout accent="#ef4444">
**`publication_artifacts.rs:28`** took an **injected** `ObservationStore`, then resolved `paths::artifact_root()` ambiently. But `observation/store/artifacts.rs:879,1126` *persists* those same artifacts under `self.artifact_root()`.

A store on an explicit root **wrote to one installation and read from another, reporting existing artifacts as `Missing`.** Same shape as the readiness-probe bug from a prior wave.
</callout>

**The `runtime_package` boundary trio** — `seed_legacy_generation`, `ensure_stable_runtime_boundary`, `recover_boundary_migration` each *already had* a `config_root` and then resolved `legacy_agent_runtimes()` ambiently for the directory they rename/back up/restore. `recover` derives its `config_root` from `store.parent()`, so **a crash recovery could restore a backup recorded in installation A over installation B's live boundary.**

**`cleanup` retention** — reclaim roots injected, but the cross-process `FsIndexLock` root ambient. Two passes over the *same* repo roots could lock in two installations and **not exclude each other**.

Plus `runtime_package::refresh` (lock and generations under two separate resolves) and `patch_capture` (scratch dir and published `.diff` resolved independently inside one capture).

## What `entity_crud!` blocked — precisely

`config.rs:1489` generates `load`/`save`/`list`/`delete`/`exists`/`create`/`rename`/`merge`, all funnelling into `config::load::<T>` → `T::config_path(id)` → `T::config_dir()` → `paths::homeboy()`.

Rooting it needs **four coordinated things**: rooted trait defaults, a rooted override for *every* implementor (`extension_store.rs:678`, `project/mod.rs:196`, `schedule/entity.rs:27`, and `homeboy-tunnel/src/entity.rs:47` — a different crate), a rooted generic CRUD surface, and rooted macro arms.

> Rooting the trait default while any override stayed ambient produces **precisely the same-kind shadowing #12595 found** — a sibling that ignores the root it was handed, invisible to the #12591 scanner. Stopped rather than guess.

## Notable unclosed reaches

- **`api_jobs/store/mod.rs:2501`** — releases a daemon workspace-owner lease by rebuilding `"daemon-workspace-claims"` from a **duplicated string literal** and a separately resolved ambient data root, while the lease was *registered* through `daemon_workspace_claim_store()`. `JobStore` carries no root to thread.
- **48 call sites** across `daemon_workspace_claim_store()` (33) and `workspace_claim_store()` (15) — every register/renew/release resolves independently. This is exactly the claim-lease-heartbeat shape from #12628; it only works today because process env is stable. Rooted factories added; the 48 handler sites not migrated.
- `engine/invocation/runtime.rs:147` + `cache_fallback_root` — **deliberately independent**, with an in-code rationale (#11266 regression, `sockaddr_un` budget, "Keep them independent"). Left alone on purpose.
- `daemon/mod.rs:5515` `config_paths_body` — display only, and **deliberately not half-rooted**: four of its ten entries come from the rig-registry and daemon-state root families, so a partially-rooted report would *look* rooted without being it.
- `notify_outbox.rs:218` — 12 call sites across the drain state machine; needs a root threaded through the whole loop.

## Verification

`cargo fmt --all` parses every file. **No newly-introduced duplicate definitions** (diffed against `origin/main`). **No public signature changed** — only private/`pub(super)`. All call sites verified by exact-name grep plus a **bare-function-reference scan over all 20 affected names** (only hit was an unrelated struct-field shorthand).

Subprocess env construction confirmed untouched: `engine/temp`'s `runtime_tmpdir_env()`/`TMPDIR`, `engine/invocation/runtime.rs`'s `HOMEBOY_INVOCATION_RUNTIME_DIR_ENV`/`XDG_CACHE_HOME`/`HOME`, `controller_runtime.rs`'s `TEST_CONTROLLER_RUNTIME_STORE_ENV`, `paths::rig_registry_root`'s `HOMEBOY_RIG_REGISTRY_ROOT`.

Not verified without cargo: ~15 `&PathBuf → &Path` coercions, whether `#[allow(clippy::too_many_arguments, reason = "…")]` on the 8-arg `capture_patch_report_in_root` satisfies clippy, and the closure-lifetime shape in `refresh_in_root`. **Most likely merge-time break: this branch adds three `store.artifact_root()` call sites while #12634 changes that type in parallel.**

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and transitive reach analysis. Review by hand.

Refs #7505
