### PR TITLE
Migrate the lifecycle terminal and recovery tests

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -138,54 +138,82 @@ fn cook_alias_status_has_no_adoption_projection_without_indexed_adoption() {
     assert!(projected.candidate_adoption.is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The alias projection is a *selection* across three indexed
+/// attempts, decided by adoption timestamps this test plants by hand. The
+/// index, all three records and the alias read have to come out of one
+/// installation or the tie-break being asserted is not the tie-break that ran.
+///
+/// `start_candidate_adoption(a, b, c, d)` is exactly
+/// `start_candidate_adoption_with_policy_in_store(store, a, b, c, d, false,
+/// false)`: the ambient entry point delegates through
+/// `start_candidate_adoption_with_rerun_policy` with both policy flags `false`.
 #[test]
 fn cook_alias_status_selects_latest_terminal_adoption_then_index_order() {
-    with_isolated_home(|_| {
-        let cook_id = "cook-issue-9168-terminal";
-        let mut runs = Vec::new();
-        for attempt in 1..=3 {
-            let run = submit_plan(&test_plan(), Some(&format!("terminal-adoption-{attempt}")))
-                .expect("terminal run");
-            record_cook_attempt(cook_id, attempt, &run.run_id).expect("index terminal run");
-            start_candidate_adoption(
-                &run.run_id,
-                &format!("{attempt:040}"),
-                "openai/gpt-5.6-sol",
-                "cargo test",
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let cook_id = "cook-issue-9168-terminal";
+    let mut runs = Vec::new();
+    for attempt in 1..=3 {
+        let run = lifecycle_store
+            .submit_plan_with_runtime_admission(
+                &test_plan(),
+                &format!("terminal-adoption-{attempt}"),
+                |_| Ok(json!({})),
             )
-            .expect("start terminal adoption");
-            finish_candidate_adoption(
-                &run.run_id,
-                (attempt != 1).then(|| format!("attempt {attempt} failed")),
-            )
-            .expect("finish terminal adoption");
-            runs.push(run);
-        }
-        for (run, timestamp) in runs.iter().zip([
-            "2026-07-20T12:00:03+00:00",
-            "2026-07-20T12:00:01+00:00",
-            "2026-07-20T12:00:03+00:00",
-        ]) {
-            rewrite_record_for_test(&run.run_id, |record| {
-                record
-                    .candidate_adoption
-                    .as_mut()
-                    .expect("terminal adoption")
-                    .updated_at = timestamp.to_string();
-            })
-            .expect("set deterministic adoption timestamp");
-        }
+            .expect("terminal run");
+        record_cook_attempt_in_store(&lifecycle_store, cook_id, attempt, &run.run_id)
+            .expect("index terminal run");
+        start_candidate_adoption_with_policy_in_store(
+            &lifecycle_store,
+            &run.run_id,
+            &format!("{attempt:040}"),
+            "openai/gpt-5.6-sol",
+            "cargo test",
+            false,
+            false,
+        )
+        .expect("start terminal adoption");
+        finish_candidate_adoption_in_store(
+            &lifecycle_store,
+            &run.run_id,
+            (attempt != 1).then(|| format!("attempt {attempt} failed")),
+        )
+        .expect("finish terminal adoption");
+        runs.push(run);
+    }
+    for (run, timestamp) in runs.iter().zip([
+        "2026-07-20T12:00:03+00:00",
+        "2026-07-20T12:00:01+00:00",
+        "2026-07-20T12:00:03+00:00",
+    ]) {
+        rewrite_record_for_test_in_store(&lifecycle_store, &run.run_id, |record| {
+            record
+                .candidate_adoption
+                .as_mut()
+                .expect("terminal adoption")
+                .updated_at = timestamp.to_string();
+        })
+        .expect("set deterministic adoption timestamp");
+    }
 
-        let projected = status(cook_id).expect("Cook alias status");
-        assert_eq!(projected.run_id, runs[2].run_id);
-        assert_eq!(
-            projected.adoption_run_id.as_deref(),
-            Some(runs[2].run_id.as_str())
-        );
-        let adoption = projected.candidate_adoption.expect("terminal projection");
-        assert_eq!(adoption.state, "failed");
-        assert_eq!(adoption.candidate_sha, format!("{:040}", 3));
-    });
+    let projected = status_in_store(
+        &lifecycle_store,
+        cook_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("Cook alias status")
+    .record;
+    assert_eq!(projected.run_id, runs[2].run_id);
+    assert_eq!(
+        projected.adoption_run_id.as_deref(),
+        Some(runs[2].run_id.as_str())
+    );
+    let adoption = projected.candidate_adoption.expect("terminal projection");
+    assert_eq!(adoption.state, "failed");
+    assert_eq!(adoption.candidate_sha, format!("{:040}", 3));
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -251,160 +279,247 @@ fn exact_run_id_status_keeps_its_own_adoption_without_alias_projection() {
     assert!(exact_latest.candidate_adoption.is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). This is one adoption walked through claim, duplicate rejection,
+/// staleness, resume, checkpoint and completion. Every step reads the state the
+/// previous step committed — `resume_count == 1` at the end is a claim about
+/// that whole sequence — so a single record in a single installation is the
+/// only arrangement that makes the walk coherent.
+///
+/// `start_candidate_adoption(a, b, c, d)` is
+/// `start_candidate_adoption_with_policy_in_store(store, a, b, c, d, false,
+/// false)`, and `start_candidate_adoption_with_rerun_policy(a, b, c, d, rerun)`
+/// is the same with `rerun_completed_gates = rerun, replace_interrupted =
+/// false`: both ambient entry points delegate straight through
+/// `start_candidate_adoption_with_policy`.
 #[test]
 fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
-    with_isolated_home(|_| {
-        let record = submit_plan(&test_plan(), Some("adoption-progress")).expect("submit");
-        let candidate = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), "adoption-progress", |_| Ok(json!({})))
+        .expect("submit");
+    let candidate = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
 
-        start_candidate_adoption(
-            &record.run_id,
-            candidate,
-            "openai/gpt-5.6-terra",
-            "cargo test",
-        )
-        .expect("claim before verifier starts");
-        let running = status(&record.run_id).expect("status exposes active adoption");
-        let adoption = running
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        candidate,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        false,
+        false,
+    )
+    .expect("claim before verifier starts");
+    let running = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status exposes active adoption")
+    .record;
+    let adoption = running
+        .candidate_adoption
+        .expect("durable adoption attempt");
+    assert_eq!(adoption.state, "verification_running");
+    assert_eq!(adoption.candidate_sha, candidate);
+    assert_eq!(adoption.active_gate, "cargo test");
+
+    let duplicate = start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        candidate,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        false,
+        false,
+    )
+    .expect_err("live duplicate is rejected");
+    assert_eq!(duplicate.details["field"], "candidate_ref");
+
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record
             .candidate_adoption
-            .expect("durable adoption attempt");
-        assert_eq!(adoption.state, "verification_running");
-        assert_eq!(adoption.candidate_sha, candidate);
-        assert_eq!(adoption.active_gate, "cargo test");
+            .as_mut()
+            .expect("attempt")
+            .owner_pid = u32::MAX;
+    })
+    .expect("make owner stale without sleeping");
+    let interrupted = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status reconciles stale owner")
+    .record;
+    assert_eq!(
+        interrupted.candidate_adoption.expect("attempt").state,
+        "interrupted"
+    );
 
-        let duplicate = start_candidate_adoption(
-            &record.run_id,
-            candidate,
+    for (other_candidate, other_model) in [
+        (
+            "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
             "openai/gpt-5.6-terra",
+        ),
+        (candidate, "openai/gpt-5.6-sol"),
+    ] {
+        let conflict = start_candidate_adoption_with_policy_in_store(
+            &lifecycle_store,
+            &record.run_id,
+            other_candidate,
+            other_model,
             "cargo test",
+            false,
+            false,
         )
-        .expect_err("live duplicate is rejected");
-        assert_eq!(duplicate.details["field"], "candidate_ref");
+        .expect_err("interrupted attempt only resumes with exact candidate and model");
+        assert_eq!(conflict.details["field"], "candidate_ref");
+    }
 
-        rewrite_record_for_test(&record.run_id, |record| {
-            record
-                .candidate_adoption
-                .as_mut()
-                .expect("attempt")
-                .owner_pid = u32::MAX;
-        })
-        .expect("make owner stale without sleeping");
-        let interrupted = status(&record.run_id).expect("status reconciles stale owner");
-        assert_eq!(
-            interrupted.candidate_adoption.expect("attempt").state,
-            "interrupted"
-        );
-
-        for (other_candidate, other_model) in [
-            (
-                "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
-                "openai/gpt-5.6-terra",
-            ),
-            (candidate, "openai/gpt-5.6-sol"),
-        ] {
-            let conflict = start_candidate_adoption(
-                &record.run_id,
-                other_candidate,
-                other_model,
-                "cargo test",
-            )
-            .expect_err("interrupted attempt only resumes with exact candidate and model");
-            assert_eq!(conflict.details["field"], "candidate_ref");
-        }
-
-        start_candidate_adoption(
-            &record.run_id,
-            candidate,
-            "openai/gpt-5.6-terra",
-            "cargo test",
-        )
-        .expect("same immutable candidate resumes");
-        checkpoint_candidate_adoption(&record.run_id, "finalization", "finalize pull request")
-            .expect("finalization checkpoint");
-        let finalizing = status(&record.run_id).expect("finalization status");
-        let adoption = finalizing.candidate_adoption.expect("attempt");
-        assert_eq!(adoption.phase, "finalization");
-        assert_eq!(adoption.active_gate, "finalize pull request");
-        finish_candidate_adoption(&record.run_id, None).expect("terminal completion");
-        let completed = status(&record.run_id).expect("completed status");
-        let adoption = completed
-            .candidate_adoption
-            .expect("terminal attempt retained");
-        assert_eq!(adoption.state, "completed");
-        assert_eq!(adoption.resume_count, 1);
-        assert!(adoption.completed_at.is_some());
-        assert!(start_candidate_adoption(
-            &record.run_id,
-            candidate,
-            "openai/gpt-5.6-terra",
-            "cargo test",
-        )
-        .is_err());
-        start_candidate_adoption_with_rerun_policy(
-            &record.run_id,
-            candidate,
-            "openai/gpt-5.6-terra",
-            "cargo test",
-            true,
-        )
-        .expect("explicit recipe policy permits a completed gate rerun");
-    });
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        candidate,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        false,
+        false,
+    )
+    .expect("same immutable candidate resumes");
+    checkpoint_candidate_adoption_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        "finalization",
+        "finalize pull request",
+    )
+    .expect("finalization checkpoint");
+    let finalizing = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("finalization status")
+    .record;
+    let adoption = finalizing.candidate_adoption.expect("attempt");
+    assert_eq!(adoption.phase, "finalization");
+    assert_eq!(adoption.active_gate, "finalize pull request");
+    finish_candidate_adoption_in_store(&lifecycle_store, &record.run_id, None)
+        .expect("terminal completion");
+    let completed = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("completed status")
+    .record;
+    let adoption = completed
+        .candidate_adoption
+        .expect("terminal attempt retained");
+    assert_eq!(adoption.state, "completed");
+    assert_eq!(adoption.resume_count, 1);
+    assert!(adoption.completed_at.is_some());
+    assert!(start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        candidate,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        false,
+        false,
+    )
+    .is_err());
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        candidate,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        true,
+        false,
+    )
+    .expect("explicit recipe policy permits a completed gate rerun");
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The audit history asserted at the end is the *original* adoption
+/// preserved alongside its replacement, so the record that gets replaced and
+/// the record the history is read from have to be the same one. The
+/// intervening `status_in_store` is what reconciles the falsified owner pid
+/// into `interrupted`, and it must see the rewrite that preceded it.
 #[test]
 fn interrupted_candidate_adoption_can_be_explicitly_replaced_with_audit_history() {
-    with_isolated_home(|_| {
-        let record = submit_plan(&test_plan(), Some("adoption-replacement")).expect("submit");
-        let original = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
-        let replacement = "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
-        start_candidate_adoption(
-            &record.run_id,
-            original,
-            "openai/gpt-5.6-terra",
-            "cargo test",
-        )
-        .expect("start original adoption");
-        assert!(start_candidate_adoption_with_policy(
-            &record.run_id,
-            replacement,
-            "openai/gpt-5.6-sol",
-            "cargo test",
-            false,
-            true,
-        )
-        .is_err());
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), "adoption-replacement", |_| Ok(json!({})))
+        .expect("submit");
+    let original = "a3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+    let replacement = "b3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1";
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        original,
+        "openai/gpt-5.6-terra",
+        "cargo test",
+        false,
+        false,
+    )
+    .expect("start original adoption");
+    assert!(start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        replacement,
+        "openai/gpt-5.6-sol",
+        "cargo test",
+        false,
+        true,
+    )
+    .is_err());
 
-        rewrite_record_for_test(&record.run_id, |record| {
-            record
-                .candidate_adoption
-                .as_mut()
-                .expect("original adoption")
-                .owner_pid = u32::MAX;
-        })
-        .unwrap();
-        status(&record.run_id).expect("reconcile stale owner");
-        let replaced = start_candidate_adoption_with_policy(
-            &record.run_id,
-            replacement,
-            "openai/gpt-5.6-sol",
-            "cargo test",
-            false,
-            true,
-        )
-        .expect("explicitly replace interrupted adoption");
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record
+            .candidate_adoption
+            .as_mut()
+            .expect("original adoption")
+            .owner_pid = u32::MAX;
+    })
+    .unwrap();
+    status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reconcile stale owner");
+    let replaced = start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        replacement,
+        "openai/gpt-5.6-sol",
+        "cargo test",
+        false,
+        true,
+    )
+    .expect("explicitly replace interrupted adoption");
 
