### PR TITLE
Migrate the observation and evidence tests onto injected roots

### DIFF
--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -281,40 +281,42 @@ fn test_runner_artifact_token_round_trips_escaped_segments() {
 /// wherever the daemon asked. It is now reduced to one component in the cache.
 #[test]
 fn test_download_placement_sanitizes_a_traversal_filename() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let token = RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1")
-            .expect("parse token");
-        let artifact_root = homeboy_core::paths::artifact_root().expect("artifact root");
-        let cache = artifact_root.join("runner").join("lab").join("run-1");
+    // `resolve_placement` already takes its artifact root as a parameter, so
+    // the root can simply be injected rather than resolved out of the process
+    // environment (#7505).
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let token =
+        RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1").expect("parse token");
+    let artifact_root = context.artifact_dir();
+    let cache = artifact_root.join("runner").join("lab").join("run-1");
 
-        for hostile in [
-            "../../../../../../root/.ssh/authorized_keys",
-            "/root/.ssh/authorized_keys",
-            "..",
-            "../../etc/passwd",
-        ] {
-            let placement = resolve_placement(&artifact_root, &token, None, Some(hostile))
-                .expect("placement resolves");
-            assert_eq!(
-                placement.output_path.parent(),
-                Some(cache.as_path()),
-                "{hostile} escaped to {}",
-                placement.output_path.display()
-            );
-            assert_eq!(placement.cache_dir.as_deref(), Some(cache.as_path()));
-            assert!(!placement.file_name.contains('/'));
-            // The reported artifact-ref name is the name on disk, never the
-            // remote's, so no downstream consumer can rebuild the escape.
-            assert_eq!(
-                placement
-                    .output_path
-                    .file_name()
-                    .expect("file name")
-                    .to_string_lossy(),
-                placement.file_name.as_str()
-            );
-        }
-    });
+    for hostile in [
+        "../../../../../../root/.ssh/authorized_keys",
+        "/root/.ssh/authorized_keys",
+        "..",
+        "../../etc/passwd",
+    ] {
+        let placement = resolve_placement(&artifact_root, &token, None, Some(hostile))
+            .expect("placement resolves");
+        assert_eq!(
+            placement.output_path.parent(),
+            Some(cache.as_path()),
+            "{hostile} escaped to {}",
+            placement.output_path.display()
+        );
+        assert_eq!(placement.cache_dir.as_deref(), Some(cache.as_path()));
+        assert!(!placement.file_name.contains('/'));
+        // The reported artifact-ref name is the name on disk, never the
+        // remote's, so no downstream consumer can rebuild the escape.
+        assert_eq!(
+            placement
+                .output_path
+                .file_name()
+                .expect("file name")
+                .to_string_lossy(),
+            placement.file_name.as_str()
+        );
+    }
 }
 
 /// The same defect through the token instead of the body.
@@ -326,59 +328,57 @@ fn test_download_placement_sanitizes_a_traversal_filename() {
 /// silently rewriting one would put bytes somewhere unpredictable.
 #[test]
 fn test_download_placement_rejects_a_percent_encoded_traversal_token() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        // The root is injected and never consulted: both identifiers are
-        // refused before anything is joined onto it.
-        let artifact_root = home.path().join("artifacts");
-        let token = RemoteArtifactToken::parse(
-            "runner-artifact://lab/%2E%2E%2F%2E%2E%2F%2E%2E%2Froot%2F.ssh/authorized_keys",
-        )
-        .expect("token still parses; that is the point");
-        // The parser hands the writer an already-decoded traversal.
-        assert_eq!(token.run_id, "../../../root/.ssh");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    // The root is injected and never consulted: both identifiers are
+    // refused before anything is joined onto it.
+    let artifact_root = context.root().join("artifacts");
+    let token = RemoteArtifactToken::parse(
+        "runner-artifact://lab/%2E%2E%2F%2E%2E%2F%2E%2E%2Froot%2F.ssh/authorized_keys",
+    )
+    .expect("token still parses; that is the point");
+    // The parser hands the writer an already-decoded traversal.
+    assert_eq!(token.run_id, "../../../root/.ssh");
 
-        let error = resolve_placement(&artifact_root, &token, None, Some("authorized_keys"))
-            .expect_err("the writer must refuse it");
-        assert_eq!(error.code.as_str(), "validation.invalid_argument");
-        assert!(
-            error.message.contains("single path component"),
-            "{}",
-            error.message
-        );
+    let error = resolve_placement(&artifact_root, &token, None, Some("authorized_keys"))
+        .expect_err("the writer must refuse it");
+    assert_eq!(error.code.as_str(), "validation.invalid_argument");
+    assert!(
+        error.message.contains("single path component"),
+        "{}",
+        error.message
+    );
 
-        // And through the runner id, which reaches the same join.
-        let runner_token =
-            RemoteArtifactToken::parse("runner-artifact://%2E%2E%2F%2E%2E%2Fetc/run-1/artifact-1")
-                .expect("parse token");
-        assert_eq!(runner_token.runner_id, "../../etc");
-        let error = resolve_placement(&artifact_root, &runner_token, None, Some("passwd"))
-            .expect_err("the writer must refuse it");
-        assert_eq!(error.code.as_str(), "validation.invalid_argument");
-    });
+    // And through the runner id, which reaches the same join.
+    let runner_token =
+        RemoteArtifactToken::parse("runner-artifact://%2E%2E%2F%2E%2E%2Fetc/run-1/artifact-1")
+            .expect("parse token");
+    assert_eq!(runner_token.runner_id, "../../etc");
+    let error = resolve_placement(&artifact_root, &runner_token, None, Some("passwd"))
+        .expect_err("the writer must refuse it");
+    assert_eq!(error.code.as_str(), "validation.invalid_argument");
 }
 
 /// An explicit `--output` is the caller's own path and is not relocated into
 /// the cache — and it is not tagged, because homeboy does not reclaim it.
 #[test]
 fn test_download_placement_honours_an_explicit_output_without_tagging_it() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let token = RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1")
-            .expect("parse token");
-        let explicit = home.path().join("elsewhere").join("report.json");
-        let artifact_root = home.path().join("artifacts");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let token =
+        RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1").expect("parse token");
+    let explicit = context.root().join("elsewhere").join("report.json");
+    let artifact_root = context.root().join("artifacts");
 
-        let placement = resolve_placement(
-            &artifact_root,
-            &token,
-            Some(explicit.clone()),
-            Some("../../evil"),
-        )
-        .expect("resolve");
+    let placement = resolve_placement(
+        &artifact_root,
+        &token,
+        Some(explicit.clone()),
+        Some("../../evil"),
+    )
+    .expect("resolve");
 
-        assert_eq!(placement.output_path, explicit);
-        assert!(placement.cache_dir.is_none());
-        assert_eq!(placement.file_name, "report.json");
-    });
+    assert_eq!(placement.output_path, explicit);
+    assert!(placement.cache_dir.is_none());
+    assert_eq!(placement.file_name, "report.json");
 }
 
 #[test]
@@ -401,145 +401,143 @@ fn test_content_disposition_filename_parses_quoted_attachment_name() {
 /// the writer, and this asserts both halves of that split (#10586).
 #[test]
 fn test_content_disposition_traversal_is_neutralized_by_the_writer() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let mut headers = header::HeaderMap::new();
-        headers.insert(
-            header::CONTENT_DISPOSITION,
-            header::HeaderValue::from_static("attachment; filename=\"../../../../etc/cron.d/x\""),
-        );
-        let parsed = content_disposition_filename(&headers).expect("filename");
-        assert_eq!(parsed, "../../../../etc/cron.d/x");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        header::HeaderValue::from_static("attachment; filename=\"../../../../etc/cron.d/x\""),
+    );
+    let parsed = content_disposition_filename(&headers).expect("filename");
+    assert_eq!(parsed, "../../../../etc/cron.d/x");
 
-        let token = RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1")
-            .expect("parse token");
-        let artifact_root = homeboy_core::paths::artifact_root().expect("artifact root");
-        let placement =
-            resolve_placement(&artifact_root, &token, None, Some(&parsed)).expect("resolve");
-        let cache = artifact_root.join("runner").join("lab").join("run-1");
-        assert_eq!(placement.output_path.parent(), Some(cache.as_path()));
-        assert_eq!(placement.file_name, "etc_cron.d_x");
-    });
+    let token =
+        RemoteArtifactToken::parse("runner-artifact://lab/run-1/artifact-1").expect("parse token");
+    let artifact_root = context.artifact_dir();
+    let placement =
+        resolve_placement(&artifact_root, &token, None, Some(&parsed)).expect("resolve");
+    let cache = artifact_root.join("runner").join("lab").join("run-1");
+    assert_eq!(placement.output_path.parent(), Some(cache.as_path()));
+    assert_eq!(placement.file_name, "etc_cron.d_x");
 }
 
 #[test]
 fn test_reportable_artifact_evidence_requires_local_or_retrievable_path() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let local = home.path().join("artifact.json");
-        fs::write(&local, b"{}").expect("artifact");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let local = context.root().join("artifact.json");
+    fs::write(&local, b"{}").expect("artifact");
 
-        assert!(is_reportable_artifact_evidence_path(
-            &local.to_string_lossy()
-        ));
-        assert!(is_reportable_artifact_evidence_path(
-            "runner-artifact://lab/run-1/artifact-1"
-        ));
-        assert!(is_reportable_artifact_evidence_path(
-            "metadata-only:trace.zip"
-        ));
-        assert!(is_reportable_artifact_evidence_path(
-            "artifacts/relative-trace.zip"
-        ));
-        assert!(!is_reportable_artifact_evidence_path(
-            "/srv/remote-only/trace.zip"
-        ));
-        assert!(!is_retrievable_runner_artifact(
-            "runner-artifact://missing-segments"
-        ));
-    });
+    assert!(is_reportable_artifact_evidence_path(
+        &local.to_string_lossy()
+    ));
+    assert!(is_reportable_artifact_evidence_path(
+        "runner-artifact://lab/run-1/artifact-1"
+    ));
+    assert!(is_reportable_artifact_evidence_path(
+        "metadata-only:trace.zip"
+    ));
+    assert!(is_reportable_artifact_evidence_path(
+        "artifacts/relative-trace.zip"
+    ));
+    assert!(!is_reportable_artifact_evidence_path(
+        "/srv/remote-only/trace.zip"
+    ));
+    assert!(!is_retrievable_runner_artifact(
+        "runner-artifact://missing-segments"
+    ));
 }
 
 #[test]
 fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let job_id = Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Succeeded,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: Some(1_700_000_001_000),
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
-        let lifecycle_event = json!({
-            "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
-            "identity": {
-                "runner_id": "lab",
-                "runner_job_id": job_id.to_string(),
-                "run_id": "run-typed"
-            },
-            "aggregate": {
-                "schema": "homeboy/agent-task-aggregate/v1",
-                "plan_id": "plan-from-result",
-                "status": "succeeded",
-                "totals": {"skipped": 0, "succeeded": 1, "failed": 0},
-                "outcomes": []
-            }
-        });
-        let events = vec![JobEvent {
-            sequence: 1,
-            job_id,
-            kind: JobEventKind::Result,
-            timestamp_ms: 1_700_000_001_000,
-            message: None,
-            data: Some(json!({
-                "data": {
-                    "agent_task_lifecycle_event": lifecycle_event
-                }
-            })),
-        }];
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/srv/homeboy/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &events,
-            &json!({"exit_code":0,"output":{"command":"bench"}}),
-            None,
-            Some(
-                &homeboy_core::notification_route::NotificationRoute::new(
-                    "extension",
-                    "opaque-origin-route",
-                )
-                .expect("route"),
-            ),
-        )
-        .expect("mirror job");
-        assert_eq!(run.kind, "runner-exec");
-        assert_eq!(run.status, "pass");
-        assert_eq!(run.cwd.as_deref(), Some("/srv/homeboy/project"));
-        assert_eq!(
-            run.metadata_json["lab"]["runner"]["id"].as_str(),
-            Some("lab")
-        );
-        assert_eq!(
-            run.metadata_json["lab"]["remote_job"]["id"].as_str(),
-            Some(job_id.to_string().as_str())
-        );
-        assert_eq!(
-            run.metadata_json["lab"]["agent_task_lifecycle_event"]["aggregate"]["plan_id"].as_str(),
-            Some("plan-from-result")
-        );
-        assert_eq!(
-            run.metadata_json["notification_route"]["route"],
-            "opaque-origin-route"
-        );
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let job_id = Uuid::new_v4();
+    let job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
+    let lifecycle_event = json!({
+        "schema": "homeboy/agent-task-run-plan-lifecycle-event/v1",
+        "identity": {
+            "runner_id": "lab",
+            "runner_job_id": job_id.to_string(),
+            "run_id": "run-typed"
+        },
+        "aggregate": {
+            "schema": "homeboy/agent-task-aggregate/v1",
+            "plan_id": "plan-from-result",
+            "status": "succeeded",
+            "totals": {"skipped": 0, "succeeded": 1, "failed": 0},
+            "outcomes": []
+        }
     });
+    let events = vec![JobEvent {
+        sequence: 1,
+        job_id,
+        kind: JobEventKind::Result,
+        timestamp_ms: 1_700_000_001_000,
+        message: None,
+        data: Some(json!({
+            "data": {
+                "agent_task_lifecycle_event": lifecycle_event
+            }
+        })),
+    }];
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/srv/homeboy/project",
+        &["homeboy".to_string(), "bench".to_string()],
+        &job,
+        &events,
+        &json!({"exit_code":0,"output":{"command":"bench"}}),
+        None,
+        Some(
+            &homeboy_core::notification_route::NotificationRoute::new(
+                "extension",
+                "opaque-origin-route",
+            )
+            .expect("route"),
+        ),
+    )
+    .expect("mirror job");
+    assert_eq!(run.kind, "runner-exec");
+    assert_eq!(run.status, "pass");
+    assert_eq!(run.cwd.as_deref(), Some("/srv/homeboy/project"));
+    assert_eq!(
+        run.metadata_json["lab"]["runner"]["id"].as_str(),
+        Some("lab")
+    );
+    assert_eq!(
+        run.metadata_json["lab"]["remote_job"]["id"].as_str(),
+        Some(job_id.to_string().as_str())
+    );
+    assert_eq!(
+        run.metadata_json["lab"]["agent_task_lifecycle_event"]["aggregate"]["plan_id"].as_str(),
+        Some("plan-from-result")
+    );
+    assert_eq!(
+        run.metadata_json["notification_route"]["route"],
+        "opaque-origin-route"
+    );
 }
 
 #[test]
@@ -640,169 +638,169 @@ fn explicit_generic_runner_exec_run_skips_missing_remote_run_projection() {
 
 #[test]
 fn failed_job_without_terminal_exit_code_projects_root_failure_fallback() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        job.status = JobStatus::Failed;
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/runner/project",
-            &["homeboy".to_string(), "bench".to_string()],
-            &job,
-            &[],
-            &json!({ "stderr": "failed before result" }),
-            None,
-            None,
-        )
-        .expect("mirror failed job");
-        assert_eq!(run.metadata_json["exit_code"], 1);
-        assert_eq!(run.metadata_json["lab"]["failure"]["exit_code"], 1);
-    });
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    job.status = JobStatus::Failed;
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/runner/project",
+        &["homeboy".to_string(), "bench".to_string()],
+        &job,
+        &[],
+        &json!({ "stderr": "failed before result" }),
+        None,
+        None,
+    )
+    .expect("mirror failed job");
+    assert_eq!(run.metadata_json["exit_code"], 1);
+    assert_eq!(run.metadata_json["lab"]["failure"]["exit_code"], 1);
 }
 
 #[test]
 fn synthetic_runner_run_identity_is_stable_across_repeated_progress_mirrors() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let runner = ssh_runner();
-        let job = terminal_runner_job();
-        let command = vec!["homeboy".to_string(), "test".to_string()];
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let runner = ssh_runner();
+    let job = terminal_runner_job();
+    let command = vec!["homeboy".to_string(), "test".to_string()];
 
