### PR TITLE
Stop the rooted offload tests reaching the operator runtime store

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -17,42 +17,6 @@ use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
-/// The submission a rooted Lab-offload test hands to the
-/// `*_with_submission_in_store` entry points.
-///
-/// Every Lab offload entry point reads its record first and submits only on the
-/// fall-through, and that fall-through is the one reach a rooted Lab offload
-/// function still makes past its lifecycle store: the default
-/// `admitted_lab_offload_submission` calls `submit_plan_in_store`, which admits
-/// through `homeboy_core::controller_runtime`, whose FIFO admission queue and
-/// content-addressed pin store hang off `paths::controller_runtimes_store()` and
-/// are machine-global on purpose (#7505, #12608). A test that no longer mutates
-/// HOME would therefore enqueue against the *real operator* runtime store and
-/// block on its cross-process lock. Naming the submission keeps the whole
-/// operation inside the injected store and reaches nothing process-global at
-/// all.
-///
-/// It is named even where the record already exists and the fall-through
-/// therefore cannot be reached: if that reasoning is ever wrong, a stub
-/// submission fails loudly inside the injected store instead of quietly
-/// enqueueing against the operator's real home.
-///
-/// The consequence to keep in mind when choosing what to migrate: the durable
-/// run this creates carries `{}` for its controller-runtime pin rather than a
-/// real admission, so a test that asserts on controller-runtime *provenance*
-/// stays on `with_isolated_home`.
-///
-/// This mirrors the identically named helper in the `handoff_and_proxy`
-/// partition; each partition is its own module, so the two are separate items
-/// rather than a redefinition.
-fn stub_lab_offload_submission(
-    lifecycle_store: &AgentTaskLifecycleStore,
-    plan: &AgentTaskPlan,
-    run_id: &str,
-) -> Result<AgentTaskRunRecord> {
-    lifecycle_store.submit_plan_with_runtime_admission(plan, run_id, |_| Ok(json!({})))
-}
-
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The submission, the hand-written running projection and the status
 /// read that judges it are one home, so "the accepted daemon authority kept

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -510,7 +510,7 @@ fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
         crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
     let attempt_run_id = "cook-7970-attempt-1-staging-failure";
     let plan = test_plan();