-        let current = replaced.candidate_adoption.expect("replacement adoption");
-        assert_eq!(current.candidate_sha, replacement);
-        assert_eq!(current.ai_model, "openai/gpt-5.6-sol");
-        assert_eq!(
-            replaced.metadata["candidate_adoption_replacements"][0]["candidate_sha"],
-            original
-        );
-        assert_eq!(
-            replaced.metadata["candidate_adoption_replacements"][0]["state"],
-            "interrupted"
-        );
-    });
+    let current = replaced.candidate_adoption.expect("replacement adoption");
+    assert_eq!(current.candidate_sha, replacement);
+    assert_eq!(current.ai_model, "openai/gpt-5.6-sol");
+    assert_eq!(
+        replaced.metadata["candidate_adoption_replacements"][0]["candidate_sha"],
+        original
+    );
+    assert_eq!(
+        replaced.metadata["candidate_adoption_replacements"][0]["state"],
+        "interrupted"
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -557,90 +672,158 @@ fn private_candidate_adoption_gate_progress_is_redacted_before_persistence() {
     assert!(!persisted.contains("private output secret"));
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The alias resolves across two indexed attempts to project the
+/// adoption owned by the *earlier* one, so the Cook index, both runs and the
+/// alias read all have to name one installation. An alias resolved against
+/// another home's index would name attempts this store has never heard of.
 #[test]
 fn cook_alias_status_projects_active_adoption_remediation() {
-    homeboy_core::test_support::with_isolated_home(|_| {
-        let cook_id = "cook-adoption-remediation-status";
-        let source_run_id = "cook-adoption-remediation-status-attempt-1";
-        let remediation_run_id = "cook-adoption-remediation-status-attempt-2";
-        let plan = test_plan();
-        submit_plan(&plan, Some(source_run_id)).expect("source run");
-        submit_plan(&plan, Some(remediation_run_id)).expect("remediation run");
-        record_cook_attempt(cook_id, 1, source_run_id).expect("source attempt");
-        record_cook_attempt(cook_id, 2, remediation_run_id).expect("remediation attempt");
-        start_candidate_adoption(source_run_id, "candidate", "model", "cargo test")
-            .expect("active adoption");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let cook_id = "cook-adoption-remediation-status";
+    let source_run_id = "cook-adoption-remediation-status-attempt-1";
+    let remediation_run_id = "cook-adoption-remediation-status-attempt-2";
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, source_run_id, |_| Ok(json!({})))
+        .expect("source run");
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, remediation_run_id, |_| Ok(json!({})))
+        .expect("remediation run");
+    record_cook_attempt_in_store(&lifecycle_store, cook_id, 1, source_run_id)
+        .expect("source attempt");
+    record_cook_attempt_in_store(&lifecycle_store, cook_id, 2, remediation_run_id)
+        .expect("remediation attempt");
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        source_run_id,
+        "candidate",
+        "model",
+        "cargo test",
+        false,
+        false,
+    )
+    .expect("active adoption");
 
-        checkpoint_candidate_adoption_remediation(source_run_id, remediation_run_id)
-            .expect("remediation checkpoint");
+    checkpoint_candidate_adoption_remediation_in_store(
+        &lifecycle_store,
+        source_run_id,
+        remediation_run_id,
+    )
+    .expect("remediation checkpoint");
 
-        let projected = status(cook_id).expect("Cook alias status");
-        assert_eq!(projected.adoption_run_id.as_deref(), Some(source_run_id));
-        let adoption = projected.candidate_adoption.expect("projected adoption");
-        assert_eq!(adoption.state, "verification_running");
-        assert_eq!(adoption.phase, "provider_remediation");
-        assert_eq!(
-            adoption.remediation_run_id.as_deref(),
-            Some(remediation_run_id)
-        );
-        assert_eq!(
-            adoption.remediation_status_command.as_deref(),
-            Some("homeboy agent-task status cook-adoption-remediation-status-attempt-2 --full")
-        );
-    });
+    let projected = status_in_store(
+        &lifecycle_store,
+        cook_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("Cook alias status")
+    .record;
+    assert_eq!(projected.adoption_run_id.as_deref(), Some(source_run_id));
+    let adoption = projected.candidate_adoption.expect("projected adoption");
+    assert_eq!(adoption.state, "verification_running");
+    assert_eq!(adoption.phase, "provider_remediation");
+    assert_eq!(
+        adoption.remediation_run_id.as_deref(),
+        Some(remediation_run_id)
+    );
+    assert_eq!(
+        adoption.remediation_status_command.as_deref(),
+        Some("homeboy agent-task status cook-adoption-remediation-status-attempt-2 --full")
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The gate process group is persisted on this record and the
+/// cancellation reaps whatever group that record names, so planting the gate
+/// identity in one home and cancelling from another would either reap nothing
+/// or reap a group this test never spawned. The run is controller-local — no
+/// runner id and no runner job id — so `cancel_run_in_store` never reaches
+/// `classify_live_cancellation`'s runner-backed branch and the process-global
+/// runner-continuation registry stays untouched. Same argument as
+/// `candidate_adoption_cancellation_persists_request_before_group_termination`.
 #[cfg(unix)]
 #[test]
 fn candidate_adoption_reconciles_and_cancels_an_orphaned_gate_group() {
-    with_isolated_home(|_| {
-        let record = submit_plan(&test_plan(), Some("adoption-orphaned-gate")).expect("submit");
-        start_candidate_adoption(
-            &record.run_id,
-            "d3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
-            "openai/gpt-5.6-terra",
-            "sleep 30",
-        )
-        .expect("start adoption");
-        let mut command = std::process::Command::new("sh");
-        command.args(["-lc", "sleep 30"]);
-        homeboy_core::engine::command::isolate_process_tree(&mut command);
-        let mut child = command.spawn().expect("spawn isolated fake gate");
-        start_candidate_adoption_gate(&record.run_id, "sleep 30", child.id(), 1800)
-            .expect("persist gate identity");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record
-                .candidate_adoption
-                .as_mut()
-                .expect("adoption")
-                .owner_pid = u32::MAX;
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(&test_plan(), "adoption-orphaned-gate", |_| {
+            Ok(json!({}))
         })
-        .expect("simulate controller interruption");
+        .expect("submit");
+    start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        "d3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
+        "openai/gpt-5.6-terra",
+        "sleep 30",
+        false,
+        false,
+    )
+    .expect("start adoption");
+    let mut command = std::process::Command::new("sh");
+    command.args(["-lc", "sleep 30"]);
+    homeboy_core::engine::command::isolate_process_tree(&mut command);
+    let mut child = command.spawn().expect("spawn isolated fake gate");
+    start_candidate_adoption_gate_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        "sleep 30",
+        child.id(),
+        1800,
+    )
+    .expect("persist gate identity");
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record
+            .candidate_adoption
+            .as_mut()
+            .expect("adoption")
+            .owner_pid = u32::MAX;
+    })
+    .expect("simulate controller interruption");
 
-        let interrupted = status(&record.run_id).expect("reconcile orphaned gate");
-        assert_eq!(
-            interrupted.candidate_adoption.expect("adoption").phase,
-            "gate_orphaned"
-        );
-        assert!(start_candidate_adoption(
-            &record.run_id,
-            "d3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
-            "openai/gpt-5.6-terra",
-            "sleep 30",
-        )
-        .is_err());
-        let cancelled = cancel_run(&record.run_id, Some("recover orphaned gate"))
-            .expect("cancel orphaned gate");
-        assert_eq!(
-            cancelled.candidate_adoption.expect("adoption").state,
-            "cancelled"
-        );
-        assert!(
-            !homeboy_core::process::isolated_process_group_is_running(child.id())
-                .expect("inspect terminated gate group")
-        );
-        let _ = child.wait();
-    });
+    let interrupted = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reconcile orphaned gate")
+    .record;
+    assert_eq!(
+        interrupted.candidate_adoption.expect("adoption").phase,
+        "gate_orphaned"
+    );
+    assert!(start_candidate_adoption_with_policy_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        "d3c3ad9c2b75f8b03d503f4a09f0e2c4d47b57e1",
+        "openai/gpt-5.6-terra",
+        "sleep 30",
+        false,
+        false,
+    )
+    .is_err());
+    let cancelled = cancel_run_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        Some("recover orphaned gate"),
+    )
+    .expect("cancel orphaned gate");
+    assert_eq!(
+        cancelled.candidate_adoption.expect("adoption").state,
+        "cancelled"
+    );
+    assert!(
+        !homeboy_core::process::isolated_process_group_is_running(child.id())
+            .expect("inspect terminated gate group")
+    );
+    let _ = child.wait();
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -1425,95 +1608,133 @@ fn terminal_lab_record_persists_from_inside_a_config_lock_section() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The mirrored transport event is written onto this record and the
+/// log projection is read back off it, so the events the log exposes are the
+/// events this test persisted. `log.events.len() == 1` and `raw_events.len()
+/// == 1` are population counts over one record.
 #[test]
 fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "live-runner-events",
             runner_id: "homeboy-lab",
             runner_job_id: "job-live",
             remote_workspace: "/runner/workspace/homeboy",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        record.metadata["runner_job_events"] = json!([JobEvent {
-            sequence: 1,
-            job_id: uuid::Uuid::new_v4(),
-            kind: JobEventKind::Progress,
-            timestamp_ms: 42,
-            message: Some("provider started".to_string()),
-            data: Some(json!({
-                "provider": "openai/gpt-5.6-terra",
-                "phase": "implementing",
-                "activity": "editing lifecycle projection"
-            })),
-        }]);
-        store::write_record(&record).expect("persist mirrored event");
+        },
+    )
+    .expect("running proxy");
+    record.metadata["runner_job_events"] = json!([JobEvent {
+        sequence: 1,
+        job_id: uuid::Uuid::new_v4(),
+        kind: JobEventKind::Progress,
+        timestamp_ms: 42,
+        message: Some("provider started".to_string()),
+        data: Some(json!({
+            "provider": "openai/gpt-5.6-terra",
+            "phase": "implementing",
+            "activity": "editing lifecycle projection"
+        })),
+    }]);
+    lifecycle_store
+        .write_record(&record)
+        .expect("persist mirrored event");
 
-        let log = logs("live-runner-events").expect("live logs resolve");
+    let log = logs_in_store(&lifecycle_store, "live-runner-events").expect("live logs resolve");
 
-        assert_eq!(log.events.len(), 1);
-        assert!(log.events[0]
-            .message
-            .as_deref()
-            .is_some_and(|message| message.contains("provider started")));
-        assert_eq!(
-            log.events[0].provider.as_deref(),
-            Some("openai/gpt-5.6-terra")
-        );
-        assert_eq!(log.events[0].phase.as_deref(), Some("implementing"));
-        assert_eq!(
-            log.events[0].activity.as_deref(),
-            Some("editing lifecycle projection")
-        );
-        assert_eq!(log.events[0].heartbeat_at_ms, Some(42));
-        assert!(log.raw_events.is_empty(), "raw transport is opt-in");
+    assert_eq!(log.events.len(), 1);
+    assert!(log.events[0]
+        .message
+        .as_deref()
+        .is_some_and(|message| message.contains("provider started")));
+    assert_eq!(
+        log.events[0].provider.as_deref(),
+        Some("openai/gpt-5.6-terra")
+    );
+    assert_eq!(log.events[0].phase.as_deref(), Some("implementing"));
+    assert_eq!(
+        log.events[0].activity.as_deref(),
+        Some("editing lifecycle projection")
+    );
+    assert_eq!(log.events[0].heartbeat_at_ms, Some(42));
+    assert!(log.raw_events.is_empty(), "raw transport is opt-in");
 
-        let raw_log = logs_with_raw("live-runner-events", true).expect("raw logs resolve");
-        assert_eq!(
-            raw_log.events[0].metadata["provider"],
-            "openai/gpt-5.6-terra"
-        );
-        assert_eq!(raw_log.raw_events.len(), 1);
-        assert_eq!(
-            raw_log.raw_events[0]["data"]["activity"],
-            "editing lifecycle projection"
-        );
-    });
+    let raw_log = logs_with_raw_in_store(&lifecycle_store, "live-runner-events", true)
+        .expect("raw logs resolve");
+    assert_eq!(
+        raw_log.events[0].metadata["provider"],
+        "openai/gpt-5.6-terra"
+    );
+    assert_eq!(raw_log.raw_events.len(), 1);
+    assert_eq!(
+        raw_log.raw_events[0]["data"]["activity"],
+        "editing lifecycle projection"
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Acceptance validates the runner identity a *previously persisted*
+/// record already holds, so the rejection only proves anything if the second
+/// acceptance is validated against the record the first one wrote. Reading a
+/// different home there would either reject for the wrong reason or find no
+/// record to conflict with at all.
+///
+/// The runner-continuation registry `status_in_store` consults stays
+/// process-global by design: it is configured trust material and a subprocess
+/// contract, not a lifecycle root (#12618).
 #[test]
 fn terminal_lab_artifact_attachment_refuses_runner_provenance_mismatch() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-late-artifact-mismatch",
             runner_id: "homeboy-lab",
             runner_job_id: "job-original",
             remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact-mismatch",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        let mut record = status("agent-task-late-artifact-mismatch").expect("status");
-        apply_runner_job_terminal_state(
-            &mut record,
-            homeboy_core::api_jobs::JobStatus::Succeeded,
-            &[],
-        );
-        store::write_record(&record).expect("terminal record");
+        },
+    )
+    .expect("running proxy");
+    let mut record = status_in_store(
+        &lifecycle_store,
+        "agent-task-late-artifact-mismatch",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status")
+    .record;
+    apply_runner_job_terminal_state(
+        &mut record,
+        homeboy_core::api_jobs::JobStatus::Succeeded,
+        &[],
+    );
+    lifecycle_store
+        .write_record(&record)
+        .expect("terminal record");
 
-        let error = record_detached_lab_run(DetachedLabRunRecord {
+    let error = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-late-artifact-mismatch",
             runner_id: "different-lab",
             runner_job_id: "job-artifact-attach",
             remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact-mismatch",
             remote_command: &command,
-        })
-        .expect_err("artifact provenance must retain its original runner");
-        assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
-        assert_eq!(error.details["field"], "lab_handoff");
-    });
+        },
+    )
+    .expect_err("artifact provenance must retain its original runner");
+    assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+    assert_eq!(error.details["field"], "lab_handoff");
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -1592,89 +1813,114 @@ fn terminal_projection_keeps_prior_commit_when_interrupted_before_commit() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The fixture deliberately points `plan_path` at a *runner-local*
+/// path that does not exist here, and the claim is that hydration succeeds
+/// without reading it. Both writes, both reconciliations, the status, the
+/// artifact reports and the aggregate read all have to name one installation —
+/// and the closing idempotence assertion (still exactly one artifact after a
+/// replay) is a population count over that one home.
 #[test]
 fn terminal_proxy_reconciliation_hydrates_persisted_nested_result_idempotently() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-persisted-result",
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        record.plan_path =
-            "/home/lab/.local/share/homeboy/agent-task-runs/agent-task-persisted-result/plan.json"
-                .to_string();
-        store::write_record(&record).expect("runner-local plan projection");
-        apply_runner_job_terminal_state(
-            &mut record,
-            homeboy_core::api_jobs::JobStatus::Succeeded,
-            &[],
-        );
-        store::write_record(&record).expect("legacy terminal projection without aggregate");
+        },
+    )
+    .expect("running proxy");
+    record.plan_path =
+        "/home/lab/.local/share/homeboy/agent-task-runs/agent-task-persisted-result/plan.json"
+            .to_string();
+    lifecycle_store
+        .write_record(&record)
+        .expect("runner-local plan projection");
+    apply_runner_job_terminal_state(
+        &mut record,
+        homeboy_core::api_jobs::JobStatus::Succeeded,
+        &[],
+    );
+    lifecycle_store
+        .write_record(&record)
+        .expect("legacy terminal projection without aggregate");
 
