### PR TITLE
Persist actionable terminal notification rejections

### DIFF
--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -139,6 +139,8 @@ fn terminal_outcome(
         "delivered"
     } else if matches!(disposition, NotifyOutboxDisposition::Queued { .. }) {
         "queued"
+    } else if matches!(disposition, NotifyOutboxDisposition::Rejected) {
+        "rejected"
     } else if matches!(outcome.delivery, NotifyDelivery::NotConfigured) {
         "not_configured"
     } else {
@@ -159,6 +161,8 @@ fn terminal_outcome(
         "error_class": error_class,
         "outbox_entry_id": outbox_entry_id,
         "transport_result": safe_transport_result(outcome.result.as_ref()),
+        "rejection_reason": safe_rejection_reason(outcome.result.as_ref()),
+        "validation_context": safe_validation_context(outcome.result.as_ref()),
     })
 }
 
@@ -173,6 +177,9 @@ fn safe_transport_result(result: Option<&Value>) -> Option<Value> {
         "route_kind",
         "retryable",
         "truncated",
+        "reason_code",
+        "validation_code",
+        "validation_field",
     ];
     let object = result?.as_object()?;
     let mut safe = Map::new();
@@ -191,6 +198,26 @@ fn safe_transport_result(result: Option<&Value>) -> Option<Value> {
         }
     }
     (!safe.is_empty()).then_some(Value::Object(safe))
+}
+
+fn safe_rejection_reason(result: Option<&Value>) -> Option<Value> {
+    safe_transport_result(result).and_then(|result| {
+        result
+            .get("reason_code")
+            .or_else(|| result.get("validation_code"))
+            .cloned()
+    })
+}
+
+fn safe_validation_context(result: Option<&Value>) -> Option<Value> {
+    let result = safe_transport_result(result)?;
+    let mut context = Map::new();
+    for key in ["validation_code", "validation_field", "route_kind"] {
+        if let Some(value) = result.get(key) {
+            context.insert(key.to_string(), value.clone());
+        }
+    }
+    (!context.is_empty()).then_some(Value::Object(context))
 }
 
 fn cook_subject(cook_id: &str, run_id: &str, component: Option<&str>) -> NotifySubject {
@@ -456,7 +483,7 @@ pub(crate) fn cook_terminal(report: &AgentTaskCookReport, component: Option<&str
         // Nothing durable exists — no transport is configured, or the queue
         // could not be written. Release, exactly as before, so a later
         // terminal observer is eligible to try again.
-        NotifyOutboxDisposition::Dropped => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
             let _ = crate::agent_task_lifecycle::release_cook_terminal_notification_claim(
                 &report.cook_id,
             );
@@ -658,7 +685,7 @@ pub fn batch_terminal(
                 BATCH_TERMINAL_DELIVERED_BY,
             );
         }
-        NotifyOutboxDisposition::Dropped => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
             let _ =
                 crate::agent_task_lifecycle::release_cook_terminal_notification_claim(subject_id);
         }
@@ -930,7 +957,7 @@ pub fn run_reconciled(run_id: &str, state: &str, liveness: &str, reason: Option<
                 RUN_RECONCILED_DELIVERED_BY,
             );
         }
-        NotifyOutboxDisposition::Dropped => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
             let _ = crate::agent_task_lifecycle::release_cook_terminal_notification_claim(run_id);
         }
     }

--- a/crates/homeboy-agents/src/agent_task_notify.rs
+++ b/crates/homeboy-agents/src/agent_task_notify.rs
@@ -25,7 +25,7 @@ use homeboy_core::notification_payload::{
     NotifyAction, NotifyEventKind, NotifyLink, NotifyPayload, NotifySubject,
 };
 use homeboy_core::notification_route::{self, NotificationRoute};
-use homeboy_core::notify::{NotifyDelivery, NotifyEvent, NotifyOutcome};
+use homeboy_core::notify::{terminal_rejection_result, NotifyDelivery, NotifyEvent, NotifyOutcome};
 use homeboy_core::notify_outbox::{self, NotifyOnceMarker, NotifyOutboxDisposition};
 use serde_json::{json, Map, Value};
 use std::collections::HashSet;
