### PR TITLE
Root the recorded-artifact provider chain

### DIFF
--- a/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
+++ b/crates/homeboy-code-audit/src/detectors/artifact_portability.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::conventions::AuditFinding;
 use crate::findings::{Finding, Severity};
@@ -29,40 +29,38 @@ pub(crate) fn run_with_config(
     component_id: &str,
     config: &ArtifactPortabilityConfig,
 ) -> Vec<Finding> {
-    run_report_with_config(component_id, config).findings
+    run_report_with_config(component_id, config, None).findings
 }
 
-pub(crate) fn run_report(component_id: &str) -> ArtifactPortabilityReport {
-    run_report_with_config(component_id, &ArtifactPortabilityConfig::default())
-}
-
-/// Ambient boundary for the portability scan: resolve the artifact root once,
-/// then run rooted.
-///
-/// The boundary deliberately stops here rather than moving out into
-/// `engine::audit_internal`. The recorded runs this detector scans arrive from
-/// `recorded_artifacts::recent_recorded_runs`, which dispatches through a
-/// process-global provider registry whose only real implementation
-/// (`homeboy_core::observation::audit_artifact_provider`) opens the observation
-/// store from the *ambient* data root. Threading `PathRoots` into the audit
-/// engine would therefore honor an injected artifact root while still reading
-/// an ambient store — the split-home shape this campaign exists to remove
-/// (#7505). Rooting the audit engine has to wait for the provider contract to
-/// carry roots.
-pub(crate) fn run_report_with_config(
+pub(crate) fn run_report(
     component_id: &str,
-    config: &ArtifactPortabilityConfig,
+    artifact_root: Option<&Path>,
 ) -> ArtifactPortabilityReport {
-    let artifact_root = homeboy_paths::artifact_root().ok();
-    run_report_with_config_in_roots(component_id, config, artifact_root.as_deref())
+    run_report_with_config(
+        component_id,
+        &ArtifactPortabilityConfig::default(),
+        artifact_root,
+    )
 }
 
-/// Portability scan against an explicitly supplied artifact root.
+/// Scan a component's recorded runs for non-portable artifact paths.
 ///
-/// `None` retains the historical degrade-to-no-root behavior: without a root
-/// there is no store-anchored exemption, so only relative and non-temp paths
-/// read as portable.
-pub(crate) fn run_report_with_config_in_roots(
+/// `artifact_root` is the caller's injected artifact root. Pass `Some` ONLY
+/// when the recorded-artifact provider was registered against the same roots
+/// (`audit_artifact_provider::register_in_roots`); an injected root paired with
+/// an ambiently-registered provider compares one home's paths against another
+/// home's root and flags every stored artifact as non-portable (#7505).
+///
+/// `None` — the current behavior at every call site — takes the root from the
+/// provider that supplied the runs, so the two can never disagree. It is NOT
+/// "resolve it ambiently": this detector no longer reads process-global path
+/// state at all.
+///
+/// If neither the caller nor the provider can name a root, the scan DEGRADES:
+/// root-anchored paths simply lose their exemption and the remaining
+/// heuristics (relative, runner-artifact ref, runtime-temp markers) decide. It
+/// never becomes an error.
+pub(crate) fn run_report_with_config(
     component_id: &str,
     config: &ArtifactPortabilityConfig,
     artifact_root: Option<&Path>,
@@ -75,10 +73,12 @@ pub(crate) fn run_report_with_config_in_roots(
         run_window,
         ..Default::default()
     };
-    let runs = crate::recorded_artifacts::recent_recorded_runs(component_id, run_window);
+    let scan = crate::recorded_artifacts::recent_recorded_run_scan(component_id, run_window);
+    let artifact_root: Option<PathBuf> =
+        artifact_root.map(Path::to_path_buf).or(scan.artifact_root);
     let path_policy = config.with_generic_defaults();
 
-    for run in runs {
+    for run in scan.runs {
         report.runs_scanned += 1;
         let artifacts = &run.artifacts;
         report.artifacts_scanned += artifacts.len();
@@ -90,13 +90,17 @@ pub(crate) fn run_report_with_config_in_roots(
             if artifact.artifact_type != "file" && artifact.artifact_type != "directory" {
                 continue;
             }
-            if artifact_path_is_portable(&artifact.path, artifact_root, &path_policy) {
+            if artifact_path_is_portable(&artifact.path, artifact_root.as_deref(), &path_policy) {
                 continue;
             }
             report.findings.push(artifact_path_finding(&run, artifact));
         }
-        let metadata_scan =
-            metadata_path_findings(&run, &artifact_paths, artifact_root, &path_policy);
+        let metadata_scan = metadata_path_findings(
+            &run,
+            &artifact_paths,
+            artifact_root.as_deref(),
+            &path_policy,
+        );
         report.metadata_fields_scanned += metadata_scan.fields_scanned;
         report.findings.extend(metadata_scan.findings);
     }
@@ -342,6 +346,157 @@ mod tests {
         ArtifactRecord, NewRunRecord, ObservationStore, RunListFilter,
     };
     use homeboy_core::test_support::with_isolated_home;
+    use std::path::{Path, PathBuf};
+
+    /// One synthetic recorded run holding `artifact_path`, but only for
+    /// component `demo`.
+    ///
+    /// The component filter is not decoration. A registered provider outlives
+    /// the test that installed it — there is no unregister — so an unfiltered
+    /// provider would feed a fabricated run to every later test in this binary
+    /// that audits any component. Scoping to `demo` makes these providers
+    /// indistinguishable from the no-op for everyone else.
+    fn synthetic_runs(component_id: &str, artifact_path: &str) -> Vec<AuditRecordedRun> {
+        if component_id != "demo" {
+            return Vec::new();
+        }
+        vec![AuditRecordedRun {
+            id: "run-1".to_string(),
+            command: Some("homeboy test demo".to_string()),
+            metadata_json: serde_json::json!({}),
+            artifacts: vec![AuditRecordedArtifact {
+                id: "artifact-1".to_string(),
+                kind: "results".to_string(),
+                artifact_type: "file".to_string(),
+                path: artifact_path.to_string(),
+            }],
+        }]
+    }
+
+    /// Provider that reports a fixed artifact root and one recorded run whose
+    /// artifact sits under it. No store, no ambient state — which is the point:
+    /// it isolates "where does the detector get its root from?" (#7505).
+    struct RootedProvider {
+        artifact_root: PathBuf,
+        artifact_path: String,
+    }
+
+    impl RootedProvider {
+        fn under_root(artifact_root: PathBuf) -> Self {
+            let artifact_path = artifact_root
+                .join("run-1/results.json")
+                .to_string_lossy()
+                .into_owned();
+            Self {
+                artifact_root,
+                artifact_path,
+            }
+        }
+    }
+
+    impl AuditRecordedArtifactProvider for RootedProvider {
+        fn recent_runs(&self, component_id: &str, _limit: usize) -> Vec<AuditRecordedRun> {
+            synthetic_runs(component_id, &self.artifact_path)
+        }
+
+        fn artifact_root(&self) -> Option<PathBuf> {
+            Some(self.artifact_root.clone())
+        }
+    }
+
+    /// Same runs, but the root is unresolvable. Exercises the degrade path.
+    struct RootlessProvider {
+        artifact_path: String,
+    }
+
+    impl AuditRecordedArtifactProvider for RootlessProvider {
+        fn recent_runs(&self, component_id: &str, _limit: usize) -> Vec<AuditRecordedRun> {
+            synthetic_runs(component_id, &self.artifact_path)
+        }
+
+        fn artifact_root(&self) -> Option<PathBuf> {
+            None
+        }
+    }
+
+    /// With no injected root the detector anchors on the root the PROVIDER
+    /// reports, so an artifact under an injected home reads as portable even
+    /// though it is nowhere near the ambient artifact root. Before #7505 this
+    /// compared against `homeboy_paths::artifact_root()` and flagged it.
+    ///
+    /// Wrapped in `with_isolated_home` purely for the serialization it provides:
+    /// the recorded-artifact registry is process-global, so two tests
+    /// registering different providers concurrently would stomp each other.
+    #[test]
+    fn anchors_on_the_root_reported_by_the_provider() {
+        with_isolated_home(|_| {
+            let artifact_root = PathBuf::from("/injected-home/artifacts");
+            register_audit_recorded_artifact_provider(Box::new(RootedProvider::under_root(
+                artifact_root.clone(),
+            )));
+
+            assert!(super::run_report("demo", None).findings.is_empty());
+        });
+    }
+
+    /// Injecting the same root the provider is rooted on agrees with it. This
+    /// is the supported way to hand `artifact_portability` an injected root.
+    #[test]
+    fn injected_root_matching_the_provider_agrees_with_it() {
+        with_isolated_home(|_| {
+            let artifact_root = PathBuf::from("/injected-home/artifacts");
+            register_audit_recorded_artifact_provider(Box::new(RootedProvider::under_root(
+                artifact_root.clone(),
+            )));
+
+            assert!(super::run_report("demo", Some(artifact_root.as_path()))
+                .findings
+                .is_empty());
+        });
+    }
+
+    /// Injecting a root the provider does not share is the misuse the docs warn
+    /// about, and it still reads every stored artifact as non-portable. Pinned
+    /// so the failure mode stays visible rather than becoming folklore: the fix
+    /// is to register the provider `_in_roots`, not to change this detector.
+    #[test]
+    fn injected_root_disagreeing_with_the_provider_flags_everything() {
+        with_isolated_home(|_| {
+            register_audit_recorded_artifact_provider(Box::new(RootedProvider::under_root(
+                PathBuf::from("/injected-home/artifacts"),
+            )));
+
+            let report = super::run_report("demo", Some(Path::new("/other-home/artifacts")));
+
+            assert_eq!(report.findings.len(), 1);
+            assert_eq!(
+                report.findings[0].kind,
+                AuditFinding::NonPortableArtifactPath
+            );
+        });
+    }
+
+    /// An unresolvable artifact root DEGRADES the scan: the root-anchored
+    /// exemption is simply unavailable and the remaining heuristics decide. It
+    /// is never an error, and the report is still produced.
+    #[test]
+    fn unresolvable_artifact_root_degrades_instead_of_failing() {
+        with_isolated_home(|_| {
+            register_audit_recorded_artifact_provider(Box::new(RootlessProvider {
+                artifact_path: "/injected-home/artifacts/run-1/results.json".to_string(),
+            }));
+            let absolute = super::run_report("demo", None);
+            assert_eq!(absolute.runs_scanned, 1);
+            assert_eq!(absolute.findings.len(), 1);
+
+            register_audit_recorded_artifact_provider(Box::new(RootlessProvider {
+                artifact_path: "artifacts/run-1/results.json".to_string(),
+            }));
+            let relative = super::run_report("demo", None);
+            assert_eq!(relative.runs_scanned, 1);
+            assert!(relative.findings.is_empty());
+        });
+    }
 
     /// Store-backed recorded-artifact provider registered directly into the audit
     /// crate's own registry, so these in-crate tests read from the same static
@@ -388,6 +543,12 @@ mod tests {
                     }
                 })
                 .collect()
+        }
+
+        /// This provider opens the store ambiently, so its root is the ambient
+        /// one — the same root the runs it just returned were written under.
+        fn artifact_root(&self) -> Option<PathBuf> {
+            homeboy_paths::artifact_root().ok()
         }
     }
 
@@ -741,7 +902,7 @@ mod tests {
             }
 
             register_store_artifact_provider();
-            let report = super::run_report("demo");
+            let report = super::run_report("demo", None);
 
             assert_eq!(report.run_window, DEFAULT_OBSERVATION_RUN_WINDOW);
             assert_eq!(report.runs_scanned, 60);
@@ -790,6 +951,7 @@ mod tests {
                     observation_run_window: Some(2),
                     ..Default::default()
                 },
+                None,
             );
 
             assert_eq!(report.run_window, 2);

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -856,6 +856,13 @@ struct ArtifactPortabilityUnit {
 /// concurrently with the other detector families. The scan-statistics logging
 /// stays with the caller, which is what keeps the log lines in their original
 /// order.
+///
+/// The `None` artifact root is not a gap: the engine holds no injected roots
+/// yet, and `None` makes the detector anchor on the root reported by the
+/// recorded-artifact provider that supplied the runs. When `audit_internal`
+/// grows a `PathRoots`, pass `Some(roots.artifacts())` here — and register the
+/// provider with `audit_artifact_provider::register_in_roots` for the same
+/// roots, or the two halves disagree (#7505).
 fn run_artifact_portability(
     plan: &AuditExecutionPlan,
     component_id: &str,
@@ -866,11 +873,12 @@ fn run_artifact_portability(
         plan.detector_enabled("artifact_portability"),
         || {
             if audit_config.artifact_portability.is_empty() {
-                artifact_portability::run_report(component_id)
+                artifact_portability::run_report(component_id, None)
             } else {
                 artifact_portability::run_report_with_config(
                     component_id,
                     &audit_config.artifact_portability,
+                    None,
                 )
             }
         },
@@ -939,18 +947,20 @@ fn audit_root_only(
     );
 
     // `artifact_portability` stays hand-sequenced (logs scan statistics even
-    // when empty), mirroring the full path.
+    // when empty), mirroring the full path. See `run_artifact_portability` for
+    // why the artifact root is `None` here.
     let artifact_portability_report = time_audit_detector(
         timing,
         "detector.artifact_portability",
         plan.detector_enabled("artifact_portability"),
         || {
             if audit_config.artifact_portability.is_empty() {
-                artifact_portability::run_report(component_id)
+                artifact_portability::run_report(component_id, None)
             } else {
                 artifact_portability::run_report_with_config(
                     component_id,
                     &audit_config.artifact_portability,
+                    None,
                 )
             }
         },

--- a/crates/homeboy-code-audit/src/recorded_artifacts.rs
+++ b/crates/homeboy-code-audit/src/recorded_artifacts.rs
@@ -13,6 +13,18 @@
 //! evidence provider hooks). When no provider is registered — e.g. audit running
 //! standalone — the no-op provider yields no runs, which the detector already
 //! treats as "nothing recorded to check".
+//!
+//! # Rooting (#7505)
+//!
+//! The runs a provider returns and the artifact root those runs' paths are
+//! anchored to are ONE fact, not two. A detector that reads runs from here and
+//! separately resolves `homeboy_paths::artifact_root()` compares an injected
+//! root against an ambiently-read store the moment anything upstream is rooted
+//! — and then every stored artifact reads as non-portable. So the provider
+//! answers both, and `RecordedRunScan` carries them out of a single registry
+//! acquisition so they cannot be torn apart by a concurrent re-register.
+
+use std::path::PathBuf;
 
 /// A recorded artifact, projected to what the portability detector needs.
 #[derive(Debug, Clone, Default)]
@@ -39,6 +51,25 @@ pub trait AuditRecordedArtifactProvider: Send + Sync {
     /// Return the most recent recorded runs (with their artifacts) for a
     /// component, newest first, up to `limit`.
     fn recent_runs(&self, component_id: &str, limit: usize) -> Vec<AuditRecordedRun>;
+
+    /// The artifact root the runs returned by [`Self::recent_runs`] are indexed
+    /// against, or `None` when it cannot be resolved.
+    ///
+    /// Deliberately has no default implementation: an implementor that reads
+    /// runs from a rooted store but lets the detector fall back to the ambient
+    /// root produces the split this method exists to prevent, and a defaulted
+    /// `None` would let that mistake compile (#7505).
+    ///
+    /// `None` is a real answer — "I cannot resolve one" — and the detector
+    /// degrades on it rather than failing.
+    fn artifact_root(&self) -> Option<PathBuf>;
+}
+
+/// Runs plus the artifact root they are anchored to, read from one provider in
+/// one registry acquisition. See the module docs for why these travel together.
+pub(crate) struct RecordedRunScan {
+    pub(crate) runs: Vec<AuditRecordedRun>,
+    pub(crate) artifact_root: Option<PathBuf>,
 }
 
 /// Default provider used when no observation layer is registered: no recorded
@@ -49,6 +80,12 @@ struct NoopProvider;
 impl AuditRecordedArtifactProvider for NoopProvider {
     fn recent_runs(&self, _component_id: &str, _limit: usize) -> Vec<AuditRecordedRun> {
         Vec::new()
+    }
+
+    /// No runs, so no root to anchor them to. The detector never consults this
+    /// because the run list it accompanies is empty.
+    fn artifact_root(&self) -> Option<PathBuf> {
+        None
     }
 }
 
@@ -63,10 +100,17 @@ homeboy_engine_primitives::provider_registry! {
     with: fn with_provider,
 }
 
-/// Recent recorded runs (with artifacts) for a component via the registered
-/// provider.
-pub(crate) fn recent_recorded_runs(component_id: &str, limit: usize) -> Vec<AuditRecordedRun> {
-    with_provider(|p| p.recent_runs(component_id, limit))
+/// Recent recorded runs (with artifacts) for a component, plus the artifact
+/// root they are anchored to, via the registered provider.
+///
+/// Both come from ONE `with_provider` call: two calls could straddle a
+/// `register_audit_recorded_artifact_provider` from another thread and pair one
+/// provider's runs with another provider's root.
+pub(crate) fn recent_recorded_run_scan(component_id: &str, limit: usize) -> RecordedRunScan {
+    with_provider(|p| RecordedRunScan {
+        runs: p.recent_runs(component_id, limit),
+        artifact_root: p.artifact_root(),
+    })
 }
 
 #[cfg(test)]
@@ -77,5 +121,10 @@ mod tests {
     fn noop_provider_yields_no_runs() {
         let noop = NoopProvider;
         assert!(noop.recent_runs("any", 10).is_empty());
+    }
+
+    #[test]
+    fn noop_provider_resolves_no_artifact_root() {
+        assert!(NoopProvider.artifact_root().is_none());
     }
 }

--- a/crates/homeboy-core/src/observation/audit_artifact_provider.rs
+++ b/crates/homeboy-core/src/observation/audit_artifact_provider.rs
@@ -6,6 +6,21 @@
 //! artifacts, and projecting each into the slim view audit's portability
 //! detector needs. It is registered at binary startup by the CLI, mirroring the
 //! manifest / runner-evidence provider hooks.
+//!
+//! # Rooting (#7505)
+//!
+//! The registry itself stays process-global: it exists so the observation layer
+//! can be swapped in at startup, and nothing about that is ambient state. What
+//! WAS ambient is the value registered into it — a unit struct that reopened
+//! `ObservationStore::open_initialized()` on every call. So the roots live on
+//! the registered provider instead: [`register_in_roots`] pins one
+//! [`PathRoots`], and both halves of the answer (the runs and the artifact root
+//! they are anchored to) then come from that same value.
+
+use std::path::PathBuf;
+
+use crate::paths::PathRoots;
+use crate::Result;
 
 use crate::code_audit::recorded_artifacts::{
     register_audit_recorded_artifact_provider, AuditRecordedArtifact,
@@ -13,11 +28,33 @@ use crate::code_audit::recorded_artifacts::{
 };
 use crate::observation::{ObservationStore, RunListFilter};
 
-struct StoreArtifactProvider;
+/// Store-backed provider, optionally pinned to injected roots.
+///
+/// `roots: None` is the ambient boundary and is what the CLI registers today.
+/// `roots: Some(_)` reads runs from the database under `roots.data()` and
+/// reports `roots.artifacts()` as the artifact root, so a caller auditing an
+/// injected home never mixes the two.
+struct StoreArtifactProvider {
+    roots: Option<PathRoots>,
+}
+
+impl StoreArtifactProvider {
+    /// Open the store this provider reads from, honoring its pinned roots.
+    ///
+    /// `open_initialized_in_roots` roots BOTH the database and artifact
+    /// resolution, so a rooted provider cannot end up indexing an injected
+    /// artifact tree with an ambient database (or vice versa).
+    fn open_store(&self) -> Result<ObservationStore> {
+        match &self.roots {
+            Some(roots) => ObservationStore::open_initialized_in_roots(roots),
+            None => ObservationStore::open_initialized(),
+        }
+    }
+}
 
 impl AuditRecordedArtifactProvider for StoreArtifactProvider {
     fn recent_runs(&self, component_id: &str, limit: usize) -> Vec<AuditRecordedRun> {
-        let Ok(store) = ObservationStore::open_initialized() else {
+        let Ok(store) = self.open_store() else {
             return Vec::new();
         };
         let Ok(runs) = store.list_runs(RunListFilter {
@@ -53,10 +90,45 @@ impl AuditRecordedArtifactProvider for StoreArtifactProvider {
             })
             .collect()
     }
+
+    /// The artifact root the runs from [`Self::recent_runs`] are anchored to.
+    ///
+    /// A rooted provider answers from its own `PathRoots` — the identical value
+    /// `open_store` hands `ObservationStore::open_initialized_in_roots`, which
+    /// is in turn exactly what `ObservationStore::artifact_root()` would report
+    /// for that store. Resolving it here avoids a second store open (and its
+    /// startup artifact maintenance) purely to read a path back out.
+    ///
+    /// An ambient provider answers from `paths::artifact_root()`, which is
+    /// verbatim the fallback an ambiently-opened `ObservationStore` uses, so
+    /// this stays the root the runs were actually written under.
+    ///
+    /// `None` (unresolvable ambient root) is a degrade signal, not an error:
+    /// the detector drops the root-anchored exemption and keeps scanning.
+    fn artifact_root(&self) -> Option<PathBuf> {
+        match &self.roots {
+            Some(roots) => Some(roots.artifacts().to_path_buf()),
+            None => crate::paths::artifact_root().ok(),
+        }
+    }
 }
 
-/// Register the observation-backed recorded-artifact provider. Called once at
-/// binary startup by the CLI.
+/// Register the observation-backed recorded-artifact provider against the
+/// ambient path boundary. Called once at binary startup by the CLI.
 pub fn register() {
-    register_audit_recorded_artifact_provider(Box::new(StoreArtifactProvider));
+    register_audit_recorded_artifact_provider(Box::new(StoreArtifactProvider { roots: None }));
+}
+
+/// Register the observation-backed recorded-artifact provider against injected
+/// roots.
+///
+/// This is the counterpart a caller must use before handing
+/// `artifact_portability` an injected artifact root: the detector's root and
+/// the store the runs come from then derive from the same `PathRoots`, instead
+/// of comparing an injected root against an ambient database — which would flag
+/// every recorded artifact as non-portable (#7505).
+pub fn register_in_roots(roots: &PathRoots) {
+    register_audit_recorded_artifact_provider(Box::new(StoreArtifactProvider {
+        roots: Some(roots.clone()),
+    }));
 }


### PR DESCRIPTION
## Summary

The `provider_registry!` chain that blocked the audit engine. Prior waves scoped it precisely:

> If someone threads `PathRoots` into `engine::audit_internal`, `artifact_portability` would compare recorded artifact paths against an **injected** artifact root while `recent_recorded_runs` reads the **ambient** observation store — so **every artifact from the real store reads as non-portable**.

All three required pieces are done: **(a)** `StoreArtifactProvider` is a roots-carrying struct opening via `open_initialized_in_roots`; **(b)** `register_in_roots(&PathRoots)` added; **(c)** the detector takes `Option<&Path>`.

## Can the detector now take an injected root safely? Yes — closed from two directions

(a)+(b)+(c) alone only make it *possible* to get right, not *hard to get wrong*. So:

1. **The provider trait gained a REQUIRED `artifact_root() -> Option<PathBuf>`.** Required, not defaulted — a defaulted `None` would let an implementor read runs from a rooted store while the detector silently fell back to ambient. That is the split.
2. **`recent_recorded_runs` → `recent_recorded_run_scan`**, returning `RecordedRunScan { runs, artifact_root }` from **one** `with_provider` call. Two calls could straddle a re-register and pair one provider's runs with another's root.
3. **The `None` case anchors on the provider's root**, not `homeboy_paths::artifact_root()`. **The detector reads no process-global path state on any path.**

The residual split — injecting a root without rooting the provider — is structurally unavoidable while the registry is global, so it is **pinned by a test** (`injected_root_disagreeing_with_the_provider_flags_everything`) rather than left as folklore. The safe default (`None`) is now the coherent one.

## `provider_registry!` judgments

Read the macro body (`engine-primitives/src/provider_registry.rs:190-232`): it generates a `static Mutex<Option<Box<dyn T>>>`, a `register_*`, and a `with_*` that no-ops. **It carries no path state of its own** — it is a startup swap seam plus a link-time inventory descriptor.

- **`recorded_artifacts` — deliberately global, KEPT global.** The ambient state was never in the slot; it was in the unit struct that reopened `open_initialized()` on every call. Fix = give the registered *value* a roots channel.
- **`extension_manifests.rs:67` and `component_provider.rs:80` — same shape, NOT fixed.** Their impls dispatch to `load_all_extensions`/`component::load`/`resolve_effective`, none of which have rooted siblings. Rooting the registered value would produce exactly the half-injected split this PR removes.

`register()` itself is unchanged: CLI startup wiring (`cli_runtime.rs:200`) has no roots to pass, and `provider_registry_completeness` inventories that registration.

## Degrade-not-fail preserved

`Option` all the way through. `None` only removes the root-anchored exemption; it is never an error, and the report still carries full `runs_scanned`. Pinned by `unresolvable_artifact_root_degrades_instead_of_failing`, asserting both the absolute (1 finding) and relative (0 findings) branches.

## Not closed

- `extension_store.rs:41,57` — behind `extension_manifests` `load_all`/`load`. Config-root, no rooted sibling.
- `component/inventory/listing.rs:445`, `component/resolution.rs:842`, `component/portable.rs:269` — behind `component/audit_provider.rs`. Config-root, no rooted siblings.
- `artifact_portability.rs:187` — `Path::new(field.value).exists()`. **Judged not a root split**: the path comes from the recorded run itself, not a resolver, and the check ("cleanup was promised but the dir is still there") is meaningless against anything but actual disk.

## Verification

`rustfmt --check` parses all four files. Duplicate check: the `artifact_root`/`recent_runs` repeats are **five distinct `impl` blocks** (verified by line number — 408/412, 423/427, 521/560), and `recent_runs` was already duplicated on main. Old name `recent_recorded_runs` gone tree-wide.

Not verified without cargo: type inference on `.map(Path::to_path_buf).or(scan.artifact_root)`; partial moves of `scan.artifact_root` then `scan.runs` (legal for a `Drop`-free struct); and **test logic** — the new tests hard-code `/injected-home/artifacts` and assert against `with_generic_defaults()`; each assertion was traced by hand but none were run.

Registered test providers outlive their test with no unregister; both new ones are scoped to `component_id == "demo"` so they read as the no-op for anyone else.

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and registry analysis. Review by hand.

Refs #7505