-        let mut aggregate = succeeded_aggregate(&test_plan());
-        aggregate.outcomes[0].artifacts = vec![AgentTaskArtifact {
-            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "final-patch".to_string(),
-            kind: "patch".to_string(),
-            name: Some("final.patch".to_string()),
-            label: None,
-            role: Some("patch".to_string()),
-            semantic_key: None,
-            path: Some("artifacts/final.patch".to_string()),
-            url: None,
-            mime: Some("text/x-diff".to_string()),
-            size_bytes: Some(18_928),
-            sha256: Some(
-                "062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071".to_string(),
-            ),
-            metadata: json!({ "source_snapshot": "snapshot-1" }),
-        }];
-        aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
-            kind: "transcript".to_string(),
-            uri: "homeboy://lab/transcript".to_string(),
-            label: Some("Provider transcript".to_string()),
-        }];
-        aggregate.outcomes[0].metadata = json!({
-            "provider": "opencode",
-            "provider_run_id": "provider-run-1",
-        });
-        let snapshot = persisted_terminal_result_snapshot(&aggregate);
-
-        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("hydrate persisted result");
-        let status = status(&record.run_id).expect("hydrated status without runner plan access");
-        let artifact_report = artifacts(&record.run_id).expect("hydrated artifacts");
-        assert_eq!(status.state, AgentTaskRunState::Succeeded);
-        assert_eq!(artifact_report.artifacts.len(), 1);
-        assert_eq!(artifact_report.artifacts[0].id, "final-patch");
-        assert_eq!(artifact_report.artifacts[0].size_bytes, Some(18_928));
-        assert_eq!(
-            artifact_report.artifacts[0].sha256.as_deref(),
-            Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
-        );
-        assert!(artifact_report
-            .evidence_refs
-            .iter()
-            .any(|reference| reference.kind == "transcript"));
-        let aggregate =
-            store::read_aggregate(&record.run_id).expect("persisted authoritative aggregate");
-        let review =
-            crate::agent_task_aggregate::AgentTaskAggregateReport::from(aggregate.outcomes);
-        assert_eq!(review.summary.apply_candidates, 1);
-        assert_eq!(review.apply_candidates[0].artifact_ids, vec!["final-patch"]);
-
-        reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent replay");
-        assert_eq!(
-            artifacts(&record.run_id)
-                .expect("replayed artifacts")
-                .artifacts
-                .len(),
-            1
-        );
+    let mut aggregate = succeeded_aggregate(&test_plan());
+    aggregate.outcomes[0].artifacts = vec![AgentTaskArtifact {
+        schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: "final-patch".to_string(),
+        kind: "patch".to_string(),
+        name: Some("final.patch".to_string()),
+        label: None,
+        role: Some("patch".to_string()),
+        semantic_key: None,
+        path: Some("artifacts/final.patch".to_string()),
+        url: None,
+        mime: Some("text/x-diff".to_string()),
+        size_bytes: Some(18_928),
+        sha256: Some(
+            "062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071".to_string(),
+        ),
+        metadata: json!({ "source_snapshot": "snapshot-1" }),
+    }];
+    aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+        kind: "transcript".to_string(),
+        uri: "homeboy://lab/transcript".to_string(),
+        label: Some("Provider transcript".to_string()),
+    }];
+    aggregate.outcomes[0].metadata = json!({
+        "provider": "opencode",
+        "provider_run_id": "provider-run-1",
     });
+    let snapshot = persisted_terminal_result_snapshot(&aggregate);
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("hydrate persisted result");
+    let status = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("hydrated status without runner plan access")
+    .record;
+    let artifact_report =
+        artifacts_in_store(&lifecycle_store, &record.run_id).expect("hydrated artifacts");
+    assert_eq!(status.state, AgentTaskRunState::Succeeded);
+    assert_eq!(artifact_report.artifacts.len(), 1);
+    assert_eq!(artifact_report.artifacts[0].id, "final-patch");
+    assert_eq!(artifact_report.artifacts[0].size_bytes, Some(18_928));
+    assert_eq!(
+        artifact_report.artifacts[0].sha256.as_deref(),
+        Some("062f5c460c2dfb279277b75d5a16a04e3178ace1f35ce7b10da5e17441b37071")
+    );
+    assert!(artifact_report
+        .evidence_refs
+        .iter()
+        .any(|reference| reference.kind == "transcript"));
+    let aggregate = lifecycle_store
+        .read_aggregate(&record.run_id)
+        .expect("persisted authoritative aggregate");
+    let review = crate::agent_task_aggregate::AgentTaskAggregateReport::from(aggregate.outcomes);
+    assert_eq!(review.summary.apply_candidates, 1);
+    assert_eq!(review.apply_candidates[0].artifact_ids, vec!["final-patch"]);
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("idempotent replay");
+    assert_eq!(
+        artifacts_in_store(&lifecycle_store, &record.run_id)
+            .expect("replayed artifacts")
+            .artifacts
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -2195,81 +2441,131 @@ fn sparse_aggregate_only_remote_dispatch_failure_adds_remote_evidence_refs() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The assertion is that a read left the record byte-identical, which
+/// is only meaningful if the before-read, the status and the after-read all
+/// address one record in one home.
+///
+/// `record_completed_run_in_store` reaches automatic artifact retention only
+/// when a task declares a workspace root that exists; `test_plan()` declares
+/// none, so no ambient retention pass is entered here.
 #[test]
 fn status_preserves_existing_terminal_runtime_evidence() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.tasks[0].executor.backend = "opencode".to_string();
-        let aggregate = succeeded_aggregate(&plan);
-        let record = record_completed_run(&plan, &aggregate, Some("existing-runtime"))
-            .expect("terminal record");
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.provider_runtime[0].metadata = json!({
-                "evidence_source": "native_provider",
-                "manual": true,
-            });
-        })
-        .expect("native evidence persisted");
-        let before = store::read_record(&record.run_id).expect("record before status");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    plan.tasks[0].executor.backend = "opencode".to_string();
+    let aggregate = succeeded_aggregate(&plan);
+    let record = record_completed_run_in_store(
+        &lifecycle_store,
+        &plan,
+        &aggregate,
+        Some("existing-runtime"),
+    )
+    .expect("terminal record");
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record.lifecycle.provider_runtime[0].metadata = json!({
+            "evidence_source": "native_provider",
+            "manual": true,
+        });
+    })
+    .expect("native evidence persisted");
+    let before = lifecycle_store
+        .read_record(&record.run_id)
+        .expect("record before status");
 
-        let loaded = status(&record.run_id).expect("status preserves runtime evidence");
-        let after = store::read_record(&record.run_id).expect("record after status");
+    let loaded = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status preserves runtime evidence")
+    .record;
+    let after = lifecycle_store
+        .read_record(&record.run_id)
+        .expect("record after status");
 
-        assert_eq!(before, after);
-        assert_eq!(
-            loaded.lifecycle.provider_runtime[0].metadata["manual"],
-            true
-        );
-    });
+    assert_eq!(before, after);
+    assert_eq!(
+        loaded.lifecycle.provider_runtime[0].metadata["manual"],
+        true
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). `records.len() == 1` is a population count over one installation's
+/// run directory — read ambiently it would count the operator's real runs — and
+/// the four projections (status, logs, artifacts, existence) are all asserted
+/// to describe the single run this test recorded under an unsanitized id.
+///
+/// `record_completed_run_in_store` reaches automatic artifact retention only
+/// when a task declares a workspace root that exists; this plan declares only a
+/// cleanup mode, so no ambient retention pass is entered here.
 #[test]
 fn lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
-        let mut aggregate = succeeded_aggregate(&plan);
-        aggregate.outcomes[0].artifacts = vec![artifact_ref_artifact(
-            "patch",
-            "patch",
-            None,
-            Some("/tmp/patch.diff"),
-        )];
-        aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
-            kind: "transcript".to_string(),
-            uri: "file:///tmp/transcript.json".to_string(),
-            label: Some("provider transcript".to_string()),
-        }];
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.outcomes[0].artifacts = vec![artifact_ref_artifact(
+        "patch",
+        "patch",
+        None,
+        Some("/tmp/patch.diff"),
+    )];
+    aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+        kind: "transcript".to_string(),
+        uri: "file:///tmp/transcript.json".to_string(),
+        label: Some("provider transcript".to_string()),
+    }];
 
-        let record = record_completed_run(&plan, &aggregate, Some("run/store-contract"))
-            .expect("completed run recorded");
-        let loaded = status("run/store-contract").expect("status loaded by unsanitized id");
-        let log = logs("run/store-contract").expect("logs loaded by unsanitized id");
-        let artifact_report =
-            artifacts("run/store-contract").expect("artifacts loaded by unsanitized id");
-        let records = list_records().expect("records listed");
+    let record = record_completed_run_in_store(
+        &lifecycle_store,
+        &plan,
+        &aggregate,
+        Some("run/store-contract"),
+    )
+    .expect("completed run recorded");
+    let loaded = status_in_store(
+        &lifecycle_store,
+        "run/store-contract",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status loaded by unsanitized id")
+    .record;
+    let log = logs_in_store(&lifecycle_store, "run/store-contract")
+        .expect("logs loaded by unsanitized id");
+    let artifact_report = artifacts_in_store(&lifecycle_store, "run/store-contract")
+        .expect("artifacts loaded by unsanitized id");
+    let records = list_records_in_store(&lifecycle_store).expect("records listed");
 
-        assert_eq!(record.run_id, "run_store-contract");
-        assert!(run_record_exists("run/store-contract").expect("record exists"));
-        assert_eq!(loaded.state, AgentTaskRunState::Succeeded);
-        assert_eq!(loaded.lifecycle.schema, RUN_LIFECYCLE_RECORD_SCHEMA);
-        assert_eq!(
-            loaded.lifecycle.execution.state,
-            RunExecutionState::Succeeded
-        );
-        assert_eq!(loaded.lifecycle.cleanup.state, CleanupState::Preserved);
-        assert_eq!(
-            loaded.lifecycle.artifact_retention.status,
-            ArtifactRetentionStatus::Retained
-        );
-        assert_eq!(log.schema, schemas::RUN_LOG);
-        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
-        assert_eq!(artifact_report.schema, schemas::RUN_ARTIFACTS);
-        assert_eq!(artifact_report.artifacts[0].id, "patch");
-        assert_eq!(artifact_report.evidence_refs[0].kind, "transcript");
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].run_id, "run_store-contract");
-    });
+    assert_eq!(record.run_id, "run_store-contract");
+    assert!(
+        run_record_exists_in_store(&lifecycle_store, "run/store-contract").expect("record exists")
+    );
+    assert_eq!(loaded.state, AgentTaskRunState::Succeeded);
+    assert_eq!(loaded.lifecycle.schema, RUN_LIFECYCLE_RECORD_SCHEMA);
+    assert_eq!(
+        loaded.lifecycle.execution.state,
+        RunExecutionState::Succeeded
+    );
+    assert_eq!(loaded.lifecycle.cleanup.state, CleanupState::Preserved);
+    assert_eq!(
+        loaded.lifecycle.artifact_retention.status,
+        ArtifactRetentionStatus::Retained
+    );
+    assert_eq!(log.schema, schemas::RUN_LOG);
+    assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
+    assert_eq!(artifact_report.schema, schemas::RUN_ARTIFACTS);
+    assert_eq!(artifact_report.artifacts[0].id, "patch");
+    assert_eq!(artifact_report.evidence_refs[0].kind, "transcript");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].run_id, "run_store-contract");
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -2528,46 +2824,62 @@ fn artifact_refs_treat_empty_url_as_missing_and_fall_back_to_path() {
     assert_eq!(refs[0].uri, "/tmp/artifacts/dir");
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The log projection reads back the aggregate the completed run
+/// wrote, so `log.events.len() == 2` and the per-event envelope fields
+/// describe the aggregate this test recorded rather than whatever an ambient
+/// home holds under this run id.
+///
+/// `record_completed_run_in_store` reaches automatic artifact retention only
+/// when a task declares a workspace root that exists; `test_plan()` declares
+/// none, so no ambient retention pass is entered here.
 #[test]
 fn logs_include_normalized_event_envelopes() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let mut aggregate = succeeded_aggregate(&plan);
-        aggregate.events = vec![
-            AgentTaskProgressEvent {
-                task_id: "task-a".to_string(),
-                state: AgentTaskState::Running,
-                attempt: 1,
-                message: Some("started".to_string()),
-            },
-            AgentTaskProgressEvent {
-                task_id: "task-a".to_string(),
-                state: AgentTaskState::Succeeded,
-                attempt: 1,
-                message: Some("ok".to_string()),
-            },
-        ];
-        aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
-            kind: "transcript".to_string(),
-            uri: "file:///tmp/transcript.json".to_string(),
-            label: Some("Transcript".to_string()),
-        }];
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.events = vec![
+        AgentTaskProgressEvent {
+            task_id: "task-a".to_string(),
+            state: AgentTaskState::Running,
+            attempt: 1,
+            message: Some("started".to_string()),
+        },
+        AgentTaskProgressEvent {
+            task_id: "task-a".to_string(),
+            state: AgentTaskState::Succeeded,
+            attempt: 1,
+            message: Some("ok".to_string()),
+        },
+    ];
+    aggregate.outcomes[0].evidence_refs = vec![AgentTaskEvidenceRef {
+        kind: "transcript".to_string(),
+        uri: "file:///tmp/transcript.json".to_string(),
+        label: Some("Transcript".to_string()),
+    }];
 
