### PR TITLE
Root the logs, health, and aggregate-source surface

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -1,5 +1,5 @@
 use super::*;
-use homeboy_core::observation::{ObservationStore, RunRecord};
+use homeboy_core::observation::RunRecord;
 
 pub(crate) const HEALTH_SAMPLE_LIMIT: usize = 20;
 const QUARANTINE_KEY: &str = "agent_task_lifecycle_quarantine";
@@ -69,10 +69,53 @@ pub(crate) fn record_health_item(
 }
 
 pub fn record_health_summary() -> Result<AgentTaskRecordHealthSummary> {
-    Ok(store::read_records_with_health()?.1)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_health_summary_in_store(&lifecycle_store)
+}
+
+/// [`record_health_summary`] against explicitly injected durable lifecycle
+/// roots.
+///
+/// This one really is a read — the summary is the health half of the bounded
+/// registry snapshot — but it is the diagnostic an operator reads *before*
+/// running [`reconcile_record_health_in_store`], which writes. A summary
+/// counted in one home over a repair applied in another is the shape #7505
+/// exists to stop.
+pub fn record_health_summary_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<AgentTaskRecordHealthSummary> {
+    Ok(lifecycle_store.read_records_with_health()?.1)
+}
+
+/// Parse a durable observation row without the supported-schema guard.
+///
+/// This is a pure `RunRecord` -> typed-record conversion: it opens no store and
+/// resolves no root, so calling it from a rooted body is not an ambient reach.
+/// It exists only so [`reconcile_record_health_in_store`] never has to name the
+/// `store::` shim path, which is how the #7505 scanner recognises a body that
+/// manufactured its own root — and which would be a false positive here.
+fn legacy_record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    store::record_from_run_allowing_legacy_schema(run)
 }
 
 pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconciliationReport> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_record_health_in_store(&lifecycle_store, dry_run)
+}
+
+/// [`reconcile_record_health`] against explicitly injected durable lifecycle
+/// roots.
+///
+/// Despite reading like a report, this writes on every non-dry-run pass: it
+/// commits migrated records and stamps quarantine metadata onto rows it cannot
+/// repair. The scan that decides *which* rows to touch therefore has to read
+/// the same observation database those writes land in, and the plan it consults
+/// to decide whether a row is reconstructable has to come from the same roots
+/// as the record it reconstructs (#7505).
+pub fn reconcile_record_health_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    dry_run: bool,
+) -> Result<AgentTaskRecordReconciliationReport> {
     let mut report = AgentTaskRecordReconciliationReport {
         schema: AGENT_TASK_RECORD_RECONCILIATION_SCHEMA.to_string(),
         dry_run,
@@ -81,7 +124,7 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
         quarantined: 0,
         records: Vec::new(),
     };
-    for run in store::observation_runs()? {
+    for run in lifecycle_store.observation_runs()? {
         let Err(item) = diagnose_run(&run) else {
             continue;
         };
@@ -100,7 +143,7 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
                 AgentTaskRecordHealthReason::MissingMetadata
                     | AgentTaskRecordHealthReason::MalformedMetadata
             )
-            && store::read_controller_plan(&run.id).is_ok();
+            && lifecycle_store.read_controller_plan(&run.id).is_ok();
         let action = if reconstructable || item.reason == AgentTaskRecordHealthReason::LegacySchema
         {
             "migrate"
@@ -120,10 +163,10 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
             continue;
         }
         if reconstructable {
-            store::write_record(&reconstruct_record(&run)?)?;
+            lifecycle_store.write_record(&reconstruct_record_in_store(lifecycle_store, &run)?)?;
             report.migrated += 1;
         } else if item.reason == AgentTaskRecordHealthReason::LegacySchema {
-            let mut record = store::record_from_run_allowing_legacy_schema(&run)?;
+            let mut record = legacy_record_from_run(&run)?;
             let original = serde_json::to_value(&record).unwrap_or(Value::Null);
             record.schema = schemas::RUN.to_string();
             record.lifecycle.schema = RUN_LIFECYCLE_RECORD_SCHEMA.to_string();
@@ -131,18 +174,26 @@ pub fn reconcile_record_health(dry_run: bool) -> Result<AgentTaskRecordReconcili
                 "lifecycle_reconstruction".to_string(),
                 json!({ "source": "legacy_typed_record", "original_record": original }),
             );
-            store::write_record(&record)?;
+            lifecycle_store.write_record(&record)?;
             report.migrated += 1;
         } else {
-            quarantine(&run, &item)?;
+            quarantine_in_store(lifecycle_store, &run, &item)?;
             report.quarantined += 1;
         }
     }
     Ok(report)
 }
 
-fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
-    let plan = store::read_controller_plan(&run.id)?;
+/// Rebuild a typed record from an observation row and its durable plan.
+///
+/// There is deliberately no ambient sibling: the plan this reads and the
+/// `plan_path` it stamps into the reconstructed record are two halves of one
+/// answer, and the caller is about to commit that record into the same store.
+fn reconstruct_record_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run: &RunRecord,
+) -> Result<AgentTaskRunRecord> {
+    let plan = lifecycle_store.read_controller_plan(&run.id)?;
     let state = match run.status.as_str() {
         "pass" => AgentTaskRunState::Succeeded,
         "fail" => AgentTaskRunState::Failed,
@@ -170,7 +221,8 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
         state,
         submitted_at: run.started_at.clone(),
         updated_at: timestamp,
-        plan_path: store::run_dir(&run.id)?
+        plan_path: lifecycle_store
+            .run_dir(&run.id)
             .join("plan.json")
             .display()
             .to_string(),
@@ -201,7 +253,21 @@ fn reconstruct_record(run: &RunRecord) -> Result<AgentTaskRunRecord> {
     })
 }
 
-fn quarantine(run: &RunRecord, item: &AgentTaskRecordHealthItem) -> Result<()> {
+/// Stamp quarantine evidence onto a row that cannot be repaired.
+///
+/// This used to open `ObservationStore::open_initialized()`, which roots the
+/// database at the ambient data root and artifact resolution at the ambient
+/// artifact root — so a reconciliation scanning an injected store could stamp
+/// quarantine metadata onto a row in a different home, or onto no row at all,
+/// without failing. `open_observation_initialized` binds both roots from the
+/// injected store. It is also lifecycle-mode, which defers report-only startup
+/// artifact maintenance; that maintenance is unrelated repair work, and it is
+/// the opener every other durable record write in this crate already uses.
+fn quarantine_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run: &RunRecord,
+    item: &AgentTaskRecordHealthItem,
+) -> Result<()> {
     let mut metadata = run.metadata_json.clone();
     if !metadata.is_object() {
         metadata = json!({ "homeboy_original_metadata": metadata });
@@ -215,8 +281,10 @@ fn quarantine(run: &RunRecord, item: &AgentTaskRecordHealthItem) -> Result<()> {
             "original_metadata": run.metadata_json,
         }),
     );
-    ObservationStore::open_initialized()?.upsert_imported_run_preserving_terminal(&RunRecord {
-        metadata_json: metadata,
-        ..run.clone()
-    })
+    lifecycle_store
+        .open_observation_initialized()?
+        .upsert_imported_run_preserving_terminal(&RunRecord {
+            metadata_json: metadata,
+            ..run.clone()
+        })
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2971,13 +2971,34 @@ pub(crate) fn record_provider_execution_cleanup_elapsed_in_store(
 }
 
 #[cfg(any(test, feature = "test-support"))]
