### PR TITLE
Fix the test callers of the renamed prepare

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
@@ -303,16 +303,23 @@ mod tests {
     }
     #[test]
     fn packages_and_reuses_dependency_outputs() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let root = tempfile::tempdir().unwrap();
-            fs::create_dir(root.path().join("deps")).unwrap();
-            fs::write(root.path().join("deps/a"), "ok").unwrap();
-            let first = prepare(root.path(), &plan()).unwrap().unwrap();
-            fs::remove_file(&first.path).unwrap();
-            let second = prepare(root.path(), &plan()).unwrap().unwrap();
-            assert_eq!(first.sha256, second.sha256);
-            assert_eq!(first.path, second.path);
-        });
+        // No `with_isolated_home`: `prepare_in_roots` consults `data_root` for
+        // the package cache and nothing else, so an explicit root is the whole
+        // isolation this test needs. It no longer serializes behind
+        // `home_lock`, which is the point of #7505.
+        let data_root = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("deps")).unwrap();
+        fs::write(root.path().join("deps/a"), "ok").unwrap();
+        let first = prepare_in_roots(data_root.path(), root.path(), &plan())
+            .unwrap()
+            .unwrap();
+        fs::remove_file(&first.path).unwrap();
+        let second = prepare_in_roots(data_root.path(), root.path(), &plan())
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.sha256, second.sha256);
+        assert_eq!(first.path, second.path);
     }
     #[test]
     fn rejects_hash_mismatch() {
@@ -322,8 +329,11 @@ mod tests {
     }
     #[test]
     fn reports_missing_outputs_without_a_package() {
+        let data_root = tempfile::tempdir().unwrap();
         let root = tempfile::tempdir().unwrap();
-        assert!(prepare(root.path(), &plan()).unwrap().is_none());
+        assert!(prepare_in_roots(data_root.path(), root.path(), &plan())
+            .unwrap()
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
<callout accent="#ef4444">
## `main` does not compile under `--tests`

```
error[E0425]: cannot find function `prepare` in this scope   ×3
error: could not compile `homeboy-lab-runner` (lib test)
```

`Workspace Tests Compile` is red on `main` right now. This restores it.
</callout>

## What happened

#12629 renamed `dependency_package::prepare` → `prepare_in_roots` and added a leading `data_root` parameter. Three callers in the **same file's `#[cfg(test)]` module** kept the old name and arity (`dependency_package.rs:310,312,326`).

The rename *was* verified — by a repo-wide grep for the symbol. **That is precisely the check that cannot see this.** The stale callers sit in an inline `#[cfg(test)] mod` inside the file doing the renaming, so they read as ordinary in-scope calls and the grep counted them as the definition's own neighbourhood rather than as callers.

A sweep for functions that exist *only* in an `_in_root`/`_in_roots` spelling while still being called bare returns this one and nothing else, so the blast radius is exactly these three lines.

## Why nothing caught it

The wave was admin-merged during a GitHub incident where every Test shard died at:

```
error downloading homeboy-candidate-binary-1: HTTP 503
  → jq: Could not open file homeboy-test-shard-plan.json
```

The red was read as the incident. **That reading was right about the shards and wrong about the gate** — `Workspace Tests Compile` is a separate job, it ran, and it was failing on the code rather than on artifact downloads.

## The tests do not go back on `with_isolated_home`

`prepare_in_roots` consults `data_root` for `data_root.join("cache/dependency-packages/v1")` and **nothing else**. So a tempdir passed as the root is the entire isolation either test needs, and both now own their package cache explicitly instead of borrowing the process's.

That is the payoff #7505 is after — a test that stops serializing behind `home_lock` because the code under it takes the root as an argument. Restoring the guard to fix a compile error caused by injecting the root would have inverted the point of the change.

Net: **one fewer `with_isolated_home` call site**, and both tests are now hermetic by construction rather than by mutex.

## Verification

`rustfmt --check` parses clean; zero bare `prepare(` callers remain in the file. Not compiled locally — this VPS cannot run cargo (28G `target/` against 21G free), which is the same constraint that produced the original miss. **CI on this PR is the real check, and it is the job that should have gated the original.**

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode, outside the Homeboy control plane
- **Used for:** Diagnosis and fix. Review by hand.

Refs #7505