-        record_completed_run(&plan, &aggregate, Some("run-event-envelope")).expect("recorded");
+    record_completed_run_in_store(
+        &lifecycle_store,
+        &plan,
+        &aggregate,
+        Some("run-event-envelope"),
+    )
+    .expect("recorded");
 
-        let log = logs("run-event-envelope").expect("logs");
+    let log = logs_in_store(&lifecycle_store, "run-event-envelope").expect("logs");
 
-        assert_eq!(log.schema, "homeboy/agent-task-run-log/v2");
-        assert_eq!(log.events.len(), 2);
-        assert_eq!(log.events[0].schema, schemas::EVENT);
-        assert_eq!(log.events[0].run_id, "run-event-envelope");
-        assert_eq!(log.events[0].task_id, "task-a");
-        assert_eq!(log.events[0].sequence, 1);
-        assert_eq!(log.events[0].status, AgentTaskState::Running);
-        assert_eq!(log.events[1].message.as_deref(), Some("ok"));
-        assert_eq!(log.events[1].artifact_refs.len(), 1);
-        assert!(log.raw_events.is_empty());
-    });
+    assert_eq!(log.schema, "homeboy/agent-task-run-log/v2");
+    assert_eq!(log.events.len(), 2);
+    assert_eq!(log.events[0].schema, schemas::EVENT);
+    assert_eq!(log.events[0].run_id, "run-event-envelope");
+    assert_eq!(log.events[0].task_id, "task-a");
+    assert_eq!(log.events[0].sequence, 1);
+    assert_eq!(log.events[0].status, AgentTaskState::Running);
+    assert_eq!(log.events[1].message.as_deref(), Some("ok"));
+    assert_eq!(log.events[1].artifact_refs.len(), 1);
+    assert!(log.raw_events.is_empty());
 }
 
 #[test]
