### PR TITLE
Root the notify outbox, invocation leases, and runtime manifests

### DIFF
--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -691,26 +691,39 @@ fn runtime_source_description(manifest: &AgentRuntimeManifest) -> String {
 }
 
 fn discover_standalone_agent_runtime_catalog() -> AgentRuntimeDiscoveryCatalog {
-    let mut manifests = Vec::new();
-    let mut diagnostics = Vec::new();
-    if let Ok(runtime_dir) = paths::agent_runtimes() {
-        let catalog = discover_standalone_agent_runtime_catalog_in(
-            runtime_dir,
-            paths::agent_runtime_manifest,
-        );
-        manifests.extend(catalog.manifests);
-        diagnostics.extend(catalog.diagnostics);
-    }
+    let Ok(config_root) = paths::homeboy() else {
+        return AgentRuntimeDiscoveryCatalog::default();
+    };
+    discover_standalone_agent_runtime_catalog_in_root(&config_root)
+}
+
+/// [`discover_standalone_agent_runtime_catalog`] against an already-resolved
+/// config root.
+///
+/// The directory that is *listed* and the manifest paths that are *read* now
+/// come from one root. They previously came from two independent resolutions —
+/// `paths::agent_runtimes()` and the `paths::agent_runtime_manifest` function
+/// pointer — so a repoint between the listing and a manifest read reported a
+/// runtime that exists as missing, or read a manifest belonging to a different
+/// installation than the directory entry it was keyed from (#7505).
+fn discover_standalone_agent_runtime_catalog_in_root(
+    config_root: &Path,
+) -> AgentRuntimeDiscoveryCatalog {
+    let catalog = discover_standalone_agent_runtime_catalog_in(
+        paths::agent_runtimes_in_root(config_root),
+        &|id: &str| paths::agent_runtime_manifest_in_root(config_root, id),
+    );
+    let mut manifests = catalog.manifests;
     manifests.sort_by(|a, b| a.id.cmp(&b.id));
     AgentRuntimeDiscoveryCatalog {
         manifests,
-        diagnostics,
+        diagnostics: catalog.diagnostics,
     }
 }
 
 fn discover_standalone_agent_runtime_catalog_in(
     runtime_dir: PathBuf,
-    manifest_path_for: fn(&str) -> crate::Result<PathBuf>,
+    manifest_path_for: &dyn Fn(&str) -> PathBuf,
 ) -> AgentRuntimeDiscoveryCatalog {
     let Ok(entries) = std::fs::read_dir(runtime_dir) else {
         return AgentRuntimeDiscoveryCatalog::default();
@@ -739,7 +752,7 @@ enum StandaloneAgentRuntimeManifestLoad {
 
 fn load_standalone_agent_runtime_manifest(
     path: &Path,
-    manifest_path_for: fn(&str) -> crate::Result<PathBuf>,
+    manifest_path_for: &dyn Fn(&str) -> PathBuf,
 ) -> StandaloneAgentRuntimeManifestLoad {
     if !path.is_dir() {
         return StandaloneAgentRuntimeManifestLoad::Skipped;
@@ -748,9 +761,11 @@ fn load_standalone_agent_runtime_manifest(
         return StandaloneAgentRuntimeManifestLoad::Skipped;
     };
     let id = file_name.to_string_lossy().to_string();
-    let Ok(manifest_path) = manifest_path_for(&id) else {
-        return StandaloneAgentRuntimeManifestLoad::Skipped;
-    };
+    // Infallible now that the root is supplied: the pre-injection `Skipped`
+    // arm here fired only when home resolution failed *between* listing the
+    // runtime directory and resolving one of its manifests, which is the race
+    // this rooting removes rather than a state to keep handling.
+    let manifest_path = manifest_path_for(&id);
     if !manifest_path.exists() {
         return StandaloneAgentRuntimeManifestLoad::Skipped;
     }

--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -16,7 +16,8 @@ mod child;
 mod errors;
 mod runtime;
 pub use child::{
-    cleanup_invocation_children, cleanup_stale_child_records, register_child_process,
+    cleanup_invocation_children, cleanup_invocation_children_in_root, cleanup_stale_child_records,
+    cleanup_stale_child_records_in_root, register_child_process, register_child_process_in_root,
     InvocationChildGuard, InvocationChildRecord,
 };
 pub use runtime::{
@@ -70,6 +71,14 @@ pub struct InvocationGuard {
     runtime_tmp_dir: PathBuf,
     runtime_tmp_alias: Option<PathBuf>,
     runtime_tmp_pin: Option<super::temp::RuntimeTempPin>,
+    /// The config root this lease was taken in, captured at acquire time.
+    ///
+    /// The lease is a claim/release pair: `acquire` writes it and `Drop`
+    /// removes it. Resolving the root independently at each end lets a repoint
+    /// between them release nothing and leak the lease — which also leaks its
+    /// port range and its named leases for the life of the process, since
+    /// `refresh_lease_index` only reclaims a lease whose *pid* is gone (#7505).
+    config_root: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,9 +113,16 @@ impl InvocationGuard {
     }
 
     pub(crate) fn lease_is_active(invocation_id: &str) -> bool {
-        let Ok(path) = lease_path(invocation_id) else {
+        let Ok(config_root) = paths::homeboy() else {
             return false;
         };
+        Self::lease_is_active_in_root(&config_root, invocation_id)
+    }
+
+    /// [`InvocationGuard::lease_is_active`] against an already-resolved config
+    /// root.
+    pub(crate) fn lease_is_active_in_root(config_root: &Path, invocation_id: &str) -> bool {
+        let path = lease_path_in_root(config_root, invocation_id);
         let Ok(Some(lease)) = decode_lease_file(&path) else {
             return false;
         };
@@ -122,7 +138,16 @@ impl InvocationGuard {
     /// to this invocation lease, and is exported as `TMPDIR` for child tools.
     pub fn acquire(run_dir: &RunDir, requirements: &InvocationRequirements) -> Result<Self> {
         let _ = run_dir; // retained for API compatibility (see doc comment)
-        cleanup_stale_child_records()?;
+
+        // Resolved once and then threaded through every config-rooted step of
+        // this acquire — the child-record sweep, the index lock, the lease
+        // index, and the lease file — and retained on the guard so `Drop`
+        // releases the lease in the same installation it was claimed in.
+        //
+        // The *runtime* root (state/artifact/socket dirs) is deliberately not
+        // derived from this value; see `invocation_runtime_root`.
+        let config_root = paths::homeboy()?;
+        cleanup_stale_child_records_in_root(&config_root)?;
 
         let uuid = uuid::Uuid::new_v4();
         let short = short_invocation_id();
@@ -156,15 +181,15 @@ impl InvocationGuard {
 
         let mut port_base = None;
         let mut port_max = None;
-        let _lock = acquire_invocation_index_lock()?;
-        fs::create_dir_all(invocation_leases_dir()?).map_err(|e| {
+        let _lock = acquire_invocation_index_lock_in_root(&config_root)?;
+        fs::create_dir_all(invocation_leases_dir_in_root(&config_root)).map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to create invocation lease directory: {}",
                 e
             ))
         })?;
-        let live_leases = refresh_lease_index()?;
-        validate_named_leases(&id, &requirements.named_leases)?;
+        let live_leases = refresh_lease_index_in_root(&config_root)?;
+        validate_named_leases_in_root(&config_root, &id, &requirements.named_leases)?;
 
         if let Some(size) = requirements.port_range_size {
             let (base, max) = allocate_port_range(size, &live_leases)?;
@@ -185,9 +210,9 @@ impl InvocationGuard {
             port_max,
             named_leases: requirements.named_leases.clone(),
         };
-        write_lease(&lease)?;
+        write_lease_in_root(&config_root, &lease)?;
         if let Err(error) = run_dir.bind_invocation(&id) {
-            let _ = fs::remove_file(lease_path(&id)?);
+            let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
             return Err(error);
         }
 
@@ -198,7 +223,7 @@ impl InvocationGuard {
             ) {
                 Ok(temp) => temp,
                 Err(error) => {
-                    let _ = fs::remove_file(lease_path(&id)?);
+                    let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
                     let _ = fs::remove_dir_all(&state_dir);
                     let _ = fs::remove_dir_all(&artifact_dir);
                     return Err(error);
@@ -206,7 +231,7 @@ impl InvocationGuard {
             };
         if let Err(error) = super::temp::bind_run_dir_owner(&runtime_tmp_dir, None, Some(&id)) {
             let _ = fs::remove_dir_all(&runtime_tmp_dir);
-            let _ = fs::remove_file(lease_path(&id)?);
+            let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
             let _ = fs::remove_dir_all(&state_dir);
             let _ = fs::remove_dir_all(&artifact_dir);
             return Err(error);
@@ -216,7 +241,7 @@ impl InvocationGuard {
                 Ok(exported) => exported,
                 Err(error) => {
                     let _ = fs::remove_dir_all(&runtime_tmp_dir);
-                    let _ = fs::remove_file(lease_path(&id)?);
+                    let _ = fs::remove_file(lease_path_in_root(&config_root, &id));
                     let _ = fs::remove_dir_all(&state_dir);
                     let _ = fs::remove_dir_all(&artifact_dir);
                     return Err(error);
@@ -238,6 +263,7 @@ impl InvocationGuard {
             runtime_tmp_dir,
             runtime_tmp_alias,
             runtime_tmp_pin: Some(runtime_tmp_pin),
+            config_root,
         })
     }
 
@@ -362,12 +388,12 @@ impl Drop for InvocationGuard {
         let Some(id) = &self.lease_id else {
             return;
         };
-        let Ok(_lock) = acquire_invocation_index_lock() else {
+        // The root captured at acquire, not a fresh resolution: releasing the
+        // lease anywhere other than where it was claimed releases nothing.
+        let Ok(_lock) = acquire_invocation_index_lock_in_root(&self.config_root) else {
             return;
         };
-        let Ok(path) = lease_path(id) else {
-            return;
-        };
+        let path = lease_path_in_root(&self.config_root, id);
         let Ok(Some(lease)) = decode_lease_file(&path) else {
             return;
         };
@@ -407,11 +433,15 @@ fn exported_runtime_tmp_dir(
     Ok((runtime_tmp_dir.to_path_buf(), None))
 }
 
-fn validate_named_leases(invocation_id: &str, wanted: &[String]) -> Result<()> {
+fn validate_named_leases_in_root(
+    config_root: &Path,
+    invocation_id: &str,
+    wanted: &[String],
+) -> Result<()> {
     if wanted.is_empty() {
         return Ok(());
     }
-    for lease in refresh_lease_index()? {
+    for lease in refresh_lease_index_in_root(config_root)? {
         for name in wanted {
             if lease.named_leases.contains(name) {
                 return Err(Error::validation_invalid_argument(
@@ -478,9 +508,9 @@ fn allocate_port_range(size: u16, live_leases: &[InvocationLease]) -> Result<(u1
     ))
 }
 
-fn refresh_lease_index() -> Result<Vec<InvocationLease>> {
+fn refresh_lease_index_in_root(config_root: &Path) -> Result<Vec<InvocationLease>> {
     let mut live = Vec::new();
-    for path in invocation_lease_files()? {
+    for path in invocation_lease_files_in_root(config_root)? {
         let Some(lease) = decode_lease_file(&path)? else {
             continue;
         };
@@ -493,8 +523,8 @@ fn refresh_lease_index() -> Result<Vec<InvocationLease>> {
     Ok(live)
 }
 
-fn invocation_lease_files() -> Result<Vec<PathBuf>> {
-    let dir = invocation_leases_dir()?;
+fn invocation_lease_files_in_root(config_root: &Path) -> Result<Vec<PathBuf>> {
+    let dir = invocation_leases_dir_in_root(config_root);
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -557,11 +587,11 @@ fn json_excerpt(content: &str) -> String {
     content.chars().take(200).collect()
 }
 
-fn write_lease(lease: &InvocationLease) -> Result<()> {
+fn write_lease_in_root(config_root: &Path, lease: &InvocationLease) -> Result<()> {
     let json = serde_json::to_string_pretty(lease).map_err(|e| {
         Error::internal_unexpected(format!("Failed to serialize invocation lease: {}", e))
     })?;
-    fs::write(lease_path(&lease.invocation_id)?, json).map_err(|e| {
+    fs::write(lease_path_in_root(config_root, &lease.invocation_id), json).map_err(|e| {
         Error::internal_unexpected(format!(
             "Failed to write invocation lease for '{}': {}",
             lease.invocation_id, e
@@ -569,15 +599,17 @@ fn write_lease(lease: &InvocationLease) -> Result<()> {
     })
 }
 
-fn lease_path(invocation_id: &str) -> Result<PathBuf> {
-    Ok(invocation_leases_dir()?.join(format!(
+/// Lease file below an already-resolved config root.
+fn lease_path_in_root(config_root: &Path, invocation_id: &str) -> PathBuf {
+    invocation_leases_dir_in_root(config_root).join(format!(
         "{}.json",
         paths::sanitize_path_segment(invocation_id)
-    )))
+    ))
 }
 
-fn invocation_leases_dir() -> Result<PathBuf> {
-    Ok(paths::homeboy()?.join("invocation-leases"))
+/// Lease index directory below an already-resolved config root.
+fn invocation_leases_dir_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("invocation-leases")
 }
 
 type InvocationIndexLock = FsIndexLock;
@@ -587,8 +619,11 @@ type InvocationIndexLock = FsIndexLock;
 /// Mechanics (mkdir-lock, mtime stale reclaim, the shared 30s/100-attempt/20ms
 /// tuning) live in `homeboy_engine_primitives::fs_index_lock`, which
 /// `homeboy-rig`'s lease index also uses.
-fn acquire_invocation_index_lock() -> Result<InvocationIndexLock> {
-    FsIndexLock::acquire_in(&invocation_leases_dir()?, INVOCATION_INDEX_LOCK)
+fn acquire_invocation_index_lock_in_root(config_root: &Path) -> Result<InvocationIndexLock> {
+    FsIndexLock::acquire_in(
+        &invocation_leases_dir_in_root(config_root),
+        INVOCATION_INDEX_LOCK,
+    )
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/engine/invocation/child.rs
+++ b/crates/homeboy-core/src/engine/invocation/child.rs
@@ -43,7 +43,28 @@ pub fn register_child_process(
     pgid: Option<i32>,
     command_label: String,
 ) -> Result<InvocationChildGuard> {
-    let dir = InvocationChildRecord::children_dir(invocation_id)?;
+    register_child_process_in_root(
+        &paths::homeboy()?,
+        invocation_id,
+        root_pid,
+        pgid,
+        command_label,
+    )
+}
+
+/// [`register_child_process`] against an already-resolved config root.
+///
+/// The guard retains the *resolved* record path, so release is already
+/// root-stable: `Drop` removes the file this call created rather than
+/// re-deriving one.
+pub fn register_child_process_in_root(
+    config_root: &Path,
+    invocation_id: &str,
+    root_pid: u32,
+    pgid: Option<i32>,
+    command_label: String,
+) -> Result<InvocationChildGuard> {
+    let dir = InvocationChildRecord::children_dir_in_root(config_root, invocation_id);
     fs::create_dir_all(&dir).map_err(|e| {
         Error::internal_io(
             format!(
@@ -67,7 +88,7 @@ pub fn register_child_process(
         pgid,
         started_at: chrono::Utc::now().to_rfc3339(),
     };
-    let path = InvocationChildRecord::record_path(invocation_id, root_pid)?;
+    let path = InvocationChildRecord::record_path_in_root(config_root, invocation_id, root_pid);
     let json = serde_json::to_string_pretty(&record).map_err(|e| {
         Error::internal_unexpected(format!(
             "Failed to serialize invocation child record: {}",
@@ -89,8 +110,16 @@ pub fn register_child_process(
 }
 
 pub fn cleanup_invocation_children(invocation_id: &str) -> Result<usize> {
+    cleanup_invocation_children_in_root(&paths::homeboy()?, invocation_id)
+}
+
+/// [`cleanup_invocation_children`] against an already-resolved config root.
+pub fn cleanup_invocation_children_in_root(
+    config_root: &Path,
+    invocation_id: &str,
+) -> Result<usize> {
     let mut cleaned = 0;
-    for path in InvocationChildRecord::files_for_invocation(invocation_id)? {
+    for path in InvocationChildRecord::files_for_invocation_in_root(config_root, invocation_id)? {
         let Some(record) = InvocationChildRecord::decode(&path)? else {
             continue;
         };
@@ -103,8 +132,13 @@ pub fn cleanup_invocation_children(invocation_id: &str) -> Result<usize> {
 }
 
 pub fn cleanup_stale_child_records() -> Result<usize> {
+    cleanup_stale_child_records_in_root(&paths::homeboy()?)
+}
+
+/// [`cleanup_stale_child_records`] against an already-resolved config root.
+pub fn cleanup_stale_child_records_in_root(config_root: &Path) -> Result<usize> {
     let mut cleaned = 0;
-    let root = InvocationChildRecord::root()?;
+    let root = InvocationChildRecord::root_in_root(config_root);
     if !root.exists() {
         return Ok(0);
     }
@@ -143,20 +177,35 @@ pub fn cleanup_stale_child_records() -> Result<usize> {
 }
 
 impl InvocationChildRecord {
-    fn root() -> Result<PathBuf> {
-        Ok(paths::homeboy()?.join(CHILD_RECORD_DIR))
+    /// Child-record root below an already-resolved config root.
+    fn root_in_root(config_root: &Path) -> PathBuf {
+        config_root.join(CHILD_RECORD_DIR)
     }
 
-    pub(crate) fn children_dir(invocation_id: &str) -> Result<PathBuf> {
-        Ok(Self::root()?.join(paths::sanitize_path_segment(invocation_id)))
+    /// Per-invocation child-record directory below an already-resolved config
+    /// root.
+    ///
+    /// There is deliberately no ambient sibling: every caller either already
+    /// holds the root it registered under, or is the ambient wrapper that
+    /// resolved it once for the whole operation.
+    pub(crate) fn children_dir_in_root(config_root: &Path, invocation_id: &str) -> PathBuf {
+        Self::root_in_root(config_root).join(paths::sanitize_path_segment(invocation_id))
     }
 
-    pub(crate) fn record_path(invocation_id: &str, root_pid: u32) -> Result<PathBuf> {
-        Ok(Self::children_dir(invocation_id)?.join(format!("{}.json", root_pid)))
+    /// One child record below an already-resolved config root.
+    pub(crate) fn record_path_in_root(
+        config_root: &Path,
+        invocation_id: &str,
+        root_pid: u32,
+    ) -> PathBuf {
+        Self::children_dir_in_root(config_root, invocation_id).join(format!("{}.json", root_pid))
     }
 
-    fn files_for_invocation(invocation_id: &str) -> Result<Vec<PathBuf>> {
-        Self::files_in_dir(&Self::children_dir(invocation_id)?)
+    fn files_for_invocation_in_root(
+        config_root: &Path,
+        invocation_id: &str,
+    ) -> Result<Vec<PathBuf>> {
+        Self::files_in_dir(&Self::children_dir_in_root(config_root, invocation_id))
     }
 
     fn files_in_dir(dir: &Path) -> Result<Vec<PathBuf>> {
@@ -294,7 +343,8 @@ mod audit_coverage_tests {
     #[test]
     fn test_children_dir() {
         with_isolated_home(|_| {
-            let dir = InvocationChildRecord::children_dir("inv/../audit").expect("children dir");
+            let config_root = crate::paths::homeboy().expect("config root");
+            let dir = InvocationChildRecord::children_dir_in_root(&config_root, "inv/../audit");
 
             assert!(dir.ends_with("inv____audit"));
         });
@@ -303,9 +353,10 @@ mod audit_coverage_tests {
     #[test]
     fn test_record_path() {
         with_isolated_home(|_| {
-            let dir = InvocationChildRecord::children_dir("inv/../audit").expect("children dir");
+            let config_root = crate::paths::homeboy().expect("config root");
+            let dir = InvocationChildRecord::children_dir_in_root(&config_root, "inv/../audit");
             let path =
-                InvocationChildRecord::record_path("inv/../audit", 1234).expect("record path");
+                InvocationChildRecord::record_path_in_root(&config_root, "inv/../audit", 1234);
 
             assert_eq!(
                 path.file_name().and_then(|name| name.to_str()),

--- a/crates/homeboy-core/src/notify_outbox.rs
+++ b/crates/homeboy-core/src/notify_outbox.rs
@@ -40,6 +40,20 @@
 //! re-announce it. The entry records the [`NotifyOnceMarker`] it consumed as
 //! provenance — so a dead letter names the claim it holds — not as something
 //! the outbox later settles.
+//!
+//! # Filesystem roots
+//!
+//! Every entry point comes in a pair: an ambient one that resolves the config
+//! root from the process environment, and an `_in_root` sibling that takes an
+//! already-resolved one (#7505). The ambient wrapper resolves *once* and then
+//! threads that value, so a single drain pass cannot claim an entry in one
+//! installation and reschedule or dead-letter it in another — which would
+//! strand the entry in the first installation's `inflight/` until the reclaim
+//! window elapsed, exactly the loss this module exists to prevent.
+//!
+//! The transport an attempt is delivered through is *not* rooted here: it comes
+//! from the notification-transport registry that `notify::dispatch` resolves,
+//! which is config/extension-store state rather than queue state.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -214,22 +228,44 @@ impl NotifyOutboxDrainReport {
 // Paths
 // ---------------------------------------------------------------------------
 
-fn outbox_root() -> Option<PathBuf> {
-    crate::paths::homeboy()
-        .ok()
-        .map(|home| home.join("notify-outbox"))
+/// The queue directory below an already-resolved *config* root.
+fn outbox_root_in_root(config_root: &Path) -> PathBuf {
+    config_root.join("notify-outbox")
+}
+
+fn pending_dir_in_root(config_root: &Path) -> PathBuf {
+    outbox_root_in_root(config_root).join("pending")
+}
+
+fn inflight_dir_in_root(config_root: &Path) -> PathBuf {
+    outbox_root_in_root(config_root).join("inflight")
+}
+
+fn dead_letter_dir_in_root(config_root: &Path) -> PathBuf {
+    outbox_root_in_root(config_root).join("dead-letter")
+}
+
+/// The config root the ambient wrappers hang from.
+///
+/// `None` is "no queue is reachable", which every ambient entry point already
+/// degrades to a dropped notification rather than an error (see the module
+/// header). It is resolved once per public call and then threaded, so a single
+/// drain pass cannot claim an entry in one installation and release it in
+/// another.
+fn ambient_config_root() -> Option<PathBuf> {
+    crate::paths::homeboy().ok()
 }
 
 fn pending_dir() -> Option<PathBuf> {
-    outbox_root().map(|root| root.join("pending"))
+    Some(pending_dir_in_root(&ambient_config_root()?))
 }
 
 fn inflight_dir() -> Option<PathBuf> {
-    outbox_root().map(|root| root.join("inflight"))
+    Some(inflight_dir_in_root(&ambient_config_root()?))
 }
 
 fn dead_letter_dir() -> Option<PathBuf> {
-    outbox_root().map(|root| root.join("dead-letter"))
+    Some(dead_letter_dir_in_root(&ambient_config_root()?))
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +314,28 @@ pub fn dispatch_with_outbox(
     event: &NotifyEvent,
     once_marker: Option<NotifyOnceMarker>,
 ) -> NotifyOutboxDispatch {
+    dispatch_with_outbox_inner(ambient_config_root().as_deref(), event, once_marker)
+}
+
+/// [`dispatch_with_outbox`] against an already-resolved config root.
+pub fn dispatch_with_outbox_in_root(
+    config_root: &Path,
+    event: &NotifyEvent,
+    once_marker: Option<NotifyOnceMarker>,
+) -> NotifyOutboxDispatch {
+    dispatch_with_outbox_inner(Some(config_root), event, once_marker)
+}
+
+/// `config_root` is `Option` rather than `&Path` so the ambient wrapper keeps
+/// its pre-injection laziness: an unresolvable home must still attempt inline
+/// delivery and report `Delivered`, and only the *queueing* step degrades to
+/// `Dropped`. Resolving eagerly and bailing would turn a deliverable event into
+/// a dropped one on a machine with no `HOME`.
+fn dispatch_with_outbox_inner(
+    config_root: Option<&Path>,
+    event: &NotifyEvent,
+    once_marker: Option<NotifyOnceMarker>,
+) -> NotifyOutboxDispatch {
     let outcome = notify::dispatch(event);
     if outcome.delivered {
         return NotifyOutboxDispatch {
@@ -291,7 +349,10 @@ pub fn dispatch_with_outbox(
             disposition: NotifyOutboxDisposition::Dropped,
         };
     }
-    let disposition = match enqueue_after_attempt(event, once_marker, outcome.error.clone()) {
+    let queued = config_root.and_then(|config_root| {
+        enqueue_after_attempt(config_root, event, once_marker, outcome.error.clone())
+    });
+    let disposition = match queued {
         Some(entry_id) => NotifyOutboxDisposition::Queued { entry_id },
         None => NotifyOutboxDisposition::Dropped,
     };
@@ -306,10 +367,20 @@ pub fn dispatch_with_outbox(
 /// Returns the entry id, or `None` when the queue could not be written —
 /// which is a dropped notification, never a caller error.
 pub fn enqueue(event: &NotifyEvent, once_marker: Option<NotifyOnceMarker>) -> Option<String> {
-    write_new_entry(event, once_marker, 0, Utc::now(), None)
+    enqueue_in_root(&ambient_config_root()?, event, once_marker)
+}
+
+/// [`enqueue`] against an already-resolved config root.
+pub fn enqueue_in_root(
+    config_root: &Path,
+    event: &NotifyEvent,
+    once_marker: Option<NotifyOnceMarker>,
+) -> Option<String> {
+    write_new_entry(config_root, event, once_marker, 0, Utc::now(), None)
 }
 
 fn enqueue_after_attempt(
+    config_root: &Path,
     event: &NotifyEvent,
     once_marker: Option<NotifyOnceMarker>,
     error: Option<String>,
@@ -317,10 +388,11 @@ fn enqueue_after_attempt(
     let now = Utc::now();
     let due = now
         + chrono::Duration::from_std(backoff_after(1)).unwrap_or_else(|_| chrono::Duration::zero());
-    write_new_entry(event, once_marker, 1, due, error)
+    write_new_entry(config_root, event, once_marker, 1, due, error)
 }
 
 fn write_new_entry(
+    config_root: &Path,
     event: &NotifyEvent,
     once_marker: Option<NotifyOnceMarker>,
     attempts: u32,
@@ -344,7 +416,7 @@ fn write_new_entry(
         last_error,
         once_marker,
     };
-    let path = pending_dir()?.join(format!("{entry_id}.json"));
+    let path = pending_dir_in_root(config_root).join(format!("{entry_id}.json"));
     write_entry(&path, &entry).then_some(entry_id)
 }
 
@@ -366,11 +438,29 @@ fn write_entry(path: &Path, entry: &NotifyOutboxEntry) -> bool {
 /// `Result`: a drain that cannot read its own directory has nothing to do, and
 /// that is not an error the daemon can act on.
 pub fn drain(now: DateTime<Utc>) -> NotifyOutboxDrainReport {
-    let mut report = NotifyOutboxDrainReport::empty();
-    let Some(pending) = pending_dir() else {
-        return report;
+    let Some(config_root) = ambient_config_root() else {
+        // No reachable queue: nothing to claim, nothing to release.
+        return NotifyOutboxDrainReport::empty();
     };
-    report.reclaimed = reclaim_stale_inflight(now);
+    drain_in_root(&config_root, now)
+}
+
+/// [`drain`] against an already-resolved config root.
+///
+/// Every directory this pass touches — `pending/`, `inflight/`, and
+/// `dead-letter/` — is derived from this one root and threaded through
+/// `reclaim`, `claim`, and `apply_attempt`. A claim taken in one installation
+/// can therefore never be released, rescheduled, or dead-lettered in another,
+/// which would strand the entry in the first installation's `inflight/` until
+/// its reclaim window elapsed.
+///
+/// Delivery itself (`notify::dispatch`) still resolves its transport from the
+/// ambient config; that is the notification *transport* registry, not this
+/// queue's state, and rooting it belongs to the config/extension-store layer.
+pub fn drain_in_root(config_root: &Path, now: DateTime<Utc>) -> NotifyOutboxDrainReport {
+    let mut report = NotifyOutboxDrainReport::empty();
+    let pending = pending_dir_in_root(config_root);
+    report.reclaimed = reclaim_stale_inflight(config_root, now);
 
     let mut due = due_entries(&pending, now);
     // Oldest deadline first, so a long-backed-off entry is not starved by a
@@ -382,7 +472,7 @@ pub fn drain(now: DateTime<Utc>) -> NotifyOutboxDrainReport {
     }
 
     for (_, path) in due {
-        let Some(claimed) = claim(&path) else {
+        let Some(claimed) = claim(config_root, &path) else {
             // Another drainer won the rename, or the entry vanished.
             continue;
         };
@@ -397,11 +487,11 @@ pub fn drain(now: DateTime<Utc>) -> NotifyOutboxDrainReport {
             });
             // An unparseable entry can never be delivered, and leaving it in
             // `pending/` would make every future pass re-read it forever.
-            move_to_dead_letter(&claimed);
+            move_to_dead_letter(config_root, &claimed);
             continue;
         };
         report.attempted += 1;
-        apply_attempt(&claimed, entry, now, &mut report);
+        apply_attempt(config_root, &claimed, entry, now, &mut report);
     }
     report
 }
@@ -435,8 +525,8 @@ fn due_entries(pending: &Path, now: DateTime<Utc>) -> Vec<(DateTime<Utc>, PathBu
 /// entry both call `rename`; the loser's source no longer exists and it gets
 /// `ENOENT`, exactly as the second writer of the run-completion marker gets
 /// zero updated rows.
-fn claim(path: &Path) -> Option<PathBuf> {
-    let inflight = inflight_dir()?;
+fn claim(config_root: &Path, path: &Path) -> Option<PathBuf> {
+    let inflight = inflight_dir_in_root(config_root);
     if std::fs::create_dir_all(&inflight).is_err() {
         return None;
     }
@@ -445,6 +535,7 @@ fn claim(path: &Path) -> Option<PathBuf> {
 }
 
 fn apply_attempt(
+    config_root: &Path,
     claimed: &Path,
     mut entry: NotifyOutboxEntry,
     now: DateTime<Utc>,
@@ -481,10 +572,7 @@ fn apply_attempt(
             next_attempt_at: None,
             error: entry.last_error.clone(),
         });
-        let Some(dead) = dead_letter_dir() else {
-            let _ = std::fs::remove_file(claimed);
-            return;
-        };
+        let dead = dead_letter_dir_in_root(config_root);
         let path = dead.join(format!("{}.json", entry.entry_id));
         if !write_entry(&path, &entry) {
             // Nowhere to record it; dropping is still better than leaving a
@@ -508,10 +596,7 @@ fn apply_attempt(
         next_attempt_at: Some(entry.next_attempt_at.clone()),
         error: entry.last_error.clone(),
     });
-    let Some(pending) = pending_dir() else {
-        return;
-    };
-    let path = pending.join(format!("{}.json", entry.entry_id));
+    let path = pending_dir_in_root(config_root).join(format!("{}.json", entry.entry_id));
     if write_entry(&path, &entry) {
         let _ = std::fs::remove_file(claimed);
     }
@@ -521,10 +606,9 @@ fn apply_attempt(
 }
 
 /// Return entries abandoned by a drainer that died mid-attempt.
-fn reclaim_stale_inflight(now: DateTime<Utc>) -> usize {
-    let (Some(inflight), Some(pending)) = (inflight_dir(), pending_dir()) else {
-        return 0;
-    };
+fn reclaim_stale_inflight(config_root: &Path, now: DateTime<Utc>) -> usize {
+    let inflight = inflight_dir_in_root(config_root);
+    let pending = pending_dir_in_root(config_root);
     let Ok(entries) = std::fs::read_dir(&inflight) else {
         return 0;
     };
@@ -560,11 +644,8 @@ fn reclaim_stale_inflight(now: DateTime<Utc>) -> usize {
     reclaimed
 }
 
-fn move_to_dead_letter(claimed: &Path) {
-    let Some(dead) = dead_letter_dir() else {
-        let _ = std::fs::remove_file(claimed);
-        return;
-    };
+fn move_to_dead_letter(config_root: &Path, claimed: &Path) {
+    let dead = dead_letter_dir_in_root(config_root);
     if std::fs::create_dir_all(&dead).is_err() {
         let _ = std::fs::remove_file(claimed);
         return;
@@ -601,23 +682,39 @@ fn parse_time(value: &str) -> Option<DateTime<Utc>> {
 
 /// Every entry currently queued for redelivery, oldest deadline first.
 pub fn pending_entries() -> Vec<NotifyOutboxEntry> {
-    read_dir_entries(pending_dir())
+    read_dir_entries_opt(pending_dir())
+}
+
+/// [`pending_entries`] against an already-resolved config root.
+pub fn pending_entries_in_root(config_root: &Path) -> Vec<NotifyOutboxEntry> {
+    read_dir_entries(&pending_dir_in_root(config_root))
 }
 
 /// Every entry that exhausted its attempt budget.
 pub fn dead_letter_entries() -> Vec<NotifyOutboxEntry> {
-    read_dir_entries(dead_letter_dir())
+    read_dir_entries_opt(dead_letter_dir())
+}
+
+/// [`dead_letter_entries`] against an already-resolved config root.
+pub fn dead_letter_entries_in_root(config_root: &Path) -> Vec<NotifyOutboxEntry> {
+    read_dir_entries(&dead_letter_dir_in_root(config_root))
 }
 
 /// Entries currently claimed by a drain pass.
 pub fn inflight_entries() -> Vec<NotifyOutboxEntry> {
-    read_dir_entries(inflight_dir())
+    read_dir_entries_opt(inflight_dir())
 }
 
-fn read_dir_entries(dir: Option<PathBuf>) -> Vec<NotifyOutboxEntry> {
-    let Some(dir) = dir else {
-        return Vec::new();
-    };
+/// [`inflight_entries`] against an already-resolved config root.
+pub fn inflight_entries_in_root(config_root: &Path) -> Vec<NotifyOutboxEntry> {
+    read_dir_entries(&inflight_dir_in_root(config_root))
+}
+
+fn read_dir_entries_opt(dir: Option<PathBuf>) -> Vec<NotifyOutboxEntry> {
+    dir.map(|dir| read_dir_entries(&dir)).unwrap_or_default()
+}
+
+fn read_dir_entries(dir: &Path) -> Vec<NotifyOutboxEntry> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
     };
@@ -825,6 +922,54 @@ mod tests {
                 "{report:?}"
             );
         });
+    }
+
+    #[test]
+    fn injected_roots_own_independent_queues() {
+        // No `with_isolated_home`: an injected root must not consult the
+        // process environment at all, which is the whole point of the
+        // `_in_root` pair.
+        let left = tempfile::tempdir().expect("left root");
+        let right = tempfile::tempdir().expect("right root");
+
+        let entry_id = enqueue_in_root(left.path(), &event("run-left"), None).expect("queued");
+
+        let queued = pending_entries_in_root(left.path());
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].entry_id, entry_id);
+        assert_eq!(queued[0].event.run_id, "run-left");
+        assert!(pending_entries_in_root(right.path()).is_empty());
+    }
+
+    #[test]
+    fn a_drain_claims_and_releases_inside_the_root_it_was_given() {
+        // An unparseable entry exercises claim -> release without spawning a
+        // transport, so this asserts the drain's *own* state machine rather
+        // than delivery. A claim taken under one root and released under
+        // another would strand the entry until its reclaim window elapsed.
+        let root = tempfile::tempdir().expect("root");
+        let other = tempfile::tempdir().expect("other root");
+        let pending = pending_dir_in_root(root.path());
+        std::fs::create_dir_all(&pending).expect("seed pending");
+        std::fs::write(pending.join("corrupt.json"), b"{not json").expect("seed entry");
+
+        let report = drain_in_root(root.path(), Utc::now());
+
+        assert_eq!(report.unreadable, 1);
+        assert!(!pending.join("corrupt.json").exists());
+        assert!(
+            !inflight_dir_in_root(root.path())
+                .join("corrupt.json")
+                .exists(),
+            "the claim was released, not stranded in inflight"
+        );
+        assert!(
+            dead_letter_dir_in_root(root.path())
+                .join("corrupt.json")
+                .exists(),
+            "the release landed under the same root the claim was taken in"
+        );
+        assert!(!other.path().join("notify-outbox").exists());
     }
 
     #[test]

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -167,9 +167,10 @@ fn test_cleanup_stale_child_records() {
 
         assert_eq!(cleaned, 1);
         assert_child_exits(&mut child);
-        assert!(!InvocationChildRecord::record_path("inv-stale", pid)
-            .unwrap()
-            .exists());
+        let config_root = crate::paths::homeboy().expect("config root");
+        assert!(
+            !InvocationChildRecord::record_path_in_root(&config_root, "inv-stale", pid).exists()
+        );
     });
 }
 
@@ -224,7 +225,8 @@ fn spawn_isolated_sleep() -> std::process::Child {
 
 #[cfg(unix)]
 fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, pgid: Option<i32>) {
-    let dir = InvocationChildRecord::children_dir(invocation_id).expect("child dir");
+    let config_root = crate::paths::homeboy().expect("config root");
+    let dir = InvocationChildRecord::children_dir_in_root(&config_root, invocation_id);
     std::fs::create_dir_all(&dir).expect("create child dir");
     let record = InvocationChildRecord {
         invocation_id: invocation_id.to_string(),
@@ -240,7 +242,7 @@ fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, p
     };
     let json = serde_json::to_string_pretty(&record).expect("serialize child record");
     std::fs::write(
-        InvocationChildRecord::record_path(invocation_id, root_pid).expect("record path"),
+        InvocationChildRecord::record_path_in_root(&config_root, invocation_id, root_pid),
         json,
     )
     .expect("write child record");


### PR DESCRIPTION
## Summary

Core modules the earlier sweep ran out of budget for.

## `notify_outbox` — closed end to end

All four queue directories became `*_in_root(config_root)`. `drain` resolves **once** and threads that value through `reclaim_stale_inflight` → `due_entries` → `claim` → `apply_attempt`/`move_to_dead_letter`.

<callout accent="#3b82f6">
**Drain-loop consistency, walked explicitly:**

```
pending_dir_in_root      list
inflight_dir_in_root     claim rename target
  delivery   → remove_file(claimed)
  retry      → pending_dir_in_root rewrite, then remove_file(claimed)
  exhausted  → dead_letter_dir_in_root write, then remove_file(claimed)
  unparseable→ rename inflight → dead-letter
reclaim_stale_inflight   rename inflight → pending
```

All five derive from the single `config_root` parameter. **No claim can be taken in one home and released in another.**
</callout>

Two dead branches removed: the `let Some(dead) = dead_letter_dir() else` and `pending_dir() else` fallbacks in `apply_attempt` were already unreachable (`drain` returns early on an unresolvable home). Now structurally impossible rather than dead.

Two new tests use **no environment at all** — `injected_roots_own_independent_queues` and `a_drain_claims_and_releases_inside_the_root_it_was_given`. The second asserts the claim landed in *and was released from* the same root, and that a second root was never created.

## `engine/invocation` — closed by capture, not by a new public boundary

The real bug shape was `acquire` writing the lease against one resolution and `Drop` removing it against another. `InvocationGuard` now **captures** `config_root` at acquire and `Drop` uses `self.config_root` — threading it through `cleanup_stale_child_records_in_root`, `acquire_invocation_index_lock_in_root`, `invocation_leases_dir_in_root`, `refresh_lease_index_in_root`, `validate_named_leases_in_root`, `write_lease_in_root`, and all four rollback `remove_file` paths.

**`acquire_in_root` was deliberately NOT added.** It would be a half-injected boundary: `invocation_runtime_root` is deliberately independent and managed temp resolves a different chain, so publishing an injectable `acquire` that silently ignores the injection for state/artifact/tmp dirs is exactly the advertised-but-false injection point this campaign keeps finding.

## `agent_runtime_manifest` — a bare-function-reference split, found and closed

`paths::agent_runtimes()` for the listing and the `paths::agent_runtime_manifest` **fn pointer** for each manifest read: two independent resolutions per operation. Now a `&dyn Fn(&str) -> PathBuf` closing over one root.

## `engine/temp` — deliberately skipped, and why

`runtime_root()`/`legacy_runtime_root()` reach ~5 crates plus ~40 test call sites. Worse, `superseded_runtime_roots()` genuinely needs **both** data and config roots — rooting only `runtime_root` would sweep an injected active root while comparing against an ambient legacy root. That is the "reported Missing but exists" bug class verbatim. **Half-doing it is worse than not doing it.**

## Not closed

| file:line | why |
|---|---|
| `notify.rs:273,287` | `defaults::load_config()`, `extension_store::load_all_extensions()` — other agents' scope |
| `engine/temp/implementation.rs:630,638` | above |
| `engine/temp/implementation.rs:529` | `lease_is_active_in_root` added, but `temp` has no root to pass |
| `deps_provider.rs:308` | **single** resolution, everything else relative to its entries — no split, low value against a long chain |
| `source_snapshot.rs:360,412` | test-only |

`notify.rs` is a genuine remaining split — `drain_in_root` reads its queue from an injected root but its transport from ambient config. **Documented in the module header and on `drain_in_root`** rather than left implicit. It is a different resource (transport registry vs queue state), and the claim/release hazard is fully closed.

## Explicit confirmations

**Did NOT touch** `invocation/runtime.rs`'s deliberately-independent root — read the #11266 / `sockaddr_un` rationale first; `git diff` shows zero changes to that file.

**Did NOT touch subprocess env construction.** Told apart by *who reads the path*: `env_vars()` builds `HOMEBOY_INVOCATION_*`/`TMPDIR` from already-resolved values handed to a child. What was rooted is strictly "a path this process reads/writes local state at" — queue dirs, lease files, lock dirs, child-record files, manifest paths.

**Lesson 1:** AWK pass over all four files for ambient resolvers inside root-taking bodies. Clean — and it caught one live case mid-work (`write_new_entry` took `config_root` then called `pending_dir()`).

**Lesson 2:** five `#[cfg(test)]` blocks including the `#[path]`-included `tests/core/engine/invocation_test.rs` mounted into `invocation.rs`. **Found 5 callers of two removed `pub(crate)` fns living only in those blocks** — a symbol grep would not have flagged that file as a caller of a `homeboy-core` private. All 5 updated.

**Lesson 3:** zero new duplicates vs `origin/main`. Independently re-verified before merge.

## Verification

`cargo fmt --all` clean. No public signature changed. Not verified without cargo: the `&dyn Fn(&str) -> PathBuf` HRTB coercion in `agent_runtime_manifest.rs` (**the single least certain edit** — closure-to-`dyn Fn` with a higher-ranked lifetime), dead-code on `lease_is_active_in_root`, and NLL in `dispatch_with_outbox_inner`.

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and drain-loop analysis. Review by hand.

Refs #7505
