### PR TITLE
Root the handoff reconciliation and runner projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -10,6 +10,34 @@ use super::*;
 use homeboy_core::api_jobs::RemoteRunnerJobRequest;
 
 pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
+    reconcile_active_lab_runner_handoffs_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+    )
+}
+
+/// The store-rooted counterpart of [`reconcile_active_lab_runner_handoffs`].
+///
+/// This is a queue scan that mutates every row it selects, so the scan and its
+/// consequences have to name one installation. The queue itself is read from
+/// this store's own observation database, and each of the three follow-ups is
+/// dispatched to the rooted sibling that takes its lock and commits its record
+/// in the same home:
+///
+/// * `reconcile_pending_runner_submission_intent_in_store` replays a submission
+///   key and binds the acceptance it gets back;
+/// * `expire_unaccepted_lab_handoff_in_store` takes `LabHandoffLock` on this
+///   store's `run_dir` and terminalizes;
+/// * `status_in_store` takes two advisory locks of its own and has roughly
+///   twenty durable write sites.
+///
+/// Selecting a run from one installation's queue and then expiring or
+/// terminalizing it in another is the exact shape #7505 exists to stop: the
+/// handoff lock would be held where nobody contends for it, so an acceptance
+/// racing this expiry would not be excluded by it, and the terminal record
+/// would land beside a queue row that still reads `Running`.
+pub fn reconcile_active_lab_runner_handoffs_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> Result<usize> {
     let now = chrono::Utc::now();
     let mut accepted_run_ids = Vec::new();
     let mut pending_intent_run_ids = Vec::new();
@@ -17,7 +45,7 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
     // Scan the stored snapshot so this operation owns and reports its expiry
     // mutations. `list_records` refreshes through `status`, which also expires
     // pending handoffs as a user-visible read-side convergence guarantee.
-    for record in store::read_records()? {
+    for record in lifecycle_store.read_records()? {
         if record.state == AgentTaskRunState::Running && record.has_accepted_lab_handoff() {
             accepted_run_ids.push(record.run_id);
         } else if has_pending_runner_submission_intent(&record) {
@@ -29,20 +57,30 @@ pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
 
     let mut reconciled = 0;
     for run_id in pending_intent_run_ids {
-        if reconcile_pending_runner_submission_intent(&run_id)? {
+        if reconcile_pending_runner_submission_intent_in_store(lifecycle_store, &run_id)? {
             reconciled += 1;
         }
     }
     for run_id in expired_run_ids {
-        if expire_unaccepted_lab_handoff(&run_id)? {
+        if expire_unaccepted_lab_handoff_in_store(lifecycle_store, &run_id)? {
             reconciled += 1;
         }
     }
     for run_id in accepted_run_ids {
         // `status` owns snapshot validation, persistence, and the exact
         // no-PID daemon-loss projection. A bad remote record must not prevent
-        // unrelated activity from being listed.
-        if status(&run_id).is_ok() {
+        // unrelated activity from being listed. This is the rooted body the
+        // ambient `status` entry point delegates to, with its own defaults:
+        // `AgentTaskStatusOptions::default()` and a Cook-alias-resolving
+        // (non-exact) read, which is exactly what `status` passed.
+        if status_in_store(
+            lifecycle_store,
+            &run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .is_ok()
+        {
             reconciled += 1;
         }
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -158,6 +158,43 @@ pub fn project_terminal_runner_result(
     run_id: &str,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<bool> {
+    project_terminal_runner_result_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of [`project_terminal_runner_result`].
+///
+/// Every durable touch below follows the injected store, and this one has two
+/// distinct commit targets rather than one, which is why leaving any of it
+/// ambient would split it:
+///
+/// * the runner-exec branch finalizes an *observation* row through
+///   `project_terminal_runner_exec_result_in_store`;
+/// * the agent-task branch reads the lifecycle record, binds the pending Lab
+///   handoff (a durable write, through `record_detached_lab_run_in_store` and
+///   its handoff lock on this store's `run_dir`), reads the aggregate to decide
+///   idempotence, and then either projects the terminal lifecycle event or
+///   writes the transport-only terminal record.
+///
+/// The aggregate read is the decision, not a report: comparing against another
+/// home's aggregate would either re-project a result that is already durable
+/// here or skip projecting one because a *different* installation happened to
+/// hold a matching aggregate. This function is the daemon's pre-return
+/// projection for a foreground `runner exec --run-id`, so that mistake would
+/// surface as a terminal command returned over a still-active durable run
+/// (#7505).
+///
+/// The runner-exec branch is opened through `open_observation_maintained`, not
+/// the lifecycle opener, so its startup artifact maintenance is unchanged from
+/// the ambient path it replaced.
+pub fn project_terminal_runner_result_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<bool> {
     if !matches!(
         snapshot.job.status,
         homeboy_core::api_jobs::JobStatus::Succeeded
@@ -169,11 +206,11 @@ pub fn project_terminal_runner_result(
 
     // Ad hoc runner-exec runs are observation records, not agent-task records.
     // Their daemon terminal result is complete without an inner task aggregate.
-    if project_terminal_runner_exec_result(run_id, snapshot)? {
+    if project_terminal_runner_exec_result_in_store(lifecycle_store, run_id, snapshot)? {
         return Ok(true);
     }
 
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     // Bind a still-pending controller handoff to this authoritative terminal
     // snapshot's daemon job before validating identity (issue #9240). An
     // accepted Lab job can reach a terminal daemon snapshot before the
@@ -181,21 +218,26 @@ pub fn project_terminal_runner_result(
     // establishes that identity from the same evidence rather than rejecting a
     // valid terminal snapshot against an empty controller job id. No-ops once
     // the run is already bound.
-    bind_pending_lab_handoff_snapshot(&mut record, snapshot)?;
+    bind_pending_lab_handoff_snapshot_in_store(lifecycle_store, &mut record, snapshot)?;
     validate_runner_job_snapshot(&record, snapshot)?;
     if let Some(event) = terminal_runner_lifecycle_event(&record, snapshot)? {
         let aggregate = projected_runner_aggregate(&record, &event.aggregate);
-        if store::read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
+        if lifecycle_store.read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
             return Ok(false);
         }
-        project_terminal_runner_lifecycle_event(&mut record, snapshot, &event)?;
+        project_terminal_runner_lifecycle_event_in_store(
+            lifecycle_store,
+            &mut record,
+            snapshot,
+            &event,
+        )?;
         return Ok(true);
     }
     if record.state.is_terminal() {
         return Ok(false);
     }
     project_terminal_runner_job_snapshot(&mut record, snapshot);
-    store::write_record(&record)?;
+    lifecycle_store.write_record(&record)?;
     Ok(true)
 }
 
@@ -305,20 +347,15 @@ fn terminal_runner_lifecycle_event(
     ))
 }
 
-fn project_terminal_runner_lifecycle_event(
-    record: &mut AgentTaskRunRecord,
-    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
-    event: &crate::agent_task_lifecycle::agent_task_lifecycle_event::AgentTaskRunPlanLifecycleEvent,
-) -> Result<()> {
-    project_terminal_runner_lifecycle_event_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        record,
-        snapshot,
-        event,
-    )
-}
-
-/// The store-rooted counterpart of [`project_terminal_runner_lifecycle_event`].
+/// Project one terminal runner lifecycle event onto its durable record.
+///
+/// There is deliberately no ambient wrapper any more. Both callers —
+/// `reconcile_runner_job_snapshot_in_store` and
+/// `project_terminal_runner_result_in_store` — are rooted and already hold the
+/// store whose record they are projecting, and this body commits an aggregate,
+/// a record, and an artifact projection. An ambient form would exist only to let
+/// a rooted caller decide from one installation's evidence and commit into
+/// another's (#7505).
 ///
 /// Mirrors `project_persisted_terminal_runner_events_in_store` exactly: the
 /// aggregate path stamped onto the record, the combined aggregate-and-record

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -240,24 +240,17 @@ pub(crate) fn reconcile_transport_proxy_snapshot(
 /// once claimed, so a snapshot polled before the claim legitimately has no
 /// target. Accept an absent target (the expected-Lab handoff is authority) and
 /// only reject a target that names a *different* runner.
-pub(crate) fn bind_pending_lab_handoff_snapshot(
-    record: &mut AgentTaskRunRecord,
-    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
-) -> Result<()> {
-    bind_pending_lab_handoff_snapshot_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        record,
-        snapshot,
-    )
-}
-
-/// The store-rooted counterpart of [`bind_pending_lab_handoff_snapshot`].
 ///
-/// Binding is a durable write — it replaces `record` with whatever
-/// acceptance persisted — so the installation it commits into has to be the one
-/// its caller is reconciling. A binding written to another home would leave the
-/// caller's own record permanently unbound while snapshot validation kept
-/// rejecting a perfectly valid runner job (#7505).
+/// Binding is a durable write — it replaces `record` with whatever acceptance
+/// persisted — so the installation it commits into has to be the one its caller
+/// is reconciling. A binding written to another home would leave the caller's
+/// own record permanently unbound while snapshot validation kept rejecting a
+/// perfectly valid runner job (#7505).
+///
+/// There is deliberately no ambient wrapper any more. Both callers —
+/// `reconcile_runner_job_snapshot_in_store` and
+/// `project_terminal_runner_result_in_store` — are rooted and already hold the
+/// store whose record they are binding.
 pub(crate) fn bind_pending_lab_handoff_snapshot_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
@@ -340,7 +333,8 @@ pub(crate) fn bind_pending_lab_handoff_snapshot_in_store(
 /// record when it has a planned (pre-acceptance) execution intent but no
 /// accepted runner job yet.
 ///
-/// This is the recovery-safe fallback for [`bind_pending_lab_handoff_snapshot`]:
+/// This is the recovery-safe fallback for
+/// [`bind_pending_lab_handoff_snapshot_in_store`]:
 /// it only yields a runner when the execution record is *planned* (not yet
 /// bound to a job id) and names this exact run, so binding a replacement job
 /// cannot latch onto a terminal or mismatched execution record.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -660,10 +660,38 @@ pub fn project_terminal_runner_exec_result(
     run_id: &str,
     snapshot: &RunnerJobLogSnapshot,
 ) -> Result<bool> {
+    project_terminal_runner_exec_result_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of [`project_terminal_runner_exec_result`].
+///
+/// This finalizes an observation run: it reads the row, decides from that row's
+/// own `kind`, terminal status, and artifact-promotion checkpoint whether to
+/// project at all, and then commits the result with `finish_run`. The decision
+/// and the write are the same row, so they have to be the same database — a
+/// projection that read one installation's row and finished another's would
+/// either refuse a valid terminal result or overwrite an unrelated run.
+///
+/// The observation store is opened through
+/// [`AgentTaskLifecycleStore::open_observation_maintained`], not the lifecycle
+/// opener: the ambient body used `ObservationStore::open_initialized()`, which
+/// runs startup artifact maintenance, and this path gates on a durable
+/// artifact-promotion checkpoint. Rooting it through the maintenance-deferring
+/// lifecycle opener would have changed behaviour rather than just its home
+/// (#7505).
+pub(crate) fn project_terminal_runner_exec_result_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    snapshot: &RunnerJobLogSnapshot,
+) -> Result<bool> {
     if !snapshot.job.status.is_terminal() {
         return Ok(false);
     }
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let store = lifecycle_store.open_observation_maintained()?;
     let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
         return Ok(false);
     };

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -1465,13 +1465,15 @@ fn validate_cook_index_attempt_in_store(
     Ok(())
 }
 
-pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
-    default_store()?.read_records()
-}
-
-/// The store-rooted counterpart of [`read_records`], following the same bound
-/// and the same health projection but reading this store's own observation
-/// database instead of `paths::observation_db()`.
+/// The store-rooted body of [`AgentTaskLifecycleStore::read_records`], following
+/// the same bound and the same health projection but reading this store's own
+/// observation database instead of `paths::observation_db()`.
+///
+/// The ambient `read_records()` free shim that used to sit above this is gone.
+/// Its last caller was `reconcile_active_lab_runner_handoffs`, a queue scan that
+/// mutates every row it selects — expiring, terminalizing, and reconciling them
+/// — so it now scans the store it was handed rather than deciding from one
+/// installation's queue and committing into another (#7505).
 fn read_records_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> Result<Vec<AgentTaskRunRecord>> {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -190,6 +190,25 @@ impl AgentTaskLifecycleStore {
         ObservationStore::open_readonly_in_roots(&self.roots)
     }
 
+    /// Open this store's observation database with the same startup artifact
+    /// maintenance the ambient `ObservationStore::open_initialized()` performs.
+    ///
+    /// This is deliberately not [`Self::open_observation_initialized`]. The two
+    /// are not interchangeable: the lifecycle opener defers report-only artifact
+    /// maintenance so a lifecycle transition can proceed while another process
+    /// owns SQLite's writer lock, while this one first reconciles unfinished
+    /// artifact publications and backfills artifact handles. Rooting a caller
+    /// that used the ambient `open_initialized()` therefore has to come here, or
+    /// the reroot would silently change what that caller sees — the hazard
+    /// #12618 recorded against `substantive_candidate_in_aggregate` (#7505).
+    ///
+    /// Like every opener on this store, BOTH roots come from `self`: the
+    /// database below `data` and the artifact tree it indexes below `artifacts`,
+    /// which `PathRoots` carries separately.
+    pub(crate) fn open_observation_maintained(&self) -> Result<ObservationStore> {
+        ObservationStore::open_initialized_in_roots(&self.roots)
+    }
+
     pub fn with_config_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
         homeboy_core::config::with_config_lock_at(self.roots.config(), operation)
     }


### PR DESCRIPTION
## Summary

The reconcile/projection surface. Two files, committed separately.

**`lab_handoff_reconciliation.rs`** — `reconcile_active_lab_runner_handoffs` rooted, 4 hops, **zero new downstream siblings needed** (`read_records`, `reconcile_pending_runner_submission_intent_in_store`, `expire_unaccepted_lab_handoff_in_store`, `status_in_store` all already existed). It was the **last caller** of the `store::read_records()` free shim, which would then have been dead `pub(super)` code and an error under `-D warnings` — deleted, doc folded onto `read_records_in_store`.

**`lifecycle_runner_projection.rs`** — `project_terminal_runner_result` rooted, **6 hops**, requiring two supporting changes that were mandatory rather than optional:

<callout accent="#ef4444">
**`runner_exec.rs`** — the runner-exec branch opened `ObservationStore::open_initialized()` and `finish_run`s the row it just decided from. Leaving it would have been exactly the half-injected shape — **and the scanner cannot see it**, because no `_in_store` sibling existed, so the bare call is not a "wrapper reach".
</callout>

**`lifecycle_store.rs`** — added `open_observation_maintained()`. `open_observation_initialized()` is the *maintenance-deferring* lifecycle opener; the ambient body used the *maintaining* one, and this path gates on a durable artifact-promotion checkpoint. **Swapping openers would have changed behaviour, not just the home** — the hazard #12618 recorded against `substantive_candidate_in_aggregate`. Equivalence for ambient roots was traced through `PathRoots::from_environment()` to the same shared resolver.

## Declined, with reasons

- **`apply_runner_job_terminal_state` takes no store.** It is `#[cfg(test)]` and a pure `&mut AgentTaskRunRecord` mutator — there is nothing to inject. If the real blocker is "I can't call it from an integration test", the fix is a visibility/feature change, not rooting, and doing that blind risks a `dead_code` error under `test-support` without `test`.
- **`reconcile_run` is not in either file** — it lives in `agent_task_service/reconcile.rs`.
- `has_expired_unaccepted_lab_handoff`, `has_accepted_runner_handoff`, `has_recorded_provider_progress`, `run_owes_candidate_follow_up` — read-only predicates whose callers are all outside this crate. **No rooted in-crate caller exists to be split**, so rooting them now would be API surface with no consumer.

## Named next slice

`recover_terminal_transport_proxy_evidence` in `lifecycle_transport_proxy.rs` is a 4-hop ambient body — and **all four rooted siblings already exist**. Clean next slice for whoever owns that file.

## Confirmations

Every write in both rooted bodies follows the injected store. **No lock is derived from `paths::homeboy_data()` on any path touched** — `LabHandoffLock::lock_in_store` and `status_in_store`'s two locks all use the injected store's `run_dir`. `with_runner_continuation` was hit transitively and left process-global per its trust-material role. **`lifecycle_ops.rs`: zero lines touched.**

Three dead wrappers removed, each with exactly one caller — the function that was rerooted.

## Verification

**Scanner 7/7**, before and after. Zero new duplicate definitions vs `origin/main`. **Body-scoped shadow scan** of every new `*_in_store` function — independently re-run by the orchestrating session — found **no** `default_store(`, `from_current_environment`, `paths::homeboy*`, or `store::` inside any rooted body.

<callout accent="#f59e0b">
**Not compiled, not run.** rustfmt proves every touched file parses. CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and blocker analysis. Review by hand.

Refs #7505