@@ -2578,30 +2890,40 @@ fn set_run_state_stamps_finished_at_for_candidate_recoverable_terminal_runs() {
     // hand-listed terminal subset omitted CandidateRecoverable, leaving these
     // runs without a finished_at while the legacy-record migration path stamped
     // one.
-    with_isolated_home(|_| {
-        let record =
-            submit_plan(&test_plan(), Some("candidate-recoverable-finished-at")).expect("submit");
-        rewrite_record_for_test(&record.run_id, |record| {
-            set_run_state(record, AgentTaskRunState::CandidateRecoverable);
-            assert_eq!(record.state, AgentTaskRunState::CandidateRecoverable);
-            assert!(
-                record.lifecycle.execution.finished_at.is_some(),
-                "a terminal CandidateRecoverable run must stamp finished_at"
-            );
-        })
-        .expect("rewrite record");
+    //
+    // Rooted in an explicit store rather than a mutated process environment
+    // (#7505). `set_run_state` is a pure in-memory setter; the store is only
+    // needed to own the submitted record the two rewrites read and write back.
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let record = lifecycle_store
+        .submit_plan_with_runtime_admission(
+            &test_plan(),
+            "candidate-recoverable-finished-at",
+            |_| Ok(json!({})),
+        )
+        .expect("submit");
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        set_run_state(record, AgentTaskRunState::CandidateRecoverable);
+        assert_eq!(record.state, AgentTaskRunState::CandidateRecoverable);
+        assert!(
+            record.lifecycle.execution.finished_at.is_some(),
+            "a terminal CandidateRecoverable run must stamp finished_at"
+        );
+    })
+    .expect("rewrite record");
 
-        // And a non-terminal state must NOT stamp finished_at.
-        rewrite_record_for_test(&record.run_id, |record| {
-            record.lifecycle.execution.finished_at = None;
-            set_run_state(record, AgentTaskRunState::Running);
-            assert!(
-                record.lifecycle.execution.finished_at.is_none(),
-                "a non-terminal Running run must not stamp finished_at"
-            );
-        })
-        .expect("rewrite record running");
-    });
+    // And a non-terminal state must NOT stamp finished_at.
+    rewrite_record_for_test_in_store(&lifecycle_store, &record.run_id, |record| {
+        record.lifecycle.execution.finished_at = None;
+        set_run_state(record, AgentTaskRunState::Running);
+        assert!(
+            record.lifecycle.execution.finished_at.is_none(),
+            "a non-terminal Running run must not stamp finished_at"
+        );
+    })
+    .expect("rewrite record running");
 }
 
 /// A runner-continuation provider that counts every runner interaction so a

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -31,7 +31,13 @@ struct ServiceRunnerFixture {
 
 struct FixtureAcceptanceVerifier;
 
+/// The drift fixture rewrites the candidate *from inside* verification, so it
+/// carries the store that rewrite has to land in. Reaching for the ambient
+/// `record_promotion` here would drift a record in whatever home the process
+/// environment names, while the verdict it is racing was read from — and is
+/// about to be written back into — the store the test injected (#7505).
 struct PromotionDriftVerifier {
+    lifecycle_store: AgentTaskLifecycleStore,
     run_id: String,
 }
 
@@ -96,7 +102,8 @@ impl AgentTaskAcceptanceVerifier for PromotionDriftVerifier {
         &self,
         request: &AgentTaskAcceptanceVerificationRequest,
     ) -> Result<AgentTaskAcceptanceAttestation> {
-        record_promotion(
+        record_promotion_in_store(
+            &self.lifecycle_store,
             &self.run_id,
             applied_acceptance_promotion("candidate-b", &request.base_sha),
         )?;
@@ -491,328 +498,460 @@ fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The attempt proxy is created, terminalized and read back through
+/// the same injected store, so "this attempt record is Failed with a staging
+/// phase" describes the record this test actually planted rather than one an
+/// ambient home happened to hold under the same run id.
 #[test]
 fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
-    with_isolated_home(|_| {
-        let attempt_run_id = "cook-7970-attempt-1-staging-failure";
-        let plan = test_plan();
-        record_lab_offload_phase(
-            attempt_run_id,
-            "homeboy-lab",
-            "materializing",
-            None,
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("pre-acceptance attempt record");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let attempt_run_id = "cook-7970-attempt-1-staging-failure";
+    let plan = test_plan();
+    record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: attempt_run_id,
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("pre-acceptance attempt record");
 
-        record_pre_execution_failure(
-            attempt_run_id,
-            &plan,
-            "lab_workspace_stage",
-            &Error::internal_unexpected("workspace materialization failed").with_hint(format!(
-                "Retry: homeboy agent-task retry {attempt_run_id} --run"
-            )),
-        )
-        .expect("terminal staging failure");
+    record_pre_execution_failure_in_store(
+        &lifecycle_store,
+        attempt_run_id,
+        &plan,
+        "lab_workspace_stage",
+        &Error::internal_unexpected("workspace materialization failed").with_hint(format!(
+            "Retry: homeboy agent-task retry {attempt_run_id} --run"
+        )),
+    )
+    .expect("terminal staging failure");
 
-        let record = status(attempt_run_id).expect("terminal attempt record");
-        assert_eq!(record.state, AgentTaskRunState::Failed);
-        assert_eq!(
-            record.metadata["pre_execution_failure"]["phase"],
-            "lab_workspace_stage"
-        );
-        assert!(record.metadata["pre_execution_failure"]["hints"]
-            .as_array()
-            .expect("failure hints")
-            .iter()
-            .any(|hint| hint
-                == "Retry: homeboy agent-task retry cook-7970-attempt-1-staging-failure --run"));
-        assert!(record.metadata.get("runner_job_id").is_none());
-    });
+    let record = status_in_store(
+        &lifecycle_store,
+        attempt_run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("terminal attempt record")
+    .record;
+    assert_eq!(record.state, AgentTaskRunState::Failed);
+    assert_eq!(
+        record.metadata["pre_execution_failure"]["phase"],
+        "lab_workspace_stage"
+    );
+    assert!(record.metadata["pre_execution_failure"]["hints"]
+        .as_array()
+        .expect("failure hints")
+        .iter()
+        .any(|hint| hint
+            == "Retry: homeboy agent-task retry cook-7970-attempt-1-staging-failure --run"));
+    assert!(record.metadata.get("runner_job_id").is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Only the first read is durable; every later case is an in-memory
+/// mutation of that one record. That makes the identity of the first read the
+/// whole fixture, so it has to come out of the store the pre-acceptance
+/// failure was committed into.
+///
+/// `candidate_adoption_recovery_outcome` is a pure classifier over a record and
+/// a task, so it needs no root of its own.
 #[test]
 fn failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recovery() {
-    with_isolated_home(|_| {
-        let run_id = "cook-preacceptance-recovery";
-        let plan = test_plan();
-        record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "materializing",
-            None,
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("pre-acceptance attempt record");
-        record_pre_execution_failure(
-            run_id,
-            &plan,
-            "lab_handoff_preacceptance",
-            &Error::internal_unexpected("truncated Lab handoff payload"),
-        )
-        .expect("terminal preacceptance failure");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-preacceptance-recovery";
+    let plan = test_plan();
+    record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("pre-acceptance attempt record");
+    record_pre_execution_failure_in_store(
+        &lifecycle_store,
+        run_id,
+        &plan,
+        "lab_handoff_preacceptance",
+        &Error::internal_unexpected("truncated Lab handoff payload"),
+    )
+    .expect("terminal preacceptance failure");
 
-        let mut record = status(run_id).expect("failed record");
-        record.metadata["phase"] = json!("lab_handoff_preacceptance");
-        assert_eq!(record.state, AgentTaskRunState::Failed);
-        assert!(record.aggregate_path.is_some());
-        assert!(!record.artifact_refs.is_empty());
-        assert_eq!(record.lifecycle.provider_runtime.len(), 1);
-        assert_eq!(
-            record.lifecycle.provider_runtime[0].metadata["evidence_source"],
-            "canonical_executor_outcome"
-        );
-        assert!(candidate_adoption_recovery_outcome(&record, &plan.tasks[0]).is_some());
+    let mut record = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("failed record")
+    .record;
+    record.metadata["phase"] = json!("lab_handoff_preacceptance");
+    assert_eq!(record.state, AgentTaskRunState::Failed);
+    assert!(record.aggregate_path.is_some());
+    assert!(!record.artifact_refs.is_empty());
+    assert_eq!(record.lifecycle.provider_runtime.len(), 1);
+    assert_eq!(
+        record.lifecycle.provider_runtime[0].metadata["evidence_source"],
+        "canonical_executor_outcome"
+    );
+    assert!(candidate_adoption_recovery_outcome(&record, &plan.tasks[0]).is_some());
 
-        let mut wrong_phase = record.clone();
-        wrong_phase.metadata["phase"] = json!("provider_dispatch");
-        assert!(candidate_adoption_recovery_outcome(&wrong_phase, &plan.tasks[0]).is_none());
+    let mut wrong_phase = record.clone();
+    wrong_phase.metadata["phase"] = json!("provider_dispatch");
+    assert!(candidate_adoption_recovery_outcome(&wrong_phase, &plan.tasks[0]).is_none());
 
-        let mut consumed_execution = record.clone();
-        consumed_execution.metadata["provider_executions_consumed"] = json!(1);
-        assert!(candidate_adoption_recovery_outcome(&consumed_execution, &plan.tasks[0]).is_none());
+    let mut consumed_execution = record.clone();
+    consumed_execution.metadata["provider_executions_consumed"] = json!(1);
+    assert!(candidate_adoption_recovery_outcome(&consumed_execution, &plan.tasks[0]).is_none());
 
-        let mut provider_handle = record.clone();
-        provider_handle
-            .provider_handles
-            .push(AgentTaskRunProviderHandle {
-                kind: Default::default(),
-                task_id: "task-a".to_string(),
-                backend: "test".to_string(),
-                provider_run_id: "provider-actual-run".to_string(),
-                stream_uri: None,
-                state: Some(AgentTaskState::Failed),
-                metadata: Value::Null,
-            });
-        assert!(candidate_adoption_recovery_outcome(&provider_handle, &plan.tasks[0]).is_none());
+    let mut provider_handle = record.clone();
+    provider_handle
+        .provider_handles
+        .push(AgentTaskRunProviderHandle {
+            kind: Default::default(),
+            task_id: "task-a".to_string(),
+            backend: "test".to_string(),
+            provider_run_id: "provider-actual-run".to_string(),
+            stream_uri: None,
+            state: Some(AgentTaskState::Failed),
+            metadata: Value::Null,
+        });
+    assert!(candidate_adoption_recovery_outcome(&provider_handle, &plan.tasks[0]).is_none());
 
-        let mut runner_job = record.clone();
-        runner_job.metadata["runner_job_id"] = json!("job-actual-provider");
-        assert!(candidate_adoption_recovery_outcome(&runner_job, &plan.tasks[0]).is_none());
+    let mut runner_job = record.clone();
+    runner_job.metadata["runner_job_id"] = json!("job-actual-provider");
+    assert!(candidate_adoption_recovery_outcome(&runner_job, &plan.tasks[0]).is_none());
 
-        let mut provider_runtime = record.clone();
-        provider_runtime.lifecycle.provider_runtime[0]
-            .external_runtime_ids
-            .push(homeboy_core::run_lifecycle_record::ExternalRuntimeId {
-                kind: "provider_run_id".to_string(),
-                value: "provider-actual-run".to_string(),
-                provider: Some("test".to_string()),
-                url: None,
-            });
-        assert!(candidate_adoption_recovery_outcome(&provider_runtime, &plan.tasks[0]).is_none());
+    let mut provider_runtime = record.clone();
+    provider_runtime.lifecycle.provider_runtime[0]
+        .external_runtime_ids
+        .push(homeboy_core::run_lifecycle_record::ExternalRuntimeId {
+            kind: "provider_run_id".to_string(),
+            value: "provider-actual-run".to_string(),
+            provider: Some("test".to_string()),
+            url: None,
+        });
+    assert!(candidate_adoption_recovery_outcome(&provider_runtime, &plan.tasks[0]).is_none());
 
-        let mut changed_recovery = record;
-        changed_recovery.metadata["pre_execution_failure"]["candidate_adoption_recovery"]
-            ["reason"] = json!("provider_failure");
-        assert!(candidate_adoption_recovery_outcome(&changed_recovery, &plan.tasks[0]).is_none());
-    });
+    let mut changed_recovery = record;
+    changed_recovery.metadata["pre_execution_failure"]["candidate_adoption_recovery"]["reason"] =
+        json!("provider_failure");
+    assert!(candidate_adoption_recovery_outcome(&changed_recovery, &plan.tasks[0]).is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The claim is that the *successor* plan file equals the plan the
+/// original attempt persisted, so the write, the failure, the retry successor
+/// and both plan reads have to name one installation — comparing a successor
+/// plan from one home against a source plan from another proves nothing.
+///
+/// `retry` becomes `retry_with_runtime_admission_in_store(…, false, false,
+/// None, …)` with a stub admission: that is the exact flag pair the ambient
+/// `retry` uses (`retry_in_store` → `retry_with_force_inner_in_store` with
+/// `force: false, enforce_lineage_reservation: false`). Only the
+/// controller-runtime admission is stubbed, because that queue lives under
+/// `paths::controller_runtimes_store()` and is deliberately machine-global.
+/// Same substitution as `retry_submits_new_run_from_existing_plan`.
 #[test]
 fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.plan_id = "materialized-cook-plan".to_string();
-        plan.tasks[0].instructions = "implement the original user task".to_string();
-        plan.tasks[0].workspace.root = Some("/materialized/worktree".to_string());
-        plan.rebuild_homeboy_plan();
-        let record = record_lab_offload_phase(
-            "failed-lab-cook",
-            "homeboy-lab",
-            "materializing",
-            Some("pending"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("controller records user plan before pending handoff");
-        let persisted = load_plan(&record.run_id).expect("persisted user plan");
-        record_pre_execution_failure(
-            &record.run_id,
-            &persisted,
-            "lab_handoff",
-            &Error::internal_unexpected("runner daemon restarted"),
-        )
-        .expect("terminal handoff failure");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    plan.plan_id = "materialized-cook-plan".to_string();
+    plan.tasks[0].instructions = "implement the original user task".to_string();
+    plan.tasks[0].workspace.root = Some("/materialized/worktree".to_string());
+    plan.rebuild_homeboy_plan();
+    let record = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: "failed-lab-cook",
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: Some("pending"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("controller records user plan before pending handoff");
+    let persisted =
+        load_plan_in_store(&lifecycle_store, &record.run_id).expect("persisted user plan");
+    record_pre_execution_failure_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        &persisted,
+        "lab_handoff",
+        &Error::internal_unexpected("runner daemon restarted"),
+    )
+    .expect("terminal handoff failure");
 
-        let retry = retry(&record.run_id, Some("failed-lab-cook-retry")).expect("retry record");
-        let recovered = load_plan(&retry.run_id).expect("recovered plan");
+    let retry = retry_with_runtime_admission_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        Some("failed-lab-cook-retry"),
+        false,
+        false,
+        None,
+        |_| Ok(json!({})),
+    )
+    .expect("retry record");
+    let recovered = load_plan_in_store(&lifecycle_store, &retry.run_id).expect("recovered plan");
 
-        assert_eq!(recovered, plan);
-        assert_eq!(
-            recovered.tasks[0].workspace.root.as_deref(),
-            Some("/materialized/worktree")
-        );
-        assert!(!serde_json::to_string(&recovered)
-            .expect("plan json")
-            .contains("pending"));
-        assert_eq!(retry.metadata["retry_origin"]["runner_id"], "homeboy-lab");
-        assert_eq!(
-            retry.metadata["retry_origin"]["remote_workspace"],
-            "pending"
-        );
-        assert_eq!(
-            retry.metadata["retry_origin"]["pre_execution_failure"]["phase"],
-            "lab_handoff"
-        );
-    });
+    assert_eq!(recovered, plan);
+    assert_eq!(
+        recovered.tasks[0].workspace.root.as_deref(),
+        Some("/materialized/worktree")
+    );
+    assert!(!serde_json::to_string(&recovered)
+        .expect("plan json")
+        .contains("pending"));
+    assert_eq!(retry.metadata["retry_origin"]["runner_id"], "homeboy-lab");
+    assert_eq!(
+        retry.metadata["retry_origin"]["remote_workspace"],
+        "pending"
+    );
+    assert_eq!(
+        retry.metadata["retry_origin"]["pre_execution_failure"]["phase"],
+        "lab_handoff"
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The phase history is cumulative: the second phase write appends to
+/// what the first one persisted, and the status read has to see both. Splitting
+/// those three across homes would leave a two-entry history asserted against a
+/// record that only ever saw one write.
 #[test]
 fn controller_proxy_records_pre_execution_phase_progress() {
-    with_isolated_home(|_| {
-        let source = json!({
-            "branch": "main",
-            "head": "abc123",
-        });
-        let materializing = record_lab_offload_phase(
-            "agent-task-pre-execution",
-            "homeboy-lab",
-            "materializing",
-            None,
-            Some(&source),
-            Some(&json!({"entries": [{"model": "openai/gpt-5.6-terra"}]})),
-            None,
-        )
-        .expect("materialization phase persisted");
-
-        assert_eq!(materializing.state, AgentTaskRunState::Queued);
-        assert_eq!(materializing.metadata["phase"], "materializing");
-        assert_eq!(materializing.metadata["provider_state"], "pending");
-        assert_eq!(materializing.metadata["source_checkout"]["head"], "abc123");
-        assert_eq!(
-            materializing.metadata["provider_rotation"]["entries"][0]["model"],
-            "openai/gpt-5.6-terra"
-        );
-        assert!(materializing.metadata.get("runner_job_id").is_none());
-
-        let hydrating = record_lab_offload_phase(
-            "agent-task-pre-execution",
-            "homeboy-lab",
-            "hydrating",
-            Some("/runner/workspace/repo"),
-            Some(&source),
-            None,
-            None,
-        )
-        .expect("hydration phase persisted");
-        assert_eq!(hydrating.metadata["phase"], "hydrating");
-        assert_eq!(
-            hydrating.metadata["remote_workspace"],
-            "/runner/workspace/repo"
-        );
-
-        let loaded = status("agent-task-pre-execution").expect("status resolves during setup");
-        assert_eq!(loaded.metadata["phase"], "hydrating");
-        assert_eq!(loaded.metadata["provider_state"], "pending");
-        let phases = loaded.metadata["phase_history"]
-            .as_array()
-            .expect("phase history");
-        assert_eq!(phases.len(), 2);
-        assert_eq!(phases[0]["phase"], "materializing");
-        assert!(phases[0].get("started_at").is_some());
-        assert!(phases[0].get("ended_at").is_some());
-        assert_eq!(phases[1]["phase"], "hydrating");
-        assert!(phases[1].get("started_at").is_some());
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let source = json!({
+        "branch": "main",
+        "head": "abc123",
     });
+    let materializing = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: "agent-task-pre-execution",
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: Some(&source),
+            provider_rotation: Some(&json!({"entries": [{"model": "openai/gpt-5.6-terra"}]})),
+            durable_plan: None,
+        },
+    )
+    .expect("materialization phase persisted");
+
+    assert_eq!(materializing.state, AgentTaskRunState::Queued);
+    assert_eq!(materializing.metadata["phase"], "materializing");
+    assert_eq!(materializing.metadata["provider_state"], "pending");
+    assert_eq!(materializing.metadata["source_checkout"]["head"], "abc123");
+    assert_eq!(
+        materializing.metadata["provider_rotation"]["entries"][0]["model"],
+        "openai/gpt-5.6-terra"
+    );
+    assert!(materializing.metadata.get("runner_job_id").is_none());
+
+    let hydrating = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: "agent-task-pre-execution",
+            runner_id: "homeboy-lab",
+            phase: "hydrating",
+            remote_workspace: Some("/runner/workspace/repo"),
+            source_checkout: Some(&source),
+            provider_rotation: None,
+            durable_plan: None,
+        },
+    )
+    .expect("hydration phase persisted");
+    assert_eq!(hydrating.metadata["phase"], "hydrating");
+    assert_eq!(
+        hydrating.metadata["remote_workspace"],
+        "/runner/workspace/repo"
+    );
+
+    let loaded = status_in_store(
+        &lifecycle_store,
+        "agent-task-pre-execution",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status resolves during setup")
+    .record;
+    assert_eq!(loaded.metadata["phase"], "hydrating");
+    assert_eq!(loaded.metadata["provider_state"], "pending");
+    let phases = loaded.metadata["phase_history"]
+        .as_array()
+        .expect("phase history");
+    assert_eq!(phases.len(), 2);
+    assert_eq!(phases[0]["phase"], "materializing");
+    assert!(phases[0].get("started_at").is_some());
+    assert!(phases[0].get("ended_at").is_some());
+    assert_eq!(phases[1]["phase"], "hydrating");
+    assert!(phases[1].get("started_at").is_some());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). `reconcile_active_lab_runner_handoffs_in_store` returning zero is
+/// an assertion about the *population* of one installation, so it has to sweep
+/// the same home the setup record lives in — an ambient sweep would count
+/// whatever handoffs the operator's real root holds. The closing equality
+/// between the terminal phase write and the cancellation is the same argument
+/// for a single record.
 #[test]
 fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_are_noops() {
-    with_isolated_home(|_| {
-        let run_id = "long-pre-submission-materialization";
-        let plan = test_plan();
-        let materializing = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "materializing",
-            None,
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("persist pre-submission materialization");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "long-pre-submission-materialization";
+    let plan = test_plan();
+    let materializing = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "materializing",
+            remote_workspace: None,
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("persist pre-submission materialization");
 
-        // A setup phase may run longer than the handoff lease because no complete
-        // request has crossed the durable submission boundary yet.
-        assert!(materializing.lab_handoff.is_none());
-        assert!(materializing.metadata.get("handoff_acceptance").is_none());
-        assert_eq!(
-            reconcile_active_lab_runner_handoffs().expect("read-side reconciliation"),
-            0
-        );
-        let hydrating = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "hydrating",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("long setup remains controller-owned");
-        assert_eq!(hydrating.state, AgentTaskRunState::Queued);
-        assert_eq!(hydrating.metadata["phase"], "hydrating");
+    // A setup phase may run longer than the handoff lease because no complete
+    // request has crossed the durable submission boundary yet.
+    assert!(materializing.lab_handoff.is_none());
+    assert!(materializing.metadata.get("handoff_acceptance").is_none());
+    assert_eq!(
+        reconcile_active_lab_runner_handoffs_in_store(&lifecycle_store)
+            .expect("read-side reconciliation"),
+        0
+    );
+    let hydrating = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "hydrating",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("long setup remains controller-owned");
+    assert_eq!(hydrating.state, AgentTaskRunState::Queued);
+    assert_eq!(hydrating.metadata["phase"], "hydrating");
 
-        let cancelled = cancel_run(run_id, Some("controller cancelled during setup"))
-            .expect("terminalize setup record");
-        let after_terminal_phase = record_lab_offload_phase(
-            run_id,
-            "homeboy-lab",
-            "provider_dispatch",
-            Some("/runner/workspace/homeboy"),
-            None,
-            None,
-            Some(&plan),
-        )
-        .expect("terminal phase write is a no-op");
-        assert_eq!(after_terminal_phase, cancelled);
-        assert!(after_terminal_phase.lab_handoff.is_none());
-        assert!(after_terminal_phase
-            .metadata
-            .get("handoff_acceptance")
-            .is_none());
-    });
+    let cancelled = cancel_run_in_store(
+        &lifecycle_store,
+        run_id,
+        Some("controller cancelled during setup"),
+    )
+    .expect("terminalize setup record");
+    let after_terminal_phase = record_lab_offload_phase_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "provider_dispatch",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+    )
+    .expect("terminal phase write is a no-op");
+    assert_eq!(after_terminal_phase, cancelled);
+    assert!(after_terminal_phase.lab_handoff.is_none());
+    assert!(after_terminal_phase
+        .metadata
+        .get("handoff_acceptance")
+        .is_none());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The fixture is a *missing file* — the controller plan is deleted
+/// from `record.plan_path` — and the claim is that the second acceptance
+/// tolerates its absence. The plan that gets deleted and the plan the second
+/// acceptance fails to find have to be the same file, which is only true if
+/// both acceptances and the terminal write name one installation.
+///
+/// The runner-continuation registry `status_in_store` consults stays
+/// process-global by design: it is configured trust material and a subprocess
+/// contract, not a lifecycle root (#12618).
 #[test]
 fn terminal_lab_artifact_attachment_skips_missing_controller_plan_and_preserves_runner_identity() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-late-artifact",
             runner_id: "homeboy-lab",
             runner_job_id: "job-original",
             remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact",
             remote_command: &command,
-        })
-        .expect("running proxy");
-        let mut record = status("agent-task-late-artifact").expect("status");
-        apply_runner_job_terminal_state(
-            &mut record,
-            homeboy_core::api_jobs::JobStatus::Succeeded,
-            &[],
-        );
-        store::write_record(&record).expect("terminal record");
-        std::fs::remove_file(&record.plan_path).expect("remove controller plan");
+        },
+    )
+    .expect("running proxy");
+    let mut record = status_in_store(
+        &lifecycle_store,
+        "agent-task-late-artifact",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("status")
+    .record;
+    apply_runner_job_terminal_state(
+        &mut record,
+        homeboy_core::api_jobs::JobStatus::Succeeded,
+        &[],
+    );
+    lifecycle_store
+        .write_record(&record)
+        .expect("terminal record");
+    std::fs::remove_file(&record.plan_path).expect("remove controller plan");
 
-        let attached = record_detached_lab_run(DetachedLabRunRecord {
+    let attached = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id: "agent-task-late-artifact",
             runner_id: "homeboy-lab",
             runner_job_id: "job-original",
             remote_workspace: "/home/lab/agent-task-runs/agent-task-late-artifact",
             remote_command: &command,
-        })
-        .expect("late attachment leaves terminal proxy intact");
+        },
+    )
+    .expect("late attachment leaves terminal proxy intact");
 
-        assert_eq!(attached.state, AgentTaskRunState::Succeeded);
-        assert_eq!(attached.runner_id(), Some("homeboy-lab"));
-        assert_eq!(attached.runner_job_id(), Some("job-original"));
-    });
+    assert_eq!(attached.state, AgentTaskRunState::Succeeded);
+    assert_eq!(attached.runner_id(), Some("homeboy-lab"));
+    assert_eq!(attached.runner_job_id(), Some("job-original"));
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -899,166 +1038,210 @@ fn terminal_child_projection_rejects_mismatched_persisted_run_identity() {
     assert!(lifecycle_store.read_aggregate(&record.run_id).is_err());
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The finalized-artifact fixture is the load-bearing part: the
+/// controller only adopts the inner patch because a file with that digest and
+/// size sits under `<artifacts>/executor-finalized`, and the lookup resolves
+/// that directory from the observation store's own artifact root. Seeding it at
+/// `paths::artifact_root()` while the adoption searched an injected root would
+/// silently turn the final four assertions into a test of an absent artifact.
+/// `lifecycle_store.artifact_root()` is exactly the root the injected
+/// observation store indexes, so the file this test writes is the file the
+/// adoption finds.
 #[test]
 fn transport_only_reconciliation_stays_pending_until_foreground_projection_or_inner_aggregate() {
-    with_isolated_home(|_| {
-        let run_id = "foreground-transport-only";
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let inner_patch = b"late aggregate patch";
-        let inner_patch_sha256 = format!("{:x}", sha2::Sha256::digest(inner_patch));
-        let finalized_dir = homeboy_core::paths::artifact_root()
-            .expect("artifact root")
-            .join("executor-finalized");
-        std::fs::create_dir_all(&finalized_dir).expect("controller finalized artifact directory");
-        std::fs::write(finalized_dir.join("inner-patch"), inner_patch)
-            .expect("controller finalized artifact bytes");
-        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "foreground-transport-only";
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let inner_patch = b"late aggregate patch";
+    let inner_patch_sha256 = format!("{:x}", sha2::Sha256::digest(inner_patch));
+    let finalized_dir = lifecycle_store.artifact_root().join("executor-finalized");
+    std::fs::create_dir_all(&finalized_dir).expect("controller finalized artifact directory");
+    std::fs::write(finalized_dir.join("inner-patch"), inner_patch)
+        .expect("controller finalized artifact bytes");
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id,
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000000123",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
-        })
-        .expect("running proxy");
+        },
+    )
+    .expect("running proxy");
 
