### PR TITLE
Migrate the handoff and proxy tests onto injected stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -82,6 +82,34 @@ impl RunnerContinuationProvider for ReconciliationProvider {
     }
 }
 
+/// The submission a rooted Lab-offload test hands to the
+/// `*_with_submission_in_store` entry points.
+///
+/// Every Lab offload entry point reads its record first and submits only on the
+/// fall-through, and that fall-through is the one reach a rooted Lab offload
+/// function still makes past its lifecycle store: the default
+/// `admitted_lab_offload_submission` calls `submit_plan_in_store`, which admits
+/// through `homeboy_core::controller_runtime`, whose FIFO admission queue and
+/// content-addressed pin store hang off `paths::controller_runtimes_store()` and
+/// are machine-global on purpose (#7505, #12608). A test that no longer mutates
+/// HOME would therefore enqueue against the *real operator* runtime store and
+/// block on its cross-process lock. Naming the submission keeps the whole
+/// operation inside the injected store and reaches nothing process-global at
+/// all. This is the same stub admission every other rooted test in this crate
+/// passes to `submit_plan_with_runtime_admission`.
+///
+/// The consequence to keep in mind when choosing what to migrate: the durable
+/// run this creates carries `{}` for its controller-runtime pin rather than a
+/// real admission, so a test that asserts on controller-runtime provenance
+/// stays on `with_isolated_home`.
+fn stub_lab_offload_submission(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    plan: &AgentTaskPlan,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    lifecycle_store.submit_plan_with_runtime_admission(plan, run_id, |_| Ok(json!({})))
+}
+
 fn accepted_detached_handoff(run_id: &str) -> AgentTaskRunRecord {
     let plan = test_plan();
     record_lab_offload_phase(
@@ -104,78 +132,125 @@ fn accepted_detached_handoff(run_id: &str) -> AgentTaskRunRecord {
     .expect("accept handoff")
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Acceptance is a durable transfer of one run to one runner daemon:
+/// the pending handoff, the typed acceptance, the reload that models caller
+/// loss, and the snapshot validated against it all name `lifecycle_store`, so
+/// "the accepted identity survived" is asserted about one home rather than
+/// about whichever home the process environment happened to point at.
+///
+/// `bind_accepted_lab_runner_job_in_store` still carries the default Lab
+/// offload submission, but it cannot be reached here: the pending handoff above
+/// has already written the record, so the acceptance path reads it rather than
+/// falling through to `submit_plan_in_store`.
 #[test]
 fn accepted_runner_identity_binds_before_snapshot_validation_and_survives_caller_loss() {
-    with_isolated_home(|_| {
-        let run_id = "cook-9567-pre-provider-race";
-        let plan = test_plan();
-        record_lab_offload_phase(
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-9567-pre-provider-race";
+    let plan = test_plan();
+    record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "provider_dispatch",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("persist pending handoff before daemon acceptance");
+    let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        run_id,
+        "homeboy-lab",
+        "00000000-0000-0000-0000-000000009567",
+    );
+
+    // Daemon admission persists the typed accepted identity before a
+    // foreground caller can observe a snapshot or disappear.
+    let accepted = bind_accepted_lab_runner_job_in_store(
+        &lifecycle_store,
+        &identity,
+        "/runner/workspace/homeboy",
+        &[],
+    )
+    .expect("bind accepted daemon job");
+    let replay = bind_accepted_lab_runner_job_in_store(
+        &lifecycle_store,
+        &identity,
+        "/runner/workspace/homeboy",
+        &[],
+    )
+    .expect("repeated acceptance is idempotent");
+    assert_eq!(accepted, replay);
+
+    let foreign = bind_accepted_lab_runner_job_in_store(
+        &lifecycle_store,
+        &homeboy_core::lab_contract::RunnerJobIdentity::new(
             run_id,
             "homeboy-lab",
-            "provider_dispatch",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("persist pending handoff before daemon acceptance");
-        let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
-            run_id,
-            "homeboy-lab",
-            "00000000-0000-0000-0000-000000009567",
-        );
+            "00000000-0000-0000-0000-000000009568",
+        ),
+        "/runner/workspace/homeboy",
+        &[],
+    )
+    .expect_err("a foreign daemon job cannot replace accepted identity");
+    assert_eq!(foreign.code, ErrorCode::ValidationInvalidArgument);
 
-        // Daemon admission persists the typed accepted identity before a
-        // foreground caller can observe a snapshot or disappear.
-        let accepted = bind_accepted_lab_runner_job(&identity, "/runner/workspace/homeboy", &[])
-            .expect("bind accepted daemon job");
-        let replay = bind_accepted_lab_runner_job(&identity, "/runner/workspace/homeboy", &[])
-            .expect("repeated acceptance is idempotent");
-        assert_eq!(accepted, replay);
-
-        let foreign = bind_accepted_lab_runner_job(
-            &homeboy_core::lab_contract::RunnerJobIdentity::new(
-                run_id,
-                "homeboy-lab",
-                "00000000-0000-0000-0000-000000009568",
-            ),
-            "/runner/workspace/homeboy",
-            &[],
-        )
-        .expect_err("a foreign daemon job cannot replace accepted identity");
-        assert_eq!(foreign.code, ErrorCode::ValidationInvalidArgument);
-
-        // Reloading models controller/caller loss after daemon acceptance. A
-        // status reconciliation validates the accepted job directly and never
-        // needs to replay the provider command.
-        let mut recovered = status(run_id).expect("reload accepted handoff");
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
-        snapshot.job.id = uuid::Uuid::parse_str(&identity.runner_job_id).expect("valid job id");
-        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
-        snapshot.events.clear();
-        reconcile_runner_job_snapshot(&mut recovered, &snapshot)
-            .expect("accepted identity validates recovered runner snapshot");
-        assert_eq!(
-            recovered.runner_job_id(),
-            Some(identity.runner_job_id.as_str())
-        );
-        assert_eq!(recovered.state, AgentTaskRunState::Running);
-    });
+    // Reloading models controller/caller loss after daemon acceptance. A
+    // status reconciliation validates the accepted job directly and never
+    // needs to replay the provider command.
+    let mut recovered = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reload accepted handoff")
+    .record;
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+    snapshot.job.id = uuid::Uuid::parse_str(&identity.runner_job_id).expect("valid job id");
+    snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+    snapshot.events.clear();
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut recovered, &snapshot)
+        .expect("accepted identity validates recovered runner snapshot");
+    assert_eq!(
+        recovered.runner_job_id(),
+        Some(identity.runner_job_id.as_str())
+    );
+    assert_eq!(recovered.state, AgentTaskRunState::Running);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The mutable metadata is written into, and the typed-handoff read is
+/// taken out of, one store — which is the whole claim: "metadata is not
+/// acceptance" is only meaningful when the read half and the write half name
+/// the same record. The stub admission keeps submission off the machine-global
+/// controller-runtime queue; nothing here asserts on runtime provenance.
 #[test]
 fn accepted_runner_identity_rejects_mutable_metadata_without_typed_handoff() {
-    with_isolated_home(|_| {
-        let run_id = "cook-9567-metadata-is-not-acceptance";
-        let mut record = submit_plan(&test_plan(), Some(run_id)).expect("persist run");
-        record.metadata["runner_id"] = json!("homeboy-lab");
-        record.metadata["runner_job_id"] = json!("foreign-job");
-        store::write_record(&record).expect("persist mutable metadata");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-9567-metadata-is-not-acceptance";
+    let mut record = lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), run_id, |_| Ok(json!({})))
+        .expect("persist run");
+    record.metadata["runner_id"] = json!("homeboy-lab");
+    record.metadata["runner_job_id"] = json!("foreign-job");
+    lifecycle_store
+        .write_record(&record)
+        .expect("persist mutable metadata");
 
-        assert!(accepted_lab_runner_job_identity(run_id)
+    assert!(
+        accepted_lab_runner_job_identity_in_store(&lifecycle_store, run_id)
             .expect("read typed handoff")
-            .is_none());
-    });
+            .is_none()
+    );
 }
 
 #[test]
