### PR TITLE
Fix rooted Cook pre-execution regressions

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -787,8 +787,9 @@ fn detached_handoff_siblings_advance_only_the_injected_store() {
         aliased.code.as_str(),
         ErrorCode::ValidationInvalidArgument.as_str()
     );
+    assert_eq!(aliased.details["field"], "run_id");
     assert_eq!(
-        aliased.message,
+        aliased.details["problem"],
         "detached Cook id already resolves to an existing Cook attempt"
     );
     assert_eq!(
@@ -806,8 +807,9 @@ fn detached_handoff_siblings_advance_only_the_injected_store() {
         collided.code.as_str(),
         ErrorCode::ValidationInvalidArgument.as_str()
     );
+    assert_eq!(collided.details["field"], "run_id");
     assert_eq!(
-        collided.message,
+        collided.details["problem"],
         "detached Cook id collides with an existing non-handoff run"
     );
     assert_eq!(
@@ -888,8 +890,9 @@ fn detached_handoff_siblings_advance_only_the_injected_store() {
         fenced.code.as_str(),
         ErrorCode::ValidationInvalidArgument.as_str()
     );
+    assert_eq!(fenced.details["field"], "cook_id");
     assert_eq!(
-        fenced.message,
+        fenced.details["problem"],
         "detached Cook handoff was cancelled before its attempt could materialize"
     );
 
@@ -1195,8 +1198,9 @@ fn run_outcome_siblings_record_only_into_the_injected_store() {
         contradicted.code.as_str(),
         ErrorCode::ValidationInvalidArgument.as_str()
     );
+    assert_eq!(contradicted.details["field"], "execution_placement_outcome");
     assert_eq!(
-        contradicted.message,
+        contradicted.details["problem"],
         "verified placement outcome contradicts the durable routing decision"
     );
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -1614,8 +1614,9 @@ fn run_reentry_siblings_re_enter_only_the_injected_store() {
         still_quarantined.code.as_str(),
         ErrorCode::ValidationInvalidArgument.as_str()
     );
+    assert_eq!(still_quarantined.details["field"], "run_id");
     assert_eq!(
-        still_quarantined.message,
+        still_quarantined.details["problem"],
         "agent-task run is quarantined; re-arm its exact run id after repairing durable provenance"
     );
 
@@ -1629,8 +1630,9 @@ fn run_reentry_siblings_re_enter_only_the_injected_store() {
         .is_none());
     let never_quarantined = rearm_quarantined_run_in_store(&other, quarantine_target)
         .expect_err("the second root never observed this quarantine");
+    assert_eq!(never_quarantined.details["field"], "run_id");
     assert_eq!(
-        never_quarantined.message,
+        never_quarantined.details["problem"],
         "only an exact queued quarantined run can be re-armed"
     );
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4004,7 +4004,38 @@ where
         allow_historical_terminal,
     ) {
         Ok(result) => result,
-        Err(error) => return durable_cook_error_report_with_store(store, &failure_options, error),
+        Err(error) => {
+            // Once the attempt exists, a controller-side validation failure has
+            // not reached a provider and must retain the pre-execution contract.
+            if let Ok(record) = lifecycle_store.read_record(&failure_options.initial_run_id) {
+                if record.state == agent_task_lifecycle::AgentTaskRunState::Queued {
+                    let phase = pre_execution_failure_phase(&error, None);
+                    record_pre_execution_failure(
+                        lifecycle_store,
+                        &failure_options.initial_plan,
+                        &failure_options.initial_run_id,
+                        &error,
+                        phase,
+                    )?;
+                    let record = lifecycle_store.read_record(&failure_options.initial_run_id)?;
+                    return Ok(pre_execution_failure_report(
+                        failure_options.cook_id.clone(),
+                        vec![AgentTaskCookAttemptReport {
+                            attempt: 1,
+                            run_id: failure_options.initial_run_id.clone(),
+                            run_state: format!("{:?}", record.state),
+                            aggregate_path: record.aggregate_path.clone(),
+                            promotion: None,
+                            feedback: None,
+                        }],
+                        pre_execution_failure_details(Some(&record), &error),
+                        error,
+                        Some(&failure_options.initial_run_id),
+                    ));
+                }
+            }
+            return durable_cook_error_report_with_store(store, &failure_options, error);
+        }
     };
     if let Some(run_id) = result.value.latest_run_id.as_deref() {
         let attempt = result
@@ -6068,12 +6099,6 @@ fn cook_attempt_needs_execution_with_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> bool {
-    if lifecycle_store
-        .matches_current_environment()
-        .unwrap_or(false)
-    {
-        return cook_attempt_needs_execution(run_id);
-    }
     lifecycle_store
         .read_record(run_id)
         .map(|record| cook_run_record_needs_execution(&record))

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3994,6 +3994,7 @@ where
     S: CookSideEffectService,
 {
     let failure_options = options.clone();
+    let recipe_existed = store.recipe_exists(&failure_options.cook_id);
     let result = match run_cook_with_boundaries_observed_inner_with_stores(
         store,
         lifecycle_store,
@@ -4007,8 +4008,11 @@ where
         Err(error) => {
             // Once the attempt exists, a controller-side validation failure has
             // not reached a provider and must retain the pre-execution contract.
-            if let Ok(record) = lifecycle_store.read_record(&failure_options.initial_run_id) {
-                if record.state == agent_task_lifecycle::AgentTaskRunState::Queued {
+            if let Ok(mut record) = lifecycle_store.read_record(&failure_options.initial_run_id) {
+                if !recipe_existed
+                    && store.data_root() == lifecycle_store.data_root()
+                    && record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+                {
                     let phase = pre_execution_failure_phase(&error, None);
                     record_pre_execution_failure(
                         lifecycle_store,
@@ -4017,7 +4021,12 @@ where
                         &error,
                         phase,
                     )?;
-                    let record = lifecycle_store.read_record(&failure_options.initial_run_id)?;
+                    record = lifecycle_store.read_record(&failure_options.initial_run_id)?;
+                }
+                if error.retryable != Some(true)
+                    && record.metadata["pre_execution_failure"]["phase"].as_str()
+                        == Some("cook_pre_execution")
+                {
                     return Ok(pre_execution_failure_report(
                         failure_options.cook_id.clone(),
                         vec![AgentTaskCookAttemptReport {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1575,15 +1575,6 @@ fn cook_spine_materializes_into_the_injected_stores_across_split_recipe_and_life
     sibling.task_id = "sibling".to_string();
     options.initial_plan.tasks.push(sibling);
 
-    // Seed only the run record, in the lifecycle root, so materialization never
-    // needs the ambient controller-runtime admission lock. The recipe and the
-    // Cook index below are the spine's own writes.
-    lifecycle_store
-        .submit_plan_with_runtime_admission(&options.initial_plan, run_id, |_| {
-            Ok(serde_json::json!({}))
-        })
-        .expect("seed the run record in the lifecycle root");
-
     let error = run_cook_with_boundaries_observed_inner_with_stores(
         &recipe_store,
         &lifecycle_store,


### PR DESCRIPTION
## Summary
- keep explicit-store Cook execution checks rooted in the supplied lifecycle store
- preserve non-retryable pre-execution failure reports instead of collapsing them into generic durable failures
- assert the structured invalid-argument contract in rooted lifecycle tests

## Verification
- `cargo test -p homeboy-agents agent_task_service::cook::tests -- --test-threads=1` (`193 passed`, `6 ignored`)
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::submit_and_persist -- --test-threads=1` (`47 passed`)
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Refs #7505.

## AI Assistance
OpenAI GPT-5.6-sol via OpenCode was used to reproduce the post-merge regressions, trace rooted-store control flow, implement the repair, and run verification. Chris Huber remains responsible for every line.