@@ -139,7 +139,7 @@ fn terminal_outcome(
         "delivered"
     } else if matches!(disposition, NotifyOutboxDisposition::Queued { .. }) {
         "queued"
-    } else if matches!(disposition, NotifyOutboxDisposition::Rejected) {
+    } else if matches!(disposition, NotifyOutboxDisposition::Rejected { .. }) {
         "rejected"
     } else if matches!(outcome.delivery, NotifyDelivery::NotConfigured) {
         "not_configured"
@@ -147,7 +147,8 @@ fn terminal_outcome(
         "failed"
     };
     let outbox_entry_id = match disposition {
-        NotifyOutboxDisposition::Queued { entry_id } => Some(entry_id.clone()),
+        NotifyOutboxDisposition::Queued { entry_id }
+        | NotifyOutboxDisposition::Rejected { entry_id } => Some(entry_id.clone()),
         _ => None,
     };
     json!({
@@ -161,8 +162,8 @@ fn terminal_outcome(
         "error_class": error_class,
         "outbox_entry_id": outbox_entry_id,
         "transport_result": safe_transport_result(outcome.result.as_ref()),
-        "rejection_reason": safe_rejection_reason(outcome.result.as_ref()),
-        "validation_context": safe_validation_context(outcome.result.as_ref()),
+        "rejection_reason": terminal_rejection_result(outcome.result.as_ref()).map(|rejection| rejection.reason_code),
+        "validation_context": terminal_rejection_context(outcome.result.as_ref()),
     })
 }
 
@@ -200,22 +201,14 @@ fn safe_transport_result(result: Option<&Value>) -> Option<Value> {
     (!safe.is_empty()).then_some(Value::Object(safe))
 }
 
-fn safe_rejection_reason(result: Option<&Value>) -> Option<Value> {
-    safe_transport_result(result).and_then(|result| {
-        result
-            .get("reason_code")
-            .or_else(|| result.get("validation_code"))
-            .cloned()
-    })
-}
-
-fn safe_validation_context(result: Option<&Value>) -> Option<Value> {
-    let result = safe_transport_result(result)?;
+fn terminal_rejection_context(result: Option<&Value>) -> Option<Value> {
+    let rejection = terminal_rejection_result(result)?;
     let mut context = Map::new();
-    for key in ["validation_code", "validation_field", "route_kind"] {
-        if let Some(value) = result.get(key) {
-            context.insert(key.to_string(), value.clone());
-        }
+    if let Some(value) = rejection.validation_code {
+        context.insert("validation_code".to_string(), Value::String(value));
+    }
+    if let Some(value) = rejection.validation_field {
+        context.insert("validation_field".to_string(), Value::String(value));
     }
     (!context.is_empty()).then_some(Value::Object(context))
 }
@@ -483,7 +476,7 @@ pub(crate) fn cook_terminal(report: &AgentTaskCookReport, component: Option<&str
         // Nothing durable exists — no transport is configured, or the queue
         // could not be written. Release, exactly as before, so a later
         // terminal observer is eligible to try again.
-        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected { .. } => {
             let _ = crate::agent_task_lifecycle::release_cook_terminal_notification_claim(
                 &report.cook_id,
             );
@@ -685,7 +678,7 @@ pub fn batch_terminal(
                 BATCH_TERMINAL_DELIVERED_BY,
             );
         }
-        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected { .. } => {
             let _ =
                 crate::agent_task_lifecycle::release_cook_terminal_notification_claim(subject_id);
         }
@@ -957,7 +950,7 @@ pub fn run_reconciled(run_id: &str, state: &str, liveness: &str, reason: Option<
                 RUN_RECONCILED_DELIVERED_BY,
             );
         }
-        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected => {
+        NotifyOutboxDisposition::Dropped | NotifyOutboxDisposition::Rejected { .. } => {
             let _ = crate::agent_task_lifecycle::release_cook_terminal_notification_claim(run_id);
         }
     }

--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -308,6 +308,29 @@ fn transport_rejection_and_spawn_failure_are_classified_without_transport_output
 }
 
 #[test]
+fn rejected_before_attempt_records_safe_context_and_remains_resendable() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        install_transport(
+            "test.reject-before-attempt",
+            vec!["sh", "-c", "printf '%s\\n' '{\"status\":\"failed\",\"retryable\":false,\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}'; exit 1"],
+        );
+        set_default_transport("test.reject-before-attempt");
+
+        cook_terminal(&report("durable_failure", None), None, 1);
+        let rejected = latest_delivery("cook-abc");
+        assert_eq!(rejected["status"], "rejected");
+        assert_eq!(rejected["error_class"], "transport_rejected");
+        assert_eq!(rejected["rejection_reason"], "invalid_route");
+        assert_eq!(rejected["validation_context"]["validation_field"], "route");
+        assert!(homeboy_core::notify_outbox::pending_entries().is_empty());
+        assert!(
+            crate::agent_task_lifecycle::claim_cook_terminal_notification("cook-abc", "test")
+                .unwrap()
+        );
+    });
+}
+
+#[test]
 fn a_terminal_outcome_survives_a_transport_outage() {
     // The whole point of W3-6. A cook that ran for hours must not lose its
     // outcome because the chat transport was down for a minute.

--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -312,7 +312,7 @@ fn rejected_before_attempt_records_safe_context_and_remains_resendable() {
     homeboy_core::test_support::with_isolated_home(|_| {
         install_transport(
             "test.reject-before-attempt",
-            vec!["sh", "-c", "printf '%s\\n' '{\"status\":\"failed\",\"retryable\":false,\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}'; exit 1"],
+            vec!["sh", "-c", "printf '%s\\n' '{\"schema\":\"homeboy/notification-transport-result/v1\",\"status\":\"rejected\",\"attempts\":0,\"terminal_rejection\":{\"schema\":\"homeboy/notification-transport-rejection/v1\",\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}}'; exit 1"],
         );
         set_default_transport("test.reject-before-attempt");
 
@@ -323,6 +323,7 @@ fn rejected_before_attempt_records_safe_context_and_remains_resendable() {
         assert_eq!(rejected["rejection_reason"], "invalid_route");
         assert_eq!(rejected["validation_context"]["validation_field"], "route");
         assert!(homeboy_core::notify_outbox::pending_entries().is_empty());
+        assert_eq!(homeboy_core::notify_outbox::dead_letter_entries().len(), 1);
         assert!(
             crate::agent_task_lifecycle::claim_cook_terminal_notification("cook-abc", "test")
                 .unwrap()

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -505,24 +505,32 @@ fn attach_cook_notification_delivery(
         return;
     };
     if outcome.get("status").and_then(Value::as_str) != Some("delivered") {
-        outcome["resend_command"] = Value::String(
-            agent_task_service_direct::cook_continue_command(None, cook_id, false, None),
-        );
+        let resend_command = Value::String(agent_task_service_direct::cook_continue_command(
+            None, cook_id, false, None,
+        ));
+        outcome["resend_command"] = resend_command.clone();
+        // Retain the original status contract for older consumers.
+        outcome["retry_command"] = resend_command;
         outcome["inspect_command"] =
             Value::String(format!("homeboy agent-task status {cook_id} --full"));
     }
-    if matches!(
-        outcome.get("status").and_then(Value::as_str),
-        Some("not_configured" | "rejected")
-    ) {
-        outcome["repair_command"] = Value::String(
-            "homeboy config set /notifications/default_transport '<installed-transport-id>'"
-                .to_string(),
-        );
+    if let Some(configuration_command) = notification_repair_command(&outcome) {
+        let configuration_command = Value::String(configuration_command);
+        outcome["repair_command"] = configuration_command.clone();
+        // Retain the original status contract for older consumers.
+        outcome["configuration_command"] = configuration_command;
     }
     if let Value::Object(fields) = value {
         fields.insert("notification_delivery".to_string(), outcome);
     }
+}
+
+fn notification_repair_command(outcome: &Value) -> Option<String> {
+    (outcome.get("status").and_then(Value::as_str) == Some("not_configured")
+        && outcome.get("route_classification").and_then(Value::as_str) != Some("explicit"))
+    .then(|| {
+        "homeboy config set /notifications/default_transport '<installed-transport-id>'".to_string()
+    })
 }
 
 /// A Cook owns the provider attempt's publication lifecycle. Once it records a
@@ -4377,6 +4385,8 @@ fn compact_status_summary_with_aggregate(
                 "inspect_command",
                 "repair_command",
                 "resend_command",
+                "retry_command",
+                "configuration_command",
             ],
         );
     }
@@ -6874,6 +6884,20 @@ mod tests {
         assert!(summary["notification_delivery"]
             .get("raw_destination")
             .is_none());
+    }
+
+    #[test]
+    fn explicit_notification_routes_do_not_suggest_changing_the_default_transport() {
+        assert!(notification_repair_command(&json!({
+            "status": "not_configured",
+            "route_classification": "explicit"
+        }))
+        .is_none());
+        assert!(notification_repair_command(&json!({
+            "status": "not_configured",
+            "route_classification": "default"
+        }))
+        .is_some());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -505,12 +505,17 @@ fn attach_cook_notification_delivery(
         return;
     };
     if outcome.get("status").and_then(Value::as_str) != Some("delivered") {
-        outcome["retry_command"] = Value::String(agent_task_service_direct::cook_continue_command(
-            None, cook_id, false, None,
-        ));
+        outcome["resend_command"] = Value::String(
+            agent_task_service_direct::cook_continue_command(None, cook_id, false, None),
+        );
+        outcome["inspect_command"] =
+            Value::String(format!("homeboy agent-task status {cook_id} --full"));
     }
-    if outcome.get("status").and_then(Value::as_str) == Some("not_configured") {
-        outcome["configuration_command"] = Value::String(
+    if matches!(
+        outcome.get("status").and_then(Value::as_str),
+        Some("not_configured" | "rejected")
+    ) {
+        outcome["repair_command"] = Value::String(
             "homeboy config set /notifications/default_transport '<installed-transport-id>'"
                 .to_string(),
         );
@@ -1137,22 +1142,33 @@ fn attach_agent_task_status_actionable(value: &mut Value, run_id: &str) {
 
     if let Some(command) = value
         .get("notification_delivery")
-        .and_then(|delivery| delivery.get("retry_command"))
+        .and_then(|delivery| delivery.get("inspect_command"))
         .and_then(Value::as_str)
     {
         metadata.next_actions.push(
-            CommandNextAction::new("retry terminal notification", command)
+            CommandNextAction::new("inspect terminal notification", command)
+                .with_kind(CommandNextActionKind::Show),
+        );
+    }
+
+    if let Some(command) = value
+        .get("notification_delivery")
+        .and_then(|delivery| delivery.get("resend_command"))
+        .and_then(Value::as_str)
+    {
+        metadata.next_actions.push(
+            CommandNextAction::new("resend terminal notification", command)
                 .with_kind(CommandNextActionKind::Repair),
         );
     }
 
     if let Some(command) = value
         .get("notification_delivery")
-        .and_then(|delivery| delivery.get("configuration_command"))
+        .and_then(|delivery| delivery.get("repair_command"))
         .and_then(Value::as_str)
     {
         metadata.next_actions.push(
-            CommandNextAction::new("configure terminal notifications", command)
+            CommandNextAction::new("repair terminal notifications", command)
                 .with_kind(CommandNextActionKind::Repair),
         );
     }
@@ -4356,8 +4372,11 @@ fn compact_status_summary_with_aggregate(
                 "status",
                 "error_class",
                 "transport_result",
-                "retry_command",
-                "configuration_command",
+                "rejection_reason",
+                "validation_context",
+                "inspect_command",
+                "repair_command",
+                "resend_command",
             ],
         );
     }
@@ -6840,7 +6859,7 @@ mod tests {
                     "route_classification": "explicit",
                     "status": "failed",
                     "error_class": "transport_spawn_failed",
-                    "retry_command": "homeboy agent-task cook-continue cook-1",
+                    "resend_command": "homeboy agent-task cook-continue cook-1",
                     "raw_destination": "must-not-appear"
                 }
             }),
@@ -6849,7 +6868,7 @@ mod tests {
 
         assert_eq!(summary["notification_delivery"]["status"], "failed");
         assert_eq!(
-            summary["notification_delivery"]["retry_command"],
+            summary["notification_delivery"]["resend_command"],
             "homeboy agent-task cook-continue cook-1"
         );
         assert!(summary["notification_delivery"]

--- a/crates/homeboy-core/src/notify.rs
+++ b/crates/homeboy-core/src/notify.rs
@@ -22,6 +22,52 @@ const TRANSPORT_OUTPUT_INSPECTION_LIMIT: usize = 256 * 1024;
 /// Bound on the transport diagnostic text folded into `NotifyOutcome::error`.
 const TRANSPORT_ERROR_TAIL_CHARS: usize = 800;
 
+/// Schema emitted by transports that return structured delivery results.
+pub const NOTIFICATION_TRANSPORT_RESULT_SCHEMA: &str = "homeboy/notification-transport-result/v1";
+/// Schema of an explicit terminal transport rejection.
+pub const NOTIFICATION_TRANSPORT_REJECTION_SCHEMA: &str =
+    "homeboy/notification-transport-rejection/v1";
+
+/// A transport-neutral, non-secret reason a transport declined delivery before
+/// making a delivery attempt. This is deliberately distinct from `retryable`:
+/// arbitrary transport output cannot change durable outbox state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotifyTerminalRejection {
+    pub schema: String,
+    pub reason_code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_field: Option<String>,
+}
+
+/// Read only the explicit, versioned pre-attempt rejection envelope.
+pub fn terminal_rejection_result(
+    result: Option<&serde_json::Value>,
+) -> Option<NotifyTerminalRejection> {
+    let result = result?.as_object()?;
+    if result.get("schema")?.as_str()? != NOTIFICATION_TRANSPORT_RESULT_SCHEMA
+        || result.get("status")?.as_str()? != "rejected"
+        || result.get("attempts")?.as_u64()? != 0
+    {
+        return None;
+    }
+    let rejection: NotifyTerminalRejection =
+        serde_json::from_value(result.get("terminal_rejection")?.clone()).ok()?;
+    (rejection.schema == NOTIFICATION_TRANSPORT_REJECTION_SCHEMA
+        && !rejection.reason_code.is_empty()
+        && rejection.reason_code.len() <= 128
+        && rejection
+            .validation_code
+            .as_ref()
+            .is_none_or(|value| value.len() <= 128)
+        && rejection
+            .validation_field
+            .as_ref()
+            .is_none_or(|value| value.len() <= 128))
+    .then_some(rejection)
+}
+
 /// A lifecycle event passed to extension transports as typed argv values.
 ///
 /// Deserializable so [`crate::notify_outbox`] can persist an undelivered event

--- a/crates/homeboy-core/src/notify_outbox.rs
+++ b/crates/homeboy-core/src/notify_outbox.rs
@@ -162,6 +162,9 @@ pub enum NotifyOutboxDisposition {
     /// redelivery, and leaving the claim releasable would let a second observer
     /// announce the same outcome alongside the retry.
     Queued { entry_id: String },
+    /// The transport rejected the event before making its own delivery attempt
+    /// and explicitly said retrying cannot succeed.
+    Rejected,
     /// The inline attempt failed and nothing was queued. Either the failure is
     /// not retryable (no transport configured, or the named transport is not
     /// installed) or the queue itself could not be written. A producer holding
@@ -297,7 +300,25 @@ pub fn backoff_after(attempts_made: u32) -> Duration {
 /// `not_configured` and leave the event eligible for a later observer, which
 /// stays the right behaviour.
 fn is_retryable(outcome: &NotifyOutcome) -> bool {
-    !outcome.delivered && matches!(outcome.delivery, NotifyDelivery::Transport { .. })
+    !outcome.delivered
+        && matches!(outcome.delivery, NotifyDelivery::Transport { .. })
+        && outcome
+            .result
+            .as_ref()
+            .and_then(|result| result.get("retryable"))
+            .and_then(serde_json::Value::as_bool)
+            != Some(false)
+}
+
+fn is_terminal_rejection(outcome: &NotifyOutcome) -> bool {
+    !outcome.delivered
+        && matches!(outcome.delivery, NotifyDelivery::Transport { .. })
+        && outcome
+            .result
+            .as_ref()
+            .and_then(|result| result.get("retryable"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -344,9 +365,14 @@ fn dispatch_with_outbox_inner(
         };
     }
     if !is_retryable(&outcome) {
+        let rejected = is_terminal_rejection(&outcome);
         return NotifyOutboxDispatch {
             outcome,
-            disposition: NotifyOutboxDisposition::Dropped,
+            disposition: if rejected {
+                NotifyOutboxDisposition::Rejected
+            } else {
+                NotifyOutboxDisposition::Dropped
+            },
         };
     }
     let queued = config_root.and_then(|config_root| {
@@ -801,6 +827,24 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let dispatch = dispatch_with_outbox(&event("run-unconfigured"), None);
             assert_eq!(dispatch.disposition, NotifyOutboxDisposition::Dropped);
+            assert!(pending_entries().is_empty());
+        });
+    }
+
+    #[test]
+    fn a_rejection_before_an_attempt_is_not_queued() {
+        crate::test_support::with_isolated_home(|_| {
+            install_transport(
+                "outbox.rejected",
+                vec!["sh", "-c", "printf '%s\\n' '{\"status\":\"failed\",\"retryable\":false,\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}'; exit 1"],
+            );
+            set_default_transport("outbox.rejected");
+
+            let dispatch = dispatch_with_outbox(&event("run-rejected"), None);
+            assert!(matches!(
+                dispatch.disposition,
+                NotifyOutboxDisposition::Rejected
+            ));
             assert!(pending_entries().is_empty());
         });
     }

--- a/crates/homeboy-core/src/notify_outbox.rs
+++ b/crates/homeboy-core/src/notify_outbox.rs
@@ -61,7 +61,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::notify::{self, NotifyDelivery, NotifyEvent, NotifyOutcome};
+use crate::notify::{self, NotifyDelivery, NotifyEvent, NotifyOutcome, NotifyTerminalRejection};
 
 /// Schema of a persisted outbox entry.
 pub const NOTIFY_OUTBOX_ENTRY_SCHEMA: &str = "homeboy/notification-outbox-entry/v1";
@@ -143,6 +143,9 @@ pub struct NotifyOutboxEntry {
     pub last_attempt_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
+    /// Explicit terminal rejection retained as durable dead-letter evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_rejection: Option<NotifyTerminalRejection>,
     /// The producer-owned exactly-once claim this entry consumed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub once_marker: Option<NotifyOnceMarker>,
@@ -164,7 +167,7 @@ pub enum NotifyOutboxDisposition {
     Queued { entry_id: String },
     /// The transport rejected the event before making its own delivery attempt
     /// and explicitly said retrying cannot succeed.
-    Rejected,
+    Rejected { entry_id: String },
     /// The inline attempt failed and nothing was queued. Either the failure is
     /// not retryable (no transport configured, or the named transport is not
     /// installed) or the queue itself could not be written. A producer holding
@@ -299,26 +302,16 @@ pub fn backoff_after(attempts_made: u32) -> Duration {
 /// that can only ever dead-letter. Producers already record that case as
 /// `not_configured` and leave the event eligible for a later observer, which
 /// stays the right behaviour.
+fn terminal_rejection(outcome: &NotifyOutcome) -> Option<NotifyTerminalRejection> {
+    (!outcome.delivered && matches!(outcome.delivery, NotifyDelivery::Transport { .. }))
+        .then(|| notify::terminal_rejection_result(outcome.result.as_ref()))
+        .flatten()
+}
+
 fn is_retryable(outcome: &NotifyOutcome) -> bool {
     !outcome.delivered
         && matches!(outcome.delivery, NotifyDelivery::Transport { .. })
-        && outcome
-            .result
-            .as_ref()
-            .and_then(|result| result.get("retryable"))
-            .and_then(serde_json::Value::as_bool)
-            != Some(false)
-}
-
-fn is_terminal_rejection(outcome: &NotifyOutcome) -> bool {
-    !outcome.delivered
-        && matches!(outcome.delivery, NotifyDelivery::Transport { .. })
-        && outcome
-            .result
-            .as_ref()
-            .and_then(|result| result.get("retryable"))
-            .and_then(serde_json::Value::as_bool)
-            == Some(false)
+        && terminal_rejection(outcome).is_none()
 }
 
 // ---------------------------------------------------------------------------
@@ -365,11 +358,14 @@ fn dispatch_with_outbox_inner(
         };
     }
     if !is_retryable(&outcome) {
-        let rejected = is_terminal_rejection(&outcome);
+        let rejected = terminal_rejection(&outcome);
         return NotifyOutboxDispatch {
             outcome,
-            disposition: if rejected {
-                NotifyOutboxDisposition::Rejected
+            disposition: if let Some(rejection) = rejected {
+                reject_after_attempt(config_root, event, once_marker, rejection)
+                    .map_or(NotifyOutboxDisposition::Dropped, |entry_id| {
+                        NotifyOutboxDisposition::Rejected { entry_id }
+                    })
             } else {
                 NotifyOutboxDisposition::Dropped
             },
@@ -402,7 +398,16 @@ pub fn enqueue_in_root(
     event: &NotifyEvent,
     once_marker: Option<NotifyOnceMarker>,
 ) -> Option<String> {
-    write_new_entry(config_root, event, once_marker, 0, Utc::now(), None)
+    write_new_entry(
+        config_root,
+        event,
+        once_marker,
+        0,
+        Utc::now(),
+        None,
+        None,
+        false,
+    )
 }
 
 fn enqueue_after_attempt(
@@ -414,7 +419,25 @@ fn enqueue_after_attempt(
     let now = Utc::now();
     let due = now
         + chrono::Duration::from_std(backoff_after(1)).unwrap_or_else(|_| chrono::Duration::zero());
-    write_new_entry(config_root, event, once_marker, 1, due, error)
+    write_new_entry(config_root, event, once_marker, 1, due, error, None, false)
+}
+
+fn reject_after_attempt(
+    config_root: Option<&Path>,
+    event: &NotifyEvent,
+    once_marker: Option<NotifyOnceMarker>,
+    rejection: NotifyTerminalRejection,
+) -> Option<String> {
+    write_new_entry(
+        config_root?,
+        event,
+        once_marker,
+        0,
+        Utc::now(),
+        None,
+        Some(rejection),
+        true,
+    )
 }
 
 fn write_new_entry(
@@ -424,6 +447,8 @@ fn write_new_entry(
     attempts: u32,
     next_attempt_at: DateTime<Utc>,
     last_error: Option<String>,
+    terminal_rejection: Option<NotifyTerminalRejection>,
+    dead_letter: bool,
 ) -> Option<String> {
     let now = Utc::now();
     let entry_id = format!(
@@ -440,9 +465,15 @@ fn write_new_entry(
         next_attempt_at: next_attempt_at.to_rfc3339(),
         last_attempt_at: (attempts > 0).then(|| now.to_rfc3339()),
         last_error,
+        terminal_rejection,
         once_marker,
     };
-    let path = pending_dir_in_root(config_root).join(format!("{entry_id}.json"));
+    let directory = if dead_letter {
+        dead_letter_dir_in_root(config_root)
+    } else {
+        pending_dir_in_root(config_root)
+    };
+    let path = directory.join(format!("{entry_id}.json"));
     write_entry(&path, &entry).then_some(entry_id)
 }
 
@@ -585,6 +616,22 @@ fn apply_attempt(
     }
 
     entry.last_error = outcome.error.clone();
+    if let Some(rejection) = terminal_rejection(&outcome) {
+        entry.terminal_rejection = Some(rejection);
+        report.dead_lettered += 1;
+        report.entries.push(NotifyOutboxDrainEntry {
+            entry_id: entry.entry_id.clone(),
+            attempts: entry.attempts,
+            outcome: "terminal_rejected",
+            next_attempt_at: None,
+            error: entry.last_error.clone(),
+        });
+        let path = dead_letter_dir_in_root(config_root).join(format!("{}.json", entry.entry_id));
+        if write_entry(&path, &entry) {
+            let _ = std::fs::remove_file(claimed);
+        }
+        return;
+    }
     // A now-unconfigured transport is retried like any other failure until the
     // budget runs out. Unlike the inline path there is no producer left to
     // record `not_configured` against, and an operator repairing the transport
@@ -836,16 +883,66 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             install_transport(
                 "outbox.rejected",
-                vec!["sh", "-c", "printf '%s\\n' '{\"status\":\"failed\",\"retryable\":false,\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}'; exit 1"],
+                vec!["sh", "-c", "printf '%s\\n' '{\"schema\":\"homeboy/notification-transport-result/v1\",\"status\":\"rejected\",\"attempts\":0,\"terminal_rejection\":{\"schema\":\"homeboy/notification-transport-rejection/v1\",\"reason_code\":\"invalid_route\",\"validation_field\":\"route\"}}'; exit 1"],
             );
             set_default_transport("outbox.rejected");
 
             let dispatch = dispatch_with_outbox(&event("run-rejected"), None);
             assert!(matches!(
                 dispatch.disposition,
-                NotifyOutboxDisposition::Rejected
+                NotifyOutboxDisposition::Rejected { .. }
             ));
             assert!(pending_entries().is_empty());
+            let dead = dead_letter_entries();
+            assert_eq!(dead.len(), 1);
+            assert_eq!(dead[0].attempts, 0);
+            assert_eq!(
+                dead[0]
+                    .terminal_rejection
+                    .as_ref()
+                    .map(|rejection| rejection.reason_code.as_str()),
+                Some("invalid_route")
+            );
+        });
+    }
+
+    #[test]
+    fn arbitrary_retryable_false_output_remains_retryable() {
+        crate::test_support::with_isolated_home(|_| {
+            install_transport(
+                "outbox.unversioned",
+                vec!["sh", "-c", "printf '%s\\n' '{\"retryable\":false}'; exit 1"],
+            );
+            set_default_transport("outbox.unversioned");
+
+            let dispatch = dispatch_with_outbox(&event("run-unversioned"), None);
+            assert!(matches!(
+                dispatch.disposition,
+                NotifyOutboxDisposition::Queued { .. }
+            ));
+            assert_eq!(pending_entries().len(), 1);
+            assert!(dead_letter_entries().is_empty());
+        });
+    }
+
+    #[test]
+    fn a_redelivery_rejection_is_dead_lettered_with_attempt_history() {
+        crate::test_support::with_isolated_home(|_| {
+            install_transport("outbox.reject-later", vec!["false"]);
+            set_default_transport("outbox.reject-later");
+            dispatch_with_outbox(&event("run-reject-later"), None);
+            install_transport(
+                "outbox.reject-later",
+                vec!["sh", "-c", "printf '%s\\n' '{\"schema\":\"homeboy/notification-transport-result/v1\",\"status\":\"rejected\",\"attempts\":0,\"terminal_rejection\":{\"schema\":\"homeboy/notification-transport-rejection/v1\",\"reason_code\":\"invalid_route\"}}'; exit 1"],
+            );
+
+            let report = drain(Utc::now() + chrono::Duration::seconds(30));
+            assert_eq!(report.dead_lettered, 1);
+            assert_eq!(report.entries[0].outcome, "terminal_rejected");
+            let dead = dead_letter_entries();
+            assert_eq!(dead.len(), 1);
+            assert_eq!(dead[0].attempts, 2);
+            assert!(dead[0].terminal_rejection.is_some());
         });
     }
 
@@ -951,6 +1048,7 @@ mod tests {
                 next_attempt_at: Utc::now().to_rfc3339(),
                 last_attempt_at: None,
                 last_error: None,
+                terminal_rejection: None,
                 once_marker: None,
             };
             assert!(write_entry(&inflight.join("abandoned.json"), &entry));


### PR DESCRIPTION
## Summary
- add a strict versioned generic transport-rejection contract
- dead-letter terminal rejections consistently during inline dispatch and redelivery while preserving outbox evidence
- expose bounded rejection context plus route-aware inspect, repair, retry, and resend guidance

Unstructured failures and arbitrary `retryable:false` output remain retryable for compatibility.

## Verification
- `cargo fmt --check`
- 14 core outbox tests
- focused agents rejection test
- focused CLI status and explicit-route tests
- checks for core, agents, and CLI

Fixes #12646

AI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented, independently reviewed, redesigned the rejection contract, and verified all three owning layers. Chris Huber remains responsible for the report and code.