@@ -505,172 +580,232 @@ fn retry_rebuilds_follow_up_candidate_from_durable_promotion() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The planned proxy, the plan and log projections read back off it,
+/// and the accepted child that binds it are one operation on one home — the
+/// binding is only evidence of anything if the record it advances is the record
+/// the proxy was written into. The acceptance below cannot reach the default
+/// Lab-offload submission because the planned proxy has already written the
+/// record.
 #[test]
 fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
-    with_isolated_home(|_| {
-        let command = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "cook".to_string(),
-        ];
-        let planned = record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    let planned = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "agent-task-controller-proxy",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("controller proxy recorded before handoff");
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("controller proxy recorded before handoff");
 
-        assert_eq!(planned.state, AgentTaskRunState::Queued);
-        assert!(planned.metadata.get("runner_job_id").is_none());
-        assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
-        assert!(planned.lab_handoff.is_none());
-        assert!(planned.metadata.get("handoff_acceptance").is_none());
-        assert!(load_plan("agent-task-controller-proxy")
+    assert_eq!(planned.state, AgentTaskRunState::Queued);
+    assert!(planned.metadata.get("runner_job_id").is_none());
+    assert_eq!(planned.metadata["lifecycle_store_owner"], "controller");
+    assert!(planned.lab_handoff.is_none());
+    assert!(planned.metadata.get("handoff_acceptance").is_none());
+    assert!(
+        load_plan_in_store(&lifecycle_store, "agent-task-controller-proxy")
             .expect("proxy plan")
             .tasks[0]
             .inputs
             .get("runner_job_id")
-            .is_none());
-        assert_eq!(
-            planned.metadata["runner_execution_record"]["status"],
-            "planned"
-        );
-        assert_eq!(
-            logs("agent-task-controller-proxy")
-                .expect("logs resolve")
-                .events
-                .len(),
-            1
-        );
+            .is_none()
+    );
+    assert_eq!(
+        planned.metadata["runner_execution_record"]["status"],
+        "planned"
+    );
+    assert_eq!(
+        logs_in_store(&lifecycle_store, "agent-task-controller-proxy")
+            .expect("logs resolve")
+            .events
+            .len(),
+        1
+    );
 
-        let running = record_detached_lab_run(DetachedLabRunRecord {
+    let running = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-controller-proxy",
             runner_id: "homeboy-lab",
             runner_job_id: "job-123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("accepted child binds proxy");
-        assert_eq!(running.state, AgentTaskRunState::Running);
-        assert_eq!(running.metadata["runner_job_id"], "job-123");
-        assert_eq!(running.metadata["lifecycle_store_owner"], "controller");
-        assert_eq!(running.metadata["handoff_acceptance"]["state"], "accepted");
-        assert_eq!(
-            running.metadata["runner_execution_record"]["status"],
-            "running"
-        );
-    });
+        },
+    )
+    .expect("accepted child binds proxy");
+    assert_eq!(running.state, AgentTaskRunState::Running);
+    assert_eq!(running.metadata["runner_job_id"], "job-123");
+    assert_eq!(running.metadata["lifecycle_store_owner"], "controller");
+    assert_eq!(running.metadata["handoff_acceptance"]["state"], "accepted");
+    assert_eq!(
+        running.metadata["runner_execution_record"]["status"],
+        "running"
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The whole point of this write is that an operator can find the run
+/// holding a reservation, so the reservation and the run it names have to be
+/// one home — a reservation named in one installation while the run lives in
+/// another is exactly the unfindable state #9163 forced manual job-ID
+/// cancellation for. The cancellation half follows the same store, so "a
+/// terminal run is never reopened" is asserted about the record the reservation
+/// was written onto.
 #[test]
 fn reserved_lab_admission_is_named_on_the_durable_run_before_acceptance() {
-    with_isolated_home(|_| {
-        let command = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "cook".to_string(),
-        ];
-        record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "agent-task-admission-identity",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("controller proxy recorded before admission");
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("controller proxy recorded before admission");
 
-        let reserved = record_lab_admission_reservation(
-            "agent-task-admission-identity",
-            "homeboy-lab",
-            "lease-abc",
-            "job-reservation-9163",
-            1_700_000_000_000,
-        )
-        .expect("reservation named on the durable run");
+    let reserved = record_lab_admission_reservation_in_store(
+        &lifecycle_store,
+        "agent-task-admission-identity",
+        "homeboy-lab",
+        "lease-abc",
+        "job-reservation-9163",
+        1_700_000_000_000,
+    )
+    .expect("reservation named on the durable run");
 
-        // The reservation is findable by run id the moment it is taken, so a
-        // caller killed before runner acceptance never leaves an admission that
-        // only manual job-ID surgery can identify (#9163).
-        assert_eq!(
-            reserved.metadata["lab_admission_reservation"]["reservation_job_id"],
-            "job-reservation-9163"
-        );
-        assert_eq!(
-            reserved.metadata["lab_admission_reservation"]["daemon_lease_id"],
-            "lease-abc"
-        );
-        assert_eq!(
-            reserved.metadata["lab_admission_reservation"]["runner_id"],
-            "homeboy-lab"
-        );
-        assert_eq!(
-            reserved.metadata["lab_admission_reservation"]["lease_expires_at_ms"],
-            1_700_000_000_000u64
-        );
-        assert_eq!(
-            reserved.metadata["lab_admission_reservation"]["cancel_command"],
-            "homeboy agent-task cancel agent-task-admission-identity"
-        );
-        // Naming a reservation is evidence, never acceptance.
-        assert_eq!(reserved.state, AgentTaskRunState::Queued);
-        assert!(reserved.metadata.get("runner_job_id").is_none());
+    // The reservation is findable by run id the moment it is taken, so a
+    // caller killed before runner acceptance never leaves an admission that
+    // only manual job-ID surgery can identify (#9163).
+    assert_eq!(
+        reserved.metadata["lab_admission_reservation"]["reservation_job_id"],
+        "job-reservation-9163"
+    );
+    assert_eq!(
+        reserved.metadata["lab_admission_reservation"]["daemon_lease_id"],
+        "lease-abc"
+    );
+    assert_eq!(
+        reserved.metadata["lab_admission_reservation"]["runner_id"],
+        "homeboy-lab"
+    );
+    assert_eq!(
+        reserved.metadata["lab_admission_reservation"]["lease_expires_at_ms"],
+        1_700_000_000_000u64
+    );
+    assert_eq!(
+        reserved.metadata["lab_admission_reservation"]["cancel_command"],
+        "homeboy agent-task cancel agent-task-admission-identity"
+    );
+    // Naming a reservation is evidence, never acceptance.
+    assert_eq!(reserved.state, AgentTaskRunState::Queued);
+    assert!(reserved.metadata.get("runner_job_id").is_none());
 
-        // A terminal run is never reopened by a late reservation write.
-        cancel_run("agent-task-admission-identity", Some("caller lost"))
-            .expect("cancel the reserved run");
-        let after_cancel = record_lab_admission_reservation(
-            "agent-task-admission-identity",
-            "homeboy-lab",
-            "lease-def",
-            "job-reservation-late",
-            1_700_000_000_001,
-        )
-        .expect("late reservation write is a no-op");
-        assert_eq!(
-            after_cancel.metadata["lab_admission_reservation"]["reservation_job_id"],
-            "job-reservation-9163"
-        );
-    });
+    // A terminal run is never reopened by a late reservation write.
+    cancel_run_in_store(
+        &lifecycle_store,
+        "agent-task-admission-identity",
+        Some("caller lost"),
+    )
+    .expect("cancel the reserved run");
+    let after_cancel = record_lab_admission_reservation_in_store(
+        &lifecycle_store,
+        "agent-task-admission-identity",
+        "homeboy-lab",
+        "lease-def",
+        "job-reservation-late",
+        1_700_000_000_001,
+    )
+    .expect("late reservation write is a no-op");
+    assert_eq!(
+        after_cancel.metadata["lab_admission_reservation"]["reservation_job_id"],
+        "job-reservation-9163"
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Double-acceptance is the failure this guards: an acceptance
+/// validated against one home's record and committed into another's would let
+/// two runners own the same run, and the handoff lock would have excluded
+/// neither. Every acceptance below — and the read back that proves the first
+/// one is retained — names `lifecycle_store`. The planned handoff writes the
+/// record first, so no acceptance here reaches the default submission.
 #[test]
 fn accepted_handoff_replays_idempotently_and_rejects_a_different_identity() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "immutable-handoff",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("planned handoff");
-        let input = DetachedLabRunRecord {
-            run_id: "immutable-handoff",
-            runner_id: "homeboy-lab",
-            runner_job_id: "job-immutable",
-            remote_workspace: "/runner/workspace/repo",
-            remote_command: &command,
-        };
-        let accepted = record_detached_lab_run(input.clone()).expect("accepted handoff");
-        let replay = record_detached_lab_run(input).expect("idempotent replay");
-        assert_eq!(replay, accepted);
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("planned handoff");
+    let input = DetachedLabRunRecord {
+        run_id: "immutable-handoff",
+        runner_id: "homeboy-lab",
+        runner_job_id: "job-immutable",
+        remote_workspace: "/runner/workspace/repo",
+        remote_command: &command,
+    };
+    let accepted = record_detached_lab_run_in_store(&lifecycle_store, input.clone())
+        .expect("accepted handoff");
+    let replay =
+        record_detached_lab_run_in_store(&lifecycle_store, input).expect("idempotent replay");
+    assert_eq!(replay, accepted);
 
-        let error = record_detached_lab_run(DetachedLabRunRecord {
+    let error = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "immutable-handoff",
             runner_id: "other-runner",
             runner_job_id: "other-job",
             remote_workspace: "/other/workspace",
             remote_command: &command,
-        })
-        .expect_err("different accepted identity is rejected");
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        let stored = status("immutable-handoff").expect("accepted record retained");
-        assert_eq!(stored.runner_id(), Some("homeboy-lab"));
-        assert_eq!(stored.runner_job_id(), Some("job-immutable"));
-    });
+        },
+    )
+    .expect_err("different accepted identity is rejected");
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    let stored = status_in_store(
+        &lifecycle_store,
+        "immutable-handoff",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("accepted record retained")
+    .record;
+    assert_eq!(stored.runner_id(), Some("homeboy-lab"));
+    assert_eq!(stored.runner_job_id(), Some("job-immutable"));
 }
 
 #[test]
