### PR TITLE
Migrate the adoption and lifecycle tests onto injected stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1808,124 +1808,148 @@ fn remote_dispatch_failure_preserves_structured_outcome_details() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The completed run is written and read back through one injected
+/// store, so the executor evidence and the artifact report asserted below are
+/// projections of the same home.
+///
+/// `record_completed_run` is spelled out as its own two rooted halves —
+/// submission then `record_aggregate_in_store` — which is exactly the body of
+/// `record_completed_run_in_store`. The difference is the admission: that
+/// sibling submits through `submit_plan_in_store`, which resolves the
+/// controller-runtime admission queue under `paths::controller_runtimes_store()`.
+/// That store is machine-global by design, so calling it from a test that no
+/// longer mutates HOME would enqueue against the real operator runtime store and
+/// block on its cross-process lock. The stub admission is the same one every
+/// other rooted test in this crate passes.
+///
+/// The plan carries no workspace root, so `record_aggregate_in_store` skips the
+/// automatic artifact-retention pass — which is still ambient, and is why the
+/// sibling test that asserts on `automatic_artifact_retention` was left on
+/// `with_isolated_home`.
 #[test]
 fn completed_run_exposes_latest_executor_input_output_and_expectations() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        let request = &mut plan.tasks[0];
-        request.executor.backend = "sandbox".to_string();
-        request.executor.model = Some("gpt-fixture".to_string());
-        request.component_contracts = vec![AgentTaskComponentContract {
-            slug: Some("runtime-engine".to_string()),
-            path: Some("/workspace/runtime-engine".to_string()),
-            extra: serde_json::Map::from_iter([
-                ("loadAs".to_string(), json!("plugin")),
-                ("activate".to_string(), json!(true)),
-            ]),
-        }];
-        request.metadata = json!({
-            "runtime_component_paths": ["/runtime/components/sandbox-host"]
-        });
-        request.expected_artifacts = vec!["patch".to_string()];
-        request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
-            name: "proof_bundle".to_string(),
-            artifact_type: Some("bundle".to_string()),
-            artifact_schema: None,
-            path: None,
-            required: true,
-            description: None,
-            metadata: Value::Null,
-        }];
-
-        let mut aggregate = succeeded_aggregate(&plan);
-        aggregate.outcomes[0].metadata = json!({
-            "model": "openai/gpt-5.6-terra",
-            "provider_rotation": {
-                "attempts": [{
-                    "attempt": 1,
-                    "rotation_index": 0,
-                    "backend": "sandbox",
-                    "selector": "fixture",
-                    "model": "gpt-fixture",
-                    "requested_model": "gpt-fixture",
-                    "attempted_model": "gpt-fixture",
-                    "candidate_producing_model": "gpt-fixture",
-                    "status": "provider_error",
-                    "failure_classification": "provider"
-                }, {
-                    "attempt": 2,
-                    "rotation_index": 1,
-                    "backend": "opencode",
-                    "selector": "opencode.agent-task-executor",
-                    "model": "openai/gpt-5.6-terra",
-                    "requested_model": "gpt-fixture",
-                    "attempted_model": "openai/gpt-5.6-terra",
-                    "candidate_producing_model": "openai/gpt-5.6-terra",
-                    "status": "succeeded"
-                }]
-            }
-        });
-        aggregate.outcomes[0].outputs = json!({
-            "provider_run_result": {
-                "run_id": "provider-run-123",
-                "status": "succeeded"
-            }
-        });
-
-        let record =
-            record_completed_run(&plan, &aggregate, Some("run-evidence")).expect("recorded");
-        let evidence = record
-            .latest_executor_evidence
-            .as_ref()
-            .expect("latest executor evidence");
-        let artifact_report = artifacts("run-evidence").expect("artifacts loaded");
-
-        assert_eq!(evidence.task_id, "task-a");
-        assert_eq!(evidence.backend, "opencode");
-        assert_eq!(
-            evidence.selector.as_deref(),
-            Some("opencode.agent-task-executor")
-        );
-        assert_eq!(evidence.model.as_deref(), Some("openai/gpt-5.6-terra"));
-        assert_eq!(record.tasks[0].backend, "opencode");
-        assert_eq!(
-            record.tasks[0].model.as_deref(),
-            Some("openai/gpt-5.6-terra")
-        );
-        assert_eq!(
-            evidence.provider_run_id.as_deref(),
-            Some("provider-run-123")
-        );
-        assert_eq!(evidence.component_contracts.len(), 1);
-        assert_eq!(
-            evidence.runtime_component_paths,
-            vec![
-                "/runtime/components/sandbox-host".to_string(),
-                "/workspace/runtime-engine".to_string()
-            ]
-        );
-        assert_eq!(evidence.expected_artifacts, vec!["patch".to_string()]);
-        assert_eq!(
-            evidence.typed_artifact_expectations,
-            vec!["proof_bundle".to_string()]
-        );
-        assert_eq!(
-            record.metadata["latest_executor_evidence"]["input_ref"]["uri"],
-            "homeboy://agent-task/run/run-evidence/plan#task=task-a"
-        );
-        assert!(artifact_report
-            .evidence_refs
-            .iter()
-            .any(|evidence| evidence.kind == "executor-input"));
-        assert!(artifact_report
-            .evidence_refs
-            .iter()
-            .any(|evidence| evidence.kind == "executor-normalized-output"));
-        assert!(artifact_report
-            .evidence_refs
-            .iter()
-            .any(|evidence| evidence.kind == "executor-outcome"));
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    let request = &mut plan.tasks[0];
+    request.executor.backend = "sandbox".to_string();
+    request.executor.model = Some("gpt-fixture".to_string());
+    request.component_contracts = vec![AgentTaskComponentContract {
+        slug: Some("runtime-engine".to_string()),
+        path: Some("/workspace/runtime-engine".to_string()),
+        extra: serde_json::Map::from_iter([
+            ("loadAs".to_string(), json!("plugin")),
+            ("activate".to_string(), json!(true)),
+        ]),
+    }];
+    request.metadata = json!({
+        "runtime_component_paths": ["/runtime/components/sandbox-host"]
     });
