### PR TITLE
fix(cook): make initial materialization ownership atomic

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -38,12 +38,13 @@ use super::cook_budget::{
     budget_remaining, execution_budget_usage, reserve_remediation_budget,
     validate_effective_cook_budget, ExecutionBudgetUsage,
 };
+#[cfg(test)]
+use super::cook_pre_execution::materialize_initial_cook_attempt_with_stores;
 use super::cook_pre_execution::{
-    materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores,
-    materialize_initial_cook_attempt_with_stores_outcome, pre_execution_failure_details,
-    pre_execution_failure_phase, pre_execution_failure_report, record_pre_execution_failure,
-    retryable_pre_execution_failure, terminal_executor_matches, with_pre_execution_phase,
-    CookExecutionPreparation,
+    materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores_outcome,
+    pre_execution_failure_details, pre_execution_failure_phase, pre_execution_failure_report,
+    record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
+    with_pre_execution_phase, CookExecutionPreparation,
 };
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
@@ -54,7 +55,7 @@ use super::cook_promotion::{
     refreshed_moving_base_recovery, retryable_provider_discovery_failure,
     retryable_provider_discovery_failure_with_store, CookReportInput, MovingBaseCookRecovery,
 };
-use super::cook_recipe::CookRecipeStore;
+use super::cook_recipe::{CookRecipeStore, InitialRecipeMaterialization};
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
 #[cfg(test)]
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
@@ -4259,26 +4260,26 @@ where
         .map(|record| adopted_attempt_is_ready_for_cook_continuation(&record))
         .transpose()?
         .flatten();
-    let existing_recipe = store.recipe_exists(&options.cook_id);
     // A form-only continuation has already appended and persisted its exact
     // attempt. Re-persisting it as a fresh initial recipe would falsely look
     // like an unsafe post-gate correction because the durable lineage now has
     // more attempts than the caller's one-attempt input.