@@ -790,129 +925,184 @@ fn runner_snapshot_rejects_conflicting_bound_lab_job_identity() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "Without mutation" is a claim about what did *not* change on disk,
+/// so the record read back has to be the one the refused acceptance would have
+/// mutated — the same store the pending handoff was written into.
 #[test]
 fn pending_handoff_rejects_acceptance_from_a_different_runner_without_mutation() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let planned = record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let planned = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "pending-runner-identity",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("planned handoff");
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("planned handoff");
 
-        let error = record_detached_lab_run(DetachedLabRunRecord {
+    let error = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "pending-runner-identity",
             runner_id: "other-runner",
             runner_job_id: "job-other",
             remote_workspace: "/other/workspace",
             remote_command: &command,
-        })
-        .expect_err("different runner cannot accept pending handoff");
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        let stored = status("pending-runner-identity").expect("pending handoff retained");
-        assert_eq!(stored, planned);
-    });
+        },
+    )
+    .expect_err("different runner cannot accept pending handoff");
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    let stored = status_in_store(
+        &lifecycle_store,
+        "pending-runner-identity",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("pending handoff retained")
+    .record;
+    assert_eq!(stored, planned);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "Without rewriting the legacy projection" is a claim about what the
+/// refused resume left on disk, so the accepted record read back has to be the
+/// one the resume would have rewritten.
 #[test]
 fn accepted_proxy_resume_rejects_a_different_runner_without_rewriting_legacy_projection() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "immutable-proxy",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("planned handoff");
-        record_detached_lab_run(DetachedLabRunRecord {
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("planned handoff");
+    record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "immutable-proxy",
             runner_id: "homeboy-lab",
             runner_job_id: "job-proxy",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("accepted handoff");
+        },
+    )
+    .expect("accepted handoff");
 
-        let error = record_lab_offload_planned(LabOffloadProxyPlan {
+    let error = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "immutable-proxy",
             runner_id: "other-runner",
             remote_workspace: "/other/workspace",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect_err("different runner resume is rejected");
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        let stored = status("immutable-proxy").expect("accepted record retained");
-        assert_eq!(stored.metadata["runner_id"], "homeboy-lab");
-        assert_eq!(stored.metadata["runner_job_id"], "job-proxy");
-        assert_eq!(
-            stored.metadata["runner_execution_record"]["status"],
-            "running"
-        );
-    });
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect_err("different runner resume is rejected");
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    let stored = status_in_store(
+        &lifecycle_store,
+        "immutable-proxy",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("accepted record retained")
+    .record;
+    assert_eq!(stored.metadata["runner_id"], "homeboy-lab");
+    assert_eq!(stored.metadata["runner_job_id"], "job-proxy");
+    assert_eq!(
+        stored.metadata["runner_execution_record"]["status"],
+        "running"
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "The same attempt advanced" is only assertable when the
+/// pre-acceptance record and the accepted one are the same durable row, so the
+/// phase write and the acceptance name one store.
 #[test]
 fn detached_cook_attempt_proxy_advances_after_daemon_acceptance() {
-    with_isolated_home(|_| {
-        let command = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "cook".to_string(),
-        ];
-        let attempt_run_id = "cook-7970-attempt-1-controller";
-        let queued = record_lab_offload_phase(
-            attempt_run_id,
-            "homeboy-lab",
-            "materializing",
-            None,
-            None,
-            None,
-            Some(&test_plan()),
-        )
-        .expect("pre-acceptance attempt record");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    let attempt_run_id = "cook-7970-attempt-1-controller";
+    let plan = test_plan();
+    let queued = record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: attempt_run_id,
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("pre-acceptance attempt record");
 
-        assert_eq!(queued.state, AgentTaskRunState::Queued);
-        assert_eq!(queued.metadata["phase"], "materializing");
-        assert!(queued.metadata.get("runner_job_id").is_none());
+    assert_eq!(queued.state, AgentTaskRunState::Queued);
+    assert_eq!(queued.metadata["phase"], "materializing");
+    assert!(queued.metadata.get("runner_job_id").is_none());
 
-        let accepted = record_detached_lab_run(DetachedLabRunRecord {
+    let accepted = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: attempt_run_id,
             runner_id: "homeboy-lab",
             runner_job_id: "job-7970",
             remote_workspace: "/runner/workspace/homeboy",
             remote_command: &command,
-        })
-        .expect("daemon acceptance advances the same attempt");
+        },
+    )
+    .expect("daemon acceptance advances the same attempt");
 
-        assert_eq!(accepted.run_id, attempt_run_id);
-        assert_eq!(accepted.state, AgentTaskRunState::Running);
-        assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
-        assert_eq!(accepted.metadata["phase"], "awaiting_runner_result");
-        assert_eq!(
-            accepted.metadata["phase_activity"],
-            "controller handoff complete; awaiting authoritative runner daemon result"
-        );
-        assert_eq!(accepted.metadata["runner_handoff"]["state"], "in_flight");
-        assert!(accepted.metadata.get("runner_queue").is_none());
-        assert_eq!(
-            accepted.metadata["runner_handoff"]["continuation"]["intent"],
-            "reconcile_runner_job"
-        );
-        assert_eq!(
-            accepted.metadata["runner_handoff"]["identity"]["runner_job_id"],
-            "job-7970"
-        );
-        assert_eq!(
-            accepted.metadata["runner_execution_record"]["status"],
-            "running"
-        );
-    });
+    assert_eq!(accepted.run_id, attempt_run_id);
+    assert_eq!(accepted.state, AgentTaskRunState::Running);
+    assert_eq!(accepted.metadata["runner_job_id"], "job-7970");
+    assert_eq!(accepted.metadata["phase"], "awaiting_runner_result");
+    assert_eq!(
+        accepted.metadata["phase_activity"],
+        "controller handoff complete; awaiting authoritative runner daemon result"
+    );
+    assert_eq!(accepted.metadata["runner_handoff"]["state"], "in_flight");
+    assert!(accepted.metadata.get("runner_queue").is_none());
+    assert_eq!(
+        accepted.metadata["runner_handoff"]["continuation"]["intent"],
+        "reconcile_runner_job"
+    );
+    assert_eq!(
+        accepted.metadata["runner_handoff"]["identity"]["runner_job_id"],
+        "job-7970"
+    );
+    assert_eq!(
+        accepted.metadata["runner_execution_record"]["status"],
+        "running"
+    );
 }
 
 #[test]