-        let first = mirror_job_run(
-            &store,
-            &runner,
-            "/runner/project",
-            &command,
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("first progress mirror");
-        let second = mirror_job_run(
-            &store,
-            &runner,
-            "/runner/project",
-            &command,
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("repeated progress mirror");
+    let first = mirror_job_run(
+        &store,
+        &runner,
+        "/runner/project",
+        &command,
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("first progress mirror");
+    let second = mirror_job_run(
+        &store,
+        &runner,
+        "/runner/project",
+        &command,
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("repeated progress mirror");
 
-        assert_eq!(first.id, second.id);
-        assert_eq!(store.list_artifacts(&first.id).expect("artifacts").len(), 0);
-    });
+    assert_eq!(first.id, second.id);
+    assert_eq!(store.list_artifacts(&first.id).expect("artifacts").len(), 0);
 }
 
 #[test]
 fn synthetic_progress_mirror_is_upserted_to_terminal_failure_after_restart() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let runner = ssh_runner();
-        let command = vec!["homeboy".to_string(), "bench".to_string()];
-        let mut progress = terminal_runner_job();
-        progress.status = JobStatus::Running;
-        progress.finished_at_ms = None;
-        let running = mirror_job_run(
-            &store,
-            &runner,
-            "/runner/project",
-            &command,
-            &progress,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("progress mirror");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let runner = ssh_runner();
+    let command = vec!["homeboy".to_string(), "bench".to_string()];
+    let mut progress = terminal_runner_job();
+    progress.status = JobStatus::Running;
+    progress.finished_at_ms = None;
+    let running = mirror_job_run(
+        &store,
+        &runner,
+        "/runner/project",
+        &command,
+        &progress,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("progress mirror");
 
-        let mut terminal = progress.clone();
-        terminal.status = JobStatus::Failed;
-        terminal.finished_at_ms = Some(terminal.updated_at_ms);
-        let failed = mirror_job_run(
-            &store,
-            &runner,
-            "/runner/project",
-            &command,
-            &terminal,
-            &[],
-            &json!({ "exit_code": 2, "stderr": "token=secret" }),
-            None,
-            None,
-        )
-        .expect("terminal mirror after restart");
+    let mut terminal = progress.clone();
+    terminal.status = JobStatus::Failed;
+    terminal.finished_at_ms = Some(terminal.updated_at_ms);
+    let failed = mirror_job_run(
+        &store,
+        &runner,
+        "/runner/project",
+        &command,
+        &terminal,
+        &[],
+        &json!({ "exit_code": 2, "stderr": "token=secret" }),
+        None,
+        None,
+    )
+    .expect("terminal mirror after restart");
 
-        assert_eq!(running.id, failed.id);
-        assert_eq!(failed.status, "fail");
-        assert_eq!(failed.metadata_json["lab"]["failure"]["exit_code"], 2);
-        assert_eq!(
-            failed.metadata_json["lab"]["failure"]["stderr_tail"],
-            "token=[REDACTED]"
-        );
-    });
+    assert_eq!(running.id, failed.id);
+    assert_eq!(failed.status, "fail");
+    assert_eq!(failed.metadata_json["lab"]["failure"]["exit_code"], 2);
+    assert_eq!(
+        failed.metadata_json["lab"]["failure"]["stderr_tail"],
+        "token=[REDACTED]"
+    );
 }
 
 #[test]
 fn runner_exec_matrix_summary_run_names_come_from_command_domain() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let job_id = Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Succeeded,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: Some(1_700_000_001_000),
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
-        let command = [
-            "homeboy".to_string(),
-            "trace".to_string(),
-            "matrix".to_string(),
-            "summary".to_string(),
-            "--json".to_string(),
-        ];
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let job_id = Uuid::new_v4();
+    let job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
+    let command = [
+        "homeboy".to_string(),
+        "trace".to_string(),
+        "matrix".to_string(),
+        "summary".to_string(),
+        "--json".to_string(),
+    ];
 
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/srv/homeboy/static-site-importer",
-            &command,
-            &job,
-            &[],
-            &json!({"exit_code":0}),
-            None,
-            None,
-        )
-        .expect("mirror job");
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/srv/homeboy/static-site-importer",
+        &command,
+        &job,
+        &[],
+        &json!({"exit_code":0}),
+        None,
+        None,
+    )
+    .expect("mirror job");
 
-        assert_eq!(runner_exec_run_label(&command), "trace-matrix-summary");
-        assert!(run.id.starts_with("runner-exec-trace-matrix-summary-lab-"));
-        assert!(!run.id.contains("woo-db-api-rest-query-profile"));
-        assert_eq!(
-            run.metadata_json["lab"]["run_label"].as_str(),
-            Some("trace-matrix-summary")
-        );
-    });
+    assert_eq!(runner_exec_run_label(&command), "trace-matrix-summary");
+    assert!(run.id.starts_with("runner-exec-trace-matrix-summary-lab-"));
+    assert!(!run.id.contains("woo-db-api-rest-query-profile"));
+    assert_eq!(
+        run.metadata_json["lab"]["run_label"].as_str(),
+        Some("trace-matrix-summary")
+    );
 }
 
 #[test]
@@ -832,261 +830,261 @@ fn mirrored_remote_events_keep_lifecycle_summary_without_stream_payloads() {
 
 #[test]
 fn runner_exec_explicit_run_id_overrides_inferred_name() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let job_id = Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Running,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: None,
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let job_id = Uuid::new_v4();
+    let job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Running,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: None,
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
 
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/srv/homeboy/static-site-importer",
-            &[
-                "homeboy".to_string(),
-                "runs".to_string(),
-                "list".to_string(),
-            ],
-            &job,
-            &[],
-            &json!({}),
-            Some("ssi-fixture-matrix-summary"),
-            None,
-        )
-        .expect("mirror job");
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/srv/homeboy/static-site-importer",
+        &[
+            "homeboy".to_string(),
+            "runs".to_string(),
+            "list".to_string(),
+        ],
+        &job,
+        &[],
+        &json!({}),
+        Some("ssi-fixture-matrix-summary"),
+        None,
+    )
+    .expect("mirror job");
 
-        assert_eq!(run.id, "ssi-fixture-matrix-summary");
-        assert_eq!(
-            run.metadata_json["lab"]["explicit_run_id"].as_str(),
-            Some("ssi-fixture-matrix-summary")
-        );
-    });
+    assert_eq!(run.id, "ssi-fixture-matrix-summary");
+    assert_eq!(
+        run.metadata_json["lab"]["explicit_run_id"].as_str(),
+        Some("ssi-fixture-matrix-summary")
+    );
 }
 
 #[test]
 fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let command = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "cook".to_string(),
-        ];
-        homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
-            homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
-                run_id: "agent-task-lab-mirror",
-                runner_id: "lab",
-                remote_workspace: "/srv/homeboy/project",
-                remote_command: &command,
-                durable_plan: None,
-            },
-        )
-        .expect("planned controller proxy");
-        let job_id = Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Running,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: None,
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
+        homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+            run_id: "agent-task-lab-mirror",
+            runner_id: "lab",
+            remote_workspace: "/srv/homeboy/project",
+            remote_command: &command,
+            durable_plan: None,
+        },
+    )
+    .expect("planned controller proxy");
+    let job_id = Uuid::new_v4();
+    let job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Running,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: None,
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
 
-        mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/srv/homeboy/project",
-            &command,
-            &job,
-            &[],
-            &json!({}),
-            Some("agent-task-lab-mirror"),
-            None,
-        )
-        .expect("mirror Lab job");
-        let terminal_job = Job {
-            status: JobStatus::Succeeded,
-            finished_at_ms: Some(1_700_000_002_000),
-            ..job.clone()
-        };
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/srv/homeboy/project",
-            &command,
-            &terminal_job,
-            &[],
-            &json!({"exit_code": 0}),
-            Some("agent-task-lab-mirror"),
-            None,
-        )
-        .expect("mirror terminal Lab job");
-        let lifecycle = homeboy_agents::agent_task_lifecycle::status("agent-task-lab-mirror")
-            .expect("typed lifecycle remains readable");
+    mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/srv/homeboy/project",
+        &command,
+        &job,
+        &[],
+        &json!({}),
+        Some("agent-task-lab-mirror"),
+        None,
+    )
+    .expect("mirror Lab job");
+    let terminal_job = Job {
+        status: JobStatus::Succeeded,
+        finished_at_ms: Some(1_700_000_002_000),
+        ..job.clone()
+    };
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/srv/homeboy/project",
+        &command,
+        &terminal_job,
+        &[],
+        &json!({"exit_code": 0}),
+        Some("agent-task-lab-mirror"),
+        None,
+    )
+    .expect("mirror terminal Lab job");
+    let lifecycle = homeboy_agents::agent_task_lifecycle::status("agent-task-lab-mirror")
+        .expect("typed lifecycle remains readable");
 
-        assert_eq!(run.kind, "agent-task");
-        assert!(run.metadata_json.get("agent_task_run").is_some());
-        assert_eq!(lifecycle.metadata["runner_id"], "lab");
-        assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
-        assert_eq!(
-            run.metadata_json["lab"]["remote_job"]["id"],
-            job_id.to_string()
-        );
-    });
+    assert_eq!(run.kind, "agent-task");
+    assert!(run.metadata_json.get("agent_task_run").is_some());
+    assert_eq!(lifecycle.metadata["runner_id"], "lab");
+    assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
+    assert_eq!(
+        run.metadata_json["lab"]["remote_job"]["id"],
+        job_id.to_string()
+    );
 }
 
 #[test]
 fn test_mirrored_patch_result_reports_accessible_artifact_token() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let runner = ssh_runner();
-        let job_id = Uuid::new_v4();
-        let mut job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Succeeded,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: Some(1_700_000_001_000),
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
-        let artifact_id = format!("runner-fix-patch-{job_id}");
-        job.artifacts.push(JobArtifactMetadata {
-            id: artifact_id.clone(),
-            name: Some("patch.diff".to_string()),
-            path: None,
-            url: None,
-            mime: Some("text/x-diff".to_string()),
-            size_bytes: Some(12),
-            sha256: None,
-            content_base64: None,
-            metadata: None,
-        });
-        let run = mirror_job_run(
-            &store,
-            &runner,
-            "/srv/project",
-            &[
-                "homeboy".to_string(),
-                "runner".to_string(),
-                "exec".to_string(),
-            ],
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("mirror job");
-        let source = home.path().join("patch.diff");
-        fs::write(&source, b"patch bytes!!").expect("patch bytes");
-        store
-            .record_artifact_with_id(&run.id, "lab_fix_patch", &source, &artifact_id, json!({}))
-            .expect("record controller artifact");
-
-        let patch = json!({
-            "patch_artifact_id": artifact_id,
-            "patch_artifact_path": "/srv/homeboy/.homeboy/artifacts/remote.diff",
-        });
-
-        let mirrored = mirrored_patch_result(&store, &runner, &job, Some(&patch))
-            .expect("mirror patch")
-            .expect("patch");
-
-        assert!(mirrored["patch_artifact_path"]
-            .as_str()
-            .is_some_and(|path| path.ends_with("patch.diff")));
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let runner = ssh_runner();
+    let job_id = Uuid::new_v4();
+    let mut job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
+    let artifact_id = format!("runner-fix-patch-{job_id}");
+    job.artifacts.push(JobArtifactMetadata {
+        id: artifact_id.clone(),
+        name: Some("patch.diff".to_string()),
+        path: None,
+        url: None,
+        mime: Some("text/x-diff".to_string()),
+        size_bytes: Some(12),
+        sha256: None,
+        content_base64: None,
+        metadata: None,
     });
+    let run = mirror_job_run(
+        &store,
+        &runner,
+        "/srv/project",
+        &[
+            "homeboy".to_string(),
+            "runner".to_string(),
+            "exec".to_string(),
+        ],
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("mirror job");
+    let source = context.root().join("patch.diff");
+    fs::write(&source, b"patch bytes!!").expect("patch bytes");
+    store
+        .record_artifact_with_id(&run.id, "lab_fix_patch", &source, &artifact_id, json!({}))
+        .expect("record controller artifact");
+
+    let patch = json!({
+        "patch_artifact_id": artifact_id,
+        "patch_artifact_path": "/srv/homeboy/.homeboy/artifacts/remote.diff",
+    });
+
+    let mirrored = mirrored_patch_result(&store, &runner, &job, Some(&patch))
+        .expect("mirror patch")
+        .expect("patch");
+
+    assert!(mirrored["patch_artifact_path"]
+        .as_str()
+        .is_some_and(|path| path.ends_with("patch.diff")));
 }
 
 #[test]
 fn test_mirrored_patch_result_fails_when_patch_artifact_was_not_mirrored() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let runner = ssh_runner();
-        let job_id = Uuid::new_v4();
-        let job = Job {
-            id: job_id,
-            operation: "exec".to_string(),
-            status: JobStatus::Succeeded,
-            created_at_ms: 1_700_000_000_000,
-            updated_at_ms: 1_700_000_001_000,
-            started_at_ms: Some(1_700_000_000_000),
-            finished_at_ms: Some(1_700_000_001_000),
-            event_count: 0,
-            source_snapshot: None,
-            path_materialization_plan: None,
-            stale_reason: None,
-            daemon_lease_id: None,
-            target_runner_id: None,
-            target_project_id: None,
-            claim_id: None,
-            claimed_by_runner_id: None,
-            claimed_at_ms: None,
-            claim_expires_at_ms: None,
-            artifacts: Vec::new(),
-            runner_job_projection: None,
-        };
-        let artifact_id = format!("runner-fix-patch-{job_id}");
-        let patch = json!({
-            "patch_artifact_id": artifact_id,
-            "patch_artifact_path": "/srv/homeboy/.homeboy/artifacts/remote.diff",
-        });
-
-        let err = mirrored_patch_result(&store, &runner, &job, Some(&patch))
-            .expect_err("missing mirror should fail");
-
-        assert!(err
-            .message
-            .contains("no controller-owned artifact record is available"));
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let runner = ssh_runner();
+    let job_id = Uuid::new_v4();
+    let job = Job {
+        id: job_id,
+        operation: "exec".to_string(),
+        status: JobStatus::Succeeded,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        started_at_ms: Some(1_700_000_000_000),
+        finished_at_ms: Some(1_700_000_001_000),
+        event_count: 0,
+        source_snapshot: None,
+        path_materialization_plan: None,
+        stale_reason: None,
+        daemon_lease_id: None,
+        target_runner_id: None,
+        target_project_id: None,
+        claim_id: None,
+        claimed_by_runner_id: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        artifacts: Vec::new(),
+        runner_job_projection: None,
+    };
+    let artifact_id = format!("runner-fix-patch-{job_id}");
+    let patch = json!({
+        "patch_artifact_id": artifact_id,
+        "patch_artifact_path": "/srv/homeboy/.homeboy/artifacts/remote.diff",
     });
+
+    let err = mirrored_patch_result(&store, &runner, &job, Some(&patch))
+        .expect_err("missing mirror should fail");
+
+    assert!(err
+        .message
+        .contains("no controller-owned artifact record is available"));
 }
 
 #[test]
