### PR TITLE
Fix piped stdin for timed SSH commands

### DIFF
--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -158,7 +158,8 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                 })?;
                 let timeout = command_timeout(args.timeout)?;
                 ssh_phase("command-start");
-                let output = execute_non_interactive(&client, cmd, timeout);
+                let output =
+                    execute_non_interactive(&client, cmd, timeout, std::io::stdin().is_terminal());
                 ssh_phase("command-finished");
                 ssh_phase("cleanup-finished");
 
@@ -292,7 +293,7 @@ pub(super) fn execute_raw_command(args: &SshArgs) -> homeboy::core::Result<(Stri
     })?;
     let timeout = command_timeout(args.timeout)?;
     ssh_phase("command-start");
-    let output = execute_non_interactive(&client, cmd, timeout);
+    let output = execute_non_interactive(&client, cmd, timeout, std::io::stdin().is_terminal());
     ssh_phase("command-finished");
     ssh_phase("cleanup-finished");
     Ok((output.stdout, output.stderr, output.exit_code))
@@ -302,8 +303,9 @@ fn execute_non_interactive(
     client: &SshClient,
     command: &str,
     timeout: Option<Duration>,
+    stdin_is_terminal: bool,
 ) -> homeboy::core::server::CommandOutput {
-    match (timeout, std::io::stdin().is_terminal()) {
+    match (timeout, stdin_is_terminal) {
         (Some(timeout), true) => client.execute_with_timeout(command, timeout),
         (Some(timeout), false) => client.execute_with_piped_stdin_and_timeout(command, timeout),
         (None, false) => client.execute_with_piped_stdin(command),
@@ -600,5 +602,61 @@ mod tests {
             Some(Duration::from_secs(2))
         );
         assert!(command_timeout(Some(0)).is_err());
+    }
+
+    fn localhost_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: std::collections::HashMap::new(),
+        }
+    }
+
+    /// The non-interactive SSH dispatcher must select the timed piped-stdin path
+    /// when `--timeout` is present and controller stdin is not a terminal, so
+    /// the fix for timed SSH stdin forwarding is actually exercised from the CLI.
+    #[test]
+    fn non_interactive_dispatch_selects_timed_piped_stdin_for_non_terminal_timeout() {
+        let client = localhost_client();
+
+        let output = execute_non_interactive(
+            &client,
+            "printf timed-piped",
+            Some(Duration::from_secs(5)),
+            false,
+        );
+
+        assert!(output.success, "{}", output.stderr);
+        assert_eq!(output.stdout, "timed-piped");
+    }
+
+    /// Each of the four dispatch quadrants must route to the expected execution
+    /// path. These use local execution so the test is deterministic and does not
+    /// require an SSH server.
+    #[test]
+    fn non_interactive_dispatch_routes_all_stdin_timeout_combinations() {
+        let client = localhost_client();
+
+        let timed_terminal =
+            execute_non_interactive(&client, "printf tt", Some(Duration::from_secs(5)), true);
+        assert!(timed_terminal.success);
+        assert_eq!(timed_terminal.stdout, "tt");
+
+        let timed_piped =
+            execute_non_interactive(&client, "printf tp", Some(Duration::from_secs(5)), false);
+        assert!(timed_piped.success);
+        assert_eq!(timed_piped.stdout, "tp");
+
+        let untimed_piped = execute_non_interactive(&client, "printf up", None, false);
+        assert!(untimed_piped.success);
+        assert_eq!(untimed_piped.stdout, "up");
+
+        let untimed_terminal = execute_non_interactive(&client, "printf ut", None, true);
+        assert!(untimed_terminal.success);
+        assert_eq!(untimed_terminal.stdout, "ut");
     }
 }

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -1240,9 +1240,17 @@ const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 /// Run a timed SSH command in a remote session that Homeboy explicitly owns.
 /// The remote shell, rather than the controller's local `ssh` process group,
 /// owns cleanup of descendants that inherit the SSH output pipes.