@@ -1091,81 +1281,128 @@ fn foreground_terminal_projection_binds_a_pending_handoff_before_validation() {
     // controller handoff to that snapshot's daemon job before validating
     // identity, rather than rejecting a valid terminal snapshot against an empty
     // controller job id.
-    with_isolated_home(|_| {
-        let run_id = "cook-terminal-preacceptance-bind";
-        let plan = test_plan();
-        let record = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "lab_handoff_preacceptance",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("persist pending controller handoff");
-        assert!(
-            record.runner_job_id().is_none(),
-            "handoff must still be unbound before the terminal snapshot arrives"
-        );
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
-        let accepted_job_id = snapshot.job.id.to_string();
-        // Point the terminal child lifecycle event at this controller run so the
-        // downstream child-identity validation sees the run/job the bind
-        // establishes from the same snapshot.
-        let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
-        identity["run_id"] = json!(run_id);
-        identity["persisted_run_id"] = json!(run_id);
+    //
+    // Rooted in an explicit store rather than a mutated process environment
+    // (#7505). The pending handoff, the bind the terminal snapshot performs, and
+    // the terminal record read back are one home: `project_terminal_runner_result_in_store`
+    // decides idempotence by comparing against the aggregate in the store it was
+    // handed, so a projection decided against another home's aggregate would
+    // either re-project a durable result or skip one.
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-terminal-preacceptance-bind";
+    let plan = test_plan();
+    let record = record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "lab_handoff_preacceptance",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("persist pending controller handoff");
+    assert!(
+        record.runner_job_id().is_none(),
+        "handoff must still be unbound before the terminal snapshot arrives"
+    );
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+    let accepted_job_id = snapshot.job.id.to_string();
+    // Point the terminal child lifecycle event at this controller run so the
+    // downstream child-identity validation sees the run/job the bind
+    // establishes from the same snapshot.
+    let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
+    identity["run_id"] = json!(run_id);
+    identity["persisted_run_id"] = json!(run_id);
 
-        let projected = project_terminal_runner_result(run_id, &snapshot)
-            .expect("terminal snapshot binds the pending handoff before validation");
-        assert!(
-            projected,
-            "authoritative terminal snapshot projects the run"
-        );
+    let projected = project_terminal_runner_result_in_store(&lifecycle_store, run_id, &snapshot)
+        .expect("terminal snapshot binds the pending handoff before validation");
+    assert!(
+        projected,
+        "authoritative terminal snapshot projects the run"
+    );
 
-        let bound = status(run_id).expect("bound terminal projection");
-        assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
-        assert_eq!(bound.state, AgentTaskRunState::Succeeded);
-    });
+    let bound = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("bound terminal projection")
+    .record;
+    assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
+    assert_eq!(bound.state, AgentTaskRunState::Succeeded);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "The matching aggregate was already projected" is decided by
+/// comparing the snapshot against the aggregate this store holds, so the
+/// aggregate write, the terminalizing status read, and the projection have to
+/// name one home — comparing against another installation's aggregate would
+/// skip a projection that was never made here, and would do so without failing.
 #[test]
 fn terminal_aggregate_binds_runner_job_before_snapshot_validation() {
-    with_isolated_home(|_| {
-        let run_id = "cook-terminal-aggregate-preacceptance-bind";
-        let plan = test_plan();
-        let record = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "lab_handoff_preacceptance",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("persist planned controller execution");
-        let aggregate = succeeded_aggregate(&plan);
-        store::write_aggregate(run_id, &aggregate).expect("aggregate written");
-        let terminal = status(run_id).expect("aggregate terminalizes the run");
-        assert_eq!(terminal.state, AgentTaskRunState::Succeeded);
-        assert!(terminal.runner_job_id().is_none());
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-terminal-aggregate-preacceptance-bind";
+    let plan = test_plan();
+    let record = record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "lab_handoff_preacceptance",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("persist planned controller execution");
+    let aggregate = succeeded_aggregate(&plan);
+    lifecycle_store
+        .write_aggregate(run_id, &aggregate)
+        .expect("aggregate written");
+    let terminal = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("aggregate terminalizes the run")
+    .record;
+    assert_eq!(terminal.state, AgentTaskRunState::Succeeded);
+    assert!(terminal.runner_job_id().is_none());
 
-        let mut snapshot = terminal_child_snapshot(&aggregate);
-        let accepted_job_id = snapshot.job.id.to_string();
-        let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
-        identity["run_id"] = json!(run_id);
-        identity["persisted_run_id"] = json!(run_id);
+    let mut snapshot = terminal_child_snapshot(&aggregate);
+    let accepted_job_id = snapshot.job.id.to_string();
+    let identity = &mut snapshot.events[0].data.as_mut().expect("event data")["identity"];
+    identity["run_id"] = json!(run_id);
+    identity["persisted_run_id"] = json!(run_id);
 
-        let projected = project_terminal_runner_result(&record.run_id, &snapshot)
+    let projected =
+        project_terminal_runner_result_in_store(&lifecycle_store, &record.run_id, &snapshot)
             .expect("terminal run binds the daemon job before validation");
-        assert!(!projected, "the matching aggregate was already projected");
+    assert!(!projected, "the matching aggregate was already projected");
 
-        let bound = status(run_id).expect("bound terminal run");
-        assert_eq!(bound.state, AgentTaskRunState::Succeeded);
-        assert_eq!(bound.runner_id(), Some("homeboy-lab"));
-        assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
-    });
+    let bound = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("bound terminal run")
+    .record;
+    assert_eq!(bound.state, AgentTaskRunState::Succeeded);
+    assert_eq!(bound.runner_id(), Some("homeboy-lab"));
+    assert_eq!(bound.runner_job_id(), Some(accepted_job_id.as_str()));
 }
 
 #[test]
@@ -1175,150 +1412,238 @@ fn snapshot_validation_reports_missing_controller_identity_distinctly() {
     // surface the missing identity as its own diagnostic instead of comparing a
     // valid runner UUID against an empty string and presenting it as a spurious
     // "does not match controller job " mismatch.
-    with_isolated_home(|_| {
-        let run_id = "cook-terminal-no-identity";
-        let plan = test_plan();
-        // A freshly submitted run has no lab handoff and no metadata
-        // runner_job_id: there is no controller identity to validate against and
-        // no pending handoff to bind one from.
-        let record = submit_plan(&plan, Some(run_id)).expect("submitted");
-        assert!(record.lab_handoff.is_none());
-        assert!(record.runner_job_id().is_none());
+    //
+    // Rooted in an explicit store rather than a mutated process environment
+    // (#7505). "There is no controller identity to validate against" is a
+    // property of one record in one home, so the submission and the projection
+    // that refuses it name the same store. The stub admission keeps submission
+    // off the machine-global controller-runtime queue; nothing here asserts on
+    // runtime provenance.
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-terminal-no-identity";
+    let plan = test_plan();
+    // A freshly submitted run has no lab handoff and no metadata
+    // runner_job_id: there is no controller identity to validate against and
+    // no pending handoff to bind one from.
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submitted");
+    assert!(record.lab_handoff.is_none());
+    assert!(record.runner_job_id().is_none());
 
-        let snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
-        let error = project_terminal_runner_result(&record.run_id, &snapshot)
+    let snapshot = terminal_child_snapshot(&succeeded_aggregate(&plan));
+    let error =
+        project_terminal_runner_result_in_store(&lifecycle_store, &record.run_id, &snapshot)
             .expect_err("missing controller identity fails closed with a distinct diagnostic");
 
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        assert!(
-            error.message.contains("no accepted runner job identity"),
-            "expected a missing-identity diagnostic, got: {}",
-            error.message
-        );
-        assert!(
-            !error.message.contains("does not match controller job"),
-            "missing identity must not be presented as a runner mismatch: {}",
-            error.message
-        );
-    });
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    assert!(
+        error.message.contains("no accepted runner job identity"),
+        "expected a missing-identity diagnostic, got: {}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("does not match controller job"),
+        "missing identity must not be presented as a runner mismatch: {}",
+        error.message
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The plan files this deletes are the ones the injected store owns
+/// (`record.plan_path` is that store's controller plan path), and the recovery,
+/// the refused handoff, and the terminal record read back all follow it — so
+/// "the plan was recovered" and "the handoff failed closed" are properties of
+/// one home rather than of whichever plan directory the process environment
+/// happened to point at.
 #[test]
 fn missing_lab_attempt_plan_is_recovered_before_handoff_or_terminalized() {
-    with_isolated_home(|_| {
-        let run_id = "cook-8096-attempt-1";
-        let plan = test_plan();
-        let record = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "materializing",
-            None,
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("controller attempt persisted");
-        std::fs::remove_file(&record.plan_path).expect("remove interrupted plan");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-8096-attempt-1";
+    let plan = test_plan();
+    let record = record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("controller attempt persisted");
+    std::fs::remove_file(&record.plan_path).expect("remove interrupted plan");
 
-        let recovered = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "dispatching",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("controller plan recovery");
-        assert_eq!(load_plan(run_id).expect("recovered plan"), plan);
+    let recovered = record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "dispatching",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("controller plan recovery");
+    assert_eq!(
+        load_plan_in_store(&lifecycle_store, run_id).expect("recovered plan"),
+        plan
+    );
 
-        std::fs::remove_file(&recovered.plan_path).expect("remove unrecoverable plan");
-        let error = record_detached_lab_run(DetachedLabRunRecord {
+    std::fs::remove_file(&recovered.plan_path).expect("remove unrecoverable plan");
+    let error = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id,
             runner_id: "homeboy-lab",
             runner_job_id: "job-8096",
             remote_workspace: "/runner/workspace/homeboy",
             remote_command: &[],
-        })
-        .expect_err("handoff without plan must not become running");
-        assert_eq!(error.code, ErrorCode::InternalIoError);
+        },
+    )
+    .expect_err("handoff without plan must not become running");
+    assert_eq!(error.code, ErrorCode::InternalIoError);
 
-        let terminal = status(run_id).expect("terminal recovery record");
-        assert_eq!(terminal.state, AgentTaskRunState::Failed);
-        assert_eq!(
-            terminal.metadata["pre_execution_failure"]["phase"],
-            "lab_attempt_plan_recovery"
-        );
-        assert!(terminal.metadata.get("runner_job_id").is_none());
-    });
+    let terminal = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("terminal recovery record")
+    .record;
+    assert_eq!(terminal.state, AgentTaskRunState::Failed);
+    assert_eq!(
+        terminal.metadata["pre_execution_failure"]["phase"],
+        "lab_attempt_plan_recovery"
+    );
+    assert!(terminal.metadata.get("runner_job_id").is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The whole claim is that a *runner-projected* plan path in the
+/// record is display evidence and the controller keeps reading its own durable
+/// plan — which is only meaningful when "its own" names one installation. The
+/// handoff, the mirrored aggregate, every read back (status, logs, artifacts),
+/// the retry that must reuse the durable plan, and the missing-plan fixture all
+/// follow `lifecycle_store`.
+///
+/// The retry is spelled as `retry_with_runtime_admission_in_store(.., false,
+/// false, None, ..)`, which is exactly what the ambient `retry` reduces to
+/// (`retry_in_store` -> `retry_with_force_inner_in_store` with `force: false,
+/// enforce_lineage_reservation: false`), except that its admission is the stub
+/// rather than the machine-global controller-runtime one. `test_plan()` carries
+/// no Cook candidate evidence, so both workspace restorations inside the retry
+/// are no-ops.
 #[test]
 fn cook_lab_handoff_controller_reads_ignore_runner_plan_projection() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let command = vec![
-            "homeboy".to_string(),
-            "agent-task".to_string(),
-            "run-plan".to_string(),
-        ];
-        let record = record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "run-plan".to_string(),
+    ];
+    let record = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "cook-lab-attempt",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace",
             remote_command: &command,
             durable_plan: Some(&plan),
-        })
-        .expect("cook handoff persists its controller plan");
-        let aggregate = succeeded_aggregate(&plan);
-        record_run_aggregate(&record.run_id, &plan, &aggregate)
-            .expect("runner result mirrored to the controller");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.plan_path =
-                "/home/chubes/.local/share/homeboy/agent-task-runs/cook-lab-attempt/plan.json"
-                    .to_string();
-            record.state = AgentTaskRunState::Running;
-        })
-        .expect("runner transport projection replaces display path");
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("cook handoff persists its controller plan");
+    let aggregate = succeeded_aggregate(&plan);
+    record_run_aggregate_in_store(&lifecycle_store, &record.run_id, &plan, &aggregate)
+        .expect("runner result mirrored to the controller");
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record.plan_path =
+            "/home/chubes/.local/share/homeboy/agent-task-runs/cook-lab-attempt/plan.json"
+                .to_string();
+        record.state = AgentTaskRunState::Running;
+    })
+    .expect("runner transport projection replaces display path");
 