@@ -1113,79 +1111,79 @@ fn test_remote_file_artifacts_are_indexed_as_runner_tokens() {
 
 #[test]
 fn test_remote_fuzz_artifacts_become_controller_owned_before_runner_cleanup() {
-    homeboy_core::test_support::with_isolated_home(|home| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let run = RunRecord {
-            id: "requested-fuzz-run".to_string(),
-            kind: "fuzz".to_string(),
-            component_id: Some("component-a".to_string()),
-            started_at: "2026-05-16T00:00:00Z".to_string(),
-            finished_at: Some("2026-05-16T00:00:01Z".to_string()),
-            status: "pass".to_string(),
-            command: Some("homeboy fuzz run component-a".to_string()),
-            cwd: Some("/srv/component-a".to_string()),
-            homeboy_version: None,
-            git_sha: None,
-            rig_id: None,
-            metadata_json: json!({}),
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let run = RunRecord {
+        id: "requested-fuzz-run".to_string(),
+        kind: "fuzz".to_string(),
+        component_id: Some("component-a".to_string()),
+        started_at: "2026-05-16T00:00:00Z".to_string(),
+        finished_at: Some("2026-05-16T00:00:01Z".to_string()),
+        status: "pass".to_string(),
+        command: Some("homeboy fuzz run component-a".to_string()),
+        cwd: Some("/srv/component-a".to_string()),
+        homeboy_version: None,
+        git_sha: None,
+        rig_id: None,
+        metadata_json: json!({}),
+    };
+    store.import_run(&run).expect("import fuzz run");
+
+    let fixtures = [
+        ("fuzz-results", "fuzz_results", b"results".as_slice()),
+        (
+            "execution-request",
+            "fuzz_execution_request",
+            b"request".as_slice(),
+        ),
+        (
+            "result-envelope",
+            "fuzz_result_envelope",
+            b"envelope".as_slice(),
+        ),
+        ("coverage", "fuzz_coverage", b"coverage".as_slice()),
+    ];
+    let source_root = context.root().join("runner-artifacts");
+    fs::create_dir_all(&source_root).expect("create runner artifact root");
+
+    for (id, kind, bytes) in fixtures {
+        let source = source_root.join(id);
+        fs::write(&source, bytes).expect("write runner artifact");
+        let artifact = ArtifactRecord {
+            id: id.to_string(),
+            run_id: run.id.clone(),
+            kind: kind.to_string(),
+            artifact_type: "remote_file".to_string(),
+            path: runner_artifact_token("lab", "remote-fuzz-run", id),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            size_bytes: Some(i64::try_from(bytes.len()).expect("fixture size")),
+            mime: None,
+            metadata_json: json!({ "runner_id": "lab" }),
+            created_at: "2026-05-16T00:00:01Z".to_string(),
         };
-        store.import_run(&run).expect("import fuzz run");
+        import_mirrored_artifact_with_downloader(&store, &artifact, |_| Ok(source.clone()))
+            .expect("mirror runner artifact bytes");
+    }
 
-        let fixtures = [
-            ("fuzz-results", "fuzz_results", b"results".as_slice()),
-            (
-                "execution-request",
-                "fuzz_execution_request",
-                b"request".as_slice(),
-            ),
-            (
-                "result-envelope",
-                "fuzz_result_envelope",
-                b"envelope".as_slice(),
-            ),
-            ("coverage", "fuzz_coverage", b"coverage".as_slice()),
-        ];
-        let source_root = home.path().join("runner-artifacts");
-        fs::create_dir_all(&source_root).expect("create runner artifact root");
-
-        for (id, kind, bytes) in fixtures {
-            let source = source_root.join(id);
-            fs::write(&source, bytes).expect("write runner artifact");
-            let artifact = ArtifactRecord {
-                id: id.to_string(),
-                run_id: run.id.clone(),
-                kind: kind.to_string(),
-                artifact_type: "remote_file".to_string(),
-                path: runner_artifact_token("lab", "remote-fuzz-run", id),
-                url: None,
-                public_url: None,
-                viewer_url: None,
-                viewer_links: Vec::new(),
-                sha256: Some(format!("{:x}", Sha256::digest(bytes))),
-                size_bytes: Some(i64::try_from(bytes.len()).expect("fixture size")),
-                mime: None,
-                metadata_json: json!({ "runner_id": "lab" }),
-                created_at: "2026-05-16T00:00:01Z".to_string(),
-            };
-            import_mirrored_artifact_with_downloader(&store, &artifact, |_| Ok(source.clone()))
-                .expect("mirror runner artifact bytes");
-        }
-
-        fs::remove_dir_all(&source_root).expect("simulate runner cleanup");
-        for (id, _, bytes) in fixtures {
-            let artifact = store
-                .get_artifact(id)
-                .expect("artifact lookup")
-                .expect("controller-owned artifact");
-            assert_eq!(artifact.artifact_type, "file");
-            assert_eq!(fs::read(&artifact.path).expect("durable bytes"), bytes);
-            assert_eq!(artifact.size_bytes, Some(bytes.len() as i64));
-            assert_eq!(
-                artifact.sha256.as_deref(),
-                Some(format!("{:x}", Sha256::digest(bytes)).as_str())
-            );
-        }
-    });
+    fs::remove_dir_all(&source_root).expect("simulate runner cleanup");
+    for (id, _, bytes) in fixtures {
+        let artifact = store
+            .get_artifact(id)
+            .expect("artifact lookup")
+            .expect("controller-owned artifact");
+        assert_eq!(artifact.artifact_type, "file");
+        assert_eq!(fs::read(&artifact.path).expect("durable bytes"), bytes);
+        assert_eq!(artifact.size_bytes, Some(bytes.len() as i64));
+        assert_eq!(
+            artifact.sha256.as_deref(),
+            Some(format!("{:x}", Sha256::digest(bytes)).as_str())
+        );
+    }
 }
 
 #[test]
@@ -1421,77 +1419,81 @@ fn terminal_mirroring_imports_only_the_submitted_overlapping_job_run_and_artifac
         (&first, "first-run", "second-run", "first-result"),
         (&second, "second-run", "first-run", "second-result"),
     ] {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let store = ObservationStore::open_initialized().expect("store");
-            let runner = ssh_runner();
-            let details = std::collections::HashMap::from([
-                (
-                    "first-run",
-                    json!({
-                        "id": "first-run",
-                        "kind": "fuzz",
-                        "started_at": "2023-11-14T22:13:20Z",
-                        "finished_at": "2023-11-14T22:13:21Z",
-                        "status": "pass",
-                        "artifacts": [{"id": "first-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]
-                    }),
-                ),
-                (
-                    "second-run",
-                    json!({
-                        "id": "second-run",
-                        "kind": "fuzz",
-                        "started_at": "2023-11-14T22:13:20Z",
-                        "finished_at": "2023-11-14T22:13:21Z",
-                        "status": "fail",
-                        "artifacts": [{"id": "second-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d"}]
-                    }),
-                ),
-            ]);
+        // A fresh context per iteration, so the second job cannot see the
+        // first job's mirrored rows — the same per-iteration isolation the
+        // per-iteration `with_isolated_home` gave, without touching the
+        // process environment (#7505).
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+        let runner = ssh_runner();
+        let details = std::collections::HashMap::from([
+            (
+                "first-run",
+                json!({
+                    "id": "first-run",
+                    "kind": "fuzz",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "pass",
+                    "artifacts": [{"id": "first-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"}]
+                }),
+            ),
+            (
+                "second-run",
+                json!({
+                    "id": "second-run",
+                    "kind": "fuzz",
+                    "started_at": "2023-11-14T22:13:20Z",
+                    "finished_at": "2023-11-14T22:13:21Z",
+                    "status": "fail",
+                    "artifacts": [{"id": "second-result", "kind": "fuzz_results", "type": "file", "size_bytes": 1, "sha256": "3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d"}]
+                }),
+            ),
+        ]);
 
-            let run_ids = explicit_observation_run_ids(&json!({}), job);
-            let downloaded = tempfile::tempdir().expect("download directory");
-            let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
-                &store,
-                &runner,
-                job,
-                &run_ids,
-                None,
-                |run_id| Ok(details.get(run_id).cloned()),
-                |artifact_path| {
-                    let path = downloaded
-                        .path()
-                        .join(artifact_path.rsplit('/').next().expect("artifact id"));
-                    let bytes = if artifact_path.ends_with("first-result") {
-                        b"a".as_slice()
-                    } else {
-                        b"b".as_slice()
-                    };
-                    fs::write(&path, bytes).expect("artifact bytes");
-                    Ok(path)
-                },
-            )
-            .expect("mirror submitted terminal run");
+        let run_ids = explicit_observation_run_ids(&json!({}), job);
+        let downloaded = tempfile::tempdir().expect("download directory");
+        let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
+            &store,
+            &runner,
+            job,
+            &run_ids,
+            None,
+            |run_id| Ok(details.get(run_id).cloned()),
+            |artifact_path| {
+                let path = downloaded
+                    .path()
+                    .join(artifact_path.rsplit('/').next().expect("artifact id"));
+                let bytes = if artifact_path.ends_with("first-result") {
+                    b"a".as_slice()
+                } else {
+                    b"b".as_slice()
+                };
+                fs::write(&path, bytes).expect("artifact bytes");
+                Ok(path)
+            },
+        )
+        .expect("mirror submitted terminal run");
 
-            assert_eq!(mirrored.len(), 1);
-            assert_eq!(mirrored[0].id, expected_run);
-            assert_eq!(
-                mirrored[0].metadata_json["lab"]["remote_job_id"],
-                job.id.to_string()
-            );
-            assert!(store
-                .get_run(other_run)
-                .expect("other run lookup")
-                .is_none());
-            assert_eq!(
-                store
-                    .get_artifact(artifact_id)
-                    .expect("artifact lookup")
-                    .expect("mirrored artifact")
-                    .run_id,
-                expected_run
-            );
-        });
+        assert_eq!(mirrored.len(), 1);
+        assert_eq!(mirrored[0].id, expected_run);
+        assert_eq!(
+            mirrored[0].metadata_json["lab"]["remote_job_id"],
+            job.id.to_string()
+        );
+        assert!(store
+            .get_run(other_run)
+            .expect("other run lookup")
+            .is_none());
+        assert_eq!(
+            store
+                .get_artifact(artifact_id)
+                .expect("artifact lookup")
+                .expect("mirrored artifact")
+                .run_id,
+            expected_run
+        );
     }
 }
 
@@ -1533,229 +1535,227 @@ fn terminal_mirroring_withholds_output_when_declared_run_projection_is_missing()
 
 #[test]
 fn terminal_mirroring_persists_declared_run_and_artifact_for_controller_review() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("controller store");
-        let run_id = "bench-controller-review".to_string();
-        let bytes = b"reviewable visual evidence";
-        let digest = format!("{:x}", Sha256::digest(bytes));
-        let download_dir = tempfile::tempdir().expect("download directory");
-        let download_path = download_dir.path().join("diff.png");
-        let job = terminal_runner_job();
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("controller store");
+    let run_id = "bench-controller-review".to_string();
+    let bytes = b"reviewable visual evidence";
+    let digest = format!("{:x}", Sha256::digest(bytes));
+    let download_dir = tempfile::tempdir().expect("download directory");
+    let download_path = download_dir.path().join("diff.png");
+    let job = terminal_runner_job();
 
-        let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
-            &store,
-            &ssh_runner(),
-            &job,
-            std::slice::from_ref(&run_id),
-            None,
-            |requested| {
-                assert_eq!(requested, run_id);
-                Ok(Some(json!({
-                    "id": run_id,
-                    "kind": "bench",
-                    "started_at": "2023-11-14T22:13:20Z",
-                    "finished_at": "2023-11-14T22:13:21Z",
-                    "status": "fail",
-                    "artifacts": [{
-                        "id": "visual-diff",
-                        "kind": "visual_compare",
-                        "type": "file",
-                        "size_bytes": bytes.len(),
-                        "sha256": digest,
-                        "mime": "image/png"
-                    }]
-                })))
-            },
-            |_| {
-                fs::write(&download_path, bytes).expect("write downloaded artifact");
-                Ok(download_path.clone())
-            },
-        )
-        .expect("terminal runner evidence projects to the controller");
+    let mirrored = mirror_remote_observation_runs_by_id_with_downloader(
+        &store,
+        &ssh_runner(),
+        &job,
+        std::slice::from_ref(&run_id),
+        None,
+        |requested| {
+            assert_eq!(requested, run_id);
+            Ok(Some(json!({
+                "id": run_id,
+                "kind": "bench",
+                "started_at": "2023-11-14T22:13:20Z",
+                "finished_at": "2023-11-14T22:13:21Z",
+                "status": "fail",
+                "artifacts": [{
+                    "id": "visual-diff",
+                    "kind": "visual_compare",
+                    "type": "file",
+                    "size_bytes": bytes.len(),
+                    "sha256": digest,
+                    "mime": "image/png"
+                }]
+            })))
+        },
+        |_| {
+            fs::write(&download_path, bytes).expect("write downloaded artifact");
+            Ok(download_path.clone())
+        },
+    )
+    .expect("terminal runner evidence projects to the controller");
 
-        assert_eq!(mirrored[0].id, run_id);
-        assert_eq!(
-            store
-                .get_run(&run_id)
-                .expect("controller run lookup")
-                .expect("controller run"),
-            mirrored[0]
-        );
-        let artifact = store
-            .get_artifact("visual-diff")
-            .expect("controller artifact lookup")
-            .expect("controller artifact");
-        assert_eq!(artifact.run_id, run_id);
-        assert_eq!(artifact.artifact_type, "file");
-        assert_eq!(
-            fs::read(&artifact.path).expect("reviewer reads artifact"),
-            bytes
-        );
-    });
+    assert_eq!(mirrored[0].id, run_id);
+    assert_eq!(
+        store
+            .get_run(&run_id)
+            .expect("controller run lookup")
+            .expect("controller run"),
+        mirrored[0]
+    );
+    let artifact = store
+        .get_artifact("visual-diff")
+        .expect("controller artifact lookup")
+        .expect("controller artifact");
+    assert_eq!(artifact.run_id, run_id);
+    assert_eq!(artifact.artifact_type, "file");
+    assert_eq!(
+        fs::read(&artifact.path).expect("reviewer reads artifact"),
+        bytes
+    );
 }
 
 #[test]
 fn terminal_mirroring_keeps_every_declared_visual_artifact_after_runner_cleanup() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("controller store");
-        let run_id = "bench-visual-review".to_string();
-        let workspace = tempfile::tempdir().expect("runner workspace");
-        let artifacts = (0..21)
-            .map(|index| {
-                let id = format!("visual-{index:02}");
-                let bytes = format!("png-{index}").into_bytes();
-                let path = workspace.path().join(format!("{id}.png"));
-                fs::write(&path, &bytes).expect("runner artifact");
-                json!({
-                    "id": id,
-                    "kind": "visual_compare",
-                    "type": "file",
-                    "size_bytes": bytes.len(),
-                    "sha256": format!("{:x}", Sha256::digest(&bytes)),
-                    "mime": "image/png"
-                })
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("controller store");
+    let run_id = "bench-visual-review".to_string();
+    let workspace = tempfile::tempdir().expect("runner workspace");
+    let artifacts = (0..21)
+        .map(|index| {
+            let id = format!("visual-{index:02}");
+            let bytes = format!("png-{index}").into_bytes();
+            let path = workspace.path().join(format!("{id}.png"));
+            fs::write(&path, &bytes).expect("runner artifact");
+            json!({
+                "id": id,
+                "kind": "visual_compare",
+                "type": "file",
+                "size_bytes": bytes.len(),
+                "sha256": format!("{:x}", Sha256::digest(&bytes)),
+                "mime": "image/png"
             })
-            .collect::<Vec<_>>();
-        let job = terminal_runner_job();
+        })
+        .collect::<Vec<_>>();
+    let job = terminal_runner_job();
 
-        mirror_remote_observation_runs_by_id_with_downloader(
-            &store,
-            &ssh_runner(),
-            &job,
-            std::slice::from_ref(&run_id),
-            None,
-            |_| {
-                Ok(Some(json!({
-                    "id": run_id,
-                    "kind": "bench",
-                    "started_at": "2023-11-14T22:13:20Z",
-                    "finished_at": "2023-11-14T22:13:21Z",
-                    "status": "pass",
-                    "artifacts": artifacts,
-                })))
-            },
-            |artifact_path| {
-                let id = artifact_path.rsplit('/').next().expect("artifact id");
-                Ok(workspace.path().join(format!("{id}.png")))
-            },
-        )
-        .expect("all declared visual artifacts are durably mirrored");
+    mirror_remote_observation_runs_by_id_with_downloader(
+        &store,
+        &ssh_runner(),
+        &job,
+        std::slice::from_ref(&run_id),
+        None,
+        |_| {
+            Ok(Some(json!({
+                "id": run_id,
+                "kind": "bench",
+                "started_at": "2023-11-14T22:13:20Z",
+                "finished_at": "2023-11-14T22:13:21Z",
+                "status": "pass",
+                "artifacts": artifacts,
+            })))
+        },
+        |artifact_path| {
+            let id = artifact_path.rsplit('/').next().expect("artifact id");
+            Ok(workspace.path().join(format!("{id}.png")))
+        },
+    )
+    .expect("all declared visual artifacts are durably mirrored");
 
-        workspace.close().expect("runner workspace cleanup");
-        drop(store);
+    workspace.close().expect("runner workspace cleanup");
+    drop(store);
 
-        // A reviewer opens the controller store after the runner is gone and
-        // retrieves bytes by the stable run/artifact reference alone.
-        let reader = ObservationStore::open_initialized().expect("reviewer store");
-        let persisted = reader.list_artifacts(&run_id).expect("persisted artifacts");
-        assert_eq!(persisted.len(), 21);
-        for artifact in persisted {
-            assert_eq!(artifact.artifact_type, "file");
-            assert!(artifact.sha256.is_some());
-            assert!(!fs::read(&artifact.path)
-                .expect("controller artifact")
-                .is_empty());
-        }
-        let artifact = runs_service::resolve_artifact_for_run(&reader, &run_id, "visual-00")
-            .expect("reviewer resolves durable artifact");
-        let reviewer_copy = tempfile::NamedTempFile::new().expect("reviewer output");
-        let outcome = runs_service::copy_local_file_artifact(
-            artifact,
-            Some(reviewer_copy.path().to_path_buf()),
-        )
-        .expect("reviewer retrieves durable artifact");
-        assert_eq!(outcome.run_id, run_id);
-        assert_eq!(outcome.artifact_id, "visual-00");
-        assert_eq!(
-            fs::read(reviewer_copy.path()).expect("reviewer bytes"),
-            b"png-0"
-        );
-    });
+    // A reviewer opens the controller store after the runner is gone and
+    // retrieves bytes by the stable run/artifact reference alone.
+    let reader = ObservationStore::open_initialized_in_roots(&roots).expect("reviewer store");
+    let persisted = reader.list_artifacts(&run_id).expect("persisted artifacts");
+    assert_eq!(persisted.len(), 21);
+    for artifact in persisted {
+        assert_eq!(artifact.artifact_type, "file");
+        assert!(artifact.sha256.is_some());
+        assert!(!fs::read(&artifact.path)
+            .expect("controller artifact")
+            .is_empty());
+    }
+    let artifact = runs_service::resolve_artifact_for_run(&reader, &run_id, "visual-00")
+        .expect("reviewer resolves durable artifact");
+    let reviewer_copy = tempfile::NamedTempFile::new().expect("reviewer output");
+    let outcome =
+        runs_service::copy_local_file_artifact(artifact, Some(reviewer_copy.path().to_path_buf()))
+            .expect("reviewer retrieves durable artifact");
+    assert_eq!(outcome.run_id, run_id);
+    assert_eq!(outcome.artifact_id, "visual-00");
+    assert_eq!(
+        fs::read(reviewer_copy.path()).expect("reviewer bytes"),
+        b"png-0"
+    );
 }
 
 #[test]
 fn terminal_mirroring_copies_declared_directory_with_tree_hash() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("controller store");
-        let run_id = "bench-directory-review".to_string();
-        let workspace = tempfile::tempdir().expect("runner workspace");
-        let directory = workspace.path().join("visuals");
-        fs::create_dir_all(directory.join("nested")).expect("directory");
-        fs::write(directory.join("baseline.png"), b"baseline").expect("baseline");
-        fs::write(directory.join("nested/diff.png"), b"diff").expect("diff");
-        let tree_sha256 =
-            homeboy_core::observation::directory_tree_sha256(&directory).expect("tree hash");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("controller store");
+    let run_id = "bench-directory-review".to_string();
+    let workspace = tempfile::tempdir().expect("runner workspace");
+    let directory = workspace.path().join("visuals");
+    fs::create_dir_all(directory.join("nested")).expect("directory");
+    fs::write(directory.join("baseline.png"), b"baseline").expect("baseline");
+    fs::write(directory.join("nested/diff.png"), b"diff").expect("diff");
+    let tree_sha256 =
+        homeboy_core::observation::directory_tree_sha256(&directory).expect("tree hash");
 
