### PR TITLE
Root the transport-proxy recovery surface

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -49,7 +49,29 @@ impl TransportProxyRecovery {
 /// Reconnect a transport-owned proxy through its durable runner execution
 /// record. `None` means the run is a normal scheduler-owned plan.
 pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyRecovery>> {
-    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    recover_transport_proxy_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+    )
+}
+
+/// The store-rooted counterpart of [`recover_transport_proxy`].
+///
+/// Recovery is a read-modify-write over one durable proxy record: it reads the
+/// record, reconciles a runner snapshot onto it, and commits the result. All
+/// three have to land in the same installation. A recovery that read one home's
+/// record and committed the reconnect annotation into another would leave the
+/// caller's own proxy permanently unrecovered while reporting success — the
+/// cross-home write class #7505 exists to remove.
+///
+/// `with_runner_continuation` is deliberately still process-global: the runner
+/// continuation registry is configured trust material and a subprocess
+/// contract, not a durable lifecycle root (#12618).
+pub(crate) fn recover_transport_proxy_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<TransportProxyRecovery>> {
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
     homeboy_core::controller_runtime::validate_for_mutation(
         &record.metadata,
         &homeboy_core::build_identity::current().display,
@@ -68,7 +90,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
     metadata.insert("runner_id".to_string(), json!(&runner_id));
 
     let Some(runner_job_id) = runner_job_id else {
-        return resume_transport_proxy_on_runner(record, runner_id);
+        return resume_transport_proxy_on_runner_in_store(lifecycle_store, record, runner_id);
     };
 
     metadata.insert("runner_job_id".to_string(), json!(&runner_job_id));
@@ -77,8 +99,8 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
         p.runner_job_log_snapshot(&runner_id, &runner_job_id)
     }) {
         Ok(snapshot) => {
-            reconcile_transport_proxy_snapshot(&mut record, &snapshot)?;
-            store::write_record(&record)?;
+            reconcile_transport_proxy_snapshot_in_store(lifecycle_store, &mut record, &snapshot)?;
+            lifecycle_store.write_record(&record)?;
             Ok(Some(TransportProxyRecovery::Reconciled {
                 record,
                 next_action: format!(
@@ -88,7 +110,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
         }
         Err(_) => {
             record.annotate_runner_disconnected();
-            store::write_record(&record)?;
+            lifecycle_store.write_record(&record)?;
             Ok(Some(TransportProxyRecovery::ReconnectRequired {
                 record,
                 next_action: format!("homeboy runner connect {runner_id}"),
@@ -100,6 +122,18 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
 /// Replays already-persisted terminal runner evidence into an incomplete
 /// controller projection. It is intentionally limited to an existing terminal
 /// job snapshot and cannot dispatch or resume provider work.
+///
+/// This is deliberately still ambient (#7505). Rooting it is a one-hop edit —
+/// every sibling it needs (`project_persisted_terminal_runner_events_in_store`,
+/// `reconcile_runner_job_snapshot_in_store`, and the store's own record and
+/// aggregate accessors) already exists — but it is *not* a self-contained one.
+/// These two calls are the last non-test callers of the ambient
+/// `project_persisted_terminal_runner_events` and `reconcile_runner_job_snapshot`
+/// wrappers in `lifecycle_runner_projection`. Both are `pub(crate)`, so
+/// rerouting them here leaves those wrappers reachable only from `#[cfg(test)]`
+/// code, which is a `dead_code` error under `-D warnings`. Closing this slice
+/// therefore has to gate or delete those two wrappers in the same commit, in
+/// the file that owns them.
 pub fn recover_terminal_transport_proxy_evidence(run_id: &str) -> Result<bool> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     let runtime = record
@@ -155,7 +189,14 @@ fn is_authenticated_transport_recovery_record(record: &AgentTaskRunRecord) -> bo
 /// Resume an unbound proxy where the controller never learned the runner job
 /// identity. The persisted command and workspace belong to the runner, so this
 /// must execute through the runner rather than through the local scheduler.
-fn resume_transport_proxy_on_runner(
+///
+/// There is deliberately no ambient wrapper: the only caller,
+/// [`recover_transport_proxy_in_store`], is rooted and already holds the store
+/// whose record it is resuming. Every early-return branch below commits the
+/// annotated record, and the post-continuation re-read reloads whatever the
+/// runner persisted — all of which must be the caller's own home (#7505).
+fn resume_transport_proxy_on_runner_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
     mut record: AgentTaskRunRecord,
     runner_id: String,
 ) -> Result<Option<TransportProxyRecovery>> {
@@ -165,7 +206,7 @@ fn resume_transport_proxy_on_runner(
         .and_then(Value::as_str)
         .filter(|path| !path.trim().is_empty())
     else {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         return Ok(Some(TransportProxyRecovery::ReconnectRequired {
             record,
             next_action: format!("homeboy runner connect {runner_id}"),
@@ -184,7 +225,7 @@ fn resume_transport_proxy_on_runner(
         })
         .filter(|command| !command.is_empty())
     else {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         return Ok(Some(TransportProxyRecovery::ReconnectRequired {
             record,
             next_action: format!("homeboy runner connect {runner_id}"),
@@ -192,7 +233,7 @@ fn resume_transport_proxy_on_runner(
     };
 
     if !super::runner_continuation::with_runner_continuation(|p| p.runner_exists(&runner_id)) {
-        store::write_record(&record)?;
+        lifecycle_store.write_record(&record)?;
         return Ok(Some(TransportProxyRecovery::ReconnectRequired {
             record,
             next_action: format!("homeboy runner connect {runner_id}"),
@@ -211,20 +252,51 @@ fn resume_transport_proxy_on_runner(
         )));
     }
 
-    record = store::read_record(&record.run_id)?;
+    record = lifecycle_store.read_record(&record.run_id)?;
     Ok(Some(TransportProxyRecovery::Resumed {
         next_action: format!("homeboy agent-task status {} --full", record.run_id),
         record,
     }))
 }
 
+/// The ambient half of the pair, kept so the existing test call sites need no
+/// edit while they migrate onto the rooted sibling.
+///
+/// It is `#[cfg(test)]` because that is now literally what it is: rerouting
+/// `recover_transport_proxy_in_store` onto
+/// [`reconcile_transport_proxy_snapshot_in_store`] removed its last production
+/// caller, and a `pub(crate)` function reachable only from `#[cfg(test)] mod
+/// tests` is a `dead_code` error under `-D warnings`. Gating it says so
+/// honestly instead of keeping a production-looking entry point alive for the
+/// benefit of a lint.
+#[cfg(test)]
 pub(crate) fn reconcile_transport_proxy_snapshot(
     record: &mut AgentTaskRunRecord,
     snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
 ) -> Result<()> {
+    reconcile_transport_proxy_snapshot_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        record,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of `reconcile_transport_proxy_snapshot`, and
+/// the only form compiled into a production build.
+///
+/// This is a pure alias for the transport-proxy entry into the one reconcile
+/// owner, so the store is passed straight through: the binding write, the
+/// aggregate idempotence read, and the terminal commit all belong to
+/// `reconcile_runner_job_snapshot_in_store` and are already rooted there.
+pub(crate) fn reconcile_transport_proxy_snapshot_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    snapshot: &homeboy_core::api_jobs::RunnerJobLogSnapshot,
+) -> Result<()> {
     // Binding and the queued -> running transition now live at the top of
-    // `reconcile_runner_job_snapshot` so every reconcile path shares one owner.
-    reconcile_runner_job_snapshot(record, snapshot)
+    // `reconcile_runner_job_snapshot_in_store` so every reconcile path shares
+    // one owner.
+    reconcile_runner_job_snapshot_in_store(lifecycle_store, record, snapshot)
 }
 
 /// A runner snapshot from the expected Lab is durable acceptance evidence when


### PR DESCRIPTION
## Summary

`reconcile_transport_proxy_snapshot` was the **single largest remaining blocker** in `handoff_and_proxy.rs` — 6 tests held on it alone.

| function | hops |
|---|---|
| `recover_transport_proxy` → `_in_store` | **5** durable hops |
| `resume_transport_proxy_on_runner` → `_in_store` | **4** (private, single caller — no ambient wrapper, matching the in-file `bind_pending_lab_handoff_snapshot_in_store` precedent) |
| `reconcile_transport_proxy_snapshot` → `_in_store` | 1 — the 6-test unblocker |

**6 tests unblocked, verified rather than trusted**: exactly six call sites hold on this function (lines 693, 759, 785, 1009, 1047, 1078; a 7th is in `status_and_recovery.rs:1709`). Every *other* ambient helper those six use was checked and already has a rooted sibling.

## Opener hazard: checked, does not arise

The recent `open_observation_maintained` finding made this the first thing to verify. **None of these bodies names an `ObservationStore` opener at all** — zero occurrences, on this branch and on `origin/main`. Every replaced call was a `store::` free shim, and `store::read_record` and `lifecycle_store.read_record` reach the *same* `read_record_in_store` and the *same* `open_observation_initialized()`. **Only the root changed, never the opener.**

All five writes now go through `lifecycle_store.write_record`, each routing to `with_config_lock_at(self.roots.config(), …)` and the workspace-owner renewal through `workspace_claim_store_at(self.data_root())`.

<callout accent="#ef4444">
## I rooted `recover_terminal_transport_proxy_evidence`, then reverted it

That was the assigned headline function, and the edit works — all four siblings exist and it is mechanical.

But its two projection calls are the **last non-test callers** of the ambient `project_persisted_terminal_runner_events` and `reconcile_runner_job_snapshot`. Both are `pub(crate)`. Rerouting them leaves both reachable only from `#[cfg(test)] mod tests` → `dead_code` → **error under `-D warnings`**.

This was **proven, not guessed** — with a standalone `rustc --test` probe reproducing the exact visibility shape:
- `pub(crate) fn` used only from `#[cfg(test)]` → `error: function is never used` under `-D warnings`
- `pub fn` in the same position → clean (why `recover_transport_proxy` itself is safe)
- **Dead-ness is not transitive-safe**: a dead wrapper does *not* keep its callee alive — both get flagged

The only fixes are a `#[cfg(test)]` gate or deletion **in `lifecycle_runner_projection.rs`**, which was on the do-not-edit list and had a concurrent slice against it. A red `main` from a two-line edit in another agent's file is worse than deferring. The reason is recorded in the function's doc comment so the next owner does not rediscover it.
</callout>

**Scanner blind spot confirmed by reading:** that function now has no `_in_store` sibling, so the scanner *cannot see it*. Its doc comment is the only marker.

## Verification

**Scanner 7/7.** Zero new duplicate definitions vs `origin/main`. `cargo fmt` clean (which also proves every touched file parses).

<callout accent="#f59e0b">
**Not compiled, not run.** CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and blocker analysis. Review by hand.

Refs #7505