+    request.expected_artifacts = vec!["patch".to_string()];
+    request.artifact_declarations = vec![AgentTaskArtifactDeclaration {
+        name: "proof_bundle".to_string(),
+        artifact_type: Some("bundle".to_string()),
+        artifact_schema: None,
+        path: None,
+        required: true,
+        description: None,
+        metadata: Value::Null,
+    }];
+
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.outcomes[0].metadata = json!({
+        "model": "openai/gpt-5.6-terra",
+        "provider_rotation": {
+            "attempts": [{
+                "attempt": 1,
+                "rotation_index": 0,
+                "backend": "sandbox",
+                "selector": "fixture",
+                "model": "gpt-fixture",
+                "requested_model": "gpt-fixture",
+                "attempted_model": "gpt-fixture",
+                "candidate_producing_model": "gpt-fixture",
+                "status": "provider_error",
+                "failure_classification": "provider"
+            }, {
+                "attempt": 2,
+                "rotation_index": 1,
+                "backend": "opencode",
+                "selector": "opencode.agent-task-executor",
+                "model": "openai/gpt-5.6-terra",
+                "requested_model": "gpt-fixture",
+                "attempted_model": "openai/gpt-5.6-terra",
+                "candidate_producing_model": "openai/gpt-5.6-terra",
+                "status": "succeeded"
+            }]
+        }
+    });
+    aggregate.outcomes[0].outputs = json!({
+        "provider_run_result": {
+            "run_id": "provider-run-123",
+            "status": "succeeded"
+        }
+    });
+
+    let mut submitted = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "run-evidence", |_| Ok(json!({})))
+        .expect("submitted");
+    let record = record_aggregate_in_store(&lifecycle_store, &mut submitted, &plan, &aggregate)
+        .expect("recorded");
+    let evidence = record
+        .latest_executor_evidence
+        .as_ref()
+        .expect("latest executor evidence");
+    let artifact_report =
+        artifacts_in_store(&lifecycle_store, "run-evidence").expect("artifacts loaded");
+
+    assert_eq!(evidence.task_id, "task-a");
+    assert_eq!(evidence.backend, "opencode");
+    assert_eq!(
+        evidence.selector.as_deref(),
+        Some("opencode.agent-task-executor")
+    );
+    assert_eq!(evidence.model.as_deref(), Some("openai/gpt-5.6-terra"));
+    assert_eq!(record.tasks[0].backend, "opencode");
+    assert_eq!(
+        record.tasks[0].model.as_deref(),
+        Some("openai/gpt-5.6-terra")
+    );
+    assert_eq!(
+        evidence.provider_run_id.as_deref(),
+        Some("provider-run-123")
+    );
+    assert_eq!(evidence.component_contracts.len(), 1);
+    assert_eq!(
+        evidence.runtime_component_paths,
+        vec![
+            "/runtime/components/sandbox-host".to_string(),
+            "/workspace/runtime-engine".to_string()
+        ]
+    );
+    assert_eq!(evidence.expected_artifacts, vec!["patch".to_string()]);
+    assert_eq!(
+        evidence.typed_artifact_expectations,
+        vec!["proof_bundle".to_string()]
+    );
+    assert_eq!(
+        record.metadata["latest_executor_evidence"]["input_ref"]["uri"],
+        "homeboy://agent-task/run/run-evidence/plan#task=task-a"
+    );
+    assert!(artifact_report
+        .evidence_refs
+        .iter()
+        .any(|evidence| evidence.kind == "executor-input"));
+    assert!(artifact_report
+        .evidence_refs
+        .iter()
+        .any(|evidence| evidence.kind == "executor-normalized-output"));
+    assert!(artifact_report
+        .evidence_refs
+        .iter()
+        .any(|evidence| evidence.kind == "executor-outcome"));
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1148,27 +1148,59 @@ fn retryable_workspace_metadata_transport_failure_builds_transient_outcome() {
     assert_eq!(outcome.metadata["provider_executions_consumed"], 0);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The retry runs through `retry_with_runtime_admission_in_store` with
+/// `force = false` and `enforce_lineage_reservation = false` — the exact
+/// arguments `retry_in_store` passes — and a stub admission, because controller
+/// admission is machine-global by design and would otherwise reach the real
+/// operator runtime store once the home is no longer mutated. That is the same
+/// shape `submit_and_persist.rs:1490` already uses.
 #[test]
 fn retry_uses_controller_plan_when_runner_projection_replaces_plan_path() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let record =
-            submit_plan(&plan, Some("runner-projected-retry")).expect("controller plan submitted");
-        let mut projected = store::read_record(&record.run_id).expect("source record");
-        projected.plan_path =
-            "/home/chubes/.local/share/homeboy/agent-task-runs/runner-projected-retry/plan.json"
-                .to_string();
-        store::write_record(&projected).expect("runner projection mirrored");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "runner-projected-retry", |_| Ok(json!({})))
+        .expect("controller plan submitted");
+    let mut projected = lifecycle_store
+        .read_record(&record.run_id)
+        .expect("source record");
+    projected.plan_path =
+        "/home/chubes/.local/share/homeboy/agent-task-runs/runner-projected-retry/plan.json"
+            .to_string();
+    lifecycle_store
+        .write_record(&projected)
+        .expect("runner projection mirrored");
 