-        // The outer daemon envelope has no captured patch, so its terminal
-        // transport result alone cannot represent the inner agent-task output.
-        let mut transport_only = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-        transport_only.events.clear();
-        reconcile_runner_job_snapshot(&mut record, &transport_only)
-            .expect("transport-only terminal result");
-        assert_eq!(record.state, AgentTaskRunState::Running);
-        assert_eq!(record.metadata["phase"], "awaiting_runner_synchronization");
-        assert_eq!(
-            record.metadata["runner_result_synchronization"]["state"],
-            "pending"
-        );
-        assert!(artifacts(&record.run_id)
-            .expect("transport-only artifacts")
-            .artifacts
-            .is_empty());
+    // The outer daemon envelope has no captured patch, so its terminal
+    // transport result alone cannot represent the inner agent-task output.
+    let mut transport_only = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    transport_only.events.clear();
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &transport_only)
+        .expect("transport-only terminal result");
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(record.metadata["phase"], "awaiting_runner_synchronization");
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["state"],
+        "pending"
+    );
+    assert!(artifacts_in_store(&lifecycle_store, &record.run_id)
+        .expect("transport-only artifacts")
+        .artifacts
+        .is_empty());
 
-        assert!(
-            project_terminal_runner_result(&record.run_id, &transport_only)
-                .expect("foreground transport result projects the explicit run")
-        );
-        assert_eq!(record.state, AgentTaskRunState::Running);
-        let projected = status(&record.run_id).expect("foreground terminal projection");
-        assert_eq!(projected.state, AgentTaskRunState::Succeeded);
-        assert_eq!(
-            projected.metadata["runner_result_synchronization"]["state"],
-            "projected"
-        );
-        record = projected;
+    assert!(project_terminal_runner_result_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        &transport_only
+    )
+    .expect("foreground transport result projects the explicit run"));
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    let projected = status_in_store(
+        &lifecycle_store,
+        &record.run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("foreground terminal projection")
+    .record;
+    assert_eq!(projected.state, AgentTaskRunState::Succeeded);
+    assert_eq!(
+        projected.metadata["runner_result_synchronization"]["state"],
+        "projected"
+    );
+    record = projected;
 
-        let mut aggregate = succeeded_aggregate(&test_plan());
-        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
-            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-            id: "inner-patch".to_string(),
-            kind: "patch".to_string(),
-            name: Some("candidate.patch".to_string()),
-            label: None,
-            role: Some("patch".to_string()),
-            semantic_key: None,
-            path: Some("artifacts/candidate.patch".to_string()),
-            url: Some(format!(
-                "homeboy://agent-task/run/{run_id}/artifacts#task=task-a&artifact=inner-patch"
-            )),
-            mime: Some("text/x-diff".to_string()),
-            size_bytes: Some(inner_patch.len() as u64),
-            sha256: Some(inner_patch_sha256.clone()),
-            metadata: Value::Null,
-        });
-        let mut lifecycle_snapshot = terminal_child_snapshot(&aggregate);
-        let identity = &mut lifecycle_snapshot.events[0]
-            .data
-            .as_mut()
-            .expect("lifecycle event data")["identity"];
-        identity["run_id"] = json!(run_id);
-        identity["persisted_run_id"] = json!(run_id);
-        reconcile_runner_job_snapshot(&mut record, &lifecycle_snapshot)
-            .expect("late inner lifecycle evidence is adopted");
-
-        let artifacts = artifacts(&record.run_id).expect("controller-visible artifacts");
-        assert_eq!(artifacts.artifacts.len(), 1);
-        assert_eq!(artifacts.artifacts[0].id, "inner-patch");
-        assert_eq!(
-            artifacts.artifacts[0].size_bytes,
-            Some(inner_patch.len() as u64)
-        );
-        assert_eq!(
-            artifacts.artifacts[0].sha256.as_deref(),
-            Some(inner_patch_sha256.as_str())
-        );
-        assert_eq!(
-            store::read_aggregate(&record.run_id)
-                .expect("persisted inner aggregate")
-                .outcomes[0]
-                .artifacts[0]
-                .sha256
-                .as_deref(),
-            Some(inner_patch_sha256.as_str())
-        );
+    let mut aggregate = succeeded_aggregate(&test_plan());
+    aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+        schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: "inner-patch".to_string(),
+        kind: "patch".to_string(),
+        name: Some("candidate.patch".to_string()),
+        label: None,
+        role: Some("patch".to_string()),
+        semantic_key: None,
+        path: Some("artifacts/candidate.patch".to_string()),
+        url: Some(format!(
+            "homeboy://agent-task/run/{run_id}/artifacts#task=task-a&artifact=inner-patch"
+        )),
+        mime: Some("text/x-diff".to_string()),
+        size_bytes: Some(inner_patch.len() as u64),
+        sha256: Some(inner_patch_sha256.clone()),
+        metadata: Value::Null,
     });
+    let mut lifecycle_snapshot = terminal_child_snapshot(&aggregate);
+    let identity = &mut lifecycle_snapshot.events[0]
+        .data
+        .as_mut()
+        .expect("lifecycle event data")["identity"];
+    identity["run_id"] = json!(run_id);
+    identity["persisted_run_id"] = json!(run_id);
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &lifecycle_snapshot)
+        .expect("late inner lifecycle evidence is adopted");
+
+    let artifacts =
+        artifacts_in_store(&lifecycle_store, &record.run_id).expect("controller-visible artifacts");
+    assert_eq!(artifacts.artifacts.len(), 1);
+    assert_eq!(artifacts.artifacts[0].id, "inner-patch");
+    assert_eq!(
+        artifacts.artifacts[0].size_bytes,
+        Some(inner_patch.len() as u64)
+    );
+    assert_eq!(
+        artifacts.artifacts[0].sha256.as_deref(),
+        Some(inner_patch_sha256.as_str())
+    );
+    assert_eq!(
+        lifecycle_store
+            .read_aggregate(&record.run_id)
+            .expect("persisted inner aggregate")
+            .outcomes[0]
+            .artifacts[0]
+            .sha256
+            .as_deref(),
+        Some(inner_patch_sha256.as_str())
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "Exactly once" is the assertion: the second
+/// `project_terminal_runner_result_in_store` must return `false` *because the
+/// first one already committed*. That is only a statement about idempotence if
+/// both calls, the handoff that preceded them and the status read that follows
+/// address one durable record in one installation.
 #[test]
 fn foreground_terminal_daemon_projection_finishes_success_and_failure_runs_once() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        for (run_id, daemon_status, expected_run, expected_task, expected_execution_status) in [
-            (
-                "foreground-daemon-success",
-                homeboy_core::api_jobs::JobStatus::Succeeded,
-                AgentTaskRunState::Succeeded,
-                AgentTaskState::Succeeded,
-                "succeeded",
-            ),
-            (
-                "foreground-daemon-failure",
-                homeboy_core::api_jobs::JobStatus::Failed,
-                AgentTaskRunState::Failed,
-                AgentTaskState::Failed,
-                "failed",
-            ),
-        ] {
-            record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    for (run_id, daemon_status, expected_run, expected_task, expected_execution_status) in [
+        (
+            "foreground-daemon-success",
+            homeboy_core::api_jobs::JobStatus::Succeeded,
+            AgentTaskRunState::Succeeded,
+            AgentTaskState::Succeeded,
+            "succeeded",
+        ),
+        (
+            "foreground-daemon-failure",
+            homeboy_core::api_jobs::JobStatus::Failed,
+            AgentTaskRunState::Failed,
+            AgentTaskState::Failed,
+            "failed",
+        ),
+    ] {
+        record_detached_lab_run_in_store(
+            &lifecycle_store,
+            DetachedLabRunRecord {
                 run_id,
                 runner_id: "homeboy-lab",
                 runner_job_id: "00000000-0000-0000-0000-000000000123",
                 remote_workspace: "/runner/workspace/repo",
                 remote_command: &command,
-            })
-            .expect("accepted detached handoff");
-            let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-            snapshot.job.status = daemon_status;
-            snapshot.events.clear();
+            },
+        )
+        .expect("accepted detached handoff");
+        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        snapshot.job.status = daemon_status;
+        snapshot.events.clear();
 
-            assert!(project_terminal_runner_result(run_id, &snapshot)
-                .expect("foreground daemon result is projected"));
-            assert!(!project_terminal_runner_result(run_id, &snapshot)
-                .expect("repeated terminal result is idempotent"));
+        assert!(
+            project_terminal_runner_result_in_store(&lifecycle_store, run_id, &snapshot)
+                .expect("foreground daemon result is projected")
+        );
+        assert!(
+            !project_terminal_runner_result_in_store(&lifecycle_store, run_id, &snapshot)
+                .expect("repeated terminal result is idempotent")
+        );
 
-            let projected = status(run_id).expect("terminal durable run");
-            assert_eq!(projected.state, expected_run);
-            assert_eq!(projected.tasks[0].state, expected_task);
-            assert_eq!(projected.lifecycle.execution.state, expected_run.into());
-            assert!(projected.lifecycle.execution.finished_at.is_some());
-            assert_eq!(
-                projected.metadata["runner_job_status"],
-                json!(daemon_status)
-            );
-            assert_eq!(
-                projected.metadata["runner_execution_record"]["status"],
-                expected_execution_status
-            );
-            assert_eq!(projected.metadata["runner_handoff"]["state"], "terminal");
-            assert_eq!(
-                projected.metadata["runner_result_synchronization"]["state"],
-                "projected"
-            );
-        }
-    });
+        let projected = status_in_store(
+            &lifecycle_store,
+            run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("terminal durable run")
+        .record;
+        assert_eq!(projected.state, expected_run);
+        assert_eq!(projected.tasks[0].state, expected_task);
+        assert_eq!(projected.lifecycle.execution.state, expected_run.into());
+        assert!(projected.lifecycle.execution.finished_at.is_some());
+        assert_eq!(
+            projected.metadata["runner_job_status"],
+            json!(daemon_status)
+        );
+        assert_eq!(
+            projected.metadata["runner_execution_record"]["status"],
+            expected_execution_status
+        );
+        assert_eq!(projected.metadata["runner_handoff"]["state"], "terminal");
+        assert_eq!(
+            projected.metadata["runner_result_synchronization"]["state"],
+            "projected"
+        );
+    }
 }
 
 #[test]
@@ -1318,58 +1501,73 @@ fn accepted_runner_cancellation_fails_closed_when_daemon_cannot_be_reached() {
     );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The `runner_pid` this test plants is the whole fixture — the claim