-        mirror_remote_observation_runs_by_id_with_downloader(
-            &store,
-            &ssh_runner(),
-            &terminal_runner_job(),
-            std::slice::from_ref(&run_id),
-            None,
-            |_| {
-                Ok(Some(json!({
-                    "id": run_id,
-                    "kind": "bench",
-                    "started_at": "2023-11-14T22:13:20Z",
-                    "finished_at": "2023-11-14T22:13:21Z",
-                    "status": "pass",
-                    "artifacts": [{
-                        "id": "visual-directory",
-                        "kind": "visual_compare",
-                        "type": "directory",
-                        "path": "runner-artifact://lab/bench-directory-review/visual-directory",
-                        "sha256": tree_sha256.clone()
-                    }]
-                })))
-            },
-            |_| Ok(directory.clone()),
-        )
-        .expect("directory is durably mirrored");
+    mirror_remote_observation_runs_by_id_with_downloader(
+        &store,
+        &ssh_runner(),
+        &terminal_runner_job(),
+        std::slice::from_ref(&run_id),
+        None,
+        |_| {
+            Ok(Some(json!({
+                "id": run_id,
+                "kind": "bench",
+                "started_at": "2023-11-14T22:13:20Z",
+                "finished_at": "2023-11-14T22:13:21Z",
+                "status": "pass",
+                "artifacts": [{
+                    "id": "visual-directory",
+                    "kind": "visual_compare",
+                    "type": "directory",
+                    "path": "runner-artifact://lab/bench-directory-review/visual-directory",
+                    "sha256": tree_sha256.clone()
+                }]
+            })))
+        },
+        |_| Ok(directory.clone()),
+    )
+    .expect("directory is durably mirrored");
 
-        workspace.close().expect("runner workspace cleanup");
-        let artifact = store
-            .get_artifact("visual-directory")
-            .expect("artifact lookup")
-            .expect("artifact");
-        assert_eq!(artifact.artifact_type, "directory");
-        assert_eq!(artifact.sha256.as_deref(), Some(tree_sha256.as_str()));
-        assert!(std::path::Path::new(&artifact.path).is_dir());
-    });
+    workspace.close().expect("runner workspace cleanup");
+    let artifact = store
+        .get_artifact("visual-directory")
+        .expect("artifact lookup")
+        .expect("artifact");
+    assert_eq!(artifact.artifact_type, "directory");
+    assert_eq!(artifact.sha256.as_deref(), Some(tree_sha256.as_str()));
+    assert!(std::path::Path::new(&artifact.path).is_dir());
 }
 
 #[test]
 fn terminal_mirroring_rejects_url_only_declared_artifacts() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("controller store");
-        let run_id = "bench-expired-tunnel".to_string();
-        let error = mirror_remote_observation_runs_by_id_with_downloader(
-            &store,
-            &ssh_runner(),
-            &terminal_runner_job(),
-            std::slice::from_ref(&run_id),
-            None,
-            |_| {
-                Ok(Some(json!({
-                    "id": run_id,
-                    "kind": "bench",
-                    "started_at": "2023-11-14T22:13:20Z",
-                    "finished_at": "2023-11-14T22:13:21Z",
-                    "status": "pass",
-                    "artifacts": [{
-                        "id": "expired-tunnel",
-                        "kind": "visual_compare",
-                        "type": "url",
-                        "url": "https://expired.example/visual.png"
-                    }]
-                })))
-            },
-            |_| unreachable!("URL artifacts must not be downloaded as terminal evidence"),
-        )
-        .expect_err("URL-only artifact must fail terminal projection");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("controller store");
+    let run_id = "bench-expired-tunnel".to_string();
+    let error = mirror_remote_observation_runs_by_id_with_downloader(
+        &store,
+        &ssh_runner(),
+        &terminal_runner_job(),
+        std::slice::from_ref(&run_id),
+        None,
+        |_| {
+            Ok(Some(json!({
+                "id": run_id,
+                "kind": "bench",
+                "started_at": "2023-11-14T22:13:20Z",
+                "finished_at": "2023-11-14T22:13:21Z",
+                "status": "pass",
+                "artifacts": [{
+                    "id": "expired-tunnel",
+                    "kind": "visual_compare",
+                    "type": "url",
+                    "url": "https://expired.example/visual.png"
+                }]
+            })))
+        },
+        |_| unreachable!("URL artifacts must not be downloaded as terminal evidence"),
+    )
+    .expect_err("URL-only artifact must fail terminal projection");
 
-        assert!(error.message.contains("durably project all artifacts"));
-        assert!(store.get_run(&run_id).expect("run lookup").is_none());
-    });
+    assert!(error.message.contains("durably project all artifacts"));
+    assert!(store.get_run(&run_id).expect("run lookup").is_none());
 }
 
 #[test]
@@ -2100,211 +2100,174 @@ fn legacy_terminal_artifacts_use_the_controller_runner_run_and_survive_runner_di
 
 #[test]
 fn terminal_artifacts_missing_integrity_are_permanent_provenance_errors() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        job.artifacts = vec![JobArtifactMetadata {
-            id: "missing-digest".to_string(),
-            name: None,
-            path: None,
-            url: None,
-            mime: None,
-            size_bytes: Some(1),
-            sha256: None,
-            content_base64: None,
-            metadata: None,
-        }];
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/runner",
-            &[],
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("synthetic run");
-        let error =
-            mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| Ok(vec![1]))
-                .expect_err("missing provenance is not retryable");
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        assert!(!error.retryable.unwrap_or(true));
-        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
-    });
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    job.artifacts = vec![JobArtifactMetadata {
+        id: "missing-digest".to_string(),
+        name: None,
+        path: None,
+        url: None,
+        mime: None,
+        size_bytes: Some(1),
+        sha256: None,
+        content_base64: None,
+        metadata: None,
+    }];
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/runner",
+        &[],
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("synthetic run");
+    let error =
+        mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| Ok(vec![1]))
+            .expect_err("missing provenance is not retryable");
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    assert!(!error.retryable.unwrap_or(true));
+    assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
 }
 
 #[test]
 fn terminal_artifact_missing_mime_is_a_permanent_provenance_error() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        let bytes = b"typed terminal artifact";
-        job.artifacts = vec![JobArtifactMetadata {
-            id: "missing-mime".to_string(),
-            name: Some("artifact.unknown".to_string()),
-            path: Some("/runner/artifact.unknown".to_string()),
-            url: None,
-            mime: None,
-            size_bytes: Some(bytes.len() as u64),
-            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
-            content_base64: None,
-            metadata: None,
-        }];
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/runner",
-            &[],
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("synthetic run");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    let bytes = b"typed terminal artifact";
+    job.artifacts = vec![JobArtifactMetadata {
+        id: "missing-mime".to_string(),
+        name: Some("artifact.unknown".to_string()),
+        path: Some("/runner/artifact.unknown".to_string()),
+        url: None,
+        mime: None,
+        size_bytes: Some(bytes.len() as u64),
+        sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+        content_base64: None,
+        metadata: None,
+    }];
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/runner",
+        &[],
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("synthetic run");
 
-        let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| {
-            Ok(bytes.to_vec())
-        })
-        .expect_err("missing media type is rejected");
+    let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |_| {
+        Ok(bytes.to_vec())
+    })
+    .expect_err("missing media type is rejected");
 
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        assert_eq!(
-            error.details["source_error"]["details"]["field"],
-            "artifact.mime"
-        );
-        assert!(!error.retryable.unwrap_or(true));
-        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
-    });
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    assert_eq!(
+        error.details["source_error"]["details"]["field"],
+        "artifact.mime"
+    );
+    assert!(!error.retryable.unwrap_or(true));
+    assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
 }
 
 #[test]
 fn terminal_artifact_download_failure_rolls_back_every_artifact_and_retry_is_idempotent() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        let first = b"first terminal artifact";
-        let second = b"second terminal artifact";
-        job.artifacts = [("first", first.as_slice()), ("second", second.as_slice())]
-            .into_iter()
-            .map(|(id, bytes)| JobArtifactMetadata {
-                id: id.to_string(),
-                name: None,
-                path: None,
-                url: None,
-                mime: Some("application/octet-stream".to_string()),
-                size_bytes: Some(bytes.len() as u64),
-                sha256: Some(format!("{:x}", Sha256::digest(bytes))),
-                content_base64: None,
-                metadata: None,
-            })
-            .collect();
-        let run = mirror_job_run(
-            &store,
-            &ssh_runner(),
-            "/runner",
-            &[],
-            &job,
-            &[],
-            &json!({}),
-            None,
-            None,
-        )
-        .expect("synthetic run");
-        let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
-            if id == "second" {
-                Err(Error::internal_io("runner disconnected", None))
-            } else {
-                Ok(first.to_vec())
-            }
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    let first = b"first terminal artifact";
+    let second = b"second terminal artifact";
+    job.artifacts = [("first", first.as_slice()), ("second", second.as_slice())]
+        .into_iter()
+        .map(|(id, bytes)| JobArtifactMetadata {
+            id: id.to_string(),
+            name: None,
+            path: None,
+            url: None,
+            mime: Some("application/octet-stream".to_string()),
+            size_bytes: Some(bytes.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(bytes))),
+            content_base64: None,
+            metadata: None,
         })
-        .expect_err("later artifact download fails the complete projection");
-        assert!(error.retryable.unwrap_or(false));
-        assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
+        .collect();
+    let run = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/runner",
+        &[],
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("synthetic run");
+    let error = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+        if id == "second" {
+            Err(Error::internal_io("runner disconnected", None))
+        } else {
+            Ok(first.to_vec())
+        }
+    })
+    .expect_err("later artifact download fails the complete projection");
+    assert!(error.retryable.unwrap_or(false));
+    assert!(store.list_artifacts(&run.id).expect("artifacts").is_empty());
 
-        let first_projection =
-            mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
-                Ok(if id == "first" {
-                    first.to_vec()
-                } else {
-                    second.to_vec()
-                })
-            })
-            .expect("retry projects complete artifact set");
-        let replay = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+    let first_projection =
+        mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
             Ok(if id == "first" {
                 first.to_vec()
             } else {
                 second.to_vec()
             })
         })
-        .expect("identical retry is idempotent");
-        assert_eq!(first_projection, replay);
-        assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 2);
-    });
+        .expect("retry projects complete artifact set");
+    let replay = mirror_terminal_job_artifacts_with(&store, &ssh_runner(), &job, &run, |id| {
+        Ok(if id == "first" {
+            first.to_vec()
+        } else {
+            second.to_vec()
+        })
+    })
+    .expect("identical retry is idempotent");
+    assert_eq!(first_projection, replay);
+    assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 2);
 }
 
 #[test]
 fn failed_refresh_discards_its_synthetic_run_after_artifact_projection_error() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        job.artifacts = vec![JobArtifactMetadata {
-            id: "malformed".to_string(),
-            name: None,
-            path: None,
-            url: None,
-            mime: None,
-            size_bytes: Some(1),
-            sha256: None,
-            content_base64: None,
-            metadata: None,
-        }];
-        let command = vec!["homeboy".to_string(), "test".to_string()];
-        let synthetic_id = super::util::local_job_run_id("lab", &job.id.to_string(), "test");
-        refresh_mirrored_daemon_evidence_with(
-            &store,
-            MirrorEvidenceRequest::new(
-                &ssh_runner(),
-                "/runner",
-                &command,
-                &job,
-                &[],
-                &json!({}),
-                None,
-                None,
-            ),
-            || Ok(()),
-        )
-        .expect_err("malformed terminal artifact fails refresh");
-        assert!(store
-            .get_run(&synthetic_id)
-            .expect("synthetic lookup")
-            .is_none());
-    });
-}
-
-#[test]
-fn failed_refresh_preserves_a_concurrent_synthetic_winner() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let store = ObservationStore::open_initialized().expect("store");
-        let mut job = terminal_runner_job();
-        job.artifacts = vec![JobArtifactMetadata {
-            id: "malformed".to_string(),
-            name: None,
-            path: None,
-            url: None,
-            mime: None,
-            size_bytes: Some(1),
-            sha256: None,
-            content_base64: None,
-            metadata: None,
-        }];
-        let command = vec!["homeboy".to_string(), "test".to_string()];
-        let winner = mirror_job_run(
-            &store,
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    job.artifacts = vec![JobArtifactMetadata {
+        id: "malformed".to_string(),
+        name: None,
+        path: None,
+        url: None,
+        mime: None,
+        size_bytes: Some(1),
+        sha256: None,
+        content_base64: None,
+        metadata: None,
+    }];
+    let command = vec!["homeboy".to_string(), "test".to_string()];
+    let synthetic_id = super::util::local_job_run_id("lab", &job.id.to_string(), "test");
+    refresh_mirrored_daemon_evidence_with(
+        &store,
+        MirrorEvidenceRequest::new(
             &ssh_runner(),
             "/runner",
             &command,
@@ -2313,25 +2276,62 @@ fn failed_refresh_preserves_a_concurrent_synthetic_winner() {
             &json!({}),
             None,
             None,
-        )
-        .expect("concurrent winner");
-        refresh_mirrored_daemon_evidence_with(
-            &store,
-            MirrorEvidenceRequest::new(
-                &ssh_runner(),
-                "/runner",
-                &command,
-                &job,
-                &[],
-                &json!({}),
-                None,
-                None,
-            ),
-            || Ok(()),
-        )
-        .expect_err("malformed terminal artifact fails refresh");
-        assert!(store.get_run(&winner.id).expect("winner lookup").is_some());
-    });
+        ),
+        || Ok(()),
+    )
+    .expect_err("malformed terminal artifact fails refresh");
+    assert!(store
+        .get_run(&synthetic_id)
+        .expect("synthetic lookup")
+        .is_none());
+}
+
+#[test]
+fn failed_refresh_preserves_a_concurrent_synthetic_winner() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let mut job = terminal_runner_job();
+    job.artifacts = vec![JobArtifactMetadata {
+        id: "malformed".to_string(),
+        name: None,
+        path: None,
+        url: None,
+        mime: None,
+        size_bytes: Some(1),
+        sha256: None,
+        content_base64: None,
+        metadata: None,
+    }];
+    let command = vec!["homeboy".to_string(), "test".to_string()];
+    let winner = mirror_job_run(
+        &store,
+        &ssh_runner(),
+        "/runner",
+        &command,
+        &job,
+        &[],
+        &json!({}),
+        None,
+        None,
+    )
+    .expect("concurrent winner");
+    refresh_mirrored_daemon_evidence_with(
+        &store,
+        MirrorEvidenceRequest::new(
+            &ssh_runner(),
+            "/runner",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            None,
+            None,
+        ),
+        || Ok(()),
+    )
+    .expect_err("malformed terminal artifact fails refresh");
+    assert!(store.get_run(&winner.id).expect("winner lookup").is_some());
 }
 
 #[test]

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -1,7 +1,15 @@
 //! Observation-store foundation tests.
 //!
-//! These isolate `HOME` / `XDG_DATA_HOME` so the developer's real local DB is
-//! never read or written.
+//! Most of these take their filesystem roots from a `HermeticTestContext` and
+//! open the store with [`ObservationStore::open_initialized_in_roots`], so both
+//! the database and the artifact tree it indexes are injected and no process
+//! state is mutated (#7505).
+//!
+//! The exceptions are deliberate. `test_status` and `test_database_path` pin
+//! the *ambient* resolution order itself, and `run_context_tests` assert the
+//! subprocess environment-variable wiring `start_run` reads. Those still use
+//! `with_isolated_home`, because the thing under test is the process
+//! environment.
 
 use crate::observation::store::{
     self, ObservationStore, CURRENT_MIGRATION_COUNT, CURRENT_SCHEMA_VERSION,
@@ -11,7 +19,7 @@ use crate::observation::{
     FindingListFilter, NewFindingRecord, NewRunRecord, RunContext, RunListFilter, RunProvenance,
     RunRecord, RunStatus,
 };
-use crate::test_support::with_isolated_home;
+use crate::test_support::{with_isolated_home, HermeticTestContext};
 use std::sync::{Arc, Barrier};
 
 struct XdgGuard {
@@ -125,227 +133,227 @@ mod store_init_tests {
 
     #[test]
     fn test_open_initialized() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
 
-            let store = ObservationStore::open_initialized().expect("init store");
-            let status = store.status().expect("status");
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let status = store.status().expect("status");
 
-            assert!(status.exists);
-            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
-            assert_eq!(status.table_count, 8);
-        });
+        assert!(status.exists);
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
+        assert_eq!(status.table_count, 8);
     }
 
     #[test]
     fn initialization_is_idempotent() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
 
-            ObservationStore::open_initialized().expect("first init");
-            let second = ObservationStore::open_initialized().expect("second init");
-            let status = second.status().expect("status");
+        ObservationStore::open_initialized_in_roots(&roots).expect("first init");
+        let second = ObservationStore::open_initialized_in_roots(&roots).expect("second init");
+        let status = second.status().expect("status");
 
-            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
-            assert_eq!(status.table_count, 8);
-        });
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
+        assert_eq!(status.table_count, 8);
     }
 
     #[test]
     fn initialization_recovers_when_artifact_type_migration_was_interrupted() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
 
-            ObservationStore::open_initialized().expect("initial migration");
-            let path = store::database_path().expect("db path");
-            let connection = rusqlite::Connection::open(&path).expect("open raw db");
-            connection
-                .execute("DELETE FROM schema_migrations WHERE version = 4", [])
-                .expect("remove migration marker");
-            drop(connection);
+        ObservationStore::open_initialized_in_roots(&roots).expect("initial migration");
+        // The database the rooted opens above and below use, resolved from the
+        // injected data root rather than re-derived from the environment.
+        let path = crate::paths::observation_db_in_root(roots.data());
+        let connection = rusqlite::Connection::open(&path).expect("open raw db");
+        connection
+            .execute("DELETE FROM schema_migrations WHERE version = 4", [])
+            .expect("remove migration marker");
+        drop(connection);
 
