### PR TITLE
Root the interior of the status family

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -706,7 +706,23 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
 /// Reconcile an asynchronously cancelled controller-owned staging job. This is
 /// read-side so a CLI that observed only the acknowledgement still converges the
 /// durable cook record after the provider exits.
-pub(super) fn reconcile_controller_job_cancellation(
+///
+/// The two side effects at the end — controller-scratch finalization and
+/// admission cancellation — are the reason this takes a store. Both are durable
+/// writes keyed on the run, and both had ambient forms that resolve their own
+/// roots: `finalize_run` opens `paths::homeboy_data()`'s scratch index and
+/// `paths::artifact_root()`, and `cancel_admission` opens the ambient runtime
+/// root. A read reconciling a record from injected roots would have marked
+/// another home's scratch resources finalized and released another home's
+/// admission (#7505). This mirrors `cancel_exact_run_in_store`, which already
+/// uses exactly these two rooted forms.
+///
+/// The caller mutates `record` in place and persists it itself, so no record
+/// write happens here. There is no ambient wrapper:
+/// `status_with_options_inner` is the only caller and resolves one store for
+/// the whole read.
+pub(super) fn reconcile_controller_job_cancellation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
 ) -> Result<bool> {
     let Some(cancellation) = record
@@ -780,8 +796,15 @@ pub(super) fn reconcile_controller_job_cancellation(
     metadata.remove(METADATA_KEY_STALE_RUNNING);
     metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
     record.updated_at = Some(now_timestamp());
-    crate::controller_scratch::finalize_run(&record.run_id)?;
-    homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
+    crate::controller_scratch::finalize_run_at_explicit_roots(
+        &lifecycle_store.data_root(),
+        &lifecycle_store.artifact_root(),
+        &record.run_id,
+    )?;
+    homeboy_core::controller_runtime::cancel_admission_at(
+        &lifecycle_store.data_root().join("controller-runtimes"),
+        &record.run_id,
+    )?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -912,7 +912,14 @@ pub(crate) fn terminal_provider_model_reconciliation_needed(
 /// promotion evidence, gates, totals, and artifact projections are preserved:
 /// `set_run_state` re-asserts the existing terminal state and only the
 /// model-bearing lifecycle projection is rebuilt from the record's own tasks.
-pub(crate) fn reconcile_terminal_provider_model(
+///
+/// The persist at the end is the whole point of taking a store: it is the only
+/// durable effect, so a reconciliation driven from injected roots must land its
+/// repaired model in the same installation the record and aggregate were read
+/// from. There is no ambient wrapper — `status_with_options_inner` is the only
+/// caller, and it resolves one store for the whole read.
+pub(crate) fn reconcile_terminal_provider_model_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
     plan: &AgentTaskPlan,
     aggregate: &AgentTaskAggregate,
@@ -938,7 +945,7 @@ pub(crate) fn reconcile_terminal_provider_model(
     persist_provider_handle_models(&mut record.provider_handles, plan);
     update_lifecycle_from_record(record, plan);
     record.updated_at = Some(now_timestamp());
-    store::write_record(record)
+    lifecycle_store.write_record(record)
 }
 
 /// Recover the runner identity for canonical legacy patch artifacts. Diagnostic
@@ -1095,6 +1102,35 @@ pub fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<Str
     terminal_artifact_projection_readiness_for_record(
         &record,
         store::read_aggregate(&record.run_id),
+    )
+}
+
+/// [`terminal_artifact_projection_readiness`] against an explicitly injected
+/// durable lifecycle root.
+///
+/// All three reads follow the injected store, and the third is the one that
+/// matters: the projection check opens an observation database *and* resolves
+/// an artifact root, which `PathRoots` carries separately from `data`. Answered
+/// ambiently, an otherwise-complete candidate is reported as unprojected purely
+/// because the controller-owned bytes were looked for under the wrong home
+/// (#7505, #12618, #12619) — and here that verdict is not merely cosmetic: the
+/// caller turns it into a `cook_continuation_scheduler` status that suppresses
+/// the terminal continuation enqueue.
+///
+/// This is the initializing counterpart of
+/// [`terminal_artifact_projection_readiness_bounded_in_store`]; it opens the
+/// same stores the ambient form opens rather than the read-only ones.
+pub fn terminal_artifact_projection_readiness_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<String>> {
+    let record = lifecycle_store.read_record(&super::sanitize_run_id(run_id))?;
+    terminal_artifact_projection_readiness_for_record_with(
+        &record,
+        lifecycle_store.read_aggregate(&record.run_id),
+        |record, aggregate| {
+            terminal_artifact_projection_is_verified_in_store(lifecycle_store, record, aggregate)
+        },
     )
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -10,7 +10,19 @@
 
 use super::*;
 
-pub(crate) fn project_cook_alias_adoption(
+/// Project the authoritative candidate adoption of a Cook alias onto its parent
+/// record, reading and rewriting every indexed attempt in the injected store.
+///
+/// This walks the Cook index and *writes back* each attempt whose adoption it
+/// reconciles, so the attempt reads and the attempt writes have to land in the
+/// same installation the index itself was read from. Resolved ambiently while
+/// the caller held explicit roots, this would have reported a parent adoption
+/// assembled from another home's attempts (#7505).
+///
+/// There is no ambient wrapper: `status_with_options_inner` is the only caller,
+/// and it resolves one store for the whole read.
+pub(crate) fn project_cook_alias_adoption_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
     index: &AgentTaskCookIndex,
 ) -> Result<()> {
@@ -23,11 +35,11 @@ pub(crate) fn project_cook_alias_adoption(
     )> = None;
 
     for (index_order, indexed_attempt) in index.attempts.iter().enumerate() {
-        let Ok(mut attempt_record) = store::read_record(&indexed_attempt.run_id) else {
+        let Ok(mut attempt_record) = lifecycle_store.read_record(&indexed_attempt.run_id) else {
             continue;
         };
         if reconcile_candidate_adoption(&mut attempt_record) {
-            store::write_record(&attempt_record)?;
+            lifecycle_store.write_record(&attempt_record)?;
         }
         let Some(adoption) = attempt_record.candidate_adoption else {
             continue;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3813,57 +3813,98 @@ pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
     Ok(status_with_options_inner(run_id, AgentTaskStatusOptions::default(), true)?.record)
 }
 
+/// The shared body of [`status`], [`status_with_options`], and [`exact_status`].
+///
+/// This is an *ambient entry point*, not a rooted one: it accepts no store and
+/// resolves one for itself. What changed in #7505's status slice is that it now
+/// resolves it **once** and hands that single store to every reconciliation step
+/// that has a rooted form, instead of letting a dozen `store::` shims each
+/// resolve `default_store()` independently. Behaviour is unchanged — every one
+/// of those shims resolved `AgentTaskLifecycleStore::from_current_environment()`
+/// too — but the read is now one store away from being rootable.
+///
+/// Four steps still resolve their own roots, and each is its own remaining
+/// slice rather than an oversight:
+///
+/// * `reconcile_pending_runner_submission_intent` and
+///   `expire_unaccepted_lab_handoff` — the latter calls the alias-resolving
+///   `cancel_run` spine (~400 lines, a dozen record writes,
+///   `controller_scratch::finalize_run`, managed-service reconciliation) and
+///   takes `LabHandoffLock`, whose lock path is built from `paths::homeboy_data()`
+///   directly. A lock taken in the wrong home excludes nobody, so that lock has
+///   to move with the store in the same change that roots the spine.
+/// * `reconcile_runner_job_state` — reaches `terminalize_lost_accepted_lab_job`
+///   and `reconcile_runner_job_snapshot`, both of which write aggregates.
+/// * the Cook recipe family (`load_recipe`, `load_recipe_for_attempt`,
+///   `validate_recipe_attempt_record`, `enqueue_terminal_continuation`) — a
+///   `CookRecipeStore`, not a lifecycle store. It is derivable from
+///   `lifecycle_store.data_root()`, but pairing the two stores is the shape
+///   `KNOWN_MIXED_STORE_FUNCTIONS` exists to make someone argue for.
+///
+/// `homeboy_core::controller_runtime::admission_status` has no `_at` form at
+/// all; `cancel_admission_at` does, which is why the cancellation reconciler
+/// below could be rooted and this read could not.
+///
+/// Until those close there is deliberately **no** `status_in_store`. A rooted
+/// status that reconciled four of its steps in another installation would be
+/// strictly worse than the uniform ambience it replaced.
 fn status_with_options_inner(
     run_id: &str,
     options: AgentTaskStatusOptions,
     exact: bool,
 ) -> Result<AgentTaskStatusOutcome> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     let requested_run_id = sanitize_run_id(run_id);
     let resolved_run_id = if exact {
         requested_run_id.clone()
     } else {
-        resolve_run_id(run_id)?
+        resolve_run_id_in_store(&lifecycle_store, run_id)?
     };
-    let _ = reconcile_deferred_candidate(&resolved_run_id)?;
-    let mut record = store::read_record(&resolved_run_id)?;
+    let _ = reconcile_deferred_candidate_in_store(&lifecycle_store, &resolved_run_id)?;
+    let mut record = lifecycle_store.read_record(&resolved_run_id)?;
     if let Ok(admission) = homeboy_core::controller_runtime::admission_status(&record.run_id) {
         record.metadata["controller_admission"] = admission;
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
     if reconcile_candidate_adoption(&mut record) {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
     if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
-        record = store::read_record(&resolved_run_id)?;
+        record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     if has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
         let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
-        record = store::read_record(&resolved_run_id)?;
+        record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     // A daemon can evict a completed job from its active store before a restarted
     // controller observes it. The terminal event log already mirrored into this
     // observation record is sufficient to recover the aggregate and artifacts.
     // Consume it before querying the live runner, which is no longer authority
     // once its active entry has been evicted.
-    if project_persisted_terminal_runner_events(&mut record)? {
-        record = store::read_record(&resolved_run_id)?;
+    if project_persisted_terminal_runner_events_in_store(&lifecycle_store, &mut record)? {
+        record = lifecycle_store.read_record(&resolved_run_id)?;
     }
-    if super::cancellation::reconcile_controller_job_cancellation(&mut record)? {
-        store::write_record(&record)?;
+    if super::cancellation::reconcile_controller_job_cancellation_in_store(
+        &lifecycle_store,
+        &mut record,
+    )? {
+        lifecycle_store.write_record(&record)?;
     }
     if !record.state.is_terminal() {
-        let controller_plan = store::read_controller_plan(&record.run_id)?;
-        let controller_plan_path = store::controller_plan_path(&record.run_id)?
+        let controller_plan = lifecycle_store.read_controller_plan(&record.run_id)?;
+        let controller_plan_path = lifecycle_store
+            .controller_plan_path(&record.run_id)
             .display()
             .to_string();
         if record.plan_path != controller_plan_path {
             record.plan_path = controller_plan_path;
-            store::write_record(&record)?;
+            lifecycle_store.write_record(&record)?;
         }
-        if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
-            let aggregate_path = store::aggregate_path(&record.run_id)
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|_| "aggregate.json".to_string());
+        if let Ok(aggregate) = lifecycle_store.read_aggregate(&record.run_id) {
+            let aggregate_path = lifecycle_store
+                .aggregate_path(&record.run_id)
+                .display()
+                .to_string();
             let mut reconciled = record.clone();
             let projection_plan = aggregate_projection_plan(&controller_plan, &aggregate);
             apply_aggregate_to_record(
@@ -3874,7 +3915,7 @@ fn status_with_options_inner(
             );
 
             if reconciled != record {
-                if let Err(error) = store::write_record(&reconciled) {
+                if let Err(error) = lifecycle_store.write_record(&reconciled) {
                     reconciled
                         .ensure_metadata_object()
                         .insert("finalization_error".to_string(), json!(error.message));
@@ -3885,7 +3926,7 @@ fn status_with_options_inner(
         }
     }
     if reconcile_local_provider_ownership(&mut record) {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
     // The only genuinely-remote step in this read. Skipping it for a
     // controller-local record is what makes `agent-task status` answerable while
@@ -3897,17 +3938,20 @@ fn status_with_options_inner(
     }
     record.annotate_stale_running();
     if record != before_liveness_reconciliation {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
     if record.state.is_terminal() {
-        if let Ok(aggregate) = store::read_aggregate(&record.run_id) {
+        if let Ok(aggregate) = lifecycle_store.read_aggregate(&record.run_id) {
             if reconcile_terminal_provider_models(&mut record, &aggregate) {
-                store::write_record(&record)?;
+                lifecycle_store.write_record(&record)?;
             }
-            if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified(
-                &record, &aggregate,
+            if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified_in_store(
+                &lifecycle_store,
+                &record,
+                &aggregate,
             )? {
-                crate::agent_task_lifecycle::record_terminal_artifact_projection(
+                crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+                    &lifecycle_store,
                     &mut record,
                     &aggregate,
                 )?;
@@ -3920,9 +3964,10 @@ fn status_with_options_inner(
             if crate::agent_task_lifecycle::terminal_provider_model_reconciliation_needed(
                 &record, &aggregate,
             ) {
-                let controller_plan = store::read_controller_plan(&record.run_id)?;
+                let controller_plan = lifecycle_store.read_controller_plan(&record.run_id)?;
                 let projection_plan = aggregate_projection_plan(&controller_plan, &aggregate);
-                crate::agent_task_lifecycle::reconcile_terminal_provider_model(
+                crate::agent_task_lifecycle::reconcile_terminal_provider_model_in_store(
+                    &lifecycle_store,
                     &mut record,
                     &projection_plan,
                     &aggregate,
@@ -3959,7 +4004,8 @@ fn status_with_options_inner(
                 ) {
                     Ok(()) => {
                         if let Some(reason) =
-                            crate::agent_task_lifecycle::terminal_artifact_projection_readiness(
+                            crate::agent_task_lifecycle::terminal_artifact_projection_readiness_in_store(
+                                &lifecycle_store,
                                 &record.run_id,
                             )?
                         {
@@ -3982,7 +4028,7 @@ fn status_with_options_inner(
                                     "repair_command": repair_command,
                                 }),
                             );
-                            store::write_record(&record)?;
+                            lifecycle_store.write_record(&record)?;
                             return Ok(AgentTaskStatusOutcome {
                                 record,
                                 runner_probe,
@@ -4028,7 +4074,7 @@ fn status_with_options_inner(
                                         "candidate": candidate,
                                     }),
                                 );
-                                store::write_record(&record)?;
+                                lifecycle_store.write_record(&record)?;
                             }
                             Err(error) => {
                                 record.ensure_metadata_object().insert(
@@ -4039,7 +4085,7 @@ fn status_with_options_inner(
                                         "message": error.message,
                                     }),
                                 );
-                                store::write_record(&record)?;
+                                lifecycle_store.write_record(&record)?;
                             }
                         }
                     }
@@ -4052,7 +4098,7 @@ fn status_with_options_inner(
                                 "message": error.message,
                             }),
                         );
-                        store::write_record(&record)?;
+                        lifecycle_store.write_record(&record)?;
                     }
                 }
             }
@@ -4066,13 +4112,13 @@ fn status_with_options_inner(
                         "message": error.message,
                     }),
                 );
-                store::write_record(&record)?;
+                lifecycle_store.write_record(&record)?;
             }
         }
     }
     if !exact && requested_run_id != record.run_id {
-        if let Ok(index) = store::read_cook_index(&requested_run_id) {
-            project_cook_alias_adoption(&mut record, &index)?;
+        if let Ok(index) = lifecycle_store.read_cook_index(&requested_run_id) {
+            project_cook_alias_adoption_in_store(&lifecycle_store, &mut record, &index)?;
             let metadata = record.ensure_metadata_object();
             metadata.insert("cook_alias".to_string(), json!(requested_run_id));
             metadata.insert(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -298,6 +298,23 @@ fn project_terminal_runner_lifecycle_event(
 pub(crate) fn project_persisted_terminal_runner_events(
     record: &mut AgentTaskRunRecord,
 ) -> Result<bool> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    project_persisted_terminal_runner_events_in_store(&lifecycle_store, record)
+}
+
+/// The store-rooted counterpart of [`project_persisted_terminal_runner_events`].
+///
+/// Every durable touch below follows the injected store: the aggregate
+/// idempotence read, the aggregate path stamped onto the record, the combined
+/// aggregate-and-record commit, and the terminal artifact projection. The last
+/// is why this cannot be left half-rooted — the projection registers
+/// controller-owned bytes under an artifact root that `PathRoots` carries
+/// separately from `data`, which is exactly the cross-home artifact write
+/// #12618 found (#7505).
+pub(crate) fn project_persisted_terminal_runner_events_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<bool> {
     let terminal_status = record
         .metadata
         .get("runner_job_status")
@@ -339,21 +356,26 @@ pub(crate) fn project_persisted_terminal_runner_events(
     };
     validate_terminal_child_event_identity(record, &event)?;
     let aggregate = projected_runner_aggregate(record, &event.aggregate);
-    if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
+    if lifecycle_store.read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
         return Ok(false);
     }
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
-    let aggregate_path = store::aggregate_path(&record.run_id)
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|_| "aggregate.json".to_string());
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&record.run_id)
+        .display()
+        .to_string();
     apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
     record_verified_lab_placement_outcome(record)?;
     record.ensure_metadata_object().insert(
         "terminal_transport_recovery".to_string(),
         json!("persisted_runner_job_events"),
     );
-    store::write_aggregate_and_record(record, &aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &aggregate)?;
+    lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+        lifecycle_store,
+        record,
+        &aggregate,
+    )?;
     Ok(true)
 }
 


### PR DESCRIPTION
## Summary

`status` is the last big un-rooted cluster and has been deferred by **every** prior wave. It now demonstrably blocks ~100 test migrations (#12655, #12656) and two production slices.

**This roots the interior of `status` and stops at a documented boundary. It deliberately does NOT ship `status_in_store`** — and the reason is the finding.

<callout accent="#ef4444">
## Why `status_in_store` is not in this PR

`status_with_options_inner` takes **two** advisory locks. One — `reconcile_deferred_candidate`'s per-run `deferred-candidate.lock` — derives from `store.run_dir()` and now follows the injected store.

The other is `LabHandoffLock`, taken by `expire_unaccepted_lab_handoff`, which builds its path from **`paths::homeboy_data()` directly** and is not rooted.

A `status` reading from an injected store while taking that lock in the ambient home is precisely the **"lock that excludes nobody"** bug — which this campaign has already found live twice (#12639's renewer thread, #12633's authority gate). Shipping the sibling would have looked like progress and been a regression.
</callout>

## `status` is not a read — it has 20 durable write sites

Mapped before editing:

**13 direct record writes** — controller-admission stamp; candidate-adoption interruption; controller-job-cancellation convergence; `plan_path` repair; aggregate reprojection; local-provider-ownership reconciliation; post-liveness/stale-running annotation; terminal provider-model normalization; and five `cook_continuation_scheduler` writes.

**Indirect writes through helpers** — `reconcile_deferred_candidate` (lock + aggregate + record + terminal projection), `project_persisted_terminal_runner_events` (`write_aggregate_and_record` **plus artifact projection into the observation DB and artifact root**), `record_terminal_artifact_projection`, `reconcile_terminal_provider_model`, `project_cook_alias_adoption` (writes back **every indexed attempt**), `reconcile_controller_job_cancellation` (`controller_scratch::finalize_run` + `controller_runtime::cancel_admission`).

Every write that was rooted follows the injected store — verified mechanically, not by eye.

## The family, and what happened to each

| function | disposition |
|---|---|
| `status_with_options_inner` | **resolves one store, threads it through every rootable step** |
| `status`, `status_with_options`, `exact_status` | unchanged — thin wrappers over the above |
| `run_status`, `list_records`, `list_records_with_health` | untouched — blocked behind `status` |

Confirms the claim that stalled two waves: **`persisted_status_in_store` is not substitutable.** It is a plain `read_record_bounded` — it applies no reconciliation and does not even resolve a Cook alias the way `status` does. Swapping it in would have silently deleted what ~100 tests exercise.

## The boundary, and the next slice

Stopped at **`cancel_run`** → `cancel_resolved_run` (~400 lines, 12 `store::` sites, `controller_scratch::finalize_run`, `reconcile_run_services_on_owner`, `classify_live_cancellation`, `reconcile_runner_job_snapshot`) plus `LabHandoffLock`. That is its own slice, and it is what unblocks `status_in_store`.

Also remaining: `reconcile_pending_runner_submission_intent`, `reconcile_runner_job_state`, the `CookRecipeStore` cross-kind family, and `controller_runtime::admission_status` — which has **no `_at` form at all** in `homeboy-core` (`cancel_admission_at` does exist, which is exactly why the cancellation reconciler could be rooted and this read could not).

The boundary is documented in-code at `lifecycle_ops.rs:3833` so the next person does not rediscover it.

## Allowlist — honest answer

**No row deleted, none added.** The `substantive_candidate_in_store` row is blocked on `status` being *rootable*, which this slice moves toward but does not deliver. Claiming it would have been false.

## Verification

**Scanner 7/7 pass** (standalone `rustc --test`, no cargo). Zero new duplicate definitions vs `origin/main`. `cargo fmt` clean.

**Lesson-1** scripted extraction of all five rooted bodies, grepped for `default_store(`, `store::`, `paths::homeboy*`, `from_current_environment`, plus the ambient helper names: **none in any.** Only `status_with_options_inner` names `from_current_environment` — by design, it is the ambient entry point.

**Lesson-2** all three arity changes are single-call-site helpers; whole-tree grep found the inline-test callers of the two wrappers kept ambient (`terminal_and_reconcile.rs:1144`, `:1853`, `cook_tests.rs:4217`) — both keep exact signatures.

**Lesson-4** every surviving wrapper has ≥1 caller. `terminal_artifact_projection_is_verified` survives **only as a bare function reference** at `failure_recording.rs:1179` — the scanner blind spot; checked by name, not by `(`.

<callout accent="#f59e0b">
**One deliberate behaviour change deserving a reviewer's eye.** `store::controller_plan_path`/`aggregate_path` return `Result<PathBuf>` while the store methods return bare `PathBuf`, so the `?` and the `.map(..).unwrap_or_else(.. "aggregate.json")` fallback were dropped. That fallback could only fire when the environment was unresolvable — at which point the surrounding `read_aggregate` had already failed. It is the only non-mechanical edit in the diff.

Not compiled, not run. Residual risks: borrowck on the `&mut record`/`&lifecycle_store` interleavings, and dead-code reasoning that depends on `pub use <private mod>::*` inside a `pub mod` marking items reachable.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Call-graph mapping, implementation, boundary analysis. Review by hand.

Refs #7505