+/// is that cancellation read it and declined to signal it — so the record the
+/// rewrite mutates and the record the cancellation reads have to be the same
+/// one. The accepted handoff, the rewrite and the cancellation all name
+/// `lifecycle_store`.
+///
+/// The daemon cancellation hook stays where it is: `test_cancel_hook` is a
+/// `thread_local!`, not a process-global, so it was never protected by the
+/// hermetic-home mutex and is unaffected by dropping it. Same argument as
+/// `cancellation_race_projects_runner_success_instead_of_cancelling_controller_projection`.
 #[test]
 fn accepted_runner_cancellation_does_not_signal_a_controller_local_pid() {
-    with_isolated_home(|_| {
-        let run_id = "cook-9969-runner-cancellation-authority";
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_detached_lab_run(DetachedLabRunRecord {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-9969-runner-cancellation-authority";
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
             run_id,
             runner_id: "homeboy-lab",
             runner_job_id: "00000000-0000-0000-0000-000000009970",
             remote_workspace: "/runner/workspace/homeboy",
             remote_command: &command,
-        })
-        .expect("accepted runner handoff");
+        },
+    )
+    .expect("accepted runner handoff");
 
-        let mut local_controller = Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .expect("start controller-local sentinel");
-        rewrite_record_for_test(run_id, |record| {
-            record.metadata["runner_pid"] = json!(local_controller.id());
-        })
-        .expect("persist stale controller pid");
+    let mut local_controller = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("start controller-local sentinel");
+    rewrite_record_for_test_in_store(&lifecycle_store, run_id, |record| {
+        record.metadata["runner_pid"] = json!(local_controller.id());
+    })
+    .expect("persist stale controller pid");
 
-        let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
-        snapshot.job.id = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000009970")
-            .expect("valid runner job id");
-        snapshot.job.status = homeboy_core::api_jobs::JobStatus::Cancelled;
-        let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
-            move |runner_id, runner_job_id, durable_run_id| {
-                assert_eq!(runner_id, "homeboy-lab");
-                assert_eq!(runner_job_id, snapshot.job.id.to_string());
-                assert_eq!(durable_run_id, run_id);
-                Ok((snapshot.job.clone(), snapshot.events.clone()))
-            },
-        ));
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    snapshot.job.id =
+        uuid::Uuid::parse_str("00000000-0000-0000-0000-000000009970").expect("valid runner job id");
+    snapshot.job.status = homeboy_core::api_jobs::JobStatus::Cancelled;
+    let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
+        move |runner_id, runner_job_id, durable_run_id| {
+            assert_eq!(runner_id, "homeboy-lab");
+            assert_eq!(runner_job_id, snapshot.job.id.to_string());
+            assert_eq!(durable_run_id, run_id);
+            Ok((snapshot.job.clone(), snapshot.events.clone()))
+        },
+    ));
 
-        let cancelled = cancel_run(run_id, Some("operator cancellation"))
-            .expect("runner cancellation succeeds");
-        let controller_was_not_signalled = local_controller
-            .try_wait()
-            .expect("inspect controller-local sentinel")
-            .is_none();
-        let _ = local_controller.kill();
-        let _ = local_controller.wait();
+    let cancelled = cancel_run_in_store(&lifecycle_store, run_id, Some("operator cancellation"))
+        .expect("runner cancellation succeeds");
+    let controller_was_not_signalled = local_controller
+        .try_wait()
+        .expect("inspect controller-local sentinel")
+        .is_none();
+    let _ = local_controller.kill();
+    let _ = local_controller.wait();
 
-        assert!(controller_was_not_signalled);
-        assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
-        assert_eq!(
-            cancelled.metadata["live_cancellation"]["cancellation"],
-            "runner_job_cancel"
-        );
-    });
+    assert!(controller_was_not_signalled);
+    assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+    assert_eq!(
+        cancelled.metadata["live_cancellation"]["cancellation"],
+        "runner_job_cancel"
+    );
 }
 
 #[test]
@@ -1622,35 +1820,53 @@ fn terminal_transport_recovery_accepts_a_verified_older_controller_pin() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The plan the failure is shaped from is the plan the planned proxy
+/// just wrote, and the terminal record is read back after it — three operations
+/// on one run id that only describe one lifecycle if they name one
+/// installation.
 #[test]
 fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    record_lab_offload_planned_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "agent-task-handoff-failure",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("planned proxy");
-        let plan = load_plan("agent-task-handoff-failure").expect("proxy plan");
-        record_pre_execution_failure(
-            "agent-task-handoff-failure",
-            &plan,
-            "lab_handoff",
-            &Error::internal_unexpected("runner rejected handoff"),
-        )
-        .expect("handoff failure recorded");
+        },
+    )
+    .expect("planned proxy");
+    let plan =
+        load_plan_in_store(&lifecycle_store, "agent-task-handoff-failure").expect("proxy plan");
+    record_pre_execution_failure_in_store(
+        &lifecycle_store,
+        "agent-task-handoff-failure",
+        &plan,
+        "lab_handoff",
+        &Error::internal_unexpected("runner rejected handoff"),
+    )
+    .expect("handoff failure recorded");
 
-        let record = status("agent-task-handoff-failure").expect("terminal status");
-        assert_eq!(record.state, AgentTaskRunState::Failed);
-        assert_eq!(record.metadata["runner_id"], "homeboy-lab");
-        assert_eq!(
-            record.metadata["pre_execution_failure"]["phase"],
-            "lab_handoff"
-        );
-    });
+    let record = status_in_store(
+        &lifecycle_store,
+        "agent-task-handoff-failure",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("terminal status")
+    .record;
+    assert_eq!(record.state, AgentTaskRunState::Failed);
+    assert_eq!(record.metadata["runner_id"], "homeboy-lab");
+    assert_eq!(
+        record.metadata["pre_execution_failure"]["phase"],
+        "lab_handoff"
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -2129,39 +2345,62 @@ fn acceptance_is_created_after_green_promotion_and_persists_verifier_provenance(
     assert_eq!(acceptance.history.len(), 1);
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The drift guard compares the candidate it read before verification
+/// against the candidate on disk after it, so the mid-verification promotion,
+/// the verdict that rejects it and the durable read-back must all address one
+/// record. The fixture verifier is handed a clone of the same store for exactly
+/// that reason.
+///
+/// The acceptance verifier registry stays process-global on purpose: it is
+/// configured trust material, not a lifecycle root, and
+/// `AcceptanceVerifierTestGuard` carries its own dedicated mutex, so dropping
+/// the hermetic-home mutex does not expose it.
 #[test]
 fn acceptance_rejects_a_promotion_that_changes_during_authority_verification() {
-    with_isolated_home(|_| {
-        let mut plan = test_plan();
-        plan.metadata = json!({
-            "acceptance": { "authority": "independent-review", "policy": "release-v1" },
-        });
-        let run_id = "acceptance-promotion-drift";
-        submit_plan(&plan, Some(run_id)).expect("submitted");
-        record_promotion(
-            run_id,
-            applied_acceptance_promotion("candidate-a", "base-a"),
-        )
-        .expect("promotion recorded");
-        let _verifier = AcceptanceVerifierTestGuard::install(Box::new(PromotionDriftVerifier {
-            run_id: run_id.to_string(),
-        }));
-
-        let error = record_acceptance_verdict(
-            run_id,
-            AgentTaskAcceptanceVerdict::Accepted,
-            vec!["review://fixture/7".to_string()],
-            "fixture-token".to_string(),
-        )
-        .expect_err("stale verdict must not apply");
-        assert!(error.message.contains("candidate changed"));
-        let acceptance = status(run_id)
-            .expect("durable status")
-            .acceptance
-            .expect("acceptance record");
-        assert_eq!(acceptance.verdict, AgentTaskAcceptanceVerdict::Pending);
-        assert_eq!(acceptance.candidate.head, "candidate-b");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let mut plan = test_plan();
+    plan.metadata = json!({
+        "acceptance": { "authority": "independent-review", "policy": "release-v1" },
     });
+    let run_id = "acceptance-promotion-drift";
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submitted");
+    record_promotion_in_store(
+        &lifecycle_store,
+        run_id,
+        applied_acceptance_promotion("candidate-a", "base-a"),
+    )
+    .expect("promotion recorded");
+    let _verifier = AcceptanceVerifierTestGuard::install(Box::new(PromotionDriftVerifier {
+        lifecycle_store: lifecycle_store.clone(),
+        run_id: run_id.to_string(),
+    }));
+
+    let error = record_acceptance_verdict_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskAcceptanceVerdict::Accepted,
+        vec!["review://fixture/7".to_string()],
+        "fixture-token".to_string(),
+    )
+    .expect_err("stale verdict must not apply");
+    assert!(error.message.contains("candidate changed"));
+    let acceptance = status_in_store(
+        &lifecycle_store,
+        run_id,
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("durable status")
+    .record
+    .acceptance
+    .expect("acceptance record");
+    assert_eq!(acceptance.verdict, AgentTaskAcceptanceVerdict::Pending);
+    assert_eq!(acceptance.candidate.head, "candidate-b");
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -2656,53 +2895,70 @@ fn cancel_marks_queued_run_and_tasks_cancelled() {
     });
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The fixture deletes the *local* aggregate and points the record at
+/// a remote path, then asserts the loader still resolves a local file. The path
+/// that gets deleted has to be the path the loader would have used, so the
+/// completed run, the deletion target and the loader all name one installation.
+///
+/// `record_completed_run_in_store` reaches automatic artifact retention only
+/// when a task declares a workspace root that exists; `test_plan()` declares
+/// none, so the ambient retention pass this file's sibling test depends on is
+/// never entered here.
 #[test]
 fn aggregate_source_loads_completed_run_without_path_spelunking() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        let aggregate = AgentTaskAggregate {
-            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
-            plan_id: plan.plan_id.clone(),
-            status: AgentTaskAggregateStatus::Succeeded,
-            totals: AgentTaskAggregateTotals {
-                queued: 1,
-                succeeded: 1,
-                ..AgentTaskAggregateTotals::default()
-            },
-            outcomes: vec![AgentTaskOutcome {
-                schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                task_id: "task-a".to_string(),
-                status: crate::agent_task::AgentTaskOutcomeStatus::Succeeded,
-                summary: Some("ok".to_string()),
-                failure_classification: None,
-                artifacts: Vec::new(),
-                typed_artifacts: Vec::new(),
-                evidence_refs: Vec::new(),
-                diagnostics: Vec::new(),
-                outputs: Value::Null,
-                workflow: None,
-                follow_up: None,
-                metadata: Value::Null,
-            }],
-            events: Vec::new(),
-            artifact_lineage: Vec::new(),
-            child_runs: Vec::new(),
-            artifact_bindings: Vec::new(),
-            queue: Default::default(),
-        };
-        record_completed_run(&plan, &aggregate, Some("run-source")).expect("recorded");
-        let local_path = store::aggregate_path("run-source").expect("local aggregate path");
-        let mut record = store::read_record("run-source").expect("record loaded");
-        record.aggregate_path = Some("/home/user/remote/aggregate.json".to_string());
-        store::write_record(&record).expect("remote aggregate path stored");
-        std::fs::remove_file(&local_path).expect("local aggregate removed");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    let aggregate = AgentTaskAggregate {
+        schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: plan.plan_id.clone(),
+        status: AgentTaskAggregateStatus::Succeeded,
+        totals: AgentTaskAggregateTotals {
+            queued: 1,
+            succeeded: 1,
+            ..AgentTaskAggregateTotals::default()
+        },
+        outcomes: vec![AgentTaskOutcome {
+            schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-a".to_string(),
+            status: crate::agent_task::AgentTaskOutcomeStatus::Succeeded,
+            summary: Some("ok".to_string()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            typed_artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: Value::Null,
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        }],
+        events: Vec::new(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: Default::default(),
+    };
+    record_completed_run_in_store(&lifecycle_store, &plan, &aggregate, Some("run-source"))
+        .expect("recorded");
+    let local_path = lifecycle_store.aggregate_path("run-source");
+    let mut record = lifecycle_store
+        .read_record("run-source")
+        .expect("record loaded");
+    record.aggregate_path = Some("/home/user/remote/aggregate.json".to_string());
+    lifecycle_store
+        .write_record(&record)
+        .expect("remote aggregate path stored");
+    std::fs::remove_file(&local_path).expect("local aggregate removed");
 
-        let (raw, path) = aggregate_source("run-source").expect("aggregate source");
+    let (raw, path) =
+        aggregate_source_in_store(&lifecycle_store, "run-source").expect("aggregate source");
 
-        assert!(path.ends_with("aggregate.json"));
-        assert_ne!(path, PathBuf::from("/home/user/remote/aggregate.json"));
-        assert!(raw.contains("task-a"));
-    });
+    assert!(path.ends_with("aggregate.json"));
+    assert_ne!(path, PathBuf::from("/home/user/remote/aggregate.json"));
+    assert!(raw.contains("task-a"));
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -3036,119 +3292,200 @@ fn status_does_not_terminalize_a_live_owner_after_provider_success() {
     );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The legacy shape is produced by stripping owner-proof fields off
+/// the reservation this test just made, and the classification is read back
+/// afterwards. Strip one home's reservation and classify another's and the
+/// `unverifiable` verdict would describe a record nobody wrote.
+///
+/// `reserve_provider_execution_in_store` records the *current* process as
+/// owner, which is what makes this a local-owner fixture at all; that identity
+/// is a fact about this process, not a lifecycle root.
 #[test]
 fn legacy_provider_reservation_without_owner_proof_remains_joinable() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("owner-legacy")).expect("submitted");
-        mark_running("owner-legacy").expect("running");
-        reserve_provider_execution("owner-legacy", &plan.tasks[0], 1).expect("reserved");
-        rewrite_record_for_test("owner-legacy", |record| {
-            let execution = record.metadata["provider_executions"][0]
-                .as_object_mut()
-                .expect("provider execution object");
-            execution.remove("owner_pid");
-            execution.remove("owner_linux_starttime_ticks");
-            execution.remove("owner_identity");
-        })
-        .expect("legacy reservation fixture");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "owner-legacy", |_| Ok(json!({})))
+        .expect("submitted");
+    mark_running_in_store(&lifecycle_store, "owner-legacy").expect("running");
+    reserve_provider_execution_in_store(&lifecycle_store, "owner-legacy", &plan.tasks[0], 1)
+        .expect("reserved");
+    rewrite_record_for_test_in_store(&lifecycle_store, "owner-legacy", |record| {
+        let execution = record.metadata["provider_executions"][0]
+            .as_object_mut()
+            .expect("provider execution object");
+        execution.remove("owner_pid");
+        execution.remove("owner_linux_starttime_ticks");
+        execution.remove("owner_identity");
+    })
+    .expect("legacy reservation fixture");
 
-        let record = status("owner-legacy").expect("legacy status");
-        assert_eq!(record.state, AgentTaskRunState::Running);
-        assert_eq!(
-            record.metadata["provider_executions"][0]["owner_state"],
-            json!("unverifiable")
-        );
-    });
+    let record = status_in_store(
+        &lifecycle_store,
+        "owner-legacy",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("legacy status")
+    .record;
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(
+        record.metadata["provider_executions"][0]["owner_state"],
+        json!("unverifiable")
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The reservation records this process as owner and the fixture then
+/// falsifies its start time on that same record; the reclaim verdict is read
+/// back from it. All three name `lifecycle_store`.
+///
+/// `pid_is_running` asks the kernel about this process, not a lifecycle root,
+/// so it is unaffected.
 #[cfg(target_os = "linux")]
 #[test]
 fn pid_starttime_mismatch_reclaims_a_reused_provider_pid_without_signalling_it() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("owner-pid-reused")).expect("submitted");
-        mark_running("owner-pid-reused").expect("running");
-        reserve_provider_execution("owner-pid-reused", &plan.tasks[0], 1).expect("reserved");
-        rewrite_record_for_test("owner-pid-reused", |record| {
-            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = json!(0);
-        })
-        .expect("reused PID fixture");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "owner-pid-reused", |_| Ok(json!({})))
+        .expect("submitted");
+    mark_running_in_store(&lifecycle_store, "owner-pid-reused").expect("running");
+    reserve_provider_execution_in_store(&lifecycle_store, "owner-pid-reused", &plan.tasks[0], 1)
+        .expect("reserved");
+    rewrite_record_for_test_in_store(&lifecycle_store, "owner-pid-reused", |record| {
+        record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = json!(0);
+    })
+    .expect("reused PID fixture");
 
-        let record = status("owner-pid-reused").expect("reconcile PID reuse");
-        assert_eq!(record.state, AgentTaskRunState::Cancelled);
-        assert_eq!(
-            record.metadata["provider_executions"][0]["owner_state"],
-            json!("identity_mismatch")
-        );
-        assert!(homeboy_core::process::pid_is_running(std::process::id()));
-    });
+    let record = status_in_store(
+        &lifecycle_store,
+        "owner-pid-reused",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reconcile PID reuse")
+    .record;
+    assert_eq!(record.state, AgentTaskRunState::Cancelled);
+    assert_eq!(
+        record.metadata["provider_executions"][0]["owner_state"],
+        json!("identity_mismatch")
+    );
+    assert!(homeboy_core::process::pid_is_running(std::process::id()));
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). "Once" is the assertion: the second status must observe the
+/// terminal state the first one committed. Two reads of the same record in one
+/// installation is the only arrangement in which that means anything.
 #[cfg(unix)]
 #[test]
 fn dead_local_provider_owner_terminalizes_running_reservation_once() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("owner-dead")).expect("submitted");