-            let reopened = ObservationStore::open_initialized().expect("resume migration");
-            let status = reopened.status().expect("status");
+        let reopened =
+            ObservationStore::open_initialized_in_roots(&roots).expect("resume migration");
+        let status = reopened.status().expect("status");
 
-            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
-        });
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
     }
 
     #[test]
     fn initialization_is_safe_under_concurrent_setup() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let workers = 4;
-            let barrier = Arc::new(Barrier::new(workers));
-            let handles = (0..workers)
-                .map(|_| {
-                    let barrier = Arc::clone(&barrier);
-                    std::thread::spawn(move || {
-                        barrier.wait();
-                        ObservationStore::open_initialized()
-                            .expect("concurrent init")
-                            .status()
-                            .expect("status")
-                    })
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let workers = 4;
+        let barrier = Arc::new(Barrier::new(workers));
+        let handles = (0..workers)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                let roots = roots.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ObservationStore::open_initialized_in_roots(&roots)
+                        .expect("concurrent init")
+                        .status()
+                        .expect("status")
                 })
-                .collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
-            for handle in handles {
-                let status = handle.join().expect("worker joined");
-                assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-                assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
-            }
-        });
+        for handle in handles {
+            let status = handle.join().expect("worker joined");
+            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
+        }
     }
 
     #[test]
     fn artifact_handle_backfill_recovers_after_a_transient_writer_lock() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let path = store::database_path().expect("database path");
-            std::fs::create_dir_all(path.parent().expect("database parent"))
-                .expect("create database parent");
-            let connection = super::super::schema::open_connection(&path).expect("open schema");
-            super::super::schema::apply_migrations(&connection).expect("apply schema");
-            drop(connection);
-            let writer = rusqlite::Connection::open(&path).expect("open locking connection");
-            writer
-                .execute_batch("PRAGMA journal_mode=DELETE;")
-                .expect("use rollback journal mode");
-            let store = ObservationStore {
-                connection: rusqlite::Connection::open(&path).expect("open test store"),
-                path: path.clone(),
-                readonly: false,
-                roots: None,
-            };
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
-            let artifact_id = "legacy-artifact";
-            writer
-                .execute(
-                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
-                    rusqlite::params![artifact_id, run.id],
-                )
-                .expect("insert legacy artifact");
-            writer
-                .execute_batch("BEGIN EXCLUSIVE;")
-                .expect("hold writer lock");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let path = crate::paths::observation_db_in_root(roots.data());
+        std::fs::create_dir_all(path.parent().expect("database parent"))
+            .expect("create database parent");
+        let connection = super::super::schema::open_connection(&path).expect("open schema");
+        super::super::schema::apply_migrations(&connection).expect("apply schema");
+        drop(connection);
+        let writer = rusqlite::Connection::open(&path).expect("open locking connection");
+        writer
+            .execute_batch("PRAGMA journal_mode=DELETE;")
+            .expect("use rollback journal mode");
+        // Hand-built because the test owns the connection's journal mode, but
+        // the store is still rooted: `roots` carries the artifact tree, so no
+        // handle here can resolve an ambient one (#7505).
+        let store = ObservationStore {
+            connection: rusqlite::Connection::open(&path).expect("open test store"),
+            path: path.clone(),
+            readonly: false,
+            roots: Some(roots.clone()),
+        };
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
+        let artifact_id = "legacy-artifact";
+        writer
+            .execute(
+                "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
+                rusqlite::params![artifact_id, run.id],
+            )
+            .expect("insert legacy artifact");
+        writer
+            .execute_batch("BEGIN EXCLUSIVE;")
+            .expect("hold writer lock");
 
-            let (retry_started_tx, retry_started_rx) = std::sync::mpsc::sync_channel(0);
-            let (release_retry_tx, release_retry_rx) = std::sync::mpsc::sync_channel(0);
-            let worker = std::thread::spawn(move || {
-                store.backfill_artifact_handles_with_retry(|| {
-                    retry_started_tx.send(()).expect("report retry");
-                    release_retry_rx.recv().expect("release retry");
-                })
-            });
-            retry_started_rx
-                .recv()
-                .expect("backfill attempted while locked");
-            writer
-                .execute_batch("COMMIT;")
-                .expect("release writer lock");
-            release_retry_tx.send(()).expect("resume backfill");
-
-            worker
-                .join()
-                .expect("backfill worker joined")
-                .expect("backfill recovers after lock release");
-
-            let check = rusqlite::Connection::open(path).expect("open check connection");
-            let (handle, diagnostic, rank): (String, i64, String) = check
-                .query_row(
-                    "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = ?1",
-                    [artifact_id],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                )
-                .expect("read backfilled artifact");
-            assert!(handle.starts_with("ah_"));
-            assert_eq!(diagnostic, 0);
-            assert_eq!(rank, "0");
+        let (retry_started_tx, retry_started_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_retry_tx, release_retry_rx) = std::sync::mpsc::sync_channel(0);
+        let worker = std::thread::spawn(move || {
+            store.backfill_artifact_handles_with_retry(|| {
+                retry_started_tx.send(()).expect("report retry");
+                release_retry_rx.recv().expect("release retry");
+            })
         });
+        retry_started_rx
+            .recv()
+            .expect("backfill attempted while locked");
+        writer
+            .execute_batch("COMMIT;")
+            .expect("release writer lock");
+        release_retry_tx.send(()).expect("resume backfill");
+
+        worker
+            .join()
+            .expect("backfill worker joined")
+            .expect("backfill recovers after lock release");
+
+        let check = rusqlite::Connection::open(path).expect("open check connection");
+        let (handle, diagnostic, rank): (String, i64, String) = check
+            .query_row(
+                "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = ?1",
+                [artifact_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read backfilled artifact");
+        assert!(handle.starts_with("ah_"));
+        assert_eq!(diagnostic, 0);
+        assert_eq!(rank, "0");
     }
 
     #[test]
     fn artifact_handle_backfill_does_not_replace_materialized_diagnostic_metadata() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("initialize store");
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
-            store
-                .connection
-                .execute(
-                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":1}', '2026-01-01T00:00:00Z', NULL, 0, '99')",
-                    rusqlite::params!["materialized-artifact", run.id],
-                )
-                .expect("insert partially backfilled artifact");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("initialize store");
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
+        store
+            .connection
+            .execute(
+                "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES (?1, ?2, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":1}', '2026-01-01T00:00:00Z', NULL, 0, '99')",
+                rusqlite::params!["materialized-artifact", run.id],
+            )
+            .expect("insert partially backfilled artifact");
 
-            store
-                .backfill_artifact_handles_with_retry(|| {})
-                .expect("backfill artifact handle");
+        store
+            .backfill_artifact_handles_with_retry(|| {})
+            .expect("backfill artifact handle");
 
-            let (handle, diagnostic, rank): (String, i64, String) = store
-                .connection
-                .query_row(
-                    "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = 'materialized-artifact'",
-                    [],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                )
-                .expect("read backfilled artifact");
-            assert!(handle.starts_with("ah_"));
-            assert_eq!(diagnostic, 0);
-            assert_eq!(rank, "99");
-        });
+        let (handle, diagnostic, rank): (String, i64, String) = store
+            .connection
+            .query_row(
+                "SELECT artifact_handle, failure_diagnostic, failure_diagnostic_rank FROM artifacts WHERE id = 'materialized-artifact'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read backfilled artifact");
+        assert!(handle.starts_with("ah_"));
+        assert_eq!(diagnostic, 0);
+        assert_eq!(rank, "99");
     }
 
     #[test]
     fn normal_open_backfills_artifact_handles_before_a_bounded_projection() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let path = store::database_path().expect("database path");
-            let lifecycle = ObservationStore::open_initialized_for_lifecycle_at(&path)
-                .expect("initialize lifecycle store");
-            let run = lifecycle
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
-            lifecycle
-                .connection
-                .execute(
-                    "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES ('legacy-projection-artifact', ?1, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":2}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
-                    [run.id.as_str()],
-                )
-                .expect("insert legacy artifact");
-            drop(lifecycle);
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let lifecycle = ObservationStore::open_initialized_for_lifecycle_in_roots(&roots)
+            .expect("initialize lifecycle store");
+        let run = lifecycle
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
+        lifecycle
+            .connection
+            .execute(
+                "INSERT INTO artifacts(id, run_id, kind, artifact_type, path, viewer_links_json, metadata_json, created_at, artifact_handle, failure_diagnostic, failure_diagnostic_rank) VALUES ('legacy-projection-artifact', ?1, 'evidence', 'url', 'https://example.test/evidence', '[]', '{\"failure_diagnostic\":true,\"failure_diagnostic_rank\":2}', '2026-01-01T00:00:00Z', NULL, NULL, NULL)",
+                [run.id.as_str()],
+            )
+            .expect("insert legacy artifact");
+        drop(lifecycle);
 
-            let store = ObservationStore::open_initialized().expect("normal open backfills");
-            let projection = store
-                .bounded_artifact_projection_for_runs(&[run.id], 10)
-                .expect("project backfilled artifact");
+        let store =
+            ObservationStore::open_initialized_in_roots(&roots).expect("normal open backfills");
+        let projection = store
+            .bounded_artifact_projection_for_runs(&[run.id], 10)
+            .expect("project backfilled artifact");
 
-            assert_eq!(projection.artifacts.len(), 1);
-            assert!(projection.artifacts[0].id.starts_with("ah_"));
-            assert_eq!(
-                projection.diagnostic_handle,
-                Some(projection.artifacts[0].id.clone())
-            );
-        });
+        assert_eq!(projection.artifacts.len(), 1);
+        assert!(projection.artifacts[0].id.starts_with("ah_"));
+        assert_eq!(
+            projection.diagnostic_handle,
+            Some(projection.artifacts[0].id.clone())
+        );
     }
 
     #[test]
     fn migration_from_version_8_preserves_artifacts_and_adds_query_indexes() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let path = store::database_path().expect("db path");
-            std::fs::create_dir_all(path.parent().expect("db parent")).expect("create db parent");
-            let db = rusqlite::Connection::open(&path).expect("open version 8 db");
-            db.execute_batch(
-                r#"
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let path = crate::paths::observation_db_in_root(roots.data());
+        std::fs::create_dir_all(path.parent().expect("db parent")).expect("create db parent");
+        let db = rusqlite::Connection::open(&path).expect("open version 8 db");
+        db.execute_batch(
+            r#"
                 CREATE TABLE schema_migrations (
                     version INTEGER PRIMARY KEY,
                     applied_at TEXT NOT NULL
@@ -416,229 +424,224 @@ mod store_init_tests {
                        ('artifact-2', 'run-1', 'log', '/tmp/two', '2026-01-01T00:01:00Z'),
                        ('artifact-3', 'run-2', 'log', '/tmp/three', '2026-01-01T00:02:00Z');
                 "#,
-            )
-            .expect("create version 8 fixture");
-            drop(db);
+        )
+        .expect("create version 8 fixture");
+        drop(db);
 
-            let store = ObservationStore::open_initialized_at(&path).expect("migrate version 8");
-            let status = store.status().expect("status");
-            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-            assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
+        // `open_initialized_in_roots` resolves the same database as `path`
+        // above, and additionally roots the artifact tree the migrated store
+        // indexes — which `open_initialized_at` would have left ambient.
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("migrate version 8");
+        let status = store.status().expect("status");
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, CURRENT_MIGRATION_COUNT);
 
-            let db = rusqlite::Connection::open(path).expect("inspect migrated db");
-            let indexes = db
+        let db = rusqlite::Connection::open(path).expect("inspect migrated db");
+        let indexes = db
                 .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'artifacts' ORDER BY name")
                 .expect("prepare indexes")
                 .query_map([], |row| row.get::<_, String>(0))
                 .expect("query indexes")
                 .collect::<Result<Vec<_>, _>>()
                 .expect("collect indexes");
-            assert!(indexes.contains(&"idx_artifacts_run_created".to_string()));
-            assert!(indexes.contains(&"idx_artifacts_created_at".to_string()));
+        assert!(indexes.contains(&"idx_artifacts_run_created".to_string()));
+        assert!(indexes.contains(&"idx_artifacts_created_at".to_string()));
 
-            let artifact_count: i64 = db
-                .query_row("SELECT COUNT(*) FROM artifacts", [], |row| row.get(0))
-                .expect("count migrated artifacts");
-            assert_eq!(artifact_count, 3);
+        let artifact_count: i64 = db
+            .query_row("SELECT COUNT(*) FROM artifacts", [], |row| row.get(0))
+            .expect("count migrated artifacts");
+        assert_eq!(artifact_count, 3);
 
-            for (index, columns) in [
-                (
-                    "idx_artifacts_run_created",
-                    vec![("run_id", 0), ("created_at", 0), ("id", 0)],
-                ),
-                (
-                    "idx_artifacts_created_at",
-                    vec![("created_at", 0), ("id", 0)],
-                ),
-            ] {
-                let mut statement = db
+        for (index, columns) in [
+            (
+                "idx_artifacts_run_created",
+                vec![("run_id", 0), ("created_at", 0), ("id", 0)],
+            ),
+            (
+                "idx_artifacts_created_at",
+                vec![("created_at", 0), ("id", 0)],
+            ),
+        ] {
+            let mut statement = db
                     .prepare(
                         "SELECT name, desc FROM pragma_index_xinfo(?1) WHERE \"key\" = 1 ORDER BY seqno",
                     )
                     .expect("prepare index columns");
-                let actual_columns = statement
-                    .query_map([index], |row| {
-                        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-                    })
-                    .expect("query index columns")
-                    .collect::<Result<Vec<_>, _>>()
-                    .expect("collect index columns");
-                assert_eq!(
-                    actual_columns
-                        .iter()
-                        .map(|(name, descending)| (name.as_str(), *descending))
-                        .collect::<Vec<_>>(),
-                    columns,
-                    "unexpected columns for {index}"
-                );
-            }
-        });
+            let actual_columns = statement
+                .query_map([index], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .expect("query index columns")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("collect index columns");
+            assert_eq!(
+                actual_columns
+                    .iter()
+                    .map(|(name, descending)| (name.as_str(), *descending))
+                    .collect::<Vec<_>>(),
+                columns,
+                "unexpected columns for {index}"
+            );
+        }
     }
 
     #[test]
     fn readonly_run_lookups_complete_while_import_writes_evidence() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("initialize store");
-            let persisted = sample_import_run("terminal-run");
-            store.import_run(&persisted).expect("persist terminal run");
-            store
-                .record_url_artifact(&persisted.id, "evidence", "https://example.test/evidence")
-                .expect("persist artifact");
-            let path = store::database_path().expect("database path");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("initialize store");
+        let persisted = sample_import_run("terminal-run");
+        store.import_run(&persisted).expect("persist terminal run");
+        store
+            .record_url_artifact(&persisted.id, "evidence", "https://example.test/evidence")
+            .expect("persist artifact");
 