+///
+/// The wrapper must also preserve the SSH channel's stdin. A non-job-control
+/// shell redirects the standard input of an asynchronous command to /dev/null
+/// before applying any explicit redirections, so a backgrounded `setsid` child
+/// would otherwise read EOF even though the controller is pumping bytes into
+/// the local `ssh` process. We copy the remote shell's fd 0 to fd 3 before
+/// backgrounding and then explicitly redirect the child's fd 0 from fd 3,
+/// restoring the original stdin stream.
 pub(super) fn wrap_timed_remote_command(command: &str) -> String {
     format!(
-        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy timed SSH execution requires remote setsid process authority.' >&2; exit 127; }}; setsid sh -c {} & __homeboy_remote_pid=$!; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
+        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy timed SSH execution requires remote setsid process authority.' >&2; exit 127; }}; exec 3<&0 || {{ printf '%s\\n' 'Homeboy timed SSH execution could not preserve remote stdin.' >&2; exit 1; }}; setsid sh -c {} <&3 & __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
         shell::quote_arg(command)
     )
 }

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -151,6 +151,8 @@ fn timed_ssh_envelope_owns_remote_descendant_cleanup() {
     let envelope = wrap_timed_remote_command("sleep 30 & printf terminal-result");
 
     assert!(envelope.contains("setsid sh -c"));
+    assert!(envelope.contains("exec 3<&0"));
+    assert!(envelope.contains("<&3"));
     assert!(envelope.contains("kill -TERM -\"$__homeboy_remote_pid\""));
     assert!(envelope.contains("kill -KILL -\"$__homeboy_remote_pid\""));
     assert!(envelope.contains("exit \"$__homeboy_remote_status\""));
@@ -205,6 +207,100 @@ fn timed_piped_ssh_envelope_preserves_stdin_and_output_while_reaping_descendants
         "runner disconnect left its attributed pipe-holding descendant running"
     );
     let _ = std::fs::remove_file(descendant_pid_path);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn timed_remote_wrapper_preserves_piped_stdin() {
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", &wrap_timed_remote_command("cat")])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+
+    let input = tempfile::NamedTempFile::new().expect("piped stdin fixture");
+    std::fs::write(input.path(), "piped-input").expect("write piped stdin fixture");
+    let output = execute_command_with_stdin_source_timeout(
+        command,
+        StdinSource::Piped(std::fs::File::open(input.path()).expect("open piped stdin fixture")),
+        Duration::from_secs(5),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(output.stdout, "piped-input");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn timed_and_untimed_paths_preserve_identical_stdin_bytes() {
+    let payload = vec![0, 255, 1, b'\n', 0, 42, 128];
+    let untimed_target = tempfile::NamedTempFile::new().expect("untimed payload target");
+    let timed_target = tempfile::NamedTempFile::new().expect("timed payload target");
+
+    let untimed_output = run_command_with_stdin_source(
+        piped_command(&format!(
+            "cat > {}",
+            crate::engine::shell::quote_path(&untimed_target.path().to_string_lossy())
+        )),
+        StdinSource::Reader(Box::new(Cursor::new(payload.clone()))),
+    );
+
+    let mut timed = Command::new("sh");
+    timed
+        .args([
+            "-c",
+            &wrap_timed_remote_command(&format!(
+                "cat > {}",
+                crate::engine::shell::quote_path(&timed_target.path().to_string_lossy())
+            )),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut timed);
+    let timed_output = execute_command_with_stdin_source_timeout(
+        timed,
+        StdinSource::Reader(Box::new(Cursor::new(payload.clone()))),
+        Duration::from_secs(5),
+    );
+
+    assert!(untimed_output.success, "{}", untimed_output.stderr);
+    assert!(timed_output.success, "{}", timed_output.stderr);
+    assert_eq!(
+        std::fs::read(untimed_target.path()).expect("read untimed payload"),
+        payload
+    );
+    assert_eq!(
+        std::fs::read(timed_target.path()).expect("read timed payload"),
+        payload
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn timed_remote_wrapper_with_idle_pipe_and_fast_exit_is_bounded() {
+    let (reader, _producer) = idle_pipe();
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", &wrap_timed_remote_command("exit 0")])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+    let started = Instant::now();
+
+    let output = execute_command_with_stdin_source_timeout(
+        command,
+        StdinSource::Piped(reader),
+        Duration::from_secs(5),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.exit_code, 0);
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "fast exit with an idle pipe must not wait for the full timeout"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Preserve piped stdin through Homeboy's timed SSH process-group wrapper instead of silently delivering EOF.

## What changed
- Save the SSH channel stdin on fd 3 before backgrounding the setsid child, restore it explicitly for the child, and fail closed if preservation is unavailable.
- Add Linux byte-parity and bounded-exit coverage plus deterministic CLI dispatch coverage for timeout and stdin modes.

## How to test
1. Run `cargo test -p homeboy-core server::client -- --test-threads=1`; expect 62 SSH transport and process-cleanup tests pass.
2. Run `cargo test -p homeboy-cli commands::ssh`; expect 13 SSH CLI dispatch tests pass.

## Compatibility
Ordinary SSH behavior is unchanged; timed commands preserve their existing timeout and cleanup semantics while now receiving the caller's stdin.

## Evidence
- Base unchanged since verification: main remains at fd38e4fa0a7fd3dce7e32b11db999af1b4304331.
- CI expected: Linux Rust test suite exercises the setsid fd-preservation runtime tests
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/12643
- Verified finalization base: main at fd38e4fa0a7fd3dce7e32b11db999af1b4304331
- cli-ssh: passed (13 tests passed) (Passed)
- core-ssh: passed (62 tests passed serially) (Passed)
- format: passed (cargo fmt --check) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode and Homeboy Cook)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the timed SSH stdin loss, reviewed and corrected the retained Cook candidate, and verified the implementation.

## Source relationships
- Closes #12643
