### PR TITLE
Give admission_status an injected-root sibling

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3841,9 +3841,16 @@ pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
 ///   `lifecycle_store.data_root()`, but pairing the two stores is the shape
 ///   `KNOWN_MIXED_STORE_FUNCTIONS` exists to make someone argue for.
 ///
-/// `homeboy_core::controller_runtime::admission_status` has no `_at` form at
-/// all; `cancel_admission_at` does, which is why the cancellation reconciler
-/// below could be rooted and this read could not.
+/// `homeboy_core::controller_runtime::admission_status` no longer lacks an
+/// `_at` form — `admission_status_at` now mirrors `cancel_admission_at`, so the
+/// reason the cancellation reconciler below could be rooted and this read could
+/// not has closed. The read is still spelled ambiently here only because this
+/// function is itself ambient: its store comes from
+/// `AgentTaskLifecycleStore::from_current_environment()`, so
+/// `admission_status_at(&lifecycle_store.data_root().join("controller-runtimes"), ..)`
+/// would resolve the identical path today. Switching it buys nothing until the
+/// four steps above are rooted, and belongs in the change that introduces
+/// `status_in_store`.
 ///
 /// Until those close there is deliberately **no** `status_in_store`. A rooted
 /// status that reconciled four of its steps in another installation would be

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -877,11 +877,43 @@ pub fn admit_current_for_with_cancellation_check(
 /// Return the durable admission view used by lifecycle status output.
 pub fn admission_status(request_id: &str) -> Result<Value> {
     let root = runtime_root()?;
-    let lock_path = root.join(ADMISSION_LOCK_DIR);
-    let mut queue = read_admission_queue(&lock_path)?;
+    admission_status_at(&root, request_id)
+}
+
+/// Read the durable admission view from an explicitly selected
+/// controller-runtime store. Lifecycle stores use this to keep same-ID isolated
+/// roots independent, mirroring [`cancel_admission_at`].
+///
+/// This read is wholly rooted, which is why it gets an `_at` form when the
+/// admitting siblings do not. The projection below resolves nothing but the
+/// admission queue beneath `runtime_root`, so a rooted status can never report
+/// this installation's queue position against another installation's owner.
+/// `pin_current`, `admit_current_for`, `activate_installed_generation`,
+/// `migrate_legacy_pin`, and `recover_pin` all also publish into the
+/// content-addressed pin store, which is deliberately process-global (#7505);
+/// rooting only their queue half is exactly the split this campaign forbids.
+/// Nothing here touches that store.
+pub fn admission_status_at(runtime_root: &Path, request_id: &str) -> Result<Value> {
+    fs::create_dir_all(runtime_root).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("create controller runtime directory".to_string()),
+        )
+    })?;
+    admission_status_at_lock_path(&runtime_root.join(ADMISSION_LOCK_DIR), request_id)
+}
+
+/// Project the admission view from an already-resolved admission lock path.
+///
+/// Every durable queue helper in this module is keyed on the lock path, so both
+/// entry points converge here rather than rebuilding the projection — and the
+/// queued-admission wait loop, which is already handed an explicit lock path,
+/// reads its own position through this instead of re-resolving the ambient root.
+fn admission_status_at_lock_path(lock_path: &Path, request_id: &str) -> Result<Value> {
+    let mut queue = read_admission_queue(lock_path)?;
     // Status reads never rewrite the durable queue. They still hide expired
     // waiters immediately; the next writer compacts them atomically.
-    reclaim_stale_admission_entries(&lock_path, &mut queue);
+    reclaim_stale_admission_entries(lock_path, &mut queue);
     let requests = queue["requests"].as_array().cloned().unwrap_or_default();
     let position = requests
         .iter()
@@ -1583,7 +1615,10 @@ fn acquire_queued_admission_lock_with_timeout(
     let mut backoff = timings.poll;
     let mut observed_position = None;
     loop {
-        let status = admission_status(request_id)?;
+        // Read the queue this wait was handed a path into. Reading the ambient
+        // root here would let a waiter enqueued under an explicit store poll a
+        // different installation's queue for its own position.
+        let status = admission_status_at_lock_path(path, request_id)?;
         if status["state"] == "none" {
             return Err(
                 Error::internal_unexpected("controller admission request was cancelled")


### PR DESCRIPTION
## Summary

#12657 reported that `controller_runtime::admission_status` had **no `_at` form at all**, while `cancel_admission_at` did — which is exactly why the cancellation reconciler could be rooted and this read could not.

```rust
pub fn admission_status_at(runtime_root: &Path, request_id: &str) -> Result<Value>
fn  admission_status_at_lock_path(lock_path: &Path, request_id: &str) -> Result<Value>
```

`admission_status` keeps a **byte-identical** signature and now resolves once and delegates. The issue's claim held up exactly: **it was the only one.**

## Why only one — the module has two root resolvers, and that drives everything

```
runtime_root()                  = <homeboy_data>/controller-runtimes    ← rootable
controller_runtime_store_root() = paths::homeboy_data() (or the test override)
                                  backs pinned_path / publish_pin       ← deliberately global
```

Of 23 `pub fn` in the module, **16 are "mixed"** — they resolve the admission queue root *and* publish into the content-addressed pin store: `pin_current`, `admit_current_for_with_cancellation_check`, `activate_installed_generation`, `migrate_legacy_pin`, `recover_pin`, `cleanup`/`retention_report`/`prune_pins`, and their wrappers. **Rooting only their queue half is precisely the bug this campaign has found live three times.** None was given an `_at` form.

> The roots genuinely differ: they coincide in production, **not** under `HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE`.

## A real half-injected bug, found and fixed

`acquire_queued_admission_lock_with_timeout(path: &Path, …)` is handed an **explicit lock path**, enqueues and heartbeats against it — then polled for its own queue position via the **ambient** `admission_status(request_id)`.

That is the forbidden split, living in a private function. It now reads via `admission_status_at_lock_path(path, …)`.

Behaviour-preserving: all 5 call sites (2 production, 3 inline test) pass `runtime_root()?.join(ADMISSION_LOCK_DIR)` — precisely what the ambient read resolved. Side benefit: the poll loop no longer re-runs `create_dir_all` on every iteration.

## `controller_runtimes_store()` — confirmed unchanged

`git diff --stat -- crates/homeboy-paths/` is **empty**. That store is a content-addressed executable cache keyed to the real machine and stays process-global by design; this threads an explicitly-passed parameter only.

## Verification

The param name `runtime_root` **shadows the fn `runtime_root()` in the value namespace**, so an accidental ambient call inside the new body is a hard compile error rather than a silent discard — the same protection `cancel_admission_at` already has. Lesson-1 grep on both new bodies: zero hits.

20 inline test callers of `admission_status` plus 3 of `acquire_queued_admission_lock*` enumerated and checked by hand rather than by symbol grep — **no name or arity changed**, so none needed editing. Duplicate check clean; the 8 pre-existing duplicate names are `#[cfg]` pairs present identically on main.

<callout accent="#f59e0b">
**Not compiled, not run.** The behaviour-preservation argument for the lock-path change rests on having read all 5 call sites. If one passes a different lock path while expecting the ambient queue, that test flips.

Watch on CI: `expired_head_waiter_is_reclaimed_without_blocking_later_admission`, `bounded_queue_timeout_is_retryable_and_removes_its_waiter`, `queue_timeout_names_the_wait_the_waiters_ahead_and_the_retry_command`.
</callout>

## Deliberately not done

`status_with_options_inner` can now call `admission_status_at(&store.data_root().join("controller-runtimes"), …)` — identical path today. Left ambient: switching buys nothing until the remaining blockers close, and belongs in the change that introduces `status_in_store`. The doc comment claiming no `_at` form exists was updated.

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Enumeration and implementation. Review by hand.

Refs #7505