-            let workers = 5;
-            let barrier = Arc::new(Barrier::new(workers));
-            let writer_path = path.clone();
-            let writer_barrier = Arc::clone(&barrier);
-            let writer = std::thread::spawn(move || {
-                let writer =
-                    ObservationStore::open_initialized_at(writer_path).expect("writer store");
-                writer_barrier.wait();
-                for index in 0..100 {
-                    let mut imported = sample_import_run(&format!("import-{index}"));
-                    imported.metadata_json["import_sequence"] = serde_json::json!(index);
-                    writer.import_run(&imported).expect("import evidence");
-                }
-            });
-
-            let readers = (0..workers - 1)
-                .map(|_| {
-                    let path = path.clone();
-                    let barrier = Arc::clone(&barrier);
-                    let expected = persisted.clone();
-                    std::thread::spawn(move || {
-                        barrier.wait();
-                        for _ in 0..100 {
-                            let reader = ObservationStore::open_readonly_at(&path)
-                                .expect("bounded read-only store");
-                            assert_eq!(
-                                reader.get_run(&expected.id).expect("read terminal run"),
-                                Some(expected.clone()),
-                                "readers retain a coherent terminal record while imports write"
-                            );
-                            assert_eq!(
-                                reader
-                                    .list_artifacts(&expected.id)
-                                    .expect("read terminal artifacts")
-                                    .len(),
-                                1,
-                                "readers retain coherent artifacts while imports write"
-                            );
-                        }
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            writer.join().expect("writer joined");
-            for reader in readers {
-                reader.join().expect("reader joined");
+        let workers = 5;
+        let barrier = Arc::new(Barrier::new(workers));
+        let writer_roots = roots.clone();
+        let writer_barrier = Arc::clone(&barrier);
+        let writer = std::thread::spawn(move || {
+            let writer =
+                ObservationStore::open_initialized_in_roots(&writer_roots).expect("writer store");
+            writer_barrier.wait();
+            for index in 0..100 {
+                let mut imported = sample_import_run(&format!("import-{index}"));
+                imported.metadata_json["import_sequence"] = serde_json::json!(index);
+                writer.import_run(&imported).expect("import evidence");
             }
-            assert!(store
-                .get_run("import-99")
-                .expect("read imported run")
-                .is_some());
         });
+
+        let readers = (0..workers - 1)
+            .map(|_| {
+                let roots = roots.clone();
+                let barrier = Arc::clone(&barrier);
+                let expected = persisted.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    for _ in 0..100 {
+                        let reader = ObservationStore::open_readonly_in_roots(&roots)
+                            .expect("bounded read-only store");
+                        assert_eq!(
+                            reader.get_run(&expected.id).expect("read terminal run"),
+                            Some(expected.clone()),
+                            "readers retain a coherent terminal record while imports write"
+                        );
+                        assert_eq!(
+                            reader
+                                .list_artifacts(&expected.id)
+                                .expect("read terminal artifacts")
+                                .len(),
+                            1,
+                            "readers retain coherent artifacts while imports write"
+                        );
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        writer.join().expect("writer joined");
+        for reader in readers {
+            reader.join().expect("reader joined");
+        }
+        assert!(store
+            .get_run("import-99")
+            .expect("read imported run")
+            .is_some());
     }
 
     #[test]
     fn readonly_artifact_lookup_reports_a_retryable_busy_envelope() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let _store = ObservationStore::open_initialized().expect("initialize store");
-            let path = store::database_path().expect("database path");
-            let reader = ObservationStore::open_readonly_at(&path).expect("read-only store");
-            let error = reader.read_error(
-                "list artifact records",
-                rusqlite::Error::SqliteFailure(
-                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
-                    Some("database is locked".to_string()),
-                ),
-            );
-            assert_eq!(error.code.as_str(), "observation_store.busy");
-            assert_eq!(error.retryable, Some(true));
-            assert!(error.details.to_string().contains("list artifact records"));
-        });
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let _store = ObservationStore::open_initialized_in_roots(&roots).expect("initialize store");
+        let reader = ObservationStore::open_readonly_in_roots(&roots).expect("read-only store");
+        let error = reader.read_error(
+            "list artifact records",
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some("database is locked".to_string()),
+            ),
+        );
+        assert_eq!(error.code.as_str(), "observation_store.busy");
+        assert_eq!(error.retryable, Some(true));
+        assert!(error.details.to_string().contains("list artifact records"));
     }
 
     #[test]
     fn test_record_finding() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("lint", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
 
-            let record = store
-                .record_finding(&sample_finding(&run.id, "security", "src/foo.php"))
-                .expect("record finding");
-            let fetched = store
-                .get_finding(&record.id)
-                .expect("get finding")
-                .expect("finding exists");
+        let record = store
+            .record_finding(&sample_finding(&run.id, "security", "src/foo.php"))
+            .expect("record finding");
+        let fetched = store
+            .get_finding(&record.id)
+            .expect("get finding")
+            .expect("finding exists");
 
-            assert_eq!(fetched.message, "Missing security");
-            assert_eq!(fetched.fixable, Some(true));
-        });
+        assert_eq!(fetched.message, "Missing security");
+        assert_eq!(fetched.fixable, Some(true));
     }
 
     #[test]
     fn test_record_findings() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("lint", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
 
-            let records = store
-                .record_findings(&[
-                    sample_finding(&run.id, "security", "src/foo.php"),
-                    sample_finding(&run.id, "i18n", "src/bar.php"),
-                ])
-                .expect("record findings");
+        let records = store
+            .record_findings(&[
+                sample_finding(&run.id, "security", "src/foo.php"),
+                sample_finding(&run.id, "i18n", "src/bar.php"),
+            ])
+            .expect("record findings");
 
-            assert_eq!(records.len(), 2);
-            assert_eq!(records[0].rule.as_deref(), Some("security"));
-            assert_eq!(records[1].rule.as_deref(), Some("i18n"));
-        });
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].rule.as_deref(), Some("security"));
+        assert_eq!(records[1].rule.as_deref(), Some("i18n"));
     }
 
     #[test]
     fn test_list_findings() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("lint", "homeboy"))
-                .expect("start run");
-            let records = store
-                .record_findings(&[
-                    sample_finding(&run.id, "security", "src/foo.php"),
-                    sample_finding(&run.id, "i18n", "src/bar.php"),
-                ])
-                .expect("record findings");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
+        let records = store
+            .record_findings(&[
+                sample_finding(&run.id, "security", "src/foo.php"),
+                sample_finding(&run.id, "i18n", "src/bar.php"),
+            ])
+            .expect("record findings");
 
-            let all = store
-                .list_findings(FindingListFilter {
-                    run_id: Some(run.id.clone()),
-                    tool: Some("lint".to_string()),
-                    ..FindingListFilter::default()
-                })
-                .expect("list findings");
-            let filtered = store
-                .list_findings(FindingListFilter {
-                    run_id: Some(run.id),
-                    file: Some("src/foo.php".to_string()),
-                    ..FindingListFilter::default()
-                })
-                .expect("list file findings");
+        let all = store
+            .list_findings(FindingListFilter {
+                run_id: Some(run.id.clone()),
+                tool: Some("lint".to_string()),
+                ..FindingListFilter::default()
+            })
+            .expect("list findings");
+        let filtered = store
+            .list_findings(FindingListFilter {
+                run_id: Some(run.id),
+                file: Some("src/foo.php".to_string()),
+                ..FindingListFilter::default()
+            })
+            .expect("list file findings");
 
-            assert_eq!(all.len(), 2);
-            assert_eq!(filtered.len(), 1);
-            assert_eq!(filtered[0].id, records[0].id);
-        });
+        assert_eq!(all.len(), 2);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, records[0].id);
     }
 }
 
@@ -696,27 +699,26 @@ fn sample_import_run(id: &str) -> RunRecord {
 
 #[test]
 fn test_start_run() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("init store");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-        let started = store
-            .start_run(sample_run("bench", "homeboy"))
-            .expect("start run");
+    let started = store
+        .start_run(sample_run("bench", "homeboy"))
+        .expect("start run");
 
-        assert_eq!(started.kind, "bench");
-        assert_eq!(started.component_id.as_deref(), Some("homeboy"));
-        assert_eq!(started.status, "running");
-        assert!(started.finished_at.is_none());
-        assert_eq!(started.metadata_json["scenario"], "fixture");
+    assert_eq!(started.kind, "bench");
+    assert_eq!(started.component_id.as_deref(), Some("homeboy"));
+    assert_eq!(started.status, "running");
+    assert!(started.finished_at.is_none());
+    assert_eq!(started.metadata_json["scenario"], "fixture");
 
-        let fetched = store
-            .get_run(&started.id)
-            .expect("get run")
-            .expect("run exists");
+    let fetched = store
+        .get_run(&started.id)
+        .expect("get run")
+        .expect("run exists");
 
-        assert_eq!(fetched, started);
-    });
+    assert_eq!(fetched, started);
 }
 
 mod run_context_tests {
@@ -823,202 +825,196 @@ mod run_context_tests {
 
 #[test]
 fn import_run_is_idempotent_for_existing_mirrored_run_id() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let first = ObservationStore::open_initialized().expect("first store");
-        let second = ObservationStore::open_initialized().expect("second store");
-        let run = sample_import_run("runner-run-123");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let first = ObservationStore::open_initialized_in_roots(&roots).expect("first store");
+    let second = ObservationStore::open_initialized_in_roots(&roots).expect("second store");
+    let run = sample_import_run("runner-run-123");
 
-        first.import_run(&run).expect("first import");
-        second.import_run(&run).expect("duplicate import");
+    first.import_run(&run).expect("first import");
+    second.import_run(&run).expect("duplicate import");
 
-        assert_eq!(second.get_run(&run.id).expect("get run"), Some(run));
-    });
+    assert_eq!(second.get_run(&run.id).expect("get run"), Some(run));
 }
 
 #[test]
 fn import_run_rejects_conflicting_existing_record() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("store");
-        let run = sample_import_run("runner-run-456");
-        let mut conflicting = run.clone();
-        conflicting.status = "fail".to_string();
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let run = sample_import_run("runner-run-456");
+    let mut conflicting = run.clone();
+    conflicting.status = "fail".to_string();
 
-        store.import_run(&run).expect("first import");
-        let err = store
-            .import_run(&conflicting)
-            .expect_err("conflicting duplicate should fail");
+    store.import_run(&run).expect("first import");
+    let err = store
+        .import_run(&conflicting)
+        .expect_err("conflicting duplicate should fail");
 
-        assert_eq!(err.code.as_str(), "validation.invalid_argument");
-        assert!(err.message.contains("existing run record conflicts"));
-    });
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert!(err.message.contains("existing run record conflicts"));
 }
 
 #[test]
 fn test_finish_run() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("init store");
-        let started = store
-            .start_run(sample_run("bench", "homeboy"))
-            .expect("start run");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+    let started = store
+        .start_run(sample_run("bench", "homeboy"))
+        .expect("start run");
 
-        let finished = store
-            .finish_run(
-                &started.id,
-                RunStatus::Pass,
-                Some(serde_json::json!({ "scenario": "fixture", "ok": true })),
-            )
-            .expect("finish run");
-        let fetched = store
-            .get_run(&started.id)
-            .expect("get run")
-            .expect("run exists");
+    let finished = store
+        .finish_run(
+            &started.id,
+            RunStatus::Pass,
+            Some(serde_json::json!({ "scenario": "fixture", "ok": true })),
+        )
+        .expect("finish run");
+    let fetched = store
+        .get_run(&started.id)
+        .expect("get run")
+        .expect("run exists");
 
-        assert_eq!(finished.status, "pass");
-        assert!(finished.finished_at.is_some());
-        assert_eq!(finished.metadata_json["ok"], true);
-        assert_eq!(fetched, finished);
-    });
+    assert_eq!(finished.status, "pass");
+    assert!(finished.finished_at.is_some());
+    assert_eq!(finished.metadata_json["ok"], true);
+    assert_eq!(fetched, finished);
 }
 
 #[test]
 fn finish_running_run_preserves_an_existing_terminal_outcome() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("init store");
-        let started = store
-            .start_run(sample_run("review", "homeboy"))
-            .expect("start run");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+    let started = store
+        .start_run(sample_run("review", "homeboy"))
+        .expect("start run");
 
-        let cancelled = store
-            .finish_running_run(
-                &started.id,
-                RunStatus::Skipped,
-                Some(serde_json::json!({ "cancellation": { "requested": true } })),
-            )
-            .expect("cancel running run")
-            .expect("running run was cancelled");
-        let late_completion = store
-            .finish_running_run(
-                &started.id,
-                RunStatus::Pass,
-                Some(serde_json::json!({ "passed": true })),
-            )
-            .expect("late completion query");
+    let cancelled = store
+        .finish_running_run(
+            &started.id,
+            RunStatus::Skipped,
+            Some(serde_json::json!({ "cancellation": { "requested": true } })),
+        )
+        .expect("cancel running run")
+        .expect("running run was cancelled");
+    let late_completion = store
+        .finish_running_run(
+            &started.id,
+            RunStatus::Pass,
+            Some(serde_json::json!({ "passed": true })),
+        )
+        .expect("late completion query");
 
-        assert_eq!(cancelled.status, "skipped");
-        assert!(late_completion.is_none());
-        let persisted = store
-            .get_run(&started.id)
-            .expect("get run")
-            .expect("run exists");
-        assert_eq!(persisted.status, "skipped");
-        assert_eq!(persisted.metadata_json["cancellation"]["requested"], true);
-        assert!(persisted.metadata_json.get("passed").is_none());
-    });
+    assert_eq!(cancelled.status, "skipped");
+    assert!(late_completion.is_none());
+    let persisted = store
+        .get_run(&started.id)
+        .expect("get run")
+        .expect("run exists");
+    assert_eq!(persisted.status, "skipped");
+    assert_eq!(persisted.metadata_json["cancellation"]["requested"], true);
+    assert!(persisted.metadata_json.get("passed").is_none());
 }
 
 #[test]
 fn test_list_runs() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("init store");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-        let bench = store
-            .start_run(sample_run("bench", "homeboy"))
-            .expect("start bench");
-        store
-            .finish_run(&bench.id, RunStatus::Pass, None)
-            .expect("finish bench");
+    let bench = store
+        .start_run(sample_run("bench", "homeboy"))
+        .expect("start bench");
+    store
+        .finish_run(&bench.id, RunStatus::Pass, None)
+        .expect("finish bench");
 
-        let mut trace = sample_run("trace", "homeboy");
-        trace.rig_id = Some("other-rig".to_string());
-        let trace = store.start_run(trace).expect("start trace");
-        store
-            .finish_run(&trace.id, RunStatus::Fail, None)
-            .expect("finish trace");
+    let mut trace = sample_run("trace", "homeboy");
+    trace.rig_id = Some("other-rig".to_string());
+    let trace = store.start_run(trace).expect("start trace");
+    store
+        .finish_run(&trace.id, RunStatus::Fail, None)
+        .expect("finish trace");
 
-        let filtered = store
-            .list_runs(RunListFilter {
-                kind: Some("bench".to_string()),
-                component_id: Some("homeboy".to_string()),
-                status: Some("pass".to_string()),
-                rig_id: Some("studio".to_string()),
-                limit: Some(10),
-                ..RunListFilter::default()
-            })
-            .expect("list filtered");
+    let filtered = store
+        .list_runs(RunListFilter {
+            kind: Some("bench".to_string()),
+            component_id: Some("homeboy".to_string()),
+            status: Some("pass".to_string()),
+            rig_id: Some("studio".to_string()),
+            limit: Some(10),
+            ..RunListFilter::default()
+        })
+        .expect("list filtered");
 
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].id, bench.id);
-        assert_eq!(filtered[0].status, "pass");
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].id, bench.id);
+    assert_eq!(filtered[0].status, "pass");
 
-        let missing = store
-            .list_runs(RunListFilter {
-                status: Some("error".to_string()),
-                ..RunListFilter::default()
-            })
-            .expect("list missing");
-        assert!(missing.is_empty());
-    });
+    let missing = store
+        .list_runs(RunListFilter {
+            status: Some("error".to_string()),
+            ..RunListFilter::default()
+        })
+        .expect("list missing");
+    assert!(missing.is_empty());
 }
 
 #[test]
 fn test_latest_run() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("init store");
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-        let old = store
-            .start_run(sample_run("lint", "homeboy"))
-            .expect("start old");
-        store
-            .finish_run(&old.id, RunStatus::Pass, None)
-            .expect("finish old");
-        let latest = store
-            .start_run(sample_run("lint", "homeboy"))
-            .expect("start latest");
-        store
-            .finish_run(&latest.id, RunStatus::Fail, None)
-            .expect("finish latest");
-        let other_kind = store
-            .start_run(sample_run("bench", "homeboy"))
-            .expect("start bench");
+    let old = store
+        .start_run(sample_run("lint", "homeboy"))
+        .expect("start old");
+    store
+        .finish_run(&old.id, RunStatus::Pass, None)
+        .expect("finish old");
+    let latest = store
+        .start_run(sample_run("lint", "homeboy"))
+        .expect("start latest");
+    store
+        .finish_run(&latest.id, RunStatus::Fail, None)
+        .expect("finish latest");
+    let other_kind = store
+        .start_run(sample_run("bench", "homeboy"))
+        .expect("start bench");
 
-        let selected = store
-            .latest_run(RunListFilter {
-                kind: Some("lint".to_string()),
-                component_id: Some("homeboy".to_string()),
-                ..RunListFilter::default()
-            })
-            .expect("latest run")
-            .expect("run exists");
-        let missing = store
-            .latest_run(RunListFilter {
-                status: Some("stale".to_string()),
-                ..RunListFilter::default()
-            })
-            .expect("missing latest");
+    let selected = store
+        .latest_run(RunListFilter {
+            kind: Some("lint".to_string()),
+            component_id: Some("homeboy".to_string()),
+            ..RunListFilter::default()
+        })
+        .expect("latest run")
+        .expect("run exists");
+    let missing = store
+        .latest_run(RunListFilter {
+            status: Some("stale".to_string()),
+            ..RunListFilter::default()
+        })
+        .expect("missing latest");
 
