### PR TITLE
Root the cancel spine and the lab-handoff lock

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -20,8 +20,28 @@ fn run_after_initial_cancellation_for_test() {
 }
 
 pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
+    cancel_run_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        reason,
+    )
+}
+
+/// The store-rooted counterpart of [`cancel_run`].
+///
+/// Alias resolution and cancellation are one loop: this re-resolves the Cook
+/// alias after each pass and cancels whatever became authoritative. Resolving
+/// the alias in one installation and cancelling in another would follow an
+/// index that names attempts the cancelled store has never heard of — and would
+/// terminate the loop on an equality between two different homes' answers
+/// (#7505).
+pub(crate) fn cancel_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    reason: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
     let requested_run_id = sanitize_run_id(run_id);
-    let mut resolved_run_id = resolve_run_id(&requested_run_id)?;
+    let mut resolved_run_id = resolve_run_id_in_store(lifecycle_store, &requested_run_id)?;
     // Index publication is independent from parent cancellation. Re-resolve
     // after each mutation until the Cook alias is stable, so every attempt that
     // became authoritative during this operation receives cancellation too.
@@ -30,20 +50,24 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
         // finished. Keep exact-run cancellation strict: an operator targeting
         // that literal terminal attempt still receives the terminal-state error.
         if resolved_run_id != requested_run_id {
-            let resolved_record = store::read_record(&resolved_run_id)?;
+            let resolved_record = lifecycle_store.read_record(&resolved_run_id)?;
             if resolved_record.state.is_terminal() {
                 return Ok(resolved_record);
             }
         }
-        let record = cancel_resolved_run(&resolved_run_id, reason)?;
+        let record = cancel_resolved_run_in_store(lifecycle_store, &resolved_run_id, reason)?;
         // A first child can have been submitted after reservation but before
         // index publication. Cancel it through the reservation link so it
         // cannot remain an unindexed queued record.
-        cancel_reserved_detached_cook_handoff_attempt_if_cancelled(&requested_run_id)?;
+        cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(
+            lifecycle_store,
+            &requested_run_id,
+        )?;
         if pass == 0 {
             run_after_initial_cancellation_for_test();
         }
-        let resolved_after_cancellation = resolve_run_id(&requested_run_id)?;
+        let resolved_after_cancellation =
+            resolve_run_id_in_store(lifecycle_store, &requested_run_id)?;
         if resolved_after_cancellation == resolved_run_id {
             return Ok(record);
         }
@@ -61,7 +85,11 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
 /// selected every parent/attempt record to mutate. Alias-aware cancellation is
 /// intentionally broader because it follows an advancing Cook index.
 pub fn cancel_exact_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
-    cancel_resolved_run(&sanitize_run_id(run_id), reason)
+    cancel_resolved_run_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        &sanitize_run_id(run_id),
+        reason,
+    )
 }
 
 /// Cancel one literal run through an explicitly selected lifecycle store.
@@ -304,11 +332,28 @@ fn successful_provider_execution_is_pending_import(record: &AgentTaskRunRecord) 
             })
 }
 
-fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
+/// Cancel one already-resolved durable run inside an explicitly rooted store.
+///
+/// Cancellation is destructive and it is not one write: it terminalizes the
+/// record, reaps the run's managed services, cancels a controller staging job,
+/// projects a runner-job cancellation, finalizes controller scratch, and
+/// releases the controller-runtime admission. Every one of those is keyed on
+/// the run and every one of them was ambient. A cancel that read state from one
+/// home and wrote its terminal record to another is the worst shape in this
+/// bug class — it would leave the *observed* run running with its services and
+/// admission intact while reporting success (#7505).
+///
+/// There is no ambient wrapper: both entry points ([`cancel_run_in_store`] and
+/// [`cancel_exact_run`]) resolve exactly one store for the whole operation.
+fn cancel_resolved_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    reason: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
     // Cook IDs are stable aliases. Match status and logs by following an
     // materialized attempt once one exists; before then the handoff parent is
     // the direct record and remains cancellable.
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let detached_child = record
         .metadata
         .get("detached_cook_handoff")
@@ -348,7 +393,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
                         "killed_pids": termination.killed_pids,
                     }),
                 );
-                store::write_record(&record)?;
+                lifecycle_store.write_record(&record)?;
             }
             homeboy_core::process::ProcessIdentityState::Dead => {}
             homeboy_core::process::ProcessIdentityState::IdentityMismatch
@@ -366,7 +411,8 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
     // durable ledger before terminalizing so an interrupted controller cannot
     // leave a runner-local preview alive after its run is cancelled.
     let service_cleanup =
