### PR TITLE
Clarify controller-owned gates in Cook provider prompts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -942,6 +942,53 @@ fn project_initial_finalizing_review_form_contract(options: &mut AgentTaskCookSe
     }
 }
 
+/// Make the controller/provider verification boundary explicit before the
+/// immutable Cook recipe is persisted. This keeps a provider attempt focused
+/// on a patch instead of duplicating the final gate population in its isolated
+/// workspace. Private gate programs deliberately remain undisclosed.
+fn project_controller_owned_gate_contract(options: &mut AgentTaskCookServiceOptions) {
+    let public_gates = options
+        .gates
+        .verify
+        .iter()
+        .map(|command| format!("`{command}`"))
+        .collect::<Vec<_>>();
+    let private_gate_count = options.gates.private_verify.len();
+    if public_gates.is_empty() && private_gate_count == 0 {
+        return;
+    }
+
+    let mut instructions = vec![
+        "Declared deterministic gates are controller-owned. Homeboy runs them after it harvests your candidate, so use this attempt for the source change and a focused check only when it directly reduces uncertainty.".to_string(),
+    ];
+    if !public_gates.is_empty() {
+        instructions.push(format!(
+            "Controller-owned final gates: {}.",
+            public_gates.join(", ")
+        ));
+    }
+    if private_gate_count > 0 {
+        instructions.push(format!(
+            "Homeboy also owns {private_gate_count} private deterministic gate(s); their programs are intentionally withheld from this attempt."
+        ));
+    }
+    instructions.push(
+        "Report any focused command you run and its result in the reviewer-facing verification evidence; Homeboy records the authoritative final gate evidence separately."
+            .to_string(),
+    );
+    let contract = instructions.join("\n");
+
+    for request in &mut options.initial_plan.tasks {
+        if !request
+            .instructions
+            .contains("Declared deterministic gates are controller-owned.")
+        {
+            request.instructions.push_str("\n\n");
+            request.instructions.push_str(&contract);
+        }
+    }
+}
+
 /// Executes one provider attempt while cook retains ownership of promotion,
 /// gates, retries, and finalization.
 pub trait AgentTaskCookAttemptDispatcher: Send + Sync + std::fmt::Debug {
@@ -4119,6 +4166,7 @@ where
             &options.initial_plan.options.execution_budget,
         )?;
     }
+    project_controller_owned_gate_contract(&mut options);
     project_initial_finalizing_review_form_contract(&mut options);
     // A configured provider is controller authority. Resolve it before an
     // external runner can spend a provider attempt; explicit transports are

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3708,6 +3708,35 @@ fn initial_finalizing_provider_request_projects_complete_review_form_dossier() {
 }
 
 #[test]
+fn provider_prompt_distinguishes_controller_owned_gates_from_focused_checks() {
+    let mut options = batch_cook_options(
+        "controller-owned-gate-contract",
+        Arc::new(AcceptedDetachedAttemptDispatcher),
+    );
+    options.gates.verify = vec!["cargo test --locked -p homeboy-agents".to_string()];
+    options.gates.private_verify = vec!["private-gate --token secret".to_string()];
+
+    project_controller_owned_gate_contract(&mut options);
+
+    let instructions = &options.initial_plan.tasks[0].instructions;
+    assert!(instructions.contains("Declared deterministic gates are controller-owned."));
+    assert!(instructions.contains("`cargo test --locked -p homeboy-agents`"));
+    assert!(instructions.contains("1 private deterministic gate(s)"));
+    assert!(!instructions.contains("private-gate --token secret"));
+    assert!(instructions.contains("focused check only when it directly reduces uncertainty"));
+    assert!(instructions.contains("authoritative final gate evidence separately"));
+
+    project_controller_owned_gate_contract(&mut options);
+    assert_eq!(
+        options.initial_plan.tasks[0]
+            .instructions
+            .matches("Declared deterministic gates are controller-owned.")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn no_finalize_initial_request_preserves_its_existing_contract() {
     let mut options = batch_cook_options(
         "no-finalize-review-form-contract",


### PR DESCRIPTION
## Summary
- tell coding providers that declared deterministic gates are controller-owned
- list public gates while keeping private gate programs redacted
- frame provider-side checks as focused optional evidence instead of duplicate final verification

This is the safe prompt prerequisite for #12648, not completion of typed cross-attempt Cargo cache reuse. The issue remains open for compatibility-keyed build output hydration.

## Verification
- `cargo fmt --check`
- provider prompt gate-ownership contract test
- `cargo check -p homeboy-agents --all-targets`
- `git diff --check`

Refs #12648

AI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagents scoped the safe prerequisite, implemented and independently reviewed the prompt contract, and verified it after rebase. Chris Huber remains responsible for the report and code.