-        assert_eq!(
-            status(&record.run_id).expect("controller status").plan_id,
-            plan.plan_id
-        );
-        assert_eq!(
-            logs(&record.run_id).expect("controller logs").run_id,
-            record.run_id
-        );
-        assert_eq!(
-            artifacts(&record.run_id)
-                .expect("controller artifacts")
-                .run_id,
-            record.run_id
-        );
-        let retry = retry(&record.run_id, Some("cook-lab-retry"))
-            .expect("controller retry uses its durable plan");
-        assert_eq!(
-            load_controller_plan(&retry.run_id).expect("retry plan"),
-            plan
-        );
+    assert_eq!(
+        status_in_store(
+            &lifecycle_store,
+            &record.run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("controller status")
+        .record
+        .plan_id,
+        plan.plan_id
+    );
+    assert_eq!(
+        logs_in_store(&lifecycle_store, &record.run_id)
+            .expect("controller logs")
+            .run_id,
+        record.run_id
+    );
+    assert_eq!(
+        artifacts_in_store(&lifecycle_store, &record.run_id)
+            .expect("controller artifacts")
+            .run_id,
+        record.run_id
+    );
+    let retry = retry_with_runtime_admission_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        Some("cook-lab-retry"),
+        false,
+        false,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect("controller retry uses its durable plan");
+    assert_eq!(
+        load_controller_plan_in_store(&lifecycle_store, &retry.run_id).expect("retry plan"),
+        plan
+    );
 
-        let missing_plan = record_lab_offload_planned(LabOffloadProxyPlan {
+    let missing_plan = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "cook-lab-missing-controller-plan",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace",
             remote_command: &command,
             durable_plan: Some(&plan),
-        })
-        .expect("missing-plan fixture persists its controller plan");
-        rewrite_record_for_test(&missing_plan.run_id, |record| {
-            record.plan_path = "/runner/workspace/plan.json".to_string();
-        })
-        .expect("project runner-local plan path");
-        std::fs::remove_file(missing_plan.plan_path)
-            .expect("remove authoritative controller plan despite projected display path");
-        let error = status(&missing_plan.run_id).expect_err("missing controller plan fails closed");
-        assert_eq!(error.code, ErrorCode::InternalIoError);
-    });
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("missing-plan fixture persists its controller plan");
+    rewrite_record_for_test_in_store(&lifecycle_store, &missing_plan.run_id, |record| {
+        record.plan_path = "/runner/workspace/plan.json".to_string();
+    })
+    .expect("project runner-local plan path");
+    std::fs::remove_file(missing_plan.plan_path)
+        .expect("remove authoritative controller plan despite projected display path");
+    let error = status_in_store(
+        &lifecycle_store,
+        &missing_plan.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect_err("missing controller plan fails closed");
+    assert_eq!(error.code, ErrorCode::InternalIoError);
 }
 
 #[test]