-        mark_running("owner-dead").expect("running");
-        reserve_provider_execution("owner-dead", &plan.tasks[0], 1).expect("reserved");
-        let mut owner = Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .expect("start provider owner");
-        rewrite_record_for_test("owner-dead", |record| {
-            record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
-            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
-        })
-        .expect("provider owner fixture");
-        owner.kill().expect("interrupt provider owner");
-        owner.wait().expect("reap provider owner");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "owner-dead", |_| Ok(json!({})))
+        .expect("submitted");
+    mark_running_in_store(&lifecycle_store, "owner-dead").expect("running");
+    reserve_provider_execution_in_store(&lifecycle_store, "owner-dead", &plan.tasks[0], 1)
+        .expect("reserved");
+    let mut owner = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("start provider owner");
+    rewrite_record_for_test_in_store(&lifecycle_store, "owner-dead", |record| {
+        record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
+        record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
+    })
+    .expect("provider owner fixture");
+    owner.kill().expect("interrupt provider owner");
+    owner.wait().expect("reap provider owner");
 
-        let terminal = status("owner-dead").expect("reconciled status");
-        let replay = status("owner-dead").expect("idempotent status");
-        assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
-        assert_eq!(replay.state, AgentTaskRunState::Cancelled);
-        assert_eq!(
-            replay.metadata["provider_executions"][0]["state"],
-            json!("cancelled")
-        );
-        assert_eq!(
-            replay.metadata["local_provider_ownership"]["state"],
-            json!("owner_dead")
-        );
-    });
+    let terminal = status_in_store(
+        &lifecycle_store,
+        "owner-dead",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reconciled status")
+    .record;
+    let replay = status_in_store(
+        &lifecycle_store,
+        "owner-dead",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("idempotent status")
+    .record;
+    assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
+    assert_eq!(replay.state, AgentTaskRunState::Cancelled);
+    assert_eq!(
+        replay.metadata["provider_executions"][0]["state"],
+        json!("cancelled")
+    );
+    assert_eq!(
+        replay.metadata["local_provider_ownership"]["state"],
+        json!("owner_dead")
+    );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The durable provider success the recovery must preserve is recorded
+/// in the same store the dead-owner fixture is planted in and the recovery reads
+/// back, so `CandidateRecoverable` is decided from the evidence this test wrote.
 #[cfg(unix)]
 #[test]
 fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("owner-late-success")).expect("submitted");
-        mark_running("owner-late-success").expect("running");
-        reserve_provider_execution("owner-late-success", &plan.tasks[0], 1).expect("reserved");
-        record_provider_execution_terminal("owner-late-success", "task-a", 1, "succeeded")
-            .expect("provider success recorded");
-        let mut owner = Command::new("sleep")
-            .arg("60")
-            .spawn()
-            .expect("start provider owner");
-        rewrite_record_for_test("owner-late-success", |record| {
-            record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
-            record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
-        })
-        .expect("provider owner fixture");
-        owner.kill().expect("interrupt provider owner");
-        owner.wait().expect("reap provider owner");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "owner-late-success", |_| Ok(json!({})))
+        .expect("submitted");
+    mark_running_in_store(&lifecycle_store, "owner-late-success").expect("running");
+    reserve_provider_execution_in_store(&lifecycle_store, "owner-late-success", &plan.tasks[0], 1)
+        .expect("reserved");
+    record_provider_execution_terminal_in_store(
+        &lifecycle_store,
+        "owner-late-success",
+        "task-a",
+        1,
+        "succeeded",
+    )
+    .expect("provider success recorded");
+    let mut owner = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("start provider owner");
+    rewrite_record_for_test_in_store(&lifecycle_store, "owner-late-success", |record| {
+        record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
+        record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
+    })
+    .expect("provider owner fixture");
+    owner.kill().expect("interrupt provider owner");
+    owner.wait().expect("reap provider owner");
 
-        let recovered = status("owner-late-success").expect("recovered status");
-        assert_eq!(recovered.state, AgentTaskRunState::CandidateRecoverable);
-        assert_eq!(
-            recovered.metadata["provider_executions"][0]["state"],
-            json!("succeeded")
-        );
-    });
+    let recovered = status_in_store(
+        &lifecycle_store,
+        "owner-late-success",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("recovered status")
+    .record;
+    assert_eq!(recovered.state, AgentTaskRunState::CandidateRecoverable);
+    assert_eq!(
+        recovered.metadata["provider_executions"][0]["state"],
+        json!("succeeded")
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -3188,51 +3525,78 @@ fn cancellation_race_defers_to_a_durable_provider_success() {
     );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Every assertion here is a *population count* — `malformed == 1`,
+/// `migrated == 1`, `considered == 0` — over one installation's observation
+/// rows. Run ambiently those counts would be taken over the operator's real
+/// data root and would mean nothing; run split across homes the malformed row
+/// this test seeds would never be the row the reconciliation repairs.
+///
+/// The observation store is opened with `open_initialized_in_roots`, the rooted
+/// counterpart of the ambient `open_initialized()` this fixture used — same
+/// startup maintenance behaviour, injected roots — and it resolves the same
+/// database file below `lifecycle_store`'s data root. Same pairing as
+/// `detached_lab_handoff_upgrades_existing_observation_record`.
 #[test]
 fn record_health_reconciles_plan_backed_missing_metadata_idempotently() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("repairable-metadata")).expect("submitted");
-        let store = homeboy_core::observation::ObservationStore::open_initialized().expect("store");
-        let mut observation = store
-            .get_run("repairable-metadata")
-            .expect("read")
-            .expect("observation");
-        observation.metadata_json = json!({ "legacy_source": "fixture" });
-        store
-            .upsert_imported_run(&observation)
-            .expect("malformed fixture stored");
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, "repairable-metadata", |_| Ok(json!({})))
+        .expect("submitted");
+    let store = homeboy_core::observation::ObservationStore::open_initialized_in_roots(
+        &context.path_roots(),
+    )
+    .expect("store");
+    let mut observation = store
+        .get_run("repairable-metadata")
+        .expect("read")
+        .expect("observation");
+    observation.metadata_json = json!({ "legacy_source": "fixture" });
+    store
+        .upsert_imported_run(&observation)
+        .expect("malformed fixture stored");
 
-        let before = record_health_summary().expect("health");
-        assert_eq!(before.malformed, 1);
-        assert_eq!(
-            before.samples[0].reason,
-            AgentTaskRecordHealthReason::MissingMetadata
-        );
-        let dry_run = reconcile_record_health(true).expect("dry run");
-        assert_eq!(dry_run.records[0].action, "would-migrate");
-        assert_eq!(
-            record_health_summary()
-                .expect("unmodified health")
-                .malformed,
-            1
-        );
+    let before = record_health_summary_in_store(&lifecycle_store).expect("health");
+    assert_eq!(before.malformed, 1);
+    assert_eq!(
+        before.samples[0].reason,
+        AgentTaskRecordHealthReason::MissingMetadata
+    );
+    let dry_run = reconcile_record_health_in_store(&lifecycle_store, true).expect("dry run");
+    assert_eq!(dry_run.records[0].action, "would-migrate");
+    assert_eq!(
+        record_health_summary_in_store(&lifecycle_store)
+            .expect("unmodified health")
+            .malformed,
+        1
+    );
 
-        let applied = reconcile_record_health(false).expect("applied");
-        assert_eq!(applied.migrated, 1);
-        let repaired = status("repairable-metadata").expect("reconstructed record");
-        assert_eq!(repaired.state, AgentTaskRunState::Running);
-        assert_eq!(
-            repaired.metadata["lifecycle_reconstruction"]["original_metadata"]["legacy_source"],
-            json!("fixture")
-        );
-        let healthy = record_health_summary().expect("healthy health");
-        assert_eq!(healthy.malformed + healthy.legacy + healthy.conflicting, 0);
-        assert_eq!(
-            reconcile_record_health(false).expect("repeat").considered,
-            0
-        );
-    });
+    let applied = reconcile_record_health_in_store(&lifecycle_store, false).expect("applied");
+    assert_eq!(applied.migrated, 1);
+    let repaired = status_in_store(
+        &lifecycle_store,
+        "repairable-metadata",
+        AgentTaskStatusOptions::default(),
+        false,
+    )
+    .expect("reconstructed record")
+    .record;
+    assert_eq!(repaired.state, AgentTaskRunState::Running);
+    assert_eq!(
+        repaired.metadata["lifecycle_reconstruction"]["original_metadata"]["legacy_source"],
+        json!("fixture")
+    );
+    let healthy = record_health_summary_in_store(&lifecycle_store).expect("healthy health");
+    assert_eq!(healthy.malformed + healthy.legacy + healthy.conflicting, 0);
+    assert_eq!(
+        reconcile_record_health_in_store(&lifecycle_store, false)
+            .expect("repeat")
+            .considered,
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**29 tests migrated** across the two lifecycle test files — `terminal_and_reconcile.rs` 17, `status_and_recovery.rs` 12.

```
terminal_and_reconcile.rs   33 → 15 sites
status_and_recovery.rs      35 → 22 sites
```

## A hard rule adopted mid-slice

**No migration of any test that installs a provider.** The `RunnerContinuationTestGuard` holds no mutex; today `with_isolated_home` is the only thing serializing installers. Migrating *some* installers would let them race the ones left behind. That rule accounts for most of what was left.

`PromotionDriftVerifier` gained a store field — it rewrites the candidate *from inside* verification via the ambient `record_promotion`, so it had to carry the store that rewrite lands in.

<callout accent="#ef4444">
## The one migration where a wrong root would have passed for the wrong reason

`transport_only_reconciliation…` depends on a finalized artifact existing under `<artifacts>/executor-finalized` with a matching digest and size. **If it isn't found, adoption yields nothing and four assertions become assertions about an absent artifact.**

The lookup was traced to `store.artifact_root()` on the *ObservationStore*, which under injected roots is `context.artifact_dir()`, and the fixture is seeded at `lifecycle_store.artifact_root()` — the same path. Called out in the docstring.
</callout>

## Also left

`recover_controller_runtime` / `pinned_runtime_for_mutation` — traced `recover_pin_and_persist` to `runtime_root()`, the **machine-global admission lock**, and a pin publish. Three tests call `register_runner_continuation_provider` outright with **no guard at all** — they permanently mutate the registry.

## Zero assertions changed — and the first attempt was thrown out

| file | old | new | only-old | only-new |
|---|---|---|---|---|
| `terminal_and_reconcile.rs` | 331 | 331 | 0 | 0 |
| `status_and_recovery.rs` | 290 | 290 | 0 | 0 |

The adoption calls needed care: `start_candidate_adoption`, `..._with_rerun_policy`, and `..._with_policy` all collapse onto one rooted sibling, so call heads were unified and trailing policy flags stripped — verified against source that the ambient wrappers delegate with exactly `(false,false)` and `(rerun,false)`.

Second, independent check on **setup**, using a proper Rust lexer — the first regex attempt produced garbage on file 2 and was discarded. String literals 1555→1553 and 1156→1156; numerics 416→416 and 301→301. The two dropped strings are `.expect()` messages made unreachable because `artifact_root()` and `aggregate_path()` return plain `PathBuf`, not `Result`. **No fixture value moved.**

Lesson-2's real catch: `PromotionDriftVerifier::verify_acceptance` is a **trait impl method**, invisible to a `fn`-name scan. Found by reading.

## Verification

**Scanner 7/7.** Zero new duplicate definitions vs `origin/main`. `cargo fmt` clean (which also proves every touched file parses).

<callout accent="#f59e0b">
**Not compiled, not run.** CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Implementation and blocker analysis. Review by hand.

Refs #7505