-        let retry_record = retry(&record.run_id, Some("runner-projected-retry-local"))
-            .expect("local retry uses controller plan");
-        assert_eq!(load_plan(&retry_record.run_id).expect("retry plan"), plan);
+    let retry_record = retry_with_runtime_admission_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        Some("runner-projected-retry-local"),
+        false,
+        false,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect("local retry uses controller plan");
+    assert_eq!(
+        load_plan_in_store(&lifecycle_store, &retry_record.run_id).expect("retry plan"),
+        plan
+    );
 
-        std::fs::remove_file(record.plan_path).expect("remove authoritative controller plan");
-        let error = retry(&record.run_id, Some("missing-controller-plan"))
-            .expect_err("missing controller plan fails closed");
-        assert_eq!(error.code, ErrorCode::InternalIoError);
-    });
+    std::fs::remove_file(record.plan_path).expect("remove authoritative controller plan");
+    let error = retry_with_runtime_admission_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        Some("missing-controller-plan"),
+        false,
+        false,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect_err("missing controller plan fails closed");
+    assert_eq!(error.code, ErrorCode::InternalIoError);
 }
 
 /// Persisting a terminal Lab-bound record from inside a config-lock section is
@@ -1794,57 +1826,66 @@ fn duplicate_runner_artifact_ids_fail_closed_before_projection() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Both promotion writes and the record they are read back from are
+/// the injected store's, so `latest_promotion` and the promotion history length
+/// asserted below describe one home rather than a mixture of two.
 #[test]
 fn corrected_promotion_replaces_gate_failed_latest_proof() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let run_id = "run-corrected-promotion";
