### PR TITLE
Fix archive replay process contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
@@ -200,9 +200,7 @@ fn start_or_reconcile_worker_with_retry(
             })
     }
     #[cfg(not(test))]
-    let worker = std::env::var_os("HOMEBOY_POSTPROCESS_WORKER")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| std::env::current_exe().expect("current Homeboy executable"));
+    let worker = postprocess_worker_executable();
     #[cfg(not(test))]
     let child = Command::new(worker)
         .args(["self", "postprocess-worker", "--request"])
@@ -252,6 +250,24 @@ fn start_or_reconcile_worker_with_retry(
     }
     #[cfg(not(test))]
     Err("artifact postprocess worker did not complete before scheduler wait limit".to_string())
+}
+
+fn postprocess_worker_executable() -> PathBuf {
+    let configured = std::env::var_os("HOMEBOY_POSTPROCESS_WORKER").map(PathBuf::from);
+    // Archive-replayed integration tests execute from a rooted helper copy while
+    // their compile-time override can still name the discarded build output.
+    // Prefer the configured executable when it exists; otherwise use the live
+    // test helper path inherited by the child.
+    if let Some(worker) = configured.as_ref().filter(|worker| worker.is_file()) {
+        return worker.clone();
+    }
+    if let Some(worker) = std::env::var_os("CARGO_BIN_EXE_homeboy")
+        .map(PathBuf::from)
+        .filter(|worker| worker.is_file())
+    {
+        return worker;
+    }
+    configured.unwrap_or_else(|| std::env::current_exe().expect("current Homeboy executable"))
 }
 
 /// A restarted scheduler must adopt the durable worker it finds. The worker owns

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -81,6 +81,18 @@ fn is_unsupervised_local_cook(cli: &Cli) -> bool {
         && !consume_local_cook_launch_token()
 }
 
+fn automatic_local_cook_needs_supervision(cli: &Cli, provider_placement: Option<&str>) -> bool {
+    cli.placement == homeboy::cli_surface::Placement::Auto
+        && provider_placement == Some("local")
+        && matches!(
+            &cli.command,
+            Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+                command: crate::commands::agent_task::AgentTaskCommand::Cook(cook),
+            }) if !cook.preview
+        )
+        && !consume_local_cook_launch_token()
+}
+
 fn consume_local_cook_launch_token() -> bool {
     let (Some(token), Some(path)) = (
         std::env::var_os(LOCAL_COOK_LAUNCH_TOKEN_ENV),
@@ -171,7 +183,9 @@ pub(super) fn intercept_local_detached_cook(
     provider_placement: Option<&str>,
     provider_runner_id: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
-    if !is_unsupervised_local_cook(cli) {
+    if !is_unsupervised_local_cook(cli)
+        && !automatic_local_cook_needs_supervision(cli, provider_placement)
+    {
         return Ok(None);
     }
     // Diagnostics only: an attached local Cook shares this client's lifetime and

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -822,6 +822,9 @@ pub(super) fn execute_command_with_stdin_source_timeout(
     source: StdinSource,
     timeout: Duration,
 ) -> CommandOutput {
+    // A caller supplies bytes specifically for this child. Command defaults to
+    // inheriting stdin, which leaves no ChildStdin for the pump to write.
+    cmd.stdin(std::process::Stdio::piped());
     let started = Instant::now();
     let mut child = match cmd.spawn() {
         Ok(child) => child,


### PR DESCRIPTION
## Summary
- pipe caller-provided stdin into timed SSH child processes
- resolve postprocess workers from an existing rooted executable during archive replay
- supervise automatically routed local Cooks independently of the foreground client

## Verification
- `cargo test -p homeboy --test postprocess_worker_startup`
- `cargo test -p homeboy --test cook_lab_handoff_test foreground_local_cook_survives_client_termination_with_artifacts -- --exact`
- `cargo test -p homeboy-core small_secret_stdin_payload_completes_successfully`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Supports #12596 and addresses failures observed in [archive replay run 32172107976](https://github.com/Extra-Chill/homeboy/actions/runs/32172107976).

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate the replay failures, implement the fixes, and run focused verification. Chris Huber reviewed and remains responsible for the changes.