-pub fn rewrite_record_for_test<F>(run_id: &str, mut rewrite: F) -> Result<AgentTaskRunRecord>
+pub fn rewrite_record_for_test<F>(run_id: &str, rewrite: F) -> Result<AgentTaskRunRecord>
 where
     F: FnMut(&mut AgentTaskRunRecord),
 {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    rewrite_record_for_test_in_store(&lifecycle_store, run_id, rewrite)
+}
+
+/// [`rewrite_record_for_test`] against explicitly injected durable lifecycle
+/// roots.
+///
+/// The read and the write are one read-modify-write, so they cannot be allowed
+/// to land in different homes: a rewrite that read the ambient record and
+/// committed it into the injected store would overwrite the fixture with a
+/// record built from somebody else's state, and every later read from the
+/// injected store would still succeed (#7505).
+#[cfg(any(test, feature = "test-support"))]
+pub fn rewrite_record_for_test_in_store<F>(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    mut rewrite: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnMut(&mut AgentTaskRunRecord),
+{
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     rewrite(&mut record);
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }
 
@@ -5294,7 +5315,25 @@ pub fn read_attempt_aggregate_in_store(
 }
 
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
-    let selected_run_id = match cook_index(run_id).and_then(|_| select_cook_candidate(run_id)) {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    aggregate_source_in_store(&lifecycle_store, run_id)
+}
+
+/// [`aggregate_source`] against explicitly injected durable lifecycle roots.
+///
+/// This reads like an accessor and is not one. Candidate selection consults the
+/// Cook index, and the `status_in_store` below it is the full reconciliation —
+/// two advisory locks and roughly twenty durable write sites. Selecting an
+/// attempt from one home's Cook index, reconciling it into another, and then
+/// serializing a third home's aggregate would answer with bytes no single
+/// installation ever held, without failing while it did (#7505).
+pub fn aggregate_source_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<(String, PathBuf)> {
+    let selected_run_id = match cook_index_in_store(lifecycle_store, run_id)
+        .and_then(|_| select_cook_candidate_in_store(lifecycle_store, run_id))
+    {
         Ok(selection) if selection.incomplete => {
             return Err(Error::validation_invalid_argument(
                 "cook_id",
@@ -5306,7 +5345,13 @@ pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
         Ok(selection) if !selection.run_id.is_empty() => selection.run_id,
         _ => run_id.to_string(),
     };
-    let record = status(&selected_run_id)?;
+    let record = status_in_store(
+        lifecycle_store,
+        &selected_run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )?
+    .record;
     record.aggregate_path.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -5318,14 +5363,16 @@ pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
             None,
         )
     })?;
-    let aggregate = store::read_aggregate(&record.run_id)?;
+    // `record.run_id` is already resolved, so these are the store's own exact
+    // reads rather than the alias-resolving `lifecycle_ops` wrappers.
+    let aggregate = lifecycle_store.read_aggregate(&record.run_id)?;
     let raw = serde_json::to_string_pretty(&aggregate).map_err(|error| {
         Error::internal_json(
             error.to_string(),
             Some(format!("serialize agent-task aggregate {}", record.run_id)),
         )
     })?;
-    let path = store::aggregate_path(&record.run_id)?;
+    let path = lifecycle_store.aggregate_path(&record.run_id);
     Ok((raw, path))
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
@@ -8,15 +8,43 @@ use serde_json::Value;
 use super::*;
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
-    logs_with_raw(run_id, false)
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    logs_in_store(&lifecycle_store, run_id)
+}
+
+/// [`logs`] against explicitly injected durable lifecycle roots.
+pub fn logs_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunLog> {
+    logs_with_raw_in_store(lifecycle_store, run_id, false)
 }
 
 pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    logs_with_raw_in_store(&lifecycle_store, run_id, include_raw)
+}
+
+/// [`logs_with_raw`] against explicitly injected durable lifecycle roots.
+///
+/// This projection is a genuine read: the Cook-alias resolution, the record
+/// read, and the aggregate read are the only durable touches, and every event
+/// helper below it works from the record and aggregate already in hand. Both
+/// reads have to name the same installation anyway — resolving the record in
+/// one home and its aggregate in another would report the event stream of a run
+/// that never produced it, and would do so without failing (#7505).
+pub fn logs_with_raw_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    include_raw: bool,
+) -> Result<AgentTaskRunLog> {
     // Logs are terminal inspection, not runner reconciliation. The durable
     // record remains readable when a runner is unavailable or wedged.
-    let record = persisted_status(run_id)?;
+    let record = persisted_status_in_store(lifecycle_store, run_id)?;
     let run_id = record.run_id.clone();
-    let (events, artifact_refs, raw_events) = match store::read_aggregate(&run_id) {
+    // `run_id` is already the resolved identity, so this is the store's own
+    // exact aggregate read rather than the alias-resolving lifecycle_ops one.
+    let (events, artifact_refs, raw_events) = match lifecycle_store.read_aggregate(&run_id) {
         Ok(aggregate) => {
             let refs = artifact_refs_for_outcomes(&aggregate.outcomes);
             (aggregate.events, refs, Vec::new())

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -615,6 +615,17 @@ impl AgentTaskLifecycleStore {
         Ok(self.open_observation_readonly()?.get_run(run_id)?.is_some())
     }
 
+    /// This store's bounded page of raw durable agent-task observation rows.
+    ///
+    /// Record-health reconciliation classifies rows it cannot parse into typed
+    /// records, so it cannot go through [`AgentTaskLifecycleStore::read_records`],
+    /// which silently drops them. It needs the raw rows — and it needs them from
+    /// the same roots it is about to commit the repaired record, or the
+    /// quarantine stamp, back into (#7505).
+    pub(crate) fn observation_runs(&self) -> Result<Vec<RunRecord>> {
+        observation_runs_bounded_in_store(self, 1000)
+    }
+
     /// Read this store's bounded durable registry snapshot with the health
     /// summary of the records that could not be parsed.
     pub fn read_records_with_health(
@@ -804,10 +815,11 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
     Ok(plan)
 }
 
-pub(super) fn read_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
-    read_controller_plan_in_store(&default_store()?, run_id)
-}
-
+/// The controller-owned plan is read only through a resolved store now: the
+/// last ambient caller was record-health reconciliation, which had to read the
+/// plan and commit the record it reconstructs from that plan into the same home
+/// (#7505). There is deliberately no `store::read_controller_plan` shim left to
+/// reach for.
 fn read_controller_plan_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -1516,11 +1528,6 @@ fn read_retry_successors_in_store(
     page.runs.iter().map(record_from_run).collect()
 }
 
-pub(super) fn read_records_with_health(
-) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    default_store()?.read_records_with_health()
-}
-
 pub(super) fn read_records_with_health_bounded(
     limit: usize,
 ) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
@@ -1549,15 +1556,10 @@ fn records_with_health(
     Ok((records, health))
 }
 
-pub(super) fn observation_runs() -> Result<Vec<RunRecord>> {
-    observation_runs_bounded(1000)
-}
-
-fn observation_runs_bounded(limit: usize) -> Result<Vec<RunRecord>> {
-    let store = ObservationStore::open_readonly()?;
-    store.list_runs(bounded_agent_task_filter(limit))
-}
-
+/// Raw durable rows are read only through a resolved store now. The last
+/// ambient caller was record-health reconciliation, whose scan decides which
+/// rows to migrate or quarantine and must therefore read the same observation
+/// database those writes land in (#7505).
 fn observation_runs_bounded_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     limit: usize,


### PR DESCRIPTION
## Summary

The read/diagnostic surface three migration agents named as blocking: `logs`, `logs_with_raw`, `record_health_summary`, `reconcile_record_health`, `aggregate_source`, `rewrite_record_for_test`. All rooted.

<callout accent="#ef4444">
## Three of the six "reads" are writes

- **`reconcile_record_health`** commits migrated records via `write_record` — which takes the config lock, **renews the workspace owner lease, and projects terminal workspace authority** — and stamps quarantine metadata.
- **`aggregate_source`** calls `status`, i.e. `status_in_store`: full reconciliation, **two advisory locks, ~20 durable write sites**. Plus a Cook-index consult. **Three separate root consumers in one "read".**
- **`rewrite_record_for_test`** is read-modify-write.

Genuine reads: `logs`/`logs_with_raw` and `record_health_summary`. One caveat even there — `read_aggregate` goes through `open_observation_initialized`, which **creates the directory and runs schema migrations** if the DB is absent. Not side-effect-free on a fresh root, though it writes no lifecycle state.
</callout>

## Two careful choices worth review

**`logs_in_store` uses `store.read_aggregate(&run_id)` directly, not `lifecycle_ops::read_aggregate_in_store`** — the run id is already resolved at that point, so the alias-resolving variant would have **double-resolved**.

**`quarantine` opener changed**, and it is the only semantic delta: it used `ObservationStore::open_initialized()`; the rooted version uses `open_initialized_for_lifecycle_in_roots`. Besides binding both roots, that is *lifecycle mode*, which defers report-only startup artifact maintenance — unrelated startup repair, and the opener every other durable record write in this crate already uses. Documented at the call site.

`AgentTaskLifecycleStore::observation_runs()` was added for the raw-row scan, because `read_records` **silently drops exactly the malformed rows the reconciler exists to classify.**

## Contended file

`lifecycle_ops.rs` touched in **two regions only**, no reformatting elsewhere: `rewrite_record_for_test` (2973-3003) and `aggregate_source` (5317-5378). One incidental fix — dropped a now-unused `mut`, which `-D warnings` would reject.

## A pre-existing condition, reported not fixed

`store::read_records_with_health_bounded`, `read_all_records_with_health`, and `write_record_locked_without_terminal_projection` **already have zero callers on `origin/main`**, a released CI-green commit. So either the gate tolerates `dead_code` or main is warning-dirty. Only what this change orphaned was cleaned up; those three were left alone as a pre-existing condition.

## Verification

**Scanner 7/7**, before and after. Zero new duplicate definitions vs `origin/main`. **Body-scoped shadow scan** of every new `*_in_store` function — independently re-run by the orchestrating session — found **no** `default_store(`, `from_current_environment`, `paths::homeboy*`, or `store::` inside any rooted body.

<callout accent="#f59e0b">
**Not compiled, not run.** rustfmt proves every touched file parses. CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and blocker analysis. Review by hand.

Refs #7505