@@ -1370,147 +1695,197 @@ fn runner_terminal_reconciliation_is_idempotent_and_preserves_execution_owner() 
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The acceptance is written into, and the reconciliation commits back
+/// into, one store, so the liveness the snapshot clears is the liveness this
+/// home recorded. The run does not exist yet, so the acceptance is spelled with
+/// its explicit submission rather than the default one, which would reach the
+/// machine-global controller-runtime admission queue — see
+/// `stub_lab_offload_submission`.
 #[test]
 fn reachable_running_child_clears_disconnected_liveness_and_refreshes_heartbeat() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_with_submission_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-reconnected-running",
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        record.annotate_runner_disconnected();
-        let disconnected_heartbeat = record.lifecycle.heartbeat.clone();
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("running proxy");
+    record.annotate_runner_disconnected();
+    let disconnected_heartbeat = record.lifecycle.heartbeat.clone();
 
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
-        snapshot.events.clear();
-        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("reachable reconciliation");
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+    snapshot.events.clear();
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("reachable reconciliation");
 
-        assert_eq!(record.state, AgentTaskRunState::Running);
-        assert_eq!(record.metadata["runner_liveness"], "reachable");
-        assert!(record.metadata.get("stale_running").is_none());
-        assert!(record.metadata.get("stale_running_reason").is_none());
-        assert!(record.metadata.get("retryable").is_none());
-        assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
-    });
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(record.metadata["runner_liveness"], "reachable");
+    assert!(record.metadata.get("stale_running").is_none());
+    assert!(record.metadata.get("stale_running_reason").is_none());
+    assert!(record.metadata.get("retryable").is_none());
+    assert_ne!(record.lifecycle.heartbeat, disconnected_heartbeat);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The live progress the reconciliation commits and the log projection
+/// read back out are the same home, so "the provider handle and its log event
+/// are durable" is asserted about the record the snapshot was applied to.
 #[test]
 fn running_child_snapshot_persists_provider_handle_and_live_log_progress() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_with_submission_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-live-provider",
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
-        snapshot.events = vec![homeboy_core::api_jobs::JobEvent {
-            sequence: 1,
-            job_id: snapshot.job.id,
-            kind: homeboy_core::api_jobs::JobEventKind::Progress,
-            timestamp_ms: 2,
-            message: Some("provider dispatch accepted".to_string()),
-            data: Some(json!({
-                "metadata": {
-                    "provider_handle": AgentTaskExecutionHandle {
-                        kind: crate::agent_task::AgentTaskExecutionHandleKind::ProviderRun,
-                        task_id: "task-a".to_string(),
-                        backend: "openai/gpt-5.6-terra".to_string(),
-                        run_id: "provider-run-live".to_string(),
-                        stream_uri: Some("provider://runs/provider-run-live/events".to_string()),
-                        metadata: json!({"progress": "accepted"}),
-                    }
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("running proxy");
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    snapshot.job.status = homeboy_core::api_jobs::JobStatus::Running;
+    snapshot.events = vec![homeboy_core::api_jobs::JobEvent {
+        sequence: 1,
+        job_id: snapshot.job.id,
+        kind: homeboy_core::api_jobs::JobEventKind::Progress,
+        timestamp_ms: 2,
+        message: Some("provider dispatch accepted".to_string()),
+        data: Some(json!({
+            "metadata": {
+                "provider_handle": AgentTaskExecutionHandle {
+                    kind: crate::agent_task::AgentTaskExecutionHandleKind::ProviderRun,
+                    task_id: "task-a".to_string(),
+                    backend: "openai/gpt-5.6-terra".to_string(),
+                    run_id: "provider-run-live".to_string(),
+                    stream_uri: Some("provider://runs/provider-run-live/events".to_string()),
+                    metadata: json!({"progress": "accepted"}),
                 }
-            })),
-        }];
+            }
+        })),
+    }];
 
-        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("live reconciliation");
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("live reconciliation");
 
-        assert_eq!(record.metadata["phase"], "executing");
-        assert_eq!(record.metadata["provider_state"], "active");
-        assert_eq!(record.provider_handles.len(), 1);
-        assert_eq!(
-            record.provider_handles[0].provider_run_id,
-            "provider-run-live"
-        );
-        let log = logs(&record.run_id).expect("live logs");
-        assert_eq!(log.events.len(), 1);
-        assert!(log.events[0]
-            .message
-            .as_deref()
-            .is_some_and(|message| message.contains("provider dispatch accepted")));
-    });
+    assert_eq!(record.metadata["phase"], "executing");
+    assert_eq!(record.metadata["provider_state"], "active");
+    assert_eq!(record.provider_handles.len(), 1);
+    assert_eq!(
+        record.provider_handles[0].provider_run_id,
+        "provider-run-live"
+    );
+    let log = logs_in_store(&lifecycle_store, &record.run_id).expect("live logs");
+    assert_eq!(log.events.len(), 1);
+    assert!(log.events[0]
+        .message
+        .as_deref()
+        .is_some_and(|message| message.contains("provider dispatch accepted")));
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "The stale running writer is ignored" is a claim about one durable
+/// row: the write that must lose, the terminal state that must win, and the
+/// status read that adjudicates between them all name `lifecycle_store`.
 #[test]
 fn terminal_runner_reconciliation_never_resurrects_a_controller_record() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_with_submission_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-disconnected-child",
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        let before = record.clone();
-        let terminal = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-        reconcile_runner_job_snapshot(&mut record, &terminal).expect("terminal reconciliation");
-        let terminal_record = record.clone();
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("running proxy");
+    let before = record.clone();
+    let terminal = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &terminal)
+        .expect("terminal reconciliation");
+    let terminal_record = record.clone();
 
-        store::write_record(&before).expect("stale running writer is ignored");
-        assert_eq!(
-            status(&record.run_id)
-                .expect("terminal state remains committed")
-                .state,
-            AgentTaskRunState::Succeeded
-        );
+    lifecycle_store
+        .write_record(&before)
+        .expect("stale running writer is ignored");
+    assert_eq!(
+        status_in_store(
+            &lifecycle_store,
+            &record.run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("terminal state remains committed")
+        .record
+        .state,
+        AgentTaskRunState::Succeeded
+    );
 
-        let mut running = terminal.clone();
-        running.job.status = homeboy_core::api_jobs::JobStatus::Running;
-        running.events.clear();
-        reconcile_runner_job_snapshot(&mut record, &running)
-            .expect("terminal records stay immutable");
+    let mut running = terminal.clone();
+    running.job.status = homeboy_core::api_jobs::JobStatus::Running;
+    running.events.clear();
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &running)
+        .expect("terminal records stay immutable");
 
-        assert_eq!(record, terminal_record);
-    });
+    assert_eq!(record, terminal_record);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Only the acceptance is durable here — `annotate_runner_disconnected`
+/// is an in-memory record mutation — so rooting the acceptance is the whole
+/// isolation this test needs.
 #[test]
 fn disconnected_runner_marks_nonterminal_proxy_stale_without_advancing_heartbeat() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_with_submission_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-disconnected-running",
             runner_id: "homeboy-lab",
             runner_job_id: "job-789",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        let heartbeat = record.lifecycle.heartbeat.clone();
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("running proxy");
+    let heartbeat = record.lifecycle.heartbeat.clone();
 
-        record.annotate_runner_disconnected();
+    record.annotate_runner_disconnected();
 
-        assert_eq!(record.state, AgentTaskRunState::Running);
-        assert_eq!(record.lifecycle.heartbeat, heartbeat);
-        assert_eq!(record.metadata["runner_liveness"], "disconnected");
-        assert_eq!(record.metadata["stale_running"], true);
-        assert_eq!(
-            record.metadata["stale_running_reason"],
-            "runner_disconnected"
-        );
-    });
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(record.lifecycle.heartbeat, heartbeat);
+    assert_eq!(record.metadata["runner_liveness"], "disconnected");
+    assert_eq!(record.metadata["stale_running"], true);
+    assert_eq!(
+        record.metadata["stale_running_reason"],
+        "runner_disconnected"
+    );
 }
 
 #[test]