-    let recipe = if existing_recipe {
-        let recipe = store.load_recipe(&options.cook_id)?;
-        if recipe
-            .attempts
-            .iter()
-            .any(|attempt| attempt.run_id == options.initial_run_id)
-        {
-            recipe
-        } else {
-            store.persist_initial_recipe(&options)?
-        }
-    } else {
+    if !store.recipe_exists(&options.cook_id) {
         lifecycle_store.require_detached_cook_handoff_fence_open(&options.cook_id)?;
-        store.persist_initial_recipe(&options)?
+    }
+    let recipe_materialization = match store.load_recipe(&options.cook_id) {
+        Ok(recipe)
+            if recipe
+                .attempts
+                .iter()
+                .any(|attempt| attempt.run_id == options.initial_run_id) =>
+        {
+            InitialRecipeMaterialization::reused(recipe)
+        }
+        Ok(_) | Err(_) => store.persist_initial_recipe_with_outcome(&options)?,
     };
+    let existing_recipe = !recipe_materialization.created;
+    let recipe = recipe_materialization.recipe;
     // A recipe can survive an interruption before its first lifecycle record.
     // Resume from the validated durable inputs so ambient transport state cannot
     // turn replay into a conflicting new cook.
@@ -4322,8 +4323,12 @@ where
     // Recipe persistence and lifecycle materialization are a recoverable saga.
     // Complete it before any capacity, workspace, or provider-facing work so a
     // controller interruption leaves a status-addressable, resumable attempt.
-    let materialized_by_invocation =
-        materialize_initial_cook_attempt_with_stores_outcome(store, lifecycle_store, &options)?;
+    let materialized_by_invocation = materialize_initial_cook_attempt_with_stores_outcome(
+        store,
+        lifecycle_store,
+        &options,
+        recipe_materialization.created,
+    )?;
     // A persisted recipe can replace the just-validated inputs. Re-check its
     // workspace and candidate topology before it reaches transport preparation
     // or a resumed attempt.

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3994,7 +3994,6 @@ where
     S: CookSideEffectService,
 {
     let failure_options = options.clone();
-    let recipe_existed = store.recipe_exists(&failure_options.cook_id);
     let result = match run_cook_with_boundaries_observed_inner_with_stores(
         store,
         lifecycle_store,
@@ -4009,7 +4008,16 @@ where
             // Once the attempt exists, a controller-side validation failure has
             // not reached a provider and must retain the pre-execution contract.
             if let Ok(mut record) = lifecycle_store.read_record(&failure_options.initial_run_id) {
-                if !recipe_existed
+                let owns_materialized_attempt = store
+                    .load_recipe(&failure_options.cook_id)
+                    .ok()
+                    .is_some_and(|recipe| {
+                        recipe.attempts.iter().any(|attempt| {
+                            attempt.run_id == failure_options.initial_run_id
+                                && attempt.plan == failure_options.initial_plan
+                        })
+                    });
+                if owns_materialized_attempt
                     && store.data_root() == lifecycle_store.data_root()
                     && record.state == agent_task_lifecycle::AgentTaskRunState::Queued
                 {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -40,9 +40,10 @@ use super::cook_budget::{
 };
 use super::cook_pre_execution::{
     materialize_cook_attempt_with_stores, materialize_initial_cook_attempt_with_stores,
-    pre_execution_failure_details, pre_execution_failure_phase, pre_execution_failure_report,
-    record_pre_execution_failure, retryable_pre_execution_failure, terminal_executor_matches,
-    with_pre_execution_phase, CookExecutionPreparation,
+    materialize_initial_cook_attempt_with_stores_outcome, pre_execution_failure_details,
+    pre_execution_failure_phase, pre_execution_failure_report, record_pre_execution_failure,
+    retryable_pre_execution_failure, terminal_executor_matches, with_pre_execution_phase,
+    CookExecutionPreparation,
 };
 use super::cook_promotion::{
     attempt_needs_execution_with_store, cook_report, finalize_or_load_cook_pr,
@@ -4008,16 +4009,7 @@ where
             // Once the attempt exists, a controller-side validation failure has
             // not reached a provider and must retain the pre-execution contract.
             if let Ok(mut record) = lifecycle_store.read_record(&failure_options.initial_run_id) {
-                let owns_materialized_attempt = store
-                    .load_recipe(&failure_options.cook_id)
-                    .ok()
-                    .is_some_and(|recipe| {
-                        recipe.attempts.iter().any(|attempt| {
-                            attempt.run_id == failure_options.initial_run_id
-                                && attempt.plan == failure_options.initial_plan
-                        })
-                    });
-                if owns_materialized_attempt
+                if error.details["cook_materialized_by_invocation"] == true
                     && store.data_root() == lifecycle_store.data_root()
                     && record.state == agent_task_lifecycle::AgentTaskRunState::Queued
                 {
@@ -4330,7 +4322,8 @@ where
     // Recipe persistence and lifecycle materialization are a recoverable saga.
     // Complete it before any capacity, workspace, or provider-facing work so a
     // controller interruption leaves a status-addressable, resumable attempt.
-    materialize_initial_cook_attempt_with_stores(store, lifecycle_store, &options)?;
+    let materialized_by_invocation =
+        materialize_initial_cook_attempt_with_stores_outcome(store, lifecycle_store, &options)?;
     // A persisted recipe can replace the just-validated inputs. Re-check its
     // workspace and candidate topology before it reaches transport preparation
     // or a resumed attempt.
@@ -4341,7 +4334,10 @@ where
         && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
-        validate_cook_workspace(&options)?;
+        validate_cook_workspace(&options).map_err(|mut error| {
+            error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
+            error
+        })?;
     }
     validate_cook_candidate_group(&options.initial_plan)?;
     // Reserve the source tree's projected copy before the scheduler creates its

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -252,6 +252,7 @@ pub(crate) fn materialize_initial_cook_attempt_with_stores(
         recipe_store,
         lifecycle_store,
         options,
+        false,
     )
     .map(|_| ())
 }
@@ -260,11 +261,13 @@ pub(crate) fn materialize_initial_cook_attempt_with_stores_outcome(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
+    recipe_created_by_invocation: bool,
 ) -> Result<bool> {
     materialize_initial_cook_attempt_with_store_and_lifecycle(
         recipe_store,
         lifecycle_store,
         options,
+        recipe_created_by_invocation,
     )
 }
 
@@ -272,9 +275,8 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
+    recipe_created_by_invocation: bool,
 ) -> Result<bool> {
-    let created = !recipe_store.recipe_exists(&options.cook_id)
-        && !lifecycle_store.record_exists(&options.initial_run_id)?;
     CookExecutionPreparation::new(recipe_store, lifecycle_store).materialize_with_runtime(
         &options.cook_id,
         &options.initial_run_id,
@@ -284,7 +286,7 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )?;
-    Ok(created)
+    Ok(recipe_created_by_invocation)
 }
 
 /// Complete recipe, run-record, and index registration for an attempt. Each

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -253,13 +253,28 @@ pub(crate) fn materialize_initial_cook_attempt_with_stores(
         lifecycle_store,
         options,
     )
+    .map(|_| ())
+}
+
+pub(crate) fn materialize_initial_cook_attempt_with_stores_outcome(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+) -> Result<bool> {
+    materialize_initial_cook_attempt_with_store_and_lifecycle(
+        recipe_store,
+        lifecycle_store,
+        options,
+    )
 }
 
 fn materialize_initial_cook_attempt_with_store_and_lifecycle(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
-) -> Result<()> {
+) -> Result<bool> {
+    let created = !recipe_store.recipe_exists(&options.cook_id)
+        && !lifecycle_store.record_exists(&options.initial_run_id)?;
     CookExecutionPreparation::new(recipe_store, lifecycle_store).materialize_with_runtime(
         &options.cook_id,
         &options.initial_run_id,
@@ -268,7 +283,8 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
-    )
+    )?;
+    Ok(created)
 }
 
 /// Complete recipe, run-record, and index registration for an attempt. Each

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1,13 +1,16 @@
 //! Durable, versioned input boundary for cook continuation scheduling.
 
 use homeboy_engine_primitives::content_hash;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::{Barrier, LazyLock, Mutex};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use uuid::Uuid;
 
 use crate::agent_task_lifecycle;
 use crate::agent_task_scheduler::AgentTaskPlan;
@@ -20,10 +23,40 @@ use homeboy_core::{paths, Error, Result};
 pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
 const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
 
+#[cfg(test)]
+static INITIAL_RECIPE_CREATION_BARRIER: LazyLock<Mutex<(Option<Arc<Barrier>>, usize)>> =
+    LazyLock::new(|| Mutex::new((None, 0)));
+
+#[cfg(test)]
+pub(crate) fn set_initial_recipe_creation_barrier_for_test(barrier: Option<Arc<Barrier>>) {
+    let mut hook = INITIAL_RECIPE_CREATION_BARRIER
+        .lock()
+        .expect("initial recipe creation barrier");
+    *hook = (barrier, 0);
+}
+
 /// Durable Cook storage bound to explicit filesystem roots.
 #[derive(Clone, Debug)]
 pub struct CookRecipeStore {
     data_root: PathBuf,
+}
+
+/// Result of publishing Cook's initial durable recipe.
+///
+/// `created` is elected by the exclusive recipe write, not by a caller's
+/// observation of the store before it starts materializing an attempt.
+pub(crate) struct InitialRecipeMaterialization {
+    pub(crate) recipe: AgentTaskCookRecipe,
+    pub(crate) created: bool,
+}
+
+impl InitialRecipeMaterialization {
+    pub(crate) fn reused(recipe: AgentTaskCookRecipe) -> Self {
+        Self {
+            recipe,
+            created: false,
+        }
+    }
 }
 
 impl CookRecipeStore {
@@ -94,6 +127,14 @@ impl CookRecipeStore {
         &self,
         options: &AgentTaskCookServiceOptions,
     ) -> Result<AgentTaskCookRecipe> {
+        self.persist_initial_recipe_with_outcome(options)
+            .map(|materialization| materialization.recipe)
+    }
+
+    pub(crate) fn persist_initial_recipe_with_outcome(
+        &self,
+        options: &AgentTaskCookServiceOptions,
+    ) -> Result<InitialRecipeMaterialization> {
         persist_initial_recipe_in_store(self, options)
     }
 
@@ -316,12 +357,31 @@ pub fn persist_initial_recipe(
 fn persist_initial_recipe_in_store(
     store: &CookRecipeStore,
     options: &AgentTaskCookServiceOptions,
-) -> Result<AgentTaskCookRecipe> {
+) -> Result<InitialRecipeMaterialization> {
     recover_pending_supersession(store, &options.cook_id)?;
     let mut recipe = initial_recipe(options)?;
     validate_recipe(&recipe)?;
+    #[cfg(test)]
+    let barrier = {
+        let mut hook = INITIAL_RECIPE_CREATION_BARRIER
+            .lock()
+            .expect("initial recipe creation barrier");
+        if hook.1 < 2 {
+            hook.1 += 1;
+            hook.0.clone()
+        } else {
+            None
+        }
+    };
+    #[cfg(test)]
+    if let Some(barrier) = barrier {
+        barrier.wait();
+    }
     if let Some(existing) = compatible_existing_recipe(store, &recipe)? {
-        return Ok(existing);
+        return Ok(InitialRecipeMaterialization {
+            recipe: existing,
+            created: false,
+        });
     }
     if store.recipe_exists(&recipe.cook_id) {
         let existing = store.load_recipe(&recipe.cook_id)?;
@@ -362,10 +422,95 @@ fn persist_initial_recipe_in_store(
         };
         write_supersession(store, &supersession)?;
         complete_supersession(store, &supersession)?;
-        return Ok(recipe);
+        return Ok(InitialRecipeMaterialization {
+            recipe,
+            created: false,
+        });
     }
-    store.persist_recipe(&recipe)?;
-    Ok(recipe)
+    if persist_recipe_exclusively(store, &recipe)? {
+        return Ok(InitialRecipeMaterialization {
+            recipe,
+            created: true,
+        });
+    }
+    // Another controller won creation after our read. Its immutable recipe is
+    // authoritative: a concurrent loser may reuse it only when compatible,
+    // never enter the normal correction/supersession path.
+    let winner = store.load_recipe(&recipe.cook_id)?;
+    if recipe_mismatch_fields(&winner, &recipe).is_empty() {
+        return Ok(InitialRecipeMaterialization::reused(winner));
+    }
+    Err(Error::validation_invalid_argument(
+        "cook_recipe",
+        "concurrent Cook creation conflicts with the durable recipe",
+        Some(recipe.cook_id),
+        None,
+    ))
+}
+
+fn persist_recipe_exclusively(
+    store: &CookRecipeStore,
+    recipe: &AgentTaskCookRecipe,
+) -> Result<bool> {
+    let path = store.recipe_path(&recipe.cook_id);
+    let directory = path.parent().expect("recipe path has parent");
+    fs::create_dir_all(directory)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let json = serde_json::to_string_pretty(recipe).map_err(|error| {
+        Error::internal_json(error.to_string(), Some(path.display().to_string()))
+    })?;
+    let staging = write_recipe_staging_file(directory, format!("{json}\n").as_bytes())?;
+    let installed = match fs::hard_link(&staging, &path) {
+        Ok(()) => {
+            sync_directory(directory)?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => false,
+        Err(error) => {
+            let _ = fs::remove_file(&staging);
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(path.display().to_string()),
+            ));
+        }
+    };
+    fs::remove_file(&staging).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(staging.display().to_string()))
+    })?;
+    if installed {
+        sync_directory(directory)?;
+    }
+    Ok(installed)
+}
+
+fn write_recipe_staging_file(directory: &Path, bytes: &[u8]) -> Result<PathBuf> {
+    let staging = directory.join(format!(".recipe-{}.tmp", Uuid::new_v4()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&staging).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(staging.display().to_string()))
+    })?;
+    if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+        let _ = fs::remove_file(&staging);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(staging.display().to_string()),
+        ));
+    }
+    Ok(staging)
+}
+
+fn sync_directory(directory: &Path) -> Result<()> {
+    File::open(directory)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(error.to_string(), Some(directory.display().to_string()))
+        })
 }
 
 /// Validate a Cook recipe against durable state without writing it. Fanout

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -23,7 +23,9 @@ use super::super::cook_promotion::{
     refreshed_moving_base_recovery, selected_candidate_task_id_in_store, CookReportInput,
     MovingBaseCookRecovery,
 };
