### PR TITLE
Ship status_in_store

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -781,9 +781,9 @@ fn cancel_resolved_run_in_store(
 /// uses exactly these two rooted forms.
 ///
 /// The caller mutates `record` in place and persists it itself, so no record
-/// write happens here. There is no ambient wrapper:
-/// `status_with_options_inner` is the only caller and resolves one store for
-/// the whole read.
+/// write happens here. There is no ambient wrapper: `status_in_store` is the
+/// only caller, and the store it hands down is the one its own caller
+/// injected.
 pub(super) fn reconcile_controller_job_cancellation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cook_workspace_restore.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cook_workspace_restore.rs
@@ -23,9 +23,16 @@ use crate::agent_task_scheduler::AgentTaskPlan;
 /// The durable promotion below is *not* rooted here, deliberately.
 /// `persisted_promotion_for_attempt` reads through `agent_task_lifecycle::status`,
 /// which reconciles and writes as it reads; its `_in_store` sibling is a plain
-/// record read instead. Substituting one for the other would change what an
-/// existing caller of the ambient retry sees, so rooting it waits on the slice
-/// that roots `status` itself (#7505).
+/// record read instead.
+///
+/// `status_in_store` now exists, so the missing rooted form is no longer the
+/// obstacle. What remains is a behaviour decision this slice does not get to
+/// make silently: `persisted_promotion_for_attempt_in_store` is a plain
+/// `read_record`, and pointing it at `status_in_store` would add roughly twenty
+/// durable writes and two advisory locks to every existing caller of the rooted
+/// promotion read. Either that read starts reconciling for everyone or this
+/// function keeps reading a not-yet-reconciled record — both are defensible and
+/// neither is a mechanical substitution, so it is its own slice (#7505).
 pub(super) fn restore_follow_up_cook_candidate_workspace_in_root(
     plan: &mut AgentTaskPlan,
     artifact_root: &Path,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -914,8 +914,8 @@ pub(crate) fn terminal_provider_model_reconciliation_needed(
 /// The persist at the end is the whole point of taking a store: it is the only
 /// durable effect, so a reconciliation driven from injected roots must land its
 /// repaired model in the same installation the record and aggregate were read
-/// from. There is no ambient wrapper — `status_with_options_inner` is the only
-/// caller, and it resolves one store for the whole read.
+/// from. There is no ambient wrapper — `status_in_store` is the only caller,
+/// and the store it hands down is the one its own caller injected.
 pub(crate) fn reconcile_terminal_provider_model_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -148,8 +148,31 @@ fn has_complete_pending_runner_submission_intent(record: &AgentTaskRunRecord) ->
 /// original POST returns the same job for its submission key, so this covers
 /// both controller crash boundaries without retaining secret values.
 pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> {
+    reconcile_pending_runner_submission_intent_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+    )
+}
+
+/// The store-rooted counterpart of [`reconcile_pending_runner_submission_intent`].
+///
+/// The replay decision and its consequence must name one installation. This
+/// body reads the intent that authorises the replay, and on acceptance commits
+/// the accepted handoff through `record_detached_lab_run_in_store` — which
+/// takes the handoff lock on the same store's `run_dir`. Deciding from one
+/// home's intent and binding the acceptance into another's would let two
+/// controllers replay the same submission key while neither handoff lock
+/// excluded the other (#7505).
+///
+/// The broker transport stays process-global on purpose:
+/// `with_runner_continuation` resolves the configured provider registry, which
+/// is trust material and a subprocess contract, not a lifecycle root.
+pub(crate) fn reconcile_pending_runner_submission_intent_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
     let run_id = sanitize_run_id(run_id);
-    let record = store::read_record(&run_id)?;
+    let record = lifecycle_store.read_record(&run_id)?;
     if !has_pending_runner_submission_intent(&record) {
         return Ok(false);
     }
@@ -204,17 +227,20 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
         provider.submit_reverse_broker_job(&runner_id, request)
     }) {
         Ok(job) => {
-            record_detached_lab_run(DetachedLabRunRecord {
-                run_id: &run_id,
-                runner_id: &runner_id,
-                runner_job_id: &job.id.to_string(),
-                remote_workspace: &cwd,
-                remote_command: &command,
-            })?;
+            record_detached_lab_run_in_store(
+                lifecycle_store,
+                DetachedLabRunRecord {
+                    run_id: &run_id,
+                    runner_id: &runner_id,
+                    runner_job_id: &job.id.to_string(),
+                    remote_workspace: &cwd,
+                    remote_command: &command,
+                },
+            )?;
             Ok(true)
         }
         Err(error) => {
-            let _ = store::mutate_record(&run_id, |record| {
+            let _ = lifecycle_store.mutate_record(&run_id, |record| {
                 let metadata = record.ensure_metadata_object();
                 metadata["runner_submission_intent"]["last_reconciliation_error"] = json!({
                     "code": error.code.as_str(),
@@ -461,7 +487,25 @@ pub(crate) fn expire_unaccepted_lab_handoff_in_store(
     Ok(true)
 }
 
-pub(crate) fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Result<()> {
+/// Project the runner daemon's view of an accepted job back onto the durable
+/// record below explicitly injected lifecycle roots.
+///
+/// There is deliberately no ambient wrapper. Both outcomes this dispatches to
+/// write: the snapshot branch commits a binding, a live-progress update, or a
+/// terminal aggregate, and the confirmed-absence branch replaces the record
+/// with a terminal pre-execution failure. Its only caller is `status_in_store`
+/// in `lifecycle_ops`, which already holds the store whose record it is
+/// reconciling. An ambient form would exist only to let a rooted status decide
+/// liveness against one installation's record and commit the result into
+/// another's (#7505).
+///
+/// The runner transport itself stays process-global: `with_runner_continuation`
+/// resolves a configured provider registry, which is trust material and a
+/// subprocess contract, not a lifecycle root.
+pub(crate) fn reconcile_runner_job_state_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<()> {
     if record.state != AgentTaskRunState::Running {
         return Ok(());
     }
@@ -475,11 +519,13 @@ pub(crate) fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Res
         p.reconcile_runner_job(&runner_id, &job_id)
     }) {
         super::runner_continuation::RunnerJobReconciliation::Snapshot(snapshot) => {
-            reconcile_runner_job_snapshot(record, &snapshot)
+            reconcile_runner_job_snapshot_in_store(lifecycle_store, record, &snapshot)
         }
         super::runner_continuation::RunnerJobReconciliation::ConfirmedAbsent {
             checked_generations,
-        } => terminalize_lost_accepted_lab_job(record, checked_generations),
+        } => {
+            terminalize_lost_accepted_lab_job_in_store(lifecycle_store, record, checked_generations)
+        }
         super::runner_continuation::RunnerJobReconciliation::UnconfirmedAbsence => {
             let disconnected = super::runner_continuation::with_runner_continuation(|p| {
                 !p.is_runner_connected(&runner_id)
@@ -492,14 +538,30 @@ pub(crate) fn reconcile_runner_job_state(record: &mut AgentTaskRunRecord) -> Res
     }
 }
 
-fn terminalize_lost_accepted_lab_job(
+/// Terminalize an accepted Lab job the daemon can no longer account for, below
+/// explicitly injected lifecycle roots.
+///
+/// Every step here has to name the same installation. The controller plan it
+/// reads is the plan the terminal failure is shaped from; the managed-service
+/// ledger it reaps is the one this run wrote; the terminal record it commits
+/// replaces the record the caller is holding. Reading a plan from one home and
+/// reaping another home's service ledger would report a cleanup proof for
+/// services this run never started, which is the same failure class as the
+/// permission gate that failed open in #7505.
+///
+/// Only the *local* branch of `reconcile_run_services_on_owner_at` reads a root
+/// at all — the runner branch dispatches a command the runner interprets
+/// against its own HOME — so passing this store's data root is precise rather
+/// than merely conservative.
+fn terminalize_lost_accepted_lab_job_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
     checked_generations: usize,
 ) -> Result<()> {
     if !record.has_accepted_lab_handoff() || !record.provider_handles.is_empty() {
         return Ok(());
     }
-    let plan = store::read_controller_plan(&record.run_id)?;
+    let plan = lifecycle_store.read_controller_plan(&record.run_id)?;
     let run_id = record.run_id.clone();
     let runner_id = record.runner_id().unwrap_or_default().to_string();
     let runner_job_id = record.runner_job_id().unwrap_or_default().to_string();
@@ -512,13 +574,15 @@ fn terminalize_lost_accepted_lab_job(
     // a service supervisor. Resolve that owner before replacing the run record
     // with a terminal failure so the cleanup proof remains durable.
     let service_cleanup =
-        crate::agent_task_scheduler::managed_services::reconcile_run_services_on_owner(
+        crate::agent_task_scheduler::managed_services::reconcile_run_services_on_owner_at(
+            &lifecycle_store.data_root(),
             &run_id,
             record.metadata.get("managed_service_supervisor"),
             "accepted_lab_runner_job_lost",
         )
         .map_err(Error::internal_unexpected)?;
-    let mut terminal = crate::agent_task_lifecycle::record_pre_execution_failure(
+    let mut terminal = crate::agent_task_lifecycle::record_pre_execution_failure_in_store(
+        lifecycle_store,
         &run_id,
         &plan,
         "accepted_lab_runner_job_lost",
@@ -547,7 +611,7 @@ fn terminalize_lost_accepted_lab_job(
     if let Some(handoff) = metadata.get_mut("runner_handoff") {
         handoff["state"] = json!("lost");
     }
-    store::write_record(&terminal)?;
+    lifecycle_store.write_record(&terminal)?;
     *record = terminal;
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -19,8 +19,8 @@ use super::*;
 /// the caller held explicit roots, this would have reported a parent adoption
 /// assembled from another home's attempts (#7505).
 ///
-/// There is no ambient wrapper: `status_with_options_inner` is the only caller,
-/// and it resolves one store for the whole read.
+/// There is no ambient wrapper: `status_in_store` is the only caller, and the
+/// store it hands down is the one its own caller injected.
 pub(crate) fn project_cook_alias_adoption_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1976,8 +1976,24 @@ pub(crate) fn load_controller_plan_in_store(
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
 pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
-    let run_id = resolve_run_id(run_id)?;
-    store::read_controller_plan_for_execution(&run_id)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    load_plan_for_execution_in_store(&lifecycle_store, run_id)
+}
+
+/// [`load_plan_for_execution`] against explicitly injected durable lifecycle
+/// roots.
+///
+/// Both halves follow the injected root, and the second one is a write: the
+/// legacy execution-budget upgrade rewrites `plan.json` under this store's
+/// config lock. Resolving the Cook alias against one home's index and
+/// migrating another home's plan file would rewrite a plan this caller never
+/// read (#7505).
+pub(crate) fn load_plan_for_execution_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskPlan> {
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    lifecycle_store.read_controller_plan_for_execution(&run_id)
 }
 
 /// Validate a queued lifecycle's pinned controller without scheduling provider work.
@@ -3809,7 +3825,14 @@ pub struct AgentTaskStatusOutcome {
 /// candidate, runtime admission, and runner/daemon status projection) so callers
 /// see the current, joinable controller record.
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    Ok(status_with_options(run_id, AgentTaskStatusOptions::default())?.record)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    Ok(status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )?
+    .record)
 }
 
 /// [`status`] with explicit control over whether the read may reach the runner.
@@ -3819,88 +3842,125 @@ pub fn status_with_options(
     run_id: &str,
     options: AgentTaskStatusOptions,
 ) -> Result<AgentTaskStatusOutcome> {
-    status_with_options_inner(run_id, options, false)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    status_in_store(&lifecycle_store, run_id, options, false)
 }
 
 /// Reconcile one literal durable record without following a Cook alias. Scoped
 /// repair uses this when a logical Cook id has both a handoff parent and an
 /// attempt, because each record is independently authoritative evidence.
 pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    Ok(status_with_options_inner(run_id, AgentTaskStatusOptions::default(), true)?.record)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    Ok(status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        true,
+    )?
+    .record)
 }
 
-/// The shared body of [`status`], [`status_with_options`], and [`exact_status`].
+/// The shared, store-rooted body of [`status`], [`status_with_options`], and
+/// [`exact_status`].
 ///
-/// This is an *ambient entry point*, not a rooted one: it accepts no store and
-/// resolves one for itself. What changed in #7505's status slice is that it now
-/// resolves it **once** and hands that single store to every reconciliation step
-/// that has a rooted form, instead of letting a dozen `store::` shims each
-/// resolve `default_store()` independently. Behaviour is unchanged — every one
-/// of those shims resolved `AgentTaskLifecycleStore::from_current_environment()`
-/// too — but the read is now one store away from being rootable.
+/// `status` is not a read. It takes two advisory locks and has roughly twenty
+/// durable write sites, so every step below has to name the installation the
+/// caller injected — a status that decided from one home and committed into
+/// another would be silently wrong in exactly the way #7505 exists to stop.
+/// The three entry points above are now thin ambient wrappers that resolve
+/// `AgentTaskLifecycleStore::from_current_environment()` and delegate here,
+/// which is the same store every `store::` shim used to resolve for itself, so
+/// their behaviour is unchanged.
 ///
-/// `expire_unaccepted_lab_handoff` used to head this list. It is rooted now:
-/// the cancellation slice moved `LabHandoffLock` onto the injected store's own
-/// `run_dir` in the same change that rooted the `cancel_run` spine underneath
-/// it, because a lock resolved from `paths::homeboy_data()` while the
-/// cancellation it guards followed an injected store would be held where nobody
-/// contends for it. Both had to move together or neither could.
+/// Both advisory locks follow the injected store.
+/// `reconcile_deferred_candidate_in_store` and the expiry path's
+/// `LabHandoffLock::lock_in_store` (via `expire_unaccepted_lab_handoff_in_store`
+/// and `record_detached_lab_run_in_store`) both take their lock on this store's
+/// own `run_dir`. A lock resolved from `paths::homeboy_data()` while the
+/// mutation it guards followed an injected store would be held where nobody
+/// contends for it.
 ///
-/// Three steps still resolve their own roots, and each is its own remaining
-/// slice rather than an oversight:
+/// Two roots that are *not* lifecycle state stay process-global on purpose, and
+/// neither is an oversight:
 ///
-/// * `reconcile_pending_runner_submission_intent` — replays a durable
-///   broker submission. Its transport half is provider-registry work, but it
-///   reads the intent and records the acceptance through `store::` shims.
-/// * `reconcile_runner_job_state` — `reconcile_runner_job_snapshot_in_store`
-///   now exists, but its sibling `terminalize_lost_accepted_lab_job` still
-///   reads the controller plan and writes its terminal failure ambiently.
-/// * the Cook recipe family (`load_recipe`, `load_recipe_for_attempt`,
-///   `validate_recipe_attempt_record`, `enqueue_terminal_continuation`) — a
-///   `CookRecipeStore`, not a lifecycle store. It is derivable from
-///   `lifecycle_store.data_root()`, but pairing the two stores is the shape
-///   `KNOWN_MIXED_STORE_FUNCTIONS` exists to make someone argue for.
+/// * `with_runner_continuation` — the runner/broker provider registry, reached
+///   through `reconcile_runner_job_state_in_store`. It is configured trust
+///   material and a subprocess contract, not durable lifecycle state (#12618).
+/// * `homeboy_core::build_identity::current()` — the identity of *this*
+///   coordinator process, which is the fact the continuation scheduler is
+///   recording.
 ///
-/// `homeboy_core::controller_runtime::admission_status` no longer lacks an
-/// `_at` form — `admission_status_at` now mirrors `cancel_admission_at`, so the
-/// reason the cancellation reconciler below could be rooted and this read could
-/// not has closed. The read is still spelled ambiently here only because this
-/// function is itself ambient: its store comes from
-/// `AgentTaskLifecycleStore::from_current_environment()`, so
-/// `admission_status_at(&lifecycle_store.data_root().join("controller-runtimes"), ..)`
-/// would resolve the identical path today. Switching it buys nothing until the
-/// four steps above are rooted, and belongs in the change that introduces
-/// `status_in_store`.
+/// # The Cook recipe store is derived, not injected
 ///
-/// Until those close there is deliberately **no** `status_in_store`. A rooted
-/// status that reconciled three of its steps in another installation would be
-/// strictly worse than the uniform ambience it replaced.
-fn status_with_options_inner(
+/// The Cook continuation family (`load_recipe`, `load_recipe_for_attempt`,
+/// `enqueue_terminal_continuation`) needs a `CookRecipeStore`, which is a
+/// different store kind from the lifecycle store this function accepts. That is
+/// the cross-kind shape `KNOWN_MIXED_STORE_FUNCTIONS` exists to make someone
+/// argue for, so here is the argument.
+///
+/// This function derives it: `CookRecipeStore::from_data_root(lifecycle_store
+/// .data_root())`. It does not take a second store parameter, because a second
+/// parameter would be a *hazard*, not a safeguard. `CookRecipeStore` carries
+/// exactly one field — a data root — and every path it resolves hangs off it
+/// (`<data>/agent-task-cooks`, `<data>/agent-task-cook-continuations`). There is
+/// no information in a `CookRecipeStore` that is not already in the lifecycle
+/// store's data root, so pairing them can only ever add a way for the two to
+/// disagree. A caller that passed a mismatched pair would enqueue a Cook
+/// continuation for a run whose lifecycle record lives in another home, and
+/// nothing would fail while it happened. Derivation makes that unrepresentable
+/// instead of merely discouraged.
+///
+/// The derivation is exact, not approximate: `CookRecipeStore::from_current_data_root()`
+/// resolves `paths::homeboy_data()`, and `AgentTaskLifecycleStore::from_environment()`
+/// resolves `PathRoots::from_environment()`, whose `data` is that same
+/// `paths::homeboy_data()`. For the ambient wrappers above the derived store is
+/// byte-for-byte the store the old code resolved.
+///
+/// `validate_recipe_attempt_record` is the one member of that family that is
+/// *not* recipe-store work: it reads the controller plan, which is lifecycle
+/// state. This function calls
+/// `validate_recipe_attempt_record_with_controller_plan` with a plan read from
+/// the injected lifecycle store, so the recipe half and the plan half cannot
+/// come from different homes.
+pub fn status_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     options: AgentTaskStatusOptions,
     exact: bool,
 ) -> Result<AgentTaskStatusOutcome> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let recipe_store =
+        crate::agent_task_service::CookRecipeStore::from_data_root(lifecycle_store.data_root());
     let requested_run_id = sanitize_run_id(run_id);
     let resolved_run_id = if exact {
         requested_run_id.clone()
     } else {
-        resolve_run_id_in_store(&lifecycle_store, run_id)?
+        resolve_run_id_in_store(lifecycle_store, run_id)?
     };
-    let _ = reconcile_deferred_candidate_in_store(&lifecycle_store, &resolved_run_id)?;
+    let _ = reconcile_deferred_candidate_in_store(lifecycle_store, &resolved_run_id)?;
     let mut record = lifecycle_store.read_record(&resolved_run_id)?;
-    if let Ok(admission) = homeboy_core::controller_runtime::admission_status(&record.run_id) {
+    // The admission queue is durable lifecycle-adjacent state, so it is read
+    // from this store's own controller-runtime root and not from
+    // `paths::controller_runtimes_store()`. Reporting this installation's queue
+    // position against another installation's owner is the same class of split
+    // as writing the record itself into the wrong home. This mirrors the rooted
+    // `cancel_admission_at` call in the cancellation spine.
+    if let Ok(admission) = homeboy_core::controller_runtime::admission_status_at(
+        &lifecycle_store
+            .data_root()
+            .join(homeboy_core::paths::CONTROLLER_RUNTIMES_STORE),
+        &record.run_id,
+    ) {
         record.metadata["controller_admission"] = admission;
         lifecycle_store.write_record(&record)?;
     }
     if reconcile_candidate_adoption(&mut record) {
         lifecycle_store.write_record(&record)?;
     }
-    if reconcile_pending_runner_submission_intent(&resolved_run_id)? {
+    if reconcile_pending_runner_submission_intent_in_store(lifecycle_store, &resolved_run_id)? {
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     if has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
-        let _ = expire_unaccepted_lab_handoff_in_store(&lifecycle_store, &resolved_run_id)?;
+        let _ = expire_unaccepted_lab_handoff_in_store(lifecycle_store, &resolved_run_id)?;
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     // A daemon can evict a completed job from its active store before a restarted
@@ -3908,11 +3968,11 @@ fn status_with_options_inner(
     // observation record is sufficient to recover the aggregate and artifacts.
     // Consume it before querying the live runner, which is no longer authority
     // once its active entry has been evicted.
-    if project_persisted_terminal_runner_events_in_store(&lifecycle_store, &mut record)? {
+    if project_persisted_terminal_runner_events_in_store(lifecycle_store, &mut record)? {
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
     if super::cancellation::reconcile_controller_job_cancellation_in_store(
-        &lifecycle_store,
+        lifecycle_store,
         &mut record,
     )? {
         lifecycle_store.write_record(&record)?;
@@ -3961,7 +4021,7 @@ fn status_with_options_inner(
     let runner_probe = runner_probe_plan(&record, options);
     let before_liveness_reconciliation = record.clone();
     if runner_probe.performed {
-        reconcile_runner_job_state(&mut record)?;
+        reconcile_runner_job_state_in_store(lifecycle_store, &mut record)?;
     }
     record.annotate_stale_running();
     if record != before_liveness_reconciliation {
@@ -3973,12 +4033,12 @@ fn status_with_options_inner(
                 lifecycle_store.write_record(&record)?;
             }
             if !crate::agent_task_lifecycle::terminal_artifact_projection_is_verified_in_store(
-                &lifecycle_store,
+                lifecycle_store,
                 &record,
                 &aggregate,
             )? {
                 crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
-                    &lifecycle_store,
+                    lifecycle_store,
                     &mut record,
                     &aggregate,
                 )?;
@@ -3994,7 +4054,7 @@ fn status_with_options_inner(
                 let controller_plan = lifecycle_store.read_controller_plan(&record.run_id)?;
                 let projection_plan = aggregate_projection_plan(&controller_plan, &aggregate);
                 crate::agent_task_lifecycle::reconcile_terminal_provider_model_in_store(
-                    &lifecycle_store,
+                    lifecycle_store,
                     &mut record,
                     &projection_plan,
                     &aggregate,
@@ -4014,25 +4074,38 @@ fn status_with_options_inner(
             .metadata
             .get("cook_id")
             .and_then(Value::as_str)
-            .map(crate::agent_task_service::load_recipe)
+            .map(|cook_id| recipe_store.load_recipe(cook_id))
             .transpose();
         let recipe = match recipe_by_cook_id {
             Ok(Some(recipe)) => Ok(Some(recipe)),
-            Ok(None) => crate::agent_task_service::load_recipe_for_attempt(&record.run_id),
+            Ok(None) => recipe_store.load_recipe_for_attempt(&record.run_id),
             Err(error) => Err(error),
         };
         match recipe {
             Ok(Some(recipe)) => {
                 let cook_id = recipe.cook_id.clone();
-                match crate::agent_task_service::validate_recipe_attempt_record(
-                    &recipe,
+                // The recipe half comes from the derived recipe store; the
+                // controller plan this validates against is lifecycle state and
+                // comes from the injected lifecycle store. `validate_recipe_attempt_record`
+                // reads that plan ambiently, which is why the
+                // `_with_controller_plan` form is used here instead.
+                let attempt_validation = load_controller_plan_in_store(
+                    lifecycle_store,
                     &record.run_id,
-                    &record,
-                ) {
+                )
+                .and_then(|controller_plan| {
+                    crate::agent_task_service::validate_recipe_attempt_record_with_controller_plan(
+                        &recipe,
+                        &record.run_id,
+                        &record,
+                        &controller_plan,
+                    )
+                });
+                match attempt_validation {
                     Ok(()) => {
                         if let Some(reason) =
                             crate::agent_task_lifecycle::terminal_artifact_projection_readiness_in_store(
-                                &lifecycle_store,
+                                lifecycle_store,
                                 &record.run_id,
                             )?
                         {
@@ -4068,10 +4141,7 @@ fn status_with_options_inner(
                             .and_then(|scheduler| scheduler.get("status"))
                             .and_then(Value::as_str)
                             .map(str::to_string);
-                        match crate::agent_task_service::enqueue_terminal_continuation(
-                            &cook_id,
-                            &record.run_id,
-                        ) {
+                        match recipe_store.enqueue_terminal_continuation(&cook_id, &record.run_id) {
                             Ok(enqueued) => {
                                 let run_id = record.run_id.clone();
                                 let coordinator_build_identity =
@@ -4145,7 +4215,7 @@ fn status_with_options_inner(
     }
     if !exact && requested_run_id != record.run_id {
         if let Ok(index) = lifecycle_store.read_cook_index(&requested_run_id) {
-            project_cook_alias_adoption_in_store(&lifecycle_store, &mut record, &index)?;
+            project_cook_alias_adoption_in_store(lifecycle_store, &mut record, &index)?;
             let metadata = record.ensure_metadata_object();
             metadata.insert("cook_alias".to_string(), json!(requested_run_id));
             metadata.insert(
@@ -4184,8 +4254,30 @@ pub fn persisted_status_in_store(
 /// expiry is not terminal after a runner job is recorded: the runner daemon
 /// remains the authority until it reports a terminal job result.
 pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
-    let record = status(run_id)?;
-    let aggregate = store::read_aggregate(&record.run_id).ok();
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    run_status_in_store(&lifecycle_store, run_id, since_cursor)
+}
+
+/// [`run_status`] against explicitly injected durable lifecycle roots.
+///
+/// The reconciliation underneath this projection writes — it is
+/// [`status_in_store`] — so the aggregate and plan it then reads have to come
+/// from the same installation those writes landed in. Projecting a bridge view
+/// from one home's aggregate over another home's freshly reconciled record
+/// would report progress events for a run that never produced them (#7505).
+pub fn run_status_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    since_cursor: Option<u64>,
+) -> Result<AgentTaskRunStatus> {
+    let record = status_in_store(
+        lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )?
+    .record;
+    let aggregate = lifecycle_store.read_aggregate(&record.run_id).ok();
     let (events, artifact_refs) = match aggregate.as_ref() {
         Some(aggregate) => {
             let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
@@ -4199,7 +4291,7 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
             (events, record.artifact_refs.clone())
         }
     };
-    let candidate = load_plan_for_execution(&record.run_id)
+    let candidate = load_plan_for_execution_in_store(lifecycle_store, &record.run_id)
         .ok()
         .and_then(|plan| {
             (plan.tasks.len() > 1).then(|| {
@@ -4256,10 +4348,29 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
 }
 
 pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    list_records_in_store(&lifecycle_store)
+}
+
+/// [`list_records`] against explicitly injected durable lifecycle roots.
+///
+/// The snapshot enumeration and the per-record refresh must name the same
+/// installation: this refreshes through [`status_in_store`], which writes, so
+/// enumerating one home's records and reconciling them against another's would
+/// terminalize, expire, and reproject runs that do not exist in the home the
+/// caller asked about (#7505).
+pub fn list_records_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<Vec<AgentTaskRunRecord>> {
     let mut records = Vec::new();
-    for record in store::read_records()? {
-        if let Ok(record) = status(&record.run_id) {
-            records.push(record);
+    for record in lifecycle_store.read_records()? {
+        if let Ok(record) = status_in_store(
+            lifecycle_store,
+            &record.run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        ) {
+            records.push(record.record);
             // Discovery health owns malformed-record reporting. A transient
             // status refresh failure must not reintroduce stderr-only state.
         }
@@ -4278,11 +4389,30 @@ pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
 
 pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
 {
-    let (records, health) = read_records_with_health()?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    list_records_with_health_in_store(&lifecycle_store)
+}
+
+/// [`list_records_with_health`] against explicitly injected durable lifecycle
+/// roots.
+///
+/// The health summary and the refreshed records are two views of one
+/// installation. Reporting discovery health for one home beside records
+/// reconciled in another would attribute malformed-record findings to runs the
+/// caller can read back perfectly well (#7505).
+pub fn list_records_with_health_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
+    let (records, health) = read_records_with_health_in_store(lifecycle_store)?;
     let mut refreshed = Vec::new();
     for record in records {
-        if let Ok(record) = status(&record.run_id) {
-            refreshed.push(record);
+        if let Ok(record) = status_in_store(
+            lifecycle_store,
+            &record.run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        ) {
+            refreshed.push(record.record);
         }
     }
     refreshed.sort_by(|left, right| {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -164,8 +164,9 @@ impl RunnerContinuationProvider for ConnectedRunnerProvider {
         _runner_id: &str,
         _job_id: &str,
     ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
-        // No live snapshot; `reconcile_runner_job_state` treats an error from a
-        // connected runner as "no new progress" and leaves the record running.
+        // No live snapshot; `reconcile_runner_job_state_in_store` treats an
+        // error from a connected runner as "no new progress" and leaves the
+        // record running.
         Err(Error::internal_unexpected(
             "no runner job log snapshot in test",
         ))

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -1040,26 +1040,22 @@ pub fn run_service_worker_operation(run_id: &str, operation: &str) -> Result<(),
     run_service_worker(&request_path)
 }
 
-/// Request cleanup from the execution host recorded by the controller handoff.
-/// The runner command uses its own HOME/data root, so no runner-local path is
-/// ever interpreted by the controller.
-pub(crate) fn reconcile_run_services_on_owner(
-    run_id: &str,
-    owner: Option<&Value>,
-    reason: &str,
-) -> Result<Value, String> {
-    let data_root = homeboy_core::paths::homeboy_data().map_err(|error| error.message)?;
-    reconcile_run_services_on_owner_at(&data_root, run_id, owner, reason)
-}
-
 /// Reconcile service ownership for one run below an explicit controller data
-/// root.
+/// root. Request cleanup from the execution host recorded by the controller
+/// handoff; the runner command uses its own HOME/data root, so no runner-local
+/// path is ever interpreted by the controller.
 ///
 /// Only the *local* branch reads a root at all: the runner branch dispatches
 /// commands the runner interprets against its own HOME. Splitting them here is
 /// what lets a rooted cancellation prove its local service ledger was reaped in
 /// the same installation it wrote the terminal record into, instead of reaping
 /// whichever ledger the process environment happened to point at (#7505).
+///
+/// The ambient `reconcile_run_services_on_owner` that used to resolve
+/// `paths::homeboy_data()` for callers is gone: both remaining callers —
+/// rooted cancellation and rooted lost-job terminalization — hold the lifecycle
+/// store whose record they are about to replace, and reaping a different home's
+/// ledger than the one that record lives in is exactly the split #7505 forbids.
 pub(crate) fn reconcile_run_services_on_owner_at(
     data_root: &Path,
     run_id: &str,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -831,10 +831,12 @@ fn read_controller_plan_in_store(
 /// Controller lifecycle operations resolve the plan from their durable run
 /// identity. `AgentTaskRunRecord::plan_path` can be runner-local transport
 /// evidence after a Lab projection and is never controller execution authority.
-pub(super) fn read_controller_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
-    read_controller_plan_for_execution_in_store(&default_store()?, run_id)
-}
-
+///
+/// There is no ambient `store::` shim for this any more: the migration branch
+/// below rewrites `plan.json`, so the last caller —
+/// `load_plan_for_execution` — now resolves one store and hands it here rather
+/// than letting the Cook-alias resolution and the plan rewrite land in
+/// separately resolved homes (#7505).
 fn read_controller_plan_for_execution_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,


### PR DESCRIPTION
## Summary

**`status_in_store` ships.** It has been the campaign's last big holdout — blocking **~100 test migrations** — and three prior slices each rooted a dependency and declined to ship, correctly.

```rust
pub fn status_in_store(&AgentTaskLifecycleStore, run_id, options, exact) -> Result<AgentTaskStatusOutcome>
```

`status`, `status_with_options`, `exact_status` keep their **exact** signatures as thin ambient wrappers. `status_with_options_inner` is deleted.

Also rooted, all previously blocked behind it: `run_status_in_store`, `list_records_in_store`, `list_records_with_health_in_store`, `load_plan_for_execution_in_store`, `terminalize_lost_accepted_lab_job_in_store`, `reconcile_runner_job_state_in_store`, `reconcile_pending_runner_submission_intent_in_store`.

## `status` is not a read — and everything now follows the store

**13 direct `lifecycle_store.write_record` sites** in the body, plus writes inside every rooted callee — the deferred-candidate reconciler, handoff expiry, submission-intent replay, terminal runner-event projection, the cancellation reconciler, the runner-job reconciler, both terminal artifact/model projections, `project_cook_alias_adoption_in_store`, and `enqueue_terminal_continuation`. **~20+ total, zero ambient.**

**Both advisory locks confirmed on the injected store:** `DeferredCandidateLock` at `run_dir/deferred-candidate.lock`, and `LabHandoffLock::lock_in_store` at `run_dir/lab-handoff.lock`, reached via both the expiry and acceptance paths.

Verified mechanically: the 301-line body contains **no** `default_store(`, `store::`, `paths::homeboy`, or `from_current_environment`. All 29 free-function callees were enumerated and the nine non-`_in_store` ones individually confirmed to be pure record mutators.

## The Cook recipe cross-kind decision: derive, don't pair

<callout accent="#3b82f6">
`CookRecipeStore` carries **exactly one field** — a data root — and every path it resolves hangs off it. **There is no information in a `CookRecipeStore` that is not already in `lifecycle_store.data_root()`.**

So a second store *parameter* cannot add safety. It can only add a way for the two to disagree — and a caller passing a mismatched pair would enqueue a Cook continuation for a run whose record lives in another home, **with nothing failing**.

Derivation makes that unrepresentable rather than merely discouraged. `KNOWN_MIXED_STORE_FUNCTIONS` exists for a second store carrying information you *cannot* derive. This is not that case, so **no allowlist row was added.**
</callout>

The derivation was verified *exact*, not approximate: `CookRecipeStore::from_current_data_root()` → `paths::homeboy_data()`; `AgentTaskLifecycleStore::from_environment()` → `PathRoots::from_environment()`, whose `.data` is that same function. Byte-identical for the ambient wrappers.

`validate_recipe_attempt_record` turned out **not to be recipe-store work at all** — it reads the *controller plan*, which is lifecycle state. It now takes a plan from `load_controller_plan_in_store`, chosen over `store.read_controller_plan` specifically to preserve the alias-resolution step the original had.

## `substantive_candidate_in_store` — the premise was wrong, and I'd rather report that

I removed the allowlist row and ran the scanner to get the real finding rather than assume:

```
store::           the ambient root a store:: free shim resolves for itself
exact_record(     the ambient half of the exact_record pair
read_aggregate(   the ambient half of the read_aggregate pair
```

All three come **entirely from the `None` arm** of its `Option<&AgentTaskLifecycleStore>` signature, fed by the ambient `select_cook_candidate` callers. **It never depended on `status`.** Closing it means rooting the Cook-candidate selection spine and accepting that `substantive_candidate` — which returns `Option` — would silently degrade a store-resolution failure to `None`. That is a real behaviour decision and a separate slice. **Row left in place.**

## Scanner: 7/7, and the pass is stronger than before

On `origin/main`, `status` was a scanner *base* but **not** a registered wrapper. It is now — along with `run_status`, `list_records`, `list_records_with_health`, `load_plan_for_execution`. So `_in_store` bodies are checked for `status(` **for the first time**, and none contains it.

**Naming trap hit and handled** (lesson 5 from #12667): giving `status` an `_in_store` sibling registers the bare name as an ambient wrapper, and the crate also has `agent_task_batch::status`, `agent_task_controller_service::status`, `execution::status`, `AgentTaskFanoutSupervisor::status`. Verified empirically that the scanner still passes; residual false-positive risk is flagged in the commit body for the next slice.

## Dead wrappers — this bit, as warned

Three orphans found and removed, including `lifecycle_store::read_controller_plan_for_execution` (`pub(super)`, which **would have been a `dead_code` error under `-D warnings`**). Every `store::X` shim that stopped being called was re-grepped to confirm none lost its last caller.

`terminalize_lost_accepted_lab_job_in_store` and `reconcile_runner_job_state_in_store` deliberately have **no** ambient wrapper — their only callers are rooted, and keeping one would be dead code (the first is also destructive).

<callout accent="#f59e0b">
**Not compiled, not run.** Highest borrow risk: `status_in_store`'s ~300-line body converts `&lifecycle_store` (owned) to `lifecycle_store` (borrowed) at 10 sites mechanically — though nothing in the diff extends a borrow's lifetime.

One behavioural nuance reasoned but not executed: `list_records` previously refreshed via `status`, which resolves a Cook alias. It still does, through `status_in_store(…, exact: false)` — `exact: false` was preserved everywhere the old code used `status`.

**The ~100 tests this unblocks were not run.** CI is the arbiter.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation, cross-kind analysis, scanner verification. Review by hand.

Refs #7505