@@ -1636,38 +2011,73 @@ fn terminal_reconciliation_rejects_conflicting_directly_imported_artifact() {
         .is_some_and(|error| error.contains("conflicts with terminal artifact projection")));
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The Cook index, the two attempts it names, and the alias resolution
+/// that has to land on the second one are one home — an index read in one
+/// installation while the attempts live in another would resolve a "latest" that
+/// this store never recorded.
+///
+/// `record_completed_run` is spelled out as its own two rooted halves —
+/// submission then `record_aggregate_in_store` — which is exactly the body of
+/// `record_completed_run_in_store`. The difference is the admission: that
+/// sibling submits through `submit_plan_in_store`, which resolves the
+/// controller-runtime admission queue under `paths::controller_runtimes_store()`.
+/// That store is machine-global by design, so calling it from a test that no
+/// longer mutates HOME would enqueue against the real operator runtime store.
+/// `test_plan()` carries no workspace root, so `record_aggregate_in_store` skips
+/// the still-ambient automatic artifact-retention pass.
 #[test]
 fn cook_index_keeps_repeated_attempts_unique_with_stable_latest_alias() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let aggregate = succeeded_aggregate(&plan);
-        let first_run_id = cook_attempt_run_id("cook-issue-6978", 1);
-        let second_run_id = cook_attempt_run_id("cook-issue-6978", 1);
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let aggregate = succeeded_aggregate(&plan);
+    let first_run_id = cook_attempt_run_id("cook-issue-6978", 1);
+    let second_run_id = cook_attempt_run_id("cook-issue-6978", 1);
 
-        assert_ne!(first_run_id, second_run_id);
+    assert_ne!(first_run_id, second_run_id);
 
-        record_completed_run(&plan, &aggregate, Some(&first_run_id)).expect("first run recorded");
-        record_cook_attempt("cook-issue-6978", 1, &first_run_id).expect("first cook indexed");
-        record_completed_run(&plan, &aggregate, Some(&second_run_id)).expect("second run recorded");
-        record_cook_attempt("cook-issue-6978", 1, &second_run_id).expect("second cook indexed");
+    let mut first = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, &first_run_id, |_| Ok(json!({})))
+        .expect("first run recorded");
+    record_aggregate_in_store(&lifecycle_store, &mut first, &plan, &aggregate)
+        .expect("first run recorded");
+    record_cook_attempt_in_store(&lifecycle_store, "cook-issue-6978", 1, &first_run_id)
+        .expect("first cook indexed");
+    let mut second = lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, &second_run_id, |_| Ok(json!({})))
+        .expect("second run recorded");
+    record_aggregate_in_store(&lifecycle_store, &mut second, &plan, &aggregate)
+        .expect("second run recorded");
+    record_cook_attempt_in_store(&lifecycle_store, "cook-issue-6978", 1, &second_run_id)
+        .expect("second cook indexed");
 
-        let index = cook_index("cook-issue-6978").expect("cook index loaded");
-        assert_eq!(index.latest_run_id, second_run_id);
-        assert_eq!(index.attempts.len(), 2);
-        assert_eq!(index.attempts[0].run_id, first_run_id);
-        assert_eq!(index.attempts[1].run_id, second_run_id);
+    let index =
+        cook_index_in_store(&lifecycle_store, "cook-issue-6978").expect("cook index loaded");
+    assert_eq!(index.latest_run_id, second_run_id);
+    assert_eq!(index.attempts.len(), 2);
+    assert_eq!(index.attempts[0].run_id, first_run_id);
+    assert_eq!(index.attempts[1].run_id, second_run_id);
 
-        let latest = status("cook-issue-6978").expect("stable cook id resolves");
-        assert_eq!(latest.run_id, second_run_id);
-        assert_eq!(latest.metadata["cook_alias"], "cook-issue-6978");
-        assert_eq!(
-            latest.metadata["cook_index"]["latest_run_id"],
-            second_run_id
-        );
+    let latest = status_in_store(
+        &lifecycle_store,
+        "cook-issue-6978",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("stable cook id resolves")
+    .record;
+    assert_eq!(latest.run_id, second_run_id);
+    assert_eq!(latest.metadata["cook_alias"], "cook-issue-6978");
+    assert_eq!(
+        latest.metadata["cook_index"]["latest_run_id"],
+        second_run_id
+    );
 
-        let (_raw, path) = aggregate_source("cook-issue-6978").expect("latest aggregate resolves");
-        assert!(path.display().to_string().contains(&second_run_id));
-    });
+    let (_raw, path) = aggregate_source_in_store(&lifecycle_store, "cook-issue-6978")
+        .expect("latest aggregate resolves");
+    assert!(path.display().to_string().contains(&second_run_id));
 }
 
 #[test]
@@ -2224,62 +2634,86 @@ fn status_keeps_fresh_planned_runner_submission_live() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Cancellation resolves the alias, mutates the record and then reads
+/// it back; all three name `lifecycle_store`, so the durable cancellation
+/// asserted below is the one this test committed rather than a state some other
+/// home happened to hold. The stub admission keeps submission off the
+/// machine-global controller-runtime queue.
+///
+/// The daemon cancellation hook stays where it is: `test_cancel_hook` is a
+/// `thread_local!`, not a process-global, so it was never protected by the
+/// hermetic-home mutex and is unaffected by dropping it.
 #[test]
 fn cancel_run_marks_queued_record_cancelled() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("run-cancel-queued")).expect("submitted");
-        let mut record = store::read_record("run-cancel-queued").expect("record");
-        record.metadata = json!({
-            "runner_id": "homeboy-lab",
-            "runner_job_id": "queued-reservation",
-        });
-        store::write_record(&record).expect("store runner reservation");
-        let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
-            |runner_id, job_id, _durable_run_id| {
-                assert_eq!(runner_id, "homeboy-lab");
-                assert_eq!(job_id, "queued-reservation");
-                Ok((
-                    homeboy_core::api_jobs::Job {
-                        id: uuid::Uuid::new_v4(),
-                        operation: "runner.exec".to_string(),
-                        status: homeboy_core::api_jobs::JobStatus::Cancelled,
-                        created_at_ms: 1,
-                        updated_at_ms: 2,
-                        started_at_ms: None,
-                        finished_at_ms: Some(2),
-                        event_count: 0,
-                        source_snapshot: None,
-                        path_materialization_plan: None,
-                        stale_reason: None,
-                        daemon_lease_id: None,
-                        target_runner_id: None,
-                        target_project_id: None,
-                        claim_id: None,
-                        claimed_by_runner_id: None,
-                        claimed_at_ms: None,
-                        claim_expires_at_ms: None,
-                        artifacts: Vec::new(),
-                        runner_job_projection: None,
-                    },
-                    Vec::new(),
-                ))
-            },
-        ));
-
-        let cancelled =
-            cancel_run("run-cancel-queued", Some("loser cell")).expect("queued run cancelled");
-        let loaded = status("run-cancel-queued").expect("status loaded");
-
-        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
-        assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
-        assert_eq!(cancelled.metadata["cancel_reason"], json!("loser cell"));
-        assert_eq!(
-            cancelled.metadata["live_cancellation"]["cancellation"],
-            "runner_job_cancel"
-        );
-        assert_eq!(loaded.state, AgentTaskRunState::Cancelled);
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "run-cancel-queued", |_| Ok(json!({})))
+        .expect("submitted");
+    let mut record = lifecycle_store
+        .read_record("run-cancel-queued")
+        .expect("record");
+    record.metadata = json!({
+        "runner_id": "homeboy-lab",
+        "runner_job_id": "queued-reservation",
     });
+    lifecycle_store
+        .write_record(&record)
+        .expect("store runner reservation");
+    let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
+        |runner_id, job_id, _durable_run_id| {
+            assert_eq!(runner_id, "homeboy-lab");
+            assert_eq!(job_id, "queued-reservation");
+            Ok((
+                homeboy_core::api_jobs::Job {
+                    id: uuid::Uuid::new_v4(),
+                    operation: "runner.exec".to_string(),
+                    status: homeboy_core::api_jobs::JobStatus::Cancelled,
+                    created_at_ms: 1,
+                    updated_at_ms: 2,
+                    started_at_ms: None,
+                    finished_at_ms: Some(2),
+                    event_count: 0,
+                    source_snapshot: None,
+                    path_materialization_plan: None,
+                    stale_reason: None,
+                    daemon_lease_id: None,
+                    target_runner_id: None,
+                    target_project_id: None,
+                    claim_id: None,
+                    claimed_by_runner_id: None,
+                    claimed_at_ms: None,
+                    claim_expires_at_ms: None,
+                    artifacts: Vec::new(),
+                    runner_job_projection: None,
+                },
+                Vec::new(),
+            ))
+        },
+    ));
+
+    let cancelled = cancel_run_in_store(&lifecycle_store, "run-cancel-queued", Some("loser cell"))
+        .expect("queued run cancelled");
+    let loaded = status_in_store(
+        &lifecycle_store,
+        "run-cancel-queued",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status loaded")
+    .record;
+
+    assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+    assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
+    assert_eq!(cancelled.metadata["cancel_reason"], json!("loser cell"));
+    assert_eq!(
+        cancelled.metadata["live_cancellation"]["cancellation"],
+        "runner_job_cancel"
+    );
+    assert_eq!(loaded.state, AgentTaskRunState::Cancelled);
 }
 
 #[test]