-        submit_plan(&plan, Some(run_id)).expect("submitted");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let run_id = "run-corrected-promotion";
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submitted");
 
-        let gate_failed = json!({
-            "schema": "homeboy/agent-task-promotion-report/v1",
-            "status": "gate_failed",
-            "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
-            "to_worktree": "homeboy@fix-8307",
-            "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
-            "patch_artifact": { "id": "first.patch", "kind": "patch", "path": "first.patch" },
-            "changed_files": ["src/lib.rs"],
-            "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "failed" }],
-            "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "first" } } },
-            "operator_notification": { "status": "blocked", "message": "gates failed" }
-        });
-        let corrected = json!({
-            "schema": "homeboy/agent-task-promotion-report/v1",
-            "status": "applied",
-            "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
-            "to_worktree": "homeboy@fix-8307",
-            "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
-            "patch_artifact": { "id": "corrected.patch", "kind": "patch", "path": "corrected.patch" },
-            "changed_files": ["src/lib.rs"],
-            "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "passed" }],
-            "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "corrected" } } },
-            "operator_notification": { "status": "completed", "message": "gates passed" }
-        });
-
-        record_promotion(run_id, gate_failed).expect("gate failure recorded");
-        let updated = record_promotion(run_id, corrected.clone()).expect("correction recorded");
-
-        let latest: crate::agent_task_promotion::AgentTaskPromotionReport =
-            serde_json::from_value(updated.metadata["latest_promotion"].clone())
-                .expect("latest promotion is finalization proof");
-        assert_eq!(
-            latest.status,
-            crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
-        );
-        assert_eq!(latest.patch_artifact.id, "corrected.patch");
-        assert_eq!(
-            updated.metadata["promotions"]
-                .as_array()
-                .expect("history")
-                .len(),
-            2
-        );
+    let gate_failed = json!({
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "gate_failed",
+        "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
+        "to_worktree": "homeboy@fix-8307",
+        "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
+        "patch_artifact": { "id": "first.patch", "kind": "patch", "path": "first.patch" },
+        "changed_files": ["src/lib.rs"],
+        "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "failed" }],
+        "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "first" } } },
+        "operator_notification": { "status": "blocked", "message": "gates failed" }
     });
+    let corrected = json!({
+        "schema": "homeboy/agent-task-promotion-report/v1",
+        "status": "applied",
+        "source": { "kind": "aggregate", "task_id": "task-a", "run_id": run_id },
+        "to_worktree": "homeboy@fix-8307",
+        "target": { "worktree": "homeboy@fix-8307", "path": "/repo" },
+        "patch_artifact": { "id": "corrected.patch", "kind": "patch", "path": "corrected.patch" },
+        "changed_files": ["src/lib.rs"],
+        "gate_results": [{ "id": "test", "name": "cargo test", "kind": "command", "status": "passed" }],
+        "provenance": { "candidate": { "kind": "git", "fingerprint": { "schema": "homeboy/agent-task-candidate-fingerprint/v1", "target_path": "/repo", "head": "base", "base": "base", "changed_files": ["src/lib.rs"], "sha256": "corrected" } } },
+        "operator_notification": { "status": "completed", "message": "gates passed" }
+    });
+
+    record_promotion_in_store(&lifecycle_store, run_id, gate_failed)
+        .expect("gate failure recorded");
+    let updated = record_promotion_in_store(&lifecycle_store, run_id, corrected.clone())
+        .expect("correction recorded");
+
+    let latest: crate::agent_task_promotion::AgentTaskPromotionReport =
+        serde_json::from_value(updated.metadata["latest_promotion"].clone())
+            .expect("latest promotion is finalization proof");
+    assert_eq!(
+        latest.status,
+        crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+    );
+    assert_eq!(latest.patch_artifact.id, "corrected.patch");
+    assert_eq!(
+        updated.metadata["promotions"]
+            .as_array()
+            .expect("history")
+            .len(),
+        2
+    );
 }
 
 #[test]
