### PR TITLE
Migrate the last movable lifecycle test

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -82,34 +82,6 @@ impl RunnerContinuationProvider for ReconciliationProvider {
     }
 }
 
-/// The submission a rooted Lab-offload test hands to the
-/// `*_with_submission_in_store` entry points.
-///
-/// Every Lab offload entry point reads its record first and submits only on the
-/// fall-through, and that fall-through is the one reach a rooted Lab offload
-/// function still makes past its lifecycle store: the default
-/// `admitted_lab_offload_submission` calls `submit_plan_in_store`, which admits
-/// through `homeboy_core::controller_runtime`, whose FIFO admission queue and
-/// content-addressed pin store hang off `paths::controller_runtimes_store()` and
-/// are machine-global on purpose (#7505, #12608). A test that no longer mutates
-/// HOME would therefore enqueue against the *real operator* runtime store and
-/// block on its cross-process lock. Naming the submission keeps the whole
-/// operation inside the injected store and reaches nothing process-global at
-/// all. This is the same stub admission every other rooted test in this crate
-/// passes to `submit_plan_with_runtime_admission`.
-///
-/// The consequence to keep in mind when choosing what to migrate: the durable
-/// run this creates carries `{}` for its controller-runtime pin rather than a
-/// real admission, so a test that asserts on controller-runtime provenance
-/// stays on `with_isolated_home`.
-fn stub_lab_offload_submission(
-    lifecycle_store: &AgentTaskLifecycleStore,
-    plan: &AgentTaskPlan,
-    run_id: &str,
-) -> Result<AgentTaskRunRecord> {
-    lifecycle_store.submit_plan_with_runtime_admission(plan, run_id, |_| Ok(json!({})))
-}
-
 fn accepted_detached_handoff(run_id: &str) -> AgentTaskRunRecord {
     let plan = test_plan();
     record_lab_offload_phase(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -201,6 +201,37 @@ impl RunnerContinuationProvider for ConnectedRunnerProvider {
     }
 }
 
+/// The submission a rooted Lab-offload test hands to the
+/// `*_with_submission_in_store` entry points.
+///
+/// Every Lab offload entry point reads its record first and submits only on the
+/// fall-through, and that fall-through is the one reach a rooted Lab offload
+/// function still makes past its lifecycle store: the default
+/// `admitted_lab_offload_submission` calls `submit_plan_in_store`, which admits
+/// through `homeboy_core::controller_runtime`, whose FIFO admission queue and
+/// content-addressed pin store hang off `paths::controller_runtimes_store()` and
+/// are machine-global on purpose (#7505, #12608). A test that no longer mutates
+/// HOME would therefore enqueue against the *real operator* runtime store and
+/// block on its cross-process lock. Naming the submission keeps the whole
+/// operation inside the injected store and reaches nothing process-global at
+/// all. This is the same stub admission every other rooted test in this crate
+/// passes to `submit_plan_with_runtime_admission`.
+///
+/// The consequence to keep in mind when choosing what to migrate: the durable
+/// run this creates carries `{}` for its controller-runtime pin rather than a
+/// real admission, so a test that asserts on controller-runtime provenance
+/// stays on `with_isolated_home`.
+///
+/// This lives here rather than beside its first caller because more than one
+/// partition of these tests now needs it (#7505).
+pub(super) fn stub_lab_offload_submission(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    plan: &AgentTaskPlan,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    lifecycle_store.submit_plan_with_runtime_admission(plan, run_id, |_| Ok(json!({})))
+}
+
 pub(super) fn outcome_with_refs(
     task_id: &str,
     artifacts: Vec<AgentTaskArtifact>,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1923,46 +1923,68 @@ fn terminal_proxy_reconciliation_hydrates_persisted_nested_result_idempotently()
     );
 }
 
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). Reconciliation is not a pure function of the in-memory record it
+/// mutates: it binds the pending handoff, reads the aggregate to decide
+/// idempotence and commits the terminal projection, all durably. Those writes
+/// and that read have to name the installation the planned proxy was persisted
+/// into, or the terminal record asserted below would be reconciled from one
+/// home's aggregate and committed into another's (#7505).
+///
+/// The proxy is created through the `*_with_submission_in_store` form because
+/// the default Lab-offload submission admits through the machine-global
+/// controller-runtime store; see `stub_lab_offload_submission`. Nothing here
+/// asserts on controller-runtime provenance, so the stub pin is invisible to
+/// this test.
 #[test]
 fn transport_proxy_snapshot_reconciliation_advances_queued_lifecycle() {
-    with_isolated_home(|_| {
-        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-        let mut record = record_lab_offload_planned(LabOffloadProxyPlan {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let mut record = record_lab_offload_planned_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadProxyPlan {
             run_id: "agent-task-disconnected-child",
             runner_id: "homeboy-lab",
             remote_workspace: "/runner/workspace/repo",
             remote_command: &command,
             durable_plan: None,
-        })
-        .expect("planned proxy");
-        let job_id = "00000000-0000-0000-0000-000000000123";
-        let metadata = record.ensure_metadata_object();
-        metadata.insert("runner_job_id".to_string(), json!(job_id));
-        metadata.insert(
-            "runner_execution_record".to_string(),
-            serde_json::to_value(
-                homeboy_core::runner_execution_envelope::RunnerExecutionRecord::in_flight(
-                    job_id,
-                    "homeboy-lab",
-                    "daemon",
-                )
-                .with_job_id(job_id),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("planned proxy");
+    let job_id = "00000000-0000-0000-0000-000000000123";
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("runner_job_id".to_string(), json!(job_id));
+    metadata.insert(
+        "runner_execution_record".to_string(),
+        serde_json::to_value(
+            homeboy_core::runner_execution_envelope::RunnerExecutionRecord::in_flight(
+                job_id,
+                "homeboy-lab",
+                "daemon",
             )
-            .expect("execution record"),
-        );
+            .with_job_id(job_id),
+        )
+        .expect("execution record"),
+    );
 
-        let aggregate = succeeded_aggregate(&test_plan());
-        reconcile_transport_proxy_snapshot(&mut record, &terminal_child_snapshot(&aggregate))
-            .expect("transport proxy reconciliation");
+    let aggregate = succeeded_aggregate(&test_plan());
+    reconcile_transport_proxy_snapshot_in_store(
+        &lifecycle_store,
+        &mut record,
+        &terminal_child_snapshot(&aggregate),
+    )
+    .expect("transport proxy reconciliation");
 
-        assert_eq!(record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(record.tasks[0].state, AgentTaskState::Succeeded);
-        assert_eq!(record.metadata["runner_job_status"], "succeeded");
-        assert_eq!(
-            record.metadata["runner_execution_record"]["status"],
-            "succeeded"
-        );
-    });
+    assert_eq!(record.state, AgentTaskRunState::Succeeded);
+    assert_eq!(record.tasks[0].state, AgentTaskState::Succeeded);
+    assert_eq!(record.metadata["runner_job_status"], "succeeded");
+    assert_eq!(
+        record.metadata["runner_execution_record"]["status"],
+        "succeeded"
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment


### PR DESCRIPTION
## Summary

**1 of 37 sites migrated** — and that low number is the report.

Two prior rounds already took everything takeable. Of the 37 remaining: **18 install a runner-continuation provider** (hard rule), **6 were pre-ruled-out**, and **12 have no rooted sibling for the function under test**. That leaves exactly one. All 37 were read individually; nothing was migrated that couldn't be justified from source.

The migrated test is `transport_proxy_snapshot_reconciliation_advances_queued_lifecycle`. Note the previous round's line number (1709) was **stale** — 1709 now sits inside an already-migrated test; the real site was 1928.

`stub_lab_offload_submission` was **moved** from `handoff_and_proxy.rs` to `tests/mod.rs` as `pub(super)` rather than duplicated — a duplicate private fn of the same name in a sibling module is exactly the smell lesson 3 warns about. Body byte-identical; all 19 existing call sites resolve unchanged.

<callout accent="#ef4444">
## Two pre-existing problems, already on `main`

**1. `terminal_and_reconcile.rs` uses un-stubbed rooted Lab-offload forms at 9 sites** (513, 575, 682, 751, 775, 829, 852, 874, 1834). Those default to `admitted_lab_offload_submission`, and the record does not exist yet, so the submit fall-through **is** taken → `submit_plan_in_store` → `admit_current_for_with_cancellation_check` on the machine-global `paths::controller_runtimes_store()`.

**2. `mark_running_in_store` is called from stub-admitted rooted tests at 7 sites** (`status_and_recovery.rs:2661,2684`; `terminal_and_reconcile.rs:3223,3263,3313,3358,3396,3453,3504`) — which reaches `migrate_legacy_pin_and_persist` → `runtime_root()` + `acquire_admission_lock` on the real operator data root.

Both merged in earlier rounds. Both are one-line-per-site fixes. **Not fixed here** — flagged for a dedicated follow-up.
</callout>

## Highest-value follow-up, named

`controller_leaves_runner_artifact_projection_pending_…` and `duplicate_runner_artifact_ids_fail_closed_…` are **one production sibling away**: everything else in both tests is migratable, and the sole blocker is that `run_owes_candidate_follow_up` has no `_in_store` form.

Also worth knowing: `timed_out_recoverable_lab_candidate_…` installs a process-global `register_runner_evidence_provider` with **no guard at all** — more dangerous than the guarded provider tests, not less.

## Why `cancel` was not substituted

`cancel()` has no `_in_store` sibling, and `cancel_run_in_store` is a **different operation** (live cancellation, stale reclaim, runner cancel). Substituting it would change what is under test — precisely the silent-rewrite failure mode.

## Verification

**Scanner 7/7.** Zero new duplicate definitions vs `origin/main`. `cargo fmt` / `rustfmt --check` clean, which also proves the files parse.

<callout accent="#f59e0b">
**Not compiled, not run.** CI is the first execution.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode general subagent, outside the Homeboy control plane
- **Used for:** Migration and blocker analysis. Review by hand.

Refs #7505