@@ -2322,58 +2756,68 @@ fn list_records_skips_malformed_observation_records() {
     assert_eq!(records[0].run_id, "good-run");
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The malformed rows are inserted through this store's own
+/// observation database — the same one `record_health_summary_in_store` counts
+/// — so `health.malformed == malformed_count` is an exact equality about one
+/// home. Counted ambiently it would be an equality against whichever
+/// observation DB the process environment pointed at, which on a developer or
+/// operator machine holds unrelated malformed rows and would make the assertion
+/// either fail or pass for the wrong reason.
 #[test]
 fn record_health_summary_stays_bounded_with_many_malformed_records() {
-    with_isolated_home(|_| {
-        // A state directory full of historical malformed agent-task records must
-        // not produce unbounded per-record output. The health summary aggregates
-        // every malformed record into a total count while capping the retained
-        // samples, so read-only activity/upgrade output stays bounded. (#8397)
-        let malformed_count = crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT * 3;
-        let store = homeboy_core::observation::ObservationStore::open_initialized()
-            .expect("observation store");
-        for index in 0..malformed_count {
-            store
-                .upsert_imported_run(&homeboy_core::observation::RunRecord {
-                    id: format!("bad-run-{index}"),
-                    kind: "agent-task".to_string(),
-                    component_id: None,
-                    started_at: "2026-01-01T00:00:00Z".to_string(),
-                    finished_at: None,
-                    status: "running".to_string(),
-                    command: None,
-                    cwd: None,
-                    homeboy_version: None,
-                    git_sha: None,
-                    rig_id: None,
-                    // A record with the observation schema but no `agent_task_run`
-                    // metadata is classified as MissingMetadata (malformed).
-                    metadata_json: json!({
-                        "schema": "homeboy/agent-task-observation-record/v1"
-                    }),
-                })
-                .expect("malformed record inserted");
-        }
+    // A state directory full of historical malformed agent-task records must
+    // not produce unbounded per-record output. The health summary aggregates
+    // every malformed record into a total count while capping the retained
+    // samples, so read-only activity/upgrade output stays bounded. (#8397)
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let malformed_count = crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT * 3;
+    let store = lifecycle_store
+        .open_observation_initialized()
+        .expect("observation store");
+    for index in 0..malformed_count {
+        store
+            .upsert_imported_run(&homeboy_core::observation::RunRecord {
+                id: format!("bad-run-{index}"),
+                kind: "agent-task".to_string(),
+                component_id: None,
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: None,
+                cwd: None,
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                // A record with the observation schema but no `agent_task_run`
+                // metadata is classified as MissingMetadata (malformed).
+                metadata_json: json!({
+                    "schema": "homeboy/agent-task-observation-record/v1"
+                }),
+            })
+            .expect("malformed record inserted");
+    }
 
-        let health = record_health_summary().expect("health summary");
+    let health = record_health_summary_in_store(&lifecycle_store).expect("health summary");
 
-        // Every malformed record is counted…
-        assert_eq!(health.malformed, malformed_count);
-        // …but the retained sample set stays bounded regardless of volume.
+    // Every malformed record is counted…
+    assert_eq!(health.malformed, malformed_count);
+    // …but the retained sample set stays bounded regardless of volume.
+    assert!(
+        health.samples.len() <= crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT,
+        "samples ({}) must not exceed HEALTH_SAMPLE_LIMIT ({})",
+        health.samples.len(),
+        crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT
+    );
+    // Each retained sample carries an actionable remediation command.
+    for sample in &health.samples {
         assert!(
-            health.samples.len() <= crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT,
-            "samples ({}) must not exceed HEALTH_SAMPLE_LIMIT ({})",
-            health.samples.len(),
-            crate::agent_task_lifecycle::health::HEALTH_SAMPLE_LIMIT
+            !sample.remediation.is_empty(),
+            "each malformed sample must carry a remediation hint"
         );
-        // Each retained sample carries an actionable remediation command.
-        for sample in &health.samples {
-            assert!(
-                !sample.remediation.is_empty(),
-                "each malformed sample must carry a remediation hint"
-            );
-        }
-    });
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**20 of 39 sites migrated** — up from 6 last round. All 11 tests the previous agent identified as "fully clear" are migrated, plus 9 more.

## The submission hazard — the honest answer, generalized

The previous round flagged that `record_detached_lab_run_in_store` falls through to `submit_plan_in_store` and thus the machine-global `paths::controller_runtimes_store()`.

Reading the newly-added `*_with_submission_in_store` family showed **every** Lab-offload entry point has that fall-through, not just the detached one. So one helper, `stub_lab_offload_submission`, is now used for every migrated test that materializes a run. **Nothing migrated can reach `paths::controller_runtimes_store()`.**

> Noted, not touched: the existing precedent at `terminal_and_reconcile.rs:1247` — already on `main` — *does* use plain `record_detached_lab_run_in_store` on a run that doesn't pre-exist, and so does take the machine-global admission. That's real.

## A new blocker found by reading, invisible to any grep

**`mark_running_in_store` is not safe to call from a stub-admitted rooted test today.** It unconditionally calls `migrate_record_controller_runtime_in_store` whenever the record has a `controller_runtime` key → `migrate_legacy_pin_and_persist` → `runtime_root()` → `paths::controller_runtimes_store()` **plus `acquire_admission_lock` on the real operator data root**. With a stub `{}` pin it additionally errors out of `required_runtime_string`.

## Left, with reasons

- **6 × `reconcile_transport_proxy_snapshot`** — treated as ambient; a parallel PR roots it.
- **4 tests assert on real controller-runtime admission** (`["requested"]`, `["originating"]["pinned_executable"]`, `["originating"]["build_identity"]`, retention/`activate_current_generation`). A stub writes `{}` there, so migrating turns `.expect("stamped build identity")` into a panic — **or worse, into an assertion that passes vacuously.**
- `retry_rebuilds_follow_up_candidate_from_durable_promotion` → `persisted_promotion_for_attempt`, ambient and *documented in-source* as deliberately not rooted yet.
- `resolve_workspace_terminal_authority`, `record_remote_dispatch_failure` — no sibling behind the entry point.

<callout accent="#f59e0b">
## One residual risk, flagged rather than buried

Three migrated tests call `status_in_store` on a `Running` record carrying both `runner_id` and `runner_job_id`, which reaches `with_runner_continuation` — the process-global provider registry. Under `with_isolated_home` they were serialized against the three guard-installing tests left behind. They no longer are.

Under the default `NoopProvider` behaviour is identical. If a `RunnerContinuationTestGuard` from a concurrent test is installed at that moment, `status_in_store` could return a foreign snapshot. **This is a flake risk, not a silent-pass risk — it fails loudly.** Say the word and those three revert; it's a small edit.
</callout>

## Zero assertions changed

248 → 248, same order. 9 lines differ, each same macro, operand count, order, and expected value — only an ambient call replaced by its rooted sibling. `#[test]` names: **47 → 47, identical set and order.**

Lesson-1 ran twice: the standard needle scan, then a stronger pass grepping a **50-name list** of ambient lifecycle entry points inside rooted bodies with a `(?<![\w.])name\(` boundary. Zero hits in all 27 rooted tests.

## Verification

**Scanner 7/7.** Zero new duplicate definitions vs `origin/main`. `cargo fmt` clean (which also proves every touched file parses).

<callout accent="#f59e0b">
**Not compiled, not run.** CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and blocker analysis. Review by hand.

Refs #7505