@@ -2021,48 +2062,79 @@ fn lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The successor identity, the inherited notification route, and the
+/// plan read back for it all follow the injected root, so the retry lineage
+/// asserted below is the one this store recorded. The admission is stubbed for
+/// the same reason as `retry_uses_controller_plan_when_runner_projection_replaces_plan_path`.
 #[test]
 fn retry_submits_new_run_from_existing_plan() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("run-original")).expect("submitted");
-        let mut source = store::read_record("run-original").expect("source");
-        source.metadata["notification_route"] = json!({
-            "transport": "extension",
-            "route": "opaque-origin"
-        });
-        store::write_record(&source).expect("route persisted");
-
-        let record = retry("run-original", Some("run-retry")).expect("retry submitted");
-        let loaded_plan = load_plan("run-retry").expect("retry plan loaded");
-
-        assert_eq!(record.run_id, "run-retry");
-        assert_eq!(record.state, AgentTaskRunState::Queued);
-        assert_eq!(record.metadata["retry_of"], json!("run-original"));
-        assert_eq!(
-            record.metadata["notification_route"]["route"],
-            "opaque-origin"
-        );
-        assert_eq!(loaded_plan.plan_id, "plan-a");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "run-original", |_| Ok(json!({})))
+        .expect("submitted");
+    let mut source = lifecycle_store.read_record("run-original").expect("source");
+    source.metadata["notification_route"] = json!({
+        "transport": "extension",
+        "route": "opaque-origin"
     });
+    lifecycle_store
+        .write_record(&source)
+        .expect("route persisted");
+
+    let record = retry_with_runtime_admission_in_store(
+        &lifecycle_store,
+        "run-original",
+        Some("run-retry"),
+        false,
+        false,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect("retry submitted");
+    let loaded_plan = load_plan_in_store(&lifecycle_store, "run-retry").expect("retry plan loaded");
+
+    assert_eq!(record.run_id, "run-retry");
+    assert_eq!(record.state, AgentTaskRunState::Queued);
+    assert_eq!(record.metadata["retry_of"], json!("run-original"));
+    assert_eq!(
+        record.metadata["notification_route"]["route"],
+        "opaque-origin"
+    );
+    assert_eq!(loaded_plan.plan_id, "plan-a");
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The stale record is seeded and reclaimed through the same injected
+/// store, so the reclaim evidence asserted below cannot have been produced by
+/// another home holding this run id.
 #[test]
 fn mark_running_reclaims_stale_running_record() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("run-stale-dead-owner")).expect("submitted");
-        let mut record = store::read_record("run-stale-dead-owner").expect("record");
-        record.state = AgentTaskRunState::Running;
-        record.metadata = json!({ "runner_pid": u32::MAX });
-        store::write_record(&record).expect("stored stale record");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "run-stale-dead-owner", |_| Ok(json!({})))
+        .expect("submitted");
+    let mut record = lifecycle_store
+        .read_record("run-stale-dead-owner")
+        .expect("record");
+    record.state = AgentTaskRunState::Running;
+    record.metadata = json!({ "runner_pid": u32::MAX });
+    lifecycle_store
+        .write_record(&record)
+        .expect("stored stale record");
 
-        let running = mark_running("run-stale-dead-owner").expect("reclaimed");
+    let running =
+        mark_running_in_store(&lifecycle_store, "run-stale-dead-owner").expect("reclaimed");
 
-        assert_eq!(running.state, AgentTaskRunState::Running);
-        assert_eq!(running.metadata["reclaimed_stale_running"], json!(true));
-        assert_eq!(running.metadata["runner_pid"], json!(std::process::id()));
-    });
+    assert_eq!(running.state, AgentTaskRunState::Running);
+    assert_eq!(running.metadata["reclaimed_stale_running"], json!(true));
+    assert_eq!(running.metadata["runner_pid"], json!(std::process::id()));
 }
 
 #[cfg(unix)]
