### PR TITLE
Separate local placement capability from runner connectivity

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -16,13 +16,14 @@ use homeboy::runner::runners::{
 use super::super::CmdResult;
 use super::controller_ancestry::{commits_are_ancestral, CommitAncestry};
 use super::types::{
-    LabFollowup, LabRunnerHomeboyOutput, LabSelectedRunnerOutput, RunnerArtifactFeatureDiagnostics,
-    RunnerConnectionOutput, RunnerExecutableRequirementDiagnostics, RunnerExtra,
-    RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOperatorSummary, RunnerOutput,
-    RunnerReconciliationOutcome, RunnerReconciliationStatus, RunnerRuntimeDiagnostics,
-    RunnerRuntimePackageDiagnostics, RunnerStatusInspection, RunnerStatusUnavailable,
-    RunnerToolDiagnostics, RunnerTruncation, RunnerWorkflowBinaryGuidance, RuntimeDiagnostic,
-    RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
+    LabFollowup, LabRunnerConnectionCapability, LabRunnerHomeboyOutput, LabSelectedRunnerOutput,
+    RunnerArtifactFeatureDiagnostics, RunnerConnectionOutput,
+    RunnerExecutableRequirementDiagnostics, RunnerExecutionCapabilities, RunnerExecutionCapability,
+    RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOperatorSummary,
+    RunnerOutput, RunnerReconciliationOutcome, RunnerReconciliationStatus,
+    RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics, RunnerStatusInspection,
+    RunnerStatusUnavailable, RunnerToolDiagnostics, RunnerTruncation, RunnerWorkflowBinaryGuidance,
+    RuntimeDiagnostic, RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
 };
 
 const DEFAULT_STATUS_SESSION_LIMIT: usize = 20;
@@ -34,6 +35,24 @@ pub(super) fn status(
 ) -> CmdResult<RunnerOutput> {
     let preferred_lab_runner = runner::resolve_default_lab_runner()?;
     if let Some(id) = id {
+        if is_controller_local_runner(id) {
+            return Ok((
+                RunnerOutput {
+                    command: "runner.status".to_string(),
+                    id: Some(id.to_string()),
+                    extra: RunnerExtra {
+                        execution_capabilities: Some(execution_capabilities(&[])),
+                        operator_hints: vec![
+                            "Controller-local execution is available; use `homeboy --placement local agent-task cook ...`."
+                                .to_string(),
+                        ],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ));
+        }
         let admission_snapshot = runner::runner_admission_snapshot(id)?;
         let report = admission_snapshot.status;
         let generation_inventory = admission_snapshot.generation_inventory;
@@ -63,6 +82,7 @@ pub(super) fn status(
                     id: Some(id.to_string()),
                     extra: RunnerExtra {
                         admission_summary,
+                        execution_capabilities: Some(execution_capabilities(&[report.clone()])),
                         operator_summary: Some(operator_summary),
                         truncation: Some(RunnerTruncation {
                             omitted_generations: generation_count
@@ -94,6 +114,7 @@ pub(super) fn status(
                 id: Some(id.to_string()),
                 extra: RunnerExtra {
                     admission_summary,
+                    execution_capabilities: Some(execution_capabilities(&[report.clone()])),
                     connection: Some(RunnerConnectionOutput::Status(Box::new(
                         sanitized_status_for_output(report),
                     ))),
@@ -112,7 +133,8 @@ pub(super) fn status(
         ));
     }
 
-    let sessions = runner::persisted_statuses()?;
+    let sessions = non_local_sessions(runner::persisted_statuses()?);
+    let capabilities = execution_capabilities(&sessions);
     if !full {
         let omitted = sessions.len().saturating_sub(DEFAULT_STATUS_SESSION_LIMIT);
         let sessions = sessions
@@ -125,6 +147,7 @@ pub(super) fn status(
                 command: "runner.status".to_string(),
                 extra: RunnerExtra {
                     operator_summaries: sessions,
+                    execution_capabilities: Some(capabilities),
                     truncation: Some(RunnerTruncation {
                         omitted_generations: 0,
                         omitted_sessions: omitted,
@@ -140,6 +163,7 @@ pub(super) fn status(
         ));
     }
     let (sessions, inspection) = full_status_projections(sessions, runner::statuses_indexed());
+    let capabilities = execution_capabilities(&sessions);
     let mut operator_hints: Vec<String> = sessions
         .iter()
         .flat_map(runner_status_operator_hints)
@@ -172,6 +196,7 @@ pub(super) fn status(
                     .into_iter()
                     .map(sanitized_status_for_output)
                     .collect(),
+                execution_capabilities: Some(capabilities),
                 inspection: Some(inspection),
                 preferred_lab_runner,
                 selected_lab_runner,
@@ -185,6 +210,59 @@ pub(super) fn status(
         },
         0,
     ))
+}
+
+fn is_controller_local_runner(id: &str) -> bool {
+    id == "local"
+}
+
+pub(super) fn non_local_sessions(sessions: Vec<RunnerStatusReport>) -> Vec<RunnerStatusReport> {
+    sessions
+        .into_iter()
+        .filter(|report| !is_controller_local_runner(&report.runner_id))
+        .collect()
+}
+
+fn execution_capabilities(sessions: &[RunnerStatusReport]) -> RunnerExecutionCapabilities {
+    execution_capabilities_with_local_placement(true, sessions)
+}
+
+pub(super) fn execution_capabilities_with_local_placement(
+    local_placement_available: bool,
+    sessions: &[RunnerStatusReport],
+) -> RunnerExecutionCapabilities {
+    let connected_runner_ids = sessions
+        .iter()
+        .filter(|report| report.connected)
+        .map(|report| report.runner_id.clone())
+        .collect::<Vec<_>>();
+    let next_action = if connected_runner_ids.is_empty() {
+        sessions
+            .first()
+            .map(|report| report.status_action().render_command())
+    } else {
+        None
+    };
+    RunnerExecutionCapabilities {
+        local_placement: RunnerExecutionCapability {
+            available: local_placement_available,
+            state: if local_placement_available {
+                "available"
+            } else {
+                "unavailable"
+            },
+            next_action: if local_placement_available {
+                "homeboy --placement local agent-task cook ...".to_string()
+            } else {
+                "Inspect controller-local execution prerequisites.".to_string()
+            },
+        },
+        lab_runner_connection: LabRunnerConnectionCapability {
+            available: !connected_runner_ids.is_empty(),
+            connected_runner_ids,
+            next_action,
+        },
+    }
 }
 
 pub(super) fn reconcile(id: &str) -> CmdResult<RunnerOutput> {

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -9,8 +9,8 @@ use homeboy::core::agent_runtime_manifest::{
 use homeboy::core::daemon::{DaemonRecoveryEvidence, DaemonStaleReasonCode};
 use homeboy::runner::readonly_probe;
 use homeboy::runner::runners::{
-    self as runner, RunnerActiveJobState, RunnerBinarySource, RunnerSession, RunnerStatusReport,
-    RunnerTunnelMode, RuntimeMaterializationStatus,
+    self as runner, Runner, RunnerActiveJobState, RunnerBinarySource, RunnerKind, RunnerSession,
+    RunnerStatusReport, RunnerTunnelMode, RuntimeMaterializationStatus,
 };
 
 use super::super::CmdResult;
@@ -33,15 +33,15 @@ pub(super) fn status(
     include_generations: bool,
     full: bool,
 ) -> CmdResult<RunnerOutput> {
-    let preferred_lab_runner = runner::resolve_default_lab_runner()?;
     if let Some(id) = id {
-        if is_controller_local_runner(id) {
+        let runners = runner::list()?;
+        if is_controller_local_runner(&runners, id) {
             return Ok((
                 RunnerOutput {
                     command: "runner.status".to_string(),
                     id: Some(id.to_string()),
                     extra: RunnerExtra {
-                        execution_capabilities: Some(execution_capabilities(&[])),
+                        execution_capabilities: Some(global_execution_capabilities(&runners, None)?),
                         operator_hints: vec![
                             "Controller-local execution is available; use `homeboy --placement local agent-task cook ...`."
                                 .to_string(),
@@ -53,8 +53,10 @@ pub(super) fn status(
                 0,
             ));
         }
+        let preferred_lab_runner = runner::resolve_default_lab_runner()?;
         let admission_snapshot = runner::runner_admission_snapshot(id)?;
         let report = admission_snapshot.status;
+        let capabilities = global_execution_capabilities(&runners, Some(&report))?;
         let generation_inventory = admission_snapshot.generation_inventory;
         // Lead with the compact authoritative admission answer, summarizing the
         // draining generations by count rather than expanding the full ledger
@@ -82,7 +84,7 @@ pub(super) fn status(
                     id: Some(id.to_string()),
                     extra: RunnerExtra {
                         admission_summary,
-                        execution_capabilities: Some(execution_capabilities(&[report.clone()])),
+                        execution_capabilities: Some(capabilities),
                         operator_summary: Some(operator_summary),
                         truncation: Some(RunnerTruncation {
                             omitted_generations: generation_count
@@ -114,7 +116,7 @@ pub(super) fn status(
                 id: Some(id.to_string()),
                 extra: RunnerExtra {
                     admission_summary,
-                    execution_capabilities: Some(execution_capabilities(&[report.clone()])),
+                    execution_capabilities: Some(capabilities),
                     connection: Some(RunnerConnectionOutput::Status(Box::new(
                         sanitized_status_for_output(report),
                     ))),
@@ -133,8 +135,10 @@ pub(super) fn status(
         ));
     }
 
-    let sessions = non_local_sessions(runner::persisted_statuses()?);
-    let capabilities = execution_capabilities(&sessions);
+    let preferred_lab_runner = runner::resolve_default_lab_runner()?;
+    let runners = runner::list()?;
+    let sessions = non_local_sessions(&runners, runner::persisted_statuses()?);
+    let capabilities = execution_capabilities(&runners, &sessions);
     if !full {
         let omitted = sessions.len().saturating_sub(DEFAULT_STATUS_SESSION_LIMIT);
         let sessions = sessions
@@ -163,7 +167,7 @@ pub(super) fn status(
         ));
     }
     let (sessions, inspection) = full_status_projections(sessions, runner::statuses_indexed());
-    let capabilities = execution_capabilities(&sessions);
+    let capabilities = execution_capabilities(&runners, &sessions);
     let mut operator_hints: Vec<String> = sessions
         .iter()
         .flat_map(runner_status_operator_hints)
@@ -212,33 +216,62 @@ pub(super) fn status(
     ))
 }
 
-fn is_controller_local_runner(id: &str) -> bool {
-    id == "local"
+fn is_controller_local_runner(runners: &[Runner], id: &str) -> bool {
+    runners
+        .iter()
+        .any(|runner| runner.id == id && runner.kind == RunnerKind::Local)
 }
 
-pub(super) fn non_local_sessions(sessions: Vec<RunnerStatusReport>) -> Vec<RunnerStatusReport> {
+pub(super) fn non_local_sessions(
+    runners: &[Runner],
+    sessions: Vec<RunnerStatusReport>,
+) -> Vec<RunnerStatusReport> {
     sessions
         .into_iter()
-        .filter(|report| !is_controller_local_runner(&report.runner_id))
+        .filter(|report| !is_controller_local_runner(runners, &report.runner_id))
         .collect()
 }
 
-fn execution_capabilities(sessions: &[RunnerStatusReport]) -> RunnerExecutionCapabilities {
-    execution_capabilities_with_local_placement(true, sessions)
+fn global_execution_capabilities(
+    runners: &[Runner],
+    queried_report: Option<&RunnerStatusReport>,
+) -> homeboy::core::Result<RunnerExecutionCapabilities> {
+    let mut sessions = runner::persisted_statuses()?;
+    if let Some(queried_report) = queried_report {
+        if let Some(session) = sessions
+            .iter_mut()
+            .find(|session| session.runner_id == queried_report.runner_id)
+        {
+            *session = queried_report.clone();
+        } else {
+            sessions.push(queried_report.clone());
+        }
+    }
+    Ok(execution_capabilities(runners, &sessions))
+}
+
+fn execution_capabilities(
+    runners: &[Runner],
+    sessions: &[RunnerStatusReport],
+) -> RunnerExecutionCapabilities {
+    execution_capabilities_with_local_placement(true, runners, sessions)
 }
 
 pub(super) fn execution_capabilities_with_local_placement(
     local_placement_available: bool,
+    runners: &[Runner],
     sessions: &[RunnerStatusReport],
 ) -> RunnerExecutionCapabilities {
     let connected_runner_ids = sessions
         .iter()
+        .filter(|report| !is_controller_local_runner(runners, &report.runner_id))
         .filter(|report| report.connected)
         .map(|report| report.runner_id.clone())
         .collect::<Vec<_>>();
     let next_action = if connected_runner_ids.is_empty() {
         sessions
-            .first()
+            .iter()
+            .find(|report| !is_controller_local_runner(runners, &report.runner_id))
             .map(|report| report.status_action().render_command())
     } else {
         None

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use clap::Parser;
 use homeboy::core::agent_runtime_manifest::{
@@ -9,7 +9,7 @@ use homeboy::core::agent_runtime_manifest::{
 use homeboy::core::api_jobs::{JobEvent, JobStatus};
 use homeboy::core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
 use homeboy::runner::runners::{
-    self as runner, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
+    self as runner, Runner, RunnerKind, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
 };
 use homeboy::runner::{RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState};
 
@@ -27,6 +27,20 @@ use crate::cli_surface::Cli;
 use crate::commands::utils::response::{
     cli_response_for_json_result_for_command, map_cmd_result_to_json,
 };
+
+fn configured_runner(id: &str, kind: RunnerKind) -> Runner {
+    Runner {
+        id: id.to_string(),
+        kind,
+        server_id: None,
+        workspace_root: None,
+        settings: Default::default(),
+        env: HashMap::new(),
+        secret_env: HashMap::new(),
+        resources: HashMap::new(),
+        policy: Default::default(),
+    }
+}
 
 fn runner_session_fixture() -> RunnerSession {
     RunnerSession {
@@ -1335,25 +1349,35 @@ fn runner_status_actions_preserve_runner_ids_for_every_admission_state() {
 fn execution_capabilities_separate_local_placement_from_lab_connections() {
     let connected = connected_report();
     let disconnected = disconnected_report();
+    let remote = configured_runner("homeboy lab", RunnerKind::Ssh);
     let cases = [
-        ("local_only", Vec::new(), true, None),
+        ("local_only", Vec::new(), Vec::new(), true, None),
         (
             "lab_only",
+            vec![remote.clone()],
             vec![connected.clone()],
             false,
             Some(vec!["homeboy lab"]),
         ),
         (
             "both_ready",
+            vec![remote.clone()],
             vec![connected],
             true,
             Some(vec!["homeboy lab"]),
         ),
-        ("neither_ready", vec![disconnected], false, None),
+        (
+            "neither_ready",
+            vec![remote],
+            vec![disconnected],
+            false,
+            None,
+        ),
     ];
 
-    for (name, reports, local_available, connected_ids) in cases {
-        let capabilities = execution_capabilities_with_local_placement(local_available, &reports);
+    for (name, runners, reports, local_available, connected_ids) in cases {
+        let capabilities =
+            execution_capabilities_with_local_placement(local_available, &runners, &reports);
         let lab_connection_available = connected_ids.is_some();
         assert_eq!(
             capabilities.local_placement.available, local_available,
@@ -1379,16 +1403,44 @@ fn execution_capabilities_separate_local_placement_from_lab_connections() {
 }
 
 #[test]
-fn reserved_local_session_is_not_presented_as_a_lab_connection() {
-    let mut reserved_local = disconnected_report();
-    reserved_local.runner_id = "local".to_string();
+fn configured_local_runner_is_not_presented_as_a_lab_connection() {
+    let mut configured_local = disconnected_report();
+    configured_local.runner_id = "project-local".to_string();
     let mut concrete_local = disconnected_report();
-    concrete_local.runner_id = "project-local".to_string();
+    concrete_local.runner_id = "homeboy-lab".to_string();
+    let runners = vec![
+        configured_runner("project-local", RunnerKind::Local),
+        configured_runner("homeboy-lab", RunnerKind::Ssh),
+    ];
 
-    let sessions = non_local_sessions(vec![reserved_local, concrete_local]);
+    let sessions = non_local_sessions(&runners, vec![configured_local, concrete_local]);
 
     assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].runner_id, "project-local");
+    assert_eq!(sessions[0].runner_id, "homeboy-lab");
+}
+
+#[test]
+fn global_capabilities_include_connected_lab_for_local_and_disconnected_remote_queries() {
+    let local = configured_runner("local", RunnerKind::Local);
+    let disconnected = configured_runner("lab-disconnected", RunnerKind::Ssh);
+    let connected = configured_runner("lab-connected", RunnerKind::Ssh);
+    let mut disconnected_report = disconnected_report();
+    disconnected_report.runner_id = disconnected.id.clone();
+    let mut connected_report = connected_report();
+    connected_report.runner_id = connected.id.clone();
+
+    let capabilities = execution_capabilities_with_local_placement(
+        true,
+        &[local, disconnected, connected],
+        &[disconnected_report, connected_report],
+    );
+
+    assert!(capabilities.local_placement.available);
+    assert!(capabilities.lab_runner_connection.available);
+    assert_eq!(
+        capabilities.lab_runner_connection.connected_runner_ids,
+        ["lab-connected"]
+    );
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -17,7 +17,8 @@ use super::super::jobs::format_job_event;
 use super::super::status::{
     declared_executable_requirement_diagnostics, declared_run_followups,
     declared_runtime_diagnostics, declared_runtime_source_diagnostics, declared_tool_diagnostics,
-    lab_runner_homeboy_output, operator_summary, reconcile_output, reconciliation_outcome,
+    execution_capabilities_with_local_placement, lab_runner_homeboy_output, non_local_sessions,
+    operator_summary, reconcile_output, reconciliation_outcome,
     runner_artifact_feature_diagnostics, runner_followups, runner_followups_with_admission,
     runner_status_operator_commands, selected_admission_summary,
 };
@@ -1328,6 +1329,66 @@ fn runner_status_actions_preserve_runner_ids_for_every_admission_state() {
                 .is_empty());
         }
     }
+}
+
+#[test]
+fn execution_capabilities_separate_local_placement_from_lab_connections() {
+    let connected = connected_report();
+    let disconnected = disconnected_report();
+    let cases = [
+        ("local_only", Vec::new(), true, None),
+        (
+            "lab_only",
+            vec![connected.clone()],
+            false,
+            Some(vec!["homeboy lab"]),
+        ),
+        (
+            "both_ready",
+            vec![connected],
+            true,
+            Some(vec!["homeboy lab"]),
+        ),
+        ("neither_ready", vec![disconnected], false, None),
+    ];
+
+    for (name, reports, local_available, connected_ids) in cases {
+        let capabilities = execution_capabilities_with_local_placement(local_available, &reports);
+        let lab_connection_available = connected_ids.is_some();
+        assert_eq!(
+            capabilities.local_placement.available, local_available,
+            "{name}"
+        );
+        assert_eq!(
+            capabilities.lab_runner_connection.connected_runner_ids,
+            connected_ids.unwrap_or_default(),
+            "{name}"
+        );
+        assert_eq!(
+            capabilities.lab_runner_connection.available, lab_connection_available,
+            "{name}"
+        );
+        assert!(
+            !capabilities
+                .local_placement
+                .next_action
+                .contains("runner connect"),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn reserved_local_session_is_not_presented_as_a_lab_connection() {
+    let mut reserved_local = disconnected_report();
+    reserved_local.runner_id = "local".to_string();
+    let mut concrete_local = disconnected_report();
+    concrete_local.runner_id = "project-local".to_string();
+
+    let sessions = non_local_sessions(vec![reserved_local, concrete_local]);
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].runner_id, "project-local");
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -55,6 +55,11 @@ pub struct RunnerExtra {
     pub operator_commands: Vec<RunnerOperatorCommand>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operator_summary: Option<RunnerOperatorSummary>,
+    /// Controller-local execution and Lab connection state are separate
+    /// contracts. In particular, local placement has no runner connection to
+    /// establish.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_capabilities: Option<RunnerExecutionCapabilities>,
     /// One compact row per configured runner: what exists, whether it is
     /// reachable, and whether it can take work (#9487).
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -90,6 +95,7 @@ impl Default for RunnerExtra {
             operator_hints: Vec::new(),
             operator_commands: Vec::new(),
             operator_summary: None,
+            execution_capabilities: None,
             runner_summaries: Vec::new(),
             operator_summaries: Vec::new(),
             truncation: None,
@@ -162,6 +168,30 @@ pub struct RunnerOperatorSummary {
     pub state: String,
     pub risk: Vec<String>,
     pub next_action: String,
+}
+
+/// Execution paths available to this controller, kept apart from concrete
+/// runner identities and their connection lifecycle.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RunnerExecutionCapabilities {
+    pub local_placement: RunnerExecutionCapability,
+    pub lab_runner_connection: LabRunnerConnectionCapability,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RunnerExecutionCapability {
+    pub available: bool,
+    pub state: &'static str,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LabRunnerConnectionCapability {
+    pub available: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub connected_runner_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- expose controller-local execution capability independently from Lab connection state
- derive Lab capacity globally from configured runners and persisted sessions
- filter controller-local runners by `RunnerKind` and avoid resolving a Lab default for local-only status

## Verification
- `cargo fmt --check`
- 32 runner status tests covering local-only, Lab-only, combined, queried-remote, and configured-local states
- `cargo check -p homeboy-cli`
- `git diff --check`

Fixes #12649

AI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented, independently reviewed, corrected global/type-based capability derivation, and verified the additive schema. Chris Huber remains responsible for the report and code.