-        crate::agent_task_scheduler::managed_services::reconcile_run_services_on_owner(
+        crate::agent_task_scheduler::managed_services::reconcile_run_services_on_owner_at(
+            &lifecycle_store.data_root(),
             &record.run_id,
             record.metadata.get("managed_service_supervisor"),
             reason.unwrap_or("cancelled"),
@@ -376,7 +422,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
         record
             .ensure_metadata_object()
             .insert("managed_service_cleanup".to_string(), service_cleanup);
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
     }
     if record
         .candidate_adoption
@@ -405,7 +451,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
             json!(now),
         );
         record.updated_at = Some(now);
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
 
         if let Some(process_group) = process_group {
             if homeboy_core::process::isolated_process_group_is_running(process_group).map_err(
@@ -440,7 +486,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
         attempt.updated_at = now.clone();
         attempt.heartbeat_at = now.clone();
         record.updated_at = Some(now);
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         return Ok(record);
     }
     // A pending POST may have been accepted despite a lost response. Resolve
@@ -450,10 +496,11 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
     if matches!(
         record.state,
         AgentTaskRunState::Queued | AgentTaskRunState::Running
-    ) && super::lab_handoff_reconciliation::bind_pending_runner_submission_if_accepted(
+    ) && super::lab_handoff_reconciliation::bind_pending_runner_submission_if_accepted_in_store(
+        lifecycle_store,
         &record.run_id,
     )? {
-        record = store::read_record(&record.run_id)?;
+        record = lifecycle_store.read_record(&record.run_id)?;
     }
     if record.state == AgentTaskRunState::Cancelled {
         let cancelled_at = record
@@ -463,8 +510,12 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
             .unwrap_or_else(|| record.updated_at.as_deref().unwrap_or("unknown"))
             .to_string();
         terminalize_running_provider_executions(record.ensure_metadata_object(), &cancelled_at);
-        store::write_record(&record)?;
-        crate::controller_scratch::finalize_run(&record.run_id)?;
+        lifecycle_store.write_record(&record)?;
+        crate::controller_scratch::finalize_run_at_explicit_roots(
+            &lifecycle_store.data_root(),
+            &lifecycle_store.artifact_root(),
+            &record.run_id,
+        )?;
         return Ok(record);
     }
 
@@ -505,7 +556,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
             "cancellation_deferred_for_terminal_provider".to_string(),
             json!({ "requested_at": now, "reason": reason.unwrap_or("cancel requested") }),
         );
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         return Ok(record);
     }
 
@@ -530,7 +581,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
                 "requested_at": now_timestamp(),
             }),
         );
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         // The controller owns every child admitted during staging, including the
         // final runner job. Never bypass it merely because that child identity
         // was already projected onto the parent.
@@ -547,7 +598,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
                 "requested_at": now_timestamp(),
             }),
         );
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         if controller_job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
             return Ok(record);
         }