@@ -2509,29 +2581,42 @@ fn durable_aggregate_read_returns_partial_local_evidence_without_a_runner_probe(
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The oversized fixture is written at the path the injected store
+/// itself names and read back through the sibling handed the same store, so the
+/// partial-read evidence asserted below is about this home's aggregate file.
+///
+/// `store::DURABLE_AGGREGATE_MAX_BYTES` is the one surviving `store::` token in
+/// this body. It is a `pub(super)` byte-count constant, not a root resolution —
+/// there is no other path to it — so it reaches no ambient state.
 #[test]
 fn durable_aggregate_read_rejects_an_oversized_file_before_deserializing_it() {
-    with_isolated_home(|_| {
-        let record =
-            submit_plan(&test_plan(), Some("oversized-durable-aggregate")).expect("durable record");
-        let path = store::aggregate_path(&record.run_id).expect("aggregate path");
-        std::fs::write(
-            &path,
-            vec![b'x'; (store::DURABLE_AGGREGATE_MAX_BYTES + 1) as usize],
-        )
-        .expect("oversized aggregate fixture");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), "oversized-durable-aggregate", |_| {
+            Ok(json!({}))
+        })
+        .expect("durable record");
+    let path = lifecycle_store.aggregate_path(&record.run_id);
+    std::fs::write(
+        &path,
+        vec![b'x'; (store::DURABLE_AGGREGATE_MAX_BYTES + 1) as usize],
+    )
+    .expect("oversized aggregate fixture");
 
-        let snapshot = durable_local_read(&record.run_id).expect("partial durable read");
+    let snapshot = durable_local_read_in_store(&lifecycle_store, &record.run_id)
+        .expect("partial durable read");
 
-        assert_eq!(snapshot.record.run_id, record.run_id);
-        assert!(snapshot.aggregate.is_none());
-        assert_eq!(snapshot.unavailable_sources.len(), 1);
-        assert_eq!(snapshot.unavailable_sources[0].source, "aggregate");
-        assert_eq!(
-            snapshot.unavailable_sources[0].reason_code,
-            "durable_read.oversized"
-        );
-    });
+    assert_eq!(snapshot.record.run_id, record.run_id);
+    assert!(snapshot.aggregate.is_none());
+    assert_eq!(snapshot.unavailable_sources.len(), 1);
+    assert_eq!(snapshot.unavailable_sources[0].source, "aggregate");
+    assert_eq!(
+        snapshot.unavailable_sources[0].reason_code,
+        "durable_read.oversized"
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2131,51 +2131,67 @@ fn rejection_allows_one_repair_and_restart_revalidates_before_finalization() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Every durable write here — the submission, both promotions, and the
+/// verdict — goes through a sibling that was handed `lifecycle_store`, so the
+/// candidate the drift guard compares and the acceptance record it rewrites are
+/// read back out of the same home they were written into.
+///
+/// The acceptance verifier registry stays process-global on purpose: it is
+/// configured trust material, not a lifecycle root, and
+/// `AcceptanceVerifierTestGuard` carries its own dedicated mutex, so dropping
+/// the hermetic-home mutex does not expose it.
 #[test]
 fn acceptance_invalidates_a_dirty_candidate_replacement_at_the_same_head() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.metadata = json!({
-            "acceptance": { "authority": "independent-review", "policy": "release-v1" },
-        });
-        let run_id = "acceptance-dirty-same-head";
-        submit_plan(&plan, Some(run_id)).expect("submitted");
-        record_promotion(
-            run_id,
-            applied_acceptance_promotion_with_fingerprint(
-                "unchanged-head",
-                "base-a",
-                "clean-sha256",
-                "clean-tree",
-            ),
-        )
-        .expect("clean promotion recorded");
-        let _verifier = AcceptanceVerifierTestGuard::install(Box::new(FixtureAcceptanceVerifier));
-        record_acceptance_verdict(
-            run_id,
-            AgentTaskAcceptanceVerdict::Accepted,
-            vec!["review://fixture/7".to_string()],
-            "fixture-token".to_string(),
-        )
-        .expect("clean candidate accepted");
-
-        let replaced = record_promotion(
-            run_id,
-            applied_acceptance_promotion_with_fingerprint(
-                "unchanged-head",
-                "base-a",
-                "dirty-replacement-sha256",
-                "dirty-replacement-tree",
-            ),
-        )
-        .expect("dirty replacement recorded");
-        let acceptance = replaced.acceptance.expect("acceptance record");
-        assert_eq!(acceptance.verdict, AgentTaskAcceptanceVerdict::Pending);
-        assert_eq!(acceptance.candidate.head, "unchanged-head");
-        assert_eq!(acceptance.candidate.sha256, "dirty-replacement-sha256");
-        assert_eq!(acceptance.candidate.tree, "dirty-replacement-tree");
-        assert_eq!(acceptance.history.len(), 1);
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    plan.metadata = json!({
+        "acceptance": { "authority": "independent-review", "policy": "release-v1" },
     });
+    let run_id = "acceptance-dirty-same-head";
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submitted");
+    record_promotion_in_store(
+        &lifecycle_store,
+        run_id,
+        applied_acceptance_promotion_with_fingerprint(
+            "unchanged-head",
+            "base-a",
+            "clean-sha256",
+            "clean-tree",
+        ),
+    )
+    .expect("clean promotion recorded");
+    let _verifier = AcceptanceVerifierTestGuard::install(Box::new(FixtureAcceptanceVerifier));
+    record_acceptance_verdict_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskAcceptanceVerdict::Accepted,
+        vec!["review://fixture/7".to_string()],
+        "fixture-token".to_string(),
+    )
+    .expect("clean candidate accepted");
+
+    let replaced = record_promotion_in_store(
+        &lifecycle_store,
+        run_id,
+        applied_acceptance_promotion_with_fingerprint(
+            "unchanged-head",
+            "base-a",
+            "dirty-replacement-sha256",
+            "dirty-replacement-tree",
+        ),
+    )
+    .expect("dirty replacement recorded");
+    let acceptance = replaced.acceptance.expect("acceptance record");
+    assert_eq!(acceptance.verdict, AgentTaskAcceptanceVerdict::Pending);
+    assert_eq!(acceptance.candidate.head, "unchanged-head");
+    assert_eq!(acceptance.candidate.sha256, "dirty-replacement-sha256");
+    assert_eq!(acceptance.candidate.tree, "dirty-replacement-tree");
+    assert_eq!(acceptance.history.len(), 1);
 }
 
 #[test]