-    record_lab_offload_phase_in_store(
+    record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: attempt_run_id,
@@ -521,6 +521,7 @@ fn detached_cook_preacceptance_failure_terminalizes_attempt_proxy() {
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("pre-acceptance attempt record");
 
@@ -572,7 +573,7 @@ fn failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recov
         crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
     let run_id = "cook-preacceptance-recovery";
     let plan = test_plan();
-    record_lab_offload_phase_in_store(
+    record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: run_id,
@@ -583,6 +584,7 @@ fn failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recov
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("pre-acceptance attempt record");
     record_pre_execution_failure_in_store(
@@ -679,7 +681,7 @@ fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
     plan.tasks[0].instructions = "implement the original user task".to_string();
     plan.tasks[0].workspace.root = Some("/materialized/worktree".to_string());
     plan.rebuild_homeboy_plan();
-    let record = record_lab_offload_phase_in_store(
+    let record = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: "failed-lab-cook",
@@ -690,6 +692,7 @@ fn failed_lab_handoff_retry_recovers_the_materialized_user_plan() {
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("controller records user plan before pending handoff");
     let persisted =
@@ -748,7 +751,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
         "branch": "main",
         "head": "abc123",
     });
-    let materializing = record_lab_offload_phase_in_store(
+    let materializing = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: "agent-task-pre-execution",
@@ -759,6 +762,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             provider_rotation: Some(&json!({"entries": [{"model": "openai/gpt-5.6-terra"}]})),
             durable_plan: None,
         },
+        &stub_lab_offload_submission,
     )
     .expect("materialization phase persisted");
 
@@ -772,7 +776,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
     );
     assert!(materializing.metadata.get("runner_job_id").is_none());
 
-    let hydrating = record_lab_offload_phase_in_store(
+    let hydrating = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: "agent-task-pre-execution",
@@ -783,6 +787,7 @@ fn controller_proxy_records_pre_execution_phase_progress() {
             provider_rotation: None,
             durable_plan: None,
         },
+        &stub_lab_offload_submission,
     )
     .expect("hydration phase persisted");
     assert_eq!(hydrating.metadata["phase"], "hydrating");
@@ -826,7 +831,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
         crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
     let run_id = "long-pre-submission-materialization";
     let plan = test_plan();
-    let materializing = record_lab_offload_phase_in_store(
+    let materializing = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: run_id,
@@ -837,6 +842,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("persist pre-submission materialization");
 
@@ -849,7 +855,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
             .expect("read-side reconciliation"),
         0
     );
-    let hydrating = record_lab_offload_phase_in_store(
+    let hydrating = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: run_id,
@@ -860,6 +866,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("long setup remains controller-owned");
     assert_eq!(hydrating.state, AgentTaskRunState::Queued);
@@ -871,7 +878,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
         Some("controller cancelled during setup"),
     )
     .expect("terminalize setup record");
-    let after_terminal_phase = record_lab_offload_phase_in_store(
+    let after_terminal_phase = record_lab_offload_phase_with_submission_in_store(
         &lifecycle_store,
         LabOffloadPhaseRecord {
             requested_run_id: run_id,
@@ -882,6 +889,7 @@ fn long_pre_submission_setup_survives_reconciliation_and_terminal_phase_writes_a
             provider_rotation: None,
             durable_plan: Some(&plan),
         },
+        &stub_lab_offload_submission,
     )
     .expect("terminal phase write is a no-op");
     assert_eq!(after_terminal_phase, cancelled);
@@ -1831,7 +1839,7 @@ fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() 
     let lifecycle_store =
         crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
     let command = vec!["homeboy".to_string(), "agent-task".to_string()];
-    record_lab_offload_planned_in_store(
+    record_lab_offload_planned_with_submission_in_store(
         &lifecycle_store,
         LabOffloadProxyPlan {
             run_id: "agent-task-handoff-failure",
@@ -1840,6 +1848,7 @@ fn controller_proxy_becomes_terminal_when_handoff_fails_before_child_creation() 
             remote_command: &command,
             durable_plan: None,
         },
+        &stub_lab_offload_submission,
     )
     .expect("planned proxy");
     let plan =


### PR DESCRIPTION
<callout accent="#ef4444">
## Six rooted tests were enqueueing against the operator real data root

Nine call sites in `terminal_and_reconcile.rs` call `record_lab_offload_{phase,planned}_in_store`, whose default submission is `admitted_lab_offload_submission`.

**None of the six writes the run record first**, so the absent-record fall-through in `record_detached_lab_run_in_store` fires every time → `submit_plan_in_store` → `admit_current_for_with_cancellation_check` on `paths::controller_runtimes_store()`.

That store is deliberately process-global — a content-addressed cache keyed to the real machine. A test that no longer sets `HOME` **enqueues against the operator own data root and blocks on its cross-process admission lock.** On the box this repo is developed from, that is the machine actually running homeboy.
</callout>

## Why it slipped through

The tests were migrated correctly in every other respect. **The fall-through is invisible at the call site** and appears in no name-based screen, because the function being called *is* genuinely the rooted sibling.

It was found by reading `record_detached_lab_run_in_store`'s body while auditing a different file — the same way every other real defect in this campaign has been found.

All nine now pass `&stub_lab_offload_submission` through the `_with_submission_in_store` form, which is the shape the already-migrated tests in `handoff_and_proxy.rs` use.

## A duplicate helper, and why it was worth removing

Two parallel migrations each introduced a `stub_lab_offload_submission` — a `pub(super)` definition in `tests/mod.rs` and a private copy in `submit_and_persist.rs`.

**The private copy shadowed the glob import rather than colliding with it, so both compiled and neither CI run complained.** That is precisely the shape worth collapsing now rather than leaving to be discovered later. One definition remains, crate-wide.

## Verification

**Assertions untouched: 331 → 331, zero differing** (balanced-paren extraction, whitespace-normalized, diffed against `origin/main`).

**Scanner 7/7.** Un-stubbed offload calls in rooted tests: **9 → 0**. `rustfmt --check` clean.

<callout accent="#f59e0b">
**Not compiled, not run.** The second issue that audit surfaced — `mark_running_in_store` reaching `migrate_legacy_pin_and_persist` → `runtime_root()` + `acquire_admission_lock` from ~7 stub-admitted rooted tests — is **not fixed here**. It needs those tests reverted to ambient or a rooted `mark_running`, which is a design decision rather than a mechanical swap.
</callout>

## AI assistance

- **AI assistance:** Yes · **Tool(s):** OpenCode. Defect found by a subagent audit; fix and verification by the orchestrating session.
- **Used for:** Diagnosis and mechanical rewrite. Review by hand.

Refs #7505