@@ -578,7 +629,8 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
     // overwriting completed work with a controller-only cancellation.
     if let LiveCancellationOutcome::RunnerJobCancelled { job, events } = &cancellation {
         if job.status.is_terminal() && job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
-            reconcile_runner_job_snapshot(
+            reconcile_runner_job_snapshot_in_store(
+                lifecycle_store,
                 &mut record,
                 &homeboy_core::api_jobs::RunnerJobLogSnapshot {
                     job: *job.clone(),
@@ -595,7 +647,7 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
     // above. Make the final decision under the record mutation lock so a late
     // success is either observed here or cancellation wins before it can be
     // imported; never overwrite an already durable success.
-    let record = store::mutate_record(&record.run_id, |record| {
+    let record = lifecycle_store.mutate_record(&record.run_id, |record| {
         // An aggregate or runner projection may have finished after the live
         // cancellation transport returned. Its terminal state is authoritative.
         if record.state.is_terminal() {
@@ -695,10 +747,21 @@ fn cancel_resolved_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRu
         metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
         true
     })?
-    .unwrap_or(store::read_record(&record.run_id)?);
+    .unwrap_or(lifecycle_store.read_record(&record.run_id)?);
     if record.state == AgentTaskRunState::Cancelled {
-        crate::controller_scratch::finalize_run(&record.run_id)?;
-        homeboy_core::controller_runtime::cancel_admission(&record.run_id)?;
+        // The same two rooted side effects `cancel_exact_run_in_store` already
+        // uses: scratch finalization needs both the data and artifact roots,
+        // and admission release needs the controller-runtime store below this
+        // store's data root.
+        crate::controller_scratch::finalize_run_at_explicit_roots(
+            &lifecycle_store.data_root(),
+            &lifecycle_store.artifact_root(),
+            &record.run_id,
+        )?;
+        homeboy_core::controller_runtime::cancel_admission_at(
+            &lifecycle_store.data_root().join("controller-runtimes"),
+            &record.run_id,
+        )?;
     }
     Ok(record)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -737,14 +737,12 @@ pub(crate) fn record_aggregate_in_store(
     Ok(record.clone())
 }
 
-pub(crate) fn record_terminal_artifact_projection(
-    record: &mut AgentTaskRunRecord,
-    aggregate: &AgentTaskAggregate,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_terminal_artifact_projection_in_store(&lifecycle_store, record, aggregate)
-}
-
+/// Register a terminal run's artifacts into its own store's projection root.
+///
+/// There is no ambient wrapper: the last caller that resolved its own root was
+/// `project_terminal_runner_lifecycle_event`, and it now takes a store (#7505).
+/// Leaving an unused ambient form behind would only be a new way to reach the
+/// process artifact root by accident.
 pub(crate) fn record_terminal_artifact_projection_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -231,9 +231,18 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
 /// Resolve a possibly accepted submission without replaying it. This is used
 /// only after the acceptance deadline or an operator cancellation request:
 /// those paths must never create new runner work.
-pub(crate) fn bind_pending_runner_submission_if_accepted(run_id: &str) -> Result<bool> {
+///
+/// There is deliberately no ambient wrapper. Both callers — expiry and
+/// cancellation — are destructive, and each already holds the store whose
+/// record it is about to terminalize. An ambient form would exist only to let a
+/// future caller decide acceptance from one installation's intent and bind the
+/// acceptance into another's (#7505).
+pub(crate) fn bind_pending_runner_submission_if_accepted_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::read_record(&run_id)?;
+    let record = lifecycle_store.read_record(&run_id)?;
     if record.runner_job_id().is_some()
         || record
             .metadata
@@ -285,13 +294,16 @@ pub(crate) fn bind_pending_runner_submission_if_accepted(run_id: &str) -> Result
     });
     match lookup {
         Ok(homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Accepted { job }) => {
-            record_detached_lab_run(DetachedLabRunRecord {
-                run_id: &run_id,
-                runner_id: &runner_id,
-                runner_job_id: &job.id.to_string(),
-                remote_workspace: request.cwd.as_deref().unwrap_or_default(),
-                remote_command: &request.command,
-            })?;
+            record_detached_lab_run_in_store(
+                lifecycle_store,
+                DetachedLabRunRecord {
+                    run_id: &run_id,
+                    runner_id: &runner_id,
+                    runner_job_id: &job.id.to_string(),
+                    remote_workspace: request.cwd.as_deref().unwrap_or_default(),
+                    remote_command: &request.command,
+                },
+            )?;
             Ok(true)
         }
         Ok(
@@ -299,14 +311,16 @@ pub(crate) fn bind_pending_runner_submission_if_accepted(run_id: &str) -> Result
             | homeboy_core::api_jobs::RemoteRunnerSubmissionLookup::Expired { .. },
         ) => Ok(false),
         Err(error) => {
-            let _ = store::mutate_record(&run_id, |record| {
-                record.ensure_metadata_object()["runner_submission_intent"]["last_lookup_error"] = json!({
-                    "code": error.code.as_str(),
-                    "message": error.message.clone(),
-                    "retryable": true,
-                });
-                true
-            })?;
+            let _ =
+                lifecycle_store.mutate_record(&run_id, |record| {
+                    record.ensure_metadata_object()["runner_submission_intent"]
+                        ["last_lookup_error"] = json!({
+                        "code": error.code.as_str(),
+                        "message": error.message.clone(),
+                        "retryable": true,
+                    });
+                    true
+                })?;
             Err(error)
         }
     }
@@ -365,20 +379,41 @@ pub(crate) fn is_accepted_runner_handoff(record: &AgentTaskRunRecord) -> bool {
 /// their aggregate-free legacy shape; preacceptance failures retain their
 /// canonical failure aggregate and its synthetic runtime projection.
 pub(crate) fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
+    expire_unaccepted_lab_handoff_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+    )
+}
+
+/// The store-rooted counterpart of [`expire_unaccepted_lab_handoff`].
+///
+/// This is the operation the handoff lock exists for: expiry and acceptance
+/// race for the same run, and only one may win. That is why the lock and the
+/// cancellation spine had to be rooted in the same change (#7505) — a lock
+/// resolved from `paths::homeboy_data()` while the acceptance check, the
+/// cancellation, and the terminal record write all followed an injected store
+/// would be held in an installation nobody else contends in. Acceptance and
+/// expiry would each believe they were exclusive, and expiry would terminalize
+/// a run a runner had just accepted.
+pub(crate) fn expire_unaccepted_lab_handoff_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
     // An expired pending request may have been accepted immediately before its
     // response was lost. Querying its key is read-only; never replay here.
-    if bind_pending_runner_submission_if_accepted(run_id)? {
+    if bind_pending_runner_submission_if_accepted_in_store(lifecycle_store, run_id)? {
         return Ok(true);
     }
-    let _lock = LabHandoffLock::lock(run_id)?;
+    let _lock = LabHandoffLock::lock_in_store(lifecycle_store, run_id)?;
     // Re-read while holding the handoff lock: an accepted job is runner-owned
     // and must never be terminalized by controller deadline recovery.
-    let record = store::read_record(run_id)?;
+    let record = lifecycle_store.read_record(run_id)?;
     if !has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
         return Ok(false);
     }
 
-    let mut record = cancel_run(run_id, Some(EXPIRED_LAB_HANDOFF_REASON))?;
+    let mut record =
+        cancel_run_in_store(lifecycle_store, run_id, Some(EXPIRED_LAB_HANDOFF_REASON))?;
     let expired_at = now_timestamp();
     let record_run_id = record.run_id.clone();
     let runner_id = record.runner_id().unwrap_or_default().to_string();
@@ -422,7 +457,7 @@ pub(crate) fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
         )
         .unwrap_or(Value::Null),
     );
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -266,19 +266,35 @@ fn record_lab_offload_phase_metadata(
 }
 
 pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentTaskRunRecord> {
+    record_detached_lab_run_in_store(&AgentTaskLifecycleStore::from_current_environment()?, input)
+}
+
+/// The store-rooted counterpart of [`record_detached_lab_run`].
+///
+/// Lab acceptance is the single durable transfer of a run to a runner daemon:
+/// it takes the handoff lock, reads (or resubmits) the record, validates the
+/// accepted identity against what is already persisted, and writes the accepted
+/// handoff back. Every one of those steps has to name the same installation —
+/// an acceptance validated against one home's record and committed into
+/// another's would silently permit two different runners to own the same run,
+/// and the handoff lock would not have excluded either of them (#7505).
+pub(crate) fn record_detached_lab_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    input: DetachedLabRunRecord<'_>,
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(input.run_id);
-    let _lock = LabHandoffLock::lock(&run_id)?;
+    let _lock = LabHandoffLock::lock_in_store(lifecycle_store, &run_id)?;
     let plan = detached_lab_plan(&run_id, &input);
-    let mut record = match store::read_record(&run_id) {
+    let mut record = match lifecycle_store.read_record(&run_id) {
         Ok(record) => record,
         Err(error)
             if error.code == ErrorCode::InternalJsonError
-                && store::record_lacks_typed_metadata(&run_id)? =>
+                && lifecycle_store.record_lacks_typed_metadata(&run_id)? =>
         {
-            submit_plan(&plan, Some(&run_id))?
+            submit_plan_in_store(lifecycle_store, &plan, Some(&run_id))?
         }
         Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
-            submit_plan(&plan, Some(&run_id))?
+            submit_plan_in_store(lifecycle_store, &plan, Some(&run_id))?
         }
         Err(error) => return Err(error),
     };
@@ -292,8 +308,10 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     }
     // The accepted handoff is the controller-side attachment authority. Capture
     // the exact durable run binding here so later attachment writes cannot be
-    // authorized by a substituted workspace claim.
-    require_record_workspace_owner(&record)?;
+    // authorized by a substituted workspace claim. The claim ledger is a
+    // permission gate over the retained workspace, so it is read from this
+    // store's own roots rather than the process environment's (#7505).
+    require_record_workspace_owner_in_store(&lifecycle_store.workspace_claim_store(), &record)?;
     if let Some(accepted) = record.lab_handoff.as_ref().filter(|handoff| {
         handoff.state == AgentTaskLabHandoffState::Accepted
             && handoff.authority == AgentTaskLabHandoffAuthority::RunnerDaemon
@@ -386,8 +404,8 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
             None,
         ));
     }
-    if let Err(error) = store::read_controller_plan(&run_id) {
-        fail_missing_lab_attempt_plan(&mut record, &error)?;
+    if let Err(error) = lifecycle_store.read_controller_plan(&run_id) {
+        fail_missing_lab_attempt_plan_in_store(lifecycle_store, &mut record, &error)?;
         return Err(Error::internal_io(
             format!(
                 "cannot bind Lab runner job because durable attempt plan is unavailable: {}",
@@ -485,7 +503,7 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
     metadata.remove(METADATA_KEY_STALE_RUNNING);
     metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -522,17 +540,26 @@ fn record_lab_offload_proxy(
     if let Some(metadata) = plan.metadata.as_object_mut() {
         metadata.remove("runner_job_id");
     }
-    let mut record = match store::read_record(&run_id) {
+    // Ambient entry point: resolve one root here and use it for every durable
+    // touch below, rather than letting each `store::` shim resolve its own.
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let mut record = match lifecycle_store.read_record(&run_id) {
         Ok(record) => record,
         Err(error)
             if error.code == ErrorCode::InternalJsonError
-                && store::record_lacks_typed_metadata(&run_id)? =>
+                && lifecycle_store.record_lacks_typed_metadata(&run_id)? =>
         {
-            submit_plan(durable_plan.unwrap_or(&plan), Some(&run_id))?
+            submit_plan_in_store(
+                &lifecycle_store,
+                durable_plan.unwrap_or(&plan),
+                Some(&run_id),
+            )?
         }
-        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => {
-            submit_plan(durable_plan.unwrap_or(&plan), Some(&run_id))?
-        }
+        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => submit_plan_in_store(
+            &lifecycle_store,
+            durable_plan.unwrap_or(&plan),
+            Some(&run_id),
+        )?,
         Err(error) => return Err(error),
     };
     if let Some(problem) = record.lab_handoff_validation_error() {
@@ -563,20 +590,23 @@ fn record_lab_offload_proxy(
     // A previous interruption may have committed the record but not its plan.
     // Repair from the controller-compiled plan before exposing another handoff
     // phase; without it the runner would later create a fake running attempt.
-    if store::read_controller_plan(&run_id).is_err() {
+    if lifecycle_store.read_controller_plan(&run_id).is_err() {
         if let Some(durable_plan) = durable_plan {
-            let plan_path = store::write_plan(&run_id, durable_plan)?;
+            let plan_path = lifecycle_store.write_controller_plan(&run_id, durable_plan)?;
             record.plan_path = plan_path.display().to_string();
         } else {
             let error = Error::internal_io(
                 "durable attempt plan is unavailable during Lab handoff recovery",
                 Some(record.plan_path.clone()),
             );
-            fail_missing_lab_attempt_plan(&mut record, &error)?;
+            fail_missing_lab_attempt_plan_in_store(&lifecycle_store, &mut record, &error)?;
             return Err(error);
         }
     }
-    record.plan_path = store::controller_plan_path(&run_id)?.display().to_string();
+    record.plan_path = lifecycle_store
+        .controller_plan_path(&run_id)
+        .display()
+        .to_string();
     if record.state.is_terminal() {
         return Ok(record);
     }
@@ -620,7 +650,7 @@ fn record_lab_offload_proxy(
         )
         .unwrap_or(Value::Null),
     );
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -669,7 +699,17 @@ mod admission_tests {
     }
 }
 
-fn fail_missing_lab_attempt_plan(record: &mut AgentTaskRunRecord, error: &Error) -> Result<()> {
+/// Terminalize a Lab attempt whose durable plan is unrecoverable.
+///
+/// The failure is decided from a plan read out of one store, so it is written
+/// back to that same store: a terminal failure recorded in a different
+/// installation than the one that was missing the plan would be evidence about
+/// a run nobody asked about (#7505).
+fn fail_missing_lab_attempt_plan_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    error: &Error,
+) -> Result<()> {
     record.updated_at = Some(now_timestamp());
     set_run_state(record, AgentTaskRunState::Failed);
     for task in &mut record.tasks {
@@ -686,7 +726,7 @@ fn fail_missing_lab_attempt_plan(record: &mut AgentTaskRunRecord, error: &Error)
         }),
     );
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
-    store::write_record(record)
+    lifecycle_store.write_record(record)
 }
 
 fn detached_lab_plan(run_id: &str, input: &DetachedLabRunRecord<'_>) -> AgentTaskPlan {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -232,11 +232,27 @@ pub(crate) struct LabHandoffLock {
 }
 
 impl LabHandoffLock {
-    pub(crate) fn lock(run_id: &str) -> Result<Self> {
-        let lock_path = paths::homeboy_data()?
-            .join("agent-task-runs")
-            .join(run_id)
-            .join("lab-handoff.lock");
+    /// Take the Lab handoff acceptance lock inside an explicitly rooted store.
+    ///
+    /// There is deliberately no ambient constructor. This lock serializes
+    /// acceptance against expiry for one run, and every state it guards — the
+    /// record, its submission intent, its aggregate — is read and written
+    /// through a lifecycle store. A lock file resolved from
+    /// `paths::homeboy_data()` while those reads and writes followed an
+    /// injected store would sit in a different installation than the state it
+    /// protects, and a lock taken in the wrong home excludes nobody: expiry and
+    /// acceptance would both believe they held it (#7505). Requiring the store
+    /// in the signature is what makes that divergence unrepresentable.
+    ///
+    /// Deriving the path from `run_dir` also sanitizes the run id, which the
+    /// ambient form did not, so the lock now names a path that agrees with the
+    /// run's own record and aggregate — the same correction
+    /// `reconcile_deferred_candidate_in_store` made for its per-run lock.
+    pub(crate) fn lock_in_store(
+        lifecycle_store: &AgentTaskLifecycleStore,
+        run_id: &str,
+    ) -> Result<Self> {
+        let lock_path = lifecycle_store.run_dir(run_id).join("lab-handoff.lock");
         if let Some(parent) = lock_path.parent() {
             fs::create_dir_all(parent)
                 .map_err(|error| Error::internal_io(error.to_string(), None))?;
@@ -3823,18 +3839,22 @@ pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// of those shims resolved `AgentTaskLifecycleStore::from_current_environment()`
 /// too — but the read is now one store away from being rootable.
 ///
-/// Four steps still resolve their own roots, and each is its own remaining
+/// `expire_unaccepted_lab_handoff` used to head this list. It is rooted now:
+/// the cancellation slice moved `LabHandoffLock` onto the injected store's own
+/// `run_dir` in the same change that rooted the `cancel_run` spine underneath
+/// it, because a lock resolved from `paths::homeboy_data()` while the
+/// cancellation it guards followed an injected store would be held where nobody
+/// contends for it. Both had to move together or neither could.
+///
+/// Three steps still resolve their own roots, and each is its own remaining
 /// slice rather than an oversight:
 ///
-/// * `reconcile_pending_runner_submission_intent` and
-///   `expire_unaccepted_lab_handoff` — the latter calls the alias-resolving
-///   `cancel_run` spine (~400 lines, a dozen record writes,
-///   `controller_scratch::finalize_run`, managed-service reconciliation) and
-///   takes `LabHandoffLock`, whose lock path is built from `paths::homeboy_data()`
-///   directly. A lock taken in the wrong home excludes nobody, so that lock has
-///   to move with the store in the same change that roots the spine.
-/// * `reconcile_runner_job_state` — reaches `terminalize_lost_accepted_lab_job`
-///   and `reconcile_runner_job_snapshot`, both of which write aggregates.
+/// * `reconcile_pending_runner_submission_intent` — replays a durable
+///   broker submission. Its transport half is provider-registry work, but it
+///   reads the intent and records the acceptance through `store::` shims.
+/// * `reconcile_runner_job_state` — `reconcile_runner_job_snapshot_in_store`
+///   now exists, but its sibling `terminalize_lost_accepted_lab_job` still
+///   reads the controller plan and writes its terminal failure ambiently.
 /// * the Cook recipe family (`load_recipe`, `load_recipe_for_attempt`,
 ///   `validate_recipe_attempt_record`, `enqueue_terminal_continuation`) — a
 ///   `CookRecipeStore`, not a lifecycle store. It is derivable from
@@ -3846,7 +3866,7 @@ pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// below could be rooted and this read could not.
 ///
 /// Until those close there is deliberately **no** `status_in_store`. A rooted
-/// status that reconciled four of its steps in another installation would be
+/// status that reconciled three of its steps in another installation would be
 /// strictly worse than the uniform ambience it replaced.
 fn status_with_options_inner(
     run_id: &str,
@@ -3873,7 +3893,7 @@ fn status_with_options_inner(
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     if has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
-        let _ = expire_unaccepted_lab_handoff(&resolved_run_id)?;
+        let _ = expire_unaccepted_lab_handoff_in_store(&lifecycle_store, &resolved_run_id)?;
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     // A daemon can evict a completed job from its active store before a restarted

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -13,13 +13,35 @@ pub(crate) fn reconcile_runner_job_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
+    reconcile_runner_job_snapshot_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        record,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of [`reconcile_runner_job_snapshot`].
+///
+/// This is the read-back half of the Lab handoff and it writes: the binding,
+/// the live-progress record, the aggregate idempotence read, the terminal
+/// aggregate-and-record commit, and the artifact projection underneath it. The
+/// idempotence read is the reason none of it may be left ambient — it decides
+/// whether an authoritative terminal result is projected at all. Comparing
+/// against another home's aggregate would either re-project a result that is
+/// already durable here or, worse, skip projecting one because a *different*
+/// installation happened to hold a matching aggregate (#7505).
+pub(crate) fn reconcile_runner_job_snapshot_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<()> {
     // Single owner of pre-acceptance binding: bind a still-pending controller
     // handoff to this snapshot's daemon job before any validation or projection,
     // then advance a freshly-bound queued proxy to running. Every reconcile path
     // (transport-proxy, runner-job-state, terminal-evidence recovery) flows
     // through here, so binding cannot diverge across callers. Both steps no-op
     // once the run is already bound / no longer queued.
-    bind_pending_lab_handoff_snapshot(record, snapshot)?;
+    bind_pending_lab_handoff_snapshot_in_store(lifecycle_store, record, snapshot)?;
     if record.state == AgentTaskRunState::Queued {
         set_run_state(record, AgentTaskRunState::Running);
         for task in &mut record.tasks {
@@ -34,8 +56,13 @@ pub(crate) fn reconcile_runner_job_snapshot(
         // when it proves the same controller run rather than losing its patch.
         if let Some(event) = terminal_runner_lifecycle_event(record, snapshot)? {
             let aggregate = projected_runner_aggregate(record, &event.aggregate);
-            if store::read_aggregate(&record.run_id).ok().as_ref() != Some(&aggregate) {
-                project_terminal_runner_lifecycle_event(record, snapshot, &event)?;
+            if lifecycle_store.read_aggregate(&record.run_id).ok().as_ref() != Some(&aggregate) {
+                project_terminal_runner_lifecycle_event_in_store(
+                    lifecycle_store,
+                    record,
+                    snapshot,
+                    &event,
+                )?;
             }
         }
         return Ok(());
@@ -101,16 +128,21 @@ pub(crate) fn reconcile_runner_job_snapshot(
                 metadata.insert("active_provider".to_string(), provider.clone());
             }
             merge_live_provider_handles(&mut reconciled, &snapshot.events);
-            store::write_record(&reconciled)?;
+            lifecycle_store.write_record(&reconciled)?;
         }
         homeboy_core::api_jobs::JobStatus::Succeeded
         | homeboy_core::api_jobs::JobStatus::Failed
         | homeboy_core::api_jobs::JobStatus::Cancelled => {
             if let Some(event) = terminal_runner_lifecycle_event(&reconciled, snapshot)? {
-                project_terminal_runner_lifecycle_event(&mut reconciled, snapshot, &event)?;
+                project_terminal_runner_lifecycle_event_in_store(
+                    lifecycle_store,
+                    &mut reconciled,
+                    snapshot,
+                    &event,
+                )?;
             } else {
                 record_pending_runner_synchronization(&mut reconciled, snapshot);
-                store::write_record(&reconciled)?;
+                lifecycle_store.write_record(&reconciled)?;
             }
         }
     }
@@ -278,21 +310,49 @@ fn project_terminal_runner_lifecycle_event(
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
     event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
 ) -> Result<()> {
+    project_terminal_runner_lifecycle_event_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        record,
+        snapshot,
+        event,
+    )
+}
+
+/// The store-rooted counterpart of [`project_terminal_runner_lifecycle_event`].
+///
+/// Mirrors `project_persisted_terminal_runner_events_in_store` exactly: the
+/// aggregate path stamped onto the record, the combined aggregate-and-record
+/// commit, and the terminal artifact projection all follow the injected store.
+/// The artifact projection is the one that cannot be left ambient — it
+/// registers controller-owned bytes under the artifact root `PathRoots` carries
+/// separately from `data`, which is the cross-home artifact write #12618 found
+/// (#7505).
+fn project_terminal_runner_lifecycle_event_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+    event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
+) -> Result<()> {
     preserve_terminal_runner_identity(record, event)?;
     validate_runner_job_snapshot(record, snapshot)?;
     validate_terminal_child_identity(record, snapshot, event)?;
     let aggregate = projected_runner_aggregate(record, &event.aggregate);
     let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
-    let aggregate_path = store::aggregate_path(&record.run_id)
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|_| "aggregate.json".to_string());
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&record.run_id)
+        .display()
+        .to_string();
     apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
     record_verified_lab_placement_outcome(record)?;
     // The aggregate is the task result. A successful enclosing daemon job only
     // proves transport completion, not task success.
     record_runner_job_terminal_metadata(record, snapshot.job.status, &snapshot.events);
-    store::write_aggregate_and_record(record, &aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection(record, &aggregate)
+    lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
+    crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+        lifecycle_store,
+        record,
+        &aggregate,
+    )
 }
 
 pub(crate) fn project_persisted_terminal_runner_events(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -244,6 +244,25 @@ pub(crate) fn bind_pending_lab_handoff_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
+    bind_pending_lab_handoff_snapshot_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        record,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of [`bind_pending_lab_handoff_snapshot`].
+///
+/// Binding is a durable write — it replaces `record` with whatever
+/// acceptance persisted — so the installation it commits into has to be the one
+/// its caller is reconciling. A binding written to another home would leave the
+/// caller's own record permanently unbound while snapshot validation kept
+/// rejecting a perfectly valid runner job (#7505).
+pub(crate) fn bind_pending_lab_handoff_snapshot_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<()> {
     if record.runner_job_id().is_some() {
         return Ok(());
     }
@@ -296,17 +315,24 @@ pub(crate) fn bind_pending_lab_handoff_snapshot(
         // The runner can finish and mirror its aggregate before the controller
         // projects the daemon snapshot. Preserve that terminal outcome while
         // attaching the authoritative job identity needed for validation.
-        *record =
-            record_runner_job_identity(&record.run_id, &runner_id, &snapshot.job.id.to_string())?;
+        *record = record_runner_job_identity_in_store(
+            lifecycle_store,
+            &record.run_id,
+            &runner_id,
+            &snapshot.job.id.to_string(),
+        )?;
         return Ok(());
     }
-    *record = record_detached_lab_run(DetachedLabRunRecord {
-        run_id: &record.run_id,
-        runner_id: &runner_id,
-        runner_job_id: &snapshot.job.id.to_string(),
-        remote_workspace: &remote_workspace,
-        remote_command: &remote_command,
-    })?;
+    *record = record_detached_lab_run_in_store(
+        lifecycle_store,
+        DetachedLabRunRecord {
+            run_id: &record.run_id,
+            runner_id: &runner_id,
+            runner_job_id: &snapshot.job.id.to_string(),
+            remote_workspace: &remote_workspace,
+            remote_command: &remote_command,
+        },
+    )?;
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -15,11 +15,29 @@ pub fn record_runner_job_identity(
     runner_id: &str,
     runner_job_id: &str,
 ) -> Result<AgentTaskRunRecord> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    record_runner_job_identity_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        runner_id,
+        runner_job_id,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_job_identity`].
+///
+/// The read and the write are one operation — the record read back is the one
+/// returned to the caller — so they must name the same installation (#7505).
+pub(crate) fn record_runner_job_identity_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    runner_id: &str,
+    runner_job_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     let metadata = record.ensure_metadata_object();
     metadata.insert("runner_id".to_string(), json!(runner_id));
     metadata.insert("runner_job_id".to_string(), json!(runner_job_id));
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -972,8 +990,13 @@ pub fn record_lab_offload_submission_intent(
     secret_env_names: &[String],
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let _lock = LabHandoffLock::lock(&run_id)?;
-    let mut record = store::read_record(&run_id)?;
+    // One store for the lock and for every record touch below it. This is an
+    // ambient entry point, so it resolves a root; what it must not do is
+    // resolve one root for the lock and let each `store::` shim resolve its own
+    // (#7505).
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let _lock = LabHandoffLock::lock_in_store(&lifecycle_store, &run_id)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
     let submission_key = format!("agent-task:v1:{runner_id}:{run_id}");
     if let Some(handoff) = record.lab_handoff.as_mut() {
         handoff.submission_key = Some(submission_key.clone());
@@ -1001,7 +1024,7 @@ pub fn record_lab_offload_submission_intent(
         "phase_activity".to_string(),
         json!("durable broker submission intent recorded; waiting for runner capacity"),
     );
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -1012,8 +1035,10 @@ pub fn record_lab_offload_submission_request(
     request: &RemoteRunnerJobRequest,
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let _lock = LabHandoffLock::lock(&run_id)?;
-    let mut record = store::read_record(&run_id)?;
+    // As above: the lock and the record write it guards resolve one root once.
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let _lock = LabHandoffLock::lock_in_store(&lifecycle_store, &run_id)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
     if record.state.is_terminal() {
         return Ok(record);
     }
@@ -1050,6 +1075,6 @@ pub fn record_lab_offload_submission_request(
             "deadline_at": handoff.acceptance_deadline_at,
         }),
     );
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -1048,15 +1048,35 @@ pub(crate) fn reconcile_run_services_on_owner(
     owner: Option<&Value>,
     reason: &str,
 ) -> Result<Value, String> {
+    let data_root = homeboy_core::paths::homeboy_data().map_err(|error| error.message)?;
+    reconcile_run_services_on_owner_at(&data_root, run_id, owner, reason)
+}
+
+/// Reconcile service ownership for one run below an explicit controller data
+/// root.
+///
+/// Only the *local* branch reads a root at all: the runner branch dispatches
+/// commands the runner interprets against its own HOME. Splitting them here is
+/// what lets a rooted cancellation prove its local service ledger was reaped in
+/// the same installation it wrote the terminal record into, instead of reaping
+/// whichever ledger the process environment happened to point at (#7505).
+pub(crate) fn reconcile_run_services_on_owner_at(
+    data_root: &Path,
+    run_id: &str,
+    owner: Option<&Value>,
+    reason: &str,
+) -> Result<Value, String> {
     let Some(owner) = owner else {
-        return Ok(
-            json!({ "transport": "local", "services": reconcile_run_services(run_id, reason)? }),
-        );
+        return Ok(json!({
+            "transport": "local",
+            "services": reconcile_run_services_at(data_root, run_id, reason)?,
+        }));
     };
     let Some(runner_id) = owner.get("runner_id").and_then(Value::as_str) else {
-        return Ok(
-            json!({ "transport": "local", "services": reconcile_run_services(run_id, reason)? }),
-        );
+        return Ok(json!({
+            "transport": "local",
+            "services": reconcile_run_services_at(data_root, run_id, reason)?,
+        }));
     };
     let command = |operation: &str| {
         vec![

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -587,6 +587,19 @@ impl AgentTaskLifecycleStore {
         super::lifecycle_ops::record_run_aggregate_in_store(self, run_id, plan, aggregate)
     }
 
+    /// Whether this store's observation record predates typed agent-task
+    /// metadata, so a legacy row can be resubmitted rather than rejected.
+    ///
+    /// The answer is a property of one observation database, so it has to be
+    /// read from the same roots the caller is about to write the replacement
+    /// record into (#7505).
+    pub(crate) fn record_lacks_typed_metadata(&self, run_id: &str) -> Result<bool> {
+        Ok(self
+            .open_observation_initialized()?
+            .get_run(run_id)?
+            .is_some_and(|run| run.metadata_json.get("agent_task_run").is_none()))
+    }
+
     /// Check this store for one exact durable run identity without Cook alias
     /// resolution.
     pub fn record_exists(&self, run_id: &str) -> Result<bool> {
@@ -813,10 +826,6 @@ fn read_controller_plan_in_store(
     validate_execution_budget(&plan)?;
     validate_managed_services(&plan)?;
     Ok(plan)
-}
-
-pub(super) fn controller_plan_path(run_id: &str) -> Result<PathBuf> {
-    Ok(default_store()?.controller_plan_path(run_id))
 }
 
 /// Controller lifecycle operations resolve the plan from their durable run
@@ -1452,12 +1461,6 @@ fn validate_cook_index_attempt_in_store(
         ));
     }
     Ok(())
-}
-
-pub(super) fn record_lacks_typed_metadata(run_id: &str) -> Result<bool> {
-    Ok(ObservationStore::open_initialized_for_lifecycle()?
-        .get_run(run_id)?
-        .is_some_and(|run| run.metadata_json.get("agent_task_run").is_none()))
 }
 
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {


### PR DESCRIPTION
## Summary

#12657 rooted the interior of `status` and stopped at a documented boundary, because `LabHandoffLock` built its path from `paths::homeboy_data()` directly and **a lock taken in the wrong home excludes nobody.** This is that slice.

<callout accent="#3b82f6">
## The wrong home is now a compile error

`LabHandoffLock` has exactly one constructor: `lock_in_store(lifecycle_store, run_id)`, path `lifecycle_store.run_dir(run_id).join("lab-handoff.lock")`.

**The ambient `lock` is removed, not deprecated.** A handoff lock in the wrong home is no longer representable.
</callout>

All four call sites pass a store — `record_detached_lab_run_in_store`, `expire_unaccepted_lab_handoff_in_store`, and both `record_lab_offload_submission_*` entry points, which now resolve one root and use it for the lock **and** the record writes that lock guards.

**Bonus correction:** `run_dir` sanitizes the run id; the ambient form did not. The lock path now agrees with the run's own record and aggregate paths — the same class of mismatch #12639 found in `reconcile_deferred_candidate`.

## `cancel_resolved_run_in_store` — 12 durable writes, all on the injected store

Detached-child termination · managed-service cleanup · both candidate-adoption checkpoints (`cancel_requested`, `cancelled`) · re-read after accepted-submission rebind · already-cancelled convergence · deferred-terminal-provider · both controller-job cancellation records · the terminal `mutate_record` · its `unwrap_or` fallback re-read · the runner-terminal-race projection.

Terminal side effects moved to the rooted forms `cancel_exact_run_in_store` already used: `finalize_run_at_explicit_roots(data_root, artifact_root, run_id)` and `cancel_admission_at(data_root/controller-runtimes, run_id)`. Managed-service reap goes through a new `reconcile_run_services_on_owner_at`; **the runner branch is deliberately unchanged, because the runner interprets those commands against its own HOME.**

Root-independent by design, left alone: `classify_live_cancellation` (syscalls + record fields), `cancel_runner_job` (provider registry), `LocalControllerJobClient::connect()` (daemon transport — the same call the already-rooted `reconcile_controller_job_cancellation_in_store` makes).

## Is `status_in_store` shippable now? No — and I'd rather say so

This closes **one of four** blockers its doc comment lists. Still in the way:

- `reconcile_pending_runner_submission_intent` — reads intent and records acceptance through `store::` shims
- `reconcile_runner_job_state` → `terminalize_lost_accepted_lab_job` — **this one is now small**: every dependency it needs (`store.read_controller_plan`, `reconcile_run_services_on_owner_at`, `store.record_pre_execution_failure`, `store.write_record`) exists after this change
- the Cook recipe family — a `CookRecipeStore`; genuinely cross-kind, which is what `KNOWN_MIXED_STORE_FUNCTIONS` exists to make someone argue for
- `controller_runtime::admission_status` — no `_at` form **(closed in parallel by #12659)**

The doc comment was updated to say exactly this rather than leave it claiming a fixed blocker.

## A scanner-shape trap steered around

Naming the method `lock` with an `_in_store` sibling would have registered `lock` as an ambient wrapper — and the scanner's token match `"lock("` would then have **falsely flagged** `reconcile_deferred_candidate_in_store` for its `DeferredCandidateLock::lock(file)`. `lock_in_store` matches `RetryLineageLock::lock_in_store` in the same file and avoids it.

## Verification

**Scanner 7/7.** No allowlist row added or deleted — neither existing row is touched by this slice, so deleting one would have been a false claim.

Three orphaned wrappers deleted (`record_terminal_artifact_projection`, `store::controller_plan_path`, `store::record_lacks_typed_metadata`); the eight surviving ones each verified to still have callers. Lesson-1 scan over every store-holding function in the diff: one hit, `substantive_candidate_in_store`, pre-existing and allowlisted. Lesson-2: every `#[cfg(test)]` block in all ten files scanned for the eight changed symbols — zero references. Duplicate check: the second `lock_in_store` is `RetryLineageLock`'s vs `LabHandoffLock`'s, **confirmed as separate impl blocks**; `lifecycle_store.rs` *loses* the `controller_plan_path` shim/method duplicate, which was the intent.

<callout accent="#f59e0b">
**Not compiled, not run.** Highest-risk spot is `mutate_record(...).unwrap_or(read_record(...)?)` — shadowing and argument-evaluation order are identical to the `store::` original.

**One path relationship changed**: `lab-handoff.lock` moved from `<data>/agent-task-runs/<raw id>/` to `<data>/agent-task-runs/<sanitized id>/`. No test asserts that path by grep — but per this repo's own history, a grep for a filename is weaker evidence than a run. **If CI fails, look there first.**
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and write-surface mapping. Review by hand.

Refs #7505