-        assert_eq!(selected.id, latest.id);
-        assert_ne!(selected.id, old.id);
-        assert_ne!(selected.id, other_kind.id);
-        assert!(missing.is_none());
-    });
+    assert_eq!(selected.id, latest.id);
+    assert_ne!(selected.id, old.id);
+    assert_ne!(selected.id, other_kind.id);
+    assert!(missing.is_none());
 }
 
 #[test]
 fn latest_queries_use_timestamp_indexes_for_large_history() {
-    with_isolated_home(|_home| {
-        let _xdg = XdgGuard::unset();
-        let store = ObservationStore::open_initialized().expect("store");
-        let path = store.status().expect("status").path;
-        let db = rusqlite::Connection::open(path).expect("raw db");
-        let tx = db.unchecked_transaction().expect("transaction");
-        for index in 0..2_000 {
-            tx.execute(
+    let context = HermeticTestContext::new();
+    let roots = context.path_roots();
+    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let path = store.status().expect("status").path;
+    let db = rusqlite::Connection::open(path).expect("raw db");
+    let tx = db.unchecked_transaction().expect("transaction");
+    for index in 0..2_000 {
+        tx.execute(
                 "INSERT INTO runs(id, kind, component_id, started_at, status, metadata_json) VALUES (?1, ?2, ?3, ?4, 'pass', '{}')",
                 rusqlite::params![
                     format!("run-{index:04}"),
@@ -1027,34 +1023,39 @@ fn latest_queries_use_timestamp_indexes_for_large_history() {
                     format!("2026-01-01T00:{:02}:{:02}Z", (index / 60) % 60, index % 60),
                 ],
             ).expect("insert history");
-        }
-        tx.commit().expect("commit history");
+    }
+    tx.commit().expect("commit history");
 
-        let latest = store
-            .latest_run(RunListFilter {
-                kind: Some("triage".to_string()),
-                component_id: Some("workspace".to_string()),
-                limit: Some(1),
-                ..RunListFilter::default()
-            })
-            .expect("latest")
-            .expect("matching run");
-        assert_eq!(latest.id, "run-1998");
+    let latest = store
+        .latest_run(RunListFilter {
+            kind: Some("triage".to_string()),
+            component_id: Some("workspace".to_string()),
+            limit: Some(1),
+            ..RunListFilter::default()
+        })
+        .expect("latest")
+        .expect("matching run");
+    assert_eq!(latest.id, "run-1998");
 
-        for sql in [
-            "EXPLAIN QUERY PLAN SELECT id FROM runs ORDER BY started_at DESC, id DESC LIMIT 1",
-            "EXPLAIN QUERY PLAN SELECT id FROM runs WHERE kind = 'triage' AND component_id = 'workspace' ORDER BY started_at DESC, id DESC LIMIT 1",
-        ] {
-            let plan = db.prepare(sql).expect("plan").query_map([], |row| row.get::<_, String>(3))
-                .expect("plan rows").collect::<Result<Vec<_>, _>>().expect("plan detail").join(" ");
-            assert!(plan.contains("INDEX"), "expected index-backed plan: {plan}");
-            assert!(!plan.contains("TEMP B-TREE"), "unexpected sort: {plan}");
-            assert!(
-                !plan.contains("SCAN runs") || plan.contains("USING COVERING INDEX"),
-                "unexpected table scan: {plan}"
-            );
-        }
-    });
+    for sql in [
+        "EXPLAIN QUERY PLAN SELECT id FROM runs ORDER BY started_at DESC, id DESC LIMIT 1",
+        "EXPLAIN QUERY PLAN SELECT id FROM runs WHERE kind = 'triage' AND component_id = 'workspace' ORDER BY started_at DESC, id DESC LIMIT 1",
+    ] {
+        let plan = db
+            .prepare(sql)
+            .expect("plan")
+            .query_map([], |row| row.get::<_, String>(3))
+            .expect("plan rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("plan detail")
+            .join(" ");
+        assert!(plan.contains("INDEX"), "expected index-backed plan: {plan}");
+        assert!(!plan.contains("TEMP B-TREE"), "unexpected sort: {plan}");
+        assert!(
+            !plan.contains("SCAN runs") || plan.contains("USING COVERING INDEX"),
+            "unexpected table scan: {plan}"
+        );
+    }
 }
 
 mod store_artifact_tests {
@@ -1062,134 +1063,138 @@ mod store_artifact_tests {
 
     #[test]
     fn test_record_artifact() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("trace", "homeboy"))
-                .expect("start run");
-            let artifact_path = home.path().join("trace-results.json");
-            std::fs::write(&artifact_path, br#"{"status":"pass"}"#).expect("write artifact");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start run");
+        let artifact_path = context.root().join("trace-results.json");
+        std::fs::write(&artifact_path, br#"{"status":"pass"}"#).expect("write artifact");
 
-            let artifact = store
-                .record_artifact(&run.id, "trace-results", &artifact_path)
-                .expect("record artifact");
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let artifact = store
+            .record_artifact(&run.id, "trace-results", &artifact_path)
+            .expect("record artifact");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
 
-            assert_eq!(artifacts, vec![artifact.clone()]);
-            assert_eq!(artifact.run_id, run.id);
-            assert_eq!(artifact.kind, "trace-results");
-            assert_eq!(artifact.artifact_type, "file");
-            assert_ne!(artifact.path, artifact_path.to_string_lossy());
-            assert!(std::path::PathBuf::from(&artifact.path).is_file());
-            assert_eq!(
-                std::fs::read_to_string(&artifact.path).expect("read persisted artifact"),
-                "{\"status\":\"pass\"}"
-            );
-            assert_eq!(artifact.url, None);
-            assert_eq!(artifact.size_bytes, Some(17));
-            assert_eq!(artifact.mime.as_deref(), Some("application/json"));
-            assert_eq!(
-                artifact.sha256.as_deref(),
-                Some("117367705c6e7ef5d779dd71de15a95ee62339e1ef635f08246f8e1ec99167e2")
-            );
-        });
+        assert_eq!(artifacts, vec![artifact.clone()]);
+        assert_eq!(artifact.run_id, run.id);
+        assert_eq!(artifact.kind, "trace-results");
+        assert_eq!(artifact.artifact_type, "file");
+        assert_ne!(artifact.path, artifact_path.to_string_lossy());
+        assert!(std::path::PathBuf::from(&artifact.path).is_file());
+        assert_eq!(
+            std::fs::read_to_string(&artifact.path).expect("read persisted artifact"),
+            "{\"status\":\"pass\"}"
+        );
+        assert_eq!(artifact.url, None);
+        assert_eq!(artifact.size_bytes, Some(17));
+        assert_eq!(artifact.mime.as_deref(), Some("application/json"));
+        assert_eq!(
+            artifact.sha256.as_deref(),
+            Some("117367705c6e7ef5d779dd71de15a95ee62339e1ef635f08246f8e1ec99167e2")
+        );
     }
 
     #[test]
     fn publication_manifest_artifact_store_refs_are_indexed() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start run");
-            let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
-            let artifact_root = home.path().join(".local/share/homeboy/artifacts");
-            let nested_path = artifact_root.join(locator);
-            std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
-                .expect("create artifact-store parent");
-            std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
-            let manifest_path = home.path().join("publication-manifest.json");
-            std::fs::write(
-                &manifest_path,
-                serde_json::json!({
-                    "schema": "example/publication-manifest/v1",
-                    "id": "publish-run-1",
-                    "artifacts": [{
-                        "schema": "example/artifact-reference/v1",
-                        "id": "scenario/adapter/attempt-1/blueprint.after",
-                        "kind": "published-blueprint-after",
-                        "role": "output",
-                        "locator": {
-                            "type": "artifact-store",
-                            "value": locator,
-                        },
-                        "media_type": "application/json",
-                        "bytes": 12,
-                        "sha256": "abc123",
-                        "created_at": "2026-06-11T15:42:42Z"
-                    }]
-                })
-                .to_string(),
-            )
-            .expect("manifest artifact");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
+        // The artifact root this store indexes against, asked of the store
+        // itself rather than reconstructed from an ambient home layout. A
+        // rooted store answers from its injected roots (#7505).
+        let artifact_root = store.artifact_root().expect("store artifact root");
+        let nested_path = artifact_root.join(locator);
+        std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
+            .expect("create artifact-store parent");
+        std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
+        let manifest_path = context.root().join("publication-manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::json!({
+                "schema": "example/publication-manifest/v1",
+                "id": "publish-run-1",
+                "artifacts": [{
+                    "schema": "example/artifact-reference/v1",
+                    "id": "scenario/adapter/attempt-1/blueprint.after",
+                    "kind": "published-blueprint-after",
+                    "role": "output",
+                    "locator": {
+                        "type": "artifact-store",
+                        "value": locator,
+                    },
+                    "media_type": "application/json",
+                    "bytes": 12,
+                    "sha256": "abc123",
+                    "created_at": "2026-06-11T15:42:42Z"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("manifest artifact");
 
-            let source = store
-                .record_artifact(&run.id, "publication_manifest", &manifest_path)
-                .expect("record manifest");
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
-            let nested = artifacts
-                .iter()
-                .find(|artifact| artifact.id != source.id)
-                .expect("nested artifact indexed");
+        let source = store
+            .record_artifact(&run.id, "publication_manifest", &manifest_path)
+            .expect("record manifest");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let nested = artifacts
+            .iter()
+            .find(|artifact| artifact.id != source.id)
+            .expect("nested artifact indexed");
 
-            assert_eq!(artifacts.len(), 2);
-            assert_eq!(nested.kind, "published-blueprint-after");
-            assert_eq!(nested.artifact_type, "file");
-            assert_eq!(nested.path, nested_path.to_string_lossy());
-            assert_eq!(nested.mime.as_deref(), Some("application/json"));
-            assert_eq!(nested.size_bytes, Some(12));
-            assert_eq!(nested.sha256.as_deref(), Some("abc123"));
-            assert_eq!(
-                nested.metadata_json["source_manifest_artifact_id"].as_str(),
-                Some(source.id.as_str())
-            );
-            assert_eq!(
-                nested.metadata_json["original_manifest_id"].as_str(),
-                Some("scenario/adapter/attempt-1/blueprint.after")
-            );
-            assert_eq!(
-                nested.metadata_json["name"].as_str(),
-                Some("blueprint.after")
-            );
-            assert_eq!(
-                store
-                    .get_artifact_for_run_token(&run.id, "blueprint.after")
-                    .expect("lookup by name")
-                    .expect("artifact by name")
-                    .id,
-                nested.id
-            );
-        });
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(nested.kind, "published-blueprint-after");
+        assert_eq!(nested.artifact_type, "file");
+        assert_eq!(nested.path, nested_path.to_string_lossy());
+        assert_eq!(nested.mime.as_deref(), Some("application/json"));
+        assert_eq!(nested.size_bytes, Some(12));
+        assert_eq!(nested.sha256.as_deref(), Some("abc123"));
+        assert_eq!(
+            nested.metadata_json["source_manifest_artifact_id"].as_str(),
+            Some(source.id.as_str())
+        );
+        assert_eq!(
+            nested.metadata_json["original_manifest_id"].as_str(),
+            Some("scenario/adapter/attempt-1/blueprint.after")
+        );
+        assert_eq!(
+            nested.metadata_json["name"].as_str(),
+            Some("blueprint.after")
+        );
+        assert_eq!(
+            store
+                .get_artifact_for_run_token(&run.id, "blueprint.after")
+                .expect("lookup by name")
+                .expect("artifact by name")
+                .id,
+            nested.id
+        );
     }
 
     #[test]
     fn publication_manifest_public_url_refs_are_indexed_from_artifact_origin() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start run");
-            let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
-            let artifact_root = home.path().join(".local/share/homeboy/artifacts");
-            let nested_path = artifact_root.join(locator);
-            std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
-                .expect("create artifact-store parent");
-            std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
-            let manifest_path = home.path().join("publication-manifest.json");
-            std::fs::write(
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
+        // The artifact root this store indexes against, asked of the store
+        // itself rather than reconstructed from an ambient home layout. A
+        // rooted store answers from its injected roots (#7505).
+        let artifact_root = store.artifact_root().expect("store artifact root");
+        let nested_path = artifact_root.join(locator);
+        std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
+            .expect("create artifact-store parent");
+        std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
+        let manifest_path = context.root().join("publication-manifest.json");
+        std::fs::write(
                 &manifest_path,
                 serde_json::json!({
                     "schema": "example/publication-manifest/v1",
@@ -1217,192 +1222,184 @@ mod store_artifact_tests {
             )
             .expect("manifest artifact");
 
-            let source = store
-                .record_artifact(&run.id, "publication_manifest", &manifest_path)
-                .expect("record manifest");
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
-            let nested = artifacts
-                .iter()
-                .find(|artifact| artifact.id != source.id)
-                .expect("nested artifact indexed");
+        let source = store
+            .record_artifact(&run.id, "publication_manifest", &manifest_path)
+            .expect("record manifest");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let nested = artifacts
+            .iter()
+            .find(|artifact| artifact.id != source.id)
+            .expect("nested artifact indexed");
 
-            assert_eq!(artifacts.len(), 2);
-            assert_eq!(nested.kind, "published-blueprint-after");
-            assert_eq!(nested.path, nested_path.to_string_lossy());
-            assert_eq!(
-                nested.metadata_json["locator"]["value"].as_str(),
-                Some(locator)
-            );
-            assert_eq!(
-                nested.metadata_json["public_url"].as_str(),
-                Some("https://artifacts.example.test/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json")
-            );
-        });
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(nested.kind, "published-blueprint-after");
+        assert_eq!(nested.path, nested_path.to_string_lossy());
+        assert_eq!(
+            nested.metadata_json["locator"]["value"].as_str(),
+            Some(locator)
+        );
+        assert_eq!(
+            nested.metadata_json["public_url"].as_str(),
+            Some(
+                "https://artifacts.example.test/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json"
+            )
+        );
     }
 
     #[test]
     fn test_record_directory_artifact() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start run");
-            let artifact_path = home.path().join("visual-comparisons");
-            std::fs::create_dir_all(artifact_path.join("nested")).expect("mkdir artifact");
-            std::fs::write(artifact_path.join("summary.json"), br#"{"status":"skip"}"#)
-                .expect("write artifact");
-            std::fs::write(artifact_path.join("nested/detail.txt"), "detail")
-                .expect("write nested");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let artifact_path = context.root().join("visual-comparisons");
+        std::fs::create_dir_all(artifact_path.join("nested")).expect("mkdir artifact");
+        std::fs::write(artifact_path.join("summary.json"), br#"{"status":"skip"}"#)
+            .expect("write artifact");
+        std::fs::write(artifact_path.join("nested/detail.txt"), "detail").expect("write nested");
 
-            let artifact = store
-                .record_directory_artifact(&run.id, "bench_artifact", &artifact_path)
-                .expect("record directory artifact");
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let artifact = store
+            .record_directory_artifact(&run.id, "bench_artifact", &artifact_path)
+            .expect("record directory artifact");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
 
-            assert_eq!(artifacts, vec![artifact.clone()]);
-            assert_eq!(artifact.run_id, run.id);
-            assert_eq!(artifact.kind, "bench_artifact");
-            assert_eq!(artifact.artifact_type, "directory");
-            assert_ne!(artifact.path, artifact_path.to_string_lossy());
-            let persisted = std::path::PathBuf::from(&artifact.path);
-            assert!(persisted.is_dir());
-            assert_eq!(
-                std::fs::read_to_string(persisted.join("summary.json")).expect("read persisted"),
-                "{\"status\":\"skip\"}"
-            );
-            assert_eq!(
-                std::fs::read_to_string(persisted.join("nested/detail.txt")).expect("read nested"),
-                "detail"
-            );
-            // The immutable tree digest lives in `sha256`, not `url`.
-            // `record_directory_artifact_with_id_and_metadata` computes
-            // `directory_tree_sha256` and stores it there -- it is also what the
-            // idempotent-reuse check compares (`existing.sha256.as_deref()`).
-            // This assertion had the two fields swapped and failed for that
-            // reason.
-            assert_eq!(
-                artifact.sha256,
-                Some(
-                    crate::observation::directory_tree_sha256(&persisted)
-                        .expect("directory digest")
-                )
-            );
-            assert_eq!(artifact.size_bytes, None);
-            assert_eq!(artifact.mime, None);
-            assert_eq!(artifact.url, None);
-        });
+        assert_eq!(artifacts, vec![artifact.clone()]);
+        assert_eq!(artifact.run_id, run.id);
+        assert_eq!(artifact.kind, "bench_artifact");
+        assert_eq!(artifact.artifact_type, "directory");
+        assert_ne!(artifact.path, artifact_path.to_string_lossy());
+        let persisted = std::path::PathBuf::from(&artifact.path);
+        assert!(persisted.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(persisted.join("summary.json")).expect("read persisted"),
+            "{\"status\":\"skip\"}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(persisted.join("nested/detail.txt")).expect("read nested"),
+            "detail"
+        );
+        // The immutable tree digest lives in `sha256`, not `url`.
+        // `record_directory_artifact_with_id_and_metadata` computes
+        // `directory_tree_sha256` and stores it there -- it is also what the
+        // idempotent-reuse check compares (`existing.sha256.as_deref()`).
+        // This assertion had the two fields swapped and failed for that
+        // reason.
+        assert_eq!(
+            artifact.sha256,
+            Some(crate::observation::directory_tree_sha256(&persisted).expect("directory digest"))
+        );
+        assert_eq!(artifact.size_bytes, None);
+        assert_eq!(artifact.mime, None);
+        assert_eq!(artifact.url, None);
     }
 
     #[test]
     fn test_record_url_artifact() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
 
-            let artifact = store
-                .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
-                .expect("record URL artifact");
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let artifact = store
+            .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
+            .expect("record URL artifact");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
 
-            assert_eq!(artifacts, vec![artifact.clone()]);
-            assert_eq!(artifact.kind, "frontend_url");
-            assert_eq!(artifact.artifact_type, "url");
-            assert_eq!(artifact.path, "https://example.test/");
-            assert_eq!(artifact.url.as_deref(), Some("https://example.test/"));
-            assert_eq!(artifact.sha256, None);
-            assert_eq!(artifact.size_bytes, None);
-            assert_eq!(artifact.mime, None);
-        });
+        assert_eq!(artifacts, vec![artifact.clone()]);
+        assert_eq!(artifact.kind, "frontend_url");
+        assert_eq!(artifact.artifact_type, "url");
+        assert_eq!(artifact.path, "https://example.test/");
+        assert_eq!(artifact.url.as_deref(), Some("https://example.test/"));
+        assert_eq!(artifact.sha256, None);
+        assert_eq!(artifact.size_bytes, None);
+        assert_eq!(artifact.mime, None);
     }
 
     #[test]
     fn test_list_artifacts() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("trace", "homeboy"))
-                .expect("start run");
-            let first_path = home.path().join("first.json");
-            let second_path = home.path().join("second.log");
-            std::fs::write(&first_path, b"first").expect("write first");
-            std::fs::write(&second_path, b"second").expect("write second");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start run");
+        let first_path = context.root().join("first.json");
+        let second_path = context.root().join("second.log");
+        std::fs::write(&first_path, b"first").expect("write first");
+        std::fs::write(&second_path, b"second").expect("write second");
 
-            let first = store
-                .record_artifact(&run.id, "first", &first_path)
-                .expect("record first");
-            let second = store
-                .record_artifact(&run.id, "second", &second_path)
-                .expect("record second");
+        let first = store
+            .record_artifact(&run.id, "first", &first_path)
+            .expect("record first");
+        let second = store
+            .record_artifact(&run.id, "second", &second_path)
+            .expect("record second");
 
-            let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
-            assert_eq!(artifacts.len(), 2);
-            assert_eq!(artifacts[0].id, first.id);
-            assert_eq!(artifacts[1].id, second.id);
-        });
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts[0].id, first.id);
+        assert_eq!(artifacts[1].id, second.id);
     }
 
     #[test]
     fn test_list_artifacts_for_runs() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let first_run = store
-                .start_run(sample_run("trace", "homeboy"))
-                .expect("start first run");
-            let second_run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start second run");
-            let empty_run = store
-                .start_run(sample_run("lint", "homeboy"))
-                .expect("start empty run");
-            let first_path = home.path().join("first.json");
-            let second_path = home.path().join("second.log");
-            std::fs::write(&first_path, b"first").expect("write first");
-            std::fs::write(&second_path, b"second").expect("write second");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let first_run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start first run");
+        let second_run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start second run");
+        let empty_run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start empty run");
+        let first_path = context.root().join("first.json");
+        let second_path = context.root().join("second.log");
+        std::fs::write(&first_path, b"first").expect("write first");
+        std::fs::write(&second_path, b"second").expect("write second");
 
-            let first = store
-                .record_artifact(&first_run.id, "first", &first_path)
-                .expect("record first");
-            let second = store
-                .record_artifact(&second_run.id, "second", &second_path)
-                .expect("record second");
+        let first = store
+            .record_artifact(&first_run.id, "first", &first_path)
+            .expect("record first");
+        let second = store
+            .record_artifact(&second_run.id, "second", &second_path)
+            .expect("record second");
 
-            let artifacts = store
-                .list_artifacts_for_runs(&[
-                    first_run.id.clone(),
-                    second_run.id.clone(),
-                    empty_run.id.clone(),
-                ])
-                .expect("list artifacts for runs");
-            assert_eq!(artifacts[&first_run.id], vec![first]);
-            assert_eq!(artifacts[&second_run.id], vec![second]);
-            assert!(artifacts[&empty_run.id].is_empty());
-        });
+        let artifacts = store
+            .list_artifacts_for_runs(&[
+                first_run.id.clone(),
+                second_run.id.clone(),
+                empty_run.id.clone(),
+            ])
+            .expect("list artifacts for runs");
+        assert_eq!(artifacts[&first_run.id], vec![first]);
+        assert_eq!(artifacts[&second_run.id], vec![second]);
+        assert!(artifacts[&empty_run.id].is_empty());
     }
 
     #[test]
     fn missing_artifact_file_returns_clear_error() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("bench", "homeboy"))
-                .expect("start run");
-            let missing = home.path().join("missing.json");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let missing = context.root().join("missing.json");
 
-            let err = store
-                .record_artifact(&run.id, "missing", &missing)
-                .expect_err("missing artifact should fail");
+        let err = store
+            .record_artifact(&run.id, "missing", &missing)
+            .expect_err("missing artifact should fail");
 
-            assert_eq!(err.code.as_str(), "validation.invalid_argument");
-            assert!(err.message.contains("artifact file not found"));
-            assert!(err.details.to_string().contains("missing.json"));
-        });
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("artifact file not found"));
+        assert!(err.details.to_string().contains("missing.json"));
     }
 }
 
@@ -1499,108 +1496,103 @@ mod notification_delivery_marker_tests {
 
     #[test]
     fn mark_notification_delivered_sets_marker_and_returns_true() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
 
-            assert!(!store.is_notification_delivered(&run.id).unwrap());
-            let won = store
-                .mark_notification_delivered(&run.id, "runner-direct")
-                .unwrap();
+        assert!(!store.is_notification_delivered(&run.id).unwrap());
+        let won = store
+            .mark_notification_delivered(&run.id, "runner-direct")
+            .unwrap();
 
-            assert!(won);
-            assert!(store.is_notification_delivered(&run.id).unwrap());
-        });
+        assert!(won);
+        assert!(store.is_notification_delivered(&run.id).unwrap());
     }
 
     #[test]
     fn mark_notification_delivered_idempotent_second_call_returns_false() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
 
-            let first = store
-                .mark_notification_delivered(&run.id, "runner-direct")
-                .unwrap();
-            let second = store
-                .mark_notification_delivered(&run.id, "controller")
-                .unwrap();
+        let first = store
+            .mark_notification_delivered(&run.id, "runner-direct")
+            .unwrap();
+        let second = store
+            .mark_notification_delivered(&run.id, "controller")
+            .unwrap();
 
-            assert!(first);
-            assert!(!second);
-            assert!(store.is_notification_delivered(&run.id).unwrap());
-        });
+        assert!(first);
+        assert!(!second);
+        assert!(store.is_notification_delivered(&run.id).unwrap());
     }
 
     #[test]
     fn is_notification_delivered_returns_false_for_missing_run() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-            assert!(!store.is_notification_delivered("nonexistent-run").unwrap());
-        });
+        assert!(!store.is_notification_delivered("nonexistent-run").unwrap());
     }
 
     #[test]
     fn notification_delivered_marker_preserves_existing_metadata() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
 
-            store
-                .mark_notification_delivered(&run.id, "runner-direct")
-                .unwrap();
+        store
+            .mark_notification_delivered(&run.id, "runner-direct")
+            .unwrap();
 
-            let fetched = store
-                .get_run(&run.id)
-                .expect("get run")
-                .expect("run exists");
-            assert_eq!(fetched.metadata_json["scenario"], "fixture");
-            assert_eq!(
-                fetched.metadata_json["notification_delivered"]["by"],
-                "runner-direct"
-            );
-            assert!(fetched.metadata_json["notification_delivered"]["at"]
-                .as_str()
-                .is_some());
-        });
+        let fetched = store
+            .get_run(&run.id)
+            .expect("get run")
+            .expect("run exists");
+        assert_eq!(fetched.metadata_json["scenario"], "fixture");
+        assert_eq!(
+            fetched.metadata_json["notification_delivered"]["by"],
+            "runner-direct"
+        );
+        assert!(fetched.metadata_json["notification_delivered"]["at"]
+            .as_str()
+            .is_some());
     }
 
     #[test]
     fn runner_and_controller_race_only_one_wins() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("test", "homeboy"))
-                .expect("start run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("test", "homeboy"))
+            .expect("start run");
 
-            let runner_won = store
-                .mark_notification_delivered(&run.id, "runner-direct")
-                .unwrap();
-            let controller_won = store
-                .mark_notification_delivered(&run.id, "controller")
-                .unwrap();
+        let runner_won = store
+            .mark_notification_delivered(&run.id, "runner-direct")
+            .unwrap();
+        let controller_won = store
+            .mark_notification_delivered(&run.id, "controller")
+            .unwrap();
 
-            assert!(runner_won);
-            assert!(!controller_won);
-            let marker = &store
-                .get_run(&run.id)
-                .expect("get run")
-                .expect("run exists")
-                .metadata_json["notification_delivered"];
-            assert_eq!(marker["by"], "runner-direct");
-        });
+        assert!(runner_won);
+        assert!(!controller_won);
+        let marker = &store
+            .get_run(&run.id)
+            .expect("get run")
+            .expect("run exists")
+            .metadata_json["notification_delivered"];
+        assert_eq!(marker["by"], "runner-direct");
     }
 }
 
@@ -1615,16 +1607,15 @@ mod referential_integrity_tests {
 
     #[test]
     fn an_initialized_store_enforces_the_declared_foreign_keys() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-            assert!(
-                crate::observation::store::schema::foreign_keys_enforced(&store.connection)
-                    .expect("read enforcement"),
-                "an initialized store must enforce the foreign keys it declares"
-            );
-        });
+        assert!(
+            crate::observation::store::schema::foreign_keys_enforced(&store.connection)
+                .expect("read enforcement"),
+            "an initialized store must enforce the foreign keys it declares"
+        );
     }
 
     /// The invariant made observable: a run cannot be dropped out from under a
@@ -1633,31 +1624,30 @@ mod referential_integrity_tests {
     /// retention had already reclaimed.
     #[test]
     fn a_run_cannot_be_deleted_while_a_child_row_still_references_it() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("trace", "homeboy"))
-                .expect("start run");
-            let artifact_path = home.path().join("trace-results.json");
-            std::fs::write(&artifact_path, b"{}").expect("write artifact");
-            store
-                .record_artifact(&run.id, "trace-results", &artifact_path)
-                .expect("record artifact");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start run");
+        let artifact_path = context.root().join("trace-results.json");
+        std::fs::write(&artifact_path, b"{}").expect("write artifact");
+        store
+            .record_artifact(&run.id, "trace-results", &artifact_path)
+            .expect("record artifact");
 
-            let orphaning = store
-                .connection
-                .execute("DELETE FROM runs WHERE id = ?1", [&run.id]);
+        let orphaning = store
+            .connection
+            .execute("DELETE FROM runs WHERE id = ?1", [&run.id]);
 
-            assert!(
-                orphaning.is_err(),
-                "deleting a referenced run must be refused, not silently orphan its artifact"
-            );
-            assert_eq!(
-                store.list_artifacts(&run.id).expect("list artifacts").len(),
-                1
-            );
-        });
+        assert!(
+            orphaning.is_err(),
+            "deleting a referenced run must be refused, not silently orphan its artifact"
+        );
+        assert_eq!(
+            store.list_artifacts(&run.id).expect("list artifacts").len(),
+            1
+        );
     }
 
     /// The delete paths enumerate child tables by hand. If a sixth child table
@@ -1666,35 +1656,34 @@ mod referential_integrity_tests {
     /// list against the live schema so the omission fails here instead.
     #[test]
     fn every_table_referencing_runs_is_covered_by_the_delete_paths() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("init store");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
 
-            let mut referencing: Vec<String> = {
-                let mut statement = store
-                    .connection
-                    .prepare(
-                        "SELECT name FROM sqlite_master \
-                         WHERE type = 'table' AND sql LIKE '%REFERENCES runs(id)%'",
-                    )
-                    .expect("prepare schema scan");
-                let rows = statement
-                    .query_map([], |row| row.get::<_, String>(0))
-                    .expect("scan schema");
-                rows.map(|row| row.expect("read table name")).collect()
-            };
-            referencing.sort();
-            let mut covered: Vec<String> = RUN_OWNED_CHILD_TABLES
-                .iter()
-                .map(|table| (*table).to_string())
-                .collect();
-            covered.sort();
+        let mut referencing: Vec<String> = {
+            let mut statement = store
+                .connection
+                .prepare(
+                    "SELECT name FROM sqlite_master \
+                     WHERE type = 'table' AND sql LIKE '%REFERENCES runs(id)%'",
+                )
+                .expect("prepare schema scan");
+            let rows = statement
+                .query_map([], |row| row.get::<_, String>(0))
+                .expect("scan schema");
+            rows.map(|row| row.expect("read table name")).collect()
+        };
+        referencing.sort();
+        let mut covered: Vec<String> = RUN_OWNED_CHILD_TABLES
+            .iter()
+            .map(|table| (*table).to_string())
+            .collect();
+        covered.sort();
 
-            assert_eq!(
-                referencing, covered,
-                "every table that references runs(id) must be deleted before its run"
-            );
-        });
+        assert_eq!(
+            referencing, covered,
+            "every table that references runs(id) must be deleted before its run"
+        );
     }
 
     /// Retention deletes children first and the parent last. With enforcement
@@ -1702,44 +1691,43 @@ mod referential_integrity_tests {
     /// error -- so the happy path is worth pinning.
     #[test]
     fn terminal_retention_deletes_a_run_and_its_children_in_a_safe_order() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let mut store = ObservationStore::open_initialized().expect("init store");
-            let run = store
-                .start_run(sample_run("trace", "homeboy"))
-                .expect("start run");
-            let artifact_path = home.path().join("trace-results.json");
-            std::fs::write(&artifact_path, b"{}").expect("write artifact");
-            store
-                .record_artifact(&run.id, "trace-results", &artifact_path)
-                .expect("record artifact");
-            store
-                .record_finding(&NewFindingRecord {
-                    run_id: run.id.clone(),
-                    tool: "clippy".to_string(),
-                    rule: None,
-                    file: None,
-                    line: None,
-                    severity: None,
-                    fingerprint: None,
-                    message: "finding".to_string(),
-                    fixable: None,
-                    metadata_json: serde_json::json!({}),
-                })
-                .expect("record finding");
-            store
-                .finish_run(&run.id, RunStatus::Pass, None)
-                .expect("finish run");
+        let context = HermeticTestContext::new();
+        let roots = context.path_roots();
+        let mut store = ObservationStore::open_initialized_in_roots(&roots).expect("init store");
+        let run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start run");
+        let artifact_path = context.root().join("trace-results.json");
+        std::fs::write(&artifact_path, b"{}").expect("write artifact");
+        store
+            .record_artifact(&run.id, "trace-results", &artifact_path)
+            .expect("record artifact");
+        store
+            .record_finding(&NewFindingRecord {
+                run_id: run.id.clone(),
+                tool: "clippy".to_string(),
+                rule: None,
+                file: None,
+                line: None,
+                severity: None,
+                fingerprint: None,
+                message: "finding".to_string(),
+                fixable: None,
+                metadata_json: serde_json::json!({}),
+            })
+            .expect("record finding");
+        store
+            .finish_run(&run.id, RunStatus::Pass, None)
+            .expect("finish run");
 
-            store
-                .delete_terminal_runs(std::slice::from_ref(&run.id))
-                .expect("terminal retention must not be refused by the constraint");
+        store
+            .delete_terminal_runs(std::slice::from_ref(&run.id))
+            .expect("terminal retention must not be refused by the constraint");
 
-            assert!(store.get_run(&run.id).expect("get run").is_none());
-            assert!(store
-                .list_artifacts(&run.id)
-                .expect("list artifacts")
-                .is_empty());
-        });
+        assert!(store.get_run(&run.id).expect("get run").is_none());
+        assert!(store
+            .list_artifacts(&run.id)
+            .expect("list artifacts")
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary

First real test-side migration of #7505 — moving tests off `with_isolated_home` (which mutates process-global env behind a mutex) onto `HermeticTestContext` + injected roots.

```
tests/core/observation/store_test.rs          38 of 44 migrated
crates/homeboy-lab-runner/src/evidence/…      25 of 38 migrated
with_isolated_home in touched files           85 → 24
```

**This is the payoff proof.** `ObservationStore` was fully rooted by #12634, so its tests migrate cleanly. That ratio is not luck — it is what a rooted production API buys.

## `_in_roots` only — never `_at`

`open_initialized_at` / `open_readonly_at` inject the **database path only** and leave the artifact root ambient. Migrating onto those produces a half-rooted store that *looks* migrated.

44 + 21 `_in_roots` call sites; **zero `_at` remaining** — including two pre-existing `_at` callers that were upgraded.

Two non-mechanical ones worth review:
- `artifact_handle_backfill_recovers_after_a_transient_writer_lock` hand-builds the store (it owns the journal mode). `roots: None` → `roots: Some(roots.clone())`, so even the hand-built store is rooted.
- The publication-manifest tests reconstructed the artifact root as the literal `home/.local/share/homeboy/artifacts`. They now ask `store.artifact_root()`. **Keeping the literal would have silently broken indexing under a hermetic context** — a passing no-op.

## Left deliberately

| tests | why |
|---|---|
| `test_status`, `test_database_path` | They **assert the ambient resolution order** (`~/.local/share/homeboy/homeboy.sqlite`, `HOMEBOY_DATA_DIR` precedence). Rooting them deletes what they test. |
| 4 × `run_context_tests` | Assert `start_run` reads `HOMEBOY_*_METADATA` from the subprocess environment. **This is the env-wiring coverage #7505 explicitly wants kept.** |
| 11 evidence tests | Entry point calls `ObservationStore::open_initialized()` internally with no `_in_roots` sibling. One *depends* on the ambient reopen finding the same DB. |
| 2 evidence tests | Default downloader reaches `PathRoots::from_environment()`. Both fail closed before reaching it — so migrating would **look** rooted while leaving an ambient path in the call graph. |

**`tests/core/rig/runner_test.rs` — 0 of 36, and that is the honest answer.** `run_up`/`run_check`/`run_down`/`run_status`/`snapshot_state` have **no** rooted sibling in `homeboy-rig`, and `RigState::load`/`save` were never rooted onto the existing `rig_state_file_in_root`. The 4 `DependencyMaterializationCache` candidates route key computation through `toolchain::command_step_path`, which reads `HOME` — dropping isolation would let the developer's real `~/.cargo/bin` participate.

## Zero assertions changed — verified mechanically

Every `assert!`/`assert_eq!`/`assert_ne!` extracted with balanced-paren scanning from `git show origin/main:<file>` and from the result, whitespace-normalized, sequences diffed:

```
store_test.rs             171 → 171  (2 differ only in rustfmt wrapping)
evidence/tests/mod.rs     176 → 176  byte-identical
```

Plus a comment-stripped token-level diff of each whole file: every opcode is isolation acquisition or store construction.

Lesson-1 ambient grep over every migrated body: **0 hits.**

<callout accent="#f59e0b">
## Not compiled, not run

No cargo (28G `target/` vs 21G free). rustfmt proves both files parse; nothing proves they pass.

One honest behavioural risk: migrated tests calling `start_run` still read `HOMEBOY_*_METADATA` via `subprocess_compatibility_from_env()`, and the 4 `run_context_tests` still *mutate* those vars — but no longer exclude the migrated tests, so the `getenv`/`setenv` race window is **wider than before**. Every migrated assertion was checked as insensitive to an extra metadata key, so failures aren't expected — but this shows as a rare flake, not red CI.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Migration and mechanical assertion verification. Review by hand.

Refs #7505