@@ -2686,22 +2702,33 @@ fn run_git(cwd: &std::path::Path, args: &[&str]) {
     );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The reservation is made through the sibling that was handed
+/// `lifecycle_store` and read back through the same store, so the owner
+/// identity asserted below is the one this test actually wrote rather than
+/// whatever an ambient home happened to hold under the same run id.
 #[test]
 fn local_provider_reservation_persists_reusable_owner_identity_before_execution() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("owner-identity")).expect("submitted");
-        reserve_provider_execution("owner-identity", &plan.tasks[0], 1).expect("reserved");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "owner-identity", |_| Ok(json!({})))
+        .expect("submitted");
+    reserve_provider_execution_in_store(&lifecycle_store, "owner-identity", &plan.tasks[0], 1)
+        .expect("reserved");
 
-        let record = store::read_record("owner-identity").expect("record");
-        let execution = &record.metadata["provider_executions"][0];
-        assert_eq!(execution["owner_pid"], json!(std::process::id()));
-        assert_eq!(
-            execution["owner_identity"],
-            json!("owner-identity:task-a:1")
-        );
-        assert_eq!(execution["state"], json!("running"));
-    });
+    let record = lifecycle_store
+        .read_record("owner-identity")
+        .expect("record");
+    let execution = &record.metadata["provider_executions"][0];
+    assert_eq!(execution["owner_pid"], json!(std::process::id()));
+    assert_eq!(
+        execution["owner_identity"],
+        json!("owner-identity:task-a:1")
+    );
+    assert_eq!(execution["state"], json!("running"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Test migration for the `homeboy-agents` lifecycle and cook suites. **The headline is the blocker analysis, not the count.**

```
terminal_and_reconcile.rs    2 of 53      cook_tests.rs      8 of 144
status_and_recovery.rs       5 of 50
handoff_and_proxy.rs         1 of 44
```

<callout accent="#ef4444">
## `agent_task_lifecycle::status` has no rooted sibling, and it blocks ~100 tests

Two independent agents hit this wall separately and stopped at it.

`persisted_status_in_store` is **not** the same function. `status` applies live reconciliation (`reconcile_deferred_candidate`, admission projection). Substituting it would silently drop exactly what these tests exercise — **the no-op conversion trap.**

Also unrooted, by test count: `rewrite_record_for_test` (18), `cancel_run`/`cancel` (12), `cook_attempt_run_id` (9), plus `run_status`, `list_records`, `logs`, `reconcile_*`, `record_lab_offload_*`.
</callout>

## Four tests left for non-obvious reasons — these deserve review

1. **`completed_generic_executor_outcome_preserves_runtime_evidence…`** asserts on `automatic_artifact_retention`. `record_aggregate_in_store` calls the *ambient* `try_run_automatic_artifact_retention`, gated on a process-global `try_lock` plus an `FsIndexLock` in the real data root. **`with_isolated_home`'s mutex is currently the only thing preventing contention** — migrating makes it a `{"status":"busy"}` coin flip.
2. **`active_pinned_run_does_not_block_controller_promotion`** calls `activate_current_generation()` — would switch the **real operator's** controller-runtime generation.
3. **`retry_rebuilds_follow_up_candidate_from_durable_promotion`** — its production function's own doc records that it waits on the `status` slice.
4. **`durable_aggregate_read_returns_within_the_readonly_sqlite_contention_budget`** locks the ambient `database_path()` and asserts a contention budget. Rooting the read but not the lock **silently removes the contention the test measures.**

## A deliberate deviation worth agreeing with

`submit_plan_in_store` / `record_completed_run_in_store` / `retry_in_store` all resolve the controller-runtime admission queue under `paths::controller_runtimes_store()`. Under `with_isolated_home` that was contained; without it, a migrated test enqueues against the **real operator data root** and blocks on its cross-process lock — **on this VPS, where homeboy actually runs, that could hang.**

Used the admission-parameterized siblings with a stub instead (`submit_plan_with_runtime_admission`, `retry_with_runtime_admission_in_store`), which is the shape every existing rooted test uses and what `retry_with_runtime_admission_in_store`'s doc says the parameter is for. Cost: migrated records carry `controller_runtime: {}`; nothing asserted touches it.

One production visibility change: `resolve_adoption_target_with_attempt_in_stores` `fn` → `pub(super)`. Its body was already fully rooted.

## Zero assertions changed — verified mechanically

Extracted, whitespace-normalized, sorted, diffed against `origin/main`:

```
terminal_and_reconcile.rs   327 → 327  identical
handoff_and_proxy.rs        248 → 248  identical
status_and_recovery.rs      280 → 280  one ambient→rooted swap, same operands
cook_tests.rs               7/8 byte-identical; 8th is a one-line passthrough swap
```

**Scanner 7/7 pass**, same as baseline; no allowlist row added or deleted. Lesson-1 grep clean except one disclosed hit — `store::DURABLE_AGGREGATE_MAX_BYTES`, a `u64` constant, not a root resolution, documented on the test.

Caught mid-flight: migrating all call sites left `resolve_adoption_target_with_attempt` an **unused import** — would have broken CI under `-D warnings`.

<callout accent="#f59e0b">
**Not compiled, not run.** The real gap: each migrated test now runs concurrently with its peers instead of under the hermetic-home mutex. Shared-state hazards were reasoned about (acceptance-verifier registry has its own static mutex; retention lock avoided by leaving that test alone; admission queue avoided by stubbing) — but concurrency is exactly what reading cannot settle. **If any of these fail in CI, first hypothesis is cross-test interference, not a wrong call swap.**
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** two OpenCode general subagents, outside the Homeboy control plane
- **Used for:** Migration, blocker analysis, mechanical assertion verification. Review by hand.

Refs #7505
