### PR TITLE
DO NOT MERGE: one-off full-scope validation run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,11 @@ jobs:
       component: homeboy
       extension-ref: 691d0527d7a4b3917649043a7f91a81913a139ab
       source: .
-      scope: auto
+      # TEMPORARY -- do not merge. Forces a one-off full-suite run to validate
+      # the #7505 campaign's ~40 merged PRs. main only ever runs changed-scope
+      # (the full-scope Main Guard was removed deliberately in #10696), so the
+      # night's work has never been exercised against the whole suite.
+      scope: full
       differential-gating: 'true'
       baseline-commands: none
       test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}


### PR DESCRIPTION
<callout accent="#f59e0b">
## This PR exists to be read and closed, not merged

It flips `scope: auto` → `scope: full` in `ci.yml` so the Test gate executes **every** test once.
</callout>

## Why

`main` only ever runs **changed-scope** tests. The full-scope Main Guard was removed deliberately in #10696 (rolling releases beat a 16-35 min suite in front of every release), and `tests/audit_debt_workflow_test.rs` pins that absence — so it is a design decision, not a gap to fix.

The consequence is that roughly **forty #7505 PRs merged over the last day have never been exercised against the whole suite.** Each was gated on `Workspace Tests Compile` plus a changed-scope `Test`, and several were admin-merged while `Test` was still pending.

That gap already bit once: seven tests in `terminal_and_reconcile` were red on `main` for several hours (`controller runtime pin has no build identity`), reverted in #12700 and confirmed green by run 32231467511 — but that confirmation was itself **scoped to 54 tests**. It proves those seven are fixed. It proves nothing about the other ~1,800.

## What to do with the result

- **Green** → the campaign's blast radius is clean, close this PR, no further action.
- **Red** → the failures are the real remaining debt from the #7505 waves, and worth their own issues.

Either way this branch gets deleted. Nothing here should reach `main` — a permanent `scope: full` would reintroduce exactly the cost #10696 removed on purpose.

Refs #7505