-use super::super::cook_recipe::persist_initial_recipe;
+use super::super::cook_recipe::{
+    persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
+};
 use super::*;
 use crate::agent_task::{
     AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
@@ -3674,6 +3676,107 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
         assert_eq!(result.value.status, "durable_failure");
         assert_eq!(dispatches.load(Ordering::SeqCst), 0);
     });
+}
+
+#[test]
+fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = CookRecipeStore::new(context.path_roots());
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let mut winner = batch_cook_options(
+        "concurrent-first-cook",
+        Arc::new(AcceptedDetachedAttemptDispatcher),
+    );
+    winner.initial_plan.plan_id = "creator-plan".to_string();
+    let mut loser = winner.clone();
+    loser.initial_plan.plan_id = "loser-plan".to_string();
+
+    let barrier = Arc::new(Barrier::new(2));
+    set_initial_recipe_creation_barrier_for_test(Some(Arc::clone(&barrier)));
+    let (winner_result, loser_result) = std::thread::scope(|scope| {
+        let winner = scope.spawn(|| {
+            run_cook_with_boundaries_reported_with_stores(
+                &store,
+                &lifecycle_store,
+                winner,
+                UnusedExecutor,
+                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+                None,
+                false,
+            )
+        });
+        let loser = scope.spawn(|| {
+            run_cook_with_boundaries_reported_with_stores(
+                &store,
+                &lifecycle_store,
+                loser,
+                UnusedExecutor,
+                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
+                None,
+                false,
+            )
+        });
+        (winner.join().unwrap(), loser.join().unwrap())
+    });
+    set_initial_recipe_creation_barrier_for_test(None);
+
+    let outcomes = [winner_result.unwrap(), loser_result.unwrap()];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| outcome.value.status == "in_flight")
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| outcome.value.status == "durable_failure")
+            .count(),
+        1
+    );
+    let recipe = store
+        .load_recipe("concurrent-first-cook")
+        .expect("creator recipe");
+    let creator_options = super::super::reconstruct_options_with_dispatcher(
+        &recipe,
+        Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
+    )
+    .expect("creator options");
+    let record_before = lifecycle_store
+        .read_record(&creator_options.initial_run_id)
+        .expect("queued creator record");
+    let plan_before = lifecycle_store
+        .read_controller_plan(&creator_options.initial_run_id)
+        .expect("creator controller plan");
+    let aggregate_before = agent_task_lifecycle::read_aggregate_in_store(
+        &lifecycle_store,
+        &creator_options.initial_run_id,
+    )
+    .ok();
+
+    assert_eq!(record_before.state, AgentTaskRunState::Queued);
+    assert_eq!(
+        lifecycle_store
+            .read_record(&creator_options.initial_run_id)
+            .expect("creator record remains queued")
+            .state,
+        record_before.state
+    );
+    assert_eq!(
+        lifecycle_store
+            .read_controller_plan(&creator_options.initial_run_id)
+            .expect("creator plan remains immutable"),
+        plan_before
+    );
+    assert_eq!(
+        agent_task_lifecycle::read_aggregate_in_store(
+            &lifecycle_store,
+            &creator_options.initial_run_id,
+        )
+        .ok(),
+        aggregate_before
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve pre-execution failure ownership for the invocation that materialized the recipe attempt
- bind failure recording to the materialization result instead of a later ownership read
- atomically elect one initial recipe creator so concurrent first Cook calls cannot replace the winning plan

Follow-up to #12672. This closes the remaining Cook/materialization races exposed by the archive replay for #12596.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::submit_and_persist -- --test-threads=1` (47 passed)
- `cargo test -p homeboy-agents agent_task_service::cook::tests:: -- --test-threads=1` (194 passed, 6 ignored)

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the existing repair commits, verify the rebased branch, run the focused test suites, and prepare this pull request. Chris